### PR TITLE
Fix asorted compilation issues with GCC 12.

### DIFF
--- a/liblangutil/UniqueErrorReporter.h
+++ b/liblangutil/UniqueErrorReporter.h
@@ -96,8 +96,8 @@ public:
 	void clear() { m_errorReporter.clear(); }
 
 private:
-	ErrorReporter m_errorReporter;
 	ErrorList m_uniqueErrors;
+	ErrorReporter m_errorReporter;
 	std::map<std::pair<ErrorId, SourceLocation>, std::string> m_seenErrors;
 };
 

--- a/libsolutil/Numeric.h
+++ b/libsolutil/Numeric.h
@@ -29,7 +29,15 @@
 #error "Unsupported Boost version. At least 1.65 required."
 #endif
 
+// TODO: do this only conditionally as soon as a boost version with gcc 12 support is released.
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 #include <boost/multiprecision/cpp_int.hpp>
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic pop
+#endif
 
 #include <limits>
 

--- a/test/Metadata.cpp
+++ b/test/Metadata.cpp
@@ -94,7 +94,10 @@ public:
 				else if (value == 21)
 					return "true";
 				else
+				{
 					assertThrow(false, CBORException, "Unsupported simple value (not a boolean).");
+					return ""; // unreachable, but prevents compiler warning.
+				}
 			}
 			default:
 				assertThrow(false, CBORException, "Unsupported value type.");


### PR DESCRIPTION
Apparently gcc 12 started warning about this - and strictly speaking it's actually right in doing so, even though in our particular case, the current ordering shouldn't cause issues.