### PR TITLE
Disable non-deterministic counterexamples in some SMT tests

### DIFF
--- a/test/libsolidity/smtCheckerTests/blockchain_state/balance_receive_4.sol
+++ b/test/libsolidity/smtCheckerTests/blockchain_state/balance_receive_4.sol
@@ -11,6 +11,7 @@ contract C {
 }
 // ====
 // SMTEngine: all
+// SMTIgnoreCex: yes
 // SMTIgnoreOS: macos
 // ----
 // Warning 4984: (82-85): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.

--- a/test/libsolidity/smtCheckerTests/userTypes/conversion_4.sol
+++ b/test/libsolidity/smtCheckerTests/userTypes/conversion_4.sol
@@ -18,6 +18,7 @@ contract C {
 }
 // ====
 // SMTEngine: all
+// SMTIgnoreCex: yes
 // ----
 // Warning 6328: (407-457): CHC: Assertion violation happens here.
 // Info 1180: Contract invariant(s) for :C:\n(true || true || true)\nReentrancy property(ies) for :C:\n(((<errorCode> = 0) && ((:var 0) = (:var 1))) || true || true || true || true)\n(true || true || ((<errorCode> = 0) && ((:var 0) = (:var 1))) || true || true)\n<errorCode> = 0 -> no errors\n<errorCode> = 1 -> Assertion failed at assert(MyUInt8.unwrap(m(MyUInt16.wrap(1))) == 1)\n<errorCode> = 2 -> Assertion failed at assert(MyUInt8.unwrap(m(MyUInt16.wrap(2))) == 2)\n<errorCode> = 3 -> Assertion failed at assert(MyUInt8.unwrap(m(MyUInt16.wrap(255))) == 0xff)\n<errorCode> = 4 -> Assertion failed at assert(MyUInt8.unwrap(m(MyUInt16.wrap(255))) == 1)\n


### PR DESCRIPTION
This PR disables counterexample generation in some SMT tests that recently failed in my PR (#12938) completely unrelated to SMTChecker.

According to @leonardoalt:
> the counterexample should be unrelated though, so if it's failing we should remove it anyway

#### `balance_receive_4`
[1053502](https://app.circleci.com/pipelines/github/ethereum/solidity/23984/workflows/c867e683-2679-44b6-9eb2-209677faed1c/jobs/1053502)
```
ASSERTION FAILURE:
- file   : boostTest.cpp
- line   : 111
- message: Test expectation mismatch.
Expected result:
  Warning 4984: (82-85): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
  Warning 4984: (154-160): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
  Warning 4984: (212-218): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
  Warning 6328: (180-219): CHC: Assertion violation happens here.
  Warning 2661: (82-85): BMC: Overflow (resulting value larger than 2**256 - 1) happens here.
  Warning 2661: (154-160): BMC: Overflow (resulting value larger than 2**256 - 1) happens here.
  Warning 2661: (212-218): BMC: Overflow (resulting value larger than 2**256 - 1) happens here.
Obtained result:
  Warning 4984: (82-85): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
  Warning 4984: (154-160): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
  Warning 4984: (212-218): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
  Warning 6328: (180-219): CHC: Assertion violation happens here.\nCounterexample:\nc = 1\n\nTransaction trace:\nC.constructor()\nState: c = 0\nC.f(){ msg.value: 11 }\nState: c = 1\nC.inv()
  Warning 2661: (82-85): BMC: Overflow (resulting value larger than 2**256 - 1) happens here.
  Warning 2661: (154-160): BMC: Overflow (resulting value larger than 2**256 - 1) happens here.
  Warning 2661: (212-218): BMC: Overflow (resulting value larger than 2**256 - 1) happens here.
```

#### `conversion_4`
[1053260](https://app.circleci.com/pipelines/github/ethereum/solidity/23984/workflows/e25a8251-8ffc-4177-b05e-bd8bf079be7b/jobs/1053260)
```
ASSERTION FAILURE:
- file   : boostTest.cpp
- line   : 111
- message: Test expectation mismatch.
Expected result:
  Warning 6328: (407-457): CHC: Assertion violation happens here.
Obtained result:
  Warning 6328: (407-457): CHC: Assertion violation happens here.\nCounterexample:\n\n\nTransaction trace:\nC.constructor()\nC.w()\n    C.m(1) -- internal call\n    C.m(2) -- internal call\n    C.m(255) -- internal call\n    C.m(255) -- internal call
```