### PR TITLE
doc: improve explanation of interfaces

### DIFF
--- a/docs/contracts/interfaces.rst
+++ b/docs/contracts/interfaces.rst
@@ -10,7 +10,7 @@ Interfaces are similar to abstract contracts, but they cannot have any functions
 There are further restrictions:
 
 - They cannot inherit from other contracts, but they can inherit from other interfaces.
-- All declared functions must be external.
+- All declared functions must be external in the interface, even if they are public in the contract.
 - They cannot declare a constructor.
 - They cannot declare state variables.
 - They cannot declare modifiers.


### PR DESCRIPTION
Something that tricked me when I was learning solidity back in the days. I thought that the interface can only be constructed from external functions. When in reality, contract implementation can be public, but it MUST be external in the interface. Therefore, here is the small change in docs that might help someone. 