### PR TITLE
Treat root path in normalizeCLIPathForVFS as case insensitive on Windows

### DIFF
--- a/libsolidity/interface/FileReader.cpp
+++ b/libsolidity/interface/FileReader.cpp
@@ -269,7 +269,8 @@ boost::filesystem::path FileReader::normalizeCLIPathForVFS(
 	if (!isUNCPath(normalizedPath))
 	{
 		boost::filesystem::path workingDirRootPath = canonicalWorkDir.root_path();
-		if (normalizedRootPath == workingDirRootPath)
+		// Ignore drive letter case on Windows (C:\ <=> c:\).
+		if (boost::filesystem::equivalent(normalizedRootPath, workingDirRootPath))
 			normalizedRootPath = "/";
 	}
 


### PR DESCRIPTION
`FileReader::normalizeCLIPathForVFS` strips root name if the path and working directory are on the same drive. Root comparison should perhaps be case insensitive on Windows.
