### PR TITLE
Clarify that `bytes` values do not need to be aligned

### DIFF
--- a/docs/internals/layout_in_memory.rst
+++ b/docs/internals/layout_in_memory.rst
@@ -21,8 +21,10 @@ memory is never freed (this might change in the future).
 Elements in memory arrays in Solidity always occupy multiples of 32 bytes (this
 is even true for ``bytes1[]``, but not for ``bytes`` and ``string``).
 Multi-dimensional memory arrays are pointers to memory arrays. The length of a
-dynamic array is stored at the first slot of the array and followed by the array
-elements.
+dynamic array is stored at the first 32 bytes of the array and followed by the
+array elements. ``bytes`` and ``string`` values do not need to be aligned to
+slot boundaries, and bytes in the last slot but after the end of the data do
+not need to be zero.
 
 .. warning::
   There are some operations in Solidity that need a temporary memory area


### PR DESCRIPTION
While `new bytes(n)` may always point to a word-aligned slot, a
bytestring can be advanced to an arbitrary location by inline assembly:

```solidity
bytes memory b = bytes("hello world");
uint256 prefixLength = 6;
assembly {
    let newLength := sub(mload(b), prefixLength)
    b := add(b, prefixLength)
    mstore(b, newLength)
}
myContract.myMethod(b); // passes "world"
```

This works fine, because the first 32 bytes of `b` still represent its
length, and the next `mload(b)` bytes still hold the data. This patch
clarifies that it's explicitly allowed.

wchargin-branch: docs-bytes-unaligned-ok
