### PR TITLE
Save and restore for loop nesting level in UnusedStoreBase.

### DIFF
--- a/libyul/optimiser/UnusedStoreBase.cpp
+++ b/libyul/optimiser/UnusedStoreBase.cpp
@@ -73,6 +73,7 @@ void UnusedStoreBase::operator()(FunctionDefinition const& _functionDefinition)
 {
 	ScopedSaveAndRestore outerAssignments(m_stores, {});
 	ScopedSaveAndRestore forLoopInfo(m_forLoopInfo, {});
+	ScopedSaveAndRestore forLoopNestingDepth(m_forLoopNestingDepth, 0);
 
 	(*this)(_functionDefinition.body);
 


### PR DESCRIPTION
Came up in https://github.com/ethereum/solidity/pull/12672#discussion_r817566550
It doesn't really matter in practice, but it's weird not to do it.