### PR TITLE
[CI] Consistent CircleCI workspace layout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,13 +124,7 @@ defaults:
       command: ./scripts/docs_version_pragma_check.sh
 
   # --------------------------------------------------------------------------
-  # Artifacts Templates
-
-  # the whole build directory
-  - artifacts_build_dir: &artifacts_build_dir
-      root: build
-      paths:
-        - "*"
+  # Artifact and Workspace Content Templates
 
   # compiled solc executable target
   - artifacts_solc: &artifacts_solc
@@ -150,8 +144,13 @@ defaults:
       path: build/tools/yul-phaser
       destination: yul-phaser
 
+  # test result output directory
+  - artifacts_test_results: &artifacts_test_results
+      path: test_results/
+      destination: test_results/
+
   # compiled executable targets
-  - artifacts_executables: &artifacts_executables
+  - workspace_linux_executables: &workspace_linux_executables
       root: .
       paths:
         - build/solc/solc
@@ -159,7 +158,7 @@ defaults:
         - build/test/tools/solfuzzer
 
   # compiled OSSFUZZ targets
-  - artifacts_executables_ossfuzz: &artifacts_executables_ossfuzz
+  - workspace_linux_executables_ossfuzz: &workspace_linux_executables_ossfuzz
       root: .
       paths:
         - build/test/tools/ossfuzz/abiv2_proto_ossfuzz
@@ -176,10 +175,28 @@ defaults:
         - build/test/tools/ossfuzz/yul_proto_ossfuzz
         - build/test/tools/ossfuzz/sol_proto_ossfuzz
 
-  # test result output directory
-  - artifacts_test_results: &artifacts_test_results
-      path: test_results/
-      destination: test_results/
+  - workspace_windows_executables: &workspace_windows_executables
+      root: .
+      paths:
+        - build/solc/*/solc.exe
+        - build/test/*/soltest.exe
+
+  - workspace_emscripten_executables: &workspace_emscripten_executables
+      root: .
+      paths:
+        - build/soljson.js
+        - build/version.txt
+
+  - workspace_bytecode_reports: &workspace_bytecode_reports
+      root: .
+      paths:
+        - reports/bytecode/ubuntu-json.txt
+        - reports/bytecode/ubuntu-cli.txt
+        - reports/bytecode/osx-json.txt
+        - reports/bytecode/osx-cli.txt
+        - reports/bytecode/windows-json.txt
+        - reports/bytecode/windows-cli.txt
+        - reports/bytecode/emscripten.txt
 
   # --------------------------------------------------------------------------
   # Step Templates
@@ -618,7 +635,7 @@ jobs:
       - store_artifacts: *artifacts_solc
       - store_artifacts: *artifact_solidity_upgrade
       - store_artifacts: *artifact_yul_phaser
-      - persist_to_workspace: *artifacts_executables
+      - persist_to_workspace: *workspace_linux_executables
       - gitter_notify_failure_unless_pr
 
   # x64 ASAN build, for testing for memory related bugs
@@ -633,7 +650,7 @@ jobs:
       - checkout
       - run: *run_build
       - store_artifacts: *artifacts_solc
-      - persist_to_workspace: *artifacts_executables
+      - persist_to_workspace: *workspace_linux_executables
       - gitter_notify_failure_unless_pr
 
   b_ubu_clang: &b_ubu_clang
@@ -647,7 +664,7 @@ jobs:
       - checkout
       - run: *run_build
       - store_artifacts: *artifacts_solc
-      - persist_to_workspace: *artifacts_executables
+      - persist_to_workspace: *workspace_linux_executables
       - gitter_notify_failure_unless_pr
 
   b_ubu_asan_clang: &b_ubu_asan_clang
@@ -662,7 +679,7 @@ jobs:
       - checkout
       - run: *run_build
       - store_artifacts: *artifacts_solc
-      - persist_to_workspace: *artifacts_executables
+      - persist_to_workspace: *workspace_linux_executables
       - gitter_notify_failure_unless_pr
 
   b_ubu_ubsan_clang: &b_ubu_ubsan_clang
@@ -677,7 +694,7 @@ jobs:
       - checkout
       - run: *run_build
       - store_artifacts: *artifacts_solc
-      - persist_to_workspace: *artifacts_executables
+      - persist_to_workspace: *workspace_linux_executables
       - gitter_notify_failure_unless_pr
 
   b_ubu_release: &b_ubu_release
