### PR TITLE
Add a require statement to the Ballot contract

### DIFF
--- a/docs/examples/voting.rst
+++ b/docs/examples/voting.rst
@@ -109,6 +109,7 @@ of votes.
         function delegate(address to) external {
             // assigns reference
             Voter storage sender = voters[msg.sender];
+            require(sender.weight != 0, "You have no right to vote");
             require(!sender.voted, "You already voted.");
 
             require(to != msg.sender, "Self-delegation is disallowed.");


### PR DESCRIPTION
Currently, in the Voting example on the Solidity documentation, anonymous accounts who don't have voting rights may call the `delegate` function of the `Ballot` contract.

To fix the issue, the statement
```solidity
require(sender.weight != 0, "You have no right to vote");
```
at the beginning of the `delegate` function is necessary.