### PR TITLE
[DOCS] update contributing section meeting link

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -33,7 +33,7 @@ the team and contributors are working on, you can join our public team calls:
 - Mondays at 3pm CET/CEST.
 - Wednesdays at 2pm CET/CEST.
 
-Both calls take place on `Jitsi <https://meet.komputing.org/solidity>`_.
+Both calls take place on `Jitsi <https://meet.ethereum.org/solidity>`_.
 
 How to Report Issues
 ====================


### PR DESCRIPTION
switching meeting link from komputing to meet.ethereum.org :)