### PR TITLE
Add `mypy` checks to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -680,6 +680,21 @@ jobs:
           command: ./scripts/pylint_all.py
       - gitter_notify_failure_unless_pr
 
+  chk_mypy:
+    <<: *base_buildpack_focal_small
+    steps:
+      - checkout
+      - run:
+          name: Install pip
+          command: apt -q update && apt install -y python3-pip
+      - run:
+          name: Install mypy
+          command: python3 -m pip install mypy
+      - run:
+          name: Python Scripts Type Annotations
+          command: ./scripts/mypy_all.py
+      - gitter_notify_failure_unless_pr
+
   chk_antlr_grammar:
     <<: *base_buildpack_focal_small
     steps:
@@ -1419,6 +1434,7 @@ workflows:
       - chk_buglist: *workflow_trigger_on_tags
       - chk_proofs: *workflow_trigger_on_tags
       - chk_pylint: *workflow_trigger_on_tags
+      - chk_mypy: *workflow_trigger_on_tags
       - chk_errorcodes: *workflow_trigger_on_tags
       - chk_antlr_grammar: *workflow_trigger_on_tags
       - chk_docs_pragma_min_version: *workflow_trigger_on_tags

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ tmp
 # OS specific local files
 .DS_Store
 Thumbs.db
+
+# Python virtual environment files
+venv

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ import sys
 import os
 import re
 
+from typing import Any
 from pygments_lexer_solidity import SolidityLexer, YulLexer
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -27,7 +28,7 @@ ROOT_PATH = os.path.dirname(os.path.realpath(__file__))
 
 sys.path.insert(0, os.path.join(ROOT_PATH, 'ext'))
 
-def setup(sphinx):
+def setup(sphinx: Any) -> None:
     sphinx.add_lexer('Solidity', SolidityLexer)
     sphinx.add_lexer('Yul', YulLexer)
 
@@ -71,7 +72,7 @@ project_copyright = '2016-2021, Ethereum'
 #
 # The short X.Y version.
 with open('../CMakeLists.txt', 'r', encoding='utf8') as f:
-    version = re.search('PROJECT_VERSION "([^"]+)"', f.read()).group(1)
+    version = re.search('PROJECT_VERSION "([^"]+)"', f.read()).group(1) # type: ignore
 # The full version, including alpha/beta/rc tags.
 if not os.path.isfile('../prerelease.txt') or os.path.getsize('../prerelease.txt') == 0:
     release = version
@@ -237,7 +238,7 @@ latex_elements = {
 
 # Additional stuff for the LaTeX preamble.
 #'preamble': '',
-}
+} # type: Any
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
@@ -272,7 +273,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-]
+] # type: Any
 
 # If true, show URL addresses after external links.
 #man_show_urls = False
@@ -284,7 +285,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-]
+] # type: Any
 
 # Documents to append as an appendix to all manuals.
 #texinfo_appendices = []

--- a/docs/ext/html_extra_template_renderer.py
+++ b/docs/ext/html_extra_template_renderer.py
@@ -1,7 +1,9 @@
 import os.path
 
+from typing import Any
 
-def render_html_extra_templates(app):
+
+def render_html_extra_templates(app: Any) -> None:
     if app.builder.format != 'html':
         # Non-HTML builders do not provide .templates.render_string(). Note that a HTML
         # builder is still used also when building some other formats like json or epub.
@@ -27,7 +29,7 @@ def render_html_extra_templates(app):
         app.config.html_extra_path.append(template_config['target'])
 
 
-def setup(app):
+def setup(app: Any) -> Any:
     app.add_config_value('html_extra_templates', default={}, rebuild='', types=dict)
 
     # Register a handler for the env-before-read-docs event. Any event that's fired before static

--- a/docs/ext/remix_code_links.py
+++ b/docs/ext/remix_code_links.py
@@ -1,4 +1,5 @@
 import base64
+from typing import Any
 import docutils  # pragma pylint: disable=import-error
 
 from sphinx.util import logging  # pragma pylint: disable=import-error
@@ -9,7 +10,7 @@ MAX_SAFE_URL_LENGTH = 10000
 logger = logging.getLogger(__name__)
 
 
-def insert_node_before(child, new_sibling):
+def insert_node_before(child: Any, new_sibling: Any) -> None:
     assert child in child.parent.children
 
     for position, node in enumerate(child.parent.children):
@@ -18,39 +19,39 @@ def insert_node_before(child, new_sibling):
             break
 
 
-def remix_code_url(source_code, language, solidity_version):
+def remix_code_url(source_code: Any, language: Any, solidity_version: Any) -> Any:
     # NOTE: base64 encoded data may contain +, = and / characters. Remix seems to handle them just
     # fine without any escaping.
     base64_encoded_source = base64.b64encode(source_code.encode('utf-8')).decode('ascii')
     return f"https://remix.ethereum.org/?language={language}&version={solidity_version}&code={base64_encoded_source}"
 
 
-def build_remix_link_node(url):
-    link_icon_node = docutils.nodes.inline()
+def build_remix_link_node(url: Any) -> Any:
+    link_icon_node = docutils.nodes.inline() # type: ignore
     link_icon_node.set_class('link-icon')
 
-    link_text_node = docutils.nodes.inline(text="open in Remix")
+    link_text_node = docutils.nodes.inline(text="open in Remix") # type: ignore
     link_text_node.set_class('link-text')
 
-    reference_node = docutils.nodes.reference('', '', internal=False, refuri=url)
+    reference_node = docutils.nodes.reference('', '', internal=False, refuri=url) # type: ignore
     reference_node.set_class('remix-link')
     reference_node += [link_icon_node, link_text_node]
 
-    paragraph_node = docutils.nodes.paragraph()
+    paragraph_node = docutils.nodes.paragraph() # type: ignore
     paragraph_node.set_class('remix-link-container')
     paragraph_node += reference_node
     return paragraph_node
 
 
-def insert_remix_link(app, doctree, solidity_version):
+def insert_remix_link(app: Any, doctree: Any, solidity_version: Any) -> Any:
     if app.builder.format != 'html' or app.builder.name == 'epub':
         return
 
-    for literal_block_node in doctree.traverse(docutils.nodes.literal_block):
+    for literal_block_node in doctree.traverse(docutils.nodes.literal_block):  # type: ignore
         assert 'language' in literal_block_node.attributes
         language = literal_block_node.attributes['language'].lower()
         if language in ['solidity', 'yul']:
-            text_nodes = list(literal_block_node.traverse(docutils.nodes.Text))
+            text_nodes = list(literal_block_node.traverse(docutils.nodes.Text)) # type: ignore
             assert len(text_nodes) == 1
 
             remix_url = remix_code_url(text_nodes[0], language, solidity_version)
@@ -67,7 +68,7 @@ def insert_remix_link(app, doctree, solidity_version):
             insert_node_before(literal_block_node, build_remix_link_node(remix_url))
 
 
-def setup(app):
+def setup(app: Any) -> Any:
     # NOTE: Need to access _raw_config here because setup() runs before app.config is ready.
     solidity_version = app.config._raw_config['version']  # pylint: disable=protected-access
 

