### PR TITLE
Add `.DS_Store` and `Thumbs.db` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ CMakeLists.txt.user
 
 # place to put local temporary files
 tmp
+
+# OS specific local files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
Added OS specific local files .DS_Store (macOS) and Thumbs.db (Windows) that often sneak their way in when not explicitly included in the .gitignore file