### PR TITLE
Improved stack shuffling in corner cases.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,7 +19,7 @@ Bugfixes:
  * IR Generator: Fix IR syntax error when copying storage arrays of structs containing functions.
  * Natspec: Fix ICE when overriding a struct getter with a Natspec-documented return value and the name in the struct is different.
  * TypeChecker: Fix ICE when a constant variable declaration forward references a struct.
-
+ * Yul EVM Code Transform: Improved stack shuffling in corner cases.
 
 Solc-Js:
  * The wrapper now requires at least nodejs v10.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -147,6 +147,7 @@ set(libyul_sources
     libyul/Parser.cpp
     libyul/StackLayoutGeneratorTest.cpp
     libyul/StackLayoutGeneratorTest.h
+    libyul/StackShufflingTest.cpp
     libyul/SyntaxTest.h
     libyul/SyntaxTest.cpp
     libyul/YulInterpreterTest.cpp

--- a/test/libyul/StackShufflingTest.cpp
+++ b/test/libyul/StackShufflingTest.cpp
@@ -1,0 +1,54 @@
+/*
+    This file is part of solidity.
+
+    solidity is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    solidity is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/**
+ * Unit tests for stack shuffling.
+ */
+#include <libyul/backends/evm/StackHelpers.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+using namespace solidity::langutil;
+
+namespace solidity::yul::test
+{
+
+BOOST_AUTO_TEST_SUITE(YulStackShuffling)
+
+BOOST_AUTO_TEST_CASE(swap_cycle)
+{
+	std::vector<Scope::Variable> scopeVariables;
+	Scope::Function function;
+	std::vector<VariableSlot> v;
+	for (size_t i = 0; i < 17; ++i)
+		scopeVariables.emplace_back(Scope::Variable{""_yulstring, YulString{"v" + to_string(i)}});
+	for (size_t i = 0; i < 17; ++i)
+		v.emplace_back(VariableSlot{scopeVariables[i]});
+
+	Stack sourceStack{
+		v[0], v[1], v[2], v[3], v[4], v[5], v[6], v[7], v[9], v[10], v[11], v[12], v[13], v[14], v[15], v[16],
+		FunctionReturnLabelSlot{function}, FunctionReturnLabelSlot{function}, v[5]};
+	Stack targetStack{
+		v[1], v[0], v[2], v[3], v[4], v[5], v[6], v[7], v[9], v[10], v[11], v[12], v[13], v[14], v[15], v[16],
+		FunctionReturnLabelSlot{function}, JunkSlot{}, JunkSlot{}
+	};
+	// Used to hit a swapping cycle.
+	createStackLayout(sourceStack, targetStack, [](auto){}, [](auto){}, [](){});
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}


### PR DESCRIPTION
"Fixes" https://github.com/ethereum/solidity/issues/12570
Well, the concrete case in https://github.com/ethereum/solidity/issues/12570 is still a stack-too-deep case, so I'm not adding it as test, but I added a specific stack shuffling test for the situation that triggered a swapping cycle in the shuffling algorithm.

Generally, this PR improves some corner cases, in which junk can be popped to reduce the stack size in what would otherwise be stack-too-deep cases.

I think this being possible is a prerequisite for triggering issues like https://github.com/ethereum/solidity/issues/12570, but I'm not entirely sure. (I.e. I think the issue is only due to the target being arbitrary/junk and the best slot to move there being unreachable - popping the junk slot should both avoid the issue and ideally even make the ideal slot reachable) Would be nice to continue to have the fuzzer looking for such cases.
