### PR TITLE
Store whether a subassembly is creation code and optimize accordingly.

### DIFF
--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -74,7 +74,7 @@ public:
 		m_yulUtilFunctions(m_evmVersion, m_revertStrings, m_yulFunctionCollector)
 	{
 		if (m_runtimeContext)
-			m_runtimeSub = size_t(m_asm->newSub(m_runtimeContext->m_asm).data());
+			m_runtimeSub = size_t(m_asm->newSub(m_runtimeContext->m_asm, false).data());
 	}
 
 	langutil::EVMVersion const& evmVersion() const { return m_evmVersion; }
@@ -224,7 +224,7 @@ public:
 	}
 	/// Adds a subroutine to the code (in the data section) and pushes its size (via a tag)
 	/// on the stack. @returns the pushsub assembly item.
-	evmasm::AssemblyItem addSubroutine(evmasm::AssemblyPointer const& _assembly) { return m_asm->appendSubroutine(_assembly); }
+	evmasm::AssemblyItem addSubroutine(evmasm::AssemblyPointer const& _assembly, bool _creation) { return m_asm->appendSubroutine(_assembly, _creation); }
 	/// Pushes the size of the subroutine.
 	void pushSubroutineSize(size_t _subRoutine) { m_asm->pushSubroutineSize(_subRoutine); }
 	/// Pushes the offset of the subroutine.

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -1521,7 +1521,7 @@ void CompilerUtils::copyContractCodeToMemory(ContractDefinition const& contract,
 				_context.compiledContract(contract) :
 				_context.compiledContractRuntime(contract);
 			// pushes size
-			auto subroutine = _context.addSubroutine(assembly);
+			auto subroutine = _context.addSubroutine(assembly, _creation);
 			_context << Instruction::DUP1 << subroutine;
 			_context << Instruction::DUP4 << Instruction::CODECOPY;
 			_context << Instruction::ADD;

--- a/libyul/AssemblyStack.cpp
+++ b/libyul/AssemblyStack.cpp
@@ -37,8 +37,12 @@
 #include <libyul/optimiser/Suite.h>
 
 #include <libevmasm/Assembly.h>
+
 #include <liblangutil/Scanner.h>
+
+#include <boost/algorithm/string.hpp>
 #include <optional>
+
 
 using namespace std;
 using namespace solidity;
@@ -194,7 +198,11 @@ void AssemblyStack::optimize(Object& _object, bool _isCreation)
 	yulAssert(_object.analysisInfo, "");
 	for (auto& subNode: _object.subObjects)
 		if (auto subObject = dynamic_cast<Object*>(subNode.get()))
-			optimize(*subObject, false);
+		{
+			// TODO: determine this more properly, resp. store it earlier when the subobject is created
+			bool isCreation = !boost::ends_with(subObject->name.str(), "_deployed");
+			optimize(*subObject, isCreation);
+		}
 
 	Dialect const& dialect = languageToDialect(m_language, m_evmVersion);
 	unique_ptr<GasMeter> meter;

--- a/libyul/backends/evm/AbstractAssembly.h
+++ b/libyul/backends/evm/AbstractAssembly.h
@@ -98,7 +98,7 @@ public:
 	/// Append the assembled size as a constant.
 	virtual void appendAssemblySize() = 0;
 	/// Creates a new sub-assembly, which can be referenced using dataSize and dataOffset.
-	virtual std::pair<std::shared_ptr<AbstractAssembly>, SubID> createSubAssembly(std::string _name = "") = 0;
+	virtual std::pair<std::shared_ptr<AbstractAssembly>, SubID> createSubAssembly(std::string _name, bool _creation) = 0;
 	/// Appends the offset of the given sub-assembly or data.
 	virtual void appendDataOffset(std::vector<SubID> const& _subPath) = 0;
 	/// Appends the size of the given sub-assembly or data.

--- a/libyul/backends/evm/EVMObjectCompiler.cpp
+++ b/libyul/backends/evm/EVMObjectCompiler.cpp
@@ -28,6 +28,8 @@
 #include <libyul/Object.h>
 #include <libyul/Exceptions.h>
 
+#include <boost/algorithm/string.hpp>
+
 using namespace solidity::yul;
 using namespace std;
 
@@ -46,7 +48,9 @@ void EVMObjectCompiler::run(Object& _object, bool _optimize)
 	for (auto const& subNode: _object.subObjects)
 		if (auto* subObject = dynamic_cast<Object*>(subNode.get()))
 		{
-			auto subAssemblyAndID = m_assembly.createSubAssembly(subObject->name.str());
+			// TODO: determine this more properly, resp. store it earlier when the subobject is created
+			bool isCreation = !boost::ends_with(subObject->name.str(), "_deployed");
+			auto subAssemblyAndID = m_assembly.createSubAssembly(subObject->name.str(), isCreation);
 			context.subIDs[subObject->name] = subAssemblyAndID.second;
 			subObject->subId = subAssemblyAndID.second;
 			compile(*subObject, *subAssemblyAndID.first, m_dialect, _optimize);

--- a/libyul/backends/evm/EthAssemblyAdapter.cpp
+++ b/libyul/backends/evm/EthAssemblyAdapter.cpp
@@ -122,10 +122,10 @@ void EthAssemblyAdapter::appendAssemblySize()
 	m_assembly.appendProgramSize();
 }
 
-pair<shared_ptr<AbstractAssembly>, AbstractAssembly::SubID> EthAssemblyAdapter::createSubAssembly(string _name)
+pair<shared_ptr<AbstractAssembly>, AbstractAssembly::SubID> EthAssemblyAdapter::createSubAssembly(string _name, bool _creation)
 {
 	shared_ptr<evmasm::Assembly> assembly{make_shared<evmasm::Assembly>(std::move(_name))};
-	auto sub = m_assembly.newSub(assembly);
+	auto sub = m_assembly.newSub(assembly, _creation);
 	return {make_shared<EthAssemblyAdapter>(*assembly), static_cast<size_t>(sub.data())};
 }
 

--- a/libyul/backends/evm/EthAssemblyAdapter.h
+++ b/libyul/backends/evm/EthAssemblyAdapter.h
@@ -55,7 +55,7 @@ public:
 	void appendJumpTo(LabelID _labelId, int _stackDiffAfter, JumpType _jumpType) override;
 	void appendJumpToIf(LabelID _labelId, JumpType _jumpType) override;
 	void appendAssemblySize() override;
-	std::pair<std::shared_ptr<AbstractAssembly>, SubID> createSubAssembly(std::string _name = {}) override;
+	std::pair<std::shared_ptr<AbstractAssembly>, SubID> createSubAssembly(std::string _name, bool _creation) override;
 	void appendDataOffset(std::vector<SubID> const& _subPath) override;
 	void appendDataSize(std::vector<SubID> const& _subPath) override;
 	SubID appendData(bytes const& _data) override;

--- a/libyul/backends/evm/NoOutputAssembly.cpp
+++ b/libyul/backends/evm/NoOutputAssembly.cpp
@@ -98,7 +98,7 @@ void NoOutputAssembly::appendAssemblySize()
 	appendInstruction(evmasm::Instruction::PUSH1);
 }
 
