### PR TITLE
Prevent parallel soltest runs from overwriting each other's XML test output

### DIFF
--- a/.circleci/soltest.sh
+++ b/.circleci/soltest.sh
@@ -74,7 +74,7 @@ do
     BOOST_TEST_ARGS_RUN=(
         "--color_output=no"
         "--show_progress=yes"
-        "--logger=JUNIT,error,test_results/$(get_logfile_basename "$run").xml"
+        "--logger=JUNIT,error,test_results/$(get_logfile_basename "$((CPUs * CIRCLE_NODE_INDEX + run))").xml"
         "${BOOST_TEST_ARGS[@]}"
     )
     SOLTEST_ARGS=("--evm-version=$EVM" "${SOLTEST_FLAGS[@]}")


### PR DESCRIPTION
Fixes #12862.

Here's an example run from #12731:
- Before the fix: [`t_ubu_release_soltest_all` 1041146](https://app.circleci.com/pipelines/github/ethereum/solidity/23713/workflows/763f9267-2f40-43f0-908e-423df502e1a6/jobs/1041146).
- After the fix: [`t_ubu_release_soltest_all` 1041726](https://app.circleci.com/pipelines/github/ethereum/solidity/23724/workflows/d7d3ca41-1a4a-4b68-862a-6db35e88d1da/jobs/1041726).