### PR TITLE
Encode path conditions

### DIFF
--- a/libyul/optimiser/ReasoningBasedSimplifier.cpp
+++ b/libyul/optimiser/ReasoningBasedSimplifier.cpp
@@ -131,7 +131,7 @@ void ReasoningBasedSimplifier::operator()(ForLoop& _for)
 	}
 
 	ASTModifier::operator()(_for.body);
-	// TODO clear modified variables!
+	// TODO clear modified variables! - but only if there is a 'break'
 	ASTModifier::operator()(_for.post);
 
 	// clear variables assigned inside body and post
@@ -148,6 +148,14 @@ void ReasoningBasedSimplifier::operator()(ForLoop& _for)
 
 void ReasoningBasedSimplifier::operator()(FunctionCall& _fun)
 {
+	// TODO in general, a big problem is that all expressions involving
+	// literals have to be evaluated (expression simplifier)
+	// and rematerialized (literal rematerializer)
+	// otherwise, the mult by constant does not work.
+
+
+
+
 	ASTModifier::operator()(_fun);
 	// TODO do not forget to add path condition!
 	// TODO and(x, 0xfff) -> x if x <= 0xfff

--- a/libyul/optimiser/ReasoningBasedSimplifier.cpp
+++ b/libyul/optimiser/ReasoningBasedSimplifier.cpp
@@ -158,6 +158,15 @@ void ReasoningBasedSimplifier::operator()(FunctionDefinition& _fun)
 {
 	ScopedSaveAndRestore counters(m_variableSequenceCounter, {});
 	ScopedSaveAndRestore pathCond(m_pathCondition, true);
+	for (auto const& param: _fun.parameters)
+		encodeVariableUpdateUnknown(param.name);
+	for (auto const& retVar: _fun.returnVariables)
+	{
+		encodeVariableUpdateUnknown(retVar.name);
+		// TODO remove the redundant encoding above
+		m_solver->addAssertion(currentVariableExpression(retVar.name) == 0);
+	}
+
 	ASTModifier::operator()(_fun);
 }
 

--- a/libyul/optimiser/ReasoningBasedSimplifier.cpp
+++ b/libyul/optimiser/ReasoningBasedSimplifier.cpp
@@ -118,6 +118,9 @@ void ReasoningBasedSimplifier::operator()(ForLoop& _for)
 	else
 		m_pathCondition = branchCondition;
 	yulAssert(_for.pre.statements.empty());
+
+	//TODO clear variables assigned inside body and post
+
 	ASTModifier::operator()(_for.body);
 	// TODO clear modified variables!
 	ASTModifier::operator()(_for.post);

--- a/libyul/optimiser/ReasoningBasedSimplifier.cpp
+++ b/libyul/optimiser/ReasoningBasedSimplifier.cpp
@@ -24,6 +24,7 @@
 
 #include <libsmtutil/SMTPortfolio.h>
 #include <libsmtutil/Helpers.h>
+#include <libsmtutil/Z3Interface.h>
 
 #include <libsolutil/CommonData.h>
 
@@ -42,7 +43,8 @@ void ReasoningBasedSimplifier::run(OptimiserStepContext& _context, Block& _ast)
 {
 	ReasoningBasedSimplifier simpl{_context.dialect};
 	// Hack to inject the boolean lp solver.
-	simpl.m_solver = make_unique<BooleanLPSolver>();
+	//simpl.m_solver = make_unique<BooleanLPSolver>();
+	simpl.m_solver = make_unique<Z3Interface>();
 	simpl(_ast);
 }
 

--- a/libyul/optimiser/ReasoningBasedSimplifier.cpp
+++ b/libyul/optimiser/ReasoningBasedSimplifier.cpp
@@ -152,6 +152,7 @@ void ReasoningBasedSimplifier::operator()(FunctionCall& _fun)
 	// TODO do not forget to add path condition!
 	// TODO and(x, 0xfff) -> x if x <= 0xfff
 	// TODO if _fun is not returning, assert that the path condition is aflse
+	// -> This should be the job of the structural simplifier!
 }
 
 void ReasoningBasedSimplifier::operator()(FunctionDefinition& _fun)

