### PR TITLE
Patch ElementFi external test on for disallowed `delete` on `breaking`

### DIFF
--- a/test/externalTests/elementfi.sh
+++ b/test/externalTests/elementfi.sh
@@ -80,6 +80,7 @@ function elementfi_test
     sed -i 's|address(uint256(_data))|address(uint160(uint256(_data)))|g' lib/openzeppelin/Create2.sol
     sed -i 's|address(uint256(poolId) >> (12 \* 8))|address(uint160(uint256(poolId) >> (12 * 8)))|g' vault/PoolRegistry.sol
     sed -i 's|bytes32(uint256(pool))|bytes32(uint256(uint160(pool)))|g' vault/PoolRegistry.sol
+    sed -i 's|delete _twoTokenPoolTokens\[poolId\];|delete _twoTokenPoolTokens[poolId].tokenA;delete _twoTokenPoolTokens[poolId].tokenB;|g' vault/balances/TwoTokenPoolsBalance.sol
     popd
 
     # Several tests fail unless we use the exact versions hard-coded in package-lock.json


### PR DESCRIPTION
Fixes [breakage in the `t_native_test_ext_elementfi` job on `breaking`](https://app.circleci.com/pipelines/github/ethereum/solidity/21874/workflows/fcea4f31-03c0-4925-aa86-9a57cb062626/jobs/959272/parallel-runs/1?filterBy=FAILED).

```
TypeError: Unary operator delete cannot be applied to type struct TwoTokenPoolsBalance.TwoTokenPoolTokens storage ref: Contains a (possibly nested) mapping
   --> contracts/balancer-core-v2/vault/balances/TwoTokenPoolsBalance.sol:124:9:
    |
124 |         delete _twoTokenPoolTokens[poolId];
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This line works fine on `develop` but on breaking it's disallowed:
```
### 0.9.0 (unreleased)
Breaking changes:
...
 * Disallow ``delete`` on types that contain nested mappings.
```

Fortunately only a single line in a single file is affected by this so forking of the whole repo is not necessary.