### PR TITLE
removed comment from Types.h after previous PR rendered it incorrect

### DIFF
--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -864,7 +864,6 @@ protected:
 	std::vector<Type const*> decomposition() const override { return {m_baseType}; }
 
 private:
-	/// String is interpreted as a subtype of Bytes.
 	enum class ArrayKind { Ordinary, Bytes, String };
 
 	bigint unlimitedStaticCalldataSize(bool _padded) const;


### PR DESCRIPTION
Types.h:872 had a comment /// String is interpreted as a subtype of Bytes. - this was now incorrect after #12593 . That has been removed now