### PR TITLE
Disable external test cases in which Hardhat's heuristics break after relaxing inlining constraints

### DIFF
--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -75,6 +75,16 @@ function ens_test
     # In some cases Hardhat does not detect revert reasons properly via IR.
     # TODO: Remove this when https://github.com/NomicFoundation/hardhat/issues/2115 gets fixed.
     sed -i "s|it\(('Does not allow wrapping a name you do not own',\)|it.skip\1|g" test/wrapper/NameWrapper.js
+    # TODO: Remove this when https://github.com/NomicFoundation/hardhat/issues/2453 gets fixed.
+    sed -i "s|it\(('can set fuses and then burn ability to burn fuses',\)|it.skip\1|g" test/wrapper/NameWrapper.js
+    sed -i "s|it\(('can set fuses and burn canSetResolver and canSetTTL',\)|it.skip\1|g" test/wrapper/NameWrapper.js
+    sed -i "s|it\(('Cannot be called if CANNOT_TRANSFER is burned\.',\)|it.skip\1|g" test/wrapper/NameWrapper.js
+    sed -i "s|it\(('Cannot be called if CANNOT_SET_RESOLVER is burned\.\?',\)|it.skip\1|g" test/wrapper/NameWrapper.js
+    sed -i "s|it\(('Cannot be called if CANNOT_SET_TTL is burned\.\?',\)|it.skip\1|g" test/wrapper/NameWrapper.js
+    sed -i "s|it\(('Cannot be called if CREATE_SUBDOMAIN is burned and is a new subdomain',\)|it.skip\1|g" test/wrapper/NameWrapper.js
+    sed -i "s|it\(('Cannot be called if REPLACE_SUBDOMAIN is burned and is an existing subdomain',\)|it.skip\1|g" test/wrapper/NameWrapper.js
+    sed -i "s|it\(('Cannot be called if CANNOT_CREATE_SUBDOMAIN is burned and is a new subdomain',\)|it.skip\1|g" test/wrapper/NameWrapper.js
+    sed -i "s|it\(('Cannot be called if PARENT_CANNOT_CONTROL is burned and is an existing subdomain',\)|it.skip\1|g" test/wrapper/NameWrapper.js
 
     find . -name "*.sol" -exec sed -i -e 's/^\(\s*\)\(assembly\)/\1\/\/\/ @solidity memory-safe-assembly\n\1\2/' '{}' \;
 

--- a/test/externalTests/euler.sh
+++ b/test/externalTests/euler.sh
@@ -65,6 +65,7 @@ function euler_test
     # them for other presets but that's fine - we want same code run for benchmarks to be comparable.
     # TODO: Remove this when https://github.com/NomicFoundation/hardhat/issues/2453 gets fixed.
     sed -i "/expectError: 'JUNK_UPGRADE_TEST_FAILURE'/d" test/moduleUpgrade.js
+    sed -i "/et\.expect(errMsg)\.to\.contain('e\/collateral-violation');/d" test/flashLoanNative.js
 
     # One of the tests is currently broken in the upstream, due to changed behavior of chainid in @ethereumjs/vm.
     # TODO: Remove this when https://github.com/euler-xyz/euler-contracts/issues/119 gets fixed.

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -82,6 +82,11 @@ function gnosis_safe_test
     # TODO: Remove this when Gnosis merges https://github.com/gnosis/safe-contracts/pull/394
     sed -i "s|\(function isValidSignature(bytes \)calldata\( _data, bytes \)calldata\( _signature)\)|\1memory\2memory\3|g" contracts/handler/CompatibilityFallbackHandler.sol
 
+    # TODO: Remove this when https://github.com/NomicFoundation/hardhat/issues/2453 gets fixed.
+    sed -i "s|it\(('should enforce delegatecall'\)|it.skip\1|g" test/accessors/SimulateTxAccessor.spec.ts
+    sed -i "s|it\(('can only be called from Safe itself'\)|it.skip\1|g" test/libraries/Migration.spec.ts
+    sed -i "s|it\(('should enforce delegatecall to MultiSend'\)|it.skip\1|g" test/libraries/MultiSend.spec.ts
+
     neutralize_package_lock
     neutralize_package_json_hooks
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"

--- a/test/externalTests/pool-together.sh
+++ b/test/externalTests/pool-together.sh
@@ -59,6 +59,10 @@ function pool_together_test
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
     download_project "$repo" "$ref_type" "$ref" "$DIR"
 
