### PR TITLE
Workarounds for ext test breakage (ethers.js downgrade, disabled polygon test in zeppelin, switch to compiler-only in elementfi)

### DIFF
--- a/test/externalTests/elementfi.sh
+++ b/test/externalTests/elementfi.sh
@@ -42,15 +42,18 @@ function elementfi_test
     local config_file="hardhat.config.ts"
     local config_var=config
 
-    local compile_only_presets=()
-    local settings_presets=(
-        "${compile_only_presets[@]}"
+    local compile_only_presets=(
+        # ElementFi's test suite is hard-coded for mainnet forked via alchemy.io.
+        # Locally we can only compile.
         #ir-no-optimize           # Compilation fails with "YulException: Variable var_amount_9311 is 10 slot(s) too deep inside the stack."
         #ir-optimize-evm-only     # Compilation fails with "YulException: Variable var_amount_9311 is 10 slot(s) too deep inside the stack."
         ir-optimize-evm+yul
         legacy-no-optimize
         legacy-optimize-evm-only
         legacy-optimize-evm+yul
+    )
+    local settings_presets=(
+        "${compile_only_presets[@]}"
     )
 
     [[ $SELECTED_PRESETS != "" ]] || SELECTED_PRESETS=$(circleci_select_steps_multiarg "${settings_presets[@]}")

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -65,6 +65,10 @@ function ens_test
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")"
     yarn install
 
+    # With ethers.js 5.6.2 many tests for revert messages fail.
+    # TODO: Remove when https://github.com/ethers-io/ethers.js/discussions/2849 is resolved.
+    yarn add ethers@5.6.1
+
     replace_version_pragmas
     neutralize_packaged_contracts
 

--- a/test/externalTests/euler.sh
+++ b/test/externalTests/euler.sh
@@ -68,6 +68,10 @@ function euler_test
     force_hardhat_unlimited_contract_size "$config_file"
     npm install
 
+    # With ethers.js 5.6.2 many tests for revert messages fail.
+    # TODO: Remove when https://github.com/ethers-io/ethers.js/discussions/2849 is resolved.
+    npm install ethers@5.6.1
+
     replace_version_pragmas
     neutralize_packaged_contracts
 

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -81,6 +81,10 @@ function gnosis_safe_test
     npm install
     npm install hardhat-gas-reporter
 
+    # With ethers.js 5.6.2 many tests for revert messages fail.
+    # TODO: Remove when https://github.com/ethers-io/ethers.js/discussions/2849 is resolved.
+    npm install ethers@5.6.1
+
     replace_version_pragmas
     [[ $BINARY_TYPE == solcjs ]] && force_solc_modules "${DIR}/solc/dist"
 

--- a/test/externalTests/perpetual-pools.sh
+++ b/test/externalTests/perpetual-pools.sh
@@ -66,11 +66,6 @@ function perpetual_pools_test
     force_hardhat_unlimited_contract_size "$config_file" "$config_var"
     yarn install
 
-    # The project depends on @openzeppelin/hardhat-upgrades, which is currently not prepared
-    # for the parallel compilation introduced in Hardhat 2.9.0.
-    # TODO: Remove when https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/528 is fixed.
-    yarn add hardhat@2.8.4
-
     # With ethers.js 5.6.2 many tests for revert messages fail.
     # TODO: Remove when https://github.com/ethers-io/ethers.js/discussions/2849 is resolved.
     yarn add ethers@5.6.1

--- a/test/externalTests/perpetual-pools.sh
+++ b/test/externalTests/perpetual-pools.sh
@@ -71,6 +71,10 @@ function perpetual_pools_test
     # TODO: Remove when https://github.com/OpenZeppelin/openzeppelin-upgrades/issues/528 is fixed.
     yarn add hardhat@2.8.4
 
+    # With ethers.js 5.6.2 many tests for revert messages fail.
+    # TODO: Remove when https://github.com/ethers-io/ethers.js/discussions/2849 is resolved.
+    yarn add ethers@5.6.1
+
     replace_version_pragmas
 
     for preset in $SELECTED_PRESETS; do

--- a/test/externalTests/uniswap.sh
+++ b/test/externalTests/uniswap.sh
@@ -77,6 +77,10 @@ function uniswap_test
     yarn install
     yarn add hardhat-gas-reporter
 
+    # With ethers.js 5.6.2 many tests for revert messages fail.
+    # TODO: Remove when https://github.com/ethers-io/ethers.js/discussions/2849 is resolved.
+    yarn add ethers@5.6.1
+
     replace_version_pragmas
 
     for preset in $SELECTED_PRESETS; do

--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -70,6 +70,8 @@ function zeppelin_test
     # In some cases Hardhat does not detect revert reasons properly via IR.
     # TODO: Remove this when https://github.com/NomicFoundation/hardhat/issues/2453 gets fixed.
     sed -i "s|it(\('reverts if the current value is 0'\)|it.skip(\1|g" test/utils/Counters.test.js
+    # TODO: Remove this when https://github.com/NomicFoundation/hardhat/issues/2115 gets fixed.
+    sed -i "s|describe\(('Polygon-Child'\)|describe.skip\1|g" test/crosschain/CrossChainEnabled.test.js
 
     neutralize_package_json_hooks
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"


### PR DESCRIPTION
This is a bunch of workarounds for recent breakage in external tests. The PR was originally addressing just the ethers.js one but breakage keeps piling up. I decided to just add new fixes here so that it can be merged without special provileges. Otherwise the ethers.js fix on its own would not pass tests and would require a force merge. 
1) Workaround for breakage caused by https://github.com/ethers-io/ethers.js/discussions/2849.
2) Removal of the workaround added in #12733 since that seems to have been fixed upstream.
3) OpenZeppelin has a new test related to polygon that hits https://github.com/NomicFoundation/hardhat/issues/2115 and had to be disabled
4) ElementFi now completely stopped working without alchemy.io key. All I could do was to switch all presets to compile-only mode. We won't be able to run the test suite but at least we can still run compilation via IR and we'll get bytecode size in benchmarks.
    - I originally thought that only some of their tests ran with alchemy. Apparently that's pretty much all of them. They had alchemy.io key hard-coded in the config file and the current breakage is caused by it finally being removed. This explains why this ext test was so flaky.