### PR TITLE
Parallel run number in gitter CI notifcations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,11 @@ commands:
             workflow_info=$(curl --silent "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}") || true
             workflow_name=$(echo "$workflow_info" | grep -E '"\s*name"\s*:\s*".*"' | cut -d \" -f 4 || echo "$CIRCLE_WORKFLOW_ID")
 
-            [[ "<< parameters.event >>" == "failure" ]] && message=" ❌ [${workflow_name}] Job **${CIRCLE_JOB}** failed on **${CIRCLE_BRANCH}**. Please see [build ${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}) for details."
-            [[ "<< parameters.event >>" == "success" ]] && message=" ✅ [${workflow_name}] Job **${CIRCLE_JOB}** succeeded on **${CIRCLE_BRANCH}**. Please see [build ${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}) for details."
+            [[ $CIRCLE_NODE_TOTAL == 1 ]] && job="**${CIRCLE_JOB}**"
+            [[ $CIRCLE_NODE_TOTAL != 1 ]] && job="**${CIRCLE_JOB}** (run $((CIRCLE_NODE_INDEX + 1))/${CIRCLE_NODE_TOTAL})"
+
+            [[ "<< parameters.event >>" == "failure" ]] && message=" ❌ [${workflow_name}] Job ${job} failed on **${CIRCLE_BRANCH}**. Please see [build ${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}) for details."
+            [[ "<< parameters.event >>" == "success" ]] && message=" ✅ [${workflow_name}] Job ${job} succeeded on **${CIRCLE_BRANCH}**. Please see [build ${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}) for details."
 
             curl "https://api.gitter.im/v1/rooms/${GITTER_NOTIFY_ROOM_ID}/chatMessages" \
               --request POST \


### PR DESCRIPTION
Currently if a job has multiple parallel runs and more than one fails we get gitter notifications that look like duplicates:

> ❌ [main] Job **t_native_test_ext_trident** failed on **develop**. Please see [build 942772](https://circleci.com/gh/ethereum/solidity/942772) for details.
> ❌ [main] Job **t_native_test_ext_trident** failed on **develop**. Please see [build 942772](https://circleci.com/gh/ethereum/solidity/942772) for details.
> ❌ [main] Job **t_native_test_ext_trident** failed on **develop**. Please see [build 942772](https://circleci.com/gh/ethereum/solidity/942772) for details.

This PR adds a run number to the notification to make it clear that these are just separate runs of the same job:
> ❌ [main] Job **t_native_test_ext_trident** (run 1/3) failed on **develop**. Please see [build 942772](https://circleci.com/gh/ethereum/solidity/942772) for details.
> ❌ [main] Job **t_native_test_ext_trident** (run 2/3) failed on **develop**. Please see [build 942772](https://circleci.com/gh/ethereum/solidity/942772) for details.
> ❌ [main] Job **t_native_test_ext_trident** (run 3/3) failed on **develop**. Please see [build 942772](https://circleci.com/gh/ethereum/solidity/942772) for details.