### PR TITLE
Euler timeout fix: switch to TEST_TIMEOUT variable

### DIFF
--- a/test/externalTests/euler.sh
+++ b/test/externalTests/euler.sh
@@ -32,7 +32,10 @@ BINARY_PATH="$2"
 SELECTED_PRESETS="$3"
 
 function compile_fn { npm run compile; }
-function test_fn { npx --no hardhat --no-compile test; }
+function test_fn {
+    # The default timeout of 20000 ms is too short for unoptimized code (https://github.com/ethereum/solidity/pull/12765).
+    TEST_TIMEOUT=100000 npx --no hardhat --no-compile test
+}
 
 function euler_test
 {
@@ -63,8 +66,6 @@ function euler_test
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")"
     force_hardhat_unlimited_contract_size "$config_file"
-    # Workaround for the timeout that's too short for unoptimized code (https://github.com/ethereum/solidity/pull/12765)
-    force_hardhat_timeout "$config_file" "" 100000
     npm install
 
     replace_version_pragmas


### PR DESCRIPTION
Followup to #12765. The failure in [22877](https://app.circleci.com/pipelines/github/ethereum/solidity/22877/workflows/224204c3-78fc-457c-ae2a-b0a980550af6/jobs/1004400) shows that the fix suggested in https://github.com/euler-xyz/euler-contracts/issues/97 does not work. The `mocha.timeout` setting is ignored. After some experimenting I determined that it's because Euler [overrides that timeout in `eTestLib.js`](https://github.com/euler-xyz/euler-contracts/blob/master/test/lib/eTestLib.js#L1007-L1017) so the setting is ignored.

Fortunately you can set a custom timeout via `TEST_TIMEOUT` env variable and this is what I'm doing in this PR.

I verified that setting `TEST_TIMEOUT` to a very low value makes all tests time out so I think this time it's going to work as expected.

I'm leaving in the helper I added in #12765. It's not used by any test now but it might still come in handy in the future.