### PR TITLE
Always allow full filesystem access to LSP.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1280,6 +1280,12 @@ jobs:
       - run:
           name: "Run soltest"
           command: .circleci/soltest.ps1
+      - run:
+          name: Install LSP test dependencies
+          command: python -m pip install --user deepdiff colorama
+      - run:
+          name: Executing solc LSP test suite
+          command: python ./test/lsp.py .\build\solc\Release\solc.exe
       - store_test_results: *store_test_results
       - store_artifacts: *artifacts_test_results
       - gitter_notify_failure_unless_pr

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1284,6 +1284,9 @@ jobs:
           name: Install LSP test dependencies
           command: python -m pip install --user deepdiff colorama
       - run:
+          name: Inspect lsp.py
+          command: Get-Content ./test/lsp.py
+      - run:
           name: Executing solc LSP test suite
           command: python ./test/lsp.py .\build\solc\Release\solc.exe
       - store_test_results: *store_test_results

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Compiler Features:
  * Assembly-Json: Export: Include source list in `sourceList` field.
  * Commandline Interface: option ``--pretty-json`` works also with the following options: ``--abi``, ``--asm-json``, ``--ast-compact-json``, ``--devdoc``, ``--storage-layout``, ``--userdoc``.
  * SMTChecker: Support ``abi.encodeCall`` taking into account the called selector.
+ * Language Server: Allow full filesystem access to language server.
 
 
 Bugfixes:

