### PR TITLE
Deterministic test order in Trident external test

### DIFF
--- a/test/externalTests/trident.sh
+++ b/test/externalTests/trident.sh
@@ -58,9 +58,8 @@ function trident_test
         legacy-optimize-evm+yul
     )
 
-    local selected_optimizer_presets
-    selected_optimizer_presets=$(circleci_select_steps_multiarg "${settings_presets[@]}")
-    print_optimizer_presets_or_exit "$selected_optimizer_presets"
+    [[ $SELECTED_PRESETS != "" ]] || SELECTED_PRESETS=$(circleci_select_steps_multiarg "${settings_presets[@]}")
+    print_presets_or_exit "$SELECTED_PRESETS"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
     download_project "$repo" "$ref_type" "$ref" "$DIR"
@@ -71,7 +70,7 @@ function trident_test
 
     neutralize_package_json_hooks
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"
-    force_hardhat_compiler_settings "$config_file" "$(first_word "$selected_optimizer_presets")" "$config_var"
+    force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")" "$config_var"
     yarn install
 
     replace_version_pragmas
@@ -89,7 +88,7 @@ function trident_test
     # version check. It's not used by tests so we can remove it.
     rm -r node_modules/@sushiswap/core/
 
-    for preset in $selected_optimizer_presets; do
+    for preset in $SELECTED_PRESETS; do
         hardhat_run_test "$config_file" "$preset" "${compile_only_presets[*]}" compile_fn test_fn "$config_var"
     done
 }

--- a/test/externalTests/trident.sh
+++ b/test/externalTests/trident.sh
@@ -43,6 +43,7 @@ function trident_test
 {
     local repo="https://github.com/sushiswap/trident"
     local ref_type=commit
+    # FIXME: Switch back to master branch when https://github.com/sushiswap/trident/issues/303 gets fixed.
     local ref="0cab5ae884cc9a41223d52791be775c3a053cb26" # master as of 2021-12-16
     local config_file="hardhat.config.ts"
     local config_var=config

--- a/test/externalTests/trident.sh
+++ b/test/externalTests/trident.sh
@@ -35,7 +35,7 @@ function test_fn {
     TS_NODE_TRANSPILE_ONLY=1 npx hardhat test --no-compile $(
         # TODO: We need to skip Migration.test.ts because it fails and makes other tests fail too.
         # Replace this with `yarn test` once https://github.com/sushiswap/trident/issues/283 is fixed.
-        find test/ -name "*.test.ts" ! -path "test/Migration.test.ts"
+        find test/ -name "*.test.ts" ! -path "test/Migration.test.ts" | LC_ALL=C sort
     )
 }
 


### PR DESCRIPTION
Follow-up to #12509. 
~Depends on #12512.~ Merged.

This PR ensures that tests run in the same order on different machines - by sorting them. This is unfortunately not a fix for https://github.com/sushiswap/trident/issues/303 by itself - the sorted order happens to be one where tests fail - but I don't want to make it more complicated by piling on more workarounds. It would be much better to get the problem fixed upstream.