### PR TITLE
Clarifying a doc entry on Address.balance

### DIFF
--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -246,7 +246,7 @@ Members of Address Types
 ------------------------
 
 ``<address>.balance`` (``uint256``)
-    balance of the :ref:`address` in Wei
+    balance of the :ref:`address` in Wei. In the case of msg.sender, the returned value is reduced by the expected gas cost of the transaction (tx gas limit * ``tx.gasprice``)
 
 ``<address>.code`` (``bytes memory``)
     code at the :ref:`address` (can be empty)


### PR DESCRIPTION
Fixes #12772.

The value returned by `address.balance` is slightly different for `msg.sender`. In that case it is reduced by the transaction's gas limit multiplied by the `tx.gasprice`.

Code that attempts to compare balances and make decisions should be aware of this.

I have proposed a tweak to the documentation for `address.balance`. Please review and edit as appropriate.

Thank you.