### PR TITLE
Fix typo in control-structures.rst

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -699,7 +699,7 @@ safest action is to revert all changes and make the whole transaction
 (or at least call) without effect.
 
 In both cases, the caller can react on such failures using ``try``/``catch``, but
-the changes in the caller will always be reverted.
+the changes in the callee will always be reverted.
 
 .. note::
 


### PR DESCRIPTION
I'm learning Solidity by reading these docs and found this statement confusing. I'm fairly certain that the correct description here is that the *callee* changes get reverted, but the caller is able to react to the failures.

I tested this with the following snippet in Remix, which resulted in a successful transaction when deployed:

```
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.7;

contract A {
    uint public value;

    function a(uint newValue, bool shouldRevert) external {
        value = newValue;
        if (shouldRevert) {
            revert();
        }
    }
}

contract B {
    function b() external {
        A a = new A();
        try a.a(50, false) {
            assert(a.value() == 50);
        } catch {
            assert(false);
        }
        a = new A();
        try a.a(50, true) {
            assert(false);
        } catch {
            assert(a.value() == 0);
        }
    }
}
```