### PR TITLE
Fix import directive visits in type checker and view pure checker.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ Compiler Features:
 
 Bugfixes:
  * General: Fix internal error for locales with unusual capitalization rules. Locale set in the environment is now completely ignored.
+ * Type Checker: Fix incorrect type checker errors when importing overloaded functions.
  * Yul IR Code Generation: Optimize embedded creation code with correct settings. This fixes potential mismatches between the constructor code of a contract compiled in isolation and the bytecode in ``type(C).creationCode``, resp. the bytecode used for ``new C(...)``.
 
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -268,6 +268,11 @@ TypePointers TypeChecker::typeCheckMetaTypeFunctionAndRetrieveReturnType(Functio
 	return {TypeProvider::meta(dynamic_cast<TypeType const&>(*firstArgType).actualType())};
 }
 
+bool TypeChecker::visit(ImportDirective const&)
+{
+	return false;
+}
+
 void TypeChecker::endVisit(InheritanceSpecifier const& _inheritance)
 {
 	auto base = dynamic_cast<ContractDefinition const*>(&dereference(_inheritance.name()));

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -125,6 +125,8 @@ private:
 		FunctionType const* _functionType
 	);
 
+	bool visit(ImportDirective const&) override;
+
 	void endVisit(InheritanceSpecifier const& _inheritance) override;
 	void endVisit(ModifierDefinition const& _modifier) override;
 	bool visit(FunctionDefinition const& _function) override;

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -134,6 +134,11 @@ bool ViewPureChecker::check()
 	return !m_errors;
 }
 
+bool ViewPureChecker::visit(ImportDirective const&)
+{
+	return false;
+}
+
 bool ViewPureChecker::visit(FunctionDefinition const& _funDef)
 {
 	solAssert(!m_currentFunction, "");

--- a/libsolidity/analysis/ViewPureChecker.h
+++ b/libsolidity/analysis/ViewPureChecker.h
@@ -50,6 +50,8 @@ private:
 		langutil::SourceLocation location;
 	};
 
+	bool visit(ImportDirective const&) override;
+
 	bool visit(FunctionDefinition const& _funDef) override;
 	void endVisit(FunctionDefinition const& _funDef) override;
 	bool visit(ModifierDefinition const& _modifierDef) override;

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -115,6 +115,12 @@ void SMTEncoder::endVisit(ContractDefinition const& _contract)
 		m_context.popSolver();
 }
 
+bool SMTEncoder::visit(ImportDirective const&)
+{
+	// do not visit because the identifier therein will confuse us.
+	return false;
+}
+
 void SMTEncoder::endVisit(VariableDeclaration const& _varDecl)
 {
 	// State variables are handled by the constructor.

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -136,6 +136,7 @@ protected:
 	// because the order of expression evaluation is undefined
 	// TODO: or just force a certain order, but people might have a different idea about that.
 
+	bool visit(ImportDirective const& _node) override;
 	bool visit(ContractDefinition const& _node) override;
 	void endVisit(ContractDefinition const& _node) override;
 	void endVisit(VariableDeclaration const& _node) override;

--- a/test/libsolidity/semanticTests/multiSource/import_overloaded_function.sol
+++ b/test/libsolidity/semanticTests/multiSource/import_overloaded_function.sol
@@ -1,0 +1,15 @@
+==== Source: A ====
+function sub(uint256 x, uint256 y) pure returns (uint) { return 1; }
+function sub(uint256 x) pure returns (uint) { return 2; }
+==== Source: B ====
+import {sub} from "A";
+contract C
+{
+    function f() public pure returns (uint, uint) {
+        return (sub(1, 2), sub(2));
+    }
+}
+// ====
+// compileViaYul: also
+// ----
+// f() -> 1, 2


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/12780

This was an unfortunate omission in https://github.com/ethereum/solidity/pull/12494