@@ -700,7 +717,7 @@ jobs:
           name: strip binary
           command: strip build/solc/solc
       - store_artifacts: *artifacts_solc
-      - persist_to_workspace: *artifacts_executables
+      - persist_to_workspace: *workspace_linux_executables
       - gitter_notify_failure_unless_pr
 
   b_ubu_codecov:
@@ -713,7 +730,7 @@ jobs:
     steps:
       - checkout
       - run: *run_build
-      - persist_to_workspace: *artifacts_executables
+      - persist_to_workspace: *workspace_linux_executables
       - gitter_notify_failure_unless_pr
 
   t_ubu_codecov:
@@ -757,7 +774,7 @@ jobs:
       - checkout
       - run: *setup_prerelease_commit_hash
       - run: *run_build_ossfuzz
-      - persist_to_workspace: *artifacts_executables_ossfuzz
+      - persist_to_workspace: *workspace_linux_executables_ossfuzz
       - gitter_notify_failure_unless_pr
 
   t_ubu_ossfuzz: &t_ubu_ossfuzz
@@ -790,7 +807,7 @@ jobs:
       - checkout
       - run: *run_build
       - store_artifacts: *artifacts_solc
-      - persist_to_workspace: *artifacts_executables
+      - persist_to_workspace: *workspace_linux_executables
       - gitter_notify_failure_unless_pr
 
   b_osx:
@@ -822,12 +839,7 @@ jobs:
       - store_artifacts: *artifacts_solc
       - store_artifacts: *artifact_solidity_upgrade
       - store_artifacts: *artifact_yul_phaser
-      - persist_to_workspace:
-          root: .
-          paths:
-            - build/solc/solc
-            - build/test/soltest
-            - build/test/tools/solfuzzer
+      - persist_to_workspace: *workspace_linux_executables
       - gitter_notify_failure_unless_pr
 
   t_osx_soltest:
@@ -878,11 +890,7 @@ jobs:
       - run: mkdir -p build/
       - run: cp emscripten_build/libsolc/soljson.js build/soljson.js
       - run: scripts/get_version.sh > build/version.txt
-      - persist_to_workspace:
-          root: .
-          paths:
-            - build/soljson.js
-            - build/version.txt
+      - persist_to_workspace: *workspace_emscripten_executables
       - gitter_notify_failure_unless_pr
 
   b_docs:
@@ -1120,11 +1128,7 @@ jobs:
           name: "Run solc.exe to make sure build was successful."
           command: .\build\solc\Release\solc.exe --version
       - store_artifacts: *artifact_solc_windows
-      - persist_to_workspace:
-          root: .
-          paths:
-            - build\solc\*\solc.exe
-            - build\test\*\soltest.exe
+      - persist_to_workspace: *workspace_windows_executables
       - gitter_notify_failure_unless_pr
 
   b_win_release:
@@ -1167,11 +1171,7 @@ jobs:
           path: reports/bytecode/ubuntu-json.txt
       - store_artifacts:
           path: reports/bytecode/ubuntu-cli.txt
-      - persist_to_workspace:
-          root: .
-          paths:
-            - reports/bytecode/ubuntu-json.txt
-            - reports/bytecode/ubuntu-cli.txt
+      - persist_to_workspace: *workspace_bytecode_reports
       - gitter_notify_failure_unless_pr
 
   b_bytecode_osx:
@@ -1188,11 +1188,7 @@ jobs:
           path: reports/bytecode/osx-json.txt
       - store_artifacts:
           path: reports/bytecode/osx-cli.txt
-      - persist_to_workspace:
-          root: .
-          paths:
-            - reports/bytecode/osx-json.txt
-            - reports/bytecode/osx-cli.txt
+      - persist_to_workspace: *workspace_bytecode_reports
       - gitter_notify_failure_unless_pr
 
   b_bytecode_win:
@@ -1212,11 +1208,7 @@ jobs:
           path: reports/bytecode/windows-json.txt
       - store_artifacts:
           path: reports/bytecode/windows-cli.txt
-      - persist_to_workspace:
-          root: .
-          paths:
-            - reports/bytecode/windows-json.txt
-            - reports/bytecode/windows-cli.txt
+      - persist_to_workspace: *workspace_bytecode_reports
       - gitter_notify_failure_unless_pr
 
   b_bytecode_ems:
