### PR TITLE
Pin Trident external test to a specific commit to work around failing tests on master

### DIFF
--- a/test/externalTests/colony.sh
+++ b/test/externalTests/colony.sh
@@ -34,7 +34,8 @@ function test_fn { yarn run test:contracts; }
 function colony_test
 {
     local repo="https://github.com/solidity-external-tests/colonyNetwork.git"
-    local branch=develop_080
+    local ref_type=branch
+    local ref="develop_080"
     local config_file="truffle.js"
 
     local compile_only_presets=(
@@ -54,7 +55,7 @@ function colony_test
     print_optimizer_presets_or_exit "$selected_optimizer_presets"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$branch" "$DIR"
+    download_project "$repo" "$ref_type" "$ref" "$DIR"
     [[ $BINARY_TYPE == native ]] && replace_global_solc "$BINARY_PATH"
 
     neutralize_package_json_hooks

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -77,12 +77,24 @@ function setup_solc
 function download_project
 {
     local repo="$1"
-    local solcjs_branch="$2"
-    local test_dir="$3"
+    local ref_type="$2"
+    local solcjs_ref="$3"
+    local test_dir="$4"
 
-    printLog "Cloning $solcjs_branch of $repo..."
-    git clone --depth 1 "$repo" -b "$solcjs_branch" "$test_dir/ext"
-    cd ext
+    [[ $ref_type == commit || $ref_type == branch || $ref_type == tag ]] || assertFail
+
+    printLog "Cloning ${ref_type} ${solcjs_ref} of ${repo}..."
+    if [[ $ref_type == commit ]]; then
+        mkdir ext
+        cd ext
+        git init
+        git remote add origin "$repo"
+        git fetch --depth 1 origin "$solcjs_ref"
+        git reset --hard FETCH_HEAD
+    else
+        git clone --depth 1 "$repo" -b "$solcjs_ref" "$test_dir/ext"
+        cd ext
+    fi
     echo "Current commit hash: $(git rev-parse HEAD)"
 }
 

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -34,7 +34,8 @@ function test_fn { yarn test; }
 function ens_test
 {
     local repo="https://github.com/ensdomains/ens-contracts.git"
-    local branch="v0.0.8"  # The project is in flux right now and master might be too unstable for us
+    local ref_type=tag
+    local ref="v0.0.8"     # The project is in flux right now and master might be too unstable for us
     local config_file="hardhat.config.js"
 
     local compile_only_presets=(
@@ -54,7 +55,7 @@ function ens_test
     print_optimizer_presets_or_exit "$selected_optimizer_presets"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$branch" "$DIR"
+    download_project "$repo" "$ref_type" "$ref" "$DIR"
     [[ $BINARY_TYPE == native ]] && replace_global_solc "$BINARY_PATH"
 
     neutralize_package_lock

--- a/test/externalTests/gnosis-v2.sh
+++ b/test/externalTests/gnosis-v2.sh
@@ -34,7 +34,8 @@ function test_fn { npm test; }
 function gnosis_safe_test
 {
     local repo="https://github.com/solidity-external-tests/safe-contracts.git"
-    local branch=v2_080
+    local ref_type=branch
+    local ref="v2_080"
     local config_file="truffle-config.js"
 
     local compile_only_presets=(
@@ -54,7 +55,7 @@ function gnosis_safe_test
     print_optimizer_presets_or_exit "$selected_optimizer_presets"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$branch" "$DIR"
+    download_project "$repo" "$ref_type" "$ref" "$DIR"
     [[ $BINARY_TYPE == native ]] && replace_global_solc "$BINARY_PATH"
 
     sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_080|g' package.json

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -34,7 +34,8 @@ function test_fn { npm test; }
 function gnosis_safe_test
 {
     local repo="https://github.com/solidity-external-tests/safe-contracts.git"
-    local branch=development_080
+    local ref_type=branch
+    local ref="development_080"
     local config_file="truffle-config.js"
 
     local compile_only_presets=()
@@ -53,7 +54,7 @@ function gnosis_safe_test
     print_optimizer_presets_or_exit "$selected_optimizer_presets"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$branch" "$DIR"
+    download_project "$repo" "$ref_type" "$ref" "$DIR"
     [[ $BINARY_TYPE == native ]] && replace_global_solc "$BINARY_PATH"
 
     sed -i 's|github:gnosis/mock-contract#sol_0_5_0|github:solidity-external-tests/mock-contract#master_080|g' package.json

--- a/test/externalTests/trident.sh
+++ b/test/externalTests/trident.sh
@@ -42,8 +42,8 @@ function test_fn {
 function trident_test
 {
     local repo="https://github.com/sushiswap/trident"
-    local ref_type=branch
-    local ref="master"
+    local ref_type=commit
+    local ref="0cab5ae884cc9a41223d52791be775c3a053cb26" # master as of 2021-12-16
     local config_file="hardhat.config.ts"
     local config_var=config
 

--- a/test/externalTests/trident.sh
+++ b/test/externalTests/trident.sh
@@ -42,7 +42,8 @@ function test_fn {
 function trident_test
 {
     local repo="https://github.com/sushiswap/trident"
-    local branch=master
+    local ref_type=branch
+    local ref="master"
     local config_file="hardhat.config.ts"
     local config_var=config
 
@@ -62,7 +63,7 @@ function trident_test
     print_optimizer_presets_or_exit "$selected_optimizer_presets"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$branch" "$DIR"
+    download_project "$repo" "$ref_type" "$ref" "$DIR"
 
     # TODO: Currently tests work only with the exact versions from yarn.lock.
     # Re-enable this when https://github.com/sushiswap/trident/issues/284 is fixed.

--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -34,7 +34,8 @@ function test_fn { npm test; }
 function zeppelin_test
 {
     local repo="https://github.com/OpenZeppelin/openzeppelin-contracts.git"
-    local branch=master
+    local ref_type=branch
+    local ref="master"
     local config_file="hardhat.config.js"
 
     local compile_only_presets=(
@@ -54,7 +55,7 @@ function zeppelin_test
     print_optimizer_presets_or_exit "$selected_optimizer_presets"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$branch" "$DIR"
+    download_project "$repo" "$ref_type" "$ref" "$DIR"
 
     neutralize_package_json_hooks
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"


### PR DESCRIPTION
#12197 did not pass the trident test but github auto-merged it anyway because that check is not marked as required.

The failing job was [`t_native_test_ext_trident`](https://app.circleci.com/pipelines/github/ethereum/solidity/21505/workflows/b0a5e25d-5bb4-419f-b306-772c9e44ae21/jobs/942648). One of the reasons it fails is that the file I need to ignore to work around https://github.com/sushiswap/trident/issues/283 was moved. ~This PR fixes that specifically.~

I'm not sure if it's a complete fix yet because the failing job had some other failures I'm not seeing locally and they look more serious:
```
1) Constant Product Pool Old
       #mint
         Add liquidity in 16 different ways before swap fees:

      AssertionError: Expected "46000000000000000000" to be equal 0
      + expected - actual

       {
      -  "_hex": "0x00"
      +  "_hex": "0x027e60d44813f80000"
         "_isBigNumber": true
       }
```
The PR is a draft until I ensure that this one is fixed too.

**EDIT**: It's still failing. To work around this I'm switching to an earlier upstream commit that should still work. This required adding support for checking out specific commits in ext tests.

I'm also removing the change for the moved file from this PR because it has not yet been moved in this upstream revision.