--- a/libsolidity/CMakeLists.txt
+++ b/libsolidity/CMakeLists.txt
@@ -176,3 +176,4 @@ set(sources
 
 add_library(solidity ${sources})
 target_link_libraries(solidity PUBLIC yul evmasm langutil smtutil solutil Boost::boost fmt::fmt-header-only)
+

--- a/libsolidity/lsp/FileRepository.cpp
+++ b/libsolidity/lsp/FileRepository.cpp
@@ -17,48 +17,130 @@
 // SPDX-License-Identifier: GPL-3.0
 
 #include <libsolidity/lsp/FileRepository.h>
+#include <libsolidity/lsp/Utils.h>
+
+#include <libsolutil/StringUtils.h>
+#include <libsolutil/CommonIO.h>
+
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/transform.hpp>
+
+#include <regex>
 
 using namespace std;
 using namespace solidity;
 using namespace solidity::lsp;
+using namespace solidity::frontend;
 
-namespace
-{
+using solidity::util::readFileAsString;
+using solidity::util::joinHumanReadable;
 
-string stripFilePrefix(string const& _path)
+FileRepository::FileRepository(boost::filesystem::path _basePath): m_basePath(std::move(_basePath))
 {
-	if (_path.find("file://") == 0)
-		return _path.substr(7);
-	else
-		return _path;
 }
 
-}
-
-string FileRepository::sourceUnitNameToClientPath(string const& _sourceUnitName) const
+string FileRepository::sourceUnitNameToUri(string const& _sourceUnitName) const
 {
-	if (m_sourceUnitNamesToClientPaths.count(_sourceUnitName))
-		return m_sourceUnitNamesToClientPaths.at(_sourceUnitName);
+	regex const windowsDriveLetterPath("^[a-zA-Z]:/");
+
+	if (m_sourceUnitNamesToUri.count(_sourceUnitName))
+		return m_sourceUnitNamesToUri.at(_sourceUnitName);
 	else if (_sourceUnitName.find("file://") == 0)
 		return _sourceUnitName;
+	else if (regex_search(_sourceUnitName, windowsDriveLetterPath))
+		return "file:///" + _sourceUnitName;
+	else if (_sourceUnitName.find("/") == 0)
+		return "file://" + _sourceUnitName;
 	else
-		return "file://" + (m_fileReader.basePath() / _sourceUnitName).generic_string();
+		return "file://" + m_basePath.generic_string() + "/" + _sourceUnitName;
 }
 
-string FileRepository::clientPathToSourceUnitName(string const& _path) const
+string FileRepository::uriToSourceUnitName(string const& _path) const
 {
-	return m_fileReader.cliPathToSourceUnitName(stripFilePrefix(_path));
+	return stripFileUriSchemePrefix(_path);
 }
 
-map<string, string> const& FileRepository::sourceUnits() const
-{
-	return m_fileReader.sourceUnits();
-}
-
-void FileRepository::setSourceByClientPath(string const& _uri, string _text)
+void FileRepository::setSourceByUri(string const& _uri, string _source)
 {
 	// This is needed for uris outside the base path. It can lead to collisions,
 	// but we need to mostly rewrite this in a future version anyway.
-	m_sourceUnitNamesToClientPaths.emplace(clientPathToSourceUnitName(_uri), _uri);
-	m_fileReader.addOrUpdateFile(stripFilePrefix(_uri), move(_text));
+	auto sourceUnitName = uriToSourceUnitName(_uri);
+	m_sourceUnitNamesToUri.emplace(sourceUnitName, _uri);
+	m_sourceCodes[sourceUnitName] = std::move(_source);
 }
+
+frontend::ReadCallback::Result FileRepository::readFile(string const& _kind, string const& _sourceUnitName)
+{
+	solAssert(
+		_kind == ReadCallback::kindString(ReadCallback::Kind::ReadFile),
+		"ReadFile callback used as callback kind " + _kind
+	);
+
+	try
+	{
+		// File was read already. Use local store.
+		if (m_sourceCodes.count(_sourceUnitName))
+			return ReadCallback::Result{true, m_sourceCodes.at(_sourceUnitName)};
+
+		string const strippedSourceUnitName = stripFileUriSchemePrefix(_sourceUnitName);
+
+		if (
+			boost::filesystem::path(strippedSourceUnitName).has_root_path() &&
+			boost::filesystem::exists(strippedSourceUnitName)
+		)
+		{
+			auto contents = readFileAsString(strippedSourceUnitName);
+			solAssert(m_sourceCodes.count(_sourceUnitName) == 0, "");
+			m_sourceCodes[_sourceUnitName] = contents;
+			return ReadCallback::Result{true, move(contents)};
+		}
+
+		vector<boost::filesystem::path> candidates;
+		vector<reference_wrapper<boost::filesystem::path>> prefixes = {m_basePath};
+		prefixes += (m_includePaths | ranges::to<vector<reference_wrapper<boost::filesystem::path>>>);
+
+		auto const pathToQuotedString = [](boost::filesystem::path const& _path) { return "\"" + _path.string() + "\""; };
+
+		for (auto const& prefix: prefixes)
+		{
+			boost::filesystem::path canonicalPath = boost::filesystem::path(prefix) / boost::filesystem::path(strippedSourceUnitName);
+
+			if (boost::filesystem::exists(canonicalPath))
+				candidates.push_back(move(canonicalPath));
+		}
+
+		if (candidates.empty())
+			return ReadCallback::Result{
+				false,
+				"File not found. Searched the following locations: " +
+				joinHumanReadable(prefixes | ranges::views::transform(pathToQuotedString), ", ") +
+				"."
+			};
+
+		if (candidates.size() >= 2)
+			return ReadCallback::Result{
+				false,
+				"Ambiguous import. "
+				"Multiple matching files found inside base path and/or include paths: " +
+				joinHumanReadable(candidates | ranges::views::transform(pathToQuotedString), ", ") +
+				"."
+			};
+
+		if (!boost::filesystem::is_regular_file(candidates[0]))
+			return ReadCallback::Result{false, "Not a valid file."};
+
+		auto contents = readFileAsString(candidates[0]);
+		solAssert(m_sourceCodes.count(_sourceUnitName) == 0, "");
+		m_sourceCodes[_sourceUnitName] = contents;
+		return ReadCallback::Result{true, move(contents)};
+	}
+	catch (std::exception const& _exception)
+	{
+		return ReadCallback::Result{false, "Exception in read callback: " + boost::diagnostic_information(_exception)};
+	}
+	catch (...)
+	{
+		return ReadCallback::Result{false, "Unknown exception in read callback: " + boost::current_exception_diagnostic_information()};
+	}
+}
+

--- a/libsolidity/lsp/HandlerBase.cpp
+++ b/libsolidity/lsp/HandlerBase.cpp
@@ -47,7 +47,7 @@ Json::Value HandlerBase::toJson(SourceLocation const& _location) const
 {
 	solAssert(_location.sourceName);
 	Json::Value item = Json::objectValue;
-	item["uri"] = fileRepository().sourceUnitNameToClientPath(*_location.sourceName);
+	item["uri"] = fileRepository().sourceUnitNameToUri(*_location.sourceName);
 	item["range"] = toRange(_location);
 	return item;
 }
@@ -55,7 +55,7 @@ Json::Value HandlerBase::toJson(SourceLocation const& _location) const
 pair<string, LineColumn> HandlerBase::extractSourceUnitNameAndLineColumn(Json::Value const& _args) const
 {
 	string const uri = _args["textDocument"]["uri"].asString();
-	string const sourceUnitName = fileRepository().clientPathToSourceUnitName(uri);
+	string const sourceUnitName = fileRepository().uriToSourceUnitName(uri);
 	if (!fileRepository().sourceUnits().count(sourceUnitName))
 		BOOST_THROW_EXCEPTION(
 			RequestError(ErrorCode::RequestFailed) <<

--- a/libsolidity/lsp/LanguageServer.h
+++ b/libsolidity/lsp/LanguageServer.h
@@ -92,7 +92,7 @@ private:
 	Transport& m_client;
 	std::map<std::string, MessageHandler> m_handlers;
 
-	/// Set of files known to be open by the client.
+	/// Set of files (names in URI form) known to be open by the client.
 	std::set<std::string> m_openFiles;
 	/// Set of source unit names for which we sent diagnostics to the client in the last iteration.
 	std::set<std::string> m_nonemptyDiagnostics;

--- a/libsolidity/lsp/Transport.h
+++ b/libsolidity/lsp/Transport.h
@@ -91,20 +91,44 @@ class Transport
 public:
 	virtual ~Transport() = default;
 
+	std::optional<Json::Value> receive();
+	void notify(std::string _method, Json::Value _params);
+	void reply(MessageID _id, Json::Value _result);
+	void error(MessageID _id, ErrorCode _code, std::string _message);
+
 	virtual bool closed() const noexcept = 0;
-	virtual std::optional<Json::Value> receive() = 0;
-	virtual void notify(std::string _method, Json::Value _params) = 0;
-	virtual void reply(MessageID _id, Json::Value _result) = 0;
-	virtual void error(MessageID _id, ErrorCode _code, std::string _message) = 0;
 
 	void trace(std::string _message, Json::Value _extra = Json::nullValue);
 
 	TraceValue traceValue() const noexcept { return m_logTrace; }
 	void setTrace(TraceValue _value) noexcept { m_logTrace = _value; }
 
-
 private:
 	TraceValue m_logTrace = TraceValue::Off;
+
+protected:
+	/// Reads from the transport and parses the headers until the beginning
+	/// of the contents.
+	std::optional<std::map<std::string, std::string>> parseHeaders();
+
+	/// Consumes exactly @p _byteCount bytes, as needed for consuming
+	/// the message body from the transport line.
+	virtual std::string readBytes(size_t _byteCount) = 0;
+
+	// Mimmicks std::getline() on this Transport API.
+	virtual std::string getline() = 0;
+
+	/// Writes the given payload @p _data to transport.
+	/// This call may or may not buffer.
+	virtual void writeBytes(std::string_view _data) = 0;
+
+	/// Ensures transport output is flushed.
+	virtual void flushOutput() = 0;
+
+	/// Sends an arbitrary raw message to the client.
+	///
+	/// Used by the notify/reply/error function family.
+	virtual void send(Json::Value _message, MessageID _id = Json::nullValue);
 };
 
 /**
@@ -119,27 +143,34 @@ public:
 	/// @param _out for example std::cout (stdout)
 	IOStreamTransport(std::istream& _in, std::ostream& _out);
 
-	// Constructs a JSON transport using standard I/O streams.
-	IOStreamTransport();
-
 	bool closed() const noexcept override;
-	std::optional<Json::Value> receive() override;
-	void notify(std::string _method, Json::Value _params) override;
-	void reply(MessageID _id, Json::Value _result) override;
-	void error(MessageID _id, ErrorCode _code, std::string _message) override;
 
 protected:
-	/// Sends an arbitrary raw message to the client.
-	///
-	/// Used by the notify/reply/error function family.
-	virtual void send(Json::Value _message, MessageID _id = Json::nullValue);
-
-	/// Parses header section from the client including message-delimiting empty line.
-	std::optional<std::map<std::string, std::string>> parseHeaders();
+	std::string readBytes(size_t _byteCount) override;
+	std::string getline() override;
+	void writeBytes(std::string_view _data) override;
+	void flushOutput() override;
 
 private:
 	std::istream& m_input;
 	std::ostream& m_output;
+};
+
+/**
+ * Standard I/O transport Layer utilizing stdin/stdout for communication.
+ */
+class StdioTransport: public Transport
+{
+public:
+	StdioTransport();
+
+	bool closed() const noexcept override;
+
+protected:
+	std::string readBytes(size_t _byteCount) override;
+	std::string getline() override;
+	void writeBytes(std::string_view _data) override;
+	void flushOutput() override;
 };
 
 }

--- a/libsolidity/lsp/Utils.cpp
+++ b/libsolidity/lsp/Utils.cpp
@@ -22,7 +22,7 @@
 #include <libsolidity/lsp/FileRepository.h>
 #include <libsolidity/lsp/Utils.h>
 
-#include <fmt/format.h>
+#include <regex>
 #include <fstream>
 
 namespace solidity::lsp
@@ -113,6 +113,17 @@ optional<SourceLocation> parseRange(FileRepository const& _fileRepository, strin
 	solAssert(*start->sourceName == *end->sourceName);
 	start->end = end->end;
 	return start;
+}
+
+string stripFileUriSchemePrefix(string const& _path)
+{
+	regex const windowsDriveLetterPath("^file:///[a-zA-Z]:/");
+	if (regex_search(_path, windowsDriveLetterPath))
+		return _path.substr(8);
+	if (_path.find("file://") == 0)
+		return _path.substr(7);
+	else
+		return _path;
 }
 
 }

