### PR TITLE
Workaround for `getStorageAt()` bug in Hardhat 2.9.5 for gnosis external test

### DIFF
--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -85,6 +85,10 @@ function gnosis_safe_test
     # TODO: Remove when https://github.com/ethers-io/ethers.js/discussions/2849 is resolved.
     npm install ethers@5.6.1
 
+    # Hardhat 2.9.5 introduced a bug with handling padded arguments to getStorageAt().
+    # TODO: Remove when https://github.com/NomicFoundation/hardhat/issues/2709 is fixed.
+    npm install hardhat@2.9.4
+
     replace_version_pragmas
     [[ $BINARY_TYPE == solcjs ]] && force_solc_modules "${DIR}/solc/dist"
 


### PR DESCRIPTION
Gnosis external test started failing due to and extra sanity check introduced by [Hardhat 2.9.5](https://github.com/NomicFoundation/hardhat/releases/tag/hardhat%402.9.5):

> Besides that, now the `eth_getStorageAt` method is spec-compliant. This means that the storage slot argument **must** have a length of 32 bytes (a hex-encoded, 0x-prefixed string of length 66).

This makes gnosis job fail in some PRs. E.g. [1059920](https://app.circleci.com/pipelines/github/ethereum/solidity/24123/workflows/55bf989e-120b-4f1d-8cd5-9f0a6e23b716/jobs/1059920):
```
 1) Migration
       migrate
         can migrate:
     InvalidArgumentsError: Errors encountered in param 1: Storage slot argument must have a length of 66 ("0x" + 32 bytes), but '0x6' has a length of 3
```

I have submitted an upstream fix (https://github.com/safe-global/safe-contracts/pull/404) but unfortunately Hardhat has a bug and does not really accept properly padded storage address either (https://github.com/NomicFoundation/hardhat/issues/2709).

For now the simplest workaround is to stay at 2.9.4.