### PR TITLE
Compatibility fixes for solc-js TypeScript migration

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -23,6 +23,7 @@ Bugfixes:
 
 Solc-Js:
  * The wrapper now requires at least nodejs v10.
+ * The code has been ported to TypeScript.
 
 
 ### 0.8.11 (2021-12-20)

--- a/ReleaseChecklist.md
+++ b/ReleaseChecklist.md
@@ -66,7 +66,7 @@
 ### Release solc-js
  - [ ] Wait until solc-bin was properly deployed. You can test this via remix - a test run through remix is advisable anyway.
  - [ ] Increment the version number, create a pull request for that, merge it after tests succeeded.
- - [ ] Run ``node verifyVersion.js && npm publish`` in the updated ``solc-js`` repository.
+ - [ ] Run ``npm run updateBinary && npm publish`` in the updated ``solc-js`` repository.
  - [ ] Create a tag using ``git tag --annotate v$VERSION`` and push it with ``git push --tags``.
 
 ### Post-release

--- a/scripts/bytecodecompare/prepare_report.js
+++ b/scripts/bytecodecompare/prepare_report.js
@@ -2,7 +2,7 @@
 const process = require('process')
 const fs = require('fs')
 
-const compiler = require('./solc-js/wrapper.js')(require('./solc-js/soljson.js'))
+const compiler = require('solc')
 
 
 function loadSource(sourceFileName, stripSMTPragmas)

--- a/scripts/bytecodecompare/storebytecode.sh
+++ b/scripts/bytecodecompare/storebytecode.sh
@@ -42,11 +42,18 @@ TMPDIR=$(mktemp -d)
 
     if [[ "$SOLC_EMSCRIPTEN" = "On" ]]
     then
+        echo "Installing solc-js..."
         # npm install solc
         git clone --depth 1 https://github.com/ethereum/solc-js.git solc-js
         cp "$REPO_ROOT/emscripten_build/libsolc/soljson.js" solc-js/
+        pushd solc-js/
+        npm install
+        npm run build
+        popd
+
         cp "$REPO_ROOT/scripts/bytecodecompare/prepare_report.js" .
-        ( npm install solc-js/ )
+        npm install solc-js/
+
         echo "Running the compiler..."
         # shellcheck disable=SC2035
         ./prepare_report.js *.sol > report.txt

--- a/scripts/bytecodecompare/storebytecode.sh
+++ b/scripts/bytecodecompare/storebytecode.sh
@@ -44,9 +44,9 @@ TMPDIR=$(mktemp -d)
     then
         # npm install solc
         git clone --depth 1 https://github.com/ethereum/solc-js.git solc-js
-        ( cd solc-js; npm install )
         cp "$REPO_ROOT/emscripten_build/libsolc/soljson.js" solc-js/
         cp "$REPO_ROOT/scripts/bytecodecompare/prepare_report.js" .
+        ( npm install solc-js/ )
         echo "Running the compiler..."
         # shellcheck disable=SC2035
         ./prepare_report.js *.sol > report.txt

--- a/scripts/solc-bin/bytecode_reports_for_modified_binaries.sh
+++ b/scripts/solc-bin/bytecode_reports_for_modified_binaries.sh
@@ -109,6 +109,7 @@ cd "$tmp_dir"
 git clone https://github.com/ethereum/solc-js.git "$solcjs_dir"
 cd "$solcjs_dir"
 npm install
+npm run build
 
 cd "${solc_bin_dir}/${platform}/"
 echo "Commit range: ${base_ref}..${top_ref}"
@@ -147,11 +148,12 @@ for binary_name in $platform_binaries; do
 
         if [[ $platform == emscripten-wasm32 ]] || [[ $platform == emscripten-asmjs ]]; then
             ln -sf "${solc_bin_dir}/${platform}/${binary_name}" "${solcjs_dir}/soljson.js"
+            ln -sf "${solc_bin_dir}/${platform}/${binary_name}" "${solcjs_dir}/dist/soljson.js"
             ln -s "${solcjs_dir}" solc-js
             cp "${script_dir}/bytecodecompare/prepare_report.js" prepare_report.js
 
             validate_reported_version \
-                "$(solc-js/solc.js --version)" \
+                "$(solc-js/dist/solc.js --version)" \
                 "$solidity_version_and_commit"
 
             # shellcheck disable=SC2035

--- a/scripts/wasm-rebuild/docker-scripts/rebuild_tags.sh
+++ b/scripts/wasm-rebuild/docker-scripts/rebuild_tags.sh
@@ -228,6 +228,7 @@ mkdir -p "${OUTPUTDIR}"/bin
 echo "Prepare solc-js."
 cd /root/solc-js
 npm install >/dev/null 2>&1
+npm run build >/dev/null 2>&1
 
 echo "Install semver helper."
 npm install -g semver >/dev/null 2>&1

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -84,7 +84,8 @@ function setup_solc
         pushd "$install_dir"
         npm install
         cp "$binary_path" soljson.js
-        SOLCVERSION=$(./solc.js --version)
+        npm run build
+        SOLCVERSION=$(dist/solc.js --version)
         popd
     else
         printLog "Setting up solc..."


### PR DESCRIPTION
This PR adjusts the command we run from solc-js and adds `npm run build` required to compile the TypeScript code. It should be merged after https://github.com/ethereum/solc-js/pull/566.