### PR TITLE
Increase Hardhat timeout in Euler ext test

### DIFF
--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -233,12 +233,34 @@ function force_truffle_compiler_settings
 function name_hardhat_default_export
 {
     local config_file="$1"
-    local config_var_name="$2"
 
     local import="import {HardhatUserConfig} from 'hardhat/types';"
     local config="const config: HardhatUserConfig = {"
     sed -i "s|^\s*export\s*default\s*{|${import}\n${config}|g" "$config_file"
     echo "export default config;" >> "$config_file"
+}
+
+function force_hardhat_timeout
+{
+    local config_file="$1"
+    local config_var_name="$2"
+    local new_timeout="$3"
+
+    printLog "Configuring Hardhat..."
+    echo "-------------------------------------"
+    echo "Timeout: ${new_timeout}"
+    echo "-------------------------------------"
+
+    if [[ $config_file == *\.js ]]; then
+        [[ $config_var_name == "" ]] || assertFail
+        echo "module.exports.mocha = module.exports.mocha || {timeout: ${new_timeout}}"
+        echo "module.exports.mocha.timeout =  ${new_timeout}"
+    else
+        [[ $config_file == *\.ts ]] || assertFail
+        [[ $config_var_name != "" ]] || assertFail
+        echo "${config_var_name}.mocha = ${config_var_name}.mocha ?? {timeout: ${new_timeout}};"
+        echo "${config_var_name}.mocha!.timeout = ${new_timeout}"
+    fi >> "$config_file"
 }
 
 function force_hardhat_compiler_binary

--- a/test/externalTests/euler.sh
+++ b/test/externalTests/euler.sh
@@ -63,6 +63,8 @@ function euler_test
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")"
     force_hardhat_unlimited_contract_size "$config_file"
+    # Workaround for the timeout that's too short for unoptimized code (https://github.com/ethereum/solidity/pull/12765)
+    force_hardhat_timeout "$config_file" "" 100000
     npm install
 
     replace_version_pragmas


### PR DESCRIPTION
Euler has prepared a branch that increases the timeout to 100 sec (https://github.com/euler-xyz/euler-contracts/issues/97#issuecomment-1061000033) so we should start seeing fewer failures due to this.

~Unfortunately I don't see any way of properly evaluating it other than just merging it and seeing if we keep running into timeouts. They happen regularly but even if I just rerun tests a few times here, it won't prove that the issue is fixed.~