### PR TITLE
Fix MSVC Debug crash

### DIFF
--- a/libyul/optimiser/StructuralSimplifier.cpp
+++ b/libyul/optimiser/StructuralSimplifier.cpp
@@ -93,26 +93,31 @@ void StructuralSimplifier::operator()(Block& _block)
 
 void StructuralSimplifier::simplify(std::vector<yul::Statement>& _statements)
 {
-	util::GenericVisitor visitor{
-		util::VisitorFallback<OptionalStatements>{},
-		[&](If& _ifStmt) -> OptionalStatements {
-			if (expressionAlwaysTrue(*_ifStmt.condition))
-				return {std::move(_ifStmt.body.statements)};
-			else if (expressionAlwaysFalse(*_ifStmt.condition))
-				return {vector<Statement>{}};
-			return {};
-		},
-		[&](Switch& _switchStmt) -> OptionalStatements {
-			if (std::optional<u256> const constExprVal = hasLiteralValue(*_switchStmt.expression))
-				return replaceConstArgSwitch(_switchStmt, constExprVal.value());
-			return {};
-		},
-		[&](ForLoop& _forLoop) -> OptionalStatements {
-			if (expressionAlwaysFalse(*_forLoop.condition))
-				return {std::move(_forLoop.pre.statements)};
-			return {};
-		}
+	// Explicit local variables ifLambda, switchLambda, forLoopLambda are created to avoid MSVC C++17 Debug test crash
+	// (Run-Time Check Failure #2 - Stack around the variable '....' was corrupted).
+	// As soon as the issue is fixed, this workaround can be removed.
+	auto ifLambda = [&](If& _ifStmt) -> OptionalStatements
+	{
+		if (expressionAlwaysTrue(*_ifStmt.condition))
+			return {std::move(_ifStmt.body.statements)};
+		else if (expressionAlwaysFalse(*_ifStmt.condition))
+			return {vector<Statement>{}};
+		return {};
 	};
+	auto switchLambda = [&](Switch& _switchStmt) -> OptionalStatements
+	{
+		if (std::optional<u256> const constExprVal = hasLiteralValue(*_switchStmt.expression))
+			return replaceConstArgSwitch(_switchStmt, constExprVal.value());
+		return {};
+	};
+	auto forLoopLambda = [&](ForLoop& _forLoop) -> OptionalStatements
+	{
+		if (expressionAlwaysFalse(*_forLoop.condition))
+			return {std::move(_forLoop.pre.statements)};
+		return {};
+	};
+
+	util::GenericVisitor visitor{util::VisitorFallback<OptionalStatements>{}, ifLambda, switchLambda, forLoopLambda};
 
 	util::iterateReplacing(
 		_statements,


### PR DESCRIPTION
After 44093f2ed63782e02ee3611e701c92b2bdf9bd0c `soltest` reports corrupted stack in in MSVC **Debug**.

The commit looks OK and it is likely a MSVC issue. The following code

```
template<typename A, typename B> struct S : A, B{};
template<typename A, typename B> S(A, B)->S<A, B>;

int main()
{
    S s{ [](){}, [](){} };
}
```
causes an error "_Run-Time Check Failure #<!-- -->2 - Stack around the variable 's' was corrupted._" for **C++17** **Debug**. Observed in **VS2019** and **VS2022**. It does not occur for **C++20**, and it does not occur in **Release**.

