### PR TITLE
Fix tests failing due to the develop branch merge

### DIFF
--- a/test/libsolidity/syntaxTests/negation.sol
+++ b/test/libsolidity/syntaxTests/negation.sol
@@ -6,4 +6,4 @@ contract test {
     }
 }
 // ----
-// TypeError 4907: (97-99): Unary operator - cannot be applied to type uint256: Unary negation is only allowed for signed integers.
+// TypeError 4907: (97-99): Unary operator - cannot be applied to type uint256. Unary negation is only allowed for signed integers.

--- a/test/libsolidity/syntaxTests/types/mapping/delete_storage_struct_with_mapping.sol
+++ b/test/libsolidity/syntaxTests/types/mapping/delete_storage_struct_with_mapping.sol
@@ -11,4 +11,4 @@ contract D {
 	}
 }
 // ----
-// TypeError 9767: (102-113): Unary operator delete cannot be applied to type struct D.Test storage ref: Contains a (possibly nested) mapping
+// TypeError 9767: (102-113): Unary operator delete cannot be applied to type struct D.Test storage ref. Contains a (possibly nested) mapping

--- a/test/libsolidity/syntaxTests/viewPureChecker/inline_assembly_instructions_allowed_pure.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/inline_assembly_instructions_allowed_pure.sol
@@ -43,8 +43,8 @@ contract C {
             pop(calldataload(0))
             pop(calldatasize())
             calldatacopy(0, 1, 2)
-            pop(codesize())
-            codecopy(0, 1, 2)
+            //pop(codesize())
+            //codecopy(0, 1, 2)
             //pop(extcodesize(0))
             //extcodecopy(0, 1, 2, 3)
             pop(returndatasize())
@@ -85,6 +85,6 @@ contract C {
 // ====
 // EVMVersion: >=london
 // ----
-// Warning 5740: (94-1755): Unreachable code.
-// Warning 5740: (1768-1780): Unreachable code.
-// Warning 5740: (1823-1832): Unreachable code.
+// Warning 5740: (94-1759): Unreachable code.
+// Warning 5740: (1772-1784): Unreachable code.
+// Warning 5740: (1827-1836): Unreachable code.


### PR DESCRIPTION
This PR fixes tests failing due to recent develop branch merge.

1) [inline_assembly_instructions_allowed_pure.sol](https://github.com/ethereum/solidity/blob/breaking/test/libsolidity/syntaxTests/viewPureChecker/inline_assembly_instructions_allowed_pure.sol) is failing due to changes delivered with #12261.

2) [negation.sol](https://github.com/ethereum/solidity/blob/f39decee8f3d60235252b67f6db785fbe7ddc271/test/libsolidity/syntaxTests/negation.sol) and [delete_storage_struct_with_mapping.sol](https://github.com/ethereum/solidity/blob/breaking/test/libsolidity/syntaxTests/types/mapping/delete_storage_struct_with_mapping.sol) are failing due to error message reformating.