### PR TITLE
Get rid of MSVC message "The contents of <span> are available only with C++20 or later."

### DIFF
--- a/cmake/range-v3.cmake
+++ b/cmake/range-v3.cmake
@@ -6,16 +6,26 @@ else()
     set(RANGE_V3_CMAKE_COMMAND ${CMAKE_COMMAND})
 endif()
 
+# MSVC reports "The contents of <span> are available only with C++20 or later." 200+ times.
+# A fix (https://github.com/ericniebler/range-v3/commit/2a3f9cb999) is available,
+# but not included in the latest release.
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    set(RANGE_V3_PATCH_COMMAND git apply --ignore-whitespace --directory=build/deps/src/range-v3-project ${CMAKE_SOURCE_DIR}/patches/avoid-including-empty-span-header-when-using-msvc.patch)
+else()
+    set(RANGE_V3_PATCH_COMMAND "")
+endif()
+
 set(prefix "${CMAKE_BINARY_DIR}/deps")
 set(RANGE_V3_INCLUDE_DIR "${prefix}/include")
 
 ExternalProject_Add(range-v3-project
     PREFIX "${prefix}"
     DOWNLOAD_DIR "${CMAKE_SOURCE_DIR}/deps/downloads"
-    DOWNLOAD_NAME range-v3-0.11.0.tar.gz
+    DOWNLOAD_NAME range-v3-0.11.0.tar.gz  # remove RANGE_V3_PATCH_COMMAND and .patch on version update
     URL https://github.com/ericniebler/range-v3/archive/0.11.0.tar.gz
     URL_HASH SHA256=376376615dbba43d3bef75aa590931431ecb49eb36d07bb726a19f680c75e20c
     CMAKE_COMMAND ${RANGE_V3_CMAKE_COMMAND}
+    PATCH_COMMAND ${RANGE_V3_PATCH_COMMAND}
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                -DBUILD_TESTING=OFF

--- a/patches/avoid-including-empty-span-header-when-using-msvc.patch
+++ b/patches/avoid-including-empty-span-header-when-using-msvc.patch
@@ -1,0 +1,75 @@
+From 2a3f9cb99955ca49c0fb7f2c93027311092c4a92 Mon Sep 17 00:00:00 2001
+From: Facundo Tuesca <facu@tuesca.com>
+Date: Thu, 3 Sep 2020 10:42:39 +0200
+Subject: [PATCH] Avoid including empty <span> header when using MSVC and C++17
+
+MSVC's <span> only works when compiling with C++20. Otherwise it can
+be included but not used. Including it causes the compiler to print
+a warning.
+---
+ include/range/v3/detail/config.hpp  | 5 +++++
+ include/range/v3/range/access.hpp   | 4 +++-
+ include/range/v3/range/concepts.hpp | 4 +++-
+ 3 files changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/include/range/v3/detail/config.hpp b/include/range/v3/detail/config.hpp
+index a5d062fda..069bb3eca 100644
+--- a/include/range/v3/detail/config.hpp
++++ b/include/range/v3/detail/config.hpp
+@@ -280,6 +280,11 @@ namespace ranges
+ #define RANGES_WORKAROUND_MSVC_OLD_LAMBDA
+ #endif
+ 
++#if _MSVC_LANG <= 201703L
++#define RANGES_WORKAROUND_MSVC_UNUSABLE_SPAN // MSVC provides a <span> header that is
++                                             // guarded against use with std <= 17
++#endif
++
+ #elif defined(__GNUC__) || defined(__clang__)
+ #define RANGES_PRAGMA(X) _Pragma(#X)
+ #define RANGES_DIAGNOSTIC_PUSH RANGES_PRAGMA(GCC diagnostic push)
+diff --git a/include/range/v3/range/access.hpp b/include/range/v3/range/access.hpp
+index 3ded73815..5d9fbd002 100644
+--- a/include/range/v3/range/access.hpp
++++ b/include/range/v3/range/access.hpp
+@@ -14,6 +14,8 @@
+ #ifndef RANGES_V3_RANGE_ACCESS_HPP
+ #define RANGES_V3_RANGE_ACCESS_HPP
+ 
++#include <range/v3/detail/config.hpp>
++
+ #include <functional> // for reference_wrapper (whose use with begin/end is deprecated)
+ #include <initializer_list>
+ #include <iterator>
+@@ -21,7 +23,7 @@
+ #include <utility>
+ 
+ #ifdef __has_include
+-#if __has_include(<span>)
++#if __has_include(<span>) && !defined(RANGES_WORKAROUND_MSVC_UNUSABLE_SPAN)
+ #include <span>
+ #endif
+ #if __has_include(<string_view>)
+diff --git a/include/range/v3/range/concepts.hpp b/include/range/v3/range/concepts.hpp
+index 543669cac..680e70bfa 100644
+--- a/include/range/v3/range/concepts.hpp
++++ b/include/range/v3/range/concepts.hpp
+@@ -14,12 +14,14 @@
+ #ifndef RANGES_V3_RANGE_CONCEPTS_HPP
+ #define RANGES_V3_RANGE_CONCEPTS_HPP
+ 
++#include <range/v3/detail/config.hpp>
++
+ #include <initializer_list>
+ #include <type_traits>
+ #include <utility>
+ 
+ #ifdef __has_include
+-#if __has_include(<span>)
++#if __has_include(<span>) && !defined(RANGES_WORKAROUND_MSVC_UNUSABLE_SPAN)
+ #include <span>
+ #endif
+ #if __has_include(<string_view>)
+-- 
+2.29.2.windows.1
+

--- a/scripts/check_style.sh
+++ b/scripts/check_style.sh
@@ -6,6 +6,7 @@ ERROR_LOG="$(mktemp -t check_style_XXXXXX.log)"
 
 EXCLUDE_FILES=(
     "libsolutil/picosha2.h"
+    "patches/avoid-including-empty-span-header-when-using-msvc.patch"
     "test/cmdlineTests/strict_asm_only_cr/input.yul"
     "test/cmdlineTests/strict_asm_only_cr/err"
     "test/libsolutil/UTF8.cpp"


### PR DESCRIPTION
MSVC `<span>` header contains
```
#if !_HAS_CXX20
#pragma message("The contents of <span> are available only with C++20 or later.")
. . . .
```
and shows the message if the header gets compiled with earlier version of C++.

`range-v3` includes `<span>` if it is available (e.g. in `range/v3/range/concepts.h`):
```
#ifdef __has_include
#if __has_include(<span>)
#include <span>
#endif
```

That leads to 204 messages during MSVC compilation.

`range-v3` [has a fix](https://github.com/ericniebler/range-v3/commit/2a3f9cb999), but it is not in the release. This PR applies corresponding patch.

I'm not very happy introducing a new `patches` directory, and not fully convinced it worth troubles. But a repeating compilation message is also annoying.
