### PR TITLE
[CI] Automate preparation of release binaries for publishing (via workspace)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,6 +418,13 @@ defaults:
         tags:
           only: /.*/
 
+  - workflow_trigger_on_releases: &workflow_trigger_on_releases
+      filters:
+        tags:
+          only: /^v.*/
+        branches:
+          ignore: /.*/
+
   - workflow_ubuntu2004: &workflow_ubuntu2004
       <<: *workflow_trigger_on_tags
       requires:
@@ -1416,6 +1423,46 @@ jobs:
           path: all-bytecode-reports.zip
       - gitter_notify_failure_unless_pr
 
+  c_release_binaries:
+    <<: *base_ubuntu2004
+    steps:
+      - checkout
+      - attach_workspace:
+          at: workspace
+      - run:
+          name: Gather and rename binaries from dependent jobs
+          command: |
+            mkdir github/
+            cp workspace/solc/solc             github/solc-static-linux
+            cp workspace/build/solc/solc       github/solc-macos
+            cp workspace/solc/Release/solc.exe github/solc-windows.exe
+            cp workspace/soljson.js            github/soljson.js
+
+            cd github/
+            tar --create --file ../github-binaries.tar *
+      - store_artifacts:
+          path: github-binaries.tar
+      - run:
+          name: Rename binaries to solc-bin naming convention
+          command: |
+            full_version=$(
+              github/solc-static-linux --version |
+              sed -En 's/^Version: ([0-9.]+.*\+commit\.[0-9a-f]+(\.mod)?).*$/\1/p'
+            )
+
+            mkdir -p solc-bin/{linux-amd64,macosx-amd64,windows-amd64,bin}
+
+            mv github/solc-static-linux "solc-bin/linux-amd64/solc-linux-amd64-${full_version}"
+            mv github/solc-macos        "solc-bin/macosx-amd64/solc-macosx-amd64-${full_version}"
+            mv github/solc-windows.exe  "solc-bin/windows-amd64/solc-windows-amd64-${full_version}.exe"
+            mv github/soljson.js        "solc-bin/bin/soljson-${full_version}.js"
+
+            cd solc-bin/
+            tar --create --file ../solc-bin-binaries.tar *
+      - store_artifacts:
+          path: solc-bin-binaries.tar
+      - gitter_notify_failure_unless_pr
+
 workflows:
   version: 2
 
@@ -1535,6 +1582,15 @@ workflows:
             - b_bytecode_win
             - b_bytecode_osx
             - b_bytecode_ems
+
+      # Final artifacts
+      - c_release_binaries:
+          <<: *workflow_trigger_on_releases
+          requires:
+            - b_ubu_static
+            - b_osx
+            - b_win_release
+            - b_ems
 
   nightly:
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ commands:
     parameters:
       event:
         type: enum
-        enum: ["failure", "success"]
+        enum: ["failure", "success", "release"]
       condition:
         type: string
     steps:
@@ -58,6 +58,10 @@ commands:
 
             [[ "<< parameters.event >>" == "failure" ]] && message=" ❌ [${workflow_name}] Job ${job} failed on **${CIRCLE_BRANCH}**. Please see [build ${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}) for details."
             [[ "<< parameters.event >>" == "success" ]] && message=" ✅ [${workflow_name}] Job ${job} succeeded on **${CIRCLE_BRANCH}**. Please see [build ${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}) for details."
+            [[ "<< parameters.event >>" == "release" ]] && message=" 📦 Release binaries for version **${CIRCLE_TAG}** are ready and attached as artifacts to [build ${CIRCLE_BUILD_NUM}](${CIRCLE_BUILD_URL}). **Please make sure the whole workflow succeeded before using them.**"
+
+            # The release notification only makes sense on tagged commits. If the commit is untagged, just bail out.
+            [[ "<< parameters.event >>" == "release" ]] && { [[ $CIRCLE_TAG != "" ]] || { echo "Not a tagged commit - notification skipped."; exit 0; } }
 
             curl "https://api.gitter.im/v1/rooms/${GITTER_NOTIFY_ROOM_ID}/chatMessages" \
               --request POST \
@@ -79,6 +83,13 @@ commands:
     steps:
       - gitter_notify_unless_pr:
           event: success