--- a/scripts/bytecodecompare/prepare_report.py
+++ b/scripts/bytecodecompare/prepare_report.py
@@ -10,7 +10,7 @@ from enum import Enum
 from glob import glob
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 
 CONTRACT_SEPARATOR_PATTERN = re.compile(
@@ -91,7 +91,7 @@ class Statistics:
     missing_bytecode_count: int = 0
     missing_metadata_count: int = 0
 
-    def aggregate(self, report: FileReport):
+    def aggregate(self, report: FileReport) -> None:
         contract_reports = report.contract_reports if report.contract_reports is not None else []
 
         self.file_count += 1
@@ -233,7 +233,7 @@ def prepare_compiler_input(
     return (command_line, compiler_input)
 
 
-def detect_metadata_cli_option_support(compiler_path: Path):
+def detect_metadata_cli_option_support(compiler_path: Path) -> Any:
     process = subprocess.run(
         [str(compiler_path.absolute()), '--metadata', '-'],
         input="contract C {}",
@@ -329,7 +329,7 @@ def generate_report(
     report_file_path: Path,
     verbose: bool,
     exit_on_error: bool,
-):
+) -> None:
     statistics = Statistics()
     metadata_option_supported = detect_metadata_cli_option_support(compiler_path)
 

--- a/scripts/endToEndExtraction/remove-testcases.py
+++ b/scripts/endToEndExtraction/remove-testcases.py
@@ -6,10 +6,11 @@ import os
 import sys
 import getopt
 import tempfile
+from typing import Any
 from getkey import getkey
 
 
-def parse_call(call):
+def parse_call(call: Any) -> Any:
     function = ''
     arguments = ""
     results = ""
@@ -33,7 +34,7 @@ def parse_call(call):
     return function.strip(), arguments.strip(), results.strip()
 
 
-def colorize(left, right, index):
+def colorize(left: Any, right: Any, index: Any) -> Any:
     red = "\x1b[31m"
     yellow = "\x1b[33m"
     reset = "\x1b[0m"
@@ -52,7 +53,7 @@ def colorize(left, right, index):
     return "    " + left + "\n" + bottom  # " {:<90} {:<90}\n{}".format(left, right, bottom)
 
 
-def get_checks(content, sol_file_path):
+def get_checks(content: Any, sol_file_path: Any) -> Any:
     constructors = []
     checks = []
     for line in content.split("\n"):
@@ -79,7 +80,7 @@ def get_checks(content, sol_file_path):
         return checks, sol_checks
 
 
-def show_test(name, content, sol_file_path, current_test, test_count):
+def show_test(name: Any, content: Any, sol_file_path: Any, current_test: Any, test_count: Any) -> None:
     with tempfile.NamedTemporaryFile(delete=False) as cpp_file:
         cpp_file.write(content.encode())
         cpp_file.close()
@@ -108,7 +109,7 @@ def show_test(name, content, sol_file_path, current_test, test_count):
         print()
 
 
-def get_tests(e2e_path):
+def get_tests(e2e_path: Any) -> Any:
     tests = []
     for f in os.listdir(e2e_path):
         if f.endswith(".sol"):
@@ -116,7 +117,7 @@ def get_tests(e2e_path):
     return tests
 
 
-def process_input_file(e2e_path, input_file, interactive):
+def process_input_file(e2e_path: Any, input_file: Any, interactive: Any) -> None:
     tests = get_tests(e2e_path)
     with open(input_file, "r", encoding='utf8') as cpp_file:
         inside_test = False
@@ -154,7 +155,7 @@ def process_input_file(e2e_path, input_file, interactive):
         sys.stdout.flush()
 
 
-def main(argv):
+def main(argv: Any) -> None:
     interactive = False
     input_file = None
     try:

--- a/scripts/endToEndExtraction/verify-testcases.py
+++ b/scripts/endToEndExtraction/verify-testcases.py
@@ -16,9 +16,10 @@ import sys
 import getopt
 import json
 
+from typing import Any
 
 class Trace:
-    def __init__(self, kind, parameter):
+    def __init__(self, kind: Any, parameter: Any) -> None:
         self.kind = kind
         self.parameter = parameter
         self._input = ""
@@ -27,25 +28,25 @@ class Trace:
         self.result = ""
         self.gas = ""
 
-    def get_input(self):
+    def get_input(self) -> Any:
         return self._input
 
-    def set_input(self, bytecode):
+    def set_input(self, bytecode: Any) -> None:
         if self.kind == "create":
             # remove cbor encoded metadata from bytecode
             length = int(bytecode[-4:], 16) * 2
             self._input = bytecode[:len(bytecode) - length - 4]
 
-    def get_output(self):
+    def get_output(self) -> Any:
         return self._output
 
-    def set_output(self, output):
+    def set_output(self, output: Any) -> None:
         if self.kind == "create":
             # remove cbor encoded metadata from bytecode
             length = int(output[-4:], 16) * 2
             self._output = output[:len(output) - length - 4]
 
-    def __str__(self):
+    def __str__(self) -> Any:
         # we ignore the used gas
         result = str(
             "kind='" + self.kind + "' parameter='" + self.parameter + "' input='" + self._input +
@@ -55,24 +56,24 @@ class Trace:
 
 
 class TestCase:
-    def __init__(self, name):
+    def __init__(self, name: Any) -> None:
         self.name = name
         self.metadata = None
-        self.traces = []
+        self.traces = [] # type: Any
 
-    def add_trace(self, kind, parameter):
+    def add_trace(self, kind: Any, parameter: Any) -> Any:
         trace = Trace(kind, parameter)
         self.traces.append(trace)
         return trace
 
 
 class TraceAnalyser:
-    def __init__(self, file):
+    def __init__(self, file: Any) -> None:
         self.file = file
-        self.tests = {}
+        self.tests = {}  # type: Any
         self.ready = False
 
-    def analyse(self):
+    def analyse(self) -> None:
         with open(self.file, "r", encoding='utf8') as trace_file:
             trace = None
             test_case = None
@@ -85,17 +86,17 @@ class TraceAnalyser:
 
                 metadata = re.search(r'\s*metadata:\s*(.*)$', line, re.M | re.I)
                 if metadata:
-                    test_case.metadata = json.loads(metadata.group(1))
-                    del test_case.metadata["sources"]
-                    del test_case.metadata["compiler"]["version"]
+                    test_case.metadata = json.loads(metadata.group(1)) # type: ignore
+                    del test_case.metadata["sources"] # type: ignore
+                    del test_case.metadata["compiler"]["version"] # type: ignore
 
                 create = re.search(r'CREATE\s*([a-fA-F0-9]*):', line, re.M | re.I)
                 if create:
-                    trace = test_case.add_trace("create", create.group(1))
+                    trace = test_case.add_trace("create", create.group(1)) # type: ignore
 
                 call = re.search(r'CALL\s*([a-fA-F0-9]*)\s*->\s*([a-fA-F0-9]*):', line, re.M | re.I)
                 if call:
-                    trace = test_case.add_trace("call", call.group(1))  # + "->" + call.group(2))
+                    trace = test_case.add_trace("call", call.group(1))  # type: ignore
 
                 if not create and not call:
                     self.parse_parameters(line, trace)
@@ -107,7 +108,7 @@ class TraceAnalyser:
             self.ready = True
 
     @staticmethod
-    def parse_parameters(line, trace):
+    def parse_parameters(line: Any, trace: Any) -> None:
         input_match = re.search(r'\s*in:\s*([a-fA-F0-9]*)', line, re.M | re.I)
         if input_match:
             trace.input = input_match.group(1)
@@ -124,7 +125,7 @@ class TraceAnalyser:
         if value_match:
             trace.value = value_match.group(1)
 
-    def diff(self, analyser):
+    def diff(self, analyser: Any) -> None:
         if not self.ready:
             self.analyse()
         if not analyser.ready:
@@ -153,7 +154,7 @@ class TraceAnalyser:
         print(len(intersection), "test-cases - ", len(mismatches), " mismatche(s)")
 
     @classmethod
-    def check_traces(cls, test_name, left, right, mismatches):
+    def check_traces(cls, test_name: Any, left: Any, right: Any, mismatches: Any) -> None:
         for trace_id, trace in enumerate(left.traces):
             left_trace = trace
             right_trace = right.traces[trace_id]
@@ -174,7 +175,7 @@ class TraceAnalyser:
                 mismatches.add((test_name, mismatch_info))
 
 
-def main(argv):
+def main(argv: Any) -> None:
     extracted_tests_trace_file = None
     end_to_end_trace_file = None
     try:

--- a/scripts/error_codes.py
+++ b/scripts/error_codes.py
@@ -5,12 +5,13 @@ import os
 import getopt
 import sys
 from os import path
+from typing import Any
 
 ENCODING = "utf-8"
 SOURCE_FILE_PATTERN = r"\b\d+_error\b"
 
 
-def read_file(file_name):
+def read_file(file_name: Any) -> Any:
     content = None
     _, tail = path.split(file_name)
     is_latin = tail == "invalid_utf8_sequence.sol"
@@ -23,12 +24,12 @@ def read_file(file_name):
     return content
 
 
-def write_file(file_name, content):
+def write_file(file_name: Any, content: Any) -> None:
     with open(file_name, "w", encoding=ENCODING) as f:
         f.write(content)
 
 
-def in_comment(source, pos):
+def in_comment(source: Any, pos: Any) -> Any:
     slash_slash_pos = source.rfind("//", 0, pos)
     lf_pos = source.rfind("\n", 0, pos)
     if slash_slash_pos > lf_pos:
@@ -38,7 +39,7 @@ def in_comment(source, pos):
     return slash_star_pos > star_slash_pos
 
 
-def find_ids_in_source_file(file_name, id_to_file_names):
+def find_ids_in_source_file(file_name: Any, id_to_file_names: Any) -> None:
     source = read_file(file_name)
     for m in re.finditer(SOURCE_FILE_PATTERN, source):
         if in_comment(source, m.start()):
@@ -51,23 +52,23 @@ def find_ids_in_source_file(file_name, id_to_file_names):
             id_to_file_names[error_id] = [file_name]
 
 
-def find_ids_in_source_files(file_names):
+def find_ids_in_source_files(file_names: Any) -> Any:
     """Returns a dictionary with list of source files for every appearance of every id"""
 
-    id_to_file_names = {}
+    id_to_file_names = {} # type: Any
     for file_name in file_names:
         find_ids_in_source_file(file_name, id_to_file_names)
     return id_to_file_names
 
 
-def get_next_id(available_ids):
+def get_next_id(available_ids: Any) -> Any:
     assert len(available_ids) > 0, "Out of IDs"
     next_id = random.choice(list(available_ids))
     available_ids.remove(next_id)
     return next_id
 
 
-def fix_ids_in_source_file(file_name, id_to_count, available_ids):
+def fix_ids_in_source_file(file_name: Any, id_to_count: Any, available_ids: Any) -> Any:
     source = read_file(file_name)
 
     k = 0
@@ -92,13 +93,13 @@ def fix_ids_in_source_file(file_name, id_to_count, available_ids):
 
     destination.extend(source[k:])
 
-    destination = ''.join(destination)
+    destination = ''.join(destination) # type: ignore
     if source != destination:
         write_file(file_name, destination)
         print(f"Fixed file: {file_name}")
 
 
-def fix_ids_in_source_files(file_names, id_to_count):
+def fix_ids_in_source_files(file_names: Any, id_to_count: Any) -> Any:
     """
     Fixes ids in given source files;
     id_to_count contains number of appearances of every id in sources
@@ -109,7 +110,7 @@ def fix_ids_in_source_files(file_names, id_to_count):
         fix_ids_in_source_file(file_name, id_to_count, available_ids)
 
 
-def find_files(top_dir, sub_dirs, extensions):
+def find_files(top_dir: Any, sub_dirs: Any, extensions: Any) -> Any:
     """Builds a list of files with given extensions in specified subdirectories"""
 
     source_file_names = []
@@ -123,13 +124,13 @@ def find_files(top_dir, sub_dirs, extensions):
     return source_file_names
 
 
-def find_ids_in_test_file(file_name):
+def find_ids_in_test_file(file_name: Any) -> Any:
     source = read_file(file_name)
     pattern = r"^// (.*Error|Warning|Info) \d\d\d\d:"
     return {m.group(0)[-5:-1] for m in re.finditer(pattern, source, flags=re.MULTILINE)}
 
 
-def find_ids_in_test_files(file_names):
+def find_ids_in_test_files(file_names: Any) -> Any:
     """Returns a set containing all ids in tests"""
 
     ids = set()
@@ -138,13 +139,13 @@ def find_ids_in_test_files(file_names):
     return ids
 
 
-def find_ids_in_cmdline_test_err(file_name):
+def find_ids_in_cmdline_test_err(file_name: Any) -> Any:
     source = read_file(file_name)
     pattern = r' \(\d\d\d\d\):'
     return {m.group(0)[-6:-2] for m in re.finditer(pattern, source, flags=re.MULTILINE)}
 
 
-def print_ids(ids):
+def print_ids(ids: Any) -> None:
     for k, error_id in enumerate(sorted(ids)):
         if k % 10 > 0:
             print(" ", end="")
@@ -153,8 +154,8 @@ def print_ids(ids):
         print(error_id, end="")
 
 
-def print_ids_per_file(ids, id_to_file_names, top_dir):
-    file_name_to_ids = {}
+def print_ids_per_file(ids: Any, id_to_file_names: Any, top_dir: Any) -> None:
+    file_name_to_ids = {} # type: Any
     for error_id in ids:
         for file_name in id_to_file_names[error_id]:
             relpath = path.relpath(file_name, top_dir)
@@ -169,7 +170,7 @@ def print_ids_per_file(ids, id_to_file_names, top_dir):
         print()
 
 
-def examine_id_coverage(top_dir, source_id_to_file_names, new_ids_only=False):
+def examine_id_coverage(top_dir: Any, source_id_to_file_names: Any, new_ids_only: Any=False) -> Any:
     test_sub_dirs = [
         path.join("test", "libsolidity", "errorRecoveryTests"),
         path.join("test", "libsolidity", "smtCheckerTests"),
@@ -253,7 +254,7 @@ def examine_id_coverage(top_dir, source_id_to_file_names, new_ids_only=False):
     return True
 
 
-def main(argv):
+def main(argv: Any) -> None:
     check = False
     fix = False
     no_confirm = False

--- a/scripts/externalTests/benchmark_diff.py
+++ b/scripts/externalTests/benchmark_diff.py
@@ -134,7 +134,7 @@ class BenchmarkDiffer:
         return diff
 
     def _humanize_diff(self, diff: Union[str, int, float]) -> str:
-        def wrap(value: str, symbol: str):
+        def wrap(value: str, symbol: str) -> Any:
             return f"{symbol}{value}{symbol}"
 
         markdown = (self.output_format == OutputFormat.MARKDOWN)
@@ -275,7 +275,7 @@ class DiffTableFormatter:
     """)
 
     @classmethod
-    def run(cls, diff_table_set: DiffTableSet, output_format: OutputFormat):
+    def run(cls, diff_table_set: DiffTableSet, output_format: OutputFormat) -> Any:
         if output_format == OutputFormat.JSON:
             return json.dumps(diff_table_set.cells, indent=4, sort_keys=True)
         else:
@@ -313,7 +313,7 @@ class DiffTableFormatter:
             return output
 
     @classmethod
-    def _format_separator_row(cls, widths: Sequence[int], output_format: OutputFormat):
+    def _format_separator_row(cls, widths: Sequence[int], output_format: OutputFormat) -> Any:
         assert output_format in {OutputFormat.CONSOLE, OutputFormat.MARKDOWN}
 
         if output_format == OutputFormat.MARKDOWN:
@@ -322,7 +322,7 @@ class DiffTableFormatter:
             return '|-' + '-|-'.join('-' * width for width in widths) + '-|'
 
     @classmethod
-    def _format_data_row(cls, cells: Sequence[Union[int, float, str]], widths: Sequence[int]):
+    def _format_data_row(cls, cells: Sequence[Union[int, float, str]], widths: Sequence[int]) -> Any:
         assert len(cells) == len(widths)
 
         return '| ' + ' | '.join(str(cell).rjust(width) for cell, width in zip(cells, widths)) + ' |'
@@ -428,7 +428,7 @@ def process_commandline() -> CommandLineOptions:
     return processed_options
 
 
-def main():
+def main() -> Any:
     try:
         options = process_commandline()
 
@@ -442,7 +442,7 @@ def main():
             print(json.dumps(diff, indent=4, sort_keys=True))
         else:
             assert options.diff_mode == DiffMode.TABLE
-            print(DiffTableFormatter.run(DiffTableSet(diff), options.output_format))
+            print(DiffTableFormatter.run(DiffTableSet(diff), options.output_format)) # type: ignore
 
         return 0
     except CommandLineError as exception:

--- a/scripts/externalTests/parse_eth_gas_report.py
+++ b/scripts/externalTests/parse_eth_gas_report.py
@@ -2,7 +2,7 @@
 # coding=utf-8
 
 from dataclasses import asdict, dataclass, field
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 import json
 import re
 import sys
@@ -55,11 +55,11 @@ class ReportValidationError(ReportError):
     pass
 
 class ReportParsingError(Exception):
-    def __init__(self, message: str, line: str, line_number: int):
+    def __init__(self, message: str, line: str, line_number: int) -> None:
         # pylint: disable=useless-super-delegation  # It's not useless, it adds type annotations.
         super().__init__(message, line, line_number)
 
-    def __str__(self):
+    def __str__(self) -> Any:
         return f"Parsing error on line {self.args[2] + 1}: {self.args[0]}\n{self.args[1]}"
 
 
@@ -71,7 +71,7 @@ class MethodGasReport:
     call_count: int
     total_gas: int = field(init=False)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         object.__setattr__(self, 'total_gas', self.avg_gas * self.call_count)
 
 
@@ -83,7 +83,7 @@ class ContractGasReport:
     methods: Optional[Dict[str, MethodGasReport]]
     total_method_gas: int = field(init=False, default=0)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.methods is not None:
             object.__setattr__(self, 'total_method_gas', sum(method.total_gas for method in self.methods.values()))
 
@@ -98,7 +98,7 @@ class GasReport:
     total_method_gas: int = field(init=False)
     total_deployment_gas: int = field(init=False)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         object.__setattr__(self, 'total_method_gas', sum(
             total_method_gas
             for total_method_gas in (contract.total_method_gas for contract in self.contracts.values())
@@ -110,7 +110,7 @@ class GasReport:
             if contract.avg_deployment_gas is not None
         ))
 
-    def to_json(self):
+    def to_json(self) -> Any:
         return json.dumps(asdict(self), indent=4, sort_keys=True)
 
 
@@ -159,15 +159,15 @@ def parse_method_row(line: str, line_number: int) -> Optional[Tuple[str, str, Me
         match['contract'].strip(),
         match['method'].strip(),
         MethodGasReport(
-            min_gas=parse_optional_int(match['min'], avg_gas),
-            max_gas=parse_optional_int(match['max'], avg_gas),
-            avg_gas=avg_gas,
+            min_gas=parse_optional_int(match['min'], avg_gas), # type: ignore
+            max_gas=parse_optional_int(match['max'], avg_gas), # type: ignore
+            avg_gas=avg_gas, # type: ignore
             call_count=call_count,
         )
     )
 
 
-def parse_deployment_row(line: str, line_number: int) -> Tuple[str, int, int, int]:
+def parse_deployment_row(line: str, line_number: int) -> Any:
     match = DEPLOYMENT_ROW_REGEX.match(line)
     if match is None:
         raise ReportParsingError("Expected a table row with deployment details.", line, line_number)
@@ -188,7 +188,7 @@ def preprocess_unicode_frames(input_string: str) -> str:
 
 def parse_report(rst_report: str) -> GasReport:
     report_params = None
-    methods_by_contract = {}
+    methods_by_contract = {} # type: Any
     deployment_costs = {}
     expected_row_type = None
 

--- a/scripts/extract_test_cases.py
+++ b/scripts/extract_test_cases.py
@@ -9,7 +9,9 @@
 import sys
 import re
 
-def extract_test_cases(_path):
+from typing import Any
+
+def extract_test_cases(_path: Any) -> Any:
     with open(_path, mode='rb', encoding='utf8') as f:
         lines = f.read().splitlines()
 

--- a/scripts/gas_diff_stats.py
+++ b/scripts/gas_diff_stats.py
@@ -20,6 +20,7 @@ repository. The changes are compared against ``origin/develop``.
 import subprocess
 from pathlib import Path
 from enum import Enum
+from typing import Any
 from parsec import generate, ParseError, regex, string
 from tabulate import tabulate
 
@@ -43,12 +44,12 @@ gas_ir_optimized = string("gas irOptimized").result(Kind.IrOptimized)
 gas_legacy_optimized = string("gas legacyOptimized").result(Kind.LegacyOptimized)
 gas_legacy = string("gas legacy").result(Kind.Legacy)
 
-def number() -> int:
+def number() -> Any:
     """Parse number."""
     return regex(r"([0-9]*)").parsecmap(int)
 
 @generate
-def diff_string() -> (Kind, Diff, int):
+def diff_string() -> Any:
     """Usage: diff_string.parse(string)
 
     Example string:
@@ -65,7 +66,7 @@ def diff_string() -> (Kind, Diff, int):
     val = yield number()
     return (diff_kind, codegen_kind, val)
 
-def collect_statistics(lines) -> (int, int, int, int, int, int):
+def collect_statistics(lines: Any) -> Any:
     """Returns
 
     (old_ir_optimized, old_legacy_optimized, old_legacy, new_ir_optimized,
@@ -77,7 +78,7 @@ def collect_statistics(lines) -> (int, int, int, int, int, int):
     if not lines:
         raise Exception("Empty list")
 
-    def try_parse(line):
+    def try_parse(line: Any) -> Any:
         try:
             return diff_string.parse(line)
         except ParseError:
@@ -97,9 +98,9 @@ def collect_statistics(lines) -> (int, int, int, int, int, int):
         for _codegen_kind in codegen_kinds
     )
 
-def semantictest_statistics():
+def semantictest_statistics() -> Any:
     """Prints the tabulated statistics that can be pasted in github."""
-    def try_parse_git_diff(fname):
+    def try_parse_git_diff(fname: Any) -> Any:
         try:
             diff_output = subprocess.check_output(
                 "git diff --unified=0 origin/develop HEAD " + fname,
@@ -112,7 +113,7 @@ def semantictest_statistics():
             print("Error in the git diff:")
             print(e.output)
         return None
-    def stat(old, new):
+    def stat(old: Any, new: Any) -> Any:
         return ((new - old) / old) * 100  if old else 0
 
     table = []

--- a/scripts/isolate_tests.py
+++ b/scripts/isolate_tests.py
@@ -12,14 +12,15 @@ import hashlib
 from os.path import join, isfile, basename
 from argparse import ArgumentParser
 from textwrap import indent, dedent
+from typing import Any
 
-def extract_test_cases(path):
+def extract_test_cases(path: Any) -> Any:
     with open(path, encoding="utf8", errors='ignore', mode='r', newline='') as file:
         lines = file.read().splitlines()
 
     inside = False
     delimiter = ''
-    tests = []
+    tests = [] # type: Any
 
     for l in lines:
         if inside:
@@ -36,7 +37,7 @@ def extract_test_cases(path):
 
     return tests
 
-def extract_solidity_docs_cases(path):
+def extract_solidity_docs_cases(path: Any) -> Any:
     tests = extract_docs_cases(path, [".. code-block:: solidity", '::'])
 
     codeStart = "(// SPDX-License-Identifier:|pragma solidity|contract.*{|library.*{|interface.*{)"
@@ -48,10 +49,10 @@ def extract_solidity_docs_cases(path):
         if re.search(r'^\s{4}' + codeStart, test, re.MULTILINE) is not None
     ]
 
-def extract_yul_docs_cases(path):
+def extract_yul_docs_cases(path: Any) -> Any:
     tests = extract_docs_cases(path, [".. code-block:: yul"])
 
-    def wrap_in_object(code):
+    def wrap_in_object(code: Any) -> Any:
         for line in code.splitlines():
             line = line.lstrip()
             if line.startswith("//"):
@@ -71,10 +72,10 @@ def extract_yul_docs_cases(path):
 # Extract code examples based on the 'beginMarker' parameter
 # up until we reach EOF or a line that is not empty and doesn't start with 4
 # spaces.
-def extract_docs_cases(path, beginMarkers):
+def extract_docs_cases(path: Any, beginMarkers: Any) -> Any:
     immediatelyAfterMarker = False
     insideBlock = False
-    tests = []
+    tests = [] # type: Any
 
     # Collect all snippets of indented blocks
     with open(path, mode='r', errors='ignore', encoding='utf8', newline='') as f:
@@ -100,7 +101,7 @@ def extract_docs_cases(path, beginMarkers):
 
     return tests
 
-def write_cases(f, solidityTests, yulTests):
+def write_cases(f: Any, solidityTests: Any, yulTests: Any) -> None:
     cleaned_filename = f.replace(".","_").replace("-","_").replace(" ","_").lower()
     for language, test in [("sol", t) for t in solidityTests] + [("yul", t) for t in yulTests]:
         # When code examples are extracted they are indented by 8 spaces, which violates the style guide,
@@ -111,7 +112,7 @@ def write_cases(f, solidityTests, yulTests):
         with open(sol_filename, mode='w', encoding='utf8', newline='') as fi:
             fi.write(remainder)
 
-def extract_and_write(path, language):
+def extract_and_write(path: Any, language: Any) -> None:
     assert language in ["solidity", "yul", ""]
     yulCases = []
     cases = []

--- a/scripts/mypy.ini
+++ b/scripts/mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+strict_optional = True
+disallow_incomplete_defs = True
+disallow_untyped_defs = True
+
+warn_unused_ignores = True
+warn_unused_configs = True
+warn_redundant_casts = True
+
+ignore_missing_imports = True

--- a/scripts/mypy_all.py
+++ b/scripts/mypy_all.py
@@ -1,0 +1,103 @@
+#! /usr/bin/env python3
+
+"""
+Runs mypy on all Python files in project directories known to contain Python scripts.
+"""
+
+from argparse import ArgumentParser
+from os import path, walk
+from textwrap import dedent
+import subprocess
+import sys
+
+from typing import Any
+
+PROJECT_ROOT = path.dirname(path.dirname(path.realpath(__file__)))
+MYPY_CONFIG = f"{PROJECT_ROOT}/scripts/mypy.ini"
+
+SGR_INFO = "\033[1;32m"
+SGR_CLEAR = "\033[0m"
+
+def mypy_all_filenames(dev_mode: Any, rootdirs: Any) -> bool:
+    """ Performs type annotation checks on all python files within given root directory (recursively).  """
+
+    BARE_COMMAND = [
+        "mypy",
+        f"--config-file={MYPY_CONFIG}",
+        "--namespace-packages",
+        "--explicit-package-bases",
+        "--install-types",
+        "--non-interactive"
+    ]
+
+    filenames = []
+    for rootdir in rootdirs:
+        for rootpath, _, filenames_w in walk(rootdir):
+            for filename in filenames_w:
+                if filename.endswith('.py'):
+                    filenames.append(path.join(rootpath, filename))
+
+    if not dev_mode:
+        command_line = BARE_COMMAND + filenames
+        return subprocess.run(command_line, check=False).returncode == 0
+
+    for i, filename in enumerate(filenames):
+        command_line = BARE_COMMAND + [filename]
+        print(
+            f"{SGR_INFO}"
+            f"[{i + 1}/{len(filenames)}] "
+            f"Running mypy on file: {filename}{SGR_CLEAR}"
+        )
+
+        process = subprocess.run(command_line, check=False)
+
+        if process.returncode != 0:
+            return False
+
+    print()
+    return True
+
+
+def parse_command_line() -> Any:
+    script_description = dedent("""
+        Runs type annotation checks on all Python files in project directories known to contain Python scripts.
+
+        This script is meant to be run from the CI but can also be easily used in the local dev
+        environment.
+    """)
+
+    parser = ArgumentParser(description=script_description)
+    parser.add_argument(
+        '-d', '--dev-mode',
+        dest='dev_mode',
+        default=False,
+        action='store_true',
+        help=(
+            "Abort on first error. "
+            "In this mode every script is passed to mypy separately. "
+        )
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    options = parse_command_line()
+
+    rootdirs = [
+        f"{PROJECT_ROOT}/docs",
+        f"{PROJECT_ROOT}/scripts",
+        f"{PROJECT_ROOT}/test",
+    ]
+    success = mypy_all_filenames(options.dev_mode, rootdirs)
+
+    if not success:
+        sys.exit(1)
+    else:
+        print("No problems found.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit("Interrupted by user. Exiting.")

--- a/scripts/pylint_all.py
+++ b/scripts/pylint_all.py
@@ -10,13 +10,15 @@ from textwrap import dedent
 import subprocess
 import sys
 
+from typing import Any
+
 PROJECT_ROOT = path.dirname(path.dirname(path.realpath(__file__)))
 PYLINT_RCFILE = f"{PROJECT_ROOT}/scripts/pylintrc"
 
 SGR_INFO = "\033[1;32m"
 SGR_CLEAR = "\033[0m"
 
-def pylint_all_filenames(dev_mode, rootdirs):
+def pylint_all_filenames(dev_mode: Any, rootdirs: Any) -> Any:
     """ Performs pylint on all python files within given root directory (recursively).  """
 
     BARE_COMMAND = [
@@ -56,7 +58,7 @@ def pylint_all_filenames(dev_mode, rootdirs):
     return True
 
 
-def parse_command_line():
+def parse_command_line() -> Any:
     script_description = dedent("""
         Runs pylint on all Python files in project directories known to contain Python scripts.
 
@@ -78,7 +80,7 @@ def parse_command_line():
     return parser.parse_args()
 
 
-def main():
+def main() -> None:
     options = parse_command_line()
 
     rootdirs = [

--- a/scripts/regressions.py
+++ b/scripts/regressions.py
@@ -9,19 +9,21 @@ import glob
 import threading
 import time
 
+from typing import Any
+
 DESCRIPTION = """Regressor is a tool to run regression tests in a CI env."""
 
 class PrintDotsThread:
     """Prints a dot every "interval" (default is 300) seconds"""
 
-    def __init__(self, interval=300):
+    def __init__(self, interval: Any=300) -> None:
         self.interval = interval
 
         thread = threading.Thread(target=self.run, args=())
         thread.daemon = True
         thread.start()
 
-    def run(self):
+    def run(self) -> None:
         """ Runs until the main Python thread exits. """
         ## Print a newline at the very beginning.
         print("")
@@ -33,7 +35,7 @@ class PrintDotsThread:
 class regressor:
     _re_sanitizer_log = re.compile(r"""ERROR: (libFuzzer|UndefinedBehaviorSanitizer)""")
 
-    def __init__(self, description, args):
+    def __init__(self, description: Any, args: Any) -> None:
         self._description = description
         self._args = self.parseCmdLine(description, args)
         self._repo_root = os.path.dirname(sys.path[0])
@@ -42,14 +44,14 @@ class regressor:
         self._logpath = os.path.join(self._repo_root, "test_results")
 
     @classmethod
-    def parseCmdLine(cls, description, args):
+    def parseCmdLine(cls, description: Any, args: Any) -> Any:
         argParser = ArgumentParser(description)
         argParser.add_argument('-o', '--out-dir', required=True, type=str,
                                help="""Directory where test results will be written""")
         return argParser.parse_args(args)
 
     @staticmethod
-    def run_cmd(command, logfile=None, env=None):
+    def run_cmd(command: Any, logfile: Any=None, env: Any=None) -> Any:
         """
         Args:
             command (str): command to run
@@ -76,7 +78,7 @@ class regressor:
                 logfh.close()
                 return ret
 
-    def process_log(self, logfile):
+    def process_log(self, logfile: Any) -> Any:
         """
         Args:
             logfile (str): log file name
@@ -93,7 +95,7 @@ class regressor:
             rawtext = str(f.read())
         return not re.search(self._re_sanitizer_log, rawtext)
 
-    def run(self):
+    def run(self) -> Any:
         """
         Returns:
             bool: Test status.

--- a/scripts/splitSources.py
+++ b/scripts/splitSources.py
@@ -13,11 +13,13 @@ import sys
 import os
 import traceback
 
+from typing import Any
+
 hasMultipleSources = False
 createdSources = []
 
 
-def uncaught_exception_hook(exc_type, exc_value, exc_traceback):
+def uncaught_exception_hook(exc_type: Any, exc_value: Any, exc_traceback: Any) -> None:
     # The script `scripts/ASTImportTest.sh` will interpret return code 3
     # as a critical error (because of the uncaught exception) and will
     # terminate further execution.
@@ -25,7 +27,7 @@ def uncaught_exception_hook(exc_type, exc_value, exc_traceback):
     sys.exit(3)
 
 
-def extractSourceName(line):
+def extractSourceName(line: Any) -> Any:
     if line.find("/") > -1:
         filePath = line[13: line.rindex("/")]
         # fileName = line[line.rindex("/")+1: line.find(" ====")]
@@ -36,7 +38,7 @@ def extractSourceName(line):
 
 # expects the first line of lines to be "==== Source: sourceName ===="
 # writes the following source into a file named sourceName
-def writeSourceToFile(lines):
+def writeSourceToFile(lines: Any) -> None:
     filePath, srcName = extractSourceName(lines[0])
     # print("sourceName is ", srcName)
     # print("filePath is", filePath)

--- a/scripts/update_bugs_by_version.py
+++ b/scripts/update_bugs_by_version.py
@@ -11,14 +11,16 @@ import json
 import re
 import sys
 
-def comp(version_string):
+from typing import Any
+
+def comp(version_string: Any) -> Any:
     return [int(c) for c in version_string.split('.')]
 
 path = os.path.dirname(os.path.realpath(__file__))
 with open(path + '/../docs/bugs.json', encoding='utf8') as bugsFile:
     bugs = json.load(bugsFile)
 
-versions = {}
+versions = {} # type: Any
 with open(path + '/../Changelog.md', encoding='utf8') as changelog:
     for line in changelog:
         m = re.search(r'^### (\S+) \((\d+-\d+-\d+)\)$', line)

--- a/scripts/wasm-rebuild/docker-scripts/isolate_tests.py
+++ b/scripts/wasm-rebuild/docker-scripts/isolate_tests.py
@@ -9,15 +9,16 @@ import os
 import hashlib
 # Pylint for some reason insists that isfile() is unused
 from os.path import join, isfile  # pylint: disable=unused-import
+from typing import Any
 
 
-def extract_test_cases(path):
+def extract_test_cases(path: Any) -> Any:
     with open(path, encoding="utf8", errors='ignore', mode='rb') as f:
         lines = f.read().splitlines()
 
     inside = False
     delimiter = ''
-    tests = []
+    tests = [] # type: Any
 
     for l in lines:
       if inside:
@@ -35,7 +36,7 @@ def extract_test_cases(path):
 
     return tests
 
-def extract_and_write(f, path):
+def extract_and_write(f: Any, path: Any) -> None:
     if f.endswith('.sol'):
         with open(path, 'r', encoding='utf8') as _f:
             cases = [_f.read()]
@@ -43,7 +44,7 @@ def extract_and_write(f, path):
         cases = extract_test_cases(path)
     write_cases(f, cases)
 
-def write_cases(f, tests):
+def write_cases(f: Any, tests: Any) -> None:
     cleaned_filename = f.replace(".","_").replace("-","_").replace(" ","_").lower()
     for test in tests:
         remainder = re.sub(r'^ {4}', '', test, 0, re.MULTILINE)

--- a/test/formal/opcodes.py
+++ b/test/formal/opcodes.py
@@ -1,63 +1,64 @@
+from typing import Any
 from z3 import BitVecVal, BV2Int, If, LShR, UDiv, ULT, UGT, URem
 
-def ADD(x, y):
+def ADD(x: Any, y: Any) -> Any:
 	return x + y
 
-def MUL(x, y):
+def MUL(x: Any, y: Any) -> Any:
 	return x * y
 
-def SUB(x, y):
+def SUB(x: Any, y: Any) -> Any:
 	return x - y
 
-def DIV(x, y):
+def DIV(x: Any, y: Any) -> Any:
 	return If(y == 0, 0, UDiv(x, y))
 
-def SDIV(x, y):
+def SDIV(x: Any, y: Any) -> Any:
 	return If(y == 0, 0, x / y)
 
-def MOD(x, y):
+def MOD(x: Any, y: Any) -> Any:
 	return If(y == 0, 0, URem(x, y))
 
-def SMOD(x, y):
+def SMOD(x: Any, y: Any) -> Any:
 	return If(y == 0, 0, x % y)
 
-def LT(x, y):
+def LT(x: Any, y: Any) -> Any:
 	return If(ULT(x, y), BitVecVal(1, x.size()), BitVecVal(0, x.size()))
 
-def GT(x, y):
+def GT(x: Any, y: Any) -> Any:
 	return If(UGT(x, y), BitVecVal(1, x.size()), BitVecVal(0, x.size()))
 
-def SLT(x, y):
+def SLT(x: Any, y: Any) -> Any:
 	return If(x < y, BitVecVal(1, x.size()), BitVecVal(0, x.size()))
 
-def SGT(x, y):
+def SGT(x: Any, y: Any) -> Any:
 	return If(x > y, BitVecVal(1, x.size()), BitVecVal(0, x.size()))
 
-def EQ(x, y):
+def EQ(x: Any, y: Any) -> Any:
 	return If(x == y, BitVecVal(1, x.size()), BitVecVal(0, x.size()))
 
-def ISZERO(x):
+def ISZERO(x: Any) -> Any:
 	return If(x == 0, BitVecVal(1, x.size()), BitVecVal(0, x.size()))
 
-def AND(x, y):
+def AND(x: Any, y: Any) -> Any:
 	return x & y
 
-def OR(x, y):
+def OR(x: Any, y: Any) -> Any:
 	return x | y
 
-def NOT(x):
+def NOT(x: Any) -> Any:
 	return ~(x)
 
-def SHL(x, y):
+def SHL(x: Any, y: Any) -> Any:
 	return y << x
 
-def SHR(x, y):
+def SHR(x: Any, y: Any) -> Any:
 	return LShR(y, x)
 
-def SAR(x, y):
+def SAR(x: Any, y: Any) -> Any:
 	return y >> x
 
-def BYTE(i, x):
+def BYTE(i: Any, x: Any) -> Any:
 	bit = (i + 1) * 8
 	return If(
 		UGT(i, x.size() / 8 - 1),
@@ -65,7 +66,7 @@ def BYTE(i, x):
 		(LShR(x, (x.size() - bit))) & 0xff
 	)
 
-def SIGNEXTEND(i, x):
+def SIGNEXTEND(i: Any, x: Any) -> Any:
 	bitBV = i * 8 + 7
 	bitInt = BV2Int(i) * 8 + 7
 	test = BitVecVal(1, x.size()) << bitBV

--- a/test/formal/redundant_store_unrelated.py
+++ b/test/formal/redundant_store_unrelated.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Any
 from z3 import Solver, Int, unsat
 
 """
@@ -12,11 +13,11 @@ n_bits = 256
 solver = Solver()
 solver.set("timeout", 60000)
 
-def restrict(x):
+def restrict(x: Any) -> None:
     solver.add(x >= 0)
     solver.add(x < 2**n_bits)
 
-def restrictedInt(x):
+def restrictedInt(x: Any) -> Any:
     var = Int(x)
     restrict(var)
     return var

--- a/test/formal/rule.py
+++ b/test/formal/rule.py
@@ -1,24 +1,25 @@
 import sys
 
+from typing import Any
 from z3 import sat, Solver, unknown, unsat
 
 class Rule:
-	def __init__(self):
-		self.requirements = []
-		self.constraints = []
+	def __init__(self) -> None:
+		self.requirements = [] # type: Any
+		self.constraints = [] # type: Any
 		self.solver = Solver()
 		self.setTimeout(60000)
 
-	def setTimeout(self, _t):
+	def setTimeout(self, _t: Any) -> None:
 		self.solver.set("timeout", _t)
 
-	def __lshift__(self, _c):
+	def __lshift__(self, _c: Any) -> None:
 		self.constraints.append(_c)
 
-	def require(self, _r):
+	def require(self, _r: Any) -> None:
 		self.requirements.append(_r)
 
-	def check(self, _nonopt, _opt):
+	def check(self, _nonopt: Any, _opt: Any) -> None:
 		self.solver.add(self.requirements)
 		result = self.solver.check()
 
@@ -40,6 +41,6 @@ class Rule:
 		self.solver.pop()
 
 	@classmethod
-	def error(cls, msg):
+	def error(cls, msg: Any) -> None:
 		print(msg)
 		sys.exit(1)

--- a/test/formal/signextend_equivalence.py
+++ b/test/formal/signextend_equivalence.py
@@ -1,3 +1,4 @@
+from typing import Any
 from opcodes import SIGNEXTEND
 from rule import Rule
 from z3 import BitVec, BitVecVal, Extract, SignExt, UGT
@@ -11,7 +12,7 @@ n_bits = 256
 
 x = BitVec('X', n_bits)
 
-def SIGNEXTEND_native(i, x):
+def SIGNEXTEND_native(i: Any, x: Any) -> Any:
     return SignExt(256 - 8 * i - 8, Extract(8 * i + 7, 0, x))
 
 for i in range(0, 32):

--- a/test/formal/util.py
+++ b/test/formal/util.py
@@ -1,27 +1,28 @@
+from typing import Any
 from z3 import BitVecVal, Concat, If
 
-def BVUnsignedUpCast(x, n_bits):
+def BVUnsignedUpCast(x: Any, n_bits: Any) -> Any:
 	assert x.size() <= n_bits
 	if x.size() < n_bits:
 		return Concat(BitVecVal(0, n_bits - x.size()), x)
 	else:
 		return x
 
-def BVUnsignedMax(type_bits, n_bits):
+def BVUnsignedMax(type_bits: Any, n_bits: Any) -> Any:
 	assert type_bits <= n_bits
 	return BitVecVal((1 << type_bits) - 1, n_bits)
 
-def BVSignedUpCast(x, n_bits):
+def BVSignedUpCast(x: Any, n_bits: Any) -> Any:
 	assert x.size() <= n_bits
 	if x.size() < n_bits:
 		return Concat(If(x < 0, BitVecVal(-1, n_bits - x.size()), BitVecVal(0, n_bits - x.size())), x)
 	else:
 		return x
 
-def BVSignedMax(type_bits, n_bits):
+def BVSignedMax(type_bits: Any, n_bits: Any) -> Any:
 	assert type_bits <= n_bits
 	return BitVecVal((1 << (type_bits - 1)) - 1, n_bits)
 
-def BVSignedMin(type_bits, n_bits):
+def BVSignedMin(type_bits: Any, n_bits: Any) -> Any:
 	assert type_bits <= n_bits
 	return BitVecVal(-(1 << (type_bits - 1)), n_bits)

--- a/test/lsp.py
+++ b/test/lsp.py
@@ -27,12 +27,12 @@ class JsonRpcProcess:
     process: subprocess.Popen
     trace_io: bool
 
-    def __init__(self, exe_path: str, exe_args: List[str], trace_io: bool = True):
+    def __init__(self, exe_path: str, exe_args: List[str], trace_io: bool = True) -> None:
         self.exe_path = exe_path
         self.exe_args = exe_args
         self.trace_io = trace_io
 
-    def __enter__(self):
+    def __enter__(self) -> Any:
         self.process = subprocess.Popen(
             [self.exe_path, *self.exe_args],
             stdin=subprocess.PIPE,
@@ -41,7 +41,7 @@ class JsonRpcProcess:
         )
         return self
 
-    def __exit__(self, exception_type, exception_value, traceback) -> None:
+    def __exit__(self, exception_type: Any, exception_value: Any, traceback: Any) -> None:
         self.process.kill()
         self.process.wait(timeout=2.0)
 
@@ -118,7 +118,7 @@ SGR_STATUS_OKAY = '\033[1;32m'
 SGR_STATUS_FAIL = '\033[1;31m'
 
 class ExpectationFailed(Exception):
-    def __init__(self, actual, expected):
+    def __init__(self, actual: Any, expected: Any) -> None:
         self.actual = json.dumps(actual, sort_keys=True)
         self.expected = json.dumps(expected, sort_keys=True)
         diff = json.dumps(DeepDiff(actual, expected), indent=4)
@@ -186,7 +186,7 @@ class Marker(Enum):
 
 
 # Returns the given marker with the end extended by 'amount'
-def extendEnd(marker, amount=1):
+def extendEnd(marker: Any, amount: Any=1) -> Any:
     marker["end"]["character"] += amount
     return marker
 
@@ -198,9 +198,9 @@ class SolidityLSPTestSuite: # {{{
     trace_io: bool = False
     fail_fast: bool = False
     test_pattern: str
-    marker_regexes: {}
+    marker_regexes: Any = {}
 
-    def __init__(self):
+    def __init__(self) -> None:
         colorama.init()
         args = create_cli_parser().parse_args()
         self.solc_path = args.solc_path
@@ -256,7 +256,7 @@ class SolidityLSPTestSuite: # {{{
 
         return min(max(self.test_counter.failed, self.assertion_counter.failed), 127)
 
-    def setup_lsp(self, lsp: JsonRpcProcess, expose_project_root=True):
+    def setup_lsp(self, lsp: JsonRpcProcess, expose_project_root: Any=True) -> None:
         """
         Prepares the solc LSP server by calling `initialize`,
         and `initialized` methods.
@@ -278,20 +278,20 @@ class SolidityLSPTestSuite: # {{{
                     'workspaceFolders': True
                 }
             }
-        }
+        } # type: Any
         if not expose_project_root:
             params['rootUri'] = None
         lsp.call_method('initialize', params)
         lsp.send_notification('initialized')
 
     # {{{ helpers
-    def get_test_file_path(self, test_case_name):
+    def get_test_file_path(self, test_case_name: Any) -> Any:
         return f"{self.project_root_dir}/{test_case_name}.sol"
 
-    def get_test_file_uri(self, test_case_name):
+    def get_test_file_uri(self, test_case_name: Any) -> Any:
         return "file://" + self.get_test_file_path(test_case_name)
 
-    def get_test_file_contents(self, test_case_name):
+    def get_test_file_contents(self, test_case_name: Any) -> Any:
         """
         Reads the file contents from disc for a given test case.
         The `test_case_name` will be the basename of the file
@@ -357,7 +357,7 @@ class SolidityLSPTestSuite: # {{{
         )
         return self.wait_for_diagnostics(solc_process, max_diagnostic_reports)
 
-    def expect_equal(self, actual, expected, description="Equality") -> None:
+    def expect_equal(self, actual: Any, expected: Any, description: Any="Equality") -> None:
         self.assertion_counter.total += 1
         prefix = f"[{self.assertion_counter.total}] {SGR_ASSERT_BEGIN}{description}: "
         diff = DeepDiff(actual, expected)
@@ -378,19 +378,19 @@ class SolidityLSPTestSuite: # {{{
 
     def expect_diagnostic(
         self,
-        diagnostic,
+        diagnostic: Any,
         code: int,
         lineNo: int = None,
         startEndColumns: Tuple[int, int] = None,
-        marker: {} = None
-    ):
+        marker: Any = None
+    ) -> None:
         self.expect_equal(diagnostic['code'], code, f'diagnostic: {code}')
 
         if marker:
             self.expect_equal(diagnostic['range'], marker, "diagnostic: check range")
         else:
-            assert len(startEndColumns) == 2
-            [startColumn, endColumn] = startEndColumns
+            assert len(startEndColumns) == 2 # type: ignore
+            [startColumn, endColumn] = startEndColumns # type: ignore
             self.expect_equal(
                 diagnostic['range'],
                 {
@@ -407,7 +407,7 @@ class SolidityLSPTestSuite: # {{{
         uri: str,
         lineNo: int,
         startEndColumns: Tuple[int, int]
-    ):
+    ) -> None:
         """
         obj is an JSON object containing two keys:
             - 'uri': a string of the document URI
@@ -430,7 +430,7 @@ class SolidityLSPTestSuite: # {{{
         expected_lineNo: int,
         expected_startEndColumns: Tuple[int, int],
         description: str
-    ):
+    ) -> None:
         response = solc.call_method(
             'textDocument/definition',
             {
@@ -527,7 +527,7 @@ class SolidityLSPTestSuite: # {{{
         self.expect_diagnostic(report['diagnostics'][0], code=2072, marker=marker)
 
 
-    def get_file_tags(self, test_name: str, verbose=False):
+    def get_file_tags(self, test_name: str, verbose: bool=False) -> Any:
         """
         Finds all tags (e.g. @tagname) in the given test and returns them as a
         dictionary having the following structure: {
@@ -618,8 +618,8 @@ class SolidityLSPTestSuite: # {{{
     def verify_didOpen_with_import_diagnostics(
         self,
         published_diagnostics: List[Any],
-        main_file_name='didOpen_with_import'
-    ):
+        main_file_name: Any='didOpen_with_import'
+    ) -> None:
         self.expect_equal(len(published_diagnostics), 2, "Diagnostic reports for 2 files")
 
         # primary file:

--- a/test/pyscriptTests.py
+++ b/test/pyscriptTests.py
@@ -23,7 +23,7 @@ if __name__ == '__main__':
     sys.path.insert(0, str(SCRIPTS_DIR))
 
     # This is equivalent to `python -m unittest discover --start-directory $TEST_DIR`
-    test_suite = TestLoader().discover(start_dir=TEST_DIR)
+    test_suite = TestLoader().discover(start_dir=TEST_DIR) # type: ignore
     result = TextTestRunner().run(test_suite)
 
     if len(result.errors) > 0 or len(result.failures) > 0:

--- a/test/scripts/test_bytecodecompare_prepare_report.py
+++ b/test/scripts/test_bytecodecompare_prepare_report.py
@@ -46,12 +46,12 @@ SOLC_0_4_8_CLI_OUTPUT = load_fixture('solc_0.4.8_cli_output.txt')
 
 
 class PrepareReportTestBase(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.maxDiff = 10000
 
 
 class TestFileReport(PrepareReportTestBase):
-    def test_format_report(self):
+    def test_format_report(self) -> None:
         report = FileReport(
             file_name=Path('syntaxTests/scoping/library_inherited2.sol'),
             contract_reports=[
@@ -87,48 +87,48 @@ class TestFileReport(PrepareReportTestBase):
 
         self.assertEqual(report.format_report(), expected_output)
 
-    def test_format_report_should_print_error_if_contract_report_list_is_missing(self):
+    def test_format_report_should_print_error_if_contract_report_list_is_missing(self) -> None:
         report = FileReport(file_name=Path('file.sol'), contract_reports=None)
 
         expected_output = "file.sol: <ERROR>\n"
 
         self.assertEqual(report.format_report(), expected_output)
 
-    def test_format_report_should_not_print_anything_if_contract_report_list_is_empty(self):
+    def test_format_report_should_not_print_anything_if_contract_report_list_is_empty(self) -> None:
         report = FileReport(file_name=Path('file.sol'), contract_reports=[])
 
         self.assertEqual(report.format_report(), '')
 
 class TestPrepareReport_Statistics(unittest.TestCase):
-    def test_initialization(self):
+    def test_initialization(self) -> None:
         self.assertEqual(Statistics(), Statistics(0, 0, 0, 0, 0))
 
-    def test_aggregate_bytecode_and_metadata_present(self):
+    def test_aggregate_bytecode_and_metadata_present(self) -> None:
         statistics = Statistics()
         statistics.aggregate(FileReport(file_name=Path('F'), contract_reports=[ContractReport('C', 'c.sol', 'B', 'M')]))
         self.assertEqual(statistics, Statistics(1, 1, 0, 0, 0))
 
-    def test_aggregate_bytecode_missing(self):
+    def test_aggregate_bytecode_missing(self) -> None:
         statistics = Statistics()
         statistics.aggregate(FileReport(file_name=Path('F'), contract_reports=[ContractReport('C', 'c.sol', None, 'M')]))
         self.assertEqual(statistics, Statistics(1, 1, 0, 1, 0))
 
-    def test_aggregate_metadata_missing(self):
+    def test_aggregate_metadata_missing(self) -> None:
         statistics = Statistics()
         statistics.aggregate(FileReport(file_name=Path('F'), contract_reports=[ContractReport('C', 'c.sol', 'B', None)]))
         self.assertEqual(statistics, Statistics(1, 1, 0, 0, 1))
 
-    def test_aggregate_no_contract_reports(self):
+    def test_aggregate_no_contract_reports(self) -> None:
         statistics = Statistics()
         statistics.aggregate(FileReport(file_name=Path('F'), contract_reports=[]))
         self.assertEqual(statistics, Statistics(1, 0, 0, 0, 0))
 
-    def test_aggregate_missing_contract_report_list(self):
+    def test_aggregate_missing_contract_report_list(self) -> None:
         statistics = Statistics()
         statistics.aggregate(FileReport(file_name=Path('F'), contract_reports=None))
         self.assertEqual(statistics, Statistics(1, 0, 1, 0, 0))
 
-    def test_aggregate_multiple_contract_reports(self):
+    def test_aggregate_multiple_contract_reports(self) -> None:
         statistics = Statistics()
         statistics.aggregate(FileReport(file_name=Path('F'), contract_reports=[
             ContractReport('C', 'c.sol', 'B', 'M'),
@@ -138,7 +138,7 @@ class TestPrepareReport_Statistics(unittest.TestCase):
         ]))
         self.assertEqual(statistics, Statistics(1, 4, 0, 2, 2))
 
-    def test_str(self):
+    def test_str(self) -> None:
         statistics = Statistics()
         statistics.aggregate(FileReport(file_name=Path('F'), contract_reports=[
             ContractReport('C', 'c.sol', 'B', 'M'),
@@ -153,7 +153,7 @@ class TestPrepareReport_Statistics(unittest.TestCase):
 
 
 class TestLoadSource(PrepareReportTestBase):
-    def test_load_source_should_strip_smt_pragmas_if_requested(self):
+    def test_load_source_should_strip_smt_pragmas_if_requested(self) -> None:
         expected_file_content = (
             "\n"
             "contract C {\n"
@@ -162,11 +162,11 @@ class TestLoadSource(PrepareReportTestBase):
 
         self.assertEqual(load_source(SMT_SMOKE_TEST_SOL_PATH, SMTUse.STRIP_PRAGMAS), expected_file_content)
 
-    def test_load_source_should_not_strip_smt_pragmas_if_not_requested(self):
+    def test_load_source_should_not_strip_smt_pragmas_if_not_requested(self) -> None:
         self.assertEqual(load_source(SMT_SMOKE_TEST_SOL_PATH, SMTUse.DISABLE), SMT_SMOKE_TEST_SOL_CODE)
         self.assertEqual(load_source(SMT_SMOKE_TEST_SOL_PATH, SMTUse.PRESERVE), SMT_SMOKE_TEST_SOL_CODE)
 
-    def test_load_source_preserves_lf_newlines(self):
+    def test_load_source_preserves_lf_newlines(self) -> None:
         expected_output = (
             "\n"
             "\n"
@@ -176,7 +176,7 @@ class TestLoadSource(PrepareReportTestBase):
 
         self.assertEqual(load_source(SMT_CONTRACT_WITH_LF_NEWLINES_SOL_PATH, SMTUse.STRIP_PRAGMAS), expected_output)
 
-    def test_load_source_preserves_crlf_newlines(self):
+    def test_load_source_preserves_crlf_newlines(self) -> None:
         expected_output = (
             "\r\n"
             "\r\n"
@@ -186,7 +186,7 @@ class TestLoadSource(PrepareReportTestBase):
 
         self.assertEqual(load_source(SMT_CONTRACT_WITH_CRLF_NEWLINES_SOL_PATH, SMTUse.STRIP_PRAGMAS), expected_output)
 
-    def test_load_source_preserves_cr_newlines(self):
+    def test_load_source_preserves_cr_newlines(self) -> None:
         expected_output = (
             "\r"
             "\r"
@@ -196,7 +196,7 @@ class TestLoadSource(PrepareReportTestBase):
 
         self.assertEqual(load_source(SMT_CONTRACT_WITH_CR_NEWLINES_SOL_PATH, SMTUse.STRIP_PRAGMAS), expected_output)
 
-    def test_load_source_preserves_mixed_newlines(self):
+    def test_load_source_preserves_mixed_newlines(self) -> None:
         expected_output = (
             "\n"
             "\n"
@@ -208,7 +208,7 @@ class TestLoadSource(PrepareReportTestBase):
 
 
 class TestPrepareCompilerInput(PrepareReportTestBase):
-    def test_prepare_compiler_input_should_work_with_standard_json_interface(self):
+    def test_prepare_compiler_input_should_work_with_standard_json_interface(self) -> None:
         expected_compiler_input = {
             'language': 'Solidity',
             'sources': {
@@ -234,7 +234,7 @@ class TestPrepareCompilerInput(PrepareReportTestBase):
         self.assertEqual(command_line, ['solc', '--standard-json'])
         self.assertEqual(json.loads(compiler_input), expected_compiler_input)
 
-    def test_prepare_compiler_input_should_work_with_cli_interface(self):
+    def test_prepare_compiler_input_should_work_with_cli_interface(self) -> None:
         (command_line, compiler_input) = prepare_compiler_input(
             Path('solc'),
             SMT_SMOKE_TEST_SOL_PATH,
@@ -251,7 +251,7 @@ class TestPrepareCompilerInput(PrepareReportTestBase):
         )
         self.assertEqual(compiler_input, SMT_SMOKE_TEST_SOL_CODE)
 
-    def test_prepare_compiler_input_for_json_preserves_newlines(self):
+    def test_prepare_compiler_input_for_json_preserves_newlines(self) -> None:
         expected_compiler_input = {
             'language': 'Solidity',
             'sources': {
@@ -283,7 +283,7 @@ class TestPrepareCompilerInput(PrepareReportTestBase):
         self.assertEqual(command_line, ['solc', '--standard-json'])
         self.assertEqual(json.loads(compiler_input), expected_compiler_input)
 
-    def test_prepare_compiler_input_for_cli_preserves_newlines(self):
+    def test_prepare_compiler_input_for_cli_preserves_newlines(self) -> None:
         (_command_line, compiler_input) = prepare_compiler_input(
             Path('solc'),
             SMT_CONTRACT_WITH_MIXED_NEWLINES_SOL_PATH,
@@ -296,7 +296,7 @@ class TestPrepareCompilerInput(PrepareReportTestBase):
 
         self.assertEqual(compiler_input, SMT_CONTRACT_WITH_MIXED_NEWLINES_SOL_CODE)
 
-    def test_prepare_compiler_input_for_cli_should_handle_force_no_optimize_yul_flag(self):
+    def test_prepare_compiler_input_for_cli_should_handle_force_no_optimize_yul_flag(self) -> None:
         (command_line, compiler_input) = prepare_compiler_input(
             Path('solc'),
             SMT_SMOKE_TEST_SOL_PATH,
@@ -313,7 +313,7 @@ class TestPrepareCompilerInput(PrepareReportTestBase):
         )
         self.assertEqual(compiler_input, SMT_SMOKE_TEST_SOL_CODE)
 
-    def test_prepare_compiler_input_for_cli_should_not_use_metadata_option_if_not_supported(self):
+    def test_prepare_compiler_input_for_cli_should_not_use_metadata_option_if_not_supported(self) -> None:
         (command_line, compiler_input) = prepare_compiler_input(
             Path('solc'),
             SMT_SMOKE_TEST_SOL_PATH,
@@ -332,7 +332,7 @@ class TestPrepareCompilerInput(PrepareReportTestBase):
 
 
 class TestParseStandardJSONOutput(PrepareReportTestBase):
-    def test_parse_standard_json_output(self):
+    def test_parse_standard_json_output(self) -> None:
         expected_report = FileReport(
             file_name=Path('syntaxTests/scoping/library_inherited2.sol'),
             contract_reports=[
@@ -365,25 +365,25 @@ class TestParseStandardJSONOutput(PrepareReportTestBase):
         )
         self.assertEqual(report, expected_report)
 
-    def test_parse_standard_json_output_should_report_error_on_compiler_errors(self):
+    def test_parse_standard_json_output_should_report_error_on_compiler_errors(self) -> None:
         expected_report = FileReport(file_name=Path('syntaxTests/pragma/unknown_pragma.sol'), contract_reports=None)
 
         report = parse_standard_json_output(Path('syntaxTests/pragma/unknown_pragma.sol'), UNKNOWN_PRAGMA_SOL_JSON_OUTPUT)
         self.assertEqual(report, expected_report)
 
-    def test_parse_standard_json_output_should_report_error_on_empty_json(self):
+    def test_parse_standard_json_output_should_report_error_on_empty_json(self) -> None:
         expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
 
         self.assertEqual(parse_standard_json_output(Path('file.sol'), '{}'), expected_report)
 
-    def test_parse_standard_json_output_should_report_error_if_contracts_is_empty(self):
+    def test_parse_standard_json_output_should_report_error_if_contracts_is_empty(self) -> None:
         compiler_output = '{"contracts": {}}'
 
         expected_report = FileReport(file_name=Path('contract.sol'), contract_reports=None)
 
         self.assertEqual(parse_standard_json_output(Path('contract.sol'), compiler_output), expected_report)
 
-    def test_parse_standard_json_output_should_report_error_if_every_file_has_no_contracts(self):
+    def test_parse_standard_json_output_should_report_error_if_every_file_has_no_contracts(self) -> None:
         compiler_output = (
             "{\n"
             "    \"contracts\": {\n"
@@ -397,7 +397,7 @@ class TestParseStandardJSONOutput(PrepareReportTestBase):
 
         self.assertEqual(parse_standard_json_output(Path('contract.sol'), compiler_output), expected_report)
 
-    def test_parse_standard_json_output_should_not_report_error_if_there_is_at_least_one_file_with_contracts(self):
+    def test_parse_standard_json_output_should_not_report_error_if_there_is_at_least_one_file_with_contracts(self) -> None:
         compiler_output = (
             "{\n"
             "    \"contracts\": {\n"
@@ -414,24 +414,24 @@ class TestParseStandardJSONOutput(PrepareReportTestBase):
 
         self.assertEqual(parse_standard_json_output(Path('contract.sol'), compiler_output), expected_report)
 
-    def test_parse_standard_json_output_should_report_error_on_unimplemented_feature_error(self):
+    def test_parse_standard_json_output_should_report_error_on_unimplemented_feature_error(self) -> None:
         expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
 
         self.assertEqual(parse_standard_json_output(Path('file.sol'), UNIMPLEMENTED_FEATURE_JSON_OUTPUT), expected_report)
 
-    def test_parse_standard_json_output_should_report_error_on_stack_too_deep_error(self):
+    def test_parse_standard_json_output_should_report_error_on_stack_too_deep_error(self) -> None:
         expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
 
         self.assertEqual(parse_standard_json_output(Path('file.sol'), STACK_TOO_DEEP_JSON_OUTPUT), expected_report)
 
-    def test_parse_standard_json_output_should_report_error_on_code_generation_error(self):
+    def test_parse_standard_json_output_should_report_error_on_code_generation_error(self) -> None:
         expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
 
         self.assertEqual(parse_standard_json_output(Path('file.sol'), CODE_GENERATION_ERROR_JSON_OUTPUT), expected_report)
 
 
 class TestParseCLIOutput(PrepareReportTestBase):
-    def test_parse_standard_json_output_should_report_missing_if_value_is_just_whitespace(self):
+    def test_parse_standard_json_output_should_report_missing_if_value_is_just_whitespace(self) -> None:
         compiler_output = dedent("""\
             {
                 "contracts": {
@@ -459,7 +459,7 @@ class TestParseCLIOutput(PrepareReportTestBase):
 
         self.assertEqual(parse_standard_json_output(Path('contract.sol'), compiler_output), expected_report)
 
-    def test_parse_cli_output(self):
+    def test_parse_cli_output(self) -> None:
         expected_report = FileReport(
             file_name=Path('syntaxTests/scoping/library_inherited2.sol'),
             contract_reports=[
@@ -489,18 +489,18 @@ class TestParseCLIOutput(PrepareReportTestBase):
         report = parse_cli_output(Path('syntaxTests/scoping/library_inherited2.sol'), LIBRARY_INHERITED2_SOL_CLI_OUTPUT)
         self.assertEqual(report, expected_report)
 
-    def test_parse_cli_output_should_report_error_on_compiler_errors(self):
+    def test_parse_cli_output_should_report_error_on_compiler_errors(self) -> None:
         expected_report = FileReport(file_name=Path('syntaxTests/pragma/unknown_pragma.sol'), contract_reports=None)
 
         report = parse_cli_output(Path('syntaxTests/pragma/unknown_pragma.sol'), UNKNOWN_PRAGMA_SOL_CLI_OUTPUT)
         self.assertEqual(report, expected_report)
 
-    def test_parse_cli_output_should_report_error_on_empty_output(self):
+    def test_parse_cli_output_should_report_error_on_empty_output(self) -> None:
         expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
 
         self.assertEqual(parse_cli_output(Path('file.sol'), ''), expected_report)
 
-    def test_parse_cli_output_should_report_missing_bytecode_and_metadata(self):
+    def test_parse_cli_output_should_report_missing_bytecode_and_metadata(self) -> None:
         compiler_output = dedent("""\
             ======= syntaxTests/scoping/library_inherited2.sol:A =======
             ======= syntaxTests/scoping/library_inherited2.sol:B =======
@@ -542,22 +542,22 @@ class TestParseCLIOutput(PrepareReportTestBase):
 
         self.assertEqual(parse_cli_output(Path('syntaxTests/scoping/library_inherited2.sol'), compiler_output), expected_report)
 
-    def test_parse_cli_output_should_report_error_on_unimplemented_feature_error(self):
+    def test_parse_cli_output_should_report_error_on_unimplemented_feature_error(self) -> None:
         expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
 
         self.assertEqual(parse_cli_output(Path('file.sol'), UNIMPLEMENTED_FEATURE_CLI_OUTPUT), expected_report)
 
-    def test_parse_cli_output_should_report_error_on_stack_too_deep_error(self):
+    def test_parse_cli_output_should_report_error_on_stack_too_deep_error(self) -> None:
         expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
 
         self.assertEqual(parse_cli_output(Path('file.sol'), STACK_TOO_DEEP_CLI_OUTPUT), expected_report)
 
-    def test_parse_cli_output_should_report_error_on_code_generation_error(self):
+    def test_parse_cli_output_should_report_error_on_code_generation_error(self) -> None:
         expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
 
         self.assertEqual(parse_cli_output(Path('file.sol'), CODE_GENERATION_ERROR_CLI_OUTPUT), expected_report)
 
-    def test_parse_cli_output_should_handle_output_from_solc_0_4_0(self):
+    def test_parse_cli_output_should_handle_output_from_solc_0_4_0(self) -> None:
         expected_report = FileReport(
             file_name=Path('contract.sol'),
             contract_reports=[
@@ -572,7 +572,7 @@ class TestParseCLIOutput(PrepareReportTestBase):
 
         self.assertEqual(parse_cli_output(Path('contract.sol'), SOLC_0_4_0_CLI_OUTPUT), expected_report)
 
-    def test_parse_cli_output_should_handle_output_from_solc_0_4_8(self):
+    def test_parse_cli_output_should_handle_output_from_solc_0_4_8(self) -> None:
         expected_report = FileReport(
             file_name=Path('contract.sol'),
             contract_reports=[
@@ -589,7 +589,7 @@ class TestParseCLIOutput(PrepareReportTestBase):
 
         self.assertEqual(parse_cli_output(Path('contract.sol'), SOLC_0_4_8_CLI_OUTPUT), expected_report)
 
-    def test_parse_cli_output_should_handle_leading_and_trailing_spaces(self):
+    def test_parse_cli_output_should_handle_leading_and_trailing_spaces(self) -> None:
         compiler_output = (
             ' =======  contract.sol : C  ======= \n'
             ' Binary: \n'
@@ -607,7 +607,7 @@ class TestParseCLIOutput(PrepareReportTestBase):
 
         self.assertEqual(parse_cli_output(Path('contract.sol'), compiler_output), expected_report)
 
-    def test_parse_cli_output_should_handle_empty_bytecode_and_metadata_lines(self):
+    def test_parse_cli_output_should_handle_empty_bytecode_and_metadata_lines(self) -> None:
         compiler_output = dedent("""\
             ======= contract.sol:C =======
             Binary:
@@ -641,7 +641,7 @@ class TestParseCLIOutput(PrepareReportTestBase):
 
         self.assertEqual(parse_cli_output(Path('contract.sol'), compiler_output), expected_report)
 
-    def test_parse_cli_output_should_handle_link_references_in_bytecode(self):
+    def test_parse_cli_output_should_handle_link_references_in_bytecode(self) -> None:
         compiler_output = dedent("""\
             ======= contract.sol:C =======
             Binary:

--- a/test/scripts/test_externalTests_benchmark_diff.py
+++ b/test/scripts/test_externalTests_benchmark_diff.py
@@ -4,6 +4,7 @@ from textwrap import dedent
 import json
 import unittest
 
+from typing import Any
 from unittest_helpers import FIXTURE_DIR, load_fixture
 
 # NOTE: This test file file only works with scripts/ added to PYTHONPATH so pylint can't find the imports
@@ -19,10 +20,10 @@ SUMMARIZED_DIFF_HUMANIZED_MD = load_fixture(SUMMARIZED_DIFF_HUMANIZED_MD_PATH)
 
 
 class TestBenchmarkDiff(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.maxDiff = 10000
 
-    def test_benchmark_diff(self):
+    def test_benchmark_diff(self) -> None:
         report_before = json.loads(load_fixture(SUMMARIZED_BENCHMARKS_DEVELOP_JSON_PATH))
         report_after = json.loads(load_fixture(SUMMARIZED_BENCHMARKS_BRANCH_JSON_PATH))
         expected_diff = {
@@ -117,18 +118,18 @@ class TestBenchmarkDiff(unittest.TestCase):
 
 
 class TestBenchmarkDiffer(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.maxDiff = 10000
 
     @staticmethod
-    def _nest(value, levels):
+    def _nest(value: Any, levels: Any) -> Any:
         nested_value = value
         for level in levels:
             nested_value = {level: nested_value}
 
         return nested_value
 
-    def _assert_single_value_diff_matches(self, differ, cases, nest_result=True, nestings=None):
+    def _assert_single_value_diff_matches(self, differ: Any, cases: Any, nest_result: Any=True, nestings: Any=None) -> None:
         if nestings is None:
             nestings = [[], ['p'], ['p', 's'], ['p', 's', 'a']]
 
@@ -140,17 +141,17 @@ class TestBenchmarkDiffer(unittest.TestCase):
                     f'Wrong diff for {self._nest(before, levels)} vs {self._nest(after, levels)}'
                 )
 
-    def test_empty(self):
+    def test_empty(self) -> None:
         for style in DifferenceStyle:
             differ = BenchmarkDiffer(style, None, OutputFormat.JSON)
             self._assert_single_value_diff_matches(differ, [({}, {}, {})], nest_result=False)
 
-    def test_null(self):
+    def test_null(self) -> None:
         for style in DifferenceStyle:
             differ = BenchmarkDiffer(style, None, OutputFormat.JSON)
             self._assert_single_value_diff_matches(differ, [(None, None, {})], nest_result=False)
 
-    def test_number_diff_absolute_json(self):
+    def test_number_diff_absolute_json(self) -> None:
         for output_format in OutputFormat:
             self._assert_single_value_diff_matches(
                 BenchmarkDiffer(DifferenceStyle.ABSOLUTE, 4, output_format),
@@ -180,7 +181,7 @@ class TestBenchmarkDiffer(unittest.TestCase):
                 ],
             )
 
-    def test_number_diff_json(self):
+    def test_number_diff_json(self) -> None:
         for output_format in OutputFormat:
             self._assert_single_value_diff_matches(
                 BenchmarkDiffer(DifferenceStyle.RELATIVE, 4, output_format),
@@ -210,7 +211,7 @@ class TestBenchmarkDiffer(unittest.TestCase):
                 ],
             )
 
-    def test_number_diff_humanized_json_and_console(self):
+    def test_number_diff_humanized_json_and_console(self) -> None:
         for output_format in [OutputFormat.JSON, OutputFormat.CONSOLE]:
             self._assert_single_value_diff_matches(
                 BenchmarkDiffer(DifferenceStyle.HUMANIZED, 4, output_format),
@@ -240,7 +241,7 @@ class TestBenchmarkDiffer(unittest.TestCase):
                 ],
             )
 
-    def test_number_diff_humanized_markdown(self):
+    def test_number_diff_humanized_markdown(self) -> None:
         self._assert_single_value_diff_matches(
             BenchmarkDiffer(DifferenceStyle.HUMANIZED, 4, OutputFormat.MARKDOWN),
             [
@@ -269,7 +270,7 @@ class TestBenchmarkDiffer(unittest.TestCase):
             ],
         )
 
-    def test_type_mismatch(self):
+    def test_type_mismatch(self) -> None:
         for style in DifferenceStyle:
             self._assert_single_value_diff_matches(
                 BenchmarkDiffer(style, 4, OutputFormat.JSON),
@@ -288,7 +289,7 @@ class TestBenchmarkDiffer(unittest.TestCase):
                 ],
             )
 
-    def test_version_mismatch(self):
+    def test_version_mismatch(self) -> None:
         for style in DifferenceStyle:
             self._assert_single_value_diff_matches(
                 BenchmarkDiffer(style, 4, OutputFormat.JSON),
@@ -308,7 +309,7 @@ class TestBenchmarkDiffer(unittest.TestCase):
                 ],
             )
 
-    def test_missing(self):
+    def test_missing(self) -> None:
         for style in DifferenceStyle:
             self._assert_single_value_diff_matches(
                 BenchmarkDiffer(style, None, OutputFormat.JSON),
@@ -333,7 +334,7 @@ class TestBenchmarkDiffer(unittest.TestCase):
                 ],
             )
 
-    def test_missing_vs_null(self):
+    def test_missing_vs_null(self) -> None:
         for style in DifferenceStyle:
             self._assert_single_value_diff_matches(
                 BenchmarkDiffer(style, None, OutputFormat.JSON),
@@ -346,7 +347,7 @@ class TestBenchmarkDiffer(unittest.TestCase):
 
 
 class TestDiffTableFormatter(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.maxDiff = 10000
 
         self.report_before = {
@@ -382,7 +383,7 @@ class TestDiffTableFormatter(unittest.TestCase):
             },
         }
 
-    def test_diff_table_formatter(self):
+    def test_diff_table_formatter(self) -> None:
         report_before = json.loads(load_fixture(SUMMARIZED_BENCHMARKS_DEVELOP_JSON_PATH))
         report_after = json.loads(load_fixture(SUMMARIZED_BENCHMARKS_BRANCH_JSON_PATH))
         differ = BenchmarkDiffer(DifferenceStyle.HUMANIZED, 4, OutputFormat.MARKDOWN)
@@ -390,7 +391,7 @@ class TestDiffTableFormatter(unittest.TestCase):
 
         self.assertEqual(DiffTableFormatter.run(DiffTableSet(diff), OutputFormat.MARKDOWN), SUMMARIZED_DIFF_HUMANIZED_MD)
 
-    def test_diff_table_formatter_json_absolute(self):
+    def test_diff_table_formatter_json_absolute(self) -> None:
         differ = BenchmarkDiffer(DifferenceStyle.ABSOLUTE, 4, OutputFormat.JSON)
         diff = differ.run(self.report_before, self.report_after)
 
@@ -444,7 +445,7 @@ class TestDiffTableFormatter(unittest.TestCase):
         )
         self.assertEqual(DiffTableFormatter.run(DiffTableSet(diff), OutputFormat.JSON), expected_formatted_table)
 
-    def test_diff_table_formatter_console_relative(self):
+    def test_diff_table_formatter_console_relative(self) -> None:
         differ = BenchmarkDiffer(DifferenceStyle.RELATIVE, 4, OutputFormat.CONSOLE)
         diff = differ.run(self.report_before, self.report_after)
 
@@ -473,7 +474,7 @@ class TestDiffTableFormatter(unittest.TestCase):
         """)
         self.assertEqual(DiffTableFormatter.run(DiffTableSet(diff), OutputFormat.CONSOLE), expected_formatted_table)
 
-    def test_diff_table_formatter_markdown_humanized(self):
+    def test_diff_table_formatter_markdown_humanized(self) -> None:
         differ = BenchmarkDiffer(DifferenceStyle.HUMANIZED, 4, OutputFormat.MARKDOWN)
         diff = differ.run(self.report_before, self.report_after)
 

--- a/test/scripts/test_externalTests_parse_eth_gas_report.py
+++ b/test/scripts/test_externalTests_parse_eth_gas_report.py
@@ -17,10 +17,10 @@ ETH_GAS_REPORT_GNOSIS_RST_CONTENT = load_fixture(ETH_GAS_REPORT_GNOSIS_RST_PATH)
 
 
 class TestEthGasReport(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.maxDiff = 10000
 
-    def test_parse_report(self):
+    def test_parse_report(self) -> None:
         parsed_report = parse_report(ETH_GAS_REPORT_GNOSIS_RST_CONTENT)
 
         expected_report = {
@@ -116,13 +116,13 @@ class TestEthGasReport(unittest.TestCase):
         }
         self.assertEqual(asdict(parsed_report), expected_report)
 
-    def test_parse_report_should_fail_if_report_is_empty(self):
+    def test_parse_report_should_fail_if_report_is_empty(self) -> None:
         text_report = ""
         with self.assertRaises(ReportValidationError) as manager:
             parse_report(text_report)
         self.assertEqual(str(manager.exception), "Report header not found.")
 
-    def test_parse_report_should_fail_if_report_has_no_header(self):
+    def test_parse_report_should_fail_if_report_has_no_header(self) -> None:
         text_report = dedent("""
             | Methods                                            |
             | ERC1155Token · mint() · 1 · 3 · 2 ·          6 · - |
@@ -133,7 +133,7 @@ class TestEthGasReport(unittest.TestCase):
             parse_report(text_report)
         self.assertEqual(str(manager.exception), "Report header not found.")
 
-    def test_parse_report_should_fail_if_data_rows_have_no_headers(self):
+    def test_parse_report_should_fail_if_data_rows_have_no_headers(self) -> None:
         text_report = dedent("""
             | ERC1155Token · mint() · 1 · 3 · 2 · 6 · - |
         """).strip('\n')
@@ -146,7 +146,7 @@ class TestEthGasReport(unittest.TestCase):
             parse_report(text_report)
         self.assertEqual(str(manager.exception), expected_message)
 
-    def test_parse_report_should_fail_if_report_has_more_than_one_header(self):
+    def test_parse_report_should_fail_if_report_has_more_than_one_header(self) -> None:
         text_report = dedent("""
             | Solc version: 0.8.10 · Optimizer enabled: true  · Runs: 200 · Block limit: 100000000 gas |
             | Solc version: 0.8.9  · Optimizer enabled: false · Runs: 111 · Block limit: 999999999 gas |
@@ -160,7 +160,7 @@ class TestEthGasReport(unittest.TestCase):
             parse_report(text_report)
         self.assertEqual(str(manager.exception), expected_message)
 
-    def test_parse_report_should_fail_if_row_matching_same_method_call_appears_twice(self):
+    def test_parse_report_should_fail_if_row_matching_same_method_call_appears_twice(self) -> None:
         text_report = dedent("""
             | Methods                                               |
             | ERC1155Token · mint() · 47934 · 59804 · 57826 · 6 · - |
@@ -175,7 +175,7 @@ class TestEthGasReport(unittest.TestCase):
             parse_report(text_report)
         self.assertEqual(str(manager.exception), expected_message)
 
-    def test_parse_report_should_fail_if_row_matching_same_contract_deployment_appears_twice(self):
+    def test_parse_report_should_fail_if_row_matching_same_contract_deployment_appears_twice(self) -> None:
         text_report = dedent("""
             | Deployments          ·        · % of limit ·   │
             | ERC1155Token · - · - · 525869 ·      0.5 % · - |
@@ -190,7 +190,7 @@ class TestEthGasReport(unittest.TestCase):
             parse_report(text_report)
         self.assertEqual(str(manager.exception), expected_message)
 
-    def test_parse_report_should_fail_if_method_row_appears_under_deployments_header(self):
+    def test_parse_report_should_fail_if_method_row_appears_under_deployments_header(self) -> None:
         text_report = dedent("""
             | Deployments           ·                       · % of limit ·   │
             | ERC1155Token · mint() · 47934 · 59804 · 57826 ·          6 · - |
@@ -204,7 +204,7 @@ class TestEthGasReport(unittest.TestCase):
             parse_report(text_report)
         self.assertEqual(str(manager.exception), expected_message)
 
-    def test_parse_report_should_fail_if_deployment_row_appears_under_methods_header(self):
+    def test_parse_report_should_fail_if_deployment_row_appears_under_methods_header(self) -> None:
         text_report = dedent("""
             | Methods                               |
             | ERC1155Token · - · - · 525869 · 5 · - |

--- a/test/scripts/test_isolate_tests.py
+++ b/test/scripts/test_isolate_tests.py
@@ -3,12 +3,12 @@
 import unittest
 
 from textwrap import dedent, indent
-
+from typing import Any
 from unittest_helpers import FIXTURE_DIR, load_fixture
 
 # NOTE: This test file file only works with scripts/ added to PYTHONPATH so pylint can't find the imports
 # pragma pylint: disable=import-error
-from isolate_tests import extract_solidity_docs_cases, extract_yul_docs_cases
+from isolate_tests import extract_solidity_docs_cases, extract_yul_docs_cases # type: ignore
 # pragma pylint: enable=import-error
 
 CODE_BLOCK_RST_PATH = FIXTURE_DIR / 'code_block.rst'
@@ -16,16 +16,16 @@ CODE_BLOCK_RST_CONTENT = load_fixture(CODE_BLOCK_RST_PATH)
 CODE_BLOCK_WITH_DIRECTIVES_RST_PATH = FIXTURE_DIR / 'code_block_with_directives.rst'
 CODE_BLOCK_WITH_DIRECTIVES_RST_CONTENT = load_fixture(CODE_BLOCK_WITH_DIRECTIVES_RST_PATH)
 
-def formatCase(text):
+def formatCase(text: Any) -> Any:
     """Formats code to contain only one indentation and terminate with a \n"""
     return indent(dedent(text.lstrip("\n")), "    ") + "\n"
 
 class TestExtractDocsCases(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.maxDiff = 10000
 
 
-    def test_solidity_block(self):
+    def test_solidity_block(self) -> None:
         expected_cases = [formatCase(case) for case in [
             """
                 // SPDX-License-Identifier: GPL-3.0
@@ -43,7 +43,7 @@ class TestExtractDocsCases(unittest.TestCase):
 
         self.assertEqual(extract_solidity_docs_cases(CODE_BLOCK_RST_PATH), expected_cases)
 
-    def test_solidity_block_with_directives(self):
+    def test_solidity_block_with_directives(self) -> None:
         expected_cases = [formatCase(case) for case in [
             """
                 // SPDX-License-Identifier: GPL-3.0
@@ -68,7 +68,7 @@ class TestExtractDocsCases(unittest.TestCase):
 
         self.assertEqual(extract_solidity_docs_cases(CODE_BLOCK_WITH_DIRECTIVES_RST_PATH), expected_cases)
 
-    def test_yul_block(self):
+    def test_yul_block(self) -> None:
         expected_cases = [formatCase(case) for case in [
             """
             {
@@ -95,7 +95,7 @@ class TestExtractDocsCases(unittest.TestCase):
 
         self.assertEqual(extract_yul_docs_cases(CODE_BLOCK_RST_PATH), expected_cases)
 
-    def test_yul_block_with_directives(self):
+    def test_yul_block_with_directives(self) -> None:
         expected_cases = [formatCase(case) for case in [
             """
             {


### PR DESCRIPTION
closes #12857 

Added jobs to perform type annotation checks of python scripts in CI. Updated the current scripts to to conform to the checks by using the generic `Any` type.

All the fixes are in a separate commit for ease of review.