### PR TITLE
document that pop does not return last element

### DIFF
--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -349,7 +349,7 @@ Array Members
 **pop()**:
      Dynamic storage arrays and ``bytes`` (not ``string``) have a member
      function called ``pop()`` that you can use to remove an element from the
-     end of the array. This also implicitly calls :ref:`delete<delete>` on the removed element.
+     end of the array. This also implicitly calls :ref:`delete<delete>` on the removed element. The function returns nothing.
 
 .. note::
     Increasing the length of a storage array by calling ``push()``


### PR DESCRIPTION
It's already documented for push and this would clarify my incorrect assumption (that pop returns a value as in other languages) that caused confusion with https://github.com/ethereum/solidity/issues/13017