### PR TITLE
Clarify leading relative path segments in import paths

### DIFF
--- a/docs/path-resolution.rst
+++ b/docs/path-resolution.rst
@@ -252,12 +252,14 @@ The compiler computes a source unit name from the import path in the following w
 
 1. First a prefix is computed
 
-    - Prefix is initialized with the source unit name of the importing source unit.
-    - The last path segment with preceding slashes is removed from the prefix.
-    - Then, the leading part of the normalized import path, consisting only of ``/`` and ``.``
+    a) Prefix is initialized with the source unit name of the importing source unit.
+    b) The last path segment with preceding slashes is removed from the prefix.
+    c) Then, the leading part of the normalized import path, consisting only of ``/`` and ``.``
       characters is considered.
-      For every ``..`` segment found in this part the last path segment with preceding slashes is
-      removed from the prefix.
+      For every ``.`` segment found in this part of the import path, the segment is removed from the
+      import path.
+      For every ``..`` segment found in this part of the import path the last path segment with
+      preceding slashes is removed from the prefix, and the corresponding element in the import path
 
 2. Then the prefix is prepended to the normalized import path.
    If the prefix is non-empty, a single slash is inserted between it and the import path.
@@ -291,6 +293,14 @@ Here are some examples of what you can expect if they are not:
     import "../util/../array/util.sol"; // source unit name: lib/src/array/util.sol
     import "../.././../util.sol";       // source unit name: util.sol
     import "../../.././../util.sol";    // source unit name: util.sol
+
+.. note::
+
+   This rule may lead to counterintuitive behavior for prefixes that end in relative path segments.
+   For example, when used to compute the import path ``../bar.sol``, the prefix ``a/b/..``
+   (e.g., from a source file ``a/b/../foo.sol``) becomes ``a/b`` and the import path becomes ``bar.sol``.
+   The result is ``a/b/bar.sol``. You may have expected the result to be ``bar.sol`` because
+   ``a/b/../../bar.sol`` evaluates to ``bar.sol`` when normalized as a full path without this rule.
 
 .. note::
 


### PR DESCRIPTION
Note: The "Preview" tab on github did *NOT* show the .. code:: block around line ~290 even before my changes. Not sure what's up with that. The rst seems correct, and it displays properly  at ``https://docs.soliditylang.org/en/latest/path-resolution.html#import-callback``

Also, I inferred the rule for ``.`` in the leading part of the import path based on the description that the import path itself is first normalized. My edit may therefore be incorrect if ``..`` segments in the leading part of the import path behave the same way as they do in the instant rule (e.g. if ``././../foo.bar`` in the import path means ``./foo.bar``). Doubtful.

Also note, the "normalization" of the import path is not exactly the normalization referred to in the CLI path normalization, since it remains relative. Probably ok not to mention explicitly.