### PR TITLE
Update control-structures.rst

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -895,6 +895,6 @@ in scope in the block that follows.
     The error might have happened deeper down in the call chain and the
     called contract just forwarded it. Also, it could be due to an
     out-of-gas situation and not a deliberate error condition:
-    The caller always retains 63/64th of the gas in a call and thus
+    The caller always retains at least 1/64th of the gas in a call and thus
     even if the called contract goes out of gas, the caller still
     has some gas left.


### PR DESCRIPTION
According to https://docs.soliditylang.org/en/v0.8.11/introduction-to-smart-contracts.html?highlight=63%2F64#message-calls, the caller forwards 63/64th of its gas, but here we seem to contradict that by saying the caller retains 63/64th of its gas.