### PR TITLE
Make ImmutableValidator more precise while analyzing branches

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Language Features:
 
 
 Compiler Features:
+* TypeChecker: Support initializing immutable variables inside if-else branches.
 * Yul Optimizer: Allow replacing the previously hard-coded cleanup sequence by specifying custom steps after a colon delimiter (``:``) in the sequence string.
 
 

--- a/test/libsolidity/syntaxTests/immutable/conditionally_initialized.sol
+++ b/test/libsolidity/syntaxTests/immutable/conditionally_initialized.sol
@@ -1,9 +1,0 @@
-contract C {
-    uint immutable x;
-    constructor() {
-        if (false)
-            x = 1;
-    }
-}
-// ----
-// TypeError 4599: (86-87): Cannot write to immutable here: Immutable variables cannot be initialized inside an if statement.

--- a/test/libsolidity/syntaxTests/immutable/conditionally_initialized_multiple_writes_fail.sol
+++ b/test/libsolidity/syntaxTests/immutable/conditionally_initialized_multiple_writes_fail.sol
@@ -1,0 +1,14 @@
+contract C {
+    uint immutable multipleWrites;
+
+    constructor() {
+        if (true) {
+            multipleWrites = 1;
+        } else {
+            multipleWrites = 1;
+        }
+        multipleWrites = 2; // error
+    }
+}
+// ----
+// TypeError 1574: (188-202): Immutable state variable already initialized.

