### PR TITLE
Error messages from abi encodecall are giving more details about the types of the involved variables

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2204,9 +2204,9 @@ void TypeChecker::typeCheckABIEncodeCallFunction(FunctionCall const& _functionCa
 				"Cannot implicitly convert component at position " +
 				to_string(i) +
 				" from \"" +
-				argType.canonicalName() +
+				argType.toString() +
 				"\" to \"" +
-				functionPointerType->parameterTypes()[i]->canonicalName() +
+				functionPointerType->parameterTypes()[i]->toString() +
 				"\"" +
 				(result.message().empty() ?  "." : ": " + result.message())
 			);

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encode_convert_address_to_address_payable.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encode_convert_address_to_address_payable.sol
@@ -1,0 +1,11 @@
+interface I {
+    function f(address payable) external;
+}
+
+contract C {
+    function main() external view {
+        abi.encodeCall(I.f, (address(0)));
+    }
+}
+// ----
+// TypeError 5407: (136-148): Cannot implicitly convert component at position 0 from "address" to "address payable".

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encode_convert_function_pointer_to_different_function_pointer.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encode_convert_function_pointer_to_different_function_pointer.sol
@@ -1,0 +1,13 @@
+interface I {
+    function f(function (string calldata) external) external;
+}
+
+contract C {
+    function g(string calldata) external {}
+
+    function main() external view {
+        abi.encodeCall(I.f, (this.g));
+    }
+}
+// ----
+// TypeError 5407: (201-209): Cannot implicitly convert component at position 0 from "function (string memory) external" to "function (string calldata) external".

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encode_convert_function_to_different_function.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encode_convert_function_to_different_function.sol
@@ -1,0 +1,13 @@
+interface I {
+    function f(function (string calldata) external view returns (uint)) external;
+}
+
+contract C {
+    function g(string memory) external {}
+
+    function main() external view {
+        abi.encodeCall(I.f, (this.g));
+    }
+}
+// ----
+// TypeError 5407: (219-227): Cannot implicitly convert component at position 0 from "function (string memory) external" to "function (string calldata) view external returns (uint256)".

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encode_convert_string_to_different_string.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encode_convert_string_to_different_string.sol
@@ -1,0 +1,12 @@
+interface I {
+    function f(string calldata) external;
+}
+
+contract C {
+    string s;
+    function main() external view {
+        abi.encodeCall(I.f, (s));
+    }
+}
+// ----
+// TypeError 5407: (150-153): Cannot implicitly convert component at position 0 from "string storage ref" to "string calldata".

--- a/test/libsolidity/syntaxTests/specialFunctions/encodeCall_fail_args.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/encodeCall_fail_args.sol
@@ -24,4 +24,4 @@ contract C {
 // TypeError 7788: (382-408): Expected 1 instead of 0 components for the tuple parameter.
 // TypeError 6219: (489-511): Expected two arguments: a function pointer followed by a tuple.
 // TypeError 7515: (597-628): Expected a tuple with 2 components instead of a single non-tuple parameter.
-// TypeError 5407: (621-627): Cannot implicitly convert component at position 0 from "uint8[2]" to "int256".
+// TypeError 5407: (621-627): Cannot implicitly convert component at position 0 from "uint8[2] memory" to "int256".


### PR DESCRIPTION
closes #12776 