@@ -1235,10 +1227,7 @@ jobs:
           mv -v report.txt reports/bytecode/emscripten.txt
       - store_artifacts:
           path: reports/bytecode/emscripten.txt
-      - persist_to_workspace:
-          root: .
-          paths:
-            - reports/bytecode/emscripten.txt
+      - persist_to_workspace: *workspace_bytecode_reports
       - gitter_notify_failure_unless_pr
 
   t_bytecode_compare:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1159,19 +1159,19 @@ jobs:
       - checkout
       - attach_workspace:
           at: build
-      - run: mkdir test-cases/
+      - run: mkdir -p test-cases/ reports/bytecode/
       - run: cd test-cases && ../scripts/isolate_tests.py ../test/
-      - run: cd test-cases && ../scripts/bytecodecompare/prepare_report.py ../build/solc/solc --interface standard-json --report-file ../bytecode-report-ubuntu-json.txt
-      - run: cd test-cases && ../scripts/bytecodecompare/prepare_report.py ../build/solc/solc --interface cli --report-file ../bytecode-report-ubuntu-cli.txt
+      - run: cd test-cases && ../scripts/bytecodecompare/prepare_report.py ../build/solc/solc --interface standard-json --report-file ../reports/bytecode/ubuntu-json.txt
+      - run: cd test-cases && ../scripts/bytecodecompare/prepare_report.py ../build/solc/solc --interface cli --report-file ../reports/bytecode/ubuntu-cli.txt
       - store_artifacts:
-          path: bytecode-report-ubuntu-json.txt
+          path: reports/bytecode/ubuntu-json.txt
       - store_artifacts:
-          path: bytecode-report-ubuntu-cli.txt
+          path: reports/bytecode/ubuntu-cli.txt
       - persist_to_workspace:
           root: .
           paths:
-            - bytecode-report-ubuntu-json.txt
-            - bytecode-report-ubuntu-cli.txt
+            - reports/bytecode/ubuntu-json.txt
+            - reports/bytecode/ubuntu-cli.txt
       - gitter_notify_failure_unless_pr
 
   b_bytecode_osx:
@@ -1180,19 +1180,19 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: mkdir test-cases/
+      - run: mkdir -p test-cases/ reports/bytecode/
       - run: cd test-cases && ../scripts/isolate_tests.py ../test/
-      - run: cd test-cases && ../scripts/bytecodecompare/prepare_report.py ../build/solc/solc --interface standard-json --report-file ../bytecode-report-osx-json.txt
-      - run: cd test-cases && ../scripts/bytecodecompare/prepare_report.py ../build/solc/solc --interface cli --report-file ../bytecode-report-osx-cli.txt
+      - run: cd test-cases && ../scripts/bytecodecompare/prepare_report.py ../build/solc/solc --interface standard-json --report-file ../reports/bytecode/osx-json.txt
+      - run: cd test-cases && ../scripts/bytecodecompare/prepare_report.py ../build/solc/solc --interface cli --report-file ../reports/bytecode/osx-cli.txt
       - store_artifacts:
-          path: bytecode-report-osx-json.txt
+          path: reports/bytecode/osx-json.txt
       - store_artifacts:
-          path: bytecode-report-osx-cli.txt
+          path: reports/bytecode/osx-cli.txt
       - persist_to_workspace:
           root: .
           paths:
-            - bytecode-report-osx-json.txt
-            - bytecode-report-osx-cli.txt
+            - reports/bytecode/osx-json.txt
+            - reports/bytecode/osx-cli.txt
       - gitter_notify_failure_unless_pr
 
   b_bytecode_win:
@@ -1204,19 +1204,19 @@ jobs:
       - checkout
       - attach_workspace:
           at: build
-      - run: mkdir test-cases\
+      - run: md test-cases\ reports\bytecode\
       - run: cd test-cases\ && python ..\scripts\isolate_tests.py ..\test\
