### PR TITLE
Add FunctionHoister as a pre-requisite for equal store eliminator.

### DIFF
--- a/test/libyul/YulOptimizerTestCommon.cpp
+++ b/test/libyul/YulOptimizerTestCommon.cpp
@@ -239,6 +239,7 @@ YulOptimizerTestCommon::YulOptimizerTestCommon(
 		}},
 		{"equalStoreEliminator", [&]() {
 			disambiguate();
+			FunctionHoister::run(*m_context, *m_ast);
 			ForLoopInitRewriter::run(*m_context, *m_ast);
 			EqualStoreEliminator::run(*m_context, *m_ast);
 		}},


### PR DESCRIPTION
Otherwise, the following assertion inside NameCollector fails

https://github.com/ethereum/solidity/blob/63b6bbe15cbb478f381acad0d74ff792ab87cf39/libyul/optimiser/NameCollector.cpp#L103

Edit:

Example on which the assertion fails when only EqualStoreEliminator is run

```
{
  for { let i_0 := 0 } lt(i_0, 0x60) { i_0 := add(i_0, 0x20) } {
    function foo_n_0() {}
  }
}
```