### PR TITLE
scripts/common.sh: 'diff --color' not supported by macOS.

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -180,7 +180,7 @@ function diff_values
     shift
     shift
 
-    diff --color=auto --unified=0 <(echo "$value1") <(echo "$value2") "$@"
+    diff --unified=0 <(echo "$value1") <(echo "$value2") "$@"
 }
 
 function safe_kill


### PR DESCRIPTION
`diff --color` is not supported in macOS.

```
➜  ~ diff --color=auto
diff: unrecognized option `--color=auto'
diff: Try `diff --help' for more information.
```