-      - run: cd test-cases\ && python ..\scripts\bytecodecompare\prepare_report.py ..\build\solc\Release\solc.exe --interface standard-json --report-file ..\bytecode-report-windows-json.txt
-      - run: cd test-cases\ && python ..\scripts\bytecodecompare\prepare_report.py ..\build\solc\Release\solc.exe --interface cli --report-file ..\bytecode-report-windows-cli.txt
+      - run: cd test-cases\ && python ..\scripts\bytecodecompare\prepare_report.py ..\build\solc\Release\solc.exe --interface standard-json --report-file ..\reports\bytecode\windows-json.txt
+      - run: cd test-cases\ && python ..\scripts\bytecodecompare\prepare_report.py ..\build\solc\Release\solc.exe --interface cli --report-file ..\reports\bytecode\windows-cli.txt
       - store_artifacts:
-          path: bytecode-report-windows-json.txt
+          path: reports/bytecode/windows-json.txt
       - store_artifacts:
-          path: bytecode-report-windows-cli.txt
+          path: reports/bytecode/windows-cli.txt
       - persist_to_workspace:
           root: .
           paths:
-            - bytecode-report-windows-json.txt
-            - bytecode-report-windows-cli.txt
+            - reports/bytecode/windows-json.txt
+            - reports/bytecode/windows-cli.txt
       - gitter_notify_failure_unless_pr
 
   b_bytecode_ems:
@@ -1227,26 +1227,27 @@ jobs:
       - checkout
       - attach_workspace:
           at: emscripten_build/libsolc
-      - run: scripts/bytecodecompare/storebytecode.sh && mv -v report.txt bytecode-report-emscripten.txt
+      - run: mkdir -p emscripten_build/libsolc/ reports/bytecode/
+      - run: scripts/bytecodecompare/storebytecode.sh && mv -v report.txt reports/bytecode/emscripten.txt
       - store_artifacts:
-          path: bytecode-report-emscripten.txt
+          path: reports/bytecode/emscripten.txt
       - persist_to_workspace:
           root: .
           paths:
-            - bytecode-report-emscripten.txt
+            - reports/bytecode/emscripten.txt
       - gitter_notify_failure_unless_pr
 
   t_bytecode_compare:
     <<: *base_ubuntu2004_small
     environment:
       REPORT_FILES: |
-        bytecode-report-emscripten.txt
-        bytecode-report-ubuntu-json.txt
-        bytecode-report-ubuntu-cli.txt
-        bytecode-report-osx-json.txt
-        bytecode-report-osx-cli.txt
-        bytecode-report-windows-json.txt
-        bytecode-report-windows-cli.txt
+        reports/bytecode/emscripten.txt
+        reports/bytecode/ubuntu-json.txt
+        reports/bytecode/ubuntu-cli.txt
+        reports/bytecode/osx-json.txt
+        reports/bytecode/osx-cli.txt
+        reports/bytecode/windows-json.txt
+        reports/bytecode/windows-cli.txt
     steps:
       - attach_workspace:
           at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,8 @@ defaults:
         - build/solc/solc
         - build/test/soltest
         - build/test/tools/solfuzzer
+        - build/tools/solidity-upgrade
+        - build/tools/yul-phaser
 
   # compiled OSSFUZZ targets
   - workspace_linux_executables_ossfuzz: &workspace_linux_executables_ossfuzz
@@ -180,6 +182,9 @@ defaults:
       paths:
         - build/solc/*/solc.exe
         - build/test/*/soltest.exe
