### PR TITLE
Workaround for problems caused by forcing ethers@5.6.1 in external tests

### DIFF
--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -85,6 +85,10 @@ function gnosis_safe_test
     # TODO: Remove when https://github.com/ethers-io/ethers.js/discussions/2849 is resolved.
     npm install ethers@5.6.1
 
+    # Note that ethers@5.6.1 depends on @ethersproject/contracts@5.6.0 while the dependency on hardhat-deploy
+    # pulls @ethersproject/contracts@5.6.1 (latest). Force 5.6.0 to avoid errors due to having two copies.
+    npm install @ethersproject/contracts@5.6.0
+
     # Hardhat 2.9.5 introduced a bug with handling padded arguments to getStorageAt().
     # TODO: Remove when https://github.com/NomicFoundation/hardhat/issues/2709 is fixed.
     npm install hardhat@2.9.4

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -36,7 +36,7 @@ function test_fn { npm test; }
 
 function gnosis_safe_test
 {
-    local repo="https://github.com/gnosis/safe-contracts.git"
+    local repo="https://github.com/safe-global/safe-contracts.git"
     local ref_type=branch
     local ref=main
     local config_file="hardhat.config.ts"

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -73,6 +73,11 @@ function gnosis_safe_test
     # them for other presets but that's fine - we want same code run for benchmarks to be comparable.
     # TODO: Remove this when Hardhat adjusts heuristics for IR (https://github.com/nomiclabs/hardhat/issues/2115).
     sed -i "s|\(it\)\(('should not allow to call setup on singleton'\)|\1.skip\2|g" test/core/GnosisSafe.Setup.spec.ts
+    # TODO: Remove this when https://github.com/NomicFoundation/hardhat/issues/2453 gets fixed.
+    sed -i 's|\(it\)\(("changes the expected storage slot without touching the most important ones"\)|\1.skip\2|g' test/libraries/SignMessageLib.spec.ts
+    sed -i "s|\(it\)\(('can be used only via DELEGATECALL opcode'\)|\1.skip\2|g" test/libraries/SignMessageLib.spec.ts
+    sed -i 's|\(describe\)\(("Upgrade from Safe 1.1.1"\)|\1.skip\2|g' test/migration/UpgradeFromSafe111.spec.ts
+    sed -i 's|\(describe\)\(("Upgrade from Safe 1.2.0"\)|\1.skip\2|g' test/migration/UpgradeFromSafe120.spec.ts
 
     neutralize_package_lock
     neutralize_package_json_hooks

--- a/test/externalTests/perpetual-pools.sh
+++ b/test/externalTests/perpetual-pools.sh
@@ -66,10 +66,6 @@ function perpetual_pools_test
     force_hardhat_unlimited_contract_size "$config_file" "$config_var"
     yarn install
 
-    # With ethers.js 5.6.2 many tests for revert messages fail.
-    # TODO: Remove when https://github.com/ethers-io/ethers.js/discussions/2849 is resolved.
-    yarn add ethers@5.6.1
-
     replace_version_pragmas
 
     for preset in $SELECTED_PRESETS; do


### PR DESCRIPTION
In #12868 we had to downgrade ethers.js to 5.6.1 in several external projects because later versions break handling of revert expectations in Hardhat tests (see https://github.com/ethers-io/ethers.js/discussions/2849). This worked fine until ethers released a new version of its scoped package called `@ethersproject/contracts`. ethers 5.6.1 is hard-coded to use the older version of that package while other packages may pull in a newer one, causing errors like in [1061741](https://app.circleci.com/pipelines/github/ethereum/solidity/24148/workflows/a50dbf0e-7e4a-4bcd-848a-66c116394c4a/jobs/1061741):
```
test/migration/subTests.spec.ts:42:48 - error TS2345: Argument of type 'import("/tmp/ext-test-Gnosis-Safe-hDC41T/ext/node_modules/@ethersproject/contracts/lib/index").Contract' is not assignable to parameter of type 'import("/tmp/ext-test-Gnosis-Safe-hDC41T/ext/node_modules/ethers/node_modules/@ethersproject/contracts/lib/index").Contract'.
```

This is the case in Gnosis and Perpetual Pools external tests. The package that pulls in newer version is hardhat-deploy in this case (at least for Gnosis). The workaround is to force `@ethersproject/contracts` back to 5.6.0.

**EDIT**: Perpetual Pools fails with `@ethersproject/contracts@5.6.0` ([1062656](https://app.circleci.com/pipelines/github/ethereum/solidity/24183/workflows/2d2f0f7e-1d3e-43c1-882d-d4c87be7033f/jobs/1062656)):
```
1) PriceObserver
       add
         When called with a full observations array
           Rotates the observations array:

      AssertionError: expected [ …(24) ] to deeply equal [ …(24) ]
      + expected - actual
```

This appears to be a problem with the `.to.deep.eq()` matcher due to some version mismatch. I checked this and the values are actually exactly the same. I did not manage to figure out why the comparison fails. I suspected the fact that both `ethers@5.6.1` and `ethers@5.6.6` get installed but after forcing 5.6.1 in all transitive dependencies the problem still persisted.

Fortunately it turned out that the Perpetual Pools test no longer needs the workaround from #12868 and all tests pass with `ethers@5.6.6`. I suspect this might be because we disabled the tests that used to fail (probably due to failing Hardhat heuristics). In any case the solution was to remove that older workaround in this test.

### Details
Here's a more detailed explanation of this dependency hell in case anyone is curious:

- Hardhat does not work with ethers.js >= 5.6.2. As a workaround we're pinning it to 5.6.1 in our ext test scripts.
- ethers.js has a bunch of tiny scoped packages. One of them is `@ethersproject/contracts`. Apparently these do not have to be explicitly listed in [its `package.json`](https://github.com/ethers-io/ethers.js/blob/master/package.json) but still show up as dependencies in the package published to npm.
- ethers.js 5.6.1 published to npm depends on `@ethersproject/contracts@5.6.0` - exactly that version.
- Gnosis depends on `hardhat-deploy`, which [has a dependency on `ethers@^5.5.3`](https://github.com/wighawag/hardhat-deploy/blob/master/package.json#L67).
- When published to npm, hardhat-deploy somehow depends directly on these scoped packages rather than on `ethers`.
- It depends on `@ethersproject/contracts@^5.4.1`, which pulls in the latest version.
- Until 2 days ago the latest version of `@ethersproject/contracts` published to npm was 5.6.0. So both projects pulled that version as a dependency and all was fine.
- Now there's `@ethersproject/contracts@5.6.1` available. hardhat-deploy pulls that one while `ethers@5.6.1` we install pulls version 5.6.0. We get an error because TypeScript sees two different definitions of the `Contract` class.
