### PR TITLE
abstract-contracts.rst: Clarify when a contract may or must be marked abstract

### DIFF
--- a/docs/contracts/abstract-contracts.rst
+++ b/docs/contracts/abstract-contracts.rst
@@ -6,12 +6,15 @@
 Abstract Contracts
 ******************
 
-Contracts need to be marked as abstract when at least one of their functions is not implemented.
-Contracts may be marked as abstract even though all functions are implemented.
+Contracts must be marked as abstract when at least one of their functions is not implemented or when
+they do not provide arguments for all of their base contract constructors.
+Even if this is not the case, a contract may still be marked abstract, such as when you do not intend
+for the contract to be created directly. Abstract contracts are similar to :ref:`interfaces` but an
+interface is more limited in what it can declare.
 
-This can be done by using the ``abstract`` keyword as shown in the following example. Note that this contract needs to be
-defined as abstract, because the function ``utterance()`` was defined, but no implementation was
-provided (no implementation body ``{ }`` was given).
+An abstract contract is declared using the ``abstract`` keyword as shown in the following example.
+Note that this contract needs to be defined as abstract, because the function ``utterance()`` is declared,
+but no implementation was provided (no implementation body ``{ }`` was given).
 
 .. code-block:: solidity
 


### PR DESCRIPTION
Adds the other case where a contract must be abstract. I've noted the Solidity docs do not use certain words in a "strict" way. For example, the word "define" vs "declare" vs "implemented."  I would propose in future versions of the documentation, the word "define" should never be used if the word "declare" can be used instead. I think for most people coming from other compiled languages, the word "definition" is closer to the word "implementation" ... i.e., a definition of a thing includes all of what's necessary to instantiate the thing.