### PR TITLE
Calldatasize-check during ABI encoding from calldata values with nested dynamic arrays.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -990,7 +990,7 @@ jobs:
       - gitter_notify_failure_unless_pr
 
   t_ubu_soltest_all: &t_ubu_soltest_all
-    <<: *base_ubuntu2004
+    <<: *base_ubuntu2004_large
     parallelism: 50
     <<: *steps_soltest_all
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 ### 0.8.14 (unreleased)
 
+Important Bugfixes:
+ * ABI Encoding: When ABI-encoding values from calldata that contain nested arrays, correctly validate the nested array length against ``calldatasize()`` in all cases.
+
+
 Language Features:
 
 

--- a/docs/bugs.json
+++ b/docs/bugs.json
@@ -1,5 +1,15 @@
 [
     {
+        "uid": "SOL-2022-2",
+        "name": "NestedCallataArrayAbiReencodingSizeValidation",
+        "summary": "ABI-reencoding of nested dynamic calldata arrays did not always perform proper size checks against the size of calldata and could read beyond ``calldatasize()``.",
+        "description": "Calldata validation for nested dynamic types is deferred until the first access to the nested values. Such an access may for example be a copy to memory or an index or member access to the outer type. While in most such accesses calldata validation correctly checks that the data area of the nested array is completely contained in the passed calldata (i.e. in the range [0, calldatasize()]), this check may not be performed, when ABI encoding such nested types again directly from calldata. For instance, this can happen, if a value in calldata with a nested dynamic array is passed to an external call, used in ``abi.encode`` or emitted as event. In such cases, if the data area of the nested array extends beyond ``calldatasize()``, ABI encoding it did not revert, but continued reading values from beyond ``calldatasize()`` (i.e. zero values).",
+        "link": "https://blog.soliditylang.org/2022/05/17/calldata-reencode-size-check-bug/",
+        "introduced": "0.5.8",
+        "fixed": "0.8.14",
+        "severity": "very low"
+    },
+    {
         "uid": "SOL-2022-1",
         "name": "AbiEncodeCallLiteralAsFixedBytesBug",
         "summary": "Literals used for a fixed length bytes parameter in ``abi.encodeCall`` were encoded incorrectly.",

--- a/docs/bugs_by_version.json
+++ b/docs/bugs_by_version.json
@@ -1036,6 +1036,7 @@
     },
     "0.5.10": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
             "EmptyByteArrayCopy",
@@ -1051,6 +1052,7 @@
     },
     "0.5.11": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
             "EmptyByteArrayCopy",
@@ -1065,6 +1067,7 @@
     },
     "0.5.12": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
             "EmptyByteArrayCopy",
@@ -1079,6 +1082,7 @@
     },
     "0.5.13": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
             "EmptyByteArrayCopy",
@@ -1093,6 +1097,7 @@
     },
     "0.5.14": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
             "EmptyByteArrayCopy",
@@ -1109,6 +1114,7 @@
     },
     "0.5.15": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
             "EmptyByteArrayCopy",
@@ -1124,6 +1130,7 @@
     },
     "0.5.16": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
             "EmptyByteArrayCopy",
@@ -1138,6 +1145,7 @@
     },
     "0.5.17": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
             "EmptyByteArrayCopy",
@@ -1269,6 +1277,7 @@
     },
     "0.5.8": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
             "EmptyByteArrayCopy",
@@ -1287,6 +1296,7 @@
     },
     "0.5.9": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
             "EmptyByteArrayCopy",
@@ -1304,6 +1314,7 @@
     },
     "0.6.0": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
             "EmptyByteArrayCopy",
@@ -1319,6 +1330,7 @@
     },
     "0.6.1": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
             "EmptyByteArrayCopy",
@@ -1333,6 +1345,7 @@
     },
     "0.6.10": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
@@ -1343,6 +1356,7 @@
     },
     "0.6.11": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
@@ -1353,6 +1367,7 @@
     },
     "0.6.12": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
@@ -1363,6 +1378,7 @@
     },
     "0.6.2": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
             "EmptyByteArrayCopy",
@@ -1377,6 +1393,7 @@
     },
     "0.6.3": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
             "EmptyByteArrayCopy",
@@ -1391,6 +1408,7 @@
     },
     "0.6.4": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
             "EmptyByteArrayCopy",
@@ -1405,6 +1423,7 @@
     },
     "0.6.5": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
@@ -1419,6 +1438,7 @@
     },
     "0.6.6": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
@@ -1432,6 +1452,7 @@
     },
     "0.6.7": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
