### PR TITLE
Improved code generation for modifiers.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 ### 0.8.12 (unreleased)
 
 Compiler Features:
-
+ * Modifiers: Use internal function calls and thus prevent code duplication for modifiers that have a single `_;` at the end.
 
 
 Bugfixes:

--- a/libsolidity/analysis/SyntaxChecker.h
+++ b/libsolidity/analysis/SyntaxChecker.h
@@ -77,6 +77,7 @@ private:
 
 	bool visit(Continue const& _continueStatement) override;
 	bool visit(Break const& _breakStatement) override;
+	bool visit(Return const& _returnStatement) override;
 
 	bool visit(Throw const& _throwStatement) override;
 
@@ -100,6 +101,9 @@ private:
 
 	/// Flag that indicates whether a function modifier actually contains '_'.
 	bool m_placeholderFound = false;
+	/// Indicates that the current modifier is "simple" which means it does not contain
+	/// a "return" statement and the only placeholder is the last statement.
+	bool m_modifierIsSimple = false;
 
 	/// Flag that indicates whether some version pragma was present.
 	bool m_versionPragmaFound = false;

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -192,6 +192,9 @@ struct ErrorDefinitionAnnotation: CallableDeclarationAnnotation, StructurallyDoc
 
 struct ModifierDefinitionAnnotation: CallableDeclarationAnnotation, StructurallyDocumentedAnnotation
 {
+	/// If true, indicates that the modifier does not contain a "return" statement and only
+	/// a single `_` (placeholder) as the last statament. This means it can be called as a function.
+	bool simpleModifier = false;
 };
 
 struct VariableDeclarationAnnotation: DeclarationAnnotation, StructurallyDocumentedAnnotation

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -601,6 +601,12 @@ evmasm::AssemblyItem CompilerContext::FunctionCompilationQueue::entryLabel(
 			params = CompilerUtils::sizeOnStack(functionType.parameterTypes());
 			returns = CompilerUtils::sizeOnStack(functionType.returnParameterTypes());
 		}
+		else if (auto const* modifier = dynamic_cast<ModifierDefinition const*>(&_declaration))
+		{
+			solAssert(modifier->annotation().simpleModifier, "Can only call simple modifiers as functions.");
+			params = CompilerUtils::sizeOnStack(modifier->parameters());
+		}
+		/// TODO What else can be there apart from function and modifiers?
 
 		// some name that cannot clash with yul function names.
 		string labelName = "@" + _declaration.name() + "_" + to_string(_declaration.id());

--- a/libsolidity/codegen/ContractCompiler.h
+++ b/libsolidity/codegen/ContractCompiler.h
@@ -105,6 +105,7 @@ private:
 
 	bool visit(VariableDeclaration const& _variableDeclaration) override;
 	bool visit(FunctionDefinition const& _function) override;
+	bool visit(ModifierDefinition const& _modifier) override;
 	bool visit(InlineAssembly const& _inlineAssembly) override;
 	bool visit(TryStatement const& _tryStatement) override;
 	void handleCatch(std::vector<ASTPointer<TryCatchClause>> const& _catchClauses);
@@ -155,6 +156,8 @@ private:
 	/// Tag to jump to for a "return" statement and the stack height after freeing the local function or modifier variables.
 	/// Needs to be stacked because of modifiers.
 	std::vector<std::pair<evmasm::AssemblyItem, unsigned>> m_returnTags;
+	/// Number of placeholder statements that were ignored since we generated code for a simple modifier.
+	size_t m_ignoredPlaceholders = 0;
 	unsigned m_modifierDepth = 0;
 	FunctionDefinition const* m_currentFunction = nullptr;
 

--- a/test/libsolidity/semanticTests/modifiers/many_simple.sol
+++ b/test/libsolidity/semanticTests/modifiers/many_simple.sol
@@ -1,0 +1,24 @@
+contract C {
+    uint256 public x;
+    modifier m() {
+        x ++;
+        _;
+    }
+
+    modifier mdouble() {
+        _;
+        _;
+    }
+
+    function f() public m m m m m m m m m m mdouble m m m m m m m m m m m m m m m m returns (uint) {
+        return x;
+    }
+}
+
+// ====
+// compileToEwasm: also
+// compileViaYul: also
+// ----
+// x() -> 0
+// f() -> 0x2a
+// x() -> 0x2a

--- a/test/libsolidity/semanticTests/modifiers/simple_and_nonsimple_modifier.sol
+++ b/test/libsolidity/semanticTests/modifiers/simple_and_nonsimple_modifier.sol
@@ -1,0 +1,26 @@
+contract C {
+    uint256 public x;
+    modifier m1() {
+        x = 1;
+        _;
+    }
+
+    modifier m2(bool abort) {
+        if (abort) return;
+        _;
+    }
+
+    function f(bool abort) public m1 m2(abort) {
+        x += 2;
+    }
+}
+
+// ====
+// compileToEwasm: also
+// compileViaYul: also
+// ----
+// x() -> 0
+// f(bool): false ->
+// x() -> 3
+// f(bool): true ->
+// x() -> 1


### PR DESCRIPTION
fixes https://github.com/ethereum/solidity/issues/6584

This changes modifier invocations to use function calls to the modifier with a dynamic return jump, but only if the modifier only has a single `_;`, that is the last statement and it does not have a `return` statement.

TODO:
- [ ] some more tests (open for suggestions)
- [ ] codegen for yul