### PR TITLE
Explaining payable(msg.sender)

### DIFF
--- a/docs/examples/blind-auction.rst
+++ b/docs/examples/blind-auction.rst
@@ -121,6 +121,9 @@ to receive their money - contracts cannot activate themselves.
                 // before `send` returns.
                 pendingReturns[msg.sender] = 0;
 
+                // msg.sender is not of type `address payable` and must be
+                // explicitly converted using `payable(msg.sender)` in order
+                // use the member function `send()`.
                 if (!payable(msg.sender).send(amount)) {
                     // No need to call throw here, just reset the amount owing
                     pendingReturns[msg.sender] = amount;


### PR DESCRIPTION
At this point of the documentation a new Solidity learner will not understand this line without further explanation:
if (!payable(msg.sender).send(amount)) {
It should explain how msg.sender is of type "address" and not "address payable" so it cannot send or receive Ether. Therefore it must be explicitly converted to payable.