### PR TITLE
CSE optimization 

### DIFF
--- a/libevmasm/CommonSubexpressionEliminator.h
+++ b/libevmasm/CommonSubexpressionEliminator.h
@@ -179,7 +179,12 @@ AssemblyItemIterator CommonSubexpressionEliminator::feedItems(
 )
 {
 	assertThrow(!m_breakingItem, OptimizerException, "Invalid use of CommonSubexpressionEliminator.");
-	for (; _iterator != _end && !SemanticInformation::breaksCSEAnalysisBlock(*_iterator, _msizeImportant); ++_iterator)
+	unsigned const maxChunkSize = 1000;
+	for (
+		unsigned chunkSize = 0;
+		_iterator != _end && !SemanticInformation::breaksCSEAnalysisBlock(*_iterator, _msizeImportant) && chunkSize < maxChunkSize;
+		++_iterator, ++chunkSize
+	)
 		feedItem(*_iterator);
 	if (_iterator != _end)
 		m_breakingItem = &(*_iterator++);

--- a/libevmasm/CommonSubexpressionEliminator.h
+++ b/libevmasm/CommonSubexpressionEliminator.h
@@ -179,7 +179,7 @@ AssemblyItemIterator CommonSubexpressionEliminator::feedItems(
 )
 {
 	assertThrow(!m_breakingItem, OptimizerException, "Invalid use of CommonSubexpressionEliminator.");
-	unsigned const maxChunkSize = 1000;
+	unsigned const maxChunkSize = 2000;
 	unsigned chunkSize = 0;
 	for (
 		;

--- a/libevmasm/CommonSubexpressionEliminator.h
+++ b/libevmasm/CommonSubexpressionEliminator.h
@@ -180,13 +180,14 @@ AssemblyItemIterator CommonSubexpressionEliminator::feedItems(
 {
 	assertThrow(!m_breakingItem, OptimizerException, "Invalid use of CommonSubexpressionEliminator.");
 	unsigned const maxChunkSize = 1000;
+	unsigned chunkSize = 0;
 	for (
-		unsigned chunkSize = 0;
+		;
 		_iterator != _end && !SemanticInformation::breaksCSEAnalysisBlock(*_iterator, _msizeImportant) && chunkSize < maxChunkSize;
 		++_iterator, ++chunkSize
 	)
 		feedItem(*_iterator);
-	if (_iterator != _end)
+	if (_iterator != _end && chunkSize < maxChunkSize)
 		m_breakingItem = &(*_iterator++);
 	return _iterator;
 }

--- a/libevmasm/ExpressionClasses.h
+++ b/libevmasm/ExpressionClasses.h
@@ -24,13 +24,13 @@
 
 #pragma once
 
-#include <libsolutil/Common.h>
 #include <libevmasm/AssemblyItem.h>
 
-#include <vector>
-#include <map>
+#include <libsolutil/Common.h>
+
 #include <memory>
-#include <set>
+#include <unordered_set>
+#include <vector>
 
 namespace solidity::langutil
 {
@@ -61,8 +61,14 @@ public:
 		/// Storage modification sequence, only used for storage and memory operations.
 		unsigned sequenceNumber = 0;
 		/// Behaves as if this was a tuple of (item->type(), item->data(), arguments, sequenceNumber).
-		bool operator<(Expression const& _other) const;
+		bool operator==(Expression const& _other) const;
+
+		struct ExpressionHash
+		{
+			std::size_t operator()(Expression const& _expression) const;
+		};
 	};
+
 
 	/// Retrieves the id of the expression equivalence class resulting from the given item applied to the
 	/// given classes, might also create a new one.
@@ -122,7 +128,7 @@ private:
 	/// Expression equivalence class representatives - we only store one item of an equivalence.
 	std::vector<Expression> m_representatives;
 	/// All expression ever encountered.
-	std::set<Expression> m_expressions;
+	std::unordered_set<Expression, Expression::ExpressionHash> m_expressions;
 	std::vector<std::shared_ptr<AssemblyItem>> m_spareAssemblyItems;
 };
 


### PR DESCRIPTION
fixes #12406 

Changes:
1) m_expressions member of ExpressionClasses is now unordered_set. Tests show this change reduces [MediumVerifier.sol](https://gist.github.com/citizen-stig/a25be3d125969c64f0f2b94b28a0d160) compilation time from 21 to 14 minutes (33% compilation time reduction).

2) CommonSubexpressionEliminator::feedItems is updated to accept items in chunks with max size of 1000. With this change [MediumVerifier.sol](https://gist.github.com/citizen-stig/a25be3d125969c64f0f2b94b28a0d160) compile time is reduced to 8 seconds.

Proposed limit of 1000 items in a single chunk passed to CSE is not final yet. To shed some light on a chunk size that the compiler is usually dealing with, below statistic has been collected on external tests.

|chunk size|occurrences|chunk size|occurrences|chunk size|occurrences|chunk size|occurrences|
|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
|0|1250131|51|301|102|39|157|1
|1|113354|52|364|103|9|159|2|
|2|258753|53|206|104|24|160|2|
|3|172793|54|402|105|32|162|4|
|4|226723|55|374|106|15|165|7|
|5|159193|56|190|107|23|168|10|
|6|162382|57|404|108|16|169|2|
|7|106297|58|209|109|28|175|1|
|8|97268|59|248|110|18|176|13|
|9|74523|60|232|111|47|177|2|
|10|81716|61|246|112|3|178|4|
|11|38994|62|125|113|18|179|5|
|12|34726|63|183|114|14|181|2|
|13|30574|64|194|116|25|182|7|
|14|20208|65|84|117|7|183|1|
|15|20131|66|153|118|2|184|2|
|16|15046|67|94|119|6|190|18|
|17|14875|68|81|120|40|191|18|
|18|15160|69|191|121|13|192|4|
|19|11616|70|65|122|7|193|2|
|20|9342|71|101|123|16|194|2|
|21|8200|72|129|124|3|198|2|
|22|13707|73|74|125|25|200|2|
|23|10659|74|56|126|2|205|4|
|24|5641|75|152|127|3|215|2|
|25|4758|76|46|128|11|222|6|
|26|10939|77|66|129|7|231|2|
|27|7363|78|130|130|1|239|15|
|28|7063|79|140|131|8|244|4|
|29|3984|80|28|133|6|249|4|
|30|2672|81|25|134|4|250|4|
|31|3157|82|59|135|3|258|4|
|32|4343|83|24|136|4|262|10|
|33|2349|84|17|137|17|290|2|
|34|2126|85|61|138|3|293|16|
|35|1558|86|28|139|75|296|2|
|36|1276|87|38|141|29|309|2|
|37|2291|88|52|142|8|324|16|
|38|1363|89|47|144|9|328|46|
|39|1967|90|63|145|2|341|6|
|40|1305|91|39|146|9|347|7|
|41|1435|92|112|147|2|358|6|
|42|1337|93|57|148|7|371|4|
|43|1218|94|20|149|8|432|10|
|44|1138|95|51|150|3|1485|4|
|45|741|96|54|151|8|1487|1|
|46|803|97|75|152|6|1490|4|
|47|555|98|64|153|5|1492|1|
|48|762|99|20|154|10|1500|6|
|49|502|100|7|155|4|1505|4|
|50|528|101|16|156|2||

Another important thing is to check how limiting the chunk size affects actual projects. Below is a gas benchmark comparison  between develop and PR changes. It is formed with c_ext_benchmarks CI job usage.

_bleeps_
||bytecode_size|deployment_gas|method_gas|
|:---:|:---:|:---:|:---:|
|ir-optimize-evm+yul|0|0|0|
|legacy-optimize-evm+yul|0|0|0|


_colony_
||bytecode_size|
|:---:|:---:|
|ir-no-optimize|0|
|ir-optimize-evm+yul|0|
|ir-optimize-evm-only|0|
|legacy-no-optimize|0|
|legacy-optimize-evm+yul|0|
|legacy-optimize-evm-only|0|


_ens_
||bytecode_size|deployment_gas|method_gas|
|:---:|:---:|:---:|:---:|
|ir-optimize-evm+yul|0|24(+0%)|0|
|legacy-no-optimize|0|||
|legacy-optimize-evm+yul|0|-12(-0%)|0|
|legacy-optimize-evm-only|0|0|0|


_gnosis_
||bytecode_size|deployment_gas|method_gas|
|:---:|:---:|:---:|:---:|
|ir-optimize-evm+yul|0|36(+0%)|-647(-0%)|
|legacy-no-optimize|0|0|224(+0%)|
|legacy-optimize-evm+yul|0|12(+0%)|218(+0%)|
|legacy-optimize-evm-only|0|-12(-0%)|-596(-0%)|


_perpetual-pools_
||bytecode_size|deployment_gas|method_gas|
|:---:|:---:|:---:|:---:|
|legacy-no-optimize|0|-15(-0%)|3222(+0%)|
|legacy-optimize-evm+yul|0|-34(-0%)|-139195(`-0.02%✅`)|
|legacy-optimize-evm-only|0|-60(-0)|0|


_pool-together_
||bytecode_size|deployment_gas|method_gas|
|:---:|:---:|:---:|:---:|
|ir-optimize-evm+yul|0|12(+0%)|6(+0%)|
|legacy-no-optimize|0|-48(-0%)|50(0%)|
|legacy-optimize-evm+yul|0|0|51(+0%)|
|legacy-optimize-evm-only|0|48(+0%)|37(+0%)|


_prb-math_
||bytecode_size|deployment_gas|method_gas|
|:---:|:---:|:---:|:---:|
|ir-optimize-evm+yul|0|-12(-0%)|0|
|legacy-no-optimize|0|-12(-0%)|0|
|legacy-optimize-evm+yul|0|0|0|
|legacy-optimize-evm-only|0|-12(-0%)|0|


_trident_
||bytecode_size|deployment_gas|method_gas|
|:---:|:---:|:---:|:---:|
|ir-optimize-evm+yul|0|36(+0%)|30(+0%)|
|legacy-no-optimize|0|24(+0%)|-159(-0%)|
|legacy-optimize-evm+yul|0|-24(-0%)|42(+0%)|
|legacy-optimize-evm-only|0|12|357|


_uniswap_
||bytecode_size|deployment_gas|method_gas|
|:---:|:---:|:---:|:---:|
|legacy-no-optimize|0|0|-1810(-0%)|
|legacy-optimize-evm+yul|0|-12(0%)|320(0%)|
|legacy-optimize-evm-only|0|12(+0%)|1082(+0%)|


_yield_liquidator_
||bytecode_size|deployment_gas|method_gas|
|:---:|:---:|:---:|:---:|
|ir-optimize-evm+yul|0|0|0|
|legacy-no-optimize|0|12(+0%)|-72(+0%)|
|legacy-optimize-evm+yul|0|-12(-0%)|0|
|legacy-optimize-evm-only|0|-12(-0%)|-108(-0%)|


_zeppelin_
||bytecode_size|deployment_gas|method_gas|
|:---:|:---:|:---:|:---:|
|ir-optimize-evm+yul|0|12(+0%)|-42(-0%)|
|legacy-no-optimize|0|48(+0%)|215(+0%)|
|legacy-optimize-evm+yul|0|-60(-0%)|201(+0%)|
|legacy-optimize-evm-only|0|-120(-0%)|4(+0%)|