--- a/libsolidity/lsp/Utils.h
+++ b/libsolidity/lsp/Utils.h
@@ -64,6 +64,13 @@ std::optional<langutil::SourceLocation> parseRange(
 	Json::Value const& _range
 );
 
+/// Strips the file:// URI prefix off the given path, if present,
+/// also taking special care of Windows-drive-letter paths.
+///
+/// So file:///path/to/some/file.txt returns /path/to/some/file.txt, as well as,
+/// file:///C:/file.txt will return C:/file.txt (forward-slash is okay on Windows).
+std::string stripFileUriSchemePrefix(std::string const& _path);
+
 /// Extracts the resolved declaration of the given expression AST node.
 ///
 /// This may for example be the type declaration of an identifier,

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -912,7 +912,7 @@ void CommandLineInterface::handleAst()
 
 void CommandLineInterface::serveLSP()
 {
-	lsp::IOStreamTransport transport;
+	lsp::StdioTransport transport;
 	if (!lsp::LanguageServer{transport}.run())
 		solThrow(CommandLineExecutionError, "LSP terminated abnormally.");
 }

--- a/test/lsp.py
+++ b/test/lsp.py
@@ -1,25 +1,56 @@
 #!/usr/bin/env python3
 # pragma pylint: disable=too-many-lines
