### PR TITLE
Fixed ambiguity in the create2 address computation doc

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -283,7 +283,7 @@ which only need to be created if there is a dispute.
                 salt,
                 keccak256(abi.encodePacked(
                     type(D).creationCode,
-                    arg
+                    abi.encode(arg)
                 ))
             )))));
 


### PR DESCRIPTION
specify that arguments are encoded using abi.encode in both the text and the example code