### PR TITLE
fix(parser): error for unexpected token

### DIFF
--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -142,7 +142,7 @@ ASTPointer<SourceUnit> Parser::parse(CharStream& _charStream)
 					expectToken(Token::Semicolon);
 				}
 				else
-					fatalParserError(7858_error, "Expected pragma, import directive or contract/interface/library/struct/enum/constant/function definition.");
+					fatalParserError(7858_error, "Expected pragma, import directive or contract/interface/library/struct/enum/constant/function/error definition.");
 			}
 		}
 		solAssert(m_recursionDepth == 0, "");

--- a/test/cmdlineTests/recovery_ast_empty_contract/err
+++ b/test/cmdlineTests/recovery_ast_empty_contract/err
@@ -1,4 +1,4 @@
-Error: Expected pragma, import directive or contract/interface/library/struct/enum/constant/function definition.
+Error: Expected pragma, import directive or contract/interface/library/struct/enum/constant/function/error definition.
  --> recovery_ast_empty_contract/input.sol:3:1:
   |
 3 | c

--- a/test/libsolidity/syntaxTests/freeFunctions/free_constructor.sol
+++ b/test/libsolidity/syntaxTests/freeFunctions/free_constructor.sol
@@ -1,3 +1,3 @@
 constructor() {}
 // ----
-// ParserError 7858: (0-11): Expected pragma, import directive or contract/interface/library/struct/enum/constant/function definition.
+// ParserError 7858: (0-11): Expected pragma, import directive or contract/interface/library/struct/enum/constant/function/error definition.

--- a/test/libsolidity/syntaxTests/freeFunctions/free_fallback.sol
+++ b/test/libsolidity/syntaxTests/freeFunctions/free_fallback.sol
@@ -1,3 +1,3 @@
 fallback(){}
 // ----
-// ParserError 7858: (0-8): Expected pragma, import directive or contract/interface/library/struct/enum/constant/function definition.
+// ParserError 7858: (0-8): Expected pragma, import directive or contract/interface/library/struct/enum/constant/function/error definition.

--- a/test/libsolidity/syntaxTests/freeFunctions/free_receive.sol
+++ b/test/libsolidity/syntaxTests/freeFunctions/free_receive.sol
@@ -1,3 +1,3 @@
 receive() {}
 // ----
-// ParserError 7858: (0-7): Expected pragma, import directive or contract/interface/library/struct/enum/constant/function definition.
+// ParserError 7858: (0-7): Expected pragma, import directive or contract/interface/library/struct/enum/constant/function/error definition.

--- a/test/libsolidity/syntaxTests/unexpected.sol
+++ b/test/libsolidity/syntaxTests/unexpected.sol
@@ -1,3 +1,3 @@
 unexpected
 // ----
-// ParserError 7858: (0-10): Expected pragma, import directive or contract/interface/library/struct/enum/constant/function definition.
+// ParserError 7858: (0-10): Expected pragma, import directive or contract/interface/library/struct/enum/constant/function/error definition.


### PR DESCRIPTION
With adding custom error definitions, error message for unexpected token on the source unit level wasn't updated.