+# test line 1
 import argparse
 import fnmatch
+import functools
 import json
 import os
+import re
 import subprocess
 import sys
 import traceback
-import re
-import tty
-import functools
 from collections import namedtuple
 from copy import deepcopy
+from enum import Enum, auto
+from itertools import islice
 from pathlib import PurePath
 from typing import Any, List, Optional, Tuple, Union
-from itertools import islice
 
-from enum import Enum, auto
-
-import colorama # Enables the use of SGR & CUP terminal VT sequences on Windows.
+import colorama  # Enables the use of SGR & CUP terminal VT sequences on Windows.
 from deepdiff import DeepDiff
+
+if os.name == 'nt':
+    # pragma pylint: disable=import-error
+    import msvcrt
+else:
+    import tty
+    # Turn off user input buffering so we get the input immediately,
+    # not only after a line break
+    tty.setcbreak(sys.stdin.fileno())
+
+
+def escape_string(text: str) -> str:
+    """
+    Trivially escapes given input string's \r \n and \\.
+    """
+    return text.translate(str.maketrans({
+        "\r": r"\r",
+        "\n": r"\n",
+        "\\": r"\\"
+    }))
+
+
+def getCharFromStdin():
+    """
+    Gets a single character from stdin without line-buffering.
+    """
+    if os.name == 'nt':
+        # pragma pylint: disable=import-error
+        return msvcrt.getch().decode("utf-8")
+    else:
+        return sys.stdin.buffer.read(1)
+
 
 """
 Named tuple that holds various regexes used to parse the test specification.
@@ -101,7 +132,6 @@ class BadHeader(Exception):
     def __init__(self, msg: str):
         super().__init__("Bad header: " + msg)
 
-
 class JsonRpcProcess:
     exe_path: str
     exe_args: List[str]
@@ -144,10 +174,12 @@ class JsonRpcProcess:
                 # server quit
                 return None
             line = line.decode("utf-8")
+            if self.trace_io:
+                print(f"Received header-line: {escape_string(line)}")
             if not line.endswith("\r\n"):
                 raise BadHeader("missing newline")
-            # remove the "\r\n"
-            line = line[:-2]
+            # Safely remove the "\r\n".
+            line = line.rstrip("\r\n")
             if line == '':
                 break # done with the headers
             if line.startswith(CONTENT_LENGTH_HEADER):
@@ -589,7 +621,7 @@ class FileTestRunner:
 
         while True:
             print("(u)pdate/(r)etry/(i)gnore?")
-            user_response = sys.stdin.read(1)
+            user_response = getCharFromStdin()
             if user_response == "i":
                 return self.TestResult.SuccessOrIgnored
 
@@ -787,7 +819,7 @@ class SolidityLSPTestSuite: # {{{
         in the test path (test/libsolidity/lsp).
         """
         with open(self.get_test_file_path(test_case_name), mode="r", encoding="utf-8", newline='') as f:
