### PR TITLE
Fix: remove lower_case_with_underscores and Capitalized_Words_With_Underscores

### DIFF
--- a/docs/050-breaking-changes.rst
+++ b/docs/050-breaking-changes.rst
@@ -89,8 +89,8 @@ For most of the topics the compiler will provide suggestions.
 
 * Explicit data location for all variables of struct, array or mapping types is
   now mandatory. This is also applied to function parameters and return
-  variables.  For example, change ``uint[] x = m_x`` to ``uint[] storage x =
-  m_x``, and ``function f(uint[][] x)`` to ``function f(uint[][] memory x)``
+  variables.  For example, change ``uint[] x = z`` to ``uint[] storage x =
+  z``, and ``function f(uint[][] x)`` to ``function f(uint[][] memory x)``
   where ``memory`` is the data location and might be replaced by ``storage`` or
   ``calldata`` accordingly.  Note that ``external`` functions require
   parameters with a data location of ``calldata``.
@@ -483,7 +483,7 @@ New version:
             return data;
         }
 
-        using address_make_payable for address;
+        using AddressMakePayable for address;
         // Data location for 'arr' must be specified
         function g(uint[] memory /* arr */, bytes8 x, OtherContract otherContract, address unknownContract) public payable {
             // 'otherContract.transfer' is not provided.
@@ -500,7 +500,7 @@ New version:
             // 'address payable' should be used whenever possible.
             // To increase clarity, we suggest the use of a library for
             // the conversion (provided after the contract in this example).
-            address payable addr = unknownContract.make_payable();
+            address payable addr = unknownContract.makePayable();
             require(addr.send(1 ether));
 
             // Since uint32 (4 bytes) is smaller than bytes8 (8 bytes),
@@ -516,8 +516,8 @@ New version:
 
     // We can define a library for explicitly converting ``address``
     // to ``address payable`` as a workaround.
-    library address_make_payable {
-        function make_payable(address x) internal pure returns (address payable) {
+    library AddressMakePayable {
+        function makePayable(address x) internal pure returns (address payable) {
             return address(uint160(x));
         }
     }

--- a/docs/assembly.rst
+++ b/docs/assembly.rst
@@ -45,19 +45,19 @@ Solidity language without a compiler change.
     pragma solidity >=0.4.16 <0.9.0;
 
     library GetCode {
-        function at(address _addr) public view returns (bytes memory o_code) {
+        function at(address _addr) public view returns (bytes memory code) {
             assembly {
                 // retrieve the size of the code, this needs assembly
                 let size := extcodesize(_addr)
                 // allocate output byte array - this could also be done without assembly
-                // by using o_code = new bytes(size)
-                o_code := mload(0x40)
+                // by using code = new bytes(size)
+                code := mload(0x40)
                 // new "memory end" including padding
-                mstore(0x40, add(o_code, and(add(add(size, 0x20), 0x1f), not(0x1f))))
+                mstore(0x40, add(code, and(add(add(size, 0x20), 0x1f), not(0x1f))))
                 // store length in memory
-                mstore(o_code, size)
+                mstore(code, size)
                 // actually retrieve the code, this needs assembly
-                extcodecopy(_addr, add(o_code, 0x20), 0, size)
+                extcodecopy(_addr, add(code, 0x20), 0, size)
             }
         }
     }

--- a/docs/contracts/functions.rst
+++ b/docs/contracts/functions.rst
@@ -102,10 +102,10 @@ two integers passed as function parameters, then you use something like:
         function arithmetic(uint _a, uint _b)
             public
             pure
-            returns (uint o_sum, uint o_product)
+            returns (uint sum, uint product)
         {
-            o_sum = _a + _b;
-            o_product = _a * _b;
+            sum = _a + _b;
+            product = _a * _b;
         }
     }
 
@@ -129,7 +129,7 @@ statement:
         function arithmetic(uint _a, uint _b)
             public
             pure
-            returns (uint o_sum, uint o_product)
+            returns (uint sum, uint product)
         {
             return (_a + _b, _a * _b);
         }

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -204,7 +204,7 @@ Yes:
 
 .. code-block:: solidity
 
-    thisIsALongNestedMapping[being][set][to_some_value] = someFunction(
+    thisIsALongNestedMapping[being][set][toSomeValue] = someFunction(
         argument1,
         argument2,
         argument3,
@@ -215,7 +215,7 @@ No:
 
 .. code-block:: solidity
 
-    thisIsALongNestedMapping[being][set][to_some_value] = someFunction(argument1,
+    thisIsALongNestedMapping[being][set][toSomeValue] = someFunction(argument1,
                                                                        argument2,
                                                                        argument3,
                                                                        argument4);
@@ -439,15 +439,15 @@ Yes:
 
     x = 1;
     y = 2;
-    long_variable = 3;
+    longVariable = 3;
 
 No:
 
 .. code-block:: solidity
 
-    x             = 1;
-    y             = 2;
-    long_variable = 3;
+    x            = 1;
+    y            = 2;
+    longVariable = 3;
 
 Don't include a whitespace in the receive and fallback functions:
 
@@ -1092,12 +1092,10 @@ naming styles.
 * ``b`` (single lowercase letter)
 * ``B`` (single uppercase letter)
 * ``lowercase``
-* ``lower_case_with_underscores``
 * ``UPPERCASE``
 * ``UPPER_CASE_WITH_UNDERSCORES``
 * ``CapitalizedWords`` (or CapWords)
 * ``mixedCase`` (differs from CapitalizedWords by initial lowercase character!)
-* ``Capitalized_Words_With_Underscores``
 
 .. note:: When using initialisms in CapWords, capitalize all the letters of the initialisms. Thus HTTPServerError is better than HttpServerError. When using initialisms in mixedCase, capitalize all the letters of the initialisms, except keep the first one lower case if it is the beginning of the name. Thus xmlHTTPRequest is better than XMLHTTPRequest.
 
@@ -1256,7 +1254,7 @@ Enums, in the style of simple type declarations, should be named using the CapWo
 Avoiding Naming Collisions
 ==========================
 
-* ``single_trailing_underscore_``
+* ``singleTrailingUnderscore_``
 
 This convention is suggested when the desired name collides with that of a
 built-in or otherwise reserved name.

--- a/docs/types/mapping-types.rst
+++ b/docs/types/mapping-types.rst
@@ -166,22 +166,22 @@ the ``sum`` function iterates over to sum all the values.
             return self.data[key].keyIndex > 0;
         }
 
-        function iterate_start(itmap storage self) internal view returns (uint keyIndex) {
-            return iterate_next(self, type(uint).max);
+        function iterateStart(itmap storage self) internal view returns (uint keyIndex) {
+            return iterateNext(self, type(uint).max);
         }
 
-        function iterate_valid(itmap storage self, uint keyIndex) internal view returns (bool) {
+        function iterateValid(itmap storage self, uint keyIndex) internal view returns (bool) {
             return keyIndex < self.keys.length;
         }
 
-        function iterate_next(itmap storage self, uint keyIndex) internal view returns (uint r_keyIndex) {
+        function iterateNext(itmap storage self, uint keyIndex) internal view returns (uint r_keyIndex) {
             keyIndex++;
             while (keyIndex < self.keys.length && self.keys[keyIndex].deleted)
                 keyIndex++;
             return keyIndex;
         }
 
-        function iterate_get(itmap storage self, uint keyIndex) internal view returns (uint key, uint value) {
+        function iterateGet(itmap storage self, uint keyIndex) internal view returns (uint key, uint value) {
             key = self.keys[keyIndex].key;
             value = self.data[key].value;
         }
@@ -206,11 +206,11 @@ the ``sum`` function iterates over to sum all the values.
         // Computes the sum of all stored data.
         function sum() public view returns (uint s) {
             for (
-                uint i = data.iterate_start();
-                data.iterate_valid(i);
-                i = data.iterate_next(i)
+                uint i = data.iterateStart();
+                data.iterateValid(i);
+                i = data.iterateNext(i)
             ) {
-                (, uint value) = data.iterate_get(i);
+                (, uint value) = data.iterateGet(i);
                 s += value;
             }
         }

--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -190,11 +190,11 @@ If you want to use string parameters or other types that are not implicitly conv
     contract C {
         string s = "Storage";
         function f(bytes calldata bc, string memory sm, bytes16 b) public view {
-            string memory concat_string = string.concat(s, string(bc), "Literal", sm);
-            assert((bytes(s).length + bc.length + 7 + bytes(sm).length) == bytes(concat_string).length);
+            string memory concatString = string.concat(s, string(bc), "Literal", sm);
+            assert((bytes(s).length + bc.length + 7 + bytes(sm).length) == bytes(concatString).length);
 
-            bytes memory concat_bytes = bytes.concat(bytes(s), bc, bc[:2], "Literal", bytes(sm), b);
-            assert((bytes(s).length + bc.length + 2 + 7 + bytes(sm).length + b.length) == concat_bytes.length);
+            bytes memory concatBytes = bytes.concat(bytes(s), bc, bc[:2], "Literal", bytes(sm), b);
+            assert((bytes(s).length + bc.length + 2 + 7 + bytes(sm).length + b.length) == concatBytes.length);
         }
     }
 
@@ -376,20 +376,20 @@ Array Members
     pragma solidity >=0.6.0 <0.9.0;
 
     contract ArrayContract {
-        uint[2**20] m_aLotOfIntegers;
+        uint[2**20] aLotOfIntegers;
         // Note that the following is not a pair of dynamic arrays but a
         // dynamic array of pairs (i.e. of fixed size arrays of length two).
         // Because of that, T[] is always a dynamic array of T, even if T
         // itself is an array.
         // Data location for all state variables is storage.
-        bool[2][] m_pairsOfFlags;
+        bool[2][] pairsOfFlags;
 
         // newPairs is stored in memory - the only possibility
         // for public contract function arguments
         function setAllFlagPairs(bool[2][] memory newPairs) public {
             // assignment to a storage array performs a copy of ``newPairs`` and
-            // replaces the complete array ``m_pairsOfFlags``.
-            m_pairsOfFlags = newPairs;
+            // replaces the complete array ``pairsOfFlags``.
+            pairsOfFlags = newPairs;
         }
 
         struct StructType {
@@ -411,45 +411,45 @@ Array Members
 
         function setFlagPair(uint index, bool flagA, bool flagB) public {
             // access to a non-existing index will throw an exception
-            m_pairsOfFlags[index][0] = flagA;
-            m_pairsOfFlags[index][1] = flagB;
+            pairsOfFlags[index][0] = flagA;
+            pairsOfFlags[index][1] = flagB;
         }
 
         function changeFlagArraySize(uint newSize) public {
             // using push and pop is the only way to change the
             // length of an array
-            if (newSize < m_pairsOfFlags.length) {
-                while (m_pairsOfFlags.length > newSize)
-                    m_pairsOfFlags.pop();
-            } else if (newSize > m_pairsOfFlags.length) {
-                while (m_pairsOfFlags.length < newSize)
-                    m_pairsOfFlags.push();
+            if (newSize < pairsOfFlags.length) {
+                while (pairsOfFlags.length > newSize)
+                    pairsOfFlags.pop();
+            } else if (newSize > pairsOfFlags.length) {
+                while (pairsOfFlags.length < newSize)
+                    pairsOfFlags.push();
             }
         }
 
         function clear() public {
             // these clear the arrays completely
-            delete m_pairsOfFlags;
-            delete m_aLotOfIntegers;
+            delete pairsOfFlags;
+            delete aLotOfIntegers;
             // identical effect here
-            m_pairsOfFlags = new bool[2][](0);
+            pairsOfFlags = new bool[2][](0);
         }
 
-        bytes m_byteData;
+        bytes byteData;
 
         function byteArrays(bytes memory data) public {
             // byte arrays ("bytes") are different as they are stored without padding,
             // but can be treated identical to "uint8[]"
-            m_byteData = data;
+            byteData = data;
             for (uint i = 0; i < 7; i++)
-                m_byteData.push();
-            m_byteData[3] = 0x08;
-            delete m_byteData[2];
+                byteData.push();
+            byteData[3] = 0x08;
+            delete byteData[2];
         }
 
         function addFlag(bool[2] memory flag) public returns (uint) {
-            m_pairsOfFlags.push(flag);
-            return m_pairsOfFlags.length;
+            pairsOfFlags.push(flag);
+            return pairsOfFlags.length;
         }
 
         function createMemoryArray(uint size) public pure returns (bytes memory) {


### PR DESCRIPTION
The style guide specifically calls for the use of `mixedCase` (aka camelCase) when naming functions, function arguments, local and state variables, and modifiers.

We acknowledge that the style guide does not specifically forbid the use of lower_case_with_underscores and Capitalized_Words_With_Underscores, the style guide is based on PEP-8 (and Python does use snake_case) and further more that many users enjoy using snake_case.

However, if for no other reason than consistency, we should avoid using those style in the code examples throughout the documentation, and for the most part we do.

This pr removes the use of lower_case_with_underscores and Capitalized_Words_With_Underscores in all .rst files and references to those cases in the style guide.
