### PR TITLE
Removed "using namespace util" directive from ASTAnnotations.h #12743

### DIFF
--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -47,7 +47,6 @@ namespace solidity::frontend
 
 class Type;
 class ArrayType;
-using namespace util;
 
 struct CallGraph;
 


### PR DESCRIPTION
removed "using namespace util;"