@@ -1445,6 +1466,7 @@
     },
     "0.6.8": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
@@ -1455,6 +1477,7 @@
     },
     "0.6.9": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
@@ -1466,6 +1489,7 @@
     },
     "0.7.0": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
@@ -1476,6 +1500,7 @@
     },
     "0.7.1": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
@@ -1487,6 +1512,7 @@
     },
     "0.7.2": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
@@ -1497,6 +1523,7 @@
     },
     "0.7.3": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching",
@@ -1506,6 +1533,7 @@
     },
     "0.7.4": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching"
@@ -1514,6 +1542,7 @@
     },
     "0.7.5": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching"
@@ -1522,6 +1551,7 @@
     },
     "0.7.6": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching"
@@ -1530,6 +1560,7 @@
     },
     "0.8.0": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching"
@@ -1538,6 +1569,7 @@
     },
     "0.8.1": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching"
@@ -1545,27 +1577,34 @@
         "released": "2021-01-27"
     },
     "0.8.10": {
-        "bugs": [],
+        "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation"
+        ],
         "released": "2021-11-09"
     },
     "0.8.11": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "AbiEncodeCallLiteralAsFixedBytesBug"
         ],
         "released": "2021-12-20"
     },
     "0.8.12": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "AbiEncodeCallLiteralAsFixedBytesBug"
         ],
         "released": "2022-02-16"
     },
     "0.8.13": {
-        "bugs": [],
+        "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation"
+        ],
         "released": "2022-03-16"
     },
     "0.8.2": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory",
             "KeccakCaching"
@@ -1574,6 +1613,7 @@
     },
     "0.8.3": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables",
             "ABIDecodeTwoDimensionalArrayMemory"
         ],
@@ -1581,37 +1621,44 @@
     },
     "0.8.4": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables"
         ],
         "released": "2021-04-21"
     },
     "0.8.5": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables"
         ],
         "released": "2021-06-10"
     },
     "0.8.6": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables"
         ],
         "released": "2021-06-22"
     },
     "0.8.7": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "SignedImmutables"
         ],
         "released": "2021-08-11"
     },
     "0.8.8": {
         "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation",
             "UserDefinedValueTypesBug",
             "SignedImmutables"
         ],
         "released": "2021-09-27"
     },
     "0.8.9": {
-        "bugs": [],
+        "bugs": [
+            "NestedCallataArrayAbiReencodingSizeValidation"
+        ],
         "released": "2021-09-29"
     }
 }

--- a/libsolidity/codegen/ABIFunctions.cpp
+++ b/libsolidity/codegen/ABIFunctions.cpp
@@ -1454,7 +1454,7 @@ string ABIFunctions::calldataAccessFunction(Type const& _type)
 					length := calldataload(value)
 					value := add(value, 0x20)
 					if gt(length, 0xffffffffffffffff) { <revertStringLength>() }
-					if sgt(base_ref, sub(calldatasize(), mul(length, <calldataStride>))) { <revertStringStride>() }
+					if sgt(value, sub(calldatasize(), mul(length, <calldataStride>))) { <revertStringStride>() }
 				)")
 				("calldataStride", toCompactHexWithPrefix(arrayType->calldataStride()))
 				// TODO add test

--- a/test/libsolidity/semanticTests/abiEncoderV2/calldata_array_short.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/calldata_array_short.sol
@@ -1,0 +1,12 @@
+pragma abicoder v2;
+
+contract C {
+	function f(uint[] calldata) public {}
+}
+// ====
+// revertStrings: debug
+// compileViaYul: also
+// ----
+// f(uint256[]): 0x20, 0 ->
+// f(uint256[]): 0x20, 1 -> FAILURE, hex"08c379a0", 0x20, 0x2b, "ABI decoding: invalid calldata a", "rray stride"
+// f(uint256[]): 0x20, 2 -> FAILURE, hex"08c379a0", 0x20, 0x2b, "ABI decoding: invalid calldata a", "rray stride"

--- a/test/libsolidity/semanticTests/abiEncoderV2/calldata_array_short_no_revert_string.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/calldata_array_short_no_revert_string.sol
@@ -1,0 +1,10 @@
+contract C {
+	function f(uint[] calldata) public {}
+}
+// ====
+// compileViaYul: also
+// ----
+// f(uint256[]): 0x20, 0 ->
+// f(uint256[]): 0x20, 1 -> FAILURE
+// f(uint256[]): 0x20, 2 -> FAILURE
+

