### PR TITLE
Adds missing accepts to ImportDirective's SymbolAlias::symbol.

### DIFF
--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -571,7 +571,8 @@ bool DeclarationRegistrationHelper::visit(ImportDirective& _import)
 	if (!m_scopes[importee])
 		m_scopes[importee] = make_shared<DeclarationContainer>(nullptr, m_scopes[nullptr].get());
 	m_scopes[&_import] = m_scopes[importee];
-	return ASTVisitor::visit(_import);
+	ASTVisitor::visit(_import);
+	return false; // Do not recurse into child nodes (Identifier for symbolAliases)
 }
 
 bool DeclarationRegistrationHelper::visit(ContractDefinition& _contract)

--- a/libsolidity/ast/AST_accept.h
+++ b/libsolidity/ast/AST_accept.h
@@ -58,13 +58,19 @@ void PragmaDirective::accept(ASTConstVisitor& _visitor) const
 
 void ImportDirective::accept(ASTVisitor& _visitor)
 {
-	_visitor.visit(*this);
+	if (_visitor.visit(*this))
+		for (SymbolAlias const& symbolAlias: symbolAliases())
+			if (symbolAlias.symbol)
+				symbolAlias.symbol->accept(_visitor);
 	_visitor.endVisit(*this);
 }
 
 void ImportDirective::accept(ASTConstVisitor& _visitor) const
 {
-	_visitor.visit(*this);
+	if (_visitor.visit(*this))
+		for (SymbolAlias const& symbolAlias: symbolAliases())
+			if (symbolAlias.symbol)
+				symbolAlias.symbol->accept(_visitor);
 	_visitor.endVisit(*this);
 }
 


### PR DESCRIPTION
Found out by accident while working on goto-definition and wondering why I could not catch that AST node's `Identifier` via AST Visitor API.

Required by #12430

### ASTConstVisitor

- [x] ConstantEvaluator: looks at Identifier, but doesn't look like it's having a negative impact
- [x] ControlFlowBuilder: only looks at Variable identifiers and adds them to the current node's variable occurrences
- [x] DeclarationTypeChecker: n/a
- [x] DocStringAnalyzer: n/a
- [x] DocStringTagParser: n/a
- [x] FuncionCallGraph: performs additional checks on VarDecl's and CallableDecl's
- [x] ImmutableValidator: performs additional checks on VarDecl and CallableDecl
- [x] PostTypeChecker: cannot enter its if-condition when traversing into ImportDirective
- [x] Scoper: n/a
- [x] StaticAnalyzer: cannot enter its if-condition as it's not inside function
- [x] SyntaxChecker: n/a
- [x] ASTJsonConverter: should now contain **more** information in the exported JSON (should have a changelog entry then?)
- [x] ContractCompiler: n/a
- [x] ExpressionCompiler: does work with Identifer but is only invoked on `Expression`'s
- [x] IRGeneratorForStatements: same, but is not invoked on `ImportStatement` AST nodes
- [x] formal/Predicate: n/a
- [x] formal/VariableUsage: performs additional checks iff it's a variable that is written to (cannot happen?)

### ASTConstVisitor: unclear uses

- [x] ReferenceResolver: finds decl(s) for the identifier. It does seem to work okay.
- [x] TypeChecker: seems to work. another eye would be helpful here as it's a big handler :-)
- [x] ViewPureChecker: ?
- [x] formal/SMTEncoder: ?

### ASTVisitor

- [x] DeclarationRegistrationHelper: n/a
- [x] test/FirstExpressionExtractor: only checks expressions