+          condition: on_success
+
+  gitter_notify_release_unless_pr:
+    description: "Posts a release notification to the main room on Gitter (if not running on a PR)."
+    steps:
+      - gitter_notify_unless_pr:
+          event: release
           condition: on_success
 
 defaults:
@@ -1462,6 +1473,7 @@ jobs:
       - store_artifacts:
           path: solc-bin-binaries.tar
       - gitter_notify_failure_unless_pr
+      - gitter_notify_release_unless_pr
 
 workflows:
   version: 2

--- a/ReleaseChecklist.md
+++ b/ReleaseChecklist.md
@@ -26,29 +26,16 @@
  - [ ] Click the `PUBLISH RELEASE` button on the release page, creating the tag.
  - [ ] Wait for the CI runs on the tag itself.
 
-### Upload Release Artifacts
+### Upload Release Artifacts and Publish Binaries
  - [ ] Switch to the tag that archives have to be created for.
  - [ ] Create the ``prerelease.txt`` file: (``echo -n > prerelease.txt``).
  - [ ] Run ``scripts/create_source_tarball.sh`` while being on the tag to create the source tarball. This will create the tarball in a directory called ``upload``.
  - [ ] Take the tarball from the upload directory (its name should be ``solidity_x.x.x.tar.gz``, otherwise ``prerelease.txt`` was missing in the step before) and upload the source tarball to the release page.
- - [ ] Take the ``solc.exe`` binary from the ``b_win_release`` run of the released commit in circle-ci and add it to the release page as ``solc-windows.exe``.
- - [ ] Take the ``solc`` binary from the ``b_osx`` run of the released commit in circle-ci and add it to the release page as ``solc-macos``.
- - [ ] Take the ``solc`` binary from the ``b_ubu_static`` run of the released commit in circle-ci and add it to the release page as ``solc-static-linux``.
- - [ ] Take the ``soljson.js`` binary from the ``b_ems`` run of the released commit in circle-ci and add it to the release page as ``soljson.js``.
-
-### Update [solc-bin](https://github.com/ethereum/solc-bin/)
- - [ ] Copy files to solc-bin:
-     ```bash
-     VERSION=0.8.4
-     COMMIT="c7e474f2"
-     SOLC_BIN="/home/me/solc-bin"
-     chmod +x solc-static-linux solc-macos
-     cp soljson.js $SOLC_BIN/bin/soljson-v$VERSION+commit.$COMMIT.js
-     cp solc-static-linux $SOLC_BIN/linux-amd64/solc-linux-amd64-v$VERSION+commit.$COMMIT
-     cp solc-macos $SOLC_BIN/macosx-amd64/solc-macosx-amd64-v$VERSION+commit.$COMMIT
-     cp solc-windows.exe $SOLC_BIN/windows-amd64/solc-windows-amd64-v$VERSION+commit.$COMMIT.exe
+ - [ ] Take the ``github-binaries.tar`` tarball from ``b_release_binaries`` run of the tagged commit in circle-ci and add all binaries from it to the release page.
+   Make sure it contains four binaries: ``solc-windows.exe``, ``solc-macos``, ``solc-static-linux`` and ``soljson.js``.
+ - [ ] Take the ``solc-bin-binaries.tar`` tarball from ``b_release_binaries`` run of the tagged commit in circle-ci and add all binaries from it to solc-bin.
  - [ ] Run ``./update --reuse-hashes`` in ``solc-bin`` and verify that the script has updated ``list.js``, ``list.txt`` and ``list.json`` files correctly and that symlinks to the new release have been added in ``solc-bin/wasm/`` and ``solc-bin/emscripten-wasm32/``.
- - [ ] Create a pull request and merge.
+ - [ ] Create a pull request in solc-bin and merge.
 
 ### Homebrew and MacOS
  - [ ] Update the version and the hash (``sha256sum solidity_$VERSION.tar.gz``) in https://github.com/Homebrew/homebrew-core/blob/master/Formula/solidity.rb


### PR DESCRIPTION
Replaces #12181.
Closes #9933.

This is a simplified version of #12181 (as discussed in https://github.com/ethereum/solidity/pull/12181#pullrequestreview-882043322). Turns out it's possible to do it via workspace after all.

It's not complete automation of the publishing process as stated in #9933 but it at least takes care of the most tedious and error prone part of the process so I think it's good enough.

The PR adds a CI job that gathers release binaries from other jobs and attaches them as artifacts, under two naming conventions - for github release page and for solc-bin.