### PR TITLE
[docs] fix issue with delegating votes to wallets who cannot vote.

### DIFF
--- a/docs/examples/voting.rst
+++ b/docs/examples/voting.rst
@@ -133,7 +133,7 @@ of votes.
             Voter storage delegate_ = voters[to];
 
             // Voters cannot delegate to wallets that cannot vote.
-            require(delegate_.weight >= 1)
+            require(delegate_.weight >= 1);
             sender.voted = true;
             sender.delegate = to;
             if (delegate_.voted) {

--- a/docs/examples/voting.rst
+++ b/docs/examples/voting.rst
@@ -130,9 +130,12 @@ of votes.
 
             // Since `sender` is a reference, this
             // modifies `voters[msg.sender].voted`
+            Voter storage delegate_ = voters[to];
+
+            // Voters cannot delegate to wallets that cannot vote.
+            require(delegate_.weight >= 1)
             sender.voted = true;
             sender.delegate = to;
-            Voter storage delegate_ = voters[to];
             if (delegate_.voted) {
                 // If the delegate already voted,
                 // directly add to the number of votes


### PR DESCRIPTION
The voting example on the docs allows addresses who cannot vote yet to be delegated to. This makes it so that they lose out on their own vote. This change makes sure only people who can vote are delegated to, which fixes the problem

(due credits where credits are due: https://github.com/miaortizma pointed out that someone could delegate to addresses who couldn't vote)