### PR TITLE
Update `IterableMapping` example to indicate that the calculations will overflow on 0.8.x

### DIFF
--- a/docs/types/mapping-types.rst
+++ b/docs/types/mapping-types.rst
@@ -165,7 +165,8 @@ the ``sum`` function iterates over to sum all the values.
         function contains(itmap storage self, uint key) internal view returns (bool) {
             return self.data[key].keyIndex > 0;
         }
-
+        
+        // won't work with compiler 0.8 overflow checks
         function iterate_start(itmap storage self) internal view returns (uint keyIndex) {
             return iterate_next(self, type(uint).max);
         }


### PR DESCRIPTION
added a caveat in the comment above `iterate_start` as a notice, since fixing the issue will require a reworking of the library