### PR TITLE
Workaround for a race condition in Perpetual Pools ext test due to parallel compilation on Hardhat 2.9.0

### DIFF
--- a/test/externalTests/perpetual-pools.sh
+++ b/test/externalTests/perpetual-pools.sh
@@ -66,6 +66,11 @@ function perpetual_pools_test
     force_hardhat_unlimited_contract_size "$config_file" "$config_var"
     yarn install
 
+    # The project depends on @openzeppelin/hardhat-upgrades, which is currently not prepared
+    # for the parallel compilation introduced in Hardhat 2.9.0.
+    # TODO: Remove when https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/528 is fixed.
+    yarn add hardhat@2.8.4
+
     replace_version_pragmas
 
     for preset in $SELECTED_PRESETS; do


### PR DESCRIPTION
Hardhat 2.9.0 released a few days ago introduced parallel compilation of Solidity files. `@openzeppelin/hardhat-upgrades` breaks due to this because during compilation it stores info in a file and then reads back from it. The file gets corrupted if multiple instances of its compilation hook try to do this.

The workaround is to use Hardhat 2.8.4 until https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/528 is fixed.