### PR TITLE
Renamed AssemblyStack to YulStack

### DIFF
--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -30,7 +30,7 @@
 #include <libsolidity/codegen/ABIFunctions.h>
 #include <libsolidity/codegen/CompilerUtils.h>
 
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 #include <libyul/Utilities.h>
 
 #include <libsolutil/Algorithms.h>
@@ -95,9 +95,9 @@ pair<string, string> IRGenerator::run(
 {
 	string ir = yul::reindent(generate(_contract, _cborMetadata, _otherYulSources));
 
-	yul::AssemblyStack asmStack(
+	yul::YulStack asmStack(
 		m_evmVersion,
-		yul::AssemblyStack::Language::StrictAssembly,
+		yul::YulStack::Language::StrictAssembly,
 		m_optimiserSettings,
 		m_context.debugInfoSelection()
 	);

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -62,7 +62,7 @@
 #include <libyul/YulString.h>
 #include <libyul/AsmPrinter.h>
 #include <libyul/AsmJsonConverter.h>
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 #include <libyul/AST.h>
 #include <libyul/AsmParser.h>
 
@@ -1382,9 +1382,9 @@ void CompilerStack::generateEVMFromIR(ContractDefinition const& _contract)
 		return;
 
 	// Re-parse the Yul IR in EVM dialect
-	yul::AssemblyStack stack(
+	yul::YulStack stack(
 		m_evmVersion,
-		yul::AssemblyStack::Language::StrictAssembly,
+		yul::YulStack::Language::StrictAssembly,
 		m_optimiserSettings,
 		m_debugInfoSelection
 	);
@@ -1414,22 +1414,22 @@ void CompilerStack::generateEwasm(ContractDefinition const& _contract)
 		return;
 
 	// Re-parse the Yul IR in EVM dialect
-	yul::AssemblyStack stack(
+	yul::YulStack stack(
 		m_evmVersion,
-		yul::AssemblyStack::Language::StrictAssembly,
+		yul::YulStack::Language::StrictAssembly,
 		m_optimiserSettings,
 		m_debugInfoSelection
 	);
 	stack.parseAndAnalyze("", compiledContract.yulIROptimized);
 
 	stack.optimize();
-	stack.translate(yul::AssemblyStack::Language::Ewasm);
+	stack.translate(yul::YulStack::Language::Ewasm);
 	stack.optimize();
 
 	//cout << yul::AsmPrinter{}(*stack.parserResult()->code) << endl;
 
 	// Turn into Ewasm text representation.
-	auto result = stack.assemble(yul::AssemblyStack::Machine::Ewasm);
+	auto result = stack.assemble(yul::YulStack::Machine::Ewasm);
 	compiledContract.ewasm = std::move(result.assembly);
 	compiledContract.ewasmObject = std::move(*result.bytecode);
 }

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -25,7 +25,7 @@
 #include <libsolidity/interface/ImportRemapper.h>
 
 #include <libsolidity/ast/ASTJsonConverter.h>
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 #include <libyul/Exceptions.h>
 #include <libyul/optimiser/Suite.h>
 
@@ -1407,9 +1407,9 @@ Json::Value StandardCompiler::compileYul(InputsAndSettings _inputsAndSettings)
 		return output;
 	}
 
-	AssemblyStack stack(
+	YulStack stack(
 		_inputsAndSettings.evmVersion,
-		AssemblyStack::Language::StrictAssembly,
+		YulStack::Language::StrictAssembly,
 		_inputsAndSettings.optimiserSettings,
 		_inputsAndSettings.debugInfoSelection.has_value() ?
 			_inputsAndSettings.debugInfoSelection.value() :

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -30,8 +30,8 @@ add_library(yul
 	AsmParser.h
 	AsmPrinter.cpp
 	AsmPrinter.h
-	AssemblyStack.h
-	AssemblyStack.cpp
+	YulStack.h
+	YulStack.cpp
 	CompilabilityChecker.cpp
 	CompilabilityChecker.h
 	ControlFlowSideEffects.h

--- a/libyul/YulStack.h
+++ b/libyul/YulStack.h
@@ -63,14 +63,14 @@ struct MachineAssemblyObject
  * Full assembly stack that can support EVM-assembly and Yul as input and EVM, EVM1.5 and
  * Ewasm as output.
  */
-class AssemblyStack: public langutil::CharStreamProvider
+class YulStack: public langutil::CharStreamProvider
 {
 public:
 	enum class Language { Yul, Assembly, StrictAssembly, Ewasm };
 	enum class Machine { EVM, Ewasm };
 
-	AssemblyStack():
-		AssemblyStack(
+	YulStack():
+		YulStack(
 			langutil::EVMVersion{},
 			Language::Assembly,
 			solidity::frontend::OptimiserSettings::none(),
@@ -78,7 +78,7 @@ public:
 		)
 	{}
 
-	AssemblyStack(
+	YulStack(
 		langutil::EVMVersion _evmVersion,
 		Language _language,
 		solidity::frontend::OptimiserSettings _optimiserSettings,

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -27,7 +27,7 @@
 #include <libsolidity/interface/CompilerStack.h>
 #include <libsolidity/interface/DebugSettings.h>
 #include <libsolidity/interface/FileReader.h>
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 
 #include <iostream>
 #include <memory>
@@ -90,7 +90,7 @@ private:
 	/// @returns the full object with library placeholder hints in hex.
 	static std::string objectWithLinkRefsHex(evmasm::LinkerObject const& _obj);
 
-	void assemble(yul::AssemblyStack::Language _language, yul::AssemblyStack::Machine _targetMachine);
+	void assemble(yul::YulStack::Language _language, yul::YulStack::Machine _targetMachine);
 
 	void outputCompilationResults();
 

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -1132,8 +1132,8 @@ void CommandLineParser::processArgs()
 		}
 
 		// switch to assembly mode
-		using Input = yul::AssemblyStack::Language;
-		using Machine = yul::AssemblyStack::Machine;
+		using Input = yul::YulStack::Language;
+		using Machine = yul::YulStack::Machine;
 		m_options.assembly.inputLanguage = m_args.count(g_strYul) ? Input::Yul : (m_args.count(g_strStrictAssembly) ? Input::StrictAssembly : Input::Assembly);
 
 		if (m_args.count(g_strMachine))

--- a/solc/CommandLineParser.h
+++ b/solc/CommandLineParser.h
@@ -25,7 +25,7 @@
 #include <libsolidity/interface/FileReader.h>
 #include <libsolidity/interface/ImportRemapper.h>
 
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 
 #include <liblangutil/DebugInfoSelection.h>
 #include <liblangutil/EVMVersion.h>
@@ -190,8 +190,8 @@ struct CommandLineOptions
 
 	struct
 	{
-		yul::AssemblyStack::Machine targetMachine = yul::AssemblyStack::Machine::EVM;
-		yul::AssemblyStack::Language inputLanguage = yul::AssemblyStack::Language::StrictAssembly;
+		yul::YulStack::Machine targetMachine = yul::YulStack::Machine::EVM;
+		yul::YulStack::Language inputLanguage = yul::YulStack::Language::StrictAssembly;
 	} assembly;
 
 	struct

--- a/test/libsolidity/InlineAssembly.cpp
+++ b/test/libsolidity/InlineAssembly.cpp
@@ -26,7 +26,7 @@
 
 #include <libsolidity/ast/AST.h>
 
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 
 #include <liblangutil/DebugInfoSelection.h>
 #include <liblangutil/Exceptions.h>
@@ -56,11 +56,11 @@ std::optional<Error> parseAndReturnFirstError(
 	string const& _source,
 	bool _assemble = false,
 	bool _allowWarnings = true,
-	AssemblyStack::Language _language = AssemblyStack::Language::Assembly,
-	AssemblyStack::Machine _machine = AssemblyStack::Machine::EVM
+	YulStack::Language _language = YulStack::Language::Assembly,
+	YulStack::Machine _machine = YulStack::Machine::EVM
 )
 {
-	AssemblyStack stack(
+	YulStack stack(
 		solidity::test::CommonOptions::get().evmVersion(),
 		_language,
 		solidity::frontend::OptimiserSettings::none(),
@@ -103,24 +103,24 @@ bool successParse(
 	string const& _source,
 	bool _assemble = false,
 	bool _allowWarnings = true,
-	AssemblyStack::Language _language = AssemblyStack::Language::Assembly,
-	AssemblyStack::Machine _machine = AssemblyStack::Machine::EVM
+	YulStack::Language _language = YulStack::Language::Assembly,
+	YulStack::Machine _machine = YulStack::Machine::EVM
 )
 {
 	return !parseAndReturnFirstError(_source, _assemble, _allowWarnings, _language, _machine);
 }
 
-bool successAssemble(string const& _source, bool _allowWarnings = true, AssemblyStack::Language _language = AssemblyStack::Language::Assembly)
+bool successAssemble(string const& _source, bool _allowWarnings = true, YulStack::Language _language = YulStack::Language::Assembly)
 {
 	return
-		successParse(_source, true, _allowWarnings, _language, AssemblyStack::Machine::EVM);
+		successParse(_source, true, _allowWarnings, _language, YulStack::Machine::EVM);
 }
 
 Error expectError(
 	std::string const& _source,
 	bool _assemble,
 	bool _allowWarnings = false,
-	AssemblyStack::Language _language = AssemblyStack::Language::Assembly
+	YulStack::Language _language = YulStack::Language::Assembly
 )
 {
 
@@ -131,9 +131,9 @@ Error expectError(
 
 void parsePrintCompare(string const& _source, bool _canWarn = false)
 {
-	AssemblyStack stack(
+	YulStack stack(
 		solidity::test::CommonOptions::get().evmVersion(),
-		AssemblyStack::Language::Assembly,
+		YulStack::Language::Assembly,
 		OptimiserSettings::none(),
 		DebugInfoSelection::None()
 	);
@@ -157,7 +157,7 @@ do \
 } while(0)
 
 #define CHECK_ERROR(text, assemble, typ, substring, warnings) \
-CHECK_ERROR_LANG(text, assemble, typ, substring, warnings, AssemblyStack::Language::Assembly)
+CHECK_ERROR_LANG(text, assemble, typ, substring, warnings, YulStack::Language::Assembly)
 
 #define CHECK_PARSE_ERROR(text, type, substring) \
 CHECK_ERROR(text, false, type, substring, false)
@@ -169,13 +169,13 @@ CHECK_ERROR(text, false, type, substring, false)
 CHECK_ERROR(text, true, type, substring, false)
 
 #define CHECK_STRICT_ERROR(text, type, substring) \
-CHECK_ERROR_LANG(text, false, type, substring, false, AssemblyStack::Language::StrictAssembly)
+CHECK_ERROR_LANG(text, false, type, substring, false, YulStack::Language::StrictAssembly)
 
 #define CHECK_STRICT_WARNING(text, type, substring) \
-CHECK_ERROR(text, false, type, substring, false, AssemblyStack::Language::StrictAssembly)
+CHECK_ERROR(text, false, type, substring, false, YulStack::Language::StrictAssembly)
 
 #define SUCCESS_STRICT(text) \
-do { successParse((text), false, false, AssemblyStack::Language::StrictAssembly); } while (false)
+do { successParse((text), false, false, YulStack::Language::StrictAssembly); } while (false)
 
 
 BOOST_AUTO_TEST_SUITE(SolidityInlineAssembly)
@@ -221,9 +221,9 @@ BOOST_AUTO_TEST_CASE(print_string_literal_unicode)
 {
 	string source = "{ let x := \"\\u1bac\" }";
 	string parsed = "object \"object\" {\n    code { let x := \"\\xe1\\xae\\xac\" }\n}\n";
-	AssemblyStack stack(
+	YulStack stack(
 		solidity::test::CommonOptions::get().evmVersion(),
-		AssemblyStack::Language::Assembly,
+		YulStack::Language::Assembly,
 		OptimiserSettings::none(),
 		DebugInfoSelection::None()
 	);

--- a/test/libsolidity/SolidityExecutionFramework.cpp
+++ b/test/libsolidity/SolidityExecutionFramework.cpp
@@ -97,9 +97,9 @@ bytes SolidityExecutionFramework::multiSourceCompileContract(
 				else if (forceEnableOptimizer)
 					optimiserSettings = OptimiserSettings::full();
 
-				yul::AssemblyStack asmStack(
+				yul::YulStack asmStack(
 					m_evmVersion,
-					yul::AssemblyStack::Language::StrictAssembly,
+					yul::YulStack::Language::StrictAssembly,
 					optimiserSettings,
 					DebugInfoSelection::All()
 				);
@@ -109,7 +109,7 @@ bytes SolidityExecutionFramework::multiSourceCompileContract(
 				try
 				{
 					asmStack.optimize();
-					obj = move(*asmStack.assemble(yul::AssemblyStack::Machine::EVM).bytecode);
+					obj = move(*asmStack.assemble(yul::YulStack::Machine::EVM).bytecode);
 					obj.link(_libraryAddresses);
 					break;
 				}

--- a/test/libsolidity/SolidityExecutionFramework.h
+++ b/test/libsolidity/SolidityExecutionFramework.h
@@ -30,7 +30,7 @@
 #include <libsolidity/interface/CompilerStack.h>
 #include <libsolidity/interface/DebugSettings.h>
 
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 
 namespace solidity::frontend::test
 {

--- a/test/libyul/Common.cpp
+++ b/test/libyul/Common.cpp
@@ -26,7 +26,7 @@
 #include <libyul/optimiser/Disambiguator.h>
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmPrinter.h>
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 #include <libyul/AST.h>
 #include <libyul/backends/evm/EVMDialect.h>
 #include <libyul/backends/wasm/WasmDialect.h>
@@ -55,9 +55,9 @@ Dialect const& defaultDialect(bool _yul)
 
 pair<shared_ptr<Block>, shared_ptr<yul::AsmAnalysisInfo>> yul::test::parse(string const& _source, bool _yul)
 {
-	AssemblyStack stack(
+	YulStack stack(
 		solidity::test::CommonOptions::get().evmVersion(),
-		_yul ? AssemblyStack::Language::Yul : AssemblyStack::Language::StrictAssembly,
+		_yul ? YulStack::Language::Yul : YulStack::Language::StrictAssembly,
 		solidity::test::CommonOptions::get().optimize ?
 			solidity::frontend::OptimiserSettings::standard() :
 			solidity::frontend::OptimiserSettings::minimal(),

--- a/test/libyul/EVMCodeTransformTest.cpp
+++ b/test/libyul/EVMCodeTransformTest.cpp
@@ -19,7 +19,7 @@
 #include <test/libyul/EVMCodeTransformTest.h>
 #include <test/libyul/Common.h>
 
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 #include <libyul/backends/evm/EthAssemblyAdapter.h>
 #include <libyul/backends/evm/EVMObjectCompiler.h>
 
@@ -51,9 +51,9 @@ TestCase::TestResult EVMCodeTransformTest::run(ostream& _stream, string const& _
 	solidity::frontend::OptimiserSettings settings = solidity::frontend::OptimiserSettings::none();
 	settings.runYulOptimiser = false;
 	settings.optimizeStackAllocation = m_stackOpt;
-	AssemblyStack stack(
+	YulStack stack(
 		EVMVersion{},
-		AssemblyStack::Language::StrictAssembly,
+		YulStack::Language::StrictAssembly,
 		settings,
 		DebugInfoSelection::All()
 	);

--- a/test/libyul/EwasmTranslationTest.cpp
+++ b/test/libyul/EwasmTranslationTest.cpp
@@ -25,7 +25,7 @@
 #include <libyul/backends/evm/EVMDialect.h>
 #include <libyul/backends/wasm/WasmDialect.h>
 #include <libyul/backends/wasm/EVMToEwasmTranslator.h>
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 #include <libyul/AsmAnalysisInfo.h>
 #include <libyul/AST.h>
 #include <libyul/Object.h>
@@ -80,9 +80,9 @@ TestCase::TestResult EwasmTranslationTest::run(ostream& _stream, string const& _
 
 bool EwasmTranslationTest::parse(ostream& _stream, string const& _linePrefix, bool const _formatted)
 {
-	m_stack = AssemblyStack(
+	m_stack = YulStack(
 		solidity::test::CommonOptions::get().evmVersion(),
-		AssemblyStack::Language::StrictAssembly,
+		YulStack::Language::StrictAssembly,
 		solidity::frontend::OptimiserSettings::none(),
 		DebugInfoSelection::All()
 	);

--- a/test/libyul/EwasmTranslationTest.h
+++ b/test/libyul/EwasmTranslationTest.h
@@ -20,12 +20,12 @@
 
 #include <test/TestCase.h>
 
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 
 namespace solidity::yul
 {
 struct Object;
-class AssemblyStack;
+class YulStack;
 }
 
 namespace solidity::yul::test
@@ -48,7 +48,7 @@ private:
 	std::string interpret();
 
 	std::shared_ptr<Object> m_object;
-	AssemblyStack m_stack;
+	YulStack m_stack;
 };
 
 }

--- a/test/libyul/ObjectCompilerTest.cpp
+++ b/test/libyul/ObjectCompilerTest.cpp
@@ -22,7 +22,7 @@
 
 #include <libsolutil/AnsiColorized.h>
 
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 
 #include <libevmasm/Instruction.h>
 #include <libevmasm/Disassemble.h>
@@ -63,9 +63,9 @@ ObjectCompilerTest::ObjectCompilerTest(string const& _filename):
 
 TestCase::TestResult ObjectCompilerTest::run(ostream& _stream, string const& _linePrefix, bool const _formatted)
 {
-	AssemblyStack stack(
+	YulStack stack(
 		EVMVersion(),
-		m_wasm ? AssemblyStack::Language::Ewasm : AssemblyStack::Language::StrictAssembly,
+		m_wasm ? YulStack::Language::Ewasm : YulStack::Language::StrictAssembly,
 		OptimiserSettings::preset(m_optimisationPreset),
 		DebugInfoSelection::All()
 	);
@@ -80,7 +80,7 @@ TestCase::TestResult ObjectCompilerTest::run(ostream& _stream, string const& _li
 
 	if (m_wasm)
 	{
-		MachineAssemblyObject obj = stack.assemble(AssemblyStack::Machine::Ewasm);
+		MachineAssemblyObject obj = stack.assemble(YulStack::Machine::Ewasm);
 		solAssert(obj.bytecode, "");
 
 		m_obtainedResult = "Text:\n" + obj.assembly + "\n";
@@ -88,7 +88,7 @@ TestCase::TestResult ObjectCompilerTest::run(ostream& _stream, string const& _li
 	}
 	else
 	{
-		MachineAssemblyObject obj = stack.assemble(AssemblyStack::Machine::EVM);
+		MachineAssemblyObject obj = stack.assemble(YulStack::Machine::EVM);
 		solAssert(obj.bytecode, "");
 		solAssert(obj.sourceMappings, "");
 

--- a/test/libyul/ObjectParser.cpp
+++ b/test/libyul/ObjectParser.cpp
@@ -26,7 +26,7 @@
 #include <liblangutil/DebugInfoSelection.h>
 #include <liblangutil/Scanner.h>
 
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 #include <libyul/backends/evm/EVMDialect.h>
 
 #include <libsolidity/interface/OptimiserSettings.h>
@@ -58,9 +58,9 @@ pair<bool, ErrorList> parse(string const& _source)
 {
 	try
 	{
-		AssemblyStack asmStack(
+		YulStack asmStack(
 			solidity::test::CommonOptions::get().evmVersion(),
-			AssemblyStack::Language::StrictAssembly,
+			YulStack::Language::StrictAssembly,
 			solidity::frontend::OptimiserSettings::none(),
 			DebugInfoSelection::All()
 		);
@@ -180,9 +180,9 @@ BOOST_AUTO_TEST_CASE(to_string)
 }
 )";
 	expectation = boost::replace_all_copy(expectation, "\t", "    ");
-	AssemblyStack asmStack(
+	YulStack asmStack(
 		solidity::test::CommonOptions::get().evmVersion(),
-		AssemblyStack::Language::StrictAssembly,
+		YulStack::Language::StrictAssembly,
 		solidity::frontend::OptimiserSettings::none(),
 		DebugInfoSelection::All()
 	);

--- a/test/libyul/YulInterpreterTest.cpp
+++ b/test/libyul/YulInterpreterTest.cpp
@@ -23,7 +23,7 @@
 #include <test/Common.h>
 
 #include <libyul/backends/evm/EVMDialect.h>
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 #include <libyul/AsmAnalysisInfo.h>
 
 #include <liblangutil/DebugInfoSelection.h>
@@ -65,9 +65,9 @@ TestCase::TestResult YulInterpreterTest::run(ostream& _stream, string const& _li
 
 bool YulInterpreterTest::parse(ostream& _stream, string const& _linePrefix, bool const _formatted)
 {
-	AssemblyStack stack(
+	YulStack stack(
 		solidity::test::CommonOptions::get().evmVersion(),
-		AssemblyStack::Language::StrictAssembly,
+		YulStack::Language::StrictAssembly,
 		solidity::frontend::OptimiserSettings::none(),
 		DebugInfoSelection::All()
 	);

--- a/test/solc/CommandLineParser.cpp
+++ b/test/solc/CommandLineParser.cpp
@@ -233,23 +233,23 @@ BOOST_AUTO_TEST_CASE(via_ir_options)
 
 BOOST_AUTO_TEST_CASE(assembly_mode_options)
 {
-	static vector<tuple<vector<string>, AssemblyStack::Machine, AssemblyStack::Language>> const allowedCombinations = {
-		{{"--machine=ewasm", "--yul-dialect=ewasm", "--assemble"}, AssemblyStack::Machine::Ewasm, AssemblyStack::Language::Ewasm},
-		{{"--machine=ewasm", "--yul-dialect=ewasm", "--yul"}, AssemblyStack::Machine::Ewasm, AssemblyStack::Language::Ewasm},
-		{{"--machine=ewasm", "--yul-dialect=ewasm", "--strict-assembly"}, AssemblyStack::Machine::Ewasm, AssemblyStack::Language::Ewasm},
-		{{"--machine=ewasm", "--yul-dialect=evm", "--assemble"}, AssemblyStack::Machine::Ewasm, AssemblyStack::Language::StrictAssembly},
-		{{"--machine=ewasm", "--yul-dialect=evm", "--yul"}, AssemblyStack::Machine::Ewasm, AssemblyStack::Language::StrictAssembly},
-		{{"--machine=ewasm", "--yul-dialect=evm", "--strict-assembly"}, AssemblyStack::Machine::Ewasm, AssemblyStack::Language::StrictAssembly},
-		{{"--machine=ewasm", "--strict-assembly"}, AssemblyStack::Machine::Ewasm, AssemblyStack::Language::Ewasm},
-		{{"--machine=evm", "--yul-dialect=evm", "--assemble"}, AssemblyStack::Machine::EVM, AssemblyStack::Language::StrictAssembly},
-		{{"--machine=evm", "--yul-dialect=evm", "--yul"}, AssemblyStack::Machine::EVM, AssemblyStack::Language::StrictAssembly},
-		{{"--machine=evm", "--yul-dialect=evm", "--strict-assembly"}, AssemblyStack::Machine::EVM, AssemblyStack::Language::StrictAssembly},
-		{{"--machine=evm", "--assemble"}, AssemblyStack::Machine::EVM, AssemblyStack::Language::Assembly},
-		{{"--machine=evm", "--yul"}, AssemblyStack::Machine::EVM, AssemblyStack::Language::Yul},
-		{{"--machine=evm", "--strict-assembly"}, AssemblyStack::Machine::EVM, AssemblyStack::Language::StrictAssembly},
-		{{"--assemble"}, AssemblyStack::Machine::EVM, AssemblyStack::Language::Assembly},
-		{{"--yul"}, AssemblyStack::Machine::EVM, AssemblyStack::Language::Yul},
-		{{"--strict-assembly"}, AssemblyStack::Machine::EVM, AssemblyStack::Language::StrictAssembly},
+	static vector<tuple<vector<string>, YulStack::Machine, YulStack::Language>> const allowedCombinations = {
+		{{"--machine=ewasm", "--yul-dialect=ewasm", "--assemble"}, YulStack::Machine::Ewasm, YulStack::Language::Ewasm},
+		{{"--machine=ewasm", "--yul-dialect=ewasm", "--yul"}, YulStack::Machine::Ewasm, YulStack::Language::Ewasm},
+		{{"--machine=ewasm", "--yul-dialect=ewasm", "--strict-assembly"}, YulStack::Machine::Ewasm, YulStack::Language::Ewasm},
+		{{"--machine=ewasm", "--yul-dialect=evm", "--assemble"}, YulStack::Machine::Ewasm, YulStack::Language::StrictAssembly},
+		{{"--machine=ewasm", "--yul-dialect=evm", "--yul"}, YulStack::Machine::Ewasm, YulStack::Language::StrictAssembly},
+		{{"--machine=ewasm", "--yul-dialect=evm", "--strict-assembly"}, YulStack::Machine::Ewasm, YulStack::Language::StrictAssembly},
+		{{"--machine=ewasm", "--strict-assembly"}, YulStack::Machine::Ewasm, YulStack::Language::Ewasm},
+		{{"--machine=evm", "--yul-dialect=evm", "--assemble"}, YulStack::Machine::EVM, YulStack::Language::StrictAssembly},
+		{{"--machine=evm", "--yul-dialect=evm", "--yul"}, YulStack::Machine::EVM, YulStack::Language::StrictAssembly},
+		{{"--machine=evm", "--yul-dialect=evm", "--strict-assembly"}, YulStack::Machine::EVM, YulStack::Language::StrictAssembly},
+		{{"--machine=evm", "--assemble"}, YulStack::Machine::EVM, YulStack::Language::Assembly},
+		{{"--machine=evm", "--yul"}, YulStack::Machine::EVM, YulStack::Language::Yul},
+		{{"--machine=evm", "--strict-assembly"}, YulStack::Machine::EVM, YulStack::Language::StrictAssembly},
+		{{"--assemble"}, YulStack::Machine::EVM, YulStack::Language::Assembly},
+		{{"--yul"}, YulStack::Machine::EVM, YulStack::Language::Yul},
+		{{"--strict-assembly"}, YulStack::Machine::EVM, YulStack::Language::StrictAssembly},
 	};
 
 	for (auto const& [assemblyOptions, expectedMachine, expectedLanguage]: allowedCombinations)
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(assembly_mode_options)
 			"--ewasm-ir",
 		};
 		commandLine += assemblyOptions;
-		if (expectedLanguage == AssemblyStack::Language::StrictAssembly || expectedLanguage == AssemblyStack::Language::Ewasm)
+		if (expectedLanguage == YulStack::Language::StrictAssembly || expectedLanguage == YulStack::Language::Ewasm)
 			commandLine += vector<string>{
 				"--optimize",
 				"--optimize-runs=1000",
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE(assembly_mode_options)
 		expectedOptions.compiler.outputs.irOptimized = true;
 		expectedOptions.compiler.outputs.ewasm = true;
 		expectedOptions.compiler.outputs.ewasmIR = true;
-		if (expectedLanguage == AssemblyStack::Language::StrictAssembly || expectedLanguage == AssemblyStack::Language::Ewasm)
+		if (expectedLanguage == YulStack::Language::StrictAssembly || expectedLanguage == YulStack::Language::Ewasm)
 		{
 			expectedOptions.optimizer.enabled = true;
 			expectedOptions.optimizer.yulSteps = "agf";

--- a/test/tools/ossfuzz/SolidityEvmoneInterface.h
+++ b/test/tools/ossfuzz/SolidityEvmoneInterface.h
@@ -22,7 +22,7 @@
 
 #include <libsolidity/interface/CompilerStack.h>
 
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 
 #include <libsolutil/Keccak256.h>
 

--- a/test/tools/ossfuzz/YulEvmoneInterface.cpp
+++ b/test/tools/ossfuzz/YulEvmoneInterface.cpp
@@ -35,7 +35,7 @@ bytes YulAssembler::assemble()
 
 	if (m_optimiseYul)
 		m_stack.optimize();
-	return m_stack.assemble(AssemblyStack::Machine::EVM).bytecode->bytecode;
+	return m_stack.assemble(YulStack::Machine::EVM).bytecode->bytecode;
 }
 
 evmc::result YulEvmoneUtility::deployCode(bytes const& _input, EVMHost& _host)

--- a/test/tools/ossfuzz/YulEvmoneInterface.h
+++ b/test/tools/ossfuzz/YulEvmoneInterface.h
@@ -19,7 +19,7 @@
 
 #include <test/EVMHost.h>
 
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 
 #include <libsolidity/interface/OptimiserSettings.h>
 
@@ -37,7 +37,7 @@ public:
 	):
 		m_stack(
 			_version,
-			solidity::yul::AssemblyStack::Language::StrictAssembly,
+			solidity::yul::YulStack::Language::StrictAssembly,
 			_optSettings,
 			langutil::DebugInfoSelection::All()
 		),
@@ -46,7 +46,7 @@ public:
 	{}
 	solidity::bytes assemble();
 private:
-	solidity::yul::AssemblyStack m_stack;
+	solidity::yul::YulStack m_stack;
 	std::string m_yulProgram;
 	bool m_optimiseYul;
 };

--- a/test/tools/ossfuzz/strictasm_assembly_ossfuzz.cpp
+++ b/test/tools/ossfuzz/strictasm_assembly_ossfuzz.cpp
@@ -16,7 +16,7 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 #include <libyul/backends/evm/EVMCodeTransform.h>
 
 #include <liblangutil/DebugInfoSelection.h>
@@ -37,9 +37,9 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 	YulStringRepository::reset();
 
 	string input(reinterpret_cast<char const*>(_data), _size);
-	AssemblyStack stack(
+	YulStack stack(
 		langutil::EVMVersion(),
-		AssemblyStack::Language::StrictAssembly,
+		YulStack::Language::StrictAssembly,
 		solidity::frontend::OptimiserSettings::full(),
 		langutil::DebugInfoSelection::All()
 	);
@@ -49,7 +49,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 
 	try
 	{
-		MachineAssemblyObject obj = stack.assemble(AssemblyStack::Machine::EVM);
+		MachineAssemblyObject obj = stack.assemble(YulStack::Machine::EVM);
 		solAssert(obj.bytecode, "");
 	}
 	catch (StackTooDeepError const&)

--- a/test/tools/ossfuzz/strictasm_diff_ossfuzz.cpp
+++ b/test/tools/ossfuzz/strictasm_diff_ossfuzz.cpp
@@ -20,7 +20,7 @@
 #include <libyul/AsmAnalysis.h>
 #include <libyul/Dialect.h>
 #include <libyul/backends/evm/EVMDialect.h>
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 
 #include <liblangutil/DebugInfoSelection.h>
 #include <liblangutil/Exceptions.h>
@@ -60,9 +60,9 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 
 	YulStringRepository::reset();
 
-	AssemblyStack stack(
+	YulStack stack(
 		langutil::EVMVersion(),
-		AssemblyStack::Language::StrictAssembly,
+		YulStack::Language::StrictAssembly,
 		solidity::frontend::OptimiserSettings::full(),
 		DebugInfoSelection::All()
 	);

--- a/test/tools/ossfuzz/strictasm_opt_ossfuzz.cpp
+++ b/test/tools/ossfuzz/strictasm_opt_ossfuzz.cpp
@@ -16,7 +16,7 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 
 #include <liblangutil/DebugInfoSelection.h>
 #include <liblangutil/EVMVersion.h>
@@ -38,9 +38,9 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 	YulStringRepository::reset();
 
 	string input(reinterpret_cast<char const*>(_data), _size);
-	AssemblyStack stack(
+	YulStack stack(
 		langutil::EVMVersion(),
-		AssemblyStack::Language::StrictAssembly,
+		YulStack::Language::StrictAssembly,
 		solidity::frontend::OptimiserSettings::full(),
 		DebugInfoSelection::All()
 	);

--- a/test/tools/ossfuzz/yulProtoFuzzer.cpp
+++ b/test/tools/ossfuzz/yulProtoFuzzer.cpp
@@ -25,7 +25,7 @@
 
 #include <test/libyul/YulOptimizerTestCommon.h>
 
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 #include <libyul/Exceptions.h>
 
 #include <libyul/backends/evm/EVMDialect.h>
@@ -61,10 +61,10 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 
 	YulStringRepository::reset();
 
-	// AssemblyStack entry point
-	AssemblyStack stack(
+	// YulStack entry point
+	YulStack stack(
 		version,
-		AssemblyStack::Language::StrictAssembly,
+		YulStack::Language::StrictAssembly,
 		solidity::frontend::OptimiserSettings::full(),
 		DebugInfoSelection::All()
 	);

--- a/test/tools/ossfuzz/yulProto_diff_ossfuzz.cpp
+++ b/test/tools/ossfuzz/yulProto_diff_ossfuzz.cpp
@@ -26,7 +26,7 @@
 
 #include <src/libfuzzer/libfuzzer_macro.h>
 
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 #include <libyul/backends/evm/EVMDialect.h>
 #include <libyul/Exceptions.h>
 
@@ -60,10 +60,10 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 
 	YulStringRepository::reset();
 
-	// AssemblyStack entry point
-	AssemblyStack stack(
+	// YulStack entry point
+	YulStack stack(
 		version,
-		AssemblyStack::Language::StrictAssembly,
+		YulStack::Language::StrictAssembly,
 		solidity::frontend::OptimiserSettings::full(),
 		DebugInfoSelection::All()
 	);

--- a/test/tools/yulrun.cpp
+++ b/test/tools/yulrun.cpp
@@ -25,7 +25,7 @@
 #include <libyul/AsmAnalysis.h>
 #include <libyul/Dialect.h>
 #include <libyul/backends/evm/EVMDialect.h>
-#include <libyul/AssemblyStack.h>
+#include <libyul/YulStack.h>
 
 #include <liblangutil/DebugInfoSelection.h>
 #include <liblangutil/Exceptions.h>
@@ -56,9 +56,9 @@ namespace
 
 pair<shared_ptr<Block>, shared_ptr<AsmAnalysisInfo>> parse(string const& _source)
 {
-	AssemblyStack stack(
+	YulStack stack(
 		langutil::EVMVersion(),
-		AssemblyStack::Language::StrictAssembly,
+		YulStack::Language::StrictAssembly,
 		solidity::frontend::OptimiserSettings::none(),
 		DebugInfoSelection::Default()
 	);


### PR DESCRIPTION
Fixes #5474.

All files, references, variables, comments, etc. that were named _"AssemblyStack"_ were renamed to _"YulStack"_.

Note: This is an enhancement from an issue posted [here](https://github.com/ethereum/solidity/issues/5474).