### PR TITLE
Moves comment above the line for which it was intended.

### DIFF
--- a/docs/examples/voting.rst
+++ b/docs/examples/voting.rst
@@ -128,12 +128,12 @@ of votes.
                 require(to != msg.sender, "Found loop in delegation.");
             }
 
-            // Since `sender` is a reference, this
-            // modifies `voters[msg.sender].voted`
             Voter storage delegate_ = voters[to];
 
             // Voters cannot delegate to wallets that cannot vote.
             require(delegate_.weight >= 1);
+            // Since `sender` is a reference, this
+            // modifies `voters[msg.sender].voted`
             sender.voted = true;
             sender.delegate = to;
             if (delegate_.voted) {


### PR DESCRIPTION
That comment above the `Voter storage delegate_ = voters[to];` line is confusing, because that's not what that line of code does. This moves that comment above the line for which it was intended.