--- a/test/libsolidity/semanticTests/abiEncoderV2/calldata_nested_array_reencode.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/calldata_nested_array_reencode.sol
@@ -14,10 +14,10 @@ contract C {
 // revertStrings: debug
 // ----
 // h(uint256[][]): 0x20, 1, 0x20, 0 ->
-// h(uint256[][]): 0x20, 1, 0x20, 1 ->
-// h(uint256[][]): 0x20, 1, 0x20, 2 ->
+// h(uint256[][]): 0x20, 1, 0x20, 1 -> FAILURE, hex"08c379a0", 0x20, 0x1e, "Invalid calldata access stride"
+// h(uint256[][]): 0x20, 1, 0x20, 2 -> FAILURE, hex"08c379a0", 0x20, 0x1e, "Invalid calldata access stride"
 // h(uint256[][]): 0x20, 1, 0x20, 3 -> FAILURE, hex"08c379a0", 0x20, 0x1e, "Invalid calldata access stride"
 // f((uint256[])): 0x20, 0x20, 0 ->
-// f((uint256[])): 0x20, 0x20, 1 ->
-// f((uint256[])): 0x20, 0x20, 2 ->
+// f((uint256[])): 0x20, 0x20, 1 -> FAILURE, hex"08c379a0", 0x20, 0x1e, "Invalid calldata access stride"
+// f((uint256[])): 0x20, 0x20, 2 -> FAILURE, hex"08c379a0", 0x20, 0x1e, "Invalid calldata access stride"
 // f((uint256[])): 0x20, 0x20, 3 -> FAILURE, hex"08c379a0", 0x20, 0x1e, "Invalid calldata access stride"

--- a/test/libsolidity/semanticTests/abiEncoderV2/calldata_nested_array_reencode.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/calldata_nested_array_reencode.sol
@@ -1,0 +1,23 @@
+pragma abicoder v2;
+
+contract C {
+	function h(uint[][] calldata a) public {
+		abi.encode(a);
+	}
+	struct S { uint[] x; }
+	function f(S calldata a) public {
+		abi.encode(a);
+	}
+}
+// ====
+// compileViaYul: also
+// revertStrings: debug
+// ----
+// h(uint256[][]): 0x20, 1, 0x20, 0 ->
+// h(uint256[][]): 0x20, 1, 0x20, 1 ->
+// h(uint256[][]): 0x20, 1, 0x20, 2 ->
+// h(uint256[][]): 0x20, 1, 0x20, 3 -> FAILURE, hex"08c379a0", 0x20, 0x1e, "Invalid calldata access stride"
+// f((uint256[])): 0x20, 0x20, 0 ->
+// f((uint256[])): 0x20, 0x20, 1 ->
+// f((uint256[])): 0x20, 0x20, 2 ->
+// f((uint256[])): 0x20, 0x20, 3 -> FAILURE, hex"08c379a0", 0x20, 0x1e, "Invalid calldata access stride"

--- a/test/libsolidity/semanticTests/abiEncoderV2/calldata_nested_array_static_reencode.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/calldata_nested_array_static_reencode.sol
@@ -1,0 +1,27 @@
+pragma abicoder v2;
+
+contract C {
+	function f(uint[3][] calldata a) public {
+		abi.encode(a);
+	}
+	function f(uint[][3] calldata a) public {
+		abi.encode(a);
+	}
+	function f(uint[2][2] calldata a) public {
+		abi.encode(a);
+	}
+}
+// ====
+// compileViaYul: also
+// ----
+// f(uint256[3][]): 0x20, 1, 0x01 -> FAILURE
+// f(uint256[3][]): 0x20, 1, 0x01, 0x02 -> FAILURE
+// f(uint256[3][]): 0x20, 1, 0x01, 0x02, 0x03 ->
+// f(uint256[][3]): 0x20, 0x60, 0x60, 0x60, 3, 0x01 -> FAILURE
+// f(uint256[][3]): 0x20, 0x60, 0x60, 0x60, 3, 0x01, 0x02 -> FAILURE
+// f(uint256[][3]): 0x20, 0x60, 0x60, 0x60, 3, 0x01, 0x02, 0x03 ->
+// f(uint256[2][2]): 0x01 -> FAILURE
+// f(uint256[2][2]): 0x01, 0x02 -> FAILURE
+// f(uint256[2][2]): 0x01, 0x02, 0x03 -> FAILURE
+// f(uint256[2][2]): 0x01, 0x02, 0x03, 0x04 ->
+// f(uint256[2][2]): 0x01, 0x02, 0x03, 0x04, 0x05 ->


### PR DESCRIPTION
Mainly needs reviews on the wording in the bug list, a decision on severity and a blog post.