### PR TITLE
Allow builtins in yul identifier paths in antlr grammar.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * Antlr Grammar: Allow builtin names in ``yulPath`` to support ``.address`` in function pointers.
  * Control Flow Graph: Perform proper virtual lookup for modifiers for uninitialized variable and unreachable code analysis.
  * Immutables: Fix wrong error when the constructor of a base contract uses ``return`` and the parent contract contains immutable variables.
 

--- a/docs/grammar/SolidityParser.g4
+++ b/docs/grammar/SolidityParser.g4
@@ -564,7 +564,7 @@ yulFunctionDefinition:
  * While only identifiers without dots can be declared within inline assembly,
  * paths containing dots can refer to declarations outside the inline assembly block.
  */
-yulPath: YulIdentifier (YulPeriod YulIdentifier)*;
+yulPath: YulIdentifier (YulPeriod (YulIdentifier | YulEVMBuiltin))*;
 /**
  * A call to a function with return values can only occur as right-hand side of an assignment or
  * a variable declaration.

--- a/test/libsolidity/syntaxTests/inlineAssembly/assignment_to_function_pointer.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/assignment_to_function_pointer.sol
@@ -1,9 +1,9 @@
 contract C {
-  function f() public pure {
-    function() external g;
-    assembly {
-      g.address := 0x42
-      g.selector := 0x23
+    function f() public pure {
+        function() external g;
+        assembly {
+            g.address := 0x42
+            g.selector := 0x23
+        }
     }
-  }
 }

--- a/test/libsolidity/syntaxTests/inlineAssembly/assignment_to_function_pointer.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/assignment_to_function_pointer.sol
@@ -1,0 +1,9 @@
+contract C {
+  function f() public pure {
+    function() external g;
+    assembly {
+      g.address := 0x42
+      g.selector := 0x23
+    }
+  }
+}


### PR DESCRIPTION
Came up in https://github.com/ethereum/solidity/pull/12470