### PR TITLE
Add blank lines in style guide to make examples consistent with the blank line rule

### DIFF
--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -281,6 +281,7 @@ Yes:
         // ...
     }
 
+
     contract B is Owned {
         // ...
     }
@@ -846,14 +847,19 @@ Yes:
         constructor(uint) {
         }
     }
+
+
     contract C {
         constructor(uint, uint) {
         }
     }
+
+
     contract D {
         constructor(uint) {
         }
     }
+
 
     contract A is B, C, D {
         uint x;


### PR DESCRIPTION
There is a suggestion to surround top level declarations in solidity source with two blank lines.

But I found some examples which are not following the suggestion.

So I Add blank line to make it consistency. 
