### PR TITLE
SAT solver binary, proof logging, min-2-long cls, vector tristate

### DIFF
--- a/libsolutil/CDCL.cpp
+++ b/libsolutil/CDCL.cpp
@@ -385,4 +385,3 @@ void CDCL::write_final_proof_clauses()
 	}
 	*proof << "f " << unsat_clause_ID << " 0\n";
 }
-

--- a/libsolutil/CDCL.cpp
+++ b/libsolutil/CDCL.cpp
@@ -319,7 +319,7 @@ void CDCL::enqueue(Literal const& _literal, Clause const* _reason)
 		cout << "  because of " << toString(*_reason) << endl;
 
 	assert(value(_literal) == TriState::t_unset());
-	m_assignments[_literal.variable] = _literal.positive;
+	m_assignments[_literal.variable] = TriState(_literal.positive);
 	m_levelForVariable[_literal.variable] = currentDecisionLevel();
 	if (_reason)
 		m_reason[_literal] = _reason;

--- a/libsolutil/CDCL.cpp
+++ b/libsolutil/CDCL.cpp
@@ -75,7 +75,7 @@ optional<CDCL::Model> CDCL::solve()
 				{
 					unsat_clause_ID = clauseID++;
 					*proof << "a " << unsat_clause_ID << " 0\n";
-					write_final_proof_clauses();
+					writeFinalProofClauses();
 				}
 				return nullopt;
 			}
@@ -290,7 +290,7 @@ void CDCL::addClause(const vector<Literal>& _lits)
 	{
 		unsat_clause_ID = clauseID++;
 		*proof << "a " << unsat_clause_ID << " 0\n";
-		write_final_proof_clauses();
+		writeFinalProofClauses();
 		ok = false;
 		return;
 	}

--- a/libsolutil/CDCL.cpp
+++ b/libsolutil/CDCL.cpp
@@ -376,7 +376,7 @@ string CDCL::toProofString(Clause const& _clause) const
 	return joinHumanReadable(literals, " ");
 }
 
