### PR TITLE
Disable running smt tests in ubsan runs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1098,6 +1098,7 @@ jobs:
     parallelism: 20
     environment:
       EVM: << pipeline.parameters.evm-version >>
+      SOLTEST_FLAGS: --no-smt
     <<: *steps_soltest
 
   t_ubu_ubsan_clang_cli:


### PR DESCRIPTION
We should figure out a more selective way to disable errors on allocation issues in Z3/spacer - both for this and for the asan test runs.
But since this is what we do for the asan runs, maybe it's good enough to stop the constant failure notifications for the time being.