### PR TITLE
Implements $/setTrace and uses trace logging.

### DIFF
--- a/libsolidity/lsp/LanguageServer.h
+++ b/libsolidity/lsp/LanguageServer.h
@@ -68,6 +68,7 @@ private:
 	void requireServerInitialized();
 	void handleInitialize(MessageID _id, Json::Value const& _args);
 	void handleWorkspaceDidChangeConfiguration(Json::Value const& _args);
+	void setTrace(Json::Value const& _args);
 	void handleTextDocumentDidOpen(Json::Value const& _args);
 	void handleTextDocumentDidChange(Json::Value const& _args);
 	void handleTextDocumentDidClose(Json::Value const& _args);

--- a/libsolidity/lsp/Transport.cpp
+++ b/libsolidity/lsp/Transport.cpp
@@ -98,6 +98,18 @@ void IOStreamTransport::error(MessageID _id, ErrorCode _code, string _message)
 	send(move(json), _id);
 }
 
+void Transport::trace(std::string _message, Json::Value _extra)
+{
+	if (m_logTrace != TraceValue::Off)
+	{
+		Json::Value params;
+		if (_extra.isObject())
+			params = move(_extra);
+		params["message"] = move(_message);
+		notify("$/logTrace", move(params));
+	}
+}
+
 void IOStreamTransport::send(Json::Value _json, MessageID _id)
 {
 	solAssert(_json.isObject());

--- a/libsolidity/lsp/Transport.h
+++ b/libsolidity/lsp/Transport.h
@@ -34,6 +34,13 @@ namespace solidity::lsp
 
 using MessageID = Json::Value;
 
+enum class TraceValue
+{
+	Off,
+	Messages,
+	Verbose
+};
+
 enum class ErrorCode
 {
 	// Defined by JSON RPC
@@ -89,6 +96,15 @@ public:
 	virtual void notify(std::string _method, Json::Value _params) = 0;
 	virtual void reply(MessageID _id, Json::Value _result) = 0;
 	virtual void error(MessageID _id, ErrorCode _code, std::string _message) = 0;
+
+	void trace(std::string _message, Json::Value _extra = Json::nullValue);
+
+	TraceValue traceValue() const noexcept { return m_logTrace; }
+	void setTrace(TraceValue _value) noexcept { m_logTrace = _value; }
+
+
+private:
+	TraceValue m_logTrace = TraceValue::Off;
 };
 
 /**


### PR DESCRIPTION
For helping the caller to know in advance how many files are expected
with a response for publishDiagnostics.

This is going to help #12798.