### PR TITLE
feat: add sphinx-intl to facilitate internacionalization

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -297,3 +297,11 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+# -- Options for gettext builder ------------------------------------------
+
+# Set document text domain to markup/code. Recommended by sphinx-intl.
+gettext_compact = False
+
+# Generates uuid information for version tracking in message catalogs.
+gettext_uuid = True

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,5 +6,6 @@ sphinx_rtd_theme>=0.5.2
 pygments-lexer-solidity>=0.7.0
 sphinx-a4doc>=1.2.1
 
+sphinx-intl>=2.0.1
 # Sphinx 2.1.0 is the oldest version that accepts a lexer class in add_lexer()
 sphinx>=2.1.0

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -26,8 +26,16 @@
 # (c) 2016 solidity contributors.
 #------------------------------------------------------------------------------
 
+# List of supported languages
+LANGUAGES=("en_US" "es_EM")
+
 set -e
 cd docs
 pip3 install -r requirements.txt --upgrade --upgrade-strategy eager
-sphinx-build -nW -b html -d _build/doctrees . _build/html
+sphinx-build -b gettext . _build/gettext
+
+for i in "${LANGUAGES[@]}"; do
+	sphinx-intl update -p _build/gettext -l "${i}"
+	sphinx-build -nW -b html -d _build/doctrees -D language="${i}" . "_build/html/${i}"
+done
 cd ..


### PR DESCRIPTION
Hello,

this PR introduces the [sphinx-intl](https://sphinx-intl.readthedocs.io/en/master/) library and its usage in the `scripts/docs.sh` script.
The idea is to facilitate translation of the documentation from the source, the Sphinx framework.

Note, to archive the "full translation experience", end-to-end, there are more steps to be made, such as translating the generated files and committing back to a branch (not necessarily `develop`). But the library usage already can be used by RTD, just will contain the same content as the original English. 😅 

### Reference
- [Manage Translations for Sphinx projects](https://docs.readthedocs.io/en/stable/guides/manage-translations-sphinx.html)
- [Sphinx docs on Internationalization](https://www.sphinx-doc.org/en/master/usage/advanced/intl.html)