### PR TITLE
Natspec: Fix ICE when overriding a struct getter with a Natspec-documented return value and the name in the struct is different.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ Compiler Features:
 Bugfixes:
  * Control Flow Graph: Perform proper virtual lookup for modifiers for uninitialized variable and unreachable code analysis.
  * Immutables: Fix wrong error when the constructor of a base contract uses ``return`` and the parent contract contains immutable variables.
+ * Natspec: Fix ICE when overriding a struct getter with a Natspec-documented return value and the name in the struct is different.
  * TypeChecker: Fix ICE when a constant variable declaration forward references a struct.
 
 

--- a/libsolidity/analysis/DocStringAnalyser.h
+++ b/libsolidity/analysis/DocStringAnalyser.h
@@ -54,7 +54,8 @@ private:
 	void handleCallable(
 		CallableDeclaration const& _callable,
 		StructurallyDocumented const& _node,
-		StructurallyDocumentedAnnotation& _annotation
+		StructurallyDocumentedAnnotation& _annotation,
+		FunctionType const* _functionType = nullptr
 	);
 
 	langutil::ErrorReporter& m_errorReporter;

--- a/test/libsolidity/SolidityNatspecJSON.cpp
+++ b/test/libsolidity/SolidityNatspecJSON.cpp
@@ -2482,7 +2482,7 @@ BOOST_AUTO_TEST_CASE(custom_inheritance)
 	checkNatspec(sourceCode, "B", natspecB, false);
 }
 
-BOOST_AUTO_TEST_CASE(dev_different_amount_return_parameters)
+BOOST_AUTO_TEST_CASE(dev_struct_getter_override)
 {
 	char const *sourceCode = R"(
 		interface IThing {
@@ -2525,6 +2525,58 @@ BOOST_AUTO_TEST_CASE(dev_different_amount_return_parameters)
 				{
 					"x": "a number",
 					"y": "another number"
+				}
+			}
+		}
+	})ABCDEF";
+
+	checkNatspec(sourceCode, "IThing", natspec, false);
+	checkNatspec(sourceCode, "Thing", natspec2, false);
+}
+
+BOOST_AUTO_TEST_CASE(dev_struct_getter_override_different_return_parameter_names)
+{
+	char const *sourceCode = R"(
+		interface IThing {
+			/// @return x a number
+			/// @return y another number
+			function value() external view returns (uint128 x, uint128 y);
+		}
+
+		contract Thing is IThing {
+			struct Value {
+				uint128 a;
+				uint128 b;
+			}
+
+			Value public override value;
+		}
+	)";
+
+	char const *natspec = R"ABCDEF({
+		"methods":
+		{
+			"value()":
+			{
+			  "returns":
+			  {
+				"x": "a number",
+				"y": "another number"
+			  }
+			}
+		}
+	})ABCDEF";
+
+	char const *natspec2 = R"ABCDEF({
+		"methods": {},
+		"stateVariables":
+		{
+			"value":
+			{
+				"returns":
+				{
+					"a": "a number",
+					"b": "another number"
 				}
 			}
 		}


### PR DESCRIPTION
fixes #12528