### PR TITLE
[CI] Templates for parameterized jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -475,6 +475,91 @@ defaults:
       requires:
         - b_win_release
 
+  # --------------------------------------------------------------------------
+  # Parameterized Job Templates
+
+  # Separate compile-only runs of those external tests where a full run takes much longer.
+  - job_ems_compile_ext_colony: &job_ems_compile_ext_colony
+      <<: *workflow_emscripten
+      name: t_ems_compile_ext_colony
+      project: colony
+      binary_type: solcjs
+      compile_only: 1
+      nodejs_version: '14'
+  - job_native_compile_ext_gnosis: &job_native_compile_ext_gnosis
+      <<: *workflow_ubuntu2004_static
+      name: t_native_compile_ext_gnosis
+      project: gnosis
+      binary_type: native
+      compile_only: 1
+      nodejs_version: '14'
+
+  - job_native_test_ext_gnosis: &job_native_test_ext_gnosis
+      <<: *workflow_emscripten
+      name: t_native_test_ext_gnosis
+      project: gnosis
+      binary_type: native
+      # NOTE: Tests do not start on node.js 14 ("ganache-cli exited early with code 1").
+      nodejs_version: '12'
+  - job_native_test_ext_gnosis_v2: &job_native_test_ext_gnosis_v2
+      <<: *workflow_ubuntu2004_static
+      name: t_native_test_ext_gnosis_v2
+      project: gnosis-v2
+      binary_type: native
+      # NOTE: Tests do not start on node.js 14 ("ganache-cli exited early with code 1").
+      nodejs_version: '12'
+  - job_native_test_ext_zeppelin: &job_native_test_ext_zeppelin
+      <<: *workflow_ubuntu2004_static
+      name: t_native_test_ext_zeppelin
+      project: zeppelin
+      binary_type: native
+      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
+      nodejs_version: '16'
+      resource_class: large
+  - job_native_test_ext_ens: &job_native_test_ext_ens
+      <<: *workflow_ubuntu2004_static
+      name: t_native_test_ext_ens
+      project: ens
+      binary_type: native
+      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
+      nodejs_version: '16'
+  - job_native_test_ext_trident: &job_native_test_ext_trident
+      <<: *workflow_ubuntu2004_static
+      name: t_native_test_ext_trident
+      project: trident
+      binary_type: native
+      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
+      nodejs_version: '16'
+  - job_native_test_ext_euler: &job_native_test_ext_euler
+      <<: *workflow_ubuntu2004_static
+      name: t_native_test_ext_euler
+      project: euler
+      binary_type: native
+      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
+      nodejs_version: '16'
+  - job_native_test_ext_yield_liquidator: &job_native_test_ext_yield_liquidator
+      <<: *workflow_ubuntu2004_static
+      name: t_native_test_ext_yield_liquidator
+      project: yield-liquidator
+      binary_type: native
+      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
+      nodejs_version: '16'
+  - job_native_test_ext_bleeps: &job_native_test_ext_bleeps
+      <<: *workflow_ubuntu2004_static
+      name: t_native_test_ext_bleeps
+      project: bleeps
+      binary_type: native
+      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
+      nodejs_version: '16'
+      resource_class: medium
+  - job_ems_test_ext_colony: &job_ems_test_ext_colony
+      <<: *workflow_emscripten
+      name: t_ems_test_ext_colony
+      project: colony
+      binary_type: solcjs
+      nodejs_version: '14'
+      resource_class: medium
+
 # -----------------------------------------------------------------------------------------------
 jobs:
 
@@ -1335,82 +1420,19 @@ workflows:
       - t_ems_solcjs: *workflow_emscripten
       - t_ems_ext_hardhat: *workflow_emscripten
 
-      # Separate compile-only runs of those external tests where a full run takes much longer.
-      - t_ems_ext:
-          <<: *workflow_emscripten
-          name: t_ems_compile_ext_colony
-          project: colony
-          binary_type: solcjs
-          compile_only: 1
-          nodejs_version: '14'
-      - t_ems_ext:
-          <<: *workflow_ubuntu2004_static
-          name: t_native_compile_ext_gnosis
-          project: gnosis
-          binary_type: native
-          compile_only: 1
-          nodejs_version: '14'
+      - t_ems_ext: *job_ems_compile_ext_colony
+      - t_ems_ext: *job_native_compile_ext_gnosis
 
       # FIXME: Gnosis tests are pretty flaky right now. They often fail on CircleCI due to random ProviderError
       # and there are also other less frequent problems. See https://github.com/gnosis/safe-contracts/issues/216.
