### PR TITLE
Permit control flow mutations in global scope of a Yul program.

### DIFF
--- a/test/tools/ossfuzz/protomutators/YulProtoMutator.cpp
+++ b/test/tools/ossfuzz/protomutators/YulProtoMutator.cpp
@@ -73,6 +73,7 @@ static addControlFlow<SwitchStmt> c4;
 static addControlFlow<FunctionDef> c5;
 static addControlFlow<CaseStmt> c6;
 static addControlFlow<Code> c7;
+static addControlFlow<Program> c8;
 
 Literal* YPM::intLiteral(unsigned _value)
 {
@@ -261,6 +262,24 @@ Block* YPM::basicBlock(T* _msg)
 		return _msg->mutable_case_block();
 	else if constexpr (std::is_same_v<T, Code>)
 		return _msg->mutable_block();
+	else if constexpr (std::is_same_v<T, Program>)
+		return globalBlock(_msg);
 	else
 		static_assert(AlwaysFalse<T>::value, "Yul proto mutator: non-exhaustive visitor.");
+}
+
+Block* YPM::globalBlock(Program* _program)
+{
+	switch (_program->program_oneof_case())
+	{
+	case Program::kBlock:
+		return _program->mutable_block();
+	case Program::kObj:
+		return _program->mutable_obj()->mutable_code()->mutable_block();
+	case Program::PROGRAM_ONEOF_NOT_SET:
+	{
+		_program->set_allocated_block(new Block());
+		return _program->mutable_block();
+	}
+	}
 }

--- a/test/tools/ossfuzz/protomutators/YulProtoMutator.h
+++ b/test/tools/ossfuzz/protomutators/YulProtoMutator.h
@@ -103,5 +103,7 @@ struct YulProtoMutator
 	/// Obtain a basic block in a for stmt uniformly
 	/// at random
 	static Block* randomBlock(ForStmt* _msg);
+	/// Obtain a basic block in global scope.
+	static Block* globalBlock(Program* _program);
 };
 }


### PR DESCRIPTION
The fuzzer mutation in this PR adds control-flow changing instructions in the global scope of a Yul program. Example:

```
{}
```

becomes

```
{ if (true) {} }
```