### PR TITLE
Invalidate dependency cache on macOS in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,7 @@ defaults:
       steps:
         - restore_cache:
             keys:
-              - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+              - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}-v2
         - attach_workspace:
             at: .
 
@@ -902,14 +902,14 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+            - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}-v2
       # DO NOT EDIT between here and save_cache, but rather edit ./circleci/osx_install_dependencies.sh
       # WARNING! If you do edit anything here instead, remember to invalidate the cache manually.
       - run:
           name: Install build dependencies
           command: ./.circleci/osx_install_dependencies.sh
       - save_cache:
-          key: dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+          key: dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}-v2
           paths:
             - /usr/local/bin
             - /usr/local/sbin


### PR DESCRIPTION
Restoring cache in macOS jobs takes ~17 minutes. See for example [recent `b_osx` run on `develop`](https://app.circleci.com/pipelines/github/ethereum/solidity/23649/workflows/01a8fe85-debd-4892-874c-2745e02c10cc/jobs/1038415). There are lots of errors about symlinks being skipped, which might have something to do with it:
```
...
Skipping writing "usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.8/lib/ruby/2.6.0/bundler/env.rb" - open /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.8/lib/ruby/2.6.0/bundler/env.rb: permission denied
Skipping writing "usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.8/lib/ruby/2.6.0/bundler/environment_preserver.rb" - open /usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.8/lib/ruby/2.6.0/bundler/environment_preserver.rb: permission denied
Skipping writing "usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/2.6.8/lib/ruby/2.6.0/bundler
...
```

I think that the Homebrew in CircleCI's image must have been updated and the errors might be because we're restoring our cached, older version. If that's the case, cache invalidation should help.