### PR TITLE
Always run Hardhat on node.js 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1137,6 +1137,8 @@ jobs:
 
   t_ems_ext_hardhat:
     <<: *base_node_small
+    docker:
+      - image: circleci/node:16
     environment:
       TERM: xterm
       HARDHAT_TESTS_SOLC_PATH: /tmp/workspace/soljson.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,35 +521,30 @@ defaults:
       name: t_native_test_ext_ens
       project: ens
       binary_type: native
-      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
       nodejs_version: '16'
   - job_native_test_ext_trident: &job_native_test_ext_trident
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_trident
       project: trident
       binary_type: native
-      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
       nodejs_version: '16'
   - job_native_test_ext_euler: &job_native_test_ext_euler
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_euler
       project: euler
       binary_type: native
-      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
       nodejs_version: '16'
   - job_native_test_ext_yield_liquidator: &job_native_test_ext_yield_liquidator
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_yield_liquidator
       project: yield-liquidator
       binary_type: native
-      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
       nodejs_version: '16'
   - job_native_test_ext_bleeps: &job_native_test_ext_bleeps
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_bleeps
       project: bleeps
       binary_type: native
-      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
       nodejs_version: '16'
       resource_class: medium
   - job_native_test_ext_pool_together: &job_native_test_ext_pool_together
@@ -557,35 +552,30 @@ defaults:
       name: t_native_test_ext_pool_together
       project: pool-together
       binary_type: native
-      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
       nodejs_version: '16'
   - job_native_test_ext_perpetual_pools: &job_native_test_ext_perpetual_pools
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_perpetual_pools
       project: perpetual-pools
       binary_type: native
-      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
       nodejs_version: '16'
   - job_native_test_ext_uniswap: &job_native_test_ext_uniswap
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_uniswap
       project: uniswap
       binary_type: native
-      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
       nodejs_version: '16'
   - job_native_test_prb_math: &job_native_test_prb_math
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_prb_math
       project: prb-math
       binary_type: native
-      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
       nodejs_version: '16'
   - job_native_test_ext_elementfi: &job_native_test_ext_elementfi
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_elementfi
       project: elementfi
       binary_type: native
-      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
       nodejs_version: '16'
       resource_class: medium
   - job_ems_test_ext_colony: &job_ems_test_ext_colony

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,7 @@ defaults:
         TERM: xterm
         MAKEFLAGS: -j 2
 
-  - base_node_latest_small: &base_node_latest_small
+  - base_node_small: &base_node_small
       docker:
         - image: circleci/node
       resource_class: small
@@ -605,7 +605,7 @@ jobs:
       - gitter_notify_failure_unless_pr
 
   chk_docs_examples:
-    <<: *base_node_latest_small
+    <<: *base_node_small
     steps:
       - checkout
       - attach_workspace:
@@ -674,7 +674,7 @@ jobs:
       - gitter_notify_failure_unless_pr
 
   chk_buglist:
-    <<: *base_node_latest_small
+    <<: *base_node_small
     steps:
       - checkout
       - run:
@@ -1136,7 +1136,7 @@ jobs:
       - gitter_notify_failure_unless_pr
 
   t_ems_ext_hardhat:
-    <<: *base_node_latest_small
+    <<: *base_node_small
     environment:
       TERM: xterm
       HARDHAT_TESTS_SOLC_PATH: /tmp/workspace/soljson.js
@@ -1339,7 +1339,7 @@ jobs:
       - gitter_notify_failure_unless_pr
 
   b_bytecode_ems:
-    <<: *base_node_latest_small
+    <<: *base_node_small
     environment:
       SOLC_EMSCRIPTEN: "On"
     steps:


### PR DESCRIPTION
[Hardhat has just added a check against unsupported node.js versions](https://github.com/nomiclabs/hardhat/issues/2120). Turns out the core tests worked just fine on 17 though and we've been doing just that. Now `t_ems_ext_hardhat` job fails. This PR switches it to node.js 16.

There are also two tiny refactors:
- `base_node_latest_small` renamed to `base_node_small`. This better reflects the fact that version is just not specified and meshes better with jobs where I override the version.
- The notes about failures on node.js 17 are no longer true. Since it's officially not supported, I just removed them altogether since it's not something to fix.