### PR TITLE
Do not remove potentially reverting returndatacopy cases.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Compiler Features:
 
 Bugfixes:
  * ABI Encoder: When encoding an empty string coming from storage do not add a superfluous empty slot for data.
+ * Yul Optimizer: Do not remove ``returndatacopy`` in cases in which it might perform out-of-bounds reads that unconditionally revert as out-of-gas. Previously, any ``returndatacopy`` that wrote to memory that was never read from was removed without accounting for the out-of-bounds condition.
 
 
 ### 0.8.14 (2022-05-17)

--- a/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_fixed_size.yul
+++ b/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_fixed_size.yul
@@ -1,0 +1,9 @@
+{
+  returndatacopy(0,0,32)
+}
+// ====
+// EVMVersion: >homestead
+// ----
+// step: unusedStoreEliminator
+//
+// { { returndatacopy(0, 0, 32) } }

--- a/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_returndatasize.yul
+++ b/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_returndatasize.yul
@@ -1,0 +1,15 @@
+{
+  returndatacopy(0,0,returndatasize())
+}
+// ====
+// EVMVersion: >homestead
+// ----
+// step: unusedStoreEliminator
+//
+// {
+//     {
+//         let _1 := returndatasize()
+//         let _2 := 0
+//         let _3 := 0
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_returndatasize_nonzero_start.yul
+++ b/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_returndatasize_nonzero_start.yul
@@ -1,0 +1,13 @@
+{
+  returndatacopy(0,1,returndatasize())
+}
+// ====
+// EVMVersion: >homestead
+// ----
+// step: unusedStoreEliminator
+//
+// {
+//     {
+//         returndatacopy(0, 1, returndatasize())
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_returndatasize_var.yul
+++ b/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_returndatasize_var.yul
@@ -1,0 +1,16 @@
+{
+  let s := returndatasize()
+  returndatacopy(0,0,s)
+}
+// ====
+// EVMVersion: >homestead
+// ----
+// step: unusedStoreEliminator
+//
+// {
+//     {
+//         let s := returndatasize()
+//         let _1 := 0
+//         let _2 := 0
+//     }
+// }


### PR DESCRIPTION
I'm wondering where and how we should also generally mark this in the semantics information...
Although libevmasm marks it as having side effects and it becomes non-movable and non-removable already...
We could consider the revert behaviour as "write to other state" instead, but that's a bit weird as well...
So maybe special handling in the ``UnusedStoreEliminator`` is just enough...

Fixes https://github.com/ethereum/solidity/issues/13039