### PR TITLE
Bypass an expiration check in ElementFi until it's fixed upstream

### DIFF
--- a/test/externalTests/elementfi.sh
+++ b/test/externalTests/elementfi.sh
@@ -85,6 +85,10 @@ function elementfi_test
     sed -i 's|bytes32(uint256(pool))|bytes32(uint256(uint160(pool)))|g' vault/PoolRegistry.sol
     popd
 
+    # The test suite uses forked mainnet and an expiration period that's too short.
+    # TODO: Remove when https://github.com/element-fi/elf-contracts/issues/243 is fixed.
+    sed -i 's|^\s*require(_expiration - block\.timestamp < _unitSeconds);\s*$||g' contracts/ConvergentCurvePool.sol
+
     # Several tests fail unless we use the exact versions hard-coded in package-lock.json
     #neutralize_package_lock
 


### PR DESCRIPTION
A workaround for https://github.com/element-fi/elf-contracts/issues/243.

ElementFi test suite uses forked mainnet (so `block.timestamp` is 2021-08-15) and then uses an expiration time of half a year in one of the tests. This is too short as of yesterday and started failing: [`t_native_test_ext_elementfi`](https://circleci.com/gh/ethereum/solidity/975855). Until this is fixed, I'm disabling the check.