+    # TODO: Remove this when https://github.com/NomicFoundation/hardhat/issues/2453 gets fixed.
+    sed -i "s|it\(('should fail to return value if value passed does not fit in [0-9]\+ bits'\)|it.skip\1|g" test/libraries/ExtendedSafeCast.test.ts
+    sed -i "s|it\(('should require an rng to be requested'\)|it.skip\1|g" test/DrawBeacon.test.ts
+
     neutralize_package_lock
     neutralize_package_json_hooks
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"

--- a/test/externalTests/trident.sh
+++ b/test/externalTests/trident.sh
@@ -89,6 +89,9 @@ function trident_test
     sed -i 's|IStrategy(0)|IStrategy(address(0))|g' contracts/flat/BentoBoxV1Flat.sol
     find contracts -name "*.sol" -exec sed -i -e 's/^\(\s*\)\(assembly\)/\1\/\/\/ @solidity memory-safe-assembly\n\1\2/' '{}' \;
 
+    # TODO: Remove this when https://github.com/NomicFoundation/hardhat/issues/2453 gets fixed.
+    sed -i 's|it\(("Reverts on direct deployment via factory"\)|it.skip\1|g' test/MasterDeployer.test.ts
+
     # @sushiswap/core package contains contracts that get built with 0.6.12 and fail our compiler
     # version check. It's not used by tests so we can remove it.
     rm -r node_modules/@sushiswap/core/

--- a/test/externalTests/uniswap.sh
+++ b/test/externalTests/uniswap.sh
@@ -59,6 +59,18 @@ function uniswap_test
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
     download_project "$repo" "$ref_type" "$ref" "$DIR"
 
+    # Disable tests that won't pass on the ir presets due to Hardhat heuristics. Note that this also disables
+    # them for other presets but that's fine - we want same code run for benchmarks to be comparable.
+    # TODO: Remove this when https://github.com/NomicFoundation/hardhat/issues/2115 gets fixed.
+    sed -i "s|it\(('underpay zero for one and exact in',\)|it.skip\1|g" test/UniswapV3Pool.spec.ts
+    sed -i "s|it\(('pay in the wrong token zero for one and exact in',\)|it.skip\1|g" test/UniswapV3Pool.spec.ts
+    sed -i "s|it\(('underpay zero for one and exact out',\)|it.skip\1|g" test/UniswapV3Pool.spec.ts
+    sed -i "s|it\(('pay in the wrong token zero for one and exact out',\)|it.skip\1|g" test/UniswapV3Pool.spec.ts
+    sed -i "s|it\(('underpay one for zero and exact in',\)|it.skip\1|g" test/UniswapV3Pool.spec.ts
+    sed -i "s|it\(('pay in the wrong token one for zero and exact in',\)|it.skip\1|g" test/UniswapV3Pool.spec.ts
+    sed -i "s|it\(('underpay one for zero and exact out',\)|it.skip\1|g" test/UniswapV3Pool.spec.ts
+    sed -i "s|it\(('pay in the wrong token one for zero and exact out',\)|it.skip\1|g" test/UniswapV3Pool.spec.ts
+
     neutralize_package_json_hooks
     name_hardhat_default_export "$config_file" "$config_var"
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"

--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -19,6 +19,9 @@
 # (c) 2019 solidity contributors.
 #------------------------------------------------------------------------------
 
+# Disable shellcheck errors on quoted special chars like backticks. Too many false-positives.
+# shellcheck disable=SC2016
+
 set -e
 
 source scripts/common.sh
@@ -70,6 +73,34 @@ function zeppelin_test
     # In some cases Hardhat does not detect revert reasons properly via IR.
     # TODO: Remove this when https://github.com/NomicFoundation/hardhat/issues/2453 gets fixed.
     sed -i "s|it(\('reverts if the current value is 0'\)|it.skip(\1|g" test/utils/Counters.test.js
