### PR TITLE
cmake/EthCompilerSettings.cmake: generator expression fix for ninja.

### DIFF
--- a/cmake/EthCompilerSettings.cmake
+++ b/cmake/EthCompilerSettings.cmake
@@ -54,9 +54,10 @@ if (("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MA
 	add_compile_options(-Wsign-conversion)
 	add_compile_options(-Wconversion)
 
-	eth_add_cxx_compiler_flag_if_supported(
-		$<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>
-	)
+	check_cxx_compiler_flag(-Wextra-semi WEXTRA_SEMI)
+	if(WEXTRA_SEMI)
+		add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wextra-semi>)
+	endif()
 	eth_add_cxx_compiler_flag_if_supported(-Wfinal-dtor-non-final-class)
 	eth_add_cxx_compiler_flag_if_supported(-Wnewline-eof)
 	eth_add_cxx_compiler_flag_if_supported(-Wsuggest-destructor-override)


### PR DESCRIPTION
If Ninja is used a CMake generator, it is not possible to build Solidity due to an error `bad $-escape (literal $ must be written as $$)`.

```
➜  build git:(develop) CMAKE_GENERATOR=Ninja cmake ..
-- The C compiler identification is AppleClang 13.0.0.13000029
-- The CXX compiler identification is AppleClang 13.0.0.13000029
...
-- Performing Test $<$<COMPILE_LANGUAGECXX>-Wextra-semi>
CMake Error:
  Running

   '/opt/homebrew/bin/ninja' '-C' '/tmp/new/solidity/build/CMakeFiles/CMakeTmp' '-t' 'recompact'

  failed with:

   ninja: error: build.ninja:49: bad $-escape (literal $ must be written as $$)





CMake Error at /opt/homebrew/Cellar/cmake/3.22.2/share/cmake/Modules/Internal/CheckSourceCompiles.cmake:92 (try_compile):
  Failed to generate test project build system.
Call Stack (most recent call first):
  /opt/homebrew/Cellar/cmake/3.22.2/share/cmake/Modules/Internal/CheckCompilerFlag.cmake:71 (cmake_check_source_compiles)
  /opt/homebrew/Cellar/cmake/3.22.2/share/cmake/Modules/CheckCXXCompilerFlag.cmake:40 (cmake_check_compiler_flag)
  cmake/EthCheckCXXCompilerFlag.cmake:16 (check_cxx_compiler_flag)
  cmake/EthCompilerSettings.cmake:57 (eth_add_cxx_compiler_flag_if_supported)
  CMakeLists.txt:52 (include)


-- Configuring incomplete, errors occurred!
```