### PR TITLE
tweak: expand definition of suggested collision naming convention

### DIFF
--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -1258,7 +1258,8 @@ Avoiding Naming Collisions
 
 * ``single_trailing_underscore_``
 
-This convention is suggested when the desired name collides with that of an existing state variable, function, built-in or otherwise reserved name.
+This convention is suggested when the desired name collides with that of
+an existing state variable, function, built-in or otherwise reserved name.
 
 .. _style_guide_natspec:
 

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -1258,8 +1258,7 @@ Avoiding Naming Collisions
 
 * ``single_trailing_underscore_``
 
-This convention is suggested when the desired name collides with that of a
-built-in or otherwise reserved name.
+This convention is suggested when the desired name collides with that of an existing state variable, function, built-in or otherwise reserved name.
 
 .. _style_guide_natspec:
 


### PR DESCRIPTION
The [current style guide](https://github.com/ethereum/solidity/blob/v0.8.11/docs/style-guide.rst#avoiding-naming-collisions) suggests the use of trailing _ when the desired name of a function or variable collides with a built-in or otherwise reserved word.

However, this convention is widely used to not only apply to reserved words but also to include cases when the name would shadow an existing function or state variable name.

This pr attempts to expand the suggestion to include collisions with existing function or state variable names.