### PR TITLE
Reword the section about cleaning up variables `variable_cleanup.rst`

### DIFF
--- a/docs/internals/variable_cleanup.rst
+++ b/docs/internals/variable_cleanup.rst
@@ -1,33 +1,34 @@
 .. index: variable cleanup
 
-*********************
-Zeroing of Padding
-*********************
+*************************
+Cleaning of Padding Bits
+*************************
 
 When a value is shorter than 256 bit, in some cases the remaining (padding) bits
-must be zeroed. The Solidity compiler is designed to zero any padding bits before operations
-that might be adversely affected by garbage in the padding bits.
+must be cleaned up, by sign extending the shorter value. The Solidity
+compiler is designed to clean up padding bits before operations
+that might be adversely affected by garbage in those padding bits.
 For example, before writing a value to  memory, the padding bits need
-to be cleared because the memory contents could be used for computing
+to be cleaned because the memory contents could be used for computing
 hashes or sent as the data of a message call. Similarly, before
 storing a value in storage, padding bits need to be cleaned
-because otherwise their value can be observed, and may leak information.
+because otherwise their value can be observed.
 
-Note that inline assembly does not automatically zero padding bits
+Note that inline assembly instructions do not automatically clean padding bits
 of values used therein.
-If you use inline assembly to access and modify Solidity variables
+Furthermore, if you use inline assembly to access and modify Solidity variables
 shorter than 256 bits, the compiler does not do any automated
-cleanup of the padding bits. It is up to you to store zeroed
+cleanup of the padding bits either. It is up to you to store cleaned
 values back into the source memory or storage location.
 
 Moreover, the assembly emitted by the compiler may not zero the
-padding bits of temporary values that are not stored anywhere,
+padding bits of values,
 particularly when the following instruction(s) would behave the
 same irrespective of the content of the padding bits. Low level
 temporary values that are inputs to the `JUMPI` opcode are one
 example.
 
-In addition to the design principle above, the Solidity compiler
+In addition, the Solidity compiler
 cleans input data when it is loaded onto the stack.
 
 Different types have different rules for cleaning up invalid values:

--- a/docs/internals/variable_cleanup.rst
+++ b/docs/internals/variable_cleanup.rst
@@ -12,7 +12,9 @@ For example, before writing a value to  memory, the padding bits need
 to be cleaned because the memory contents could be used for computing
 hashes or sent as the data of a message call. Similarly, before
 storing a value in storage, padding bits need to be cleaned
-because otherwise their value can be observed.
+because otherwise their value, which may not be deterministic across
+EVM or Solidity versions, may affect operations such as cryptographic
+functions or other operations which observe those values.
 
 Note that inline assembly instructions do not automatically clean padding bits
 of values used therein.

--- a/docs/internals/variable_cleanup.rst
+++ b/docs/internals/variable_cleanup.rst
@@ -1,29 +1,31 @@
 .. index: variable cleanup
 
 *********************
-Cleaning Up Variables
+Zeroing of Padding
 *********************
 
-When a value is shorter than 256 bit, in some cases the remaining bits
-must be cleaned.
-The Solidity compiler is designed to clean such remaining bits before any operations
-that might be adversely affected by the potential garbage in the remaining bits.
-For example, before writing a value to  memory, the remaining bits need
-to be cleared because the memory contents can be used for computing
-hashes or sent as the data of a message call.  Similarly, before
-storing a value in the storage, the remaining bits need to be cleaned
-because otherwise the garbled value can be observed.
+When a value is shorter than 256 bit, in some cases the remaining (padding) bits
+must be zeroed. The Solidity compiler is designed to zero any padding bits before operations
+that might be adversely affected by garbage in the padding bits.
+For example, before writing a value to  memory, the padding bits need
+to be cleared because the memory contents could be used for computing
+hashes or sent as the data of a message call. Similarly, before
+storing a value in storage, padding bits need to be cleaned
+because otherwise their value can be observed, and may leak information.
 
-Note that access via inline assembly is not considered such an operation:
-If you use inline assembly to access Solidity variables
-shorter than 256 bits, the compiler does not guarantee that
-the value is properly cleaned up.
+Note that inline assembly does not automatically zero padding bits
+of values used therein.
+If you use inline assembly to access and modify Solidity variables
+shorter than 256 bits, the compiler does not do any automated
+cleanup of the padding bits. It is up to you to store zeroed
+values back into the source memory or storage location.
 
-Moreover, we do not clean the bits if the immediately
-following operation is not affected.  For instance, since any non-zero
-value is considered ``true`` by ``JUMPI`` instruction, we do not clean
-the boolean values before they are used as the condition for
-``JUMPI``.
+Moreover, the assembly emitted by the compiler may not zero the
+padding bits of temporary values that are not stored anywhere,
+particularly when the following instruction(s) would behave the
+same irrespective of the content of the padding bits. Low level
+temporary values that are inputs to the `JUMPI` opcode are one
+example.
 
 In addition to the design principle above, the Solidity compiler
 cleans input data when it is loaded onto the stack.


### PR DESCRIPTION
The original section title is misleading, because it sounds like it would be a discussion of memory allocation cleanup -- and that's not really a thing in Solidity or the EVM. The section actually deals with whether padding bits are zeroed. There's also some really low level discussion of JUMPI with quite a head-scratcher of an example!