### PR TITLE
Update reference-types.rst

### DIFF
--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -85,8 +85,10 @@ Data locations are not only relevant for persistency of data, but also for the s
             // The following does not work; it would need to create a new temporary /
             // unnamed array in storage, but storage is "statically" allocated:
             // y = memoryArray;
-            // This does not work either, since it would "reset" the pointer, but there
-            // is no sensible location it could point to.
+            // On the other hand: "delete y" is not valid, as assignments to local variables
+            // referencing storage objects can only be made from existing storage objects.
+            // It would "reset" the pointer, but there is no sensible location it could point to.
+            // See "delete" under Operators
             // delete y;
             g(x); // calls g, handing over a reference to x
             h(x); // calls h and creates an independent, temporary copy in memory

--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -85,10 +85,10 @@ Data locations are not only relevant for persistency of data, but also for the s
             // The following does not work; it would need to create a new temporary /
             // unnamed array in storage, but storage is "statically" allocated:
             // y = memoryArray;
-            // On the other hand: "delete y" is not valid, as assignments to local variables
+            // Similarly, "delete y" is not valid, as assignments to local variables
             // referencing storage objects can only be made from existing storage objects.
             // It would "reset" the pointer, but there is no sensible location it could point to.
-            // See "delete" under Operators
+            // For more details see the documentation of the "delete" operator.
             // delete y;
             g(x); // calls g, handing over a reference to x
             h(x); // calls h and creates an independent, temporary copy in memory


### PR DESCRIPTION
Just re-using the same text from an almost exact same example in another part of the docs, so that there is no confusion between them -- and because the statement that assignments to "storage objects can only be made from existing storage objects" enhances the semantic reason the expression is not valid, with the syntactic limit enforced by the compiler because of it.

By the way, in a few places in the doc there is discussion of "local reference variables" but I'm not sure this terminology is defined anywhere. I'll make a PR once I'm fully confident in the definition, but it appears these words refer to non-value type (i.e., complex types like arrays) variables of storage class that are not defined at the contract scope??