### PR TITLE
Clarify symlink handling on Windows

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -94,6 +94,13 @@ dependencies (`evmone <https://github.com/ethereum/evmone/releases>`_,
 On macOS some of the testing scripts expect GNU coreutils to be installed.
 This can be easiest accomplished using Homebrew: ``brew install coreutils``.
 
+On Windows systems make sure that you have a privilege to create symlinks,
+otherwise several tests may fail.
+Administrators should have that privilege, but you may also
+`grant it to other users <https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/create-symbolic-links#policy-management>`_
+or
+`enable Developer Mode <https://docs.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development>`_.
+
 Running the Tests
 -----------------
 

--- a/test/FilesystemUtils.cpp
+++ b/test/FilesystemUtils.cpp
@@ -81,5 +81,6 @@ bool solidity::test::createSymlinkIfSupportedByFilesystem(
 		BOOST_THROW_EXCEPTION(runtime_error(
 			"Failed to create a symbolic link: \"" + _linkName.string() + "\""
 			" -> " + _targetPath.string() + "\"."
+			" " + symlinkCreationError.message() + "."
 		));
 }


### PR DESCRIPTION
Taken from PR #12598.

Windows requires advanced privileges for symlink creation. Adjusted tests and documentation.
