### PR TITLE
[ci] Add simple build job using ninja.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,10 @@ defaults:
       name: Build
       command: scripts/ci/build.sh
 
+  - run_build_ninja: &run_build_ninja
+      name: Build (Ninja)
+      command: scripts/ci/build_ninja.sh
+
   - run_build_ossfuzz: &run_build_ossfuzz
       name: Build_ossfuzz
       command: scripts/ci/build_ossfuzz.sh
@@ -213,6 +217,11 @@ defaults:
             name: Executing solc LSP test suite
             command: ./test/lsp.py ./build/solc/solc
         - gitter_notify_failure_unless_pr
+
+  - steps_build_ninja: &steps_build_ninja
+      steps:
+        - checkout
+        - run: *run_build_ninja
 
   - steps_build: &steps_build
       steps:
@@ -759,6 +768,12 @@ jobs:
     # Enough other jobs depend on it that it's worth it though.
     <<: *base_ubuntu2004_xlarge
     <<: *steps_build
+
+  b_ubu_ninja: &b_ubu_ninja
+    # this runs 2x faster on xlarge but takes 4x more resources (compared to medium).
+    # Enough other jobs depend on it that it's worth it though.
+    <<: *base_ubuntu2004
+    <<: *steps_build_ninja
 
   # x64 ASAN build, for testing for memory related bugs
   b_ubu_asan: &b_ubu_asan
@@ -1448,6 +1463,7 @@ workflows:
 
       # Ubuntu build and tests
       - b_ubu: *workflow_trigger_on_tags
+      - b_ubu_ninja: *workflow_trigger_on_tags
       - t_ubu_cli: *workflow_ubuntu2004
       - t_ubu_soltest_all: *workflow_ubuntu2004
       - t_ubu_soltest_enforce_yul: *workflow_ubuntu2004

--- a/scripts/ci/build_ninja.sh
+++ b/scripts/ci/build_ninja.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -ex
+
+ROOTDIR="$(dirname "$0")/../.."
+cd "${ROOTDIR}"
+
+# shellcheck disable=SC2166
+if [ "$CIRCLE_BRANCH" = release -o -n "$CIRCLE_TAG" -o -n "$FORCE_RELEASE" ]
+then
+    echo -n "" >prerelease.txt
+else
+    # Use last commit date rather than build date to avoid ending up with builds for
+    # different platforms having different version strings (and therefore producing different bytecode)
+    # if the CI is triggered just before midnight.
+    TZ=UTC git show --quiet --date="format-local:%Y.%-m.%-d" --format="ci.%cd" >prerelease.txt
+fi
+
+if [ -n "$CIRCLE_SHA1" ]
+then
+    echo -n "$CIRCLE_SHA1" >commit_hash.txt
+fi
+
+mkdir -p build
+cd build
+
+# shellcheck disable=SC2086
+cmake --version
+cmake .. -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}" $CMAKE_OPTIONS -G "Ninja"
+ninja -j 4


### PR DESCRIPTION
It seem to be quite annoying to build with ninja on circleci. I tried to let it run with `base_ubuntu2004` but there the OOM Killer was always killing the compiler. Even `base_ubuntu2004_xlarge` was not able to let the build finish.

However, maybe its enough to just do 
```
cmake .. -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}" $CMAKE_OPTIONS -G "Ninja"
```
Maybe this is enough to check the written cmake files more pedantically.

However, the interesting thing is that the problem of https://github.com/ethereum/solidity/pull/12702 is not happening in CI. CI uses ninja `1.10.0`, I used `1.10.2`.