### PR TITLE
Neutralize packaged Uniswap contracts in yield-liquidator external test

### DIFF
--- a/test/externalTests/yield-liquidator.sh
+++ b/test/externalTests/yield-liquidator.sh
@@ -67,6 +67,7 @@ function yield_liquidator_test
     npm install
 
     replace_version_pragmas
+    neutralize_packaged_contracts
 
     for preset in $SELECTED_PRESETS; do
         hardhat_run_test "$config_file" "$preset" "${compile_only_presets[*]}" compile_fn test_fn "$config_var"


### PR DESCRIPTION
[`t_native_test_ext_yield_liquidator` job](https://app.circleci.com/pipelines/github/ethereum/solidity/22275/workflows/853f6bee-755e-45c4-a089-a5ee256c5a9f/jobs/977631) is failing:

```
Verify that the correct version (0.8.12/0.8.12-ci.2022.2.16+commit.f00d7308.Linux.g++) of the compiler was used to compile the contracts...
Wrong compiler version detected in ./node_modules/@uniswap/v3-periphery/artifacts/build-info/058253c6bdb3c3ee13532b82174ce36d.json.
```

The issue is that the project now apparently pulls in `@uniswap/v3-periphery`, which comes with prebuilt Hardhat artifacts. We want to be 100% everything is build from scratch using the latest compiler so have a check that detects them and fails. Deleting them resolves the problem.