--- a/test/libsolidity/syntaxTests/immutable/conditionally_initialized_multiple_writes_pass.sol
+++ b/test/libsolidity/syntaxTests/immutable/conditionally_initialized_multiple_writes_pass.sol
@@ -1,0 +1,12 @@
+contract C {
+    uint immutable multipleWrites;
+
+    constructor() {
+        if (true) {
+            multipleWrites = 1;
+        } else {
+            multipleWrites = 2;
+        }
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/immutable/conditionally_initialized_nested_branch_write_fail.sol
+++ b/test/libsolidity/syntaxTests/immutable/conditionally_initialized_nested_branch_write_fail.sol
@@ -1,0 +1,14 @@
+contract C {
+    uint immutable nestedBranchWrite; // error
+
+    constructor() {
+        if (true) {
+            nestedBranchWrite = 1;
+        } else {
+            if (true)
+                nestedBranchWrite = 2;
+        }
+    }
+}
+// ----
+// TypeError 4599: (32-49): Immutable is not initialized in every branch of control flow.

--- a/test/libsolidity/syntaxTests/immutable/conditionally_initialized_nested_branch_write_pass.sol
+++ b/test/libsolidity/syntaxTests/immutable/conditionally_initialized_nested_branch_write_pass.sol
@@ -1,0 +1,15 @@
+contract C {
+    uint immutable nestedBranchWrite; // good
+
+    constructor() {
+        if (true) {
+            nestedBranchWrite = 1;
+        } else {
+            if (true)
+                nestedBranchWrite = 2;
+            else
+                nestedBranchWrite = 3;
+        }
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/immutable/conditionally_initialized_nested_multiple_writes_fail.sol
+++ b/test/libsolidity/syntaxTests/immutable/conditionally_initialized_nested_multiple_writes_fail.sol
@@ -1,0 +1,18 @@
+contract C {
+    uint immutable nestedMultipleWrites;
+
+    constructor() {
+        if (true) {
+            if (true) {
+                nestedMultipleWrites = 1;
+            } else {
+                nestedMultipleWrites = 1;
+            }
+            nestedMultipleWrites = 2; // error
+        } else {
+            nestedMultipleWrites = 1;
+        }
+    }
+}
+// ----
+// TypeError 1574: (250-270): Immutable state variable already initialized.

--- a/test/libsolidity/syntaxTests/immutable/conditionally_initialized_nested_multiple_writes_pass.sol
+++ b/test/libsolidity/syntaxTests/immutable/conditionally_initialized_nested_multiple_writes_pass.sol
@@ -1,0 +1,16 @@
+contract C {
+    uint immutable nestedMultipleWrites;
+
+    constructor() {
+        if (true) {
+            if (true) {
+                nestedMultipleWrites = 1;
+            } else {
+                nestedMultipleWrites = 1;
+            }
+        } else {
+            nestedMultipleWrites = 1;
+        }
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/immutable/conditionally_initialized_nested_non_assign_init_in_branch_fail.sol
+++ b/test/libsolidity/syntaxTests/immutable/conditionally_initialized_nested_non_assign_init_in_branch_fail.sol
@@ -1,0 +1,17 @@
+contract C {
+    uint immutable nestedNonAssignInitInBranch;
+
+    constructor() {
+        if (true) {
+            nestedNonAssignInitInBranch = 1;
+        } else {
+            if (true) {
+                nestedNonAssignInitInBranch = 1;
+            } else {
+                delete nestedNonAssignInitInBranch; // init error
+            }
+        }
+    }
+}
+// ----
+// TypeError 3969: (281-308): Immutable variables must be initialized using an assignment.

--- a/test/libsolidity/syntaxTests/immutable/conditionally_initialized_nested_non_assign_init_in_branch_fail_modify.sol
+++ b/test/libsolidity/syntaxTests/immutable/conditionally_initialized_nested_non_assign_init_in_branch_fail_modify.sol
@@ -1,0 +1,18 @@
+contract C {
+    uint immutable nestedNonAssignInitInBranch;
+
+    constructor() {
+        if (true) {
+            nestedNonAssignInitInBranch = 1;
+        } else {
+            if (true) {
+                nestedNonAssignInitInBranch = 1;
+            } else {
+                nestedNonAssignInitInBranch = 1;
+                delete nestedNonAssignInitInBranch; // modify error
+            }
+        }
+    }
+}
+// ----
+// TypeError 2718: (330-357): Immutable variables cannot be modified after initialization.

--- a/test/libsolidity/syntaxTests/immutable/conditionally_initialized_nested_read_before_write_fail.sol
+++ b/test/libsolidity/syntaxTests/immutable/conditionally_initialized_nested_read_before_write_fail.sol
@@ -1,0 +1,18 @@
+contract C {
+    uint immutable nestedReadBeforeWrite;
+
+    constructor() {
+        if (true) {
+            nestedReadBeforeWrite = 1;
+        } else {
+            if (true) {
+                nestedReadBeforeWrite = 1;
+            } else {
+                nestedReadBeforeWrite + 42; // error
+                nestedReadBeforeWrite = 1;
+            }
+        }
+    }
+}
+// ----
+// TypeError 7733: (256-277): Immutable variables cannot be read before they are initialized.

--- a/test/libsolidity/syntaxTests/immutable/conditionally_initialized_nested_read_before_write_pass.sol
+++ b/test/libsolidity/syntaxTests/immutable/conditionally_initialized_nested_read_before_write_pass.sol
@@ -1,0 +1,17 @@
+contract C {
+    uint immutable nestedReadBeforeWrite;
+
+    constructor() {
+        if (true) {
+            nestedReadBeforeWrite = 1;
+        } else {
+            if (true) {
+                nestedReadBeforeWrite = 1;
+            } else {
+                nestedReadBeforeWrite = 1;
+                nestedReadBeforeWrite + 42; // good
+            }
+        }
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/immutable/conditionally_initialized_non_assign_init_in_branch_fail.sol
+++ b/test/libsolidity/syntaxTests/immutable/conditionally_initialized_non_assign_init_in_branch_fail.sol
@@ -1,0 +1,13 @@
+contract C {
+    uint immutable nonAssignInitInBranch;
+
+    constructor() {
+        if (true) {
+            nonAssignInitInBranch = 1;
+        } else {
+            delete nonAssignInitInBranch; // init error
+        }
+    }
+}
+// ----
+// TypeError 3969: (171-192): Immutable variables must be initialized using an assignment.

--- a/test/libsolidity/syntaxTests/immutable/conditionally_initialized_non_assign_init_in_branch_pass_fail_modify.sol
+++ b/test/libsolidity/syntaxTests/immutable/conditionally_initialized_non_assign_init_in_branch_pass_fail_modify.sol
@@ -1,0 +1,14 @@
+contract C {
+    uint immutable nonAssignInitInBranch;
+
+    constructor() {
+        if (true) {
+            nonAssignInitInBranch = 1;
+        } else {
+            nonAssignInitInBranch = 2;
+            delete nonAssignInitInBranch; // modify error
+        }
+    }
+}
+// ----
+// TypeError 2718: (210-231): Immutable variables cannot be modified after initialization.

--- a/test/libsolidity/syntaxTests/immutable/conditionally_initialized_read_before_write_fail.sol
+++ b/test/libsolidity/syntaxTests/immutable/conditionally_initialized_read_before_write_fail.sol
@@ -1,0 +1,14 @@
+contract C {
+    uint immutable readBeforeWrite;
+
+    constructor() {
+        if (true) {
+            readBeforeWrite = 1;
+        } else {
+            readBeforeWrite + 42; // error
+            readBeforeWrite = 1;
+        }
+    }
+}
+// ----
+// TypeError 7733: (152-167): Immutable variables cannot be read before they are initialized.

--- a/test/libsolidity/syntaxTests/immutable/conditionally_initialized_read_before_write_pass.sol
+++ b/test/libsolidity/syntaxTests/immutable/conditionally_initialized_read_before_write_pass.sol
@@ -1,0 +1,13 @@
+contract C {
+    uint immutable readBeforeWrite;
+
+    constructor() {
+        if (true) {
+            readBeforeWrite = 1;
+        } else {
+            readBeforeWrite = 1;
+            readBeforeWrite + 42; // good
+        }
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/immutable/conditionally_initialized_single_branch_write_fail.sol
+++ b/test/libsolidity/syntaxTests/immutable/conditionally_initialized_single_branch_write_fail.sol
@@ -1,0 +1,10 @@
+contract C {
+    uint immutable singleBranchWrite; // error
+
+    constructor() {
+        if (true)
+            singleBranchWrite = 1;
+    }
+}
+// ----
+// TypeError 4599: (32-49): Immutable is not initialized in every branch of control flow.

--- a/test/libsolidity/syntaxTests/immutable/conditionally_initialized_single_branch_write_pass.sol
+++ b/test/libsolidity/syntaxTests/immutable/conditionally_initialized_single_branch_write_pass.sol
@@ -1,0 +1,11 @@
+contract C {
+    uint immutable singleBranchWrite; // good
+
+    constructor() {
+        if (true)
+            singleBranchWrite = 1;
+        else
+            singleBranchWrite = 1;
+    }
+}
+// ----


### PR DESCRIPTION
## Motivation

Addresses #12864

## Mechanism

1. Delay error generation. Originally we issue error as soon as we see any write to immutable state variable inside a branch, that's can be too conservative, e.g., when both branches write to the variable.
2. Collect all immutable state variable written in a branch (and their position, obtained via the write expression). After analyzing both branch, we can inspect the set difference, and determine which ones are not written (thus initialized) in both paths. Then we issue error for those variables, _and_ collect the all written to continue this process while avoiding duplicated error generation.

## Backward Compatibility

This shouldn't break backward compatibility because we are generating less errors, i.e., correct programs remain correct. The error message is changed, but we can discuss and tweak that.

## Test Case

```solidity
contract Immutable {
    uint256 public immutable iamImmutable;

    constructor(bool shouldInitWithZero) {
        if (shouldInitWithZero) {
            if (shouldInitWithZero) {
                iamImmutable = 0;
            } else {
                iamImmutable = 1;
            }
        } else {
            if (true) {
                iamImmutable = 1;
            }
        }
    }
}
```
This generates a single error at the last write to `iamImmutable`.
If we remove the last conditional `if (true)`, no error is issued.

## Alternative

I actually think the Java way of handling such errors is worth to consider, i.e., it's no less precise than what this PR aims to achieve, and it issues a single error message at the variable declaration site, saying `the final field ... may not have been initialized`. Which is similar to error 2658 in Solidity.

This approach makes the algorithm a bit simpler -- we just need to keep track and filter out the variables-not-initialized-in-both-branches when we issue error 2658, but we lose the location of the problematic write.