### PR TITLE
Improve error message for static array with size too large

### DIFF
--- a/libsolidity/analysis/DeclarationTypeChecker.cpp
+++ b/libsolidity/analysis/DeclarationTypeChecker.cpp
@@ -297,7 +297,7 @@ void DeclarationTypeChecker::endVisit(ArrayTypeName const& _typeName)
 		else if (optional<ConstantEvaluator::TypedRational> value = ConstantEvaluator::evaluate(m_errorReporter, *length))
 			lengthValue = value->value;
 
-		if (!lengthValue || lengthValue > TypeProvider::uint256()->max())
+		if (!lengthValue)
 			m_errorReporter.typeError(
 				5462_error,
 				length->location(),
@@ -309,6 +309,12 @@ void DeclarationTypeChecker::endVisit(ArrayTypeName const& _typeName)
 			m_errorReporter.typeError(3208_error, length->location(), "Array with fractional length specified.");
 		else if (*lengthValue < 0)
 			m_errorReporter.typeError(3658_error, length->location(), "Array with negative length specified.");
+		else if (lengthValue > TypeProvider::uint256()->max())
+			m_errorReporter.typeError(
+				1847_error,
+				length->location(),
+				"Array length too large, maximum is 2**256 - 1."
+			);
 
 		_typeName.annotation().type = TypeProvider::array(
 			DataLocation::Storage,

--- a/test/libsolidity/syntaxTests/array/length/bytes32_too_large.sol
+++ b/test/libsolidity/syntaxTests/array/length/bytes32_too_large.sol
@@ -2,4 +2,4 @@ contract C {
     bytes32[8**90] ids;
 }
 // ----
-// TypeError 5462: (25-30): Invalid array length, expected integer literal or constant expression.
+// TypeError 1847: (25-30): Array length too large, maximum is 2**256 - 1.

--- a/test/libsolidity/syntaxTests/array/length/bytes32_too_large_multidim.sol
+++ b/test/libsolidity/syntaxTests/array/length/bytes32_too_large_multidim.sol
@@ -2,4 +2,4 @@ contract C {
     bytes32[8**90][500] ids;
 }
 // ----
-// TypeError 5462: (25-30): Invalid array length, expected integer literal or constant expression.
+// TypeError 1847: (25-30): Array length too large, maximum is 2**256 - 1.

--- a/test/libsolidity/syntaxTests/array/length/literal_conversion.sol
+++ b/test/libsolidity/syntaxTests/array/length/literal_conversion.sol
@@ -1,0 +1,16 @@
+contract C {
+    uint[uint(1)] valid_size_invalid_expr1;
+    uint[uint(2**256-1)] valid_size_invalid_expr2;
+    uint[uint(2**256)] invalid_size_invalid_expr3;
+
+    uint[int(1)] valid_size_invalid_expr4;
+    uint[int(2**256-1)] valid_size_invalid_expr5;
+    uint[int(2**256)] invalid_size_invalid_expr6;
+}
+// ----
+// TypeError 5462: (22-29): Invalid array length, expected integer literal or constant expression.
+// TypeError 5462: (66-80): Invalid array length, expected integer literal or constant expression.
+// TypeError 5462: (117-129): Invalid array length, expected integer literal or constant expression.
+// TypeError 5462: (169-175): Invalid array length, expected integer literal or constant expression.
+// TypeError 5462: (212-225): Invalid array length, expected integer literal or constant expression.
+// TypeError 5462: (262-273): Invalid array length, expected integer literal or constant expression.

--- a/test/libsolidity/syntaxTests/array/length/too_large.sol
+++ b/test/libsolidity/syntaxTests/array/length/too_large.sol
@@ -1,5 +1,8 @@
 contract C {
     uint[8**90] ids;
+    uint[2**256-1] okay;
+    uint[2**256] tooLarge;
 }
 // ----
-// TypeError 5462: (22-27): Invalid array length, expected integer literal or constant expression.
+// TypeError 1847: (22-27): Array length too large, maximum is 2**256 - 1.
+// TypeError 1847: (68-74): Array length too large, maximum is 2**256 - 1.

--- a/test/libsolidity/syntaxTests/array/length/uint_too_large_multidim.sol
+++ b/test/libsolidity/syntaxTests/array/length/uint_too_large_multidim.sol
@@ -2,4 +2,4 @@ contract C {
     uint[8**90][500] ids;
 }
 // ----
-// TypeError 5462: (22-27): Invalid array length, expected integer literal or constant expression.
+// TypeError 1847: (22-27): Array length too large, maximum is 2**256 - 1.


### PR DESCRIPTION
# Motivation
Addresses #12832

# Mechanism
Simply disambiguate the (1) array with size too large, and (2) array with non-constant integer size cases and generate a new error for (1).

# Backward Compatibility
I fixed all the existing test cases, and hopefully this PR should only make the error messages better, rather than breaking existing applications.