### PR TITLE
Fix running path-related tests from any Windows drive

### DIFF
--- a/libsolidity/interface/FileReader.h
+++ b/libsolidity/interface/FileReader.h
@@ -115,6 +115,17 @@ public:
 		SymlinkResolution _symlinkResolution = SymlinkResolution::Disabled
 	);
 
+	/// Normalizes a root path by excluding, in some cases, its root name.
+	/// The function is used for better portability, and intended to omit root name
+	/// if the path can be used without it.
+	/// @param _path Path to normalize the root path.
+	/// @param _workDir Current working directory path, must be absolute.
+	/// @returns a normalized root path.
+	static boost::filesystem::path normalizeCLIRootPathForVFS(
+		boost::filesystem::path const& _path,
+		boost::filesystem::path const& _workDir = boost::filesystem::current_path()
+	);
+
 	/// @returns true if all the path components of @a _prefix are present at the beginning of @a _path.
 	/// Both paths must be absolute (or have slash as root) and normalized (no . or .. segments, no
 	/// multiple consecutive slashes).

--- a/test/libsolidity/interface/FileReader.cpp
+++ b/test/libsolidity/interface/FileReader.cpp
@@ -313,8 +313,9 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_should_not_resolve_symlinks_unless_r
 	if (!createSymlinkIfSupportedByFilesystem(tempDir.path() / "abc", tempDir.path() / "sym", true))
 		return;
 
-	boost::filesystem::path expectedPrefixWithSymlinks = "/" / tempDir.path().relative_path();
-	boost::filesystem::path expectedPrefixWithoutSymlinks = "/" / boost::filesystem::weakly_canonical(tempDir).relative_path();
+	boost::filesystem::path expectedRootPath = FileReader::normalizeCLIRootPathForVFS(tempDir);
+	boost::filesystem::path expectedPrefixWithSymlinks = expectedRootPath / tempDir.path().relative_path();
+	boost::filesystem::path expectedPrefixWithoutSymlinks = expectedRootPath / boost::filesystem::weakly_canonical(tempDir).relative_path();
 
 	BOOST_CHECK_EQUAL(
 		FileReader::normalizeCLIPathForVFS(tempDir.path() / "sym/contract.sol", SymlinkResolution::Disabled),

--- a/test/solc/CommandLineInterface.cpp
+++ b/test/solc/CommandLineInterface.cpp
@@ -178,8 +178,9 @@ BOOST_AUTO_TEST_CASE(cli_input)
 	createFilesWithParentDirs({tempDir1.path() / "input1.sol"});
 	createFilesWithParentDirs({tempDir2.path() / "input2.sol"});
 
-	boost::filesystem::path expectedDir1 = "/" / tempDir1.path().relative_path();
-	boost::filesystem::path expectedDir2 = "/" / tempDir2.path().relative_path();
+	boost::filesystem::path expectedRootPath = FileReader::normalizeCLIRootPathForVFS(tempDir1);
+	boost::filesystem::path expectedDir1 = expectedRootPath / tempDir1.path().relative_path();
+	boost::filesystem::path expectedDir2 = expectedRootPath / tempDir2.path().relative_path();
 	soltestAssert(expectedDir1.is_absolute() || expectedDir1.root_path() == "/", "");
 	soltestAssert(expectedDir2.is_absolute() || expectedDir2.root_path() == "/", "");
 
@@ -223,7 +224,8 @@ BOOST_AUTO_TEST_CASE(cli_ignore_missing_some_files_exist)
 	TemporaryDirectory tempDir2(TEST_CASE_NAME);
 	createFilesWithParentDirs({tempDir1.path() / "input1.sol"});
 
-	boost::filesystem::path expectedDir1 = "/" / tempDir1.path().relative_path();
+	boost::filesystem::path expectedRootPath = FileReader::normalizeCLIRootPathForVFS(tempDir1);
+	boost::filesystem::path expectedDir1 = expectedRootPath / tempDir1.path().relative_path();
 	soltestAssert(expectedDir1.is_absolute() || expectedDir1.root_path() == "/", "");
 
 	// NOTE: Allowed paths should not be added for skipped files.


### PR DESCRIPTION
Currently a couple of tests expect the temp directory and the current working directory to be located on the same drive.

As a result, in a popular Windows setup when the system is installed on `C:` (so the default temp directory is on `C:`) and projects are on `D:`, these tests fail.

This PR adjusts the test expectations.

(I'm not fully satisfied though. In an ideal case we would need to run tests from different drives. But I am not even sure if our Windows CI has `D:`, and if that corner case worth the troubles.)