-      #- t_ems_ext:
-      #    <<: *workflow_emscripten
-      #    name: t_native_test_ext_gnosis
-      #    project: gnosis
-      #    binary_type: native
-      #    # NOTE: Tests do not start on node.js 14 ("ganache-cli exited early with code 1").
-      #    nodejs_version: '12'
-      - t_ems_ext:
-          <<: *workflow_ubuntu2004_static
-          name: t_native_test_ext_gnosis_v2
-          project: gnosis-v2
-          binary_type: native
-          # NOTE: Tests do not start on node.js 14 ("ganache-cli exited early with code 1").
-          nodejs_version: '12'
-      - t_ems_ext:
-          <<: *workflow_ubuntu2004_static
-          name: t_native_test_ext_zeppelin
-          project: zeppelin
-          binary_type: native
-          # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
-          nodejs_version: '16'
-          resource_class: large
-      - t_ems_ext:
-          <<: *workflow_ubuntu2004_static
-          name: t_native_test_ext_ens
-          project: ens
-          binary_type: native
-          # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
-          nodejs_version: '16'
-      - t_ems_ext:
-          <<: *workflow_ubuntu2004_static
-          name: t_native_test_ext_trident
-          project: trident
-          binary_type: native
-          # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
-          nodejs_version: '16'
-      - t_ems_ext:
-          <<: *workflow_ubuntu2004_static
-          name: t_native_test_ext_euler
-          project: euler
-          binary_type: native
-          # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
-          nodejs_version: '16'
-      - t_ems_ext:
-          <<: *workflow_ubuntu2004_static
-          name: t_native_test_ext_yield_liquidator
-          project: yield-liquidator
-          binary_type: native
-          # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
-          nodejs_version: '16'
-      - t_ems_ext:
-          <<: *workflow_ubuntu2004_static
-          name: t_native_test_ext_bleeps
-          project: bleeps
-          binary_type: native
-          # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
-          nodejs_version: '16'
-          resource_class: medium
+      #-t_ems_ext: *job_native_test_ext_gnosis
+      - t_ems_ext: *job_native_test_ext_gnosis_v2
+      - t_ems_ext: *job_native_test_ext_zeppelin
+      - t_ems_ext: *job_native_test_ext_ens
+      - t_ems_ext: *job_native_test_ext_trident
+      - t_ems_ext: *job_native_test_ext_euler
+      - t_ems_ext: *job_native_test_ext_yield_liquidator
+      - t_ems_ext: *job_native_test_ext_bleeps
 
       # Windows build and tests
       - b_win: *workflow_trigger_on_tags
@@ -1471,10 +1493,4 @@ workflows:
 
       # Emscripten build and tests that take more than 15 minutes to execute
       - b_ems: *workflow_trigger_on_tags
-      - t_ems_ext:
-          <<: *workflow_emscripten
-          name: t_ems_test_ext_colony
-          project: colony
-          binary_type: solcjs
-          nodejs_version: '14'
-          resource_class: medium
+      - t_ems_ext: *job_ems_test_ext_colony

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1442,18 +1442,23 @@ workflows:
 
       # Bytecode comparison:
       - b_bytecode_ubu:
+          <<: *workflow_trigger_on_tags
           requires:
             - b_ubu
       - b_bytecode_win:
+          <<: *workflow_trigger_on_tags
           requires:
             - b_win
       - b_bytecode_osx:
+          <<: *workflow_trigger_on_tags
           requires:
             - b_osx
       - b_bytecode_ems:
+          <<: *workflow_trigger_on_tags
           requires:
             - b_ems
       - t_bytecode_compare:
+          <<: *workflow_trigger_on_tags
           requires:
             - b_bytecode_ubu
             - b_bytecode_win


### PR DESCRIPTION
The lists of parameters for external test jobs are getting increasingly verbose. I'm planning to have some of them both in `main` and in `nightly` (#12522), which will cause lots of duplication. This PR solves this by refactoring them into templates. This also makes the list of jobs more concise.