### PR TITLE
[DOCS] - Add modifiers to the order of layout

### DIFF
--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -1053,7 +1053,8 @@ Inside each contract, library or interface, use the following order:
 1. Type declarations
 2. State variables
 3. Events
-4. Functions
+4. Modifiers
+5. Functions
 
 .. note::
 


### PR DESCRIPTION
There is no "official" recommendation about where to place modifiers but this seems to be a common order