### PR TITLE
Highlighted "revert" command

### DIFF
--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -222,7 +222,7 @@ than the maximum value of ``uint`` (``2**256 - 1``). This is also true for the s
 
 :ref:`Errors <errors>` allow you to provide more information to the caller about
 why a condition or operation failed. Errors are used together with the
-:ref:`revert statement <revert-statement>`. The revert statement unconditionally
+:ref:`revert statement <revert-statement>`. The ``revert`` statement unconditionally
 aborts and reverts all changes similar to the ``require`` function, but it also
 allows you to provide the name of an error and additional data which will be supplied to the caller
 (and eventually to the front-end application or block explorer) so that


### PR DESCRIPTION
When reading through the documentation, I found that highlighting was missed for the revert command and added that.