### PR TITLE
Disable dependency caching on macOS in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,23 +246,11 @@ defaults:
 
   - steps_install_dependencies_osx: &steps_install_dependencies_osx
       steps:
-        - restore_cache:
-            keys:
-              - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
-        # DO NOT EDIT between here and save_cache, but rather edit ./circleci/osx_install_dependencies.sh
-        # WARNING! If you do edit anything here instead, remember to invalidate the cache manually.
+        # FIXME: We used to cache dependencies on macOS but now it takes longer than just installing
+        # them each time. See https://github.com/ethereum/solidity/issues/12925.
         - run:
             name: Install build dependencies
             command: ./.circleci/osx_install_dependencies.sh
-        - save_cache:
-            key: dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
-            paths:
-              - /usr/local/bin
-              - /usr/local/sbin
-              - /usr/local/lib
-              - /usr/local/include
-              - /usr/local/Cellar
-              - /usr/local/Homebrew
 
   # --------------------------------------------------------------------------
   # Base Image Templates

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,8 +249,20 @@ defaults:
         - restore_cache:
             keys:
               - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
-        - attach_workspace:
-            at: .
+        # DO NOT EDIT between here and save_cache, but rather edit ./circleci/osx_install_dependencies.sh
+        # WARNING! If you do edit anything here instead, remember to invalidate the cache manually.
+        - run:
+            name: Install build dependencies
+            command: ./.circleci/osx_install_dependencies.sh
+        - save_cache:
+            key: dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
+            paths:
+              - /usr/local/bin
+              - /usr/local/sbin
+              - /usr/local/lib
+              - /usr/local/include
+              - /usr/local/Cellar
+              - /usr/local/Homebrew
 
   # --------------------------------------------------------------------------
   # Base Image Templates
@@ -900,23 +912,9 @@ jobs:
       MAKEFLAGS: -j10
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
-      # DO NOT EDIT between here and save_cache, but rather edit ./circleci/osx_install_dependencies.sh
-      # WARNING! If you do edit anything here instead, remember to invalidate the cache manually.
-      - run:
-          name: Install build dependencies
-          command: ./.circleci/osx_install_dependencies.sh
-      - save_cache:
-          key: dependencies-osx-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
-          paths:
-            - /usr/local/bin
-            - /usr/local/sbin
-            - /usr/local/lib
-            - /usr/local/include
-            - /usr/local/Cellar
-            - /usr/local/Homebrew
+      - when:
+          condition: true
+          <<: *steps_install_dependencies_osx
       - run: *run_build
       - store_artifacts: *artifacts_solc
       - store_artifacts: *artifact_solidity_upgrade
@@ -940,6 +938,8 @@ jobs:
       - when:
           condition: true
           <<: *steps_install_dependencies_osx
+      - attach_workspace:
+          at: .
       - run: *run_soltest
       - store_test_results: *store_test_results
       - store_artifacts: *artifacts_test_results
@@ -952,6 +952,8 @@ jobs:
       - when:
           condition: true
           <<: *steps_install_dependencies_osx
+      - attach_workspace:
+          at: .
       - run: *run_cmdline_tests
       - store_artifacts: *artifacts_test_results
       - gitter_notify_failure_unless_pr


### PR DESCRIPTION
Replaces #12924.

Looks like invalidating the cache does not fix the problem so I added an issue to figure it out later (#12925) and here I'm disabling the cache for now as a temporary workaround.