### PR TITLE
CSE optimization

### DIFF
--- a/libevmasm/CommonSubexpressionEliminator.cpp
+++ b/libevmasm/CommonSubexpressionEliminator.cpp
@@ -219,7 +219,7 @@ void CSECodeGenerator::addDependencies(Id _c)
 {
 	if (m_classPositions.count(_c))
 		return; // it is already on the stack
-	if (m_neededBy.count(_c))
+	if (m_neededBy.find(_c) != m_neededBy.end())
 		return; // we already computed the dependencies for _c
 	ExpressionClasses::Expression expr = m_expressionClasses.representative(_c);
 	assertThrow(expr.item, OptimizerException, "");
@@ -300,8 +300,8 @@ void CSECodeGenerator::addDependencies(Id _c)
 
 void CSECodeGenerator::generateClassElement(Id _c, bool _allowSequenced)
 {
-	for (auto it: m_classPositions)
-		for (auto p: it.second)
+	for (auto const& it: m_classPositions)
+		for (int p: it.second)
 			if (p > m_stackHeight)
 			{
 				assertThrow(false, OptimizerException, "");

--- a/libevmasm/CommonSubexpressionEliminator.h
+++ b/libevmasm/CommonSubexpressionEliminator.h
@@ -24,11 +24,12 @@
 
 #pragma once
 
-#include <vector>
 #include <map>
+#include <ostream>
 #include <set>
 #include <tuple>
-#include <ostream>
+#include <unordered_map>
+#include <vector>
 #include <libsolutil/CommonIO.h>
 #include <libsolutil/Exceptions.h>
 #include <libevmasm/ExpressionClasses.h>
@@ -154,11 +155,11 @@ private:
 	/// Current height of the stack relative to the start.
 	int m_stackHeight = 0;
 	/// If (b, a) is in m_requests then b is needed to compute a.
-	std::multimap<Id, Id> m_neededBy;
+	std::unordered_multimap<Id, Id> m_neededBy;
 	/// Current content of the stack.
 	std::map<int, Id> m_stack;
 	/// Current positions of equivalence classes, equal to the empty set if already deleted.
-	std::map<Id, std::set<int>> m_classPositions;
+	std::unordered_map<Id, std::set<int>> m_classPositions;
 
 	/// The actual equivalence class items and how to compute them.
 	ExpressionClasses& m_expressionClasses;


### PR DESCRIPTION
partially address: #12406

Proposed changes:
1) Fix the problem of missing reference in range-for with non trivial type in CSECodeGenerator::generateClassElement.
2) During optimization, the [CommonSubexpressionEliminator](https://github.com/ethereum/solidity/blob/develop/libevmasm/CommonSubexpressionEliminator.h#L62) spends much time accessing elements of [m_classPositions](https://github.com/ethereum/solidity/blob/develop/libevmasm/CommonSubexpressionEliminator.h#L161) and [m_neededBy](https://github.com/ethereum/solidity/blob/develop/libevmasm/CommonSubexpressionEliminator.h#L157). By converting these two to hash maps we gain constant access time in average scenario.
3) Because [m_neededBy](https://github.com/ethereum/solidity/blob/develop/libevmasm/CommonSubexpressionEliminator.h#L157) is a multimap it is usually more efficient to check element presence with `find` function call instead `count`.

With all above changes [MediumVerifier.sol](https://gist.github.com/citizen-stig/a25be3d125969c64f0f2b94b28a0d160) compilation time in my local environment is reduced from 2h10min to 24min.