--- a/libyul/optimiser/ReasoningBasedSimplifier.h
+++ b/libyul/optimiser/ReasoningBasedSimplifier.h
@@ -58,14 +58,16 @@ public:
 
 	using ASTModifier::operator();
 	void operator()(VariableDeclaration& _varDecl) override;
+	void operator()(Assignment& _assignment) override;
 	void operator()(If& _if) override;
 	void operator()(ForLoop& _for) override;
+	void operator()(FunctionCall& _fun) override;
+	void operator()(FunctionDefinition& _fun) override;
 
 private:
-	explicit ReasoningBasedSimplifier(
-		Dialect const& _dialect,
-		std::set<YulString> const& _ssaVariables
-	);
+	explicit ReasoningBasedSimplifier(Dialect const& _dialect);
+
+	void checkIfConditionRedundant(If& _if);
 
 	smtutil::Expression encodeEVMBuiltin(
 		evmasm::Instruction _instruction,
@@ -74,8 +76,6 @@ private:
 
 	smtutil::Expression newZeroOneVariable();
 	void restrictToEVMWord(smtutil::Expression _value);
-
-	Dialect const& m_dialect;
 };
 
 }

--- a/libyul/optimiser/SMTSolver.h
+++ b/libyul/optimiser/SMTSolver.h
@@ -47,13 +47,12 @@ namespace solidity::yul
 class SMTSolver
 {
 protected:
-	SMTSolver(
-		std::set<YulString> const& _ssaVariables,
-		Dialect const& _dialect
-	);
+	SMTSolver(Dialect const& _dialect);
 
 	/// Helper function that encodes VariableDeclaration
 	void encodeVariableDeclaration(VariableDeclaration const& _varDecl);
+	void encodeVariableAssignment(Assignment const& _assignment);
+	void encodeVariableUpdate(YulString const& _name, Expression const& _value);
 
 	/// The encoding for a builtin. The type of encoding determines what we are
 	/// solving for.
@@ -66,6 +65,10 @@ protected:
 
 	static smtutil::Expression int2bv(smtutil::Expression _arg);
 	static smtutil::Expression bv2int(smtutil::Expression _arg);
+
+	std::string variableNameAtIndex(YulString const& _name, size_t _index) const;
+	smtutil::Expression variableExpressionAtIndex(YulString const& _name, size_t _index) const;
+	smtutil::Expression currentVariableExpression(YulString const& _name) const;
 
 	smtutil::Expression newVariable();
 	smtutil::Expression newBooleanVariable();
@@ -81,9 +84,9 @@ protected:
 	static smtutil::Expression signedToTwosComplement(smtutil::Expression _value);
 	smtutil::Expression wrap(smtutil::Expression _value);
 
-	std::set<YulString> const& m_ssaVariables;
 	std::unique_ptr<smtutil::SolverInterface> m_solver;
-	std::map<YulString, smtutil::Expression> m_variables;
+	std::map<YulString, size_t> m_variableSequenceCounter;
+	std::optional<smtutil::Expression> m_pathCondition;
 
 	Dialect const& m_dialect;
 

--- a/libyul/optimiser/SMTSolver.h
+++ b/libyul/optimiser/SMTSolver.h
@@ -53,6 +53,7 @@ protected:
 	void encodeVariableDeclaration(VariableDeclaration const& _varDecl);
 	void encodeVariableAssignment(Assignment const& _assignment);
 	void encodeVariableUpdate(YulString const& _name, Expression const& _value);
+	void encodeVariableUpdateUnknown(YulString const& _name);
 
 	/// The encoding for a builtin. The type of encoding determines what we are
 	/// solving for.

--- a/test/libyul/yulOptimizerTests/commonSubexpressionEliminator/clear_assign_in_one_switch.yul
+++ b/test/libyul/yulOptimizerTests/commonSubexpressionEliminator/clear_assign_in_one_switch.yul
@@ -1,0 +1,45 @@
+{
+    let x := 10
+    switch calldataload(0)
+    case 0 {
+        x := 2
+    }
+    case 1 {
+        if calldataload(2) { revert(0, 0) }
+    }
+    // this should not be replaced by x
+    sstore(0, 10)
+
+    function f(arg) -> r {
+        switch calldataload(0)
+        case 0 {
+            r := 2
+        }
+        case 1 {
+            if calldataload(2) { revert(0, 0) }
+        }
+        // this should not be replaced by r
+        sstore(0, 0)
+    }
+}
+// ----
+// step: commonSubexpressionEliminator
+//
+// {
+//     let x := 10
+//     switch calldataload(0)
+//     case 0 { x := 2 }
+//     case 1 {
+//         if calldataload(2) { revert(0, 0) }
+//     }
+//     sstore(0, 10)
+//     function f(arg) -> r
+//     {
+//         switch calldataload(0)
+//         case 0 { r := 2 }
+//         case 1 {
+//             if calldataload(2) { revert(0, 0) }
+//         }
+//         sstore(0, 0)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/reasoningBasedSimplifier/for_increment.yul
+++ b/test/libyul/yulOptimizerTests/reasoningBasedSimplifier/for_increment.yul
@@ -1,0 +1,37 @@
+{
+    let var_x_mpos := mload(0x40)
+    let var_r := 0
+    let var_i := 0
+    for { }
+    lt(var_i, mload(var_x_mpos))
+    {
+        // "not(0)" does not work here - can we
+        // use a different step to do the bulk of the work here?
+        if eq(var_i, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff) { revert(0, 0) }
+        var_i := add(var_i, 1)
+    }
+    {
+        let _1_1 := mload(add(add(var_x_mpos, shl(5, var_i)), 32))
+        if gt(var_r, not(_1_1)) { revert(0, 0) }
+        var_r := add(var_r, _1_1)
+    }
+}
+// ----
+// step: reasoningBasedSimplifier
+//
+// {
+//     let var_x_mpos := mload(0x40)
+//     let var_r := 0
+//     let var_i := 0
+//     for { }
+//     lt(var_i, mload(var_x_mpos))
+//     {
+//         if 0 { }
+//         var_i := add(var_i, 1)
+//     }
+//     {
+//         let _1_1 := mload(add(add(var_x_mpos, shl(5, var_i)), 32))
+//         if gt(var_r, not(_1_1)) { revert(0, 0) }
+//         var_r := add(var_r, _1_1)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/reasoningBasedSimplifier/loopinc.yul
+++ b/test/libyul/yulOptimizerTests/reasoningBasedSimplifier/loopinc.yul
@@ -17,6 +17,14 @@
 //
 // {
 //     let y := calldataload(0)
-//     let t := calldataload(32)
-//     if sgt(sub(y, 1), y) { if 1 { sstore(0, 1) } }
+//     let sum := 0
+//     let x := 0
+//     for { } lt(x, y) { }
+//     {
+//         if 0 { }
+//         if 0 { }
+//         sum := calldataload(add(0x20, mul(x, 0x20)))
+//         x := add(x, 1)
+//     }
+//     sstore(0, sum)
 // }

--- a/test/libyul/yulOptimizerTests/reasoningBasedSimplifier/loopinc.yul
+++ b/test/libyul/yulOptimizerTests/reasoningBasedSimplifier/loopinc.yul
@@ -4,7 +4,7 @@
     let x := 0
     for {} lt(x, y) { } {
         // overflow check
-        if not(x) { revert(0, 0) }
+        if iszero(not(x)) { revert(0, 0) }
         // different way to do overflow check
         if lt(add(x, 1), x) { revert(0, 0) }
         sum := calldataload(add(0x20, mul(x, 0x20)))

--- a/test/libyul/yulOptimizerTests/reasoningBasedSimplifier/negative_rounding.yul
+++ b/test/libyul/yulOptimizerTests/reasoningBasedSimplifier/negative_rounding.yul
@@ -11,6 +11,6 @@
 // {
 //     let x := sub(0, 7)
 //     let y := 2
-//     if 1 { }
-//     if 0 { }
+//     if iszero(add(sdiv(x, y), 3)) { }
+//     if iszero(add(sdiv(x, y), 4)) { }
 // }


### PR DESCRIPTION
The goal of this PR is to find out how good an SMT-based optimizer step can be:
It uses z3 as a backend, so we can assume that it can solve queries at least as fast as a hand-written LP-solver can do it.

The current state is that this PR did not reduce the gas cost by much. This means we either need to refine the encoding of yul into SMT queries, we need to find better conditions or that the code is already written in a way where such a component cannot improve it by much.