### PR TITLE
Re-enable running tests via IR in external tests in cases where they don't pass due to Hardhat heuristics

### DIFF
--- a/test/externalTests/elementfi.sh
+++ b/test/externalTests/elementfi.sh
@@ -42,13 +42,12 @@ function elementfi_test
     local config_file="hardhat.config.ts"
     local config_var=config
 
-    local compile_only_presets=(
-        ir-optimize-evm+yul       # Compiles but tests fail. See https://github.com/nomiclabs/hardhat/issues/2115
-    )
+    local compile_only_presets=()
     local settings_presets=(
         "${compile_only_presets[@]}"
         #ir-no-optimize           # Compilation fails with "YulException: Variable var_amount_9311 is 10 slot(s) too deep inside the stack."
         #ir-optimize-evm-only     # Compilation fails with "YulException: Variable var_amount_9311 is 10 slot(s) too deep inside the stack."
+        ir-optimize-evm+yul
         legacy-no-optimize
         legacy-optimize-evm-only
         legacy-optimize-evm+yul
@@ -88,6 +87,13 @@ function elementfi_test
     # The test suite uses forked mainnet and an expiration period that's too short.
     # TODO: Remove when https://github.com/element-fi/elf-contracts/issues/243 is fixed.
     sed -i 's|^\s*require(_expiration - block\.timestamp < _unitSeconds);\s*$||g' contracts/ConvergentCurvePool.sol
+
+    # Disable tests that won't pass on the ir presets due to Hardhat heuristics. Note that this also disables
+    # them for other presets but that's fine - we want same code run for benchmarks to be comparable.
+    # TODO: Remove this when Hardhat adjusts heuristics for IR (https://github.com/nomiclabs/hardhat/issues/2115).
+    sed -i 's|it(\("fails to withdraw more shares than in balance"\)|it.skip(\1|g' test/compoundAssetProxyTest.ts
+    sed -i 's|it(\("should prevent withdrawal of Principal Tokens and Interest Tokens before the tranche expires "\)|it.skip(\1|g' test/trancheTest.ts
+    sed -i 's|it(\("should prevent withdrawal of more Principal Tokens and Interest Tokens than the user has"\)|it.skip(\1|g' test/trancheTest.ts
 
     # This test file is very flaky. There's one particular cases that fails randomly (see
     # https://github.com/element-fi/elf-contracts/issues/240) but some others also depends on an external

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -42,13 +42,12 @@ function gnosis_safe_test
     local config_file="hardhat.config.ts"
     local config_var=userConfig
 
-    local compile_only_presets=(
-        ir-optimize-evm+yul        # Compiles but tests fail. See https://github.com/nomiclabs/hardhat/issues/2115
-    )
+    local compile_only_presets=()
     local settings_presets=(
         "${compile_only_presets[@]}"
         #ir-no-optimize            # Compilation fails with "YulException: Variable var_call_430_mpos is 1 slot(s) too deep inside the stack."
         #ir-optimize-evm-only      # Compilation fails with "YulException: Variable var_call_430_mpos is 1 slot(s) too deep inside the stack."
+        ir-optimize-evm+yul
         legacy-no-optimize
         legacy-optimize-evm-only
         legacy-optimize-evm+yul
@@ -69,6 +68,11 @@ function gnosis_safe_test
     # Disable two tests failing due to Hardhat's heuristics not yet updated to handle solc 0.8.10.
     # TODO: Remove this when Hardhat implements them (https://github.com/nomiclabs/hardhat/issues/2051).
     sed -i "s|\(it\)\(('should revert if called directly', async () => {\)|\1.skip\2|g" test/handlers/CompatibilityFallbackHandler.spec.ts
+
+    # Disable tests that won't pass on the ir presets due to Hardhat heuristics. Note that this also disables
+    # them for other presets but that's fine - we want same code run for benchmarks to be comparable.
+    # TODO: Remove this when Hardhat adjusts heuristics for IR (https://github.com/nomiclabs/hardhat/issues/2115).
+    sed -i "s|\(it\)\(('should not allow to call setup on singleton'\)|\1.skip\2|g" test/core/GnosisSafe.Setup.spec.ts
 
     neutralize_package_lock
     neutralize_package_json_hooks


### PR DESCRIPTION
~Depends on #12195.~ Merged.

So far only compilation was enabled in IR presets for OpenZeppelin, PRBMath, ElementFi and (after #12197) Gnosis. This is due to https://github.com/nomiclabs/hardhat/issues/2115, which is still unresolved. Unfortunately this does not give us any benchmarks via IR for these projects. In this PR I'm re-enabling tests and instead disabling individual test cases that do not pass.

~The PR also disables one particularly flaky test file in ElementFi. It has one case that fails often and has been reported upstream (https://github.com/element-fi/elf-contracts/issues/240) but also many tests in the file seem to depend on an external service, which has resulted in a mass failure due to network timeout at least once when the service was down.~ **EDIT**: This part moved to #12764.