### PR TITLE
Adjust solc-js installation to match the new release process

### DIFF
--- a/scripts/bytecodecompare/storebytecode.sh
+++ b/scripts/bytecodecompare/storebytecode.sh
@@ -52,7 +52,7 @@ TMPDIR=$(mktemp -d)
         popd
 
         cp "$REPO_ROOT/scripts/bytecodecompare/prepare_report.js" .
-        npm install solc-js/
+        npm install ./solc-js/dist
 
         echo "Running the compiler..."
         # shellcheck disable=SC2035

--- a/scripts/solc-bin/bytecode_reports_for_modified_binaries.sh
+++ b/scripts/solc-bin/bytecode_reports_for_modified_binaries.sh
@@ -149,11 +149,11 @@ for binary_name in $platform_binaries; do
         if [[ $platform == emscripten-wasm32 ]] || [[ $platform == emscripten-asmjs ]]; then
             ln -sf "${solc_bin_dir}/${platform}/${binary_name}" "${solcjs_dir}/soljson.js"
             ln -sf "${solc_bin_dir}/${platform}/${binary_name}" "${solcjs_dir}/dist/soljson.js"
-            ln -s "${solcjs_dir}" solc-js
+            npm install "${solcjs_dir}/dist"
             cp "${script_dir}/bytecodecompare/prepare_report.js" prepare_report.js
 
             validate_reported_version \
-                "$(solc-js/dist/solc.js --version)" \
+                "$(node_modules/solc/solc.js --version)" \
                 "$solidity_version_and_commit"
 
             # shellcheck disable=SC2035

--- a/test/externalTests/colony.sh
+++ b/test/externalTests/colony.sh
@@ -59,7 +59,7 @@ function colony_test
     [[ $BINARY_TYPE == native ]] && replace_global_solc "$BINARY_PATH"
 
     neutralize_package_json_hooks
-    force_truffle_compiler_settings "$config_file" "$BINARY_TYPE" "${DIR}/solc" "$(first_word "$SELECTED_PRESETS")"
+    force_truffle_compiler_settings "$config_file" "$BINARY_TYPE" "${DIR}/solc/dist" "$(first_word "$SELECTED_PRESETS")"
     yarn install
     git submodule update --init
 
@@ -69,10 +69,10 @@ function colony_test
     cd ..
 
     replace_version_pragmas
-    [[ $BINARY_TYPE == solcjs ]] && force_solc_modules "${DIR}/solc"
+    [[ $BINARY_TYPE == solcjs ]] && force_solc_modules "${DIR}/solc/dist"
 
     for preset in $SELECTED_PRESETS; do
-        truffle_run_test "$config_file" "$BINARY_TYPE" "${DIR}/solc" "$preset" "${compile_only_presets[*]}" compile_fn test_fn
+        truffle_run_test "$config_file" "$BINARY_TYPE" "${DIR}/solc/dist" "$preset" "${compile_only_presets[*]}" compile_fn test_fn
     done
 }
 

--- a/test/externalTests/gnosis-v2.sh
+++ b/test/externalTests/gnosis-v2.sh
@@ -63,14 +63,14 @@ function gnosis_safe_test
 
     neutralize_package_lock
     neutralize_package_json_hooks
-    force_truffle_compiler_settings "$config_file" "$BINARY_TYPE" "${DIR}/solc" "$(first_word "$SELECTED_PRESETS")"
+    force_truffle_compiler_settings "$config_file" "$BINARY_TYPE" "${DIR}/solc/dist" "$(first_word "$SELECTED_PRESETS")"
     npm install --package-lock
 
     replace_version_pragmas
-    [[ $BINARY_TYPE == solcjs ]] && force_solc_modules "${DIR}/solc"
+    [[ $BINARY_TYPE == solcjs ]] && force_solc_modules "${DIR}/solc/dist"
 
     for preset in $SELECTED_PRESETS; do
-        truffle_run_test "$config_file" "$BINARY_TYPE" "${DIR}/solc" "$preset" "${compile_only_presets[*]}" compile_fn test_fn
+        truffle_run_test "$config_file" "$BINARY_TYPE" "${DIR}/solc/dist" "$preset" "${compile_only_presets[*]}" compile_fn test_fn
     done
 }
 

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -61,14 +61,14 @@ function gnosis_safe_test
 
     neutralize_package_lock
     neutralize_package_json_hooks
-    force_truffle_compiler_settings "$config_file" "$BINARY_TYPE" "${DIR}/solc" "$(first_word "$SELECTED_PRESETS")"
+    force_truffle_compiler_settings "$config_file" "$BINARY_TYPE" "${DIR}/solc/dist" "$(first_word "$SELECTED_PRESETS")"
     npm install --package-lock
 
     replace_version_pragmas
-    [[ $BINARY_TYPE == solcjs ]] && force_solc_modules "${DIR}/solc"
+    [[ $BINARY_TYPE == solcjs ]] && force_solc_modules "${DIR}/solc/dist"
 
     for preset in $SELECTED_PRESETS; do
-        truffle_run_test "$config_file" "$BINARY_TYPE" "${DIR}/solc" "$preset" "${compile_only_presets[*]}" compile_fn test_fn
+        truffle_run_test "$config_file" "$BINARY_TYPE" "${DIR}/solc/dist" "$preset" "${compile_only_presets[*]}" compile_fn test_fn
     done
 }
 


### PR DESCRIPTION
Related to #12583.

This should fix breakage in [`t_ems_compile_ext_colony`](https://app.circleci.com/pipelines/github/ethereum/solidity/21953/workflows/7f2b69f9-342e-4e85-8684-074134661d8c/jobs/962750) and [`b_bytecode_ems`](https://app.circleci.com/pipelines/github/ethereum/solidity/21953/workflows/7f2b69f9-342e-4e85-8684-074134661d8c/jobs/962749) that came up now that we merged https://github.com/ethereum/solc-js/pull/596.

Our publishing process changed so that now the content of `dist/` is the actual package. S
- ~I adjusted the bytecode compare script so that it now installs from the tarball and gets whatever structure we actually package. This will make it work no matter whether the published content is at the root, in `dist/` or anywhere else.~
    - **EDIT**: This breaks bytecode comparison because `npm run build:tarball` includes the command to download the release binary. Perhaps we should change it so that downloading the binary is a separate step. For now I switched to the solution with hard-coding `dist/` subdir.
- In external tests I'm hard-coding `dist/`. Using the tarball would complicate them too much IMO. This will unfortunately break once we change the structure of solc-js again but the adjustment will be simple.
- The PR check script for solc-bin also needed some adjustments (tested with https://github.com/ethereum/solc-bin/pull/109):
    - I added the `dist/` subdir.
    - I changed it so that installs the package instead of using the repo checkout directly (`prepare-report.js` now requires this).