-pair<shared_ptr<AbstractAssembly>, AbstractAssembly::SubID> NoOutputAssembly::createSubAssembly(std::string)
+pair<shared_ptr<AbstractAssembly>, AbstractAssembly::SubID> NoOutputAssembly::createSubAssembly(std::string, bool)
 {
 	yulAssert(false, "Sub assemblies not implemented.");
 	return {};

--- a/libyul/backends/evm/NoOutputAssembly.h
+++ b/libyul/backends/evm/NoOutputAssembly.h
@@ -65,7 +65,7 @@ public:
 	void appendJumpToIf(LabelID _labelId, JumpType _jumpType) override;
 
 	void appendAssemblySize() override;
-	std::pair<std::shared_ptr<AbstractAssembly>, SubID> createSubAssembly(std::string _name = "") override;
+	std::pair<std::shared_ptr<AbstractAssembly>, SubID> createSubAssembly(std::string _name, bool _creation) override;
 	void appendDataOffset(std::vector<SubID> const& _subPath) override;
 	void appendDataSize(std::vector<SubID> const& _subPath) override;
 	SubID appendData(bytes const& _data) override;

--- a/test/cmdlineTests/yul_optimize_runs/output
+++ b/test/cmdlineTests/yul_optimize_runs/output
@@ -13,7 +13,7 @@ object "RunsTest1" {
     object "Runtime" {
         code {
             {
-                sstore(0, 0xabc1234500000000000000000000000000000000000000000000000000000000)
+                sstore(0, shl(224, 0xabc12345))
             }
         }
     }
@@ -21,7 +21,7 @@ object "RunsTest1" {
 
 
 Binary representation:
-602580600c6000396000f3fe7fabc123450000000000000000000000000000000000000000000000000000000060005500
+600c80600c6000396000f3fe63abc1234560e01b60005500
 
 Text representation:
     /* "yul_optimize_runs/input.yul":106:125   */
@@ -40,8 +40,7 @@ Text representation:
 stop
 
 sub_0: assembly {
-        /* "yul_optimize_runs/input.yul":237:257   */
-      0xabc1234500000000000000000000000000000000000000000000000000000000
+      shl(0xe0, 0xabc12345)
         /* "yul_optimize_runs/input.yul":277:278   */
       0x00
         /* "yul_optimize_runs/input.yul":270:288   */

--- a/test/libevmasm/Assembler.cpp
+++ b/test/libevmasm/Assembler.cpp
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(all_assembly_items)
 	// PushData
 	_assembly.append(bytes{0x1, 0x2, 0x3, 0x4});
 	// PushSubSize
-	auto sub = _assembly.appendSubroutine(_subAsmPtr);
+	auto sub = _assembly.appendSubroutine(_subAsmPtr, false);
 	// PushSub
 	_assembly.pushSubroutineOffset(static_cast<size_t>(sub.data()));
 	// PushDeployTimeAddress
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(immutables_and_its_source_maps)
 				assembly.appendImmutableAssignment(string(1, char('a' + i - 1)));
 			}
 
-			assembly.appendSubroutine(subAsm);
+			assembly.appendSubroutine(subAsm, false);
 
 			checkCompilation(assembly);
 
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(immutable)
 	_assembly.append(u256(0));
 	_assembly.appendImmutableAssignment("someOtherImmutable");
 
-	auto sub = _assembly.appendSubroutine(_subAsmPtr);
+	auto sub = _assembly.appendSubroutine(_subAsmPtr, false);
 	_assembly.pushSubroutineOffset(static_cast<size_t>(sub.data()));
 
 	checkCompilation(_assembly);
@@ -354,8 +354,8 @@ BOOST_AUTO_TEST_CASE(subobject_encode_decode)
 	shared_ptr<Assembly> subAsmPtr = make_shared<Assembly>();
 	shared_ptr<Assembly> subSubAsmPtr = make_shared<Assembly>();
 
-	assembly.appendSubroutine(subAsmPtr);
-	subAsmPtr->appendSubroutine(subSubAsmPtr);
+	assembly.appendSubroutine(subAsmPtr, false);
+	subAsmPtr->appendSubroutine(subSubAsmPtr, false);
 
 	BOOST_CHECK(assembly.encodeSubPath({0}) == 0);
 	BOOST_REQUIRE_THROW(assembly.encodeSubPath({1}), solidity::evmasm::AssemblyException);

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -1272,7 +1272,7 @@ BOOST_AUTO_TEST_CASE(jumpdest_removal_subassemblies)
 	sub->append(t4.pushTag());
 	sub->append(Instruction::JUMP);
 
-	size_t subId = static_cast<size_t>(main.appendSubroutine(sub).data());
+	size_t subId = static_cast<size_t>(main.appendSubroutine(sub, false).data());
 	main.append(t1.toSubAssemblyTag(subId));
 	main.append(t1.toSubAssemblyTag(subId));
 	main.append(u256(8));

--- a/test/libsolidity/semanticTests/array/reusing_memory.sol
+++ b/test/libsolidity/semanticTests/array/reusing_memory.sol
@@ -26,6 +26,6 @@ contract Main {
 // compileViaYul: also
 // ----
 // f(uint256): 0x34 -> 0x46bddb1178e94d7f2892ff5f366840eb658911794f2c3a44c450aa2c505186c1
-// gas irOptimized: 113598
+// gas irOptimized: 113613
 // gas legacy: 126596
 // gas legacyOptimized: 113823

--- a/test/libsolidity/semanticTests/constructor/arrays_in_constructors.sol
+++ b/test/libsolidity/semanticTests/constructor/arrays_in_constructors.sol
@@ -26,6 +26,6 @@ contract Creator {
 // compileViaYul: also
 // ----
 // f(uint256,address[]): 7, 0x40, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 -> 7, 8
-// gas irOptimized: 443960
+// gas irOptimized: 443989
 // gas legacy: 590683
 // gas legacyOptimized: 448326

--- a/test/libsolidity/semanticTests/constructor/bytes_in_constructors_packer.sol
+++ b/test/libsolidity/semanticTests/constructor/bytes_in_constructors_packer.sol
@@ -26,6 +26,6 @@ contract Creator {
 // compileViaYul: also
 // ----
 // f(uint256,bytes): 7, 0x40, 78, "abcdefghijklmnopqrstuvwxyzabcdef", "ghijklmnopqrstuvwxyzabcdefghijkl", "mnopqrstuvwxyz" -> 7, "h"
-// gas irOptimized: 300804
+// gas irOptimized: 300837
 // gas legacy: 428917
 // gas legacyOptimized: 298128

--- a/test/libsolidity/semanticTests/functionCall/creation_function_call_with_args.sol
+++ b/test/libsolidity/semanticTests/functionCall/creation_function_call_with_args.sol
@@ -17,7 +17,7 @@ contract D {
 // compileViaYul: also
 // ----
 // constructor(): 2 ->
-// gas irOptimized: 203967
+// gas irOptimized: 203982
 // gas legacy: 245842
 // gas legacyOptimized: 195676
 // f() -> 2

--- a/test/libsolidity/semanticTests/functionCall/creation_function_call_with_salt.sol
+++ b/test/libsolidity/semanticTests/functionCall/creation_function_call_with_salt.sol
@@ -18,7 +18,7 @@ contract D {
 // compileViaYul: also
 // ----
 // constructor(): 2 ->
-// gas irOptimized: 204130
+// gas irOptimized: 204145
 // gas legacy: 246202
 // gas legacyOptimized: 195914
 // f() -> 2

--- a/test/libsolidity/semanticTests/inheritance/value_for_constructor.sol
+++ b/test/libsolidity/semanticTests/inheritance/value_for_constructor.sol
@@ -42,7 +42,7 @@ contract Main {
 // compileViaYul: also
 // ----
 // constructor(), 22 wei ->
-// gas irOptimized: 284287
+// gas irOptimized: 284321
 // gas legacy: 402045
 // gas legacyOptimized: 266772
 // getFlag() -> true

--- a/test/libsolidity/semanticTests/salted_create/salted_create_with_value.sol
+++ b/test/libsolidity/semanticTests/salted_create/salted_create_with_value.sol
@@ -22,6 +22,6 @@ contract A {
 // compileViaYul: also
 // ----
 // f(), 10 ether -> 3007, 3008, 3009
-// gas irOptimized: 272413
+// gas irOptimized: 272467
 // gas legacy: 422501
 // gas legacyOptimized: 287472


### PR DESCRIPTION
Attempt to fix https://github.com/ethereum/solidity/issues/12738
Should also fix https://github.com/ethereum/solidity/issues/11118

Not ready yet:
- [ ] needs Changelog entry
- [ ] needs unit tests
- [ ] needs a decision on whether we want a better way to determine whether a yul object is creation code than checking for the ``_deployed`` suffix.
- [ ] needs to check if the change in legacy code gen in ``libsolidity/codegen/CompilerUtils.cpp`` is needed - and should either get a test for it or have the change reverted (if it affects legacy codegen, we also have to consider if it's an "important bug")