### PR TITLE
Re-enable Bleeps external test without the failing governor test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1468,8 +1468,7 @@ workflows:
       - t_ems_ext: *job_native_test_ext_trident
       - t_ems_ext: *job_native_test_ext_euler
       - t_ems_ext: *job_native_test_ext_yield_liquidator
-      # Disabled until we have a fix for https://github.com/wighawag/bleeps/issues/2
-      #-t_ems_ext: *job_native_test_ext_bleeps
+      - t_ems_ext: *job_native_test_ext_bleeps
       - t_ems_ext: *job_native_test_ext_pool_together
       - t_ems_ext: *job_native_test_ext_perpetual_pools
       - t_ems_ext: *job_native_test_ext_uniswap

--- a/test/externalTests/bleeps.sh
+++ b/test/externalTests/bleeps.sh
@@ -72,6 +72,10 @@ function bleeps_test
     sed -i 's/msg\.sender\.transfer(/payable(msg.sender).transfer(/g' src/externals/WETH9.sol
     sed -i 's/^\s*\(Deposit\|Withdrawal\|Approval\|Transfer\)(/emit \1(/g' src/externals/WETH9.sol
 
+    # This test does not currently pass due to an upstream problem.
+    # TODO: Remove this line when https://github.com/wighawag/bleeps/issues/2 is fixed
+    rm test/BleepsDAO.governor.test.ts
+
     neutralize_package_lock
     neutralize_package_json_hooks
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"


### PR DESCRIPTION
This PR adjusts the the workaround from #12611. The problem still has not been fixed upstream and I'm not sure when it will so I thought I'd make the workaround less heavy-handed. Instead of disabling the whole external project, let's disable just the one file where tests fail.

This way we'll still get some useful benchmark output from Bleeps in #12441.