### PR TITLE
Switch from `solcjs` to `solc.js` in external tests

### DIFF
--- a/scripts/solc-bin/bytecode_reports_for_modified_binaries.sh
+++ b/scripts/solc-bin/bytecode_reports_for_modified_binaries.sh
@@ -151,7 +151,7 @@ for binary_name in $platform_binaries; do
             cp "${script_dir}/bytecodecompare/prepare_report.js" prepare_report.js
 
             validate_reported_version \
-                "$(solc-js/solcjs --version)" \
+                "$(solc-js/solc.js --version)" \
                 "$solidity_version_and_commit"
 
             # shellcheck disable=SC2035

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -84,7 +84,7 @@ function setup_solc
         pushd "$install_dir"
         npm install
         cp "$binary_path" soljson.js
-        SOLCVERSION=$(./solcjs --version)
+        SOLCVERSION=$(./solc.js --version)
         popd
     else
         printLog "Setting up solc..."


### PR DESCRIPTION
This PR fixes the breakage we got in external tests after https://github.com/ethereum/solc-js/pull/587 got merged yesterday. For example [Colony tests](https://app.circleci.com/pipelines/github/ethereum/solidity/21783/workflows/aefcceb6-82c0-419f-a3d8-f66785920024/jobs/954433) are failing because the script is now called `solc.js` rather than `solcjs`.

There's https://github.com/ethereum/solc-js/pull/590 which adds back a symlink for backwards compatibility but the link is not likely to stay there long-term so we should just switch to the new name.

Note that after https://github.com/ethereum/solc-js/pull/566, which is likely to get merged very soon, the script to run will change again (to `dist/solc.js`) so another fix will be necessary (and probably an extra command to run TypeScript compilation first).