### PR TITLE
Enable full tests in PRBMath external test

### DIFF
--- a/test/externalTests/prb-math.sh
+++ b/test/externalTests/prb-math.sh
@@ -30,7 +30,7 @@ BINARY_PATH="$2"
 SELECTED_PRESETS="$3"
 
 function compile_fn { yarn compile; }
-function test_fn { yarn test:contracts; }
+function test_fn { yarn test; }
 
 function prb_math_test
 {


### PR DESCRIPTION
I just noticed that the `yarn test:contracts` command I used in PRBMath external test does not really run any tests:

See the output of [`t_native_test_ext_prb_math`](https://app.circleci.com/pipelines/github/ethereum/solidity/21988/workflows/5e4223ec-363b-4d67-9d1b-0970d898cb52/jobs/964219/parallel-runs/1):
```
$ yarn mocha --config ./.mocharc.yaml ./test/contracts/**/*.test.ts
$ /tmp/ext-test-PRBMath-WPZPJ9/ext/node_modules/.bin/mocha --config ./.mocharc.yaml ./test/contracts/prbMathSd59x18/PRBMathSD59x18.test.ts ./test/contracts/prbMathUd60x18/PRBMathUD60x18.test.ts


  0 passing (1ms)
```

The full test suite executes 1422 tests when I run it locally and it seems to be testing operations from the contracts too so I think we should switch to that.