### PR TITLE
Memory-safety annotation for inline assembly.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.8.13 (unreleased)
 
 Language Features:
+ * General: Allow annotating inline assembly as memory-safe to allow optimizations and stack limit evasion that rely on respecting Solidity's memory model.
 
 
 Compiler Features:

--- a/docs/ir-breaking-changes.rst
+++ b/docs/ir-breaking-changes.rst
@@ -1,6 +1,8 @@
 
 .. index: ir breaking changes
 
+.. _ir-breaking-changes:
+
 *********************************
 Solidity IR-based Codegen Changes
 *********************************

--- a/libsolidity/analysis/DocStringTagParser.cpp
+++ b/libsolidity/analysis/DocStringTagParser.cpp
@@ -30,6 +30,7 @@
 #include <liblangutil/Common.h>
 
 #include <range/v3/algorithm/any_of.hpp>
+#include <range/v3/view/filter.hpp>
 
 #include <boost/algorithm/string.hpp>
 
@@ -158,6 +159,71 @@ bool DocStringTagParser::visit(EventDefinition const& _event)
 bool DocStringTagParser::visit(ErrorDefinition const& _error)
 {
 	handleCallable(_error, _error, _error.annotation());
+
+	return true;
+}
+
+bool DocStringTagParser::visit(InlineAssembly const& _assembly)
+{
+	if (!_assembly.documentation())
+		return true;
+	StructuredDocumentation documentation{-1, _assembly.location(), _assembly.documentation()};
+	ErrorList errors;
+	ErrorReporter errorReporter{errors};
+	auto docTags = DocStringParser{documentation, errorReporter}.parse();
+
+	if (!errors.empty())
+	{
+		SecondarySourceLocation ssl;
+		for (auto const& error: errors)
+			if (error->comment())
+				ssl.append(
+					*error->comment(),
+					_assembly.location()
+				);
+		m_errorReporter.warning(
+			7828_error,
+			_assembly.location(),
+			"Inline assembly has invalid NatSpec documentation.",
+			ssl
+		);
+	}
+
+	for (auto const& [tagName, tagValue]: docTags)
+	{
+		if (tagName == "solidity")
+		{
+			vector<string> values;
+			boost::split(values, tagValue.content, isWhiteSpace);
+
+			set<string> valuesSeen;
+			set<string> duplicates;
+			for (auto const& value: values | ranges::views::filter(not_fn(&string::empty)))
+				if (valuesSeen.insert(value).second)
+				{
+					if (value == "memory-safe-assembly")
+						_assembly.annotation().memorySafe = true;
+					else
+						m_errorReporter.warning(
+							8787_error,
+							_assembly.location(),
+							"Unexpected value for @solidity tag in inline assembly: " + value
+						);
+				}
+				else if (duplicates.insert(value).second)
+					m_errorReporter.warning(
+						4377_error,
+						_assembly.location(),
+						"Value for @solidity tag in inline assembly specified multiple times: " + value
+					);
+		}
+		else
+			m_errorReporter.warning(
+				6269_error,
+				_assembly.location(),
+				"Unexpected NatSpec tag \"" + tagName + "\" with value \"" + tagValue.content + "\" in inline assembly."
+			);
+	}
 
 	return true;
 }