+        - build/test/tools/*/solfuzzer.exe
+        - build/tools/*/solidity-upgrade.exe
+        - build/tools/*/yul-phaser.exe
 
   - workspace_emscripten_executables: &workspace_emscripten_executables
       root: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,29 +152,29 @@ defaults:
 
   # compiled executable targets
   - artifacts_executables: &artifacts_executables
-      root: build
+      root: .
       paths:
-        - solc/solc
-        - test/soltest
-        - test/tools/solfuzzer
+        - build/solc/solc
+        - build/test/soltest
+        - build/test/tools/solfuzzer
 
   # compiled OSSFUZZ targets
   - artifacts_executables_ossfuzz: &artifacts_executables_ossfuzz
-      root: build
+      root: .
       paths:
-        - test/tools/ossfuzz/abiv2_proto_ossfuzz
-        - test/tools/ossfuzz/abiv2_isabelle_ossfuzz
-        - test/tools/ossfuzz/const_opt_ossfuzz
-        - test/tools/ossfuzz/solc_mutator_ossfuzz
-        - test/tools/ossfuzz/solc_ossfuzz
-        - test/tools/ossfuzz/stack_reuse_codegen_ossfuzz
-        - test/tools/ossfuzz/strictasm_assembly_ossfuzz
-        - test/tools/ossfuzz/strictasm_diff_ossfuzz
-        - test/tools/ossfuzz/strictasm_opt_ossfuzz
-        - test/tools/ossfuzz/yul_proto_diff_ossfuzz
-        - test/tools/ossfuzz/yul_proto_diff_custom_mutate_ossfuzz
-        - test/tools/ossfuzz/yul_proto_ossfuzz
-        - test/tools/ossfuzz/sol_proto_ossfuzz
+        - build/test/tools/ossfuzz/abiv2_proto_ossfuzz
+        - build/test/tools/ossfuzz/abiv2_isabelle_ossfuzz
+        - build/test/tools/ossfuzz/const_opt_ossfuzz
+        - build/test/tools/ossfuzz/solc_mutator_ossfuzz
+        - build/test/tools/ossfuzz/solc_ossfuzz
+        - build/test/tools/ossfuzz/stack_reuse_codegen_ossfuzz
+        - build/test/tools/ossfuzz/strictasm_assembly_ossfuzz
+        - build/test/tools/ossfuzz/strictasm_diff_ossfuzz
+        - build/test/tools/ossfuzz/strictasm_opt_ossfuzz
+        - build/test/tools/ossfuzz/yul_proto_diff_ossfuzz
+        - build/test/tools/ossfuzz/yul_proto_diff_custom_mutate_ossfuzz
+        - build/test/tools/ossfuzz/yul_proto_ossfuzz
+        - build/test/tools/ossfuzz/sol_proto_ossfuzz
 
   # test result output directory
   - artifacts_test_results: &artifacts_test_results
@@ -192,7 +192,7 @@ defaults:
       steps:
         - checkout
         - attach_workspace:
-            at: build
+            at: .
         # NOTE: Different build jobs produce different soltest executables (release/debug,
         # clang/gcc, windows/linux/macos, etc.). The executable used by these steps comes from the
         # attached workspace and we only see the items added to the workspace by jobs we depend on.
@@ -205,7 +205,7 @@ defaults:
       steps:
         - checkout
         - attach_workspace:
-            at: build
+            at: .
         - run:
             name: Install dependencies
             command: pip install --user deepdiff colorama
@@ -218,7 +218,7 @@ defaults:
       steps:
         - checkout
         - attach_workspace:
-            at: build
+            at: .
         - run: *run_soltest_all
         - store_test_results: *store_test_results
         - store_artifacts: *artifacts_test_results
@@ -228,7 +228,7 @@ defaults:
       steps:
         - checkout
         - attach_workspace:
-            at: build
+            at: .
         - run: *run_cmdline_tests
         - store_test_results: *store_test_results
         - store_artifacts: *artifacts_test_results
@@ -475,7 +475,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: build
+          at: .
       - run:
           name: Install dependencies
           command: |
@@ -490,7 +490,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: build
+          at: .
       - run:
           name: JS deps
           command: sudo npm install -g solhint
@@ -724,7 +724,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: build
+          at: .
       - run:
           name: "soltest: Syntax Tests"
           command: build/test/soltest -t 'syntaxTest*' -- --testpath test
@@ -765,7 +765,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: build
+          at: .
       - run:
           name: Regression tests
           command: |
@@ -875,14 +875,14 @@ jobs:
       - store_artifacts:
           path: emscripten_build/libsolc/soljson.js
           destination: soljson.js
-      - run: mkdir -p workspace
-      - run: cp emscripten_build/libsolc/soljson.js workspace/soljson.js
-      - run: scripts/get_version.sh > workspace/version.txt
+      - run: mkdir -p build/
+      - run: cp emscripten_build/libsolc/soljson.js build/soljson.js
+      - run: scripts/get_version.sh > build/version.txt
       - persist_to_workspace:
-          root: workspace
+          root: .
           paths:
-            - soljson.js
-            - version.txt
+            - build/soljson.js
+            - build/version.txt
       - gitter_notify_failure_unless_pr
 
   b_docs:
@@ -1001,7 +1001,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: /tmp/workspace
+          at: .
       - run:
           name: Install test dependencies
           command: |
@@ -1013,18 +1013,17 @@ jobs:
           command: |
             node --version
             npm --version
-            test/externalTests/solc-js/solc-js.sh /tmp/workspace/soljson.js $(cat /tmp/workspace/version.txt)
+            test/externalTests/solc-js/solc-js.sh build/soljson.js $(cat build/version.txt)
       - gitter_notify_failure_unless_pr
 
   t_ems_ext_hardhat:
     <<: *base_node_latest_small
     environment:
       TERM: xterm
-      HARDHAT_TESTS_SOLC_PATH: /tmp/workspace/soljson.js
     steps:
       - checkout
       - attach_workspace:
-          at: /tmp/workspace
+          at: .
       - run: git clone --depth 1 https://github.com/nomiclabs/hardhat.git
       - run:
           name: Install dependencies
@@ -1035,7 +1034,8 @@ jobs:
           name: Run hardhat-core test suite
           command: |
             HARDHAT_TESTS_SOLC_VERSION=$(scripts/get_version.sh)
-            export HARDHAT_TESTS_SOLC_VERSION
+            HARDHAT_TESTS_SOLC_PATH="$PWD/build/soljson.js"
+            export HARDHAT_TESTS_SOLC_VERSION HARDHAT_TESTS_SOLC_PATH
 
             # NOTE: This is expected to work without running `yarn build` first.
             cd hardhat/packages/hardhat-core
@@ -1072,7 +1072,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: /tmp/workspace
+          at: .
       - run:
           name: Install lsof
           command: |
@@ -1085,7 +1085,7 @@ jobs:
             - run:
                 name: External <<parameters.project>> tests (solcjs)
                 command: |
-                  test/externalTests/<<parameters.project>>.sh solcjs /tmp/workspace/soljson.js
+                  test/externalTests/<<parameters.project>>.sh solcjs build/soljson.js
       - when:
           condition:
             equal: [<< parameters.binary_type >>, "native"]
@@ -1093,7 +1093,7 @@ jobs:
             - run:
                 name: External <<parameters.project>> tests (native)
                 command: |
-                  test/externalTests/<<parameters.project>>.sh native /tmp/workspace/solc/solc
+                  test/externalTests/<<parameters.project>>.sh native build/solc/solc
       - gitter_notify_failure_unless_pr
 
   b_win: &b_win
@@ -1121,10 +1121,10 @@ jobs:
           command: .\build\solc\Release\solc.exe --version
       - store_artifacts: *artifact_solc_windows
       - persist_to_workspace:
-          root: build
+          root: .
           paths:
-            - .\solc\*\solc.exe
-            - .\test\*\soltest.exe
+            - build\solc\*\solc.exe
+            - build\test\*\soltest.exe
       - gitter_notify_failure_unless_pr
 
   b_win_release:
@@ -1139,7 +1139,7 @@ jobs:
       # for files using CRLF that way.
       - checkout
       - attach_workspace:
-          at: build
+          at: .
       - run:
           name: "Install evmone"
           command: scripts/install_evmone.ps1
@@ -1158,7 +1158,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: build
+          at: .
       - run: mkdir -p test-cases/ reports/bytecode/
       - run: cd test-cases && ../scripts/isolate_tests.py ../test/
       - run: cd test-cases && ../scripts/bytecodecompare/prepare_report.py ../build/solc/solc --interface standard-json --report-file ../reports/bytecode/ubuntu-json.txt
@@ -1203,7 +1203,7 @@ jobs:
       - run: git config --global core.autocrlf false
       - checkout
       - attach_workspace:
-          at: build
+          at: .
       - run: md test-cases\ reports\bytecode\
       - run: cd test-cases\ && python ..\scripts\isolate_tests.py ..\test\
       - run: cd test-cases\ && python ..\scripts\bytecodecompare\prepare_report.py ..\build\solc\Release\solc.exe --interface standard-json --report-file ..\reports\bytecode\windows-json.txt
@@ -1226,9 +1226,13 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: emscripten_build/libsolc
-      - run: mkdir -p emscripten_build/libsolc/ reports/bytecode/
-      - run: scripts/bytecodecompare/storebytecode.sh && mv -v report.txt reports/bytecode/emscripten.txt
+          at: .
+      - run: |
+          mkdir -p emscripten_build/libsolc/ reports/bytecode/
+          ln -s ../../build/soljson.js emscripten_build/libsolc/soljson.js
+      - run: |
+          scripts/bytecodecompare/storebytecode.sh
+          mv -v report.txt reports/bytecode/emscripten.txt
       - store_artifacts:
           path: reports/bytecode/emscripten.txt
       - persist_to_workspace:

--- a/test/externalTests/colony.sh
+++ b/test/externalTests/colony.sh
@@ -26,7 +26,7 @@ source test/externalTests/common.sh
 
 verify_input "$@"
 BINARY_TYPE="$1"
-BINARY_PATH="$2"
+BINARY_PATH=$(realpath "$2")
 SELECTED_PRESETS="$3"
 
 function compile_fn { yarn run provision:token:contracts; }

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -328,10 +328,10 @@ function replace_global_solc
 {
     local solc_path="$1"
 
-    [[ ! -e solc ]] || fail "A file named 'solc' already exists in '${PWD}'."
+    [[ ! -e ../solc ]] || fail "A file named 'solc' already exists in '${PWD}/..'."
 
-    ln -s "$solc_path" solc
-    export PATH="$PWD:$PATH"
+    ln -s "$solc_path" ../solc
+    export PATH="$PWD/..:$PATH"
 }
 
 function truffle_compiler_settings

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -26,7 +26,7 @@ source test/externalTests/common.sh
 
 verify_input "$@"
 BINARY_TYPE="$1"
-BINARY_PATH="$2"
+BINARY_PATH=$(realpath "$2")
 SELECTED_PRESETS="$3"
 
 function compile_fn { yarn build; }

--- a/test/externalTests/gnosis-v2.sh
+++ b/test/externalTests/gnosis-v2.sh
@@ -26,7 +26,7 @@ source test/externalTests/common.sh
 
 verify_input "$@"
 BINARY_TYPE="$1"
-BINARY_PATH="$2"
+BINARY_PATH=$(realpath "$2")
 SELECTED_PRESETS="$3"
 
 function compile_fn { npx truffle compile; }

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -26,7 +26,7 @@ source test/externalTests/common.sh
 
 verify_input "$@"
 BINARY_TYPE="$1"
-BINARY_PATH="$2"
+BINARY_PATH=$(realpath "$2")
 SELECTED_PRESETS="$3"
 
 function compile_fn { npx truffle compile; }

--- a/test/externalTests/solc-js/solc-js.sh
+++ b/test/externalTests/solc-js/solc-js.sh
@@ -24,10 +24,10 @@ set -e
 source scripts/common.sh
 source test/externalTests/common.sh
 
-SOLJSON="$1"
-VERSION="$2"
+[[ $1 != "" && -f "$1" && $2 != "" ]] || fail "Usage: $0 <path to soljson.js> <version>"
 
-[[ $SOLJSON != "" && -f "$SOLJSON" && $VERSION != "" ]] || fail "Usage: $0 <path to soljson.js> <version>"
+SOLJSON=$(realpath "$1")
+VERSION="$2"
 
 function compile_fn { echo "Nothing to compile."; }
 function test_fn { npm test; }

--- a/test/externalTests/trident.sh
+++ b/test/externalTests/trident.sh
@@ -27,6 +27,7 @@ source test/externalTests/common.sh
 verify_input "$@"
 BINARY_TYPE="$1"
 BINARY_PATH="$2"
+SELECTED_PRESETS="$3"
 
 function compile_fn { yarn build; }
 

--- a/test/externalTests/trident.sh
+++ b/test/externalTests/trident.sh
@@ -26,7 +26,7 @@ source test/externalTests/common.sh
 
 verify_input "$@"
 BINARY_TYPE="$1"
-BINARY_PATH="$2"
+BINARY_PATH=$(realpath "$2")
 SELECTED_PRESETS="$3"
 
 function compile_fn { yarn build; }

--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -26,7 +26,7 @@ source test/externalTests/common.sh
 
 verify_input "$@"
 BINARY_TYPE="$1"
-BINARY_PATH="$2"
+BINARY_PATH=$(realpath "$2")
 SELECTED_PRESETS="$3"
 
 function compile_fn { npm run compile; }


### PR DESCRIPTION
This PR reorganizes the layout of files we store in CircleCI workspace to make it more consistent between jobs/platform. Currently some jobs attach the work space at repo root, others at `build/` or random locations. Now the workspace will always be attached at repo root.

The PR also changes the location of bytecode reports because I want to reuse the same dir for benchmark reports later.