### PR TITLE
Fix breakage in Bleeps and Perpetual Pools external tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1468,7 +1468,8 @@ workflows:
       - t_ems_ext: *job_native_test_ext_trident
       - t_ems_ext: *job_native_test_ext_euler
       - t_ems_ext: *job_native_test_ext_yield_liquidator
-      - t_ems_ext: *job_native_test_ext_bleeps
+      # Disabled until we have a fix for https://github.com/wighawag/bleeps/issues/2
+      #-t_ems_ext: *job_native_test_ext_bleeps
       - t_ems_ext: *job_native_test_ext_pool_together
       - t_ems_ext: *job_native_test_ext_perpetual_pools
       - t_ems_ext: *job_native_test_ext_uniswap

--- a/test/externalTests/bleeps.sh
+++ b/test/externalTests/bleeps.sh
@@ -27,6 +27,7 @@ source test/externalTests/common.sh
 verify_input "$@"
 BINARY_TYPE="$1"
 BINARY_PATH="$2"
+SELECTED_PRESETS="$3"
 
 function compile_fn { npm run compile; }
 function test_fn { npm run test; }

--- a/test/externalTests/bleeps.sh
+++ b/test/externalTests/bleeps.sh
@@ -35,8 +35,8 @@ function test_fn { npm run test; }
 function bleeps_test
 {
     local repo="https://github.com/wighawag/bleeps"
-    local ref_type=tag
-    local ref=bleeps_migrations # TODO: There's a 0.4.19 contract in 'main' that would need patching for the latest compiler.
+    local ref_type=branch
+    local ref=main
     local config_file="hardhat.config.ts"
     local config_var=config
 

--- a/test/externalTests/bleeps.sh
+++ b/test/externalTests/bleeps.sh
@@ -66,6 +66,12 @@ function bleeps_test
     pushd "contracts/"
     sed -i 's|"bleeps-common": "workspace:\*",|"bleeps-common": "file:../common-lib/",|g' package.json
 
+    sed -i 's/function() public/fallback() external/g' src/externals/WETH9.sol
+    sed -i 's/this\.balance/address(this).balance/g' src/externals/WETH9.sol
+    sed -i 's/uint(-1)/type(uint).max/g' src/externals/WETH9.sol
+    sed -i 's/msg\.sender\.transfer(/payable(msg.sender).transfer(/g' src/externals/WETH9.sol
+    sed -i 's/^\s*\(Deposit\|Withdrawal\|Approval\|Transfer\)(/emit \1(/g' src/externals/WETH9.sol
+
     neutralize_package_lock
     neutralize_package_json_hooks
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"

--- a/test/externalTests/elementfi.sh
+++ b/test/externalTests/elementfi.sh
@@ -27,6 +27,7 @@ source test/externalTests/common.sh
 verify_input "$@"
 BINARY_TYPE="$1"
 BINARY_PATH="$2"
+SELECTED_PRESETS="$3"
 
 function compile_fn { npm run build; }
 function test_fn { npm run test; }

--- a/test/externalTests/perpetual-pools.sh
+++ b/test/externalTests/perpetual-pools.sh
@@ -34,7 +34,7 @@ function test_fn { yarn test; }
 
 function perpetual_pools_test
 {
-    local repo="https://github.com/tracer-protocol/perpetual-pools-contracts"
+    local repo="https://github.com/solidity-external-tests/perpetual-pools-contracts"
     local ref_type=branch
     local ref=pools-v2
     local config_file="hardhat.config.ts"

--- a/test/externalTests/trident.sh
+++ b/test/externalTests/trident.sh
@@ -27,6 +27,7 @@ source test/externalTests/common.sh
 verify_input "$@"
 BINARY_TYPE="$1"
 BINARY_PATH="$2"
+SELECTED_PRESETS="$3"
 
 function compile_fn { yarn build; }
 

--- a/test/externalTests/uniswap.sh
+++ b/test/externalTests/uniswap.sh
@@ -27,6 +27,7 @@ source test/externalTests/common.sh
 verify_input "$@"
 BINARY_TYPE="$1"
 BINARY_PATH="$2"
+SELECTED_PRESETS="$3"
 
 function compile_fn { yarn compile; }
 function test_fn { UPDATE_SNAPSHOT=1 npx hardhat test; }


### PR DESCRIPTION
This is a bunch of tweaks meant to fix breakage we've seen today in [`t_native_test_ext_bleeps`](https://app.circleci.com/pipelines/github/ethereum/solidity/21906/workflows/8d01aa15-01ac-4924-8357-68627af6dd16/jobs/960791) and [`t_native_test_ext_perpetual_pools`](https://app.circleci.com/pipelines/github/ethereum/solidity/21906/workflows/8d01aa15-01ac-4924-8357-68627af6dd16/jobs/960787).
- Perpetual Pools repo seems to have disappeared from Github. I found a fork that looks up to date and created our own fork in https://github.com/solidity-external-tests/perpetual-pools-contracts.
- I don't know what exactly is wrong with Bleeps but I suspect that it broke due to some dependency. It's reproducible on their `main` branch so I reported the problem upstream: https://github.com/wighawag/bleeps/issues/2.
    - I don't have a workaround and using an earlier commit does not help (we're already using a tagged commit) so the only thing I can do for now is to disable the test until that gets sorted out.
    - While debugging this I also tried to switch to the `main` branch. This did not help for the problem but it's something I was planning to do anyway so I'm including that change here.
- I noticed that some external tests were missing the code to process the `SELECTED_PRESETS` argument. This must be because there was no conflict after that feature was merged and I did not notice that I had to update them. I'm adding that here too.