-            return f.read()
+            return f.read().replace("\r\n", "\n")
 
     def require_params_for_method(self, method_name: str, message: dict) -> Any:
         """
@@ -1059,7 +1091,7 @@ class SolidityLSPTestSuite: # {{{
         """
         while True:
             print("(u)pdate/(r)etry/(s)kip file?")
-            user_response = sys.stdin.read(1)
+            user_response = getCharFromStdin()
             if user_response == "u":
                 while True:
                     try:
@@ -1068,8 +1100,8 @@ class SolidityLSPTestSuite: # {{{
                     # pragma pylint: disable=broad-except
                     except Exception as e:
                         print(e)
-                        if ret := self.user_interaction_failed_autoupdate(test):
-                            return ret
+                        if self.user_interaction_failed_autoupdate(test):
+                            return True
             elif user_response == 's':
                 return True
             elif user_response == 'r':
@@ -1077,7 +1109,7 @@ class SolidityLSPTestSuite: # {{{
 
     def user_interaction_failed_autoupdate(self, test):
         print("(e)dit/(r)etry/(s)kip file?")
-        user_response = sys.stdin.read(1)
+        user_response = getCharFromStdin()
         if user_response == "r":
             print("retrying...")
             # pragma pylint: disable=no-member
@@ -1142,7 +1174,7 @@ class SolidityLSPTestSuite: # {{{
         marker = self.get_file_tags("lib")["@diagnostics"]
         self.expect_diagnostic(report['diagnostics'][0], code=2072, marker=marker)
 