--- a/libsolidity/analysis/DocStringTagParser.cpp
+++ b/libsolidity/analysis/DocStringTagParser.cpp
@@ -202,7 +202,7 @@ bool DocStringTagParser::visit(InlineAssembly const& _assembly)
 				if (valuesSeen.insert(value).second)
 				{
 					if (value == "memory-safe-assembly")
-						_assembly.annotation().memorySafe = true;
+						_assembly.annotation().markedMemorySafe = true;
 					else
 						m_errorReporter.warning(
 							8787_error,

--- a/libsolidity/analysis/DocStringTagParser.h
+++ b/libsolidity/analysis/DocStringTagParser.h
@@ -48,6 +48,7 @@ private:
 	bool visit(ModifierDefinition const& _modifier) override;
 	bool visit(EventDefinition const& _event) override;
 	bool visit(ErrorDefinition const& _error) override;
+	bool visit(InlineAssembly const& _assembly) override;
 
 	void checkParameters(
 		CallableDeclaration const& _callable,

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -221,7 +221,9 @@ struct InlineAssemblyAnnotation: StatementAnnotation
 	/// Information generated during analysis phase.
 	std::shared_ptr<yul::AsmAnalysisInfo> analysisInfo;
 	/// True, if the assembly block was annotated to be memory-safe.
-	bool memorySafe = false;
+	bool markedMemorySafe = false;
+	/// True, if the assembly block involves any memory opcode or assigns to variables in memory.
+	SetOnce<bool> hasMemoryEffects;
 };
 
 struct BlockAnnotation: StatementAnnotation, ScopableAnnotation

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -220,6 +220,8 @@ struct InlineAssemblyAnnotation: StatementAnnotation
 	std::map<yul::Identifier const*, ExternalIdentifierInfo> externalReferences;
 	/// Information generated during analysis phase.
 	std::shared_ptr<yul::AsmAnalysisInfo> analysisInfo;
+	/// True, if the assembly block was annotated to be memory-safe.
+	bool memorySafe = false;
 };
 
 struct BlockAnnotation: StatementAnnotation, ScopableAnnotation

--- a/libsolidity/codegen/ir/IRGenerationContext.h
+++ b/libsolidity/codegen/ir/IRGenerationContext.h
@@ -160,8 +160,8 @@ public:
 
 	std::set<ContractDefinition const*, ASTNode::CompareByID>& subObjectsCreated() { return m_subObjects; }
 
-	bool inlineAssemblySeen() const { return m_inlineAssemblySeen; }
-	void setInlineAssemblySeen() { m_inlineAssemblySeen = true; }
+	bool memoryUnsafeInlineAssemblySeen() const { return m_memoryUnsafeInlineAssemblySeen; }
+	void setMemoryUnsafeInlineAssemblySeen() { m_memoryUnsafeInlineAssemblySeen = true; }
 
 	/// @returns the runtime ID to be used for the function in the dispatch routine
 	/// and for internal function pointers.
@@ -202,8 +202,8 @@ private:
 	/// Whether to use checked or wrapping arithmetic.
 	Arithmetic m_arithmetic = Arithmetic::Checked;
 
-	/// Flag indicating whether any inline assembly block was seen.
-	bool m_inlineAssemblySeen = false;
+	/// Flag indicating whether any memory-unsafe inline assembly block was seen.
+	bool m_memoryUnsafeInlineAssemblySeen = false;
 
 	/// Function definitions queued for code generation. They're the Solidity functions whose calls
 	/// were discovered by the IR generator during AST traversal.

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -213,8 +213,8 @@ string IRGenerator::generate(
 	t("subObjects", subObjectSources(m_context.subObjectsCreated()));
 
 	// This has to be called only after all other code generation for the creation object is complete.
-	bool creationInvolvesAssembly = m_context.inlineAssemblySeen();
-	t("memoryInitCreation", memoryInit(!creationInvolvesAssembly));
+	bool creationInvolvesMemoryUnsafeAssembly = m_context.memoryUnsafeInlineAssemblySeen();
+	t("memoryInitCreation", memoryInit(!creationInvolvesMemoryUnsafeAssembly));
 	t("useSrcMapCreation", formatUseSrcMap(m_context));
 
 	resetContext(_contract, ExecutionContext::Deployed);
@@ -239,8 +239,8 @@ string IRGenerator::generate(
 	t("useSrcMapDeployed", formatUseSrcMap(m_context));
 
 	// This has to be called only after all other code generation for the deployed object is complete.
-	bool deployedInvolvesAssembly = m_context.inlineAssemblySeen();
-	t("memoryInitDeployed", memoryInit(!deployedInvolvesAssembly));
+	bool deployedInvolvesMemoryUnsafeAssembly = m_context.memoryUnsafeInlineAssemblySeen();
+	t("memoryInitDeployed", memoryInit(!deployedInvolvesMemoryUnsafeAssembly));
 
 	solAssert(_contract.annotation().creationCallGraph->get() != nullptr, "");
 	solAssert(_contract.annotation().deployedCallGraph->get() != nullptr, "");

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -2138,7 +2138,8 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 bool IRGeneratorForStatements::visit(InlineAssembly const& _inlineAsm)
 {
 	setLocation(_inlineAsm);
-	m_context.setInlineAssemblySeen();
+	if (!_inlineAsm.annotation().memorySafe)
+		m_context.setMemoryUnsafeInlineAssemblySeen();
 	CopyTranslate bodyCopier{_inlineAsm.dialect(), m_context, _inlineAsm.annotation().externalReferences};
 
 	yul::Statement modified = bodyCopier(_inlineAsm.operations());

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -2138,7 +2138,7 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 bool IRGeneratorForStatements::visit(InlineAssembly const& _inlineAsm)
 {
 	setLocation(_inlineAsm);
-	if (!_inlineAsm.annotation().memorySafe)
+	if (*_inlineAsm.annotation().hasMemoryEffects && !_inlineAsm.annotation().markedMemorySafe)
 		m_context.setMemoryUnsafeInlineAssemblySeen();
 	CopyTranslate bodyCopier{_inlineAsm.dialect(), m_context, _inlineAsm.annotation().externalReferences};
 

--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -316,6 +316,7 @@ vector<YulString> AsmAnalyzer::operator()(FunctionCall const& _funCall)
 			literalArguments = &f->literalArguments;
 
 		validateInstructions(_funCall);
+		m_sideEffects += f->sideEffects;
 	}
 	else if (m_currentScope->lookup(_funCall.functionName.name, GenericVisitor{
 		[&](Scope::Variable const&)

--- a/libyul/AsmAnalysis.h
+++ b/libyul/AsmAnalysis.h
@@ -94,6 +94,8 @@ public:
 	void operator()(Leave const&) { }
 	void operator()(Block const& _block);
 
+	/// @returns the worst side effects encountered during analysis (including within defined functions).
+	SideEffects const& sideEffects() const { return m_sideEffects; }
 private:
 	/// Visits the expression, expects that it evaluates to exactly one value and
 	/// returns the type. Reports errors on errors and returns the default type.
@@ -128,6 +130,8 @@ private:
 	/// Names of data objects to be referenced by builtin functions with literal arguments.
 	std::set<YulString> m_dataNames;
 	ForLoop const* m_currentForLoop = nullptr;
+	/// Worst side effects encountered during analysis (including within defined functions).
+	SideEffects m_sideEffects;
 };
 
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -83,6 +83,8 @@ set(libsolidity_sources
     libsolidity/InlineAssembly.cpp
     libsolidity/LibSolc.cpp
     libsolidity/Metadata.cpp
+    libsolidity/MemoryGuardTest.cpp
+    libsolidity/MemoryGuardTest.h
     libsolidity/SemanticTest.cpp
     libsolidity/SemanticTest.h
     libsolidity/SemVerMatcher.cpp

--- a/test/InteractiveTests.h
+++ b/test/InteractiveTests.h
@@ -22,6 +22,7 @@
 #include <test/libsolidity/ABIJsonTest.h>
 #include <test/libsolidity/ASTJSONTest.h>
 #include <test/libsolidity/GasTest.h>
+#include <test/libsolidity/MemoryGuardTest.h>
 #include <test/libsolidity/SyntaxTest.h>
 #include <test/libsolidity/SemanticTest.h>
 #include <test/libsolidity/SMTCheckerTest.h>
@@ -74,6 +75,7 @@ Testsuite const g_interactiveTestsuites[] = {
 	{"JSON ABI",               "libsolidity", "ABIJson",               false, false, &ABIJsonTest::create},
 	{"SMT Checker",            "libsolidity", "smtCheckerTests",       true,  false, &SMTCheckerTest::create},
 	{"Gas Estimates",          "libsolidity", "gasTests",              false, false, &GasTest::create},
+	{"Memory Guard Tests",     "libsolidity", "memoryGuardTests",     false, false, &MemoryGuardTest::create},
 	{"Ewasm Translation",      "libyul",      "ewasmTranslationTests", false, false, &yul::test::EwasmTranslationTest::create}
 };
 

--- a/test/cmdlineTests/constant_optimizer_yul/output
+++ b/test/cmdlineTests/constant_optimizer_yul/output
@@ -11,14 +11,15 @@ object "C_12" {
     code {
         {
             /// @src 0:61:418  "contract C {..."
-            mstore(64, 128)
+            let _1 := memoryguard(0x80)
+            mstore(64, _1)
             if callvalue() { revert(0, 0) }
             /// @src 0:103:238  "assembly {..."
             sstore(0, shl(180, 1))
             /// @src 0:61:418  "contract C {..."
-            let _1 := datasize("C_12_deployed")
-            codecopy(128, dataoffset("C_12_deployed"), _1)
-            return(128, _1)
+            let _2 := datasize("C_12_deployed")
+            codecopy(_1, dataoffset("C_12_deployed"), _2)
+            return(_1, _2)
         }
     }
     /// @use-src 0:"constant_optimizer_yul/input.sol"
@@ -26,7 +27,7 @@ object "C_12" {
         code {
             {
                 /// @src 0:61:418  "contract C {..."
-                mstore(64, 128)
+                mstore(64, memoryguard(0x80))
                 if callvalue() { revert(0, 0) }
                 /// @src 0:279:410  "assembly {..."
                 sstore(0, 0x1000000000000000000000000000000000000000000000)

--- a/test/cmdlineTests/ir_with_assembly_no_memoryguard_creation/input.sol
+++ b/test/cmdlineTests/ir_with_assembly_no_memoryguard_creation/input.sol
@@ -3,6 +3,6 @@ pragma solidity >=0.0.0;
 pragma abicoder v2;
 
 contract D {
-    constructor() { assembly {}}
+    constructor() { assembly { mstore(0,0) } }
     function f() public pure {}
 }

--- a/test/cmdlineTests/ir_with_assembly_no_memoryguard_creation/output
+++ b/test/cmdlineTests/ir_with_assembly_no_memoryguard_creation/output
@@ -10,9 +10,12 @@ Optimized IR:
 object "D_12" {
     code {
         {
-            /// @src 0:82:161  "contract D {..."
+            /// @src 0:82:175  "contract D {..."
             mstore(64, 128)
             if callvalue() { revert(0, 0) }
+            /// @src 0:115:139  "assembly { mstore(0,0) }"
+            mstore(0, 0)
+            /// @src 0:82:175  "contract D {..."
             let _1 := datasize("D_12_deployed")
             codecopy(128, dataoffset("D_12_deployed"), _1)
             return(128, _1)
@@ -22,7 +25,7 @@ object "D_12" {
     object "D_12_deployed" {
         code {
             {
-                /// @src 0:82:161  "contract D {..."
+                /// @src 0:82:175  "contract D {..."
                 let _1 := memoryguard(0x80)
                 mstore(64, _1)
                 if iszero(lt(calldatasize(), 4))

--- a/test/cmdlineTests/ir_with_assembly_no_memoryguard_runtime/input.sol
+++ b/test/cmdlineTests/ir_with_assembly_no_memoryguard_runtime/input.sol
@@ -4,6 +4,6 @@ pragma abicoder v2;
 
 contract D {
     function f() public pure {
-        assembly {}
+        assembly { mstore(0,0) }
     }
 }

--- a/test/cmdlineTests/ir_with_assembly_no_memoryguard_runtime/output
+++ b/test/cmdlineTests/ir_with_assembly_no_memoryguard_runtime/output
@@ -10,7 +10,7 @@ Optimized IR:
 object "D_8" {
     code {
         {
-            /// @src 0:82:153  "contract D {..."
+            /// @src 0:82:166  "contract D {..."
             let _1 := memoryguard(0x80)
             mstore(64, _1)
             if callvalue() { revert(0, 0) }
@@ -23,7 +23,7 @@ object "D_8" {
     object "D_8_deployed" {
         code {
             {
-                /// @src 0:82:153  "contract D {..."
+                /// @src 0:82:166  "contract D {..."
                 mstore(64, 128)
                 if iszero(lt(calldatasize(), 4))
                 {
@@ -32,6 +32,8 @@ object "D_8" {
                     {
                         if callvalue() { revert(_1, _1) }
                         if slt(add(calldatasize(), not(3)), _1) { revert(_1, _1) }
+                        /// @src 0:134:158  "assembly { mstore(0,0) }"
+                        mstore(/** @src 0:82:166  "contract D {..." */ _1, _1)
                         return(128, _1)
                     }
                 }

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -48,7 +48,7 @@ function ens_test
         "${compile_only_presets[@]}"
         #ir-no-optimize           # Compilation fails with "YulException: Variable var__945 is 1 slot(s) too deep inside the stack."
         #ir-optimize-evm-only     # Compilation fails with "YulException: Variable var__945 is 1 slot(s) too deep inside the stack."
-        #ir-optimize-evm+yul      # Compilation fails with "YulException: Variable _5 is 1 too deep in the stack [ _5 usr$i usr$h _7 usr$scratch usr$k usr$f _4 usr$len usr$j_2 RET _2 _1 var_data_mpos usr$totallen usr$x _12 ]"
+        ir-optimize-evm+yul      # Needs memory-safe inline assembly patch
         legacy-optimize-evm-only
         legacy-optimize-evm+yul
     )
@@ -67,6 +67,8 @@ function ens_test
 
     replace_version_pragmas
     neutralize_packaged_contracts
+
+    find . -name "*.sol" -exec sed -i -e 's/^\(\s*\)\(assembly\)/\1\/\/\/ @solidity memory-safe-assembly\n\1\2/' '{}' \;
 
     for preset in $SELECTED_PRESETS; do
         hardhat_run_test "$config_file" "$preset" "${compile_only_presets[*]}" compile_fn test_fn

--- a/test/externalTests/trident.sh
+++ b/test/externalTests/trident.sh
@@ -56,7 +56,7 @@ function trident_test
         "${compile_only_presets[@]}"
         #ir-no-optimize            # Compilation fails with: "YulException: Variable var_amount_165 is 9 slot(s) too deep inside the stack."
         #ir-optimize-evm-only      # Compilation fails with: "YulException: Variable var_amount_165 is 9 slot(s) too deep inside the stack."
-        #ir-optimize-evm+yul       # Compilation fails with: "YulException: Cannot swap Variable var_nearestTick with Variable _4: too deep in the stack by 4 slots"
+        ir-optimize-evm+yul       # Needs memory-safe inline assembly patch
         legacy-no-optimize
         legacy-optimize-evm-only
         legacy-optimize-evm+yul
@@ -87,6 +87,7 @@ function trident_test
     sed -i 's|uint32(-1)|type(uint32).max|g' contracts/flat/BentoBoxV1Flat.sol
     sed -i 's|IERC20(0)|IERC20(address(0))|g' contracts/flat/BentoBoxV1Flat.sol
     sed -i 's|IStrategy(0)|IStrategy(address(0))|g' contracts/flat/BentoBoxV1Flat.sol
+    find contracts -name "*.sol" -exec sed -i -e 's/^\(\s*\)\(assembly\)/\1\/\/\/ @solidity memory-safe-assembly\n\1\2/' '{}' \;
 
     # @sushiswap/core package contains contracts that get built with 0.6.12 and fail our compiler
     # version check. It's not used by tests so we can remove it.

--- a/test/libsolidity/MemoryGuardTest.cpp
+++ b/test/libsolidity/MemoryGuardTest.cpp
@@ -1,0 +1,78 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <test/libsolidity/MemoryGuardTest.h>
+
+#include <test/libyul/Common.h>
+#include <libsolidity/codegen/ir/Common.h>
+#include <libsolutil/Algorithms.h>
+#include <libyul/Object.h>
+#include <libyul/backends/evm/EVMDialect.h>
+#include <libyul/optimiser/FunctionCallFinder.h>
+#include <fstream>
+#include <memory>
+#include <stdexcept>
+
+using namespace std;
+using namespace solidity;
+using namespace solidity::util;
+using namespace solidity::util::formatting;
+using namespace solidity::langutil;
+using namespace solidity::frontend;
+using namespace solidity::frontend::test;
+using namespace yul;
+
+TestCase::TestResult MemoryGuardTest::run(ostream& _stream, string const& _linePrefix, bool _formatted)
+{
+	compiler().reset();
+	compiler().setSources(StringMap{{"", m_source}});
+	compiler().setViaIR(true);
+	compiler().setOptimiserSettings(OptimiserSettings::none());
+	if (!compiler().compile())
+		return TestResult::FatalError;
+
+	m_obtainedResult.clear();
+	for (string contractName: compiler().contractNames())
+	{
+		ErrorList errors;
+		auto [object, analysisInfo] = yul::test::parse(
+			compiler().yulIR(contractName),
+			EVMDialect::strictAssemblyForEVMObjects({}),
+			errors
+		);
+
+		if (!object || !analysisInfo || Error::containsErrors(errors))
+		{
+			AnsiColorized(_stream, _formatted, {formatting::BOLD, formatting::RED}) << _linePrefix << "Error parsing IR." << endl;
+			return TestResult::FatalError;
+		}
+
+		auto handleObject = [&](std::string const& _kind, Object const& _object) {
+			m_obtainedResult += contractName + "(" + _kind + ") " + (FunctionCallFinder::run(
+				*_object.code,
+				"memoryguard"_yulstring
+			).empty() ? "false" : "true") + "\n";
+		};
+		handleObject("creation", *object);
+		size_t deployedIndex = object->subIndexByName.at(
+			YulString(IRNames::deployedObject(compiler().contractDefinition(contractName)))
+		);
+		handleObject("runtime", dynamic_cast<Object const&>(*object->subObjects[deployedIndex]));
+	}
+	return checkResult(_stream, _linePrefix, _formatted);
+}

--- a/test/libsolidity/MemoryGuardTest.h
+++ b/test/libsolidity/MemoryGuardTest.h
@@ -1,0 +1,53 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <test/libsolidity/AnalysisFramework.h>
+#include <test/TestCase.h>
+#include <test/CommonSyntaxTest.h>
+#include <liblangutil/Exceptions.h>
+#include <libsolutil/AnsiColorized.h>
+
+#include <iosfwd>
+#include <string>
+#include <vector>
+#include <utility>
+
+namespace solidity::frontend::test
+{
+
+using solidity::test::SyntaxTestError;
+
+class MemoryGuardTest: public AnalysisFramework, public TestCase
+{
+public:
+	static std::unique_ptr<TestCase> create(Config const& _config)
+	{
+		return std::make_unique<MemoryGuardTest>(_config.filename);
+	}
+	MemoryGuardTest(std::string const& _filename): TestCase(_filename)
+	{
+		m_source = m_reader.source();
+		m_expectation = m_reader.simpleExpectations();
+	}
+
+	TestResult run(std::ostream& _stream, std::string const& _linePrefix = "", bool _formatted = false) override;
+};
+
+}

--- a/test/libsolidity/memoryGuardTests/constructor_safe_deploy_unsafe.sol
+++ b/test/libsolidity/memoryGuardTests/constructor_safe_deploy_unsafe.sol
@@ -1,0 +1,17 @@
+contract C {
+    constructor() {
+        uint256 x;
+        assembly { x := 0 }
+        f();
+    }
+    function f() internal pure {
+        /// @solidity memory-safe-assembly
+        assembly { mstore(0, 0) }
+    }
+    function g() public pure {
+        assembly { mstore(0, 0) }
+    }
+}
+// ----
+// :C(creation) true
+// :C(runtime) false

--- a/test/libsolidity/memoryGuardTests/constructor_unsafe_deploy_safe.sol
+++ b/test/libsolidity/memoryGuardTests/constructor_unsafe_deploy_safe.sol
@@ -1,0 +1,17 @@
+contract C {
+    constructor() {
+        uint256 x;
+        assembly { x := 0 }
+        f();
+    }
+    function f() internal pure {
+        assembly { mstore(0, 0) }
+    }
+    function g() public pure {
+        /// @solidity memory-safe-assembly
+        assembly { mstore(0, 0) }
+    }
+}
+// ----
+// :C(creation) false
+// :C(runtime) true

--- a/test/libsolidity/memoryGuardTests/free_function.sol
+++ b/test/libsolidity/memoryGuardTests/free_function.sol
@@ -1,0 +1,29 @@
+function safe() pure returns (uint256 x) {
+    assembly { x := 42 }
+    /// @solidity memory-safe-assembly
+    assembly { mstore(0, 0) }
+}
+function unsafe() pure returns (uint256 x) {
+    assembly { pop(mload(0)) }
+}
+contract C {
+    constructor() {
+        unsafe();
+    }
+    function f() public pure {
+        safe();
+    }
+}
+contract D {
+    constructor() {
+        safe();
+    }
+    function f() public pure {
+        unsafe();
+    }
+}
+// ----
+// :C(creation) false
+// :C(runtime) true
+// :D(creation) true
+// :D(runtime) false

--- a/test/libsolidity/memoryGuardTests/multi_annotation.sol
+++ b/test/libsolidity/memoryGuardTests/multi_annotation.sol
@@ -1,0 +1,17 @@
+contract C {
+    constructor() {
+        /// @solidity memory-safe-assembly    a memory-safe-assembly
+        assembly { mstore(0, 0) }
+    }
+    function f() internal pure {
+        /// @solidity a memory-safe-assembly
+        assembly { mstore(0, 0) }
+        /// @solidity a
+        ///           memory-safe-assembly
+        ///           b
+        assembly { mstore(0, 0) }
+    }
+}
+// ----
+// :C(creation) true
+// :C(runtime) true

--- a/test/libsolidity/memoryGuardTests/multiple_contracts.sol
+++ b/test/libsolidity/memoryGuardTests/multiple_contracts.sol
@@ -1,0 +1,25 @@
+contract C {
+    constructor(uint256 x) {
+        assembly { x := 4 }
+        /// @solidity memory-safe-assembly
+        assembly { mstore(0, 0) }
+    }
+    function f() public pure {
+        assembly { mstore(0,0) }
+    }
+}
+contract D {
+    constructor() {
+        assembly { mstore(0,0) }
+    }
+    function f(uint256 x) public pure {
+        assembly { x := 4 }
+        /// @solidity memory-safe-assembly
+        assembly { mstore(0, 0) }
+    }
+}
+// ----
+// :C(creation) true
+// :C(runtime) false
+// :D(creation) false
+// :D(runtime) true

--- a/test/libsolidity/memoryGuardTests/safe_and_unmarked_empty.sol
+++ b/test/libsolidity/memoryGuardTests/safe_and_unmarked_empty.sol
@@ -1,0 +1,10 @@
+contract C {
+    function f() external pure {
+        /// @solidity memory-safe-assembly
+        assembly {}
+        assembly {}
+    }
+}
+// ----
+// :C(creation) true
+// :C(runtime) true

--- a/test/libsolidity/memoryGuardTests/safe_and_unmarked_unsafe.sol
+++ b/test/libsolidity/memoryGuardTests/safe_and_unmarked_unsafe.sol
@@ -1,0 +1,10 @@
+contract C {
+    function f() external pure {
+        /// @solidity memory-safe-assembly
+        assembly {}
+        assembly { mstore(0,0) }
+    }
+}
+// ----
+// :C(creation) true
+// :C(runtime) false

--- a/test/libsolidity/memoryGuardTests/stub.sol
+++ b/test/libsolidity/memoryGuardTests/stub.sol
@@ -1,0 +1,4 @@
+contract C {}
+// ----
+// :C(creation) true
+// :C(runtime) true

--- a/test/libsolidity/memoryGuardTests/unmarked_but_no_memory_access.sol
+++ b/test/libsolidity/memoryGuardTests/unmarked_but_no_memory_access.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f(uint256 x, uint256 y) public pure returns (uint256 z){
+        assembly { z := add(x, y) }
+    }
+}
+// ----
+// :C(creation) true
+// :C(runtime) true

--- a/test/libsolidity/memoryGuardTests/unmarked_with_memory_access.sol
+++ b/test/libsolidity/memoryGuardTests/unmarked_with_memory_access.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f() public pure {
+        assembly { mstore(0,0) }
+    }
+}
+// ----
+// :C(creation) true
+// :C(runtime) false

--- a/test/libsolidity/memoryGuardTests/unmarked_with_memory_assignment.sol
+++ b/test/libsolidity/memoryGuardTests/unmarked_with_memory_assignment.sol
@@ -1,0 +1,11 @@
+contract C {
+    function f() public pure {
+        bytes memory x;
+        assembly {
+            x := 0
+        }
+    }
+}
+// ----
+// :C(creation) true
+// :C(runtime) false

--- a/test/libsolidity/semanticTests/externalContracts/prbmath_unsigned.sol
+++ b/test/libsolidity/semanticTests/externalContracts/prbmath_unsigned.sol
@@ -50,7 +50,7 @@ contract test {
 // compileViaYul: also
 // ----
 // constructor()
-// gas irOptimized: 1790188
+// gas irOptimized: 1792108
 // gas legacy: 2250130
 // gas legacyOptimized: 1746528
 // div(uint256,uint256): 3141592653589793238, 88714123 -> 35412542528203691288251815328

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid_natspec.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid_natspec.sol
@@ -9,6 +9,6 @@ contract C {
 	}
 }
 // ----
-// Warning 6269: (60-71): Unexpected natspec tag in inline assembly: test
+// Warning 6269: (60-71): Unexpected NatSpec tag "test" with value "test" in inline assembly.
 // Warning 8787: (95-106): Unexpected value for @solidity tag in inline assembly: test
-// Warning 7828: (122-133): Inline assembly has invalid natspec documentation.
+// Warning 7828: (122-133): Inline assembly has invalid NatSpec documentation.

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid_natspec.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid_natspec.sol
@@ -1,0 +1,14 @@
+contract C {
+	function f() public pure {
+		/// @test test
+		assembly {}
+		/// @solidity test
+		assembly {}
+		/// @param
+		assembly {}
+	}
+}
+// ----
+// Warning 6269: (60-71): Unexpected natspec tag in inline assembly: test
+// Warning 8787: (95-106): Unexpected value for @solidity tag in inline assembly: test
+// Warning 7828: (122-133): Inline assembly has invalid natspec documentation.

--- a/test/libsolidity/syntaxTests/inlineAssembly/natspec_memory_safe.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/natspec_memory_safe.sol
@@ -1,0 +1,6 @@
+contract C {
+	function f() public pure {
+		// @solidity memory-safe-assembly
+		assembly {}
+	}
+}

--- a/test/libsolidity/syntaxTests/inlineAssembly/natspec_multi.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/natspec_multi.sol
@@ -1,0 +1,23 @@
+function f() pure {
+    /// @unrelated bogus-value
+
+    /// @before bogus-value
+    ///
+    /// @solidity a   memory-safe-assembly b    c
+    ///           d
+    /// @after bogus-value
+    assembly {}
+    /// @solidity memory-safe-assembly a a a
+    ///           memory-safe-assembly
+    assembly {}
+}
+// ----
+// Warning 6269: (189-200): Unexpected NatSpec tag "after" with value "bogus-value" in inline assembly.
+// Warning 6269: (189-200): Unexpected NatSpec tag "before" with value "bogus-value" in inline assembly.
+// Warning 8787: (189-200): Unexpected value for @solidity tag in inline assembly: a
+// Warning 8787: (189-200): Unexpected value for @solidity tag in inline assembly: b
+// Warning 8787: (189-200): Unexpected value for @solidity tag in inline assembly: c
+// Warning 8787: (189-200): Unexpected value for @solidity tag in inline assembly: d
+// Warning 8787: (289-300): Unexpected value for @solidity tag in inline assembly: a
+// Warning 4377: (289-300): Value for @solidity tag in inline assembly specified multiple times: a
+// Warning 4377: (289-300): Value for @solidity tag in inline assembly specified multiple times: memory-safe-assembly

--- a/test/libsolidity/syntaxTests/inlineAssembly/natspec_multi_swallowed.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/natspec_multi_swallowed.sol
@@ -1,0 +1,19 @@
+function f() pure {
+    /// @unrelated bogus-value
+
+    /// @before
+    ///
+    /// @solidity a   memory-safe-assembly b    c
+    ///           d
+    /// @after bogus-value
+    assembly {}
+    /// @solidity memory-safe-assembly a a a
+    ///           memory-safe-assembly
+    assembly {}
+}
+// ----
+// Warning 6269: (177-188): Unexpected NatSpec tag "after" with value "bogus-value" in inline assembly.
+// Warning 6269: (177-188): Unexpected NatSpec tag "before" with value "@solidity a   memory-safe-assembly b    c           d" in inline assembly.
+// Warning 8787: (277-288): Unexpected value for @solidity tag in inline assembly: a
+// Warning 4377: (277-288): Value for @solidity tag in inline assembly specified multiple times: a
+// Warning 4377: (277-288): Value for @solidity tag in inline assembly specified multiple times: memory-safe-assembly

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(isoltest
 	../libsolidity/util/TestFileParser.cpp
 	../libsolidity/util/TestFunctionCall.cpp
 	../libsolidity/GasTest.cpp
+	../libsolidity/MemoryGuardTest.cpp
 	../libsolidity/SyntaxTest.cpp
 	../libsolidity/SemanticTest.cpp
 	../libsolidity/AnalysisFramework.cpp


### PR DESCRIPTION
We can also properly make inline assembly ``StructurallyDocumented``, etc, but then we need to double-check that existing natspec-style comments don't cause any errors to keep this fully non-breaking.