### PR TITLE
Fix ICE caused by an immutable struct with mapping

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ Compiler Features:
 Bugfixes:
  * ABI Encoder: When encoding an empty string coming from storage do not add a superfluous empty slot for data.
  * Yul Optimizer: Do not remove ``returndatacopy`` in cases in which it might perform out-of-bounds reads that unconditionally revert as out-of-gas. Previously, any ``returndatacopy`` that wrote to memory that was never read from was removed without accounting for the out-of-bounds condition.
+ * DocString Parser: Fix ICE caused by an immutable struct with mapping.
 
 
 ### 0.8.14 (2022-05-17)

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -479,12 +479,6 @@ bool CompilerStack::analyze()
 			if (auto sourceAst = source->ast)
 				noErrors = contractLevelChecker.check(*sourceAst);
 
-		// Requires ContractLevelChecker
-		DocStringAnalyser docStringAnalyser(m_errorReporter);
-		for (Source const* source: m_sourceOrder)
-			if (source->ast && !docStringAnalyser.analyseDocStrings(*source->ast))
-				noErrors = false;
-
 		// Now we run full type checks that go down to the expression level. This
 		// cannot be done earlier, because we need cross-contract types and information
 		// about whether a contract is abstract for the `new` expression.
@@ -496,6 +490,15 @@ bool CompilerStack::analyze()
 		for (Source const* source: m_sourceOrder)
 			if (source->ast && !typeChecker.checkTypeRequirements(*source->ast))
 				noErrors = false;
+
+		if (noErrors)
+		{
+			// Requires ContractLevelChecker and TypeChecker
+			DocStringAnalyser docStringAnalyser(m_errorReporter);
+			for (Source const* source: m_sourceOrder)
+				if (source->ast && !docStringAnalyser.analyseDocStrings(*source->ast))
+					noErrors = false;
+		}
 
 		if (noErrors)
 		{

--- a/test/libsolidity/syntaxTests/immutable/non-value_type_struct.sol
+++ b/test/libsolidity/syntaxTests/immutable/non-value_type_struct.sol
@@ -1,0 +1,9 @@
+contract Contract {
+    struct S {
+        int k;
+    }
+
+    S immutable s;
+}
+// ----
+// TypeError 6377: (61-74): Immutable variables cannot have a non-value type.

--- a/test/libsolidity/syntaxTests/immutable/non-value_type_struct_with_mapping.sol
+++ b/test/libsolidity/syntaxTests/immutable/non-value_type_struct_with_mapping.sol
@@ -1,0 +1,9 @@
+contract Contract {
+    struct S {
+        mapping(uint => address) map;
+    }
+
+    S immutable s;
+}
+// ----
+// TypeError 6377: (84-97): Immutable variables cannot have a non-value type.


### PR DESCRIPTION
Fixes #12953.

The ICE was introduced as a side effect of 7c0a121e456b966826afe575929bad225aa0cb15, see 
https://github.com/ethereum/solidity/commit/7c0a121e456b966826afe575929bad225aa0cb15#diff-0e0e69b13aacc21916c6074c34a2ee68a0118b5914767495870c13b383061a94R135.

It makes `DocStringAnalizer` dependent on `TypeProvider`, which requires `TypeChecker`.

Moving `DocStringAnalyser` after `TypeCherker` fixes the ICE. Is it somewhat OK or too invasive?
