### PR TITLE
Properly generated control flows for inherited modifiers

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * Control Flow Graph: Perform proper virtual lookup for modifiers for uninitialized variable and unreachable code analysis.
 
 
 Solc-Js:

--- a/libsolidity/analysis/ControlFlowBuilder.h
+++ b/libsolidity/analysis/ControlFlowBuilder.h
@@ -37,13 +37,15 @@ class ControlFlowBuilder: private ASTConstVisitor, private yul::ASTWalker
 public:
 	static std::unique_ptr<FunctionFlow> createFunctionFlow(
 		CFG::NodeContainer& _nodeContainer,
-		FunctionDefinition const& _function
+		FunctionDefinition const& _function,
+		ContractDefinition const* _contract = nullptr
 	);
 
 private:
 	explicit ControlFlowBuilder(
 		CFG::NodeContainer& _nodeContainer,
-		FunctionFlow const& _functionFlow
+		FunctionFlow const& _functionFlow,
+		ContractDefinition const* _contract = nullptr
 	);
 
 	// Visits for constructing the control flow.
@@ -157,6 +159,8 @@ private:
 	CFGNode* m_returnNode = nullptr;
 	CFGNode* m_revertNode = nullptr;
 	CFGNode* m_transactionReturnNode = nullptr;
+
+	ContractDefinition const* m_contract = nullptr;
 
 	/// The current jump destination of break Statements.
 	CFGNode* m_breakJump = nullptr;

--- a/libsolidity/analysis/ControlFlowGraph.cpp
+++ b/libsolidity/analysis/ControlFlowGraph.cpp
@@ -44,7 +44,7 @@ bool CFG::visit(ContractDefinition const& _contract)
 		for (FunctionDefinition const* function: contract->definedFunctions())
 			if (function->isImplemented())
 				m_functionControlFlow[{&_contract, function}] =
-					ControlFlowBuilder::createFunctionFlow(m_nodeContainer, *function);
+					ControlFlowBuilder::createFunctionFlow(m_nodeContainer, *function, &_contract);
 
 	return true;
 }

--- a/libsolidity/analysis/ControlFlowGraph.h
+++ b/libsolidity/analysis/ControlFlowGraph.h
@@ -98,8 +98,8 @@ struct CFGNode
 	std::vector<CFGNode*> entries;
 	/// Exit nodes. All CFG nodes to which control flow may continue after this node.
 	std::vector<CFGNode*> exits;
-	/// Function calls done by this node
-	std::vector<FunctionCall const*> functionCalls;
+	/// Function call done by this node
+	FunctionCall const* functionCall = nullptr;
 
 	/// Variable occurrences in the node.
 	std::vector<VariableOccurrence> variableOccurrences;

--- a/test/libsolidity/syntaxTests/controlFlow/localStorageVariables/modifier_declaration_fine.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/localStorageVariables/modifier_declaration_fine.sol
@@ -1,5 +1,5 @@
 contract C {
-    modifier revertIfNoReturn() {
+    modifier alwaysRevert() {
         _;
         revert();
     }
@@ -9,10 +9,10 @@ contract C {
     }
     struct S { uint a; }
     S s;
-    function f(bool flag) revertIfNoReturn() internal view {
+    function f(bool flag) alwaysRevert() internal view {
         if (flag) s;
     }
-    function g(bool flag) revertIfNoReturn() ifFlag(flag) internal view {
+    function g(bool flag) alwaysRevert() ifFlag(flag) internal view {
         s;
     }
 

--- a/test/libsolidity/syntaxTests/controlFlow/modifiers/modifier_different_functions.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/modifiers/modifier_different_functions.sol
@@ -1,0 +1,12 @@
+contract A {
+	function f() mod internal returns (uint[] storage) {
+		revert();
+	}
+	function g() mod internal returns (uint[] storage) {
+	}
+	modifier mod() virtual {
+		_;
+	}
+}
+// ----
+// TypeError 3464: (118-132): This variable is of storage pointer type and can be returned without prior assignment, which would lead to undefined behaviour.

--- a/test/libsolidity/syntaxTests/controlFlow/modifiers/modifier_override.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/modifiers/modifier_override.sol
@@ -1,0 +1,17 @@
+contract A {
+	function f() mod internal returns (uint[] storage) {
+	}
+	modifier mod() virtual {
+		revert();
+		_;
+	}
+}
+contract B is A {
+	modifier mod() override { _; }
+	function g() public {
+		f()[0] = 42;
+	}
+}
+// ----
+// Warning 5740: (65-69): Unreachable code.
+// TypeError 3464: (49-63): This variable is of storage pointer type and can be returned without prior assignment, which would lead to undefined behaviour.

--- a/test/libsolidity/syntaxTests/controlFlow/storageReturn/modifier_err.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/storageReturn/modifier_err.sol
@@ -1,5 +1,5 @@
 contract C {
-    modifier revertIfNoReturn() {
+    modifier callAndRevert() {
         _;
         revert();
     }
@@ -13,10 +13,10 @@ contract C {
         return s;
     }
 
-    function g(bool flag) ifFlag(flag) revertIfNoReturn() internal view returns(S storage) {
+    function g(bool flag) ifFlag(flag) callAndRevert() internal view returns(S storage) {
         return s;
     }
 }
 // ----
-// TypeError 3464: (249-258): This variable is of storage pointer type and can be returned without prior assignment, which would lead to undefined behaviour.
-// TypeError 3464: (367-376): This variable is of storage pointer type and can be returned without prior assignment, which would lead to undefined behaviour.
+// TypeError 3464: (246-255): This variable is of storage pointer type and can be returned without prior assignment, which would lead to undefined behaviour.
+// TypeError 3464: (361-370): This variable is of storage pointer type and can be returned without prior assignment, which would lead to undefined behaviour.

--- a/test/libsolidity/syntaxTests/controlFlow/storageReturn/modifier_fine.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/storageReturn/modifier_fine.sol
@@ -1,5 +1,5 @@
 contract C {
-    modifier revertIfNoReturn() {
+    modifier callAndRevert() {
         _;
         revert();
     }
@@ -9,10 +9,10 @@ contract C {
     }
     struct S { uint a; }
     S s;
-    function f(bool flag) revertIfNoReturn() internal view returns(S storage) {
+    function f(bool flag) callAndRevert() internal view returns(S storage) {
         if (flag) return s;
     }
-    function g(bool flag) revertIfNoReturn() ifFlag(flag) internal view returns(S storage) {
+    function g(bool flag) callAndRevert() ifFlag(flag) internal view returns(S storage) {
         return s;
     }
 


### PR DESCRIPTION
fixes #11483

What is done:
* Controlflows are built for modifiers
* They are properly analyzed for pruning
* lots of small changes all over
* functionflows are no longer a vector -> simpler code and unnecessary
* Prune modifiers
* Analyze modifiers in the later step
* Only build flows for modifiers that are actually used