### PR TITLE
Also save and restore the nesting depth.

### DIFF
--- a/libyul/optimiser/UnusedStoreBase.cpp
+++ b/libyul/optimiser/UnusedStoreBase.cpp
@@ -73,6 +73,7 @@ void UnusedStoreBase::operator()(FunctionDefinition const& _functionDefinition)
 {
 	ScopedSaveAndRestore outerAssignments(m_stores, {});
 	ScopedSaveAndRestore forLoopInfo(m_forLoopInfo, {});
+	ScopedSaveAndRestore forLoopNestingDepth(m_forLoopNestingDepth, 0);
 
 	(*this)(_functionDefinition.body);
 


### PR DESCRIPTION
Mentioned in https://github.com/ethereum/solidity/pull/12672

This is just a performance parameter, so it was not a semantic bug.