-    @functools.lru_cache # pragma pylint: disable=lru-cache-decorating-method
+    @functools.lru_cache() # pragma pylint: disable=lru-cache-decorating-method
     def get_file_tags(self, test_name: str, verbose=False):
         """
         Finds all tags (e.g. @tagname) in the given test and returns them as a
@@ -1653,10 +1685,8 @@ class SolidityLSPTestSuite: # {{{
     # }}}
     # }}}
 
+
 if __name__ == "__main__":
-    # Turn off user input buffering so we get the input immediately,
-    # not only after a line break
-    tty.setcbreak(sys.stdin.fileno())
     suite = SolidityLSPTestSuite()
     exit_code = suite.main()
     sys.exit(exit_code)

--- a/test/lsp.py
+++ b/test/lsp.py
@@ -12,6 +12,7 @@ import tty
 import functools
 from collections import namedtuple
 from copy import deepcopy
+from pathlib import PurePath
 from typing import Any, List, Optional, Tuple, Union
 from itertools import islice
 
@@ -694,7 +695,7 @@ class SolidityLSPTestSuite: # {{{
         args = create_cli_parser().parse_args()
         self.solc_path = args.solc_path
         self.project_root_dir = os.path.realpath(args.project_root_dir) + "/test/libsolidity/lsp"
-        self.project_root_uri = "file://" + self.project_root_dir
+        self.project_root_uri = PurePath(self.project_root_dir).as_uri()
         self.print_assertions = args.print_assertions
         self.trace_io = args.trace_io
         self.test_pattern = args.test_pattern
@@ -777,7 +778,7 @@ class SolidityLSPTestSuite: # {{{
         return f"{self.project_root_dir}/{test_case_name}.sol"
 
     def get_test_file_uri(self, test_case_name):
-        return "file://" + self.get_test_file_path(test_case_name)
+        return PurePath(self.get_test_file_path(test_case_name)).as_uri()
 
     def get_test_file_contents(self, test_case_name):
         """
@@ -1438,7 +1439,7 @@ class SolidityLSPTestSuite: # {{{
         """
 
         self.setup_lsp(solc)
-        FILE_A_URI = f'file://{self.project_root_dir}/a.sol'
+        FILE_A_URI = f'{self.project_root_uri}/a.sol'
         solc.send_message('textDocument/didOpen', {
             'textDocument': {
                 'uri': FILE_A_URI,
@@ -1466,7 +1467,7 @@ class SolidityLSPTestSuite: # {{{
         )
         reports = self.wait_for_diagnostics(solc)
         self.expect_equal(len(reports), 1, '')
-        self.expect_equal(reports[0]['uri'], f'file://{self.project_root_dir}/lib.sol', "")
+        self.expect_equal(reports[0]['uri'], f'{self.project_root_uri}/lib.sol', "")
         self.expect_equal(len(reports[0]['diagnostics']), 0, "should not contain diagnostics")
 
     def test_textDocument_didChange_at_eol(self, solc: JsonRpcProcess) -> None:


### PR DESCRIPTION
Maybe we need a different solution for Windows? Something like a flag to just disable the check inside the file reader?