### PR TITLE
plain `address` can be sent Ether too 

### DIFF
--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -188,7 +188,8 @@ The address type comes in two flavours, which are largely identical:
 - ``address payable``: Same as ``address``, but with the additional members ``transfer`` and ``send``.
 
 The idea behind this distinction is that ``address payable`` is an address you can send Ether to,
-while a plain ``address`` cannot be sent Ether.
+while you are not supposed to send Ether to a plain ``address``, for example because it might be a smart contract
+that was not built to accept Ether.
 
 Type conversions:
 


### PR DESCRIPTION
The docs state that a plain `address` cannot be sent Ether. But even though `send` and `transfer` members are not available for plain `address`, the `call` is. And to my knowledge, `call` can be invoked upon a plain `address` type to send Ether to the address.

For instance, the `someone` (`address` type) can be sent Ether by invoking `sendSomeone()` method in the following `Dummy` contract:

```
pragma solidity ^0.8.0;

contract Dummy {
    address someone = 0xAb8...cb2;

    function balanceOf(address addr) public view returns (uint) {
        return addr.balance;
    }

    function sendToSomeone() public payable returns (bool) {
        (bool sent, ) = someone.call{value: msg.value}("");
        return sent;
    }
}
```