### PR TITLE
solc-js external test on a local checkout

### DIFF
--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -71,15 +71,23 @@ function setup_solc
     local binary_path="$3"
     local solcjs_branch="${4:-master}"
     local install_dir="${5:-solc/}"
+    local solcjs_dir="$6"
 
     [[ $binary_type == native || $binary_type == solcjs ]] || assertFail
+    [[ $binary_type == solcjs || $solcjs_dir == "" ]] || assertFail
 
     cd "$test_dir"
 
     if [[ $binary_type == solcjs ]]
     then
         printLog "Setting up solc-js..."
-        git clone --depth 1 -b "$solcjs_branch" https://github.com/ethereum/solc-js.git "$install_dir"
+        if [[ $solcjs_dir == "" ]]; then
+            printLog "Cloning branch ${solcjs_branch}..."
+            git clone --depth 1 -b "$solcjs_branch" https://github.com/ethereum/solc-js.git "$install_dir"
+        else
+            printLog "Using local solc-js from ${solcjs_dir}..."
+            cp -ra "$solcjs_dir" solc
+        fi
 
         pushd "$install_dir"
         npm install

--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -323,20 +323,6 @@ function hardhat_clean
     rm -rf artifacts/ cache/
 }
 
-function run_test
-{
-    local compile_fn="$1"
-    local test_fn="$2"
-
-    replace_version_pragmas
-
-    printLog "Running compile function..."
-    time $compile_fn
-
-    printLog "Running test function..."
-    $test_fn
-}
-
 function settings_from_preset
 {
     local preset="$1"

--- a/test/externalTests/solc-js/solc-js.sh
+++ b/test/externalTests/solc-js/solc-js.sh
@@ -29,9 +29,6 @@ VERSION="$2"
 
 [[ $SOLJSON != "" && -f "$SOLJSON" && $VERSION != "" ]] || fail "Usage: $0 <path to soljson.js> <version>"
 
-function compile_fn { echo "Nothing to compile."; }
-function test_fn { npm test; }
-
 function solcjs_test
 {
     TEST_DIR=$(pwd)
@@ -60,7 +57,10 @@ function solcjs_test
     echo "Updating package.json to version $VERSION"
     npm version --allow-same-version --no-git-tag-version "$VERSION"
 
-    run_test compile_fn test_fn
+    replace_version_pragmas
+
+    printLog "Running test function..."
+    npm test
 }
 
 external_test solc-js solcjs_test

--- a/test/externalTests/solc-js/solc-js.sh
+++ b/test/externalTests/solc-js/solc-js.sh
@@ -26,8 +26,9 @@ source test/externalTests/common.sh
 
 SOLJSON="$1"
 VERSION="$2"
+SOLCJS_CHECKOUT="$3" # optional
 
-[[ $SOLJSON != "" && -f "$SOLJSON" && $VERSION != "" ]] || fail "Usage: $0 <path to soljson.js> <version>"
+[[ $SOLJSON != "" && -f "$SOLJSON" && $VERSION != "" ]] || fail "Usage: $0 <path to soljson.js> <version> [<path to solc-js>]"
 
 function solcjs_test
 {
@@ -35,7 +36,7 @@ function solcjs_test
     SOLCJS_INPUT_DIR="$TEST_DIR"/test/externalTests/solc-js
 
     # set up solc-js on the branch specified
-    setup_solc "$DIR" solcjs "$SOLJSON" master solc/
+    setup_solc "$DIR" solcjs "$SOLJSON" master solc/ "$SOLCJS_CHECKOUT"
     cd solc/
 
     printLog "Updating index.js file..."


### PR DESCRIPTION
Currently the solc-js external test always clones the master branch of solc-js. This is generally what we want in the main repo but I'm now trying to add a run of that test to CI in solc-js and there we actually need to be able to run on the code from a PR.

This PR extends the `solc-js.sh` script to accept a third parameter, which is a path to a local checkout of solc-js. If the argument is provided, it copies the directory and uses that. Otherwise it clones the `master` branch like it used to.