### PR TITLE
tweak: update maximum line length

### DIFF
--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -146,8 +146,7 @@ No:
 Maximum Line Length
 ===================
 
-Keeping lines under the `PEP 8 recommendation <https://www.python.org/dev/peps/pep-0008/#maximum-line-length>`_ to a maximum of 79 (or 99)
-characters helps readers easily parse the code.
+Maximum suggested line length is 120 characters.
 
 Wrapped lines should conform to the following guidelines.
 


### PR DESCRIPTION
A maximum line length of 79 characters is antiquated.  Github allows 140 character widths and etherscan shows 233 characters when displaying verified contracts.  

We should suggest a maximum of 120 and we can still reference the PEP8's maximum allowed 99 characters.