### PR TITLE
use special prerelease version precedence check only if major, minor and patch identifiers match

### DIFF
--- a/liblangutil/SemVerHandler.cpp
+++ b/liblangutil/SemVerHandler.cpp
@@ -116,7 +116,7 @@ bool SemVerMatchExpression::MatchComponent::matches(SemVerVersion const& _versio
 				cmp = static_cast<int>(_version.numbers[i] - version.numbers[i]);
 			}
 
-		if (cmp == 0 && !_version.prerelease.empty() && didCompare)
+		if (cmp == 0 && levelsPresent == 3 && !_version.prerelease.empty() && didCompare)
 			cmp = -1;
 
 		switch (prefix)


### PR DESCRIPTION
Item 11.3 in semvar specs says prerelease check is performed if and only if the major, minor and patch versions match. This commit adds a check to perform prerelease check only when the major, minor and patch version match.

fixes #12812 

**Pending:**
- add tests