### PR TITLE
Code transform fuzzer: Filter log statements and remove gas comparison.

### DIFF
--- a/test/tools/ossfuzz/StackReuseCodegenFuzzer.cpp
+++ b/test/tools/ossfuzz/StackReuseCodegenFuzzer.cpp
@@ -71,11 +71,6 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 		of.write(yul_source.data(), static_cast<streamsize>(yul_source.size()));
 	}
 
-	// Do not proceed with tests that are too large. 1200 is an arbitrary
-	// threshold.
-	if (yul_source.size() > 1200)
-		return;
-
 	YulStringRepository::reset();
 
 	solidity::frontend::OptimiserSettings settings = solidity::frontend::OptimiserSettings::full();
@@ -161,18 +156,6 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 	);
 	ostringstream optimizedState;
 	optimizedState << EVMHostPrinter{hostContext, deployResultOpt.create_address}.state();
-
-	int64_t constexpr tolerance = 1000;
-	if (callResult.gas_left > callResultOpt.gas_left)
-		if (callResult.gas_left - callResultOpt.gas_left > tolerance)
-		{
-			cout << "Gas differential " << callResult.gas_left - callResultOpt.gas_left << endl;
-			cout << "Unoptimised bytecode" << endl;
-			cout << util::toHex(unoptimisedByteCode) << endl;
-			cout << "Optimised bytecode" << endl;
-			cout << util::toHex(optimisedByteCode) << endl;
-			solAssert(false, "Optimised code consumed more than +1000 gas.");
-		}
 
 	solAssert(
 		unoptimizedState.str() == optimizedState.str(),

--- a/test/tools/ossfuzz/protoToYul.cpp
+++ b/test/tools/ossfuzz/protoToYul.cpp
@@ -1348,7 +1348,9 @@ void ProtoConverter::visit(Statement const& _x)
 			m_output << "continue\n";
 		break;
 	case Statement::kLogFunc:
-		visit(_x.log_func());
+		// Log is a stateful statement since it writes to storage.
+		if (!m_filterStatefulInstructions)
+			visit(_x.log_func());
 		break;
 	case Statement::kCopyFunc:
 		visit(_x.copy_func());


### PR DESCRIPTION
The New Yul code transform fuzzer would fail if the gas consumed by the call to a function optimized via the new code transform is greater than the gas consumed by the call to a function optimized via the legacy optimizer by `1000` gas  (arbitrary threshold). This created a problem for Yul code such as 

```
{
  addmod(i1, i2, keccak256(i3, i4))
}
```

because the new Yul code transformed code would always evaluate the keccak call first in corner cases (and fail the gas compare assertion).

The second problem that the fuzzer had was that log statements would lead to false positives because

```
{
  log1(i1, i2, i3)
}
```

would log different values depending on the content of `i1` and `i2`.

This PR fixes these two problems
  - by disabling gas comparison
  - by disabling log statement generation
