### PR TITLE
Update buildpacks to include `jq`.

### DIFF
--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
@@ -22,7 +22,7 @@
 # (c) 2016-2021 solidity contributors.
 #------------------------------------------------------------------------------
 FROM gcr.io/oss-fuzz-base/base-clang:latest as base
-LABEL version="15"
+LABEL version="16"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -32,7 +32,7 @@ RUN apt-get update; \
 		software-properties-common \
 		ninja-build git wget \
 		libbz2-dev zlib1g-dev git curl uuid-dev \
-		pkg-config openjdk-8-jdk liblzma-dev unzip mlton m4; \
+		pkg-config openjdk-8-jdk liblzma-dev unzip mlton m4 jq; \
     apt-get install -qy python3-pip;
 
 # Install cmake 3.21.2 (minimum requirement is cmake 3.10)

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:focal AS base
-LABEL version="10"
+LABEL version="11"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -37,7 +37,7 @@ RUN set -ex; \
 		cmake ninja-build \
 		libboost-filesystem-dev libboost-test-dev libboost-system-dev \
 		libboost-program-options-dev \
-		libcvc4-dev libz3-static-dev z3-static \
+		libcvc4-dev libz3-static-dev z3-static jq \
 		; \
 	apt-get install -qy python3-pip python3-sphinx; \
 	pip3 install codecov; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004.clang
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004.clang
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:focal AS base
-LABEL version="10"
+LABEL version="11"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -38,7 +38,7 @@ RUN set -ex; \
 		libboost-filesystem-dev libboost-test-dev libboost-system-dev \
 		libboost-program-options-dev \
 		clang \
-		libz3-static-dev \
+		libz3-static-dev jq \
 		; \
 	rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The asm json import/export use `jq` to compare the output (see https://github.com/ethereum/solidity/pull/12704).
