### PR TITLE
Update docs/cheatsheet.rst

### DIFF
--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -92,7 +92,7 @@ Global Variables
 - ``block.difficulty`` (``uint``): current block difficulty
 - ``block.gaslimit`` (``uint``): current block gaslimit
 - ``block.number`` (``uint``): current block number
-- ``block.timestamp`` (``uint``): current block timestamp
+- ``block.timestamp`` (``uint``): current block timestamp in seconds since Unix epoch
 - ``gasleft() returns (uint256)``: remaining gas
 - ``msg.data`` (``bytes``): complete calldata
 - ``msg.sender`` (``address``): sender of the message (current call)


### PR DESCRIPTION
- Added more description to the bullet point of `block.timestamp` (under 'Global Variables')
  - This was done to have this page more closely match [the "Units and Globally Available Variables" page](https://docs.soliditylang.org/en/latest/units-and-global-variables.html)