-void CDCL::write_final_proof_clauses()
+void CDCL::writeFinalProofClauses()
 {
 	assert(proof);
 	assert(unsat_clause_ID != 0);

--- a/libsolutil/CDCL.cpp
+++ b/libsolutil/CDCL.cpp
@@ -39,7 +39,7 @@ CDCL::CDCL(
 	m_variables(move(_variables)),
 	proof(_proof)
 {
-	m_assignments.resize(m_variables.size(), TriState::tristate_unset);
+	m_assignments.resize(m_variables.size(), tristate_unset);
 	for (const auto& clause: _clauses)
 		addClause(clause);
 
@@ -113,7 +113,7 @@ optional<CDCL::Model> CDCL::solve()
 			{
 				cout << "satisfiable." << endl;
 				for (size_t i = 0; i < m_assignments.size(); i++)
-					cout << " " << i << ": " << triStateToString(m_assignments[i]) << endl;
+					cout << " " << i << ": " << m_assignments[i].toString() << endl;
 				return m_assignments;
 			}
 		}
@@ -316,7 +316,7 @@ void CDCL::enqueue(Literal const& _literal, Clause const* _reason)
 		cout << "  because of " << toString(*_reason) << endl;
 
 	assert(!isAssigned(_literal));
-	m_assignments[_literal.variable] = boolToTriState(_literal.positive);
+	m_assignments[_literal.variable] = _literal.positive;
 	m_levelForVariable[_literal.variable] = currentDecisionLevel();
 	if (_reason)
 		m_reason[_literal] = _reason;
@@ -334,7 +334,7 @@ void CDCL::cancelUntil(size_t _backtrackLevel)
 		Literal l = m_assignmentTrail.back();
 		cout << "  undoing " << toString(l) << endl;
 		m_assignmentTrail.pop_back();
-		m_assignments[l.variable] = TriState::tristate_unset;
+		m_assignments[l.variable] = tristate_unset;
 		m_reason.erase(l);
 		// TODO maybe could do without.
 		m_levelForVariable.erase(l.variable);
@@ -347,7 +347,7 @@ void CDCL::cancelUntil(size_t _backtrackLevel)
 optional<size_t> CDCL::nextDecisionVariable() const
 {
 	for (size_t i = 0; i < m_variables.size(); i++)
-		if (m_assignments[i] == TriState::tristate_unset)
+		if (m_assignments[i] == tristate_unset)
 			return i;
 	return nullopt;
 }

--- a/libsolutil/CDCL.cpp
+++ b/libsolutil/CDCL.cpp
@@ -72,7 +72,7 @@ optional<CDCL::Model> CDCL::solve()
 				ok = false;
 				if (proof) {
 					unsat_clause_ID = clauseID++;
-					*proof << "a " << unsat_clause_ID << "0\n";
+					*proof << "a " << unsat_clause_ID << " 0\n";
 					write_final_proof_clauses();
 				}
 				return nullopt;
@@ -80,7 +80,7 @@ optional<CDCL::Model> CDCL::solve()
 			auto&& [learntClause, backtrackLevel] = analyze(move(*conflictClause));
 			cancelUntil(backtrackLevel);
 			if (proof) {
-				*proof << "a " << learntClause.ID << toProofString(learntClause) << "0\n";
+				*proof << "a " << learntClause.ID << " " << toProofString(learntClause) << " 0\n";
 			}
 			solAssert(!learntClause.empty());
 			solAssert(!isAssigned(learntClause.front()));
@@ -260,7 +260,7 @@ void CDCL::addClause(const vector<Literal>& _lits)
 
 	Clause _clause {_lits, clauseID++};
 	if (proof) {
-		*proof <<  "o " << _clause.ID << toProofString(_clause) + string("0\n");
+		*proof <<  "o " << _clause.ID << " " << toProofString(_clause) << " 0\n";
 	}
 
 	Clause _clause_updated;
@@ -278,14 +278,14 @@ void CDCL::addClause(const vector<Literal>& _lits)
 	}
 
 	if (proof) {
-		*proof << "a " << _clause_updated.ID << toProofString(_clause_updated) << "0\n";
-		*proof << "d " << _clause.ID << toProofString(_clause) << "0\n";
+		*proof << "a " << _clause_updated.ID << " " << toProofString(_clause_updated) << " 0\n";
+		*proof << "d " << _clause.ID << " " << toProofString(_clause) << " 0\n";
 	}
 
 	// Empty clause, set UNSAT and return.
 	if (_clause_updated.lits.size() == 0) {
 		unsat_clause_ID = clauseID++;
-		*proof << "a " << unsat_clause_ID << "0\n";
+		*proof << "a " << unsat_clause_ID << " 0\n";
 		write_final_proof_clauses();
 		ok = false;
 		return;
@@ -381,7 +381,7 @@ string CDCL::toString(Literal const& _literal) const
 
 string CDCL::toProofString(Literal const& _literal) const
 {
-	return (_literal.positive ? "" : "-") + m_variables.at(_literal.variable);
+	return (_literal.positive ? "" : "-") + std::to_string(_literal.variable+1);
 }
 
 string CDCL::toString(Clause const& _clause) const
@@ -406,11 +406,11 @@ void CDCL::write_final_proof_clauses()
 	assert(unsat_clause_ID != 0);
 
 	for(const auto& cl: m_clauses) {
-		*proof << "f " << cl->ID << toProofString(*cl) << "0\n";
+		*proof << "f " << cl->ID << " " << toProofString(*cl) << " 0\n";
 	}
 	for(const auto& units: unit_cl_IDs) {
-		*proof << "f " << units.second << toProofString(units.first) << "0\n";
+		*proof << "f " << units.second << " " << toProofString(units.first) << " 0\n";
 	}
-	*proof << "f " << unsat_clause_ID << "0\n";
+	*proof << "f " << unsat_clause_ID << " 0\n";
 }
 

--- a/libsolutil/CDCL.cpp
+++ b/libsolutil/CDCL.cpp
@@ -71,7 +71,8 @@ optional<CDCL::Model> CDCL::solve()
 			{
 				cout << "Unsatisfiable" << endl;
 				ok = false;
-				if (proof) {
+				if (proof)
+				{
 					unsat_clause_ID = clauseID++;
 					*proof << "a " << unsat_clause_ID << " 0\n";
 					write_final_proof_clauses();
@@ -80,9 +81,9 @@ optional<CDCL::Model> CDCL::solve()
 			}
 			auto&& [learntClause, backtrackLevel] = analyze(move(*conflictClause));
 			cancelUntil(backtrackLevel);
-			if (proof) {
+			if (proof)
 				*proof << "a " << learntClause.ID << " " << toProofString(learntClause) << " 0\n";
-			}
+
 			solAssert(!learntClause.empty());
 			solAssert(!isAssigned(learntClause.front()));
 			for (size_t i = 1; i < learntClause.size(); i++)
@@ -260,31 +261,33 @@ void CDCL::addClause(const vector<Literal>& _lits)
 	}
 
 	Clause _clause {_lits, clauseID++};
-	if (proof) {
+	if (proof)
 		*proof <<  "o " << _clause.ID << " " << toProofString(_clause) << " 0\n";
-	}
 
 	Clause _clause_updated;
 	_clause_updated.ID = clauseID++;
-	for (const auto& l: _clause) {
-		if (isAssignedTrue(l)) {
-			// Clause is satisfied, nothing to do.
+	for (const auto& l: _clause)
+	{
+		// Clause is satisfied, nothing to do.
+		if (isAssignedTrue(l))
 			return;
-		}
-		if (isAssignedFalse(l)) {
-			// Remove literal from clause.
+
+		// Remove literal from clause.
+		if (isAssignedFalse(l))
 			continue;
-		}
+
 		_clause_updated.lits.push_back(l);
 	}
 
-	if (proof) {
+	if (proof)
+	{
 		*proof << "a " << _clause_updated.ID << " " << toProofString(_clause_updated) << " 0\n";
 		*proof << "d " << _clause.ID << " " << toProofString(_clause) << " 0\n";
 	}
 
 	// Empty clause, set UNSAT and return.
-	if (_clause_updated.lits.size() == 0) {
+	if (_clause_updated.lits.size() == 0)
+	{
 		unsat_clause_ID = clauseID++;
 		*proof << "a " << unsat_clause_ID << " 0\n";
 		write_final_proof_clauses();
@@ -293,7 +296,8 @@ void CDCL::addClause(const vector<Literal>& _lits)
 	}
 
 	// Unit clause, enqueue fact.
-	if (_clause_updated.lits.size() == 1) {
+	if (_clause_updated.lits.size() == 1)
+	{
 		unit_cl_IDs[_clause_updated.lits[0]] = _clause_updated.ID;
 		enqueue(_clause_updated.lits[0], nullptr);
 		return;
@@ -377,11 +381,11 @@ void CDCL::write_final_proof_clauses()
 	assert(proof);
 	assert(unsat_clause_ID != 0);
 
-	for(const auto& cl: m_clauses) {
+	for(const auto& cl: m_clauses)
 		*proof << "f " << cl->ID << " " << toProofString(*cl) << " 0\n";
-	}
-	for(const auto& units: unit_cl_IDs) {
+
+	for(const auto& units: unit_cl_IDs)
 		*proof << "f " << units.second << " " << toProofString(units.first) << " 0\n";
-	}
+
 	*proof << "f " << unsat_clause_ID << " 0\n";
 }

--- a/libsolutil/CDCL.cpp
+++ b/libsolutil/CDCL.cpp
@@ -119,14 +119,7 @@ optional<CDCL::Model> CDCL::solve()
 void CDCL::setupWatches(Clause& _clause)
 {
 	assert(_clause.size() >= 2);
-
-	// NOTE: the 2nd literal is always unassigned.
-	// The 1st literal can be assigned ONLY in case we are attaching a learnt clause.
-	assert(!isAssigned(_clause[1]));
-	assert(!isAssigned(_clause[0]) || isAssignedTrue(_clause[0]));
-
-
-	for (size_t i = 0; i < min<size_t>(2, _clause.size()); i++)
+	for (size_t i = 0; i < 2; i++)
 		m_watches[_clause.at(i)].push_back(&_clause);
 }
 

--- a/libsolutil/CDCL.cpp
+++ b/libsolutil/CDCL.cpp
@@ -48,9 +48,8 @@ CDCL::CDCL(
 
 optional<CDCL::Model> CDCL::solve()
 {
-	if (!ok) {
+	if (!ok)
 		return nullopt;
-	}
 
 	cout << "====" << endl;
 	for (unique_ptr<Clause> const& c: m_clauses)
@@ -73,7 +72,7 @@ optional<CDCL::Model> CDCL::solve()
 				ok = false;
 				if (proof)
 				{
-					unsat_clause_ID = clauseID++;
+					unsat_clause_ID = clause_ID++;
 					*proof << "a " << unsat_clause_ID << " 0\n";
 					writeFinalProofClauses();
 				}
@@ -89,11 +88,14 @@ optional<CDCL::Model> CDCL::solve()
 			for (size_t i = 1; i < learntClause.size(); i++)
 				solAssert(isAssignedFalse(learntClause.at(i)));
 
-			if (learntClause.size() == 1) {
+			if (learntClause.size() == 1)
+			{
 				assert(currentDecisionLevel() == 0);
 				unit_cl_IDs[learntClause[0]] = learntClause.ID;
 				enqueue(learntClause[0], nullptr);
-			} else {
+			}
+			else
+			{
 				m_clauses.push_back(make_unique<Clause>(move(learntClause)));
 				setupWatches(*m_clauses.back());
 				enqueue(m_clauses.back()->front(), &(*m_clauses.back()));
@@ -197,7 +199,7 @@ std::pair<Clause, size_t> CDCL::analyze(Clause _conflictClause)
 	solAssert(!_conflictClause.empty());
 	cout << "Analyzing conflict." << endl;
 	Clause learntClause;
-	learntClause.ID = clauseID++;
+	learntClause.ID = clause_ID++;
 	size_t backtrackLevel = 0;
 
 	set<size_t> seenVariables;
@@ -260,13 +262,13 @@ void CDCL::addClause(const vector<Literal>& _lits)
 		return;
 	}
 
-	Clause _clause {_lits, clauseID++};
+	Clause clause{_lits, clause_ID++};
 	if (proof)
-		*proof <<  "o " << _clause.ID << " " << toProofString(_clause) << " 0\n";
+		*proof <<  "o " << clause.ID << " " << toProofString(clause) << " 0\n";
 
-	Clause _clause_updated;
-	_clause_updated.ID = clauseID++;
-	for (const auto& l: _clause)
+	Clause clause_updated;
+	clause_updated.ID = clause_ID++;
+	for (const auto& l: clause)
 	{
 		// Clause is satisfied, nothing to do.
 		if (isAssignedTrue(l))
@@ -276,19 +278,19 @@ void CDCL::addClause(const vector<Literal>& _lits)
 		if (isAssignedFalse(l))
 			continue;
 
-		_clause_updated.lits.push_back(l);
+		clause_updated.lits.push_back(l);
 	}
 
 	if (proof)
 	{
-		*proof << "a " << _clause_updated.ID << " " << toProofString(_clause_updated) << " 0\n";
-		*proof << "d " << _clause.ID << " " << toProofString(_clause) << " 0\n";
+		*proof << "a " << clause_updated.ID << " " << toProofString(clause_updated) << " 0\n";
+		*proof << "d " << clause.ID << " " << toProofString(clause) << " 0\n";
 	}
 
 	// Empty clause, set UNSAT and return.
-	if (_clause_updated.lits.size() == 0)
+	if (clause_updated.lits.size() == 0)
 	{
-		unsat_clause_ID = clauseID++;
+		unsat_clause_ID = clause_ID++;
 		*proof << "a " << unsat_clause_ID << " 0\n";
 		writeFinalProofClauses();
 		ok = false;
@@ -296,14 +298,14 @@ void CDCL::addClause(const vector<Literal>& _lits)
 	}
 
 	// Unit clause, enqueue fact.
-	if (_clause_updated.lits.size() == 1)
+	if (clause_updated.lits.size() == 1)
 	{
-		unit_cl_IDs[_clause_updated.lits[0]] = _clause_updated.ID;
-		enqueue(_clause_updated.lits[0], nullptr);
+		unit_cl_IDs[clause_updated.lits[0]] = clause_updated.ID;
+		enqueue(clause_updated.lits[0], nullptr);
 		return;
 	}
 
-	m_clauses.push_back(make_unique<Clause>(move(_clause_updated)));
+	m_clauses.push_back(make_unique<Clause>(move(clause_updated)));
 	setupWatches(*m_clauses.back());
 }
 
@@ -381,10 +383,10 @@ void CDCL::writeFinalProofClauses()
 	assert(proof);
 	assert(unsat_clause_ID != 0);
 
-	for(const auto& cl: m_clauses)
+	for (const auto& cl: m_clauses)
 		*proof << "f " << cl->ID << " " << toProofString(*cl) << " 0\n";
 
-	for(const auto& units: unit_cl_IDs)
+	for (const auto& units: unit_cl_IDs)
 		*proof << "f " << units.second << " " << toProofString(units.first) << " 0\n";
 
 	*proof << "f " << unsat_clause_ID << " 0\n";

--- a/libsolutil/CDCL.h
+++ b/libsolutil/CDCL.h
@@ -50,67 +50,7 @@ struct Literal
 	}
 };
 
-struct Clause {
-	const Literal& front() const
-	{
-		return lits.front();
-	}
-	const Literal& back() const
-	{
-		return lits.back();
-	}
-	Literal& front()
-	{
-		return lits.front();
-	}
-	Literal& back()
-	{
-		return lits.back();
-	}
-	const Literal& operator[](const size_t at) const
-	{
-		return lits.at(at);
-	}
-	const Literal& at(const size_t at) const
-	{
-		return lits.at(at);
-	}
-	Literal& operator[](const size_t at)
-	{
-		return lits.at(at);
-	}
-	Literal& at(const size_t at)
-	{
-		return lits.at(at);
-	}
-	auto size() const
-	{
-		return lits.size();
-	}
-	auto empty() const
-	{
-		return lits.empty();
-	}
-	auto begin() {
-		return lits.begin();
-	}
-	auto end() {
-		return lits.end();
-	}
-	auto begin() const {
-		return lits.begin();
-	}
-	auto end() const {
-		return lits.end();
-	}
-	void push_back(const Literal& l)
-	{
-		lits.push_back(l);
-	}
-
-	std::vector<Literal> lits;
-	uint64_t ID;
-};
+typedef std::vector<Literal> Clause;
 
 class TriState {
 public:
@@ -247,6 +187,7 @@ private:
 	std::map<Literal, uint64_t> unit_cl_IDs;
 	uint64_t unsat_clause_ID = 0;
 	void writeFinalProofClauses();
+	std::vector<uint64_t> clause_IDs;
 };
 
 inline bool CDCL::isAssigned(Literal const& _literal) const

--- a/libsolutil/CDCL.h
+++ b/libsolutil/CDCL.h
@@ -212,7 +212,7 @@ private:
 
 	// Proof log
 	std::ostream* proof = nullptr;
-	uint64_t clauseID = 1;
+	uint64_t clause_ID = 1;
 	std::map<Literal, uint64_t> unit_cl_IDs;
 	uint64_t unsat_clause_ID = 0;
 	void writeFinalProofClauses();

--- a/libsolutil/CDCL.h
+++ b/libsolutil/CDCL.h
@@ -54,7 +54,7 @@ typedef std::vector<Literal> Clause;
 
 class TriState {
 public:
-	constexpr TriState(const bool b) : val(b ? 1 : 0) {}
+	explicit constexpr TriState(const bool b) : val(b ? 1 : 0) {}
 	constexpr TriState() {}
 
 	bool operator==(const TriState& other) const
@@ -195,7 +195,7 @@ inline TriState CDCL::value(Literal const& _literal) const
 	if (m_assignments[_literal.variable] == TriState::t_unset())
 		return TriState::t_unset();
 	else
-		return m_assignments[_literal.variable].toBool() ^ !_literal.positive;
+		return TriState(m_assignments[_literal.variable].toBool() ^ !_literal.positive);
 }
 
 inline TriState CDCL::value(size_t const& variable) const

--- a/libsolutil/CDCL.h
+++ b/libsolutil/CDCL.h
@@ -54,16 +54,9 @@ typedef std::vector<Literal> Clause;
 
 class TriState {
 public:
-	TriState(const bool b)
-	{
-		if (b)
-			val = 1;
-		else
-			val = 0;
-	}
+	TriState(const bool b) : val(b ? 1 : 0) {}
 
-	TriState()
-	{}
+	TriState() {}
 
 	bool operator==(const TriState& other) const
 	{

--- a/libsolutil/CDCL.h
+++ b/libsolutil/CDCL.h
@@ -48,7 +48,68 @@ struct Literal
 		return std::make_tuple(positive, variable) < std::make_tuple(_other.positive, _other.variable);
 	}
 };
-using Clause = std::vector<Literal>;
+
+struct Clause {
+	const Literal& front() const
+	{
+		return lits.front();
+	}
+	const Literal& back() const
+	{
+		return lits.back();
+	}
+	Literal& front()
+	{
+		return lits.front();
+	}
+	Literal& back()
+	{
+		return lits.back();
+	}
+	const Literal& operator[](const size_t at) const
+	{
+		return lits.at(at);
+	}
+	const Literal& at(const size_t at) const
+	{
+		return lits.at(at);
+	}
+	Literal& operator[](const size_t at)
+	{
+		return lits.at(at);
+	}
+	Literal& at(const size_t at)
+	{
+		return lits.at(at);
+	}
+	auto size() const
+	{
+		return lits.size();
+	}
+	auto empty() const
+	{
+		return lits.empty();
+	}
+	auto begin() {
+		return lits.begin();
+	}
+	auto end() {
+		return lits.end();
+	}
+	auto begin() const {
+		return lits.begin();
+	}
+	auto end() const {
+		return lits.end();
+	}
+	void push_back(const Literal& l)
+	{
+		lits.push_back(l);
+	}
+
+	std::vector<Literal> lits;
+	uint64_t ID;
+};
 
 class CDCL
 {
@@ -56,7 +117,8 @@ public:
 	using Model = std::map<size_t, bool>;
 	CDCL(
 		std::vector<std::string> _variables,
-		std::vector<Clause> const& _clauses,
+		std::vector<std::vector<Literal>> const& _clauses,
+	    std::ostream* proof = nullptr,
 		std::function<std::optional<Clause>(std::map<size_t, bool> const&)> _theoryPropagator = {}
 	);
 
@@ -68,7 +130,7 @@ private:
 	std::pair<Clause, size_t> analyze(Clause _conflictClause);
 	size_t currentDecisionLevel() const { return m_decisionPoints.size(); }
 
-	void addClause(Clause _clause);
+	void addClause(const std::vector<Literal>& _lits);
 
 	void enqueue(Literal const& _literal, Clause const* _reason);
 
@@ -83,6 +145,8 @@ private:
 
 	std::string toString(Literal const& _literal) const;
 	std::string toString(Clause const& _clause) const;
+	std::string toProofString(Literal const& _literal) const;
+	std::string toProofString(Clause const& _clause) const;
 
 	/// Callback that receives an assignment and uses the theory to either returns nullopt ("satisfiable")
 	/// or a conflict clause, i.e. a clauses that is false in the theory with the given assignments.
@@ -116,6 +180,13 @@ private:
 
 	// Current state of the solver. If FALSE, we are in an UNSAT state.
 	bool ok = true;
+
+	// Proof log
+	std::ostream* proof = nullptr;
+	uint64_t clauseID = 1;
+	std::map<Literal, uint64_t> unit_cl_IDs;
+	uint64_t unsat_clause_ID = 0;
+	void write_final_proof_clauses();
 };
 
 

--- a/libsolutil/CDCL.h
+++ b/libsolutil/CDCL.h
@@ -113,6 +113,9 @@ private:
 	std::vector<size_t> m_decisionPoints;
 	/// Index into assignmentTrail: All assignments starting there have not yet been propagated.
 	size_t m_assignmentQueuePointer = 0;
+
+	// Current state of the solver. If FALSE, we are in an UNSAT state.
+	bool ok = true;
 };
 
 

--- a/libsolutil/CDCL.h
+++ b/libsolutil/CDCL.h
@@ -117,30 +117,27 @@ TriState boolToTriState(const bool b);
 inline std::string triStateToString(const TriState v);
 inline std::string triStateToString(const TriState v)
 {
-	if (v == TriState::trisate_true) {
+	if (v == TriState::trisate_true)
 		return "true";
-	} else if (v == TriState::tristate_false) {
+	else if (v == TriState::tristate_false)
 		return "false";
-	} else {
+	else
 		return "unset";
-	}
 }
 inline TriState boolToTriState(const bool b) {
-	if (b) {
+	if (b)
 		return TriState::trisate_true;
-	} else {
+	else
 		return TriState::tristate_false;
-	}
 }
 
 inline bool triStateToBool(const TriState t) {
-	if (t == TriState::trisate_true) {
+	if (t == TriState::trisate_true)
 		return true;
-	} else if (t == TriState::tristate_false) {
+	else if (t == TriState::tristate_false)
 		return false;
-	} else {
+	else
 		assert(false && "UNSET cannot be converted to bool");
-	}
 }
 
 class CDCL

--- a/libsolutil/CDCL.h
+++ b/libsolutil/CDCL.h
@@ -103,7 +103,7 @@ public:
 
 private:
 	// Default value is UNSET
-	char val = 2;
+	uint8_t val = 2;
 };
 
 const TriState trisate_true = TriState(true);

--- a/libsolutil/CDCL.h
+++ b/libsolutil/CDCL.h
@@ -112,33 +112,64 @@ struct Clause {
 	uint64_t ID;
 };
 
-enum class TriState {trisate_true, tristate_false, tristate_unset};
-TriState boolToTriState(const bool b);
-inline std::string triStateToString(const TriState v);
-inline std::string triStateToString(const TriState v)
-{
-	if (v == TriState::trisate_true)
-		return "true";
-	else if (v == TriState::tristate_false)
-		return "false";
-	else
-		return "unset";
-}
-inline TriState boolToTriState(const bool b) {
-	if (b)
-		return TriState::trisate_true;
-	else
-		return TriState::tristate_false;
-}
+class TriState {
+public:
+	TriState(const bool b)
+	{
+		if (b)
+			val = 1;
+		else
+			val = 0;
+	}
 
-inline bool triStateToBool(const TriState t) {
-	if (t == TriState::trisate_true)
-		return true;
-	else if (t == TriState::tristate_false)
-		return false;
-	else
-		assert(false && "UNSET cannot be converted to bool");
-}
+	TriState()
+	{}
+
+	bool operator==(const TriState& other) const
+	{
+		return val == other.val;
+	}
+
+	bool operator!=(const TriState& other) const
+	{
+		return val != other.val;
+	}
+
+	bool toBool() const {
+		if (val == 1)
+			return true;
+		else if (val == 0)
+			return false;
+		else
+		{
+			assert(val== 2);
+			assert(false && "UNSET cannot be converted to bool");
+		}
+	}
+
+	std::string toString()
+	{
+		if (val == 1)
+			return "true";
+		else if (val == 0)
+			return "false";
+		else
+		{
+			assert(val == 2);
+			return "unset";
+		}
+	}
+
+
+private:
+	// Default value is UNSET
+	char val = 2;
+};
+
+const TriState trisate_true = TriState(true);
+const TriState tristate_false = TriState(false);
+const TriState tristate_unset = TriState();
+
 
 class CDCL
 {
@@ -220,19 +251,19 @@ private:
 
 inline bool CDCL::isAssigned(Literal const& _literal) const
 {
-	return m_assignments[_literal.variable] != TriState::tristate_unset;
+	return m_assignments[_literal.variable] != tristate_unset;
 }
 
 inline bool CDCL::isAssignedTrue(Literal const& _literal) const
 {
 	return isAssigned(_literal) &&
-		(triStateToBool(m_assignments[_literal.variable]) ^ !_literal.positive) == true;
+		(m_assignments[_literal.variable].toBool() ^ !_literal.positive) == true;
 }
 
 inline bool CDCL::isAssignedFalse(Literal const& _literal) const
 {
 	return isAssigned(_literal) &&
-		(triStateToBool(m_assignments[_literal.variable]) ^ !_literal.positive) == false;
+		(m_assignments[_literal.variable].toBool() ^ !_literal.positive) == false;
 
 }
 

--- a/libsolutil/CDCL.h
+++ b/libsolutil/CDCL.h
@@ -215,7 +215,7 @@ private:
 	uint64_t clauseID = 1;
 	std::map<Literal, uint64_t> unit_cl_IDs;
 	uint64_t unsat_clause_ID = 0;
-	void write_final_proof_clauses();
+	void writeFinalProofClauses();
 };
 
 inline bool CDCL::isAssigned(Literal const& _literal) const

--- a/test/libsolutil/CDCL.cpp
+++ b/test/libsolutil/CDCL.cpp
@@ -85,10 +85,10 @@ BOOST_AUTO_TEST_CASE(basic_unsat3)
 {
 	auto x1 = variable("x1");
 	auto x2 = variable("x2");
-	Clause c1{x1, ~x2};
-	Clause c2{~x1, x2};
-	Clause c3{x1, x2};
-	Clause c4{~x1, ~x2};
+	vector<Literal> c1{x1, ~x2};
+	vector<Literal> c2{~x1, x2};
+	vector<Literal> c3{x1, x2};
+	vector<Literal> c4{~x1, ~x2};
 	unsatisfiable({c1, c2, c3, c4});
 }
 
@@ -104,14 +104,14 @@ BOOST_AUTO_TEST_CASE(learning)
 	auto x10 = variable("x10");
 	auto x11 = variable("x11");
 	auto x12 = variable("x12");
-	Clause c1{x1, x4};
-	Clause c2{x1, ~x3, ~x8};
-	Clause c3{x1, x8, x12};
-	Clause c4{x2, x11};
-	Clause c5{~x7, ~x3, x9};
-	Clause c6{~x7, x8, ~x9};
-	Clause c7{x7, x8, ~x10};
-	Clause c8{x7, x10, ~x12};
+	vector<Literal> c1{x1, x4};
+	vector<Literal> c2{x1, ~x3, ~x8};
+	vector<Literal> c3{x1, x8, x12};
+	vector<Literal> c4{x2, x11};
+	vector<Literal> c5{~x7, ~x3, x9};
+	vector<Literal> c6{~x7, x8, ~x9};
+	vector<Literal> c7{x7, x8, ~x10};
+	vector<Literal> c8{x7, x10, ~x12};
 	satisfiable({c1, c2, c3, c4, c5, c6, c7, c8});
 }
 

--- a/test/libsolutil/CDCL.cpp
+++ b/test/libsolutil/CDCL.cpp
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(basic_unsat2)
 	unsatisfiable({c1, c2, c3, c4});
 }
 
-BOOST_AUTO_TEST_CASE(basic_sat)
+BOOST_AUTO_TEST_CASE(basic_unsat3)
 {
 	auto x1 = variable("x1");
 	auto x2 = variable("x2");

--- a/test/libsolutil/CDCL.cpp
+++ b/test/libsolutil/CDCL.cpp
@@ -37,13 +37,13 @@ public:
 		return Literal{true, m_variables.size() - 1};
 	}
 
-	void satisfiable(vector<Clause> _clauses)
+	void satisfiable(vector<vector<Literal>> _clauses)
 	{
 		auto model = CDCL{m_variables, move(_clauses)}.solve();
 		BOOST_REQUIRE(!!model);
 	}
 
-	void unsatisfiable(vector<Clause> _clauses)
+	void unsatisfiable(vector<vector<Literal>> _clauses)
 	{
 		auto model = CDCL{m_variables, move(_clauses)}.solve();
 		BOOST_REQUIRE(!model);
@@ -60,7 +60,7 @@ BOOST_FIXTURE_TEST_SUITE(CDCL, CDCLTestFramework, *boost::unit_test::label("noop
 BOOST_AUTO_TEST_CASE(basic)
 {
 	auto x = variable("x");
-	Clause c1{x, ~x};
+	vector<Literal> c1{x, ~x};
 	satisfiable({c1});
 }
 
@@ -74,10 +74,10 @@ BOOST_AUTO_TEST_CASE(basic_unsat2)
 {
 	auto x1 = variable("x1");
 	auto x2 = variable("x2");
-	Clause c1{x1, ~x2};
-	Clause c2{~x1, x2};
-	Clause c3{x1, x2};
-	Clause c4{~x1, ~x2};
+	vector<Literal> c1{x1, ~x2};
+	vector<Literal> c2{~x1, x2};
+	vector<Literal> c3{x1, x2};
+	vector<Literal> c4{~x1, ~x2};
 	unsatisfiable({c1, c2, c3, c4});
 }
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -52,5 +52,5 @@ install(TARGETS yul-phaser DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
 
 add_executable(satsolver satsolver-main.cpp)
-target_link_libraries(satsolver PUBLIC solidity Boost::boost Boost::program_options)
+target_link_libraries(satsolver PUBLIC solidity range-v3 Boost::boost Boost::program_options)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -49,3 +49,8 @@ add_executable(yul-phaser yulPhaser/main.cpp)
 target_link_libraries(yul-phaser PRIVATE phaser)
 
 install(TARGETS yul-phaser DESTINATION "${CMAKE_INSTALL_BINDIR}")
+
+
+add_executable(satsolver satsolver-main.cpp)
+target_link_libraries(satsolver PUBLIC solidity Boost::boost Boost::program_options)
+

--- a/tools/satsolver-main.cpp
+++ b/tools/satsolver-main.cpp
@@ -33,6 +33,7 @@ using std::cout;
 using std::endl;
 using std::optional;
 using std::nullopt;
+using std::stringstream;
 using std::make_pair;
 
 const int verbose = 0;
@@ -166,9 +167,24 @@ int main(int argc, char** argv)
 
 	auto model = CDCL{m_variables, move(cls), &proof_file}.solve();
 
-	if (model)
+	if (model) {
+		const size_t line_break_after = 80;
+		stringstream ss;
+		ss << "v";
+		for(size_t i = 0; i < model->size(); i++) {
+			if (ss.str().size() > line_break_after) {
+				cout << ss.str() << endl;
+				ss.clear();
+				ss << "v";
+			}
+			if (model->at(i) != TriState::t_unset()) {
+				ss << " " << (model->at(i) == TriState::t_true() ? "" : "-") << i+1;
+			}
+
+		}
+		cout << ss.str() << " 0" << endl;
 		cout << "s SATISFIABLE" << endl;
-	else
+	} else
 		cout << "s UNSATISFIABLE" << endl;
 
 	proof_file.close();

--- a/tools/satsolver-main.cpp
+++ b/tools/satsolver-main.cpp
@@ -45,7 +45,8 @@ vector<string> cut_string_by_space(string& input)
     vector<string> parts;
 
     size_t pos = 0;
-    while ((pos = input.find(" ")) != string::npos) {
+    while ((pos = input.find(" ")) != string::npos)
+	{
         parts.push_back(input.substr(0, pos));
         input.erase(0, pos + 1);
     }
@@ -58,14 +59,15 @@ optional<vector<Literal>> parse_line(std::string& line)
 	vector<Literal> cl;
 	bool end_of_clause = false;
 	auto parts = cut_string_by_space(line);
-	for(const auto& part: parts) {
+	for(const auto& part: parts)
+	{
 		assert(!end_of_clause);
-
 		const long lit = std::stol(part);
 		const long var = std::abs(lit);
-		if (var == 0) {
-			end_of_clause = true;
+		if (var == 0)
+		{
 			//end of clause
+			end_of_clause = true;
 			continue;
 		}
 		assert(var > 0);
@@ -73,19 +75,18 @@ optional<vector<Literal>> parse_line(std::string& line)
 		cl.push_back(l);
 	}
 
-	if (verbose) {
+	if (verbose)
+	{
 		cout << "Cl: ";
-		for(const auto& l: cl) {
+		for(const auto& l: cl)
 			cout << (l.positive ? "" : "-") << (l.variable+1) << " ";
-		}
 		cout << " end: " << (int)end_of_clause << endl;
 	}
 
-	if (end_of_clause) {
+	if (end_of_clause)
 		return cl;
-	} else {
+	else
 		return nullopt;
-	}
 }
 
 std::pair<vector<vector<Literal>>, size_t> read_cnf_file(const string& fname)
@@ -113,9 +114,8 @@ std::pair<vector<vector<Literal>>, size_t> read_cnf_file(const string& fname)
 			continue;
 		}
 		const auto cl = parse_line(line);
-		if (cl) {
+		if (cl)
 			cls.push_back(cl.value());
-		}
 	}
 	if (varsByHeader == -1) {
 		cout << "ERROR: CNF did not have a header" << endl;
@@ -123,7 +123,8 @@ std::pair<vector<vector<Literal>>, size_t> read_cnf_file(const string& fname)
 	}
 
 	assert(clsByHeader >= 0);
-	if (cls.size() != (size_t)clsByHeader) {
+	if (cls.size() != (size_t)clsByHeader)
+	{
 		cout << "ERROR: header said number of clauses will be " << clsByHeader << " but we read " << cls.size() << endl;
 		exit(-1);
 	}
@@ -134,11 +135,10 @@ std::pair<vector<vector<Literal>>, size_t> read_cnf_file(const string& fname)
 size_t get_num_vars(const vector<vector<Literal>>& cls)
 {
 	size_t largestVar = 0;
-	for(const auto& cl: cls) {
-		for(const auto& l: cl) {
+	for(const auto& cl: cls)
+		for(const auto& l: cl)
 			largestVar = std::max(largestVar, l.variable+1);
-		}
-	}
+
 	return largestVar;
 }
 
@@ -157,23 +157,25 @@ int main(int argc, char** argv)
 	const size_t numVarsByCls = get_num_vars(cls);
 	vector<string> m_variables;
 
-	if (maxVarsByHeader < numVarsByCls) {
+	if (maxVarsByHeader < numVarsByCls)
+	{
 		cout << "ERROR: header promises less variables than what clauses say" << endl;
 		exit(-1);
 	}
 	assert(maxVarsByHeader >= numVarsByCls);
 
-	for(size_t i = 0; i < maxVarsByHeader; i ++) {
+	for(size_t i = 0; i < maxVarsByHeader; i ++)
+	{
 		m_variables.push_back(string("x") + std::to_string(i));
 	}
 
 	auto model = CDCL{m_variables, move(cls), &proofFile}.solve();
 
-	if (model) {
+	if (model)
 		cout << "s SATISFIABLE" << endl;
-	} else {
+	else
 		cout << "s UNSATISFIABLE" << endl;
-	}
+
 	proofFile.close();
 	return 0;
 }

--- a/tools/satsolver-main.cpp
+++ b/tools/satsolver-main.cpp
@@ -61,7 +61,11 @@ optional<vector<Literal>> parseLine(std::string& line)
 	auto parts = cutStringBySpace(line);
 	for (const auto& part: parts)
 	{
-		assert(!end_of_clause);
+		if (!end_of_clause)
+		{
+			cout << "ERROR: trailing elements after finishing `0` at the end of a clause in CNF file" << endl;
+			exit(-1);
+		}
 		const long lit = std::stol(part);
 		const long var = std::abs(lit);
 		if (var == 0)

--- a/tools/satsolver-main.cpp
+++ b/tools/satsolver-main.cpp
@@ -17,10 +17,6 @@
 // SPDX-License-Identifier: GPL-3.0
 
 #include <libsolutil/CDCL.h>
-//#include <libsolutil/BooleanLP.h>
-#include <libsolutil/LinearExpression.h>
-#include <libsmtutil/Sorts.h>
-#include <libsolutil/StringUtils.h>
 #include <vector>
 #include <string>
 #include <iostream>

--- a/tools/satsolver-main.cpp
+++ b/tools/satsolver-main.cpp
@@ -23,6 +23,8 @@
 #include <iomanip>
 #include <fstream>
 #include <sstream>
+#include <range/v3/view/split.hpp>
+#include <range/v3/to_container.hpp>
 
 using namespace solidity::util;
 using std::vector;
@@ -42,24 +44,14 @@ size_t getNumVars(const vector<vector<Literal>>& cls);
 
 vector<string> cutStringBySpace(string& input)
 {
-    vector<string> parts;
-
-    size_t pos = 0;
-    while ((pos = input.find(" ")) != string::npos)
-	{
-        parts.push_back(input.substr(0, pos));
-        input.erase(0, pos + 1);
-    }
-    parts.push_back(input);
-    return parts;
+    return input | ranges::views::split(' ') | ranges::to<vector<string>>();
 }
 
 optional<vector<Literal>> parseLine(std::string& line)
 {
 	vector<Literal> cl;
 	bool end_of_clause = false;
-	auto parts = cutStringBySpace(line);
-	for (const auto& part: parts)
+	for (const auto& part: line | ranges::views::split(' ') | ranges::to<vector<string>>())
 	{
 		if (!end_of_clause)
 		{

--- a/tools/satsolver-main.cpp
+++ b/tools/satsolver-main.cpp
@@ -17,7 +17,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 #include <libsolutil/CDCL.h>
-#include <libsolutil/BooleanLP.h>
+//#include <libsolutil/BooleanLP.h>
 #include <libsolutil/LinearExpression.h>
 #include <libsmtutil/Sorts.h>
 #include <libsolutil/StringUtils.h>

--- a/tools/satsolver-main.cpp
+++ b/tools/satsolver-main.cpp
@@ -59,7 +59,7 @@ optional<vector<Literal>> parse_line(std::string& line)
 	vector<Literal> cl;
 	bool end_of_clause = false;
 	auto parts = cut_string_by_space(line);
-	for(const auto& part: parts)
+	for (const auto& part: parts)
 	{
 		assert(!end_of_clause);
 		const long lit = std::stol(part);
@@ -78,7 +78,7 @@ optional<vector<Literal>> parse_line(std::string& line)
 	if (verbose)
 	{
 		cout << "Cl: ";
-		for(const auto& l: cl)
+		for (const auto& l: cl)
 			cout << (l.positive ? "" : "-") << (l.variable+1) << " ";
 		cout << " end: " << (int)end_of_clause << endl;
 	}
@@ -99,9 +99,8 @@ std::pair<vector<vector<Literal>>, size_t> read_cnf_file(const string& fname)
 	std::string line;
 	while (std::getline(infile, line))
 	{
-		if (line.empty()) {
+		if (line.empty())
 			continue;
-		}
 		if (line[0] == 'p') {
 			assert(line.substr(0,6) == string("p cnf "));
 			line = line.substr(6);
@@ -117,7 +116,8 @@ std::pair<vector<vector<Literal>>, size_t> read_cnf_file(const string& fname)
 		if (cl)
 			cls.push_back(cl.value());
 	}
-	if (varsByHeader == -1) {
+	if (varsByHeader == -1)
+	{
 		cout << "ERROR: CNF did not have a header" << endl;
 		exit(-1);
 	}
@@ -135,8 +135,8 @@ std::pair<vector<vector<Literal>>, size_t> read_cnf_file(const string& fname)
 size_t get_num_vars(const vector<vector<Literal>>& cls)
 {
 	size_t largestVar = 0;
-	for(const auto& cl: cls)
-		for(const auto& l: cl)
+	for (const auto& cl: cls)
+		for (const auto& l: cl)
 			largestVar = std::max(largestVar, l.variable+1);
 
 	return largestVar;
@@ -144,7 +144,8 @@ size_t get_num_vars(const vector<vector<Literal>>& cls)
 
 int main(int argc, char** argv)
 {
-	if (argc != 3) {
+	if (argc != 3)
+	{
 		cout << "ERROR: you must give CNF and proof files as parameters" << endl;
 		exit(-1);
 	}
@@ -164,10 +165,8 @@ int main(int argc, char** argv)
 	}
 	assert(maxVarsByHeader >= numVarsByCls);
 
-	for(size_t i = 0; i < maxVarsByHeader; i ++)
-	{
+	for (size_t i = 0; i < maxVarsByHeader; i ++)
 		m_variables.push_back(string("x") + std::to_string(i));
-	}
 
 	auto model = CDCL{m_variables, move(cls), &proofFile}.solve();
 

--- a/tools/satsolver-main.cpp
+++ b/tools/satsolver-main.cpp
@@ -53,7 +53,7 @@ optional<vector<Literal>> parseLine(std::string& line)
 	bool end_of_clause = false;
 	for (const auto& part: line | ranges::views::split(' '))
 	{
-		if (!end_of_clause)
+		if (end_of_clause)
 		{
 			cout << "ERROR: trailing elements after finishing `0` at the end of a clause in CNF file" << endl;
 			exit(-1);

--- a/tools/satsolver-main.cpp
+++ b/tools/satsolver-main.cpp
@@ -51,14 +51,14 @@ optional<vector<Literal>> parseLine(std::string& line)
 {
 	vector<Literal> cl;
 	bool end_of_clause = false;
-	for (const auto& part: line | ranges::views::split(' ') | ranges::to<vector<string>>())
+	for (const auto& part: line | ranges::views::split(' '))
 	{
 		if (!end_of_clause)
 		{
 			cout << "ERROR: trailing elements after finishing `0` at the end of a clause in CNF file" << endl;
 			exit(-1);
 		}
-		const long lit = std::stol(part);
+		const long lit = std::stol(ranges::to<string>(part));
 		const long var = std::abs(lit);
 		if (var == 0)
 		{

--- a/tools/satsolver-main.cpp
+++ b/tools/satsolver-main.cpp
@@ -1,0 +1,63 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libsolutil/CDCL.h>
+#include <vector>
+#include <string>
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+
+using namespace solidity::util;
+using std::vector;
+using std::string;
+using std::cout;
+using std::endl;
+
+Literal lit(string const& _name);
+
+vector<string> m_variables;
+
+Literal lit(string const& _name)
+{
+	m_variables.emplace_back(_name);
+	return Literal{true, m_variables.size() - 1};
+}
+
+int main()
+{
+	std::ofstream proofFile;
+	proofFile.open("proof.frat", std::ios::out);
+
+	auto x1 = lit("x1");
+	auto x2 = lit("x2");
+	vector<Literal> c1{x1, ~x2};
+	vector<Literal> c2{~x1, x2};
+	vector<Literal> c3{x1, x2};
+	vector<Literal> c4{~x1, ~x2};
+	const auto cls = {c1, c2, c3, c4};
+	auto model = CDCL{m_variables, move(cls), &proofFile}.solve();
+
+	if (model) {
+		cout << "SATISFIABLE" << endl;
+	} else {
+		cout << "UNSATISFIABLE" << endl;
+	}
+	proofFile.close();
+	return 0;
+}


### PR DESCRIPTION
Hi,

This adds:
- Proof logging using FRAT, see https://github.com/digama0/frat
- All clauses are at least 2-long
- tristate value of variables is now an enum, with a vector, rather than a map, for fast lookup -- O(1) lookup instead of O(log(n))
- Binary that can parse a DIMACS input and generate the solution + proof

Example:
```
$ cat a.cnf 
p cnf 2 4
1 2 0
-1 -2 0
1 -2 0
-1 2 0
$ ./satsolver a.cnf proof.frat 
====
(x0, x1)
(~x0, ~x1)
(x0, ~x1)
(~x0, x1)
====
Propagating.
[...]
 - Propagate resulted in conflict because x1 is also false.
Unsatisfiable
s UNSATISFIABLE
$ ./frat-rs fratchk proof.frat 
4 orig + 6 added - 4 deleted - 6 finalized = 0
6 missing proofs (100.0%)
type 0: 6
matesoos@tiresias:tools$ echo $?
0
```

Hence, `frat-rs` verified our proof. Notice that the lines starting with `o` in `proof.frat` MUST match the input CNF, which they do (except for 1st element, which is simply an arbitrary clause ID):
```
$ grep "^o" proof.frat | cut -d " " -f 3-
1 2 0
-1 -2 0
1 -2 0
-1 2 0
```

matching the input CNF 1-to-1. Hence, `frat-rs` verified that the proof steps were correct.
