### PR TITLE
Split content-holding from file reader.

### DIFF
--- a/libsolidity/lsp/FileRepository.h
+++ b/libsolidity/lsp/FileRepository.h
@@ -47,7 +47,7 @@ public:
 
 private:
 	std::map<std::string, std::string> m_sourceUnitNamesToClientPaths;
-	frontend::FileReader m_fileReader;
+	frontend::FileReaderWithRepository m_fileReader;
 };
 
 }

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -925,7 +925,7 @@ void CommandLineInterface::link()
 		librariesReplacements[replacement] = library.second;
 	}
 
-	FileReader::StringMap sourceCodes = m_fileReader.sourceUnits();
+	FileReaderWithRepository::StringMap sourceCodes = m_fileReader.sourceUnits();
 	for (auto& src: sourceCodes)
 	{
 		auto end = src.second.end();

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -75,7 +75,7 @@ public:
 	void processInput();
 
 	CommandLineOptions const& options() const { return m_options; }
-	FileReader const& fileReader() const { return m_fileReader; }
+	FileReaderWithRepository const& fileReader() const { return m_fileReader; }
 	std::optional<std::string> const& standardJsonInput() const { return m_standardJsonInput; }
 
 private:
@@ -137,7 +137,7 @@ private:
 	std::ostream& m_sout;
 	std::ostream& m_serr;
 	bool m_hasOutput = false;
-	FileReader m_fileReader;
+	FileReaderWithRepository m_fileReader;
 	std::optional<std::string> m_standardJsonInput;
 	std::unique_ptr<frontend::CompilerStack> m_compiler;
 	CommandLineOptions m_options;

--- a/test/solc/Common.h
+++ b/test/solc/Common.h
@@ -36,7 +36,7 @@ struct OptionsReaderAndMessages
 {
 	bool success;
 	CommandLineOptions options;
-	FileReader reader;
+	FileReaderWithRepository reader;
 	std::optional<std::string> standardJsonInput;
 	std::string stdoutContent;
 	std::string stderrContent;


### PR DESCRIPTION
This is a refactoring towards allowing custom file read callbacks for the LSP which is needed by solc-js.

I'm not yet sure if this actually goes in the right direction.