+    sed -i "s|it(\('prevent unauthorized maintenance'\)|it.skip(\1|g" test/governance/TimelockController.test.js
+    sed -i "s|it(\('cannot cancel invalid operation'\)|it.skip(\1|g" test/governance/TimelockController.test.js
+    sed -i "s|it(\('reverts if block number >= current block'\)|it.skip(\1|g" test/governance/utils/Votes.test.js
+    sed -i "s|it(\('reverts if block number >= current block'\)|it.skip(\1|g" test/governance/utils/Votes.behavior.js
+    sed -i "s|it(\('cannot call onlyInitializable function outside the scope of an initializable function'\)|it.skip(\1|g" test/proxy/utils/Initializable.test.js
+    sed -i "s|it(\('other accounts cannot unpause'\)|it.skip(\1|g" test/token/ERC20/presets/ERC20PresetMinterPauser.test.js
+    sed -i "s|it(\('other accounts cannot unpause'\)|it.skip(\1|g" test/token/ERC1155/presets/ERC1155PresetMinterPauser.test.js
+    sed -i "s|it(\('other accounts cannot pause'\)|it.skip(\1|g" test/token/ERC20/presets/ERC20PresetMinterPauser.test.js
+    sed -i "s|it(\('other accounts cannot pause'\)|it.skip(\1|g" test/token/ERC1155/presets/ERC1155PresetMinterPauser.test.js
+    sed -i "s|it(\('reverts when decreasing the allowance'\)|it.skip(\1|g" test/token/ERC20/utils/SafeERC20.test.js
+    sed -i "s|it(\('reverts when decreasing the allowance to a negative value'\)|it.skip(\1|g" test/token/ERC20/utils/SafeERC20.test.js
+    sed -i "s|it(\('cannot be released before time limit'\)|it.skip(\1|g" test/token/ERC20/utils/TokenTimelock.test.js
+    sed -i "s|it(\('cannot be released just before time limit'\)|it.skip(\1|g" test/token/ERC20/utils/TokenTimelock.test.js
+    sed -i "s|it(\('reverts when sending non-zero amounts'\)|it.skip(\1|g" test/utils/Address.test.js
+    sed -i "s|it(\('reverts when sending more than the balance'\)|it.skip(\1|g" test/utils/Address.test.js
+    sed -i "s|it(\('reverts if block number >= current block'\)|it.skip(\1|g" test/utils/Checkpoints.test.js
+    sed -i "s|it(\('fails deploying a contract if the bytecode length is zero'\)|it.skip(\1|g" test/utils/Create2.test.js
+    sed -i "s|it(\('fails deploying a contract if factory contract does not have sufficient balance'\)|it.skip(\1|g" test/utils/Create2.test.js
+    sed -i "s|it(\('reverts on withdrawals'\)|it.skip(\1|g" test/utils/escrow/ConditionalEscrow.test.js
+    sed -i "s|it(\('does not allow beneficiary withdrawal'\)|it.skip(\1|g" test/utils/escrow/RefundEscrow.test.js
+    sed -i "s|it(\('rejects deposits'\)|it.skip(\1|g" test/utils/escrow/RefundEscrow.test.js
+    sed -i "s|it(\('does not allow 0xffffffff'\)|it.skip(\1|g" test/utils/introspection/ERC165Storage.test.js
+    sed -i "s|it(\('reverts when casting -1'\)|it.skip(\1|g" test/utils/math/SafeCast.test.js
+    sed -i 's|it(\(`reverts when downcasting 2^\${bits} (\${maxValue.addn(1)})`\)|it.skip(\1|g' test/utils/math/SafeCast.test.js
+    sed -i 's|it(\(`reverts when downcasting 2^\${bits} + 1 (\${maxValue.addn(2)})`\)|it.skip(\1|g' test/utils/math/SafeCast.test.js
+    sed -i 's|it(\(`reverts when casting [^`]\+`\)|it.skip(\1|g' test/utils/math/SafeCast.test.js
+    sed -i "s|it(\('missing value'\)|it.skip(\1|g" test/utils/structs/EnumerableMap.behavior.js
+
     # TODO: Remove this when https://github.com/NomicFoundation/hardhat/issues/2115 gets fixed.
     sed -i "s|describe\(('Polygon-Child'\)|describe.skip\1|g" test/crosschain/CrossChainEnabled.test.js
 


### PR DESCRIPTION
~Depends on #12936.~ Merged.
**Should not be merged separately from #12731!**

The PR disables a bunch of tests where Hardhat can no longer detect correct revert reasons, most likely due to https://github.com/NomicFoundation/hardhat/issues/2453. I think that heuristics depend on specific opcode sequences and inlining those sequences probably throws them off.

This is really a part of #12731 because these tests work fine on `develop` but I need it in a separate PR to have a fair benchmark comparison. Disabling these tests lowers gas usage so we can't compare directly with `develop`.

I'm marking it as draft for now because it should not be merged until we decide to merge #12731 as well.