### PR TITLE
Code transform fuzzer: Only test against latest EVM version.

### DIFF
--- a/test/tools/ossfuzz/StackReuseCodegenFuzzer.cpp
+++ b/test/tools/ossfuzz/StackReuseCodegenFuzzer.cpp
@@ -60,8 +60,9 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 		filterUnboundedLoops
 	);
 	string yul_source = converter.programToString(_input);
-	// Fuzzer also fuzzes the EVM version field.
-	langutil::EVMVersion version = converter.version();
+	// Do not fuzz the EVM Version field.
+	// See https://github.com/ethereum/solidity/issues/12590
+	langutil::EVMVersion version;
 	EVMHost hostContext(version, evmone);
 	hostContext.reset();
 


### PR DESCRIPTION
Since older EVM versions may lead to unexpected output (see https://github.com/ethereum/solidity/issues/12590), only test against latest EVM version.