### PR TITLE
External test workarounds for Gnosis and Euler external test failures

### DIFF
--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -65,10 +65,6 @@ function ens_test
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")"
     yarn install
 
-    # With ethers.js 5.6.2 many tests for revert messages fail.
-    # TODO: Remove when https://github.com/ethers-io/ethers.js/discussions/2849 is resolved.
-    yarn add ethers@5.6.1
-
     replace_version_pragmas
     neutralize_packaged_contracts
 

--- a/test/externalTests/euler.sh
+++ b/test/externalTests/euler.sh
@@ -78,10 +78,6 @@ function euler_test
     force_hardhat_unlimited_contract_size "$config_file"
     npm install
 
-    # With ethers.js 5.6.2 many tests for revert messages fail.
-    # TODO: Remove when https://github.com/ethers-io/ethers.js/discussions/2849 is resolved.
-    npm install ethers@5.6.1
-
     replace_version_pragmas
     neutralize_packaged_contracts
 

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -94,6 +94,10 @@ function gnosis_safe_test
     npm install
     npm install hardhat-gas-reporter
 
+    # Typescript compilation fails with typescript >= 4.7:
+    # Error: Debug Failure. False expression: Non-string value passed to `ts.resolveTypeReferenceDirective`
+    npm install "typescript@<4.7.0"
+
     # With ethers.js 5.6.2 many tests for revert messages fail.
     # TODO: Remove when https://github.com/ethers-io/ethers.js/discussions/2849 is resolved.
     npm install ethers@5.6.1


### PR DESCRIPTION
A fresh batch of external test workarounds:

### Gnosis
Job [1072860](https://app.circleci.com/pipelines/github/ethereum/solidity/24386/workflows/1d379105-8a89-41e6-88d3-442c5339827d/jobs/1072860) fails at `hardhat compile` step:
```
An unexpected error occurred:

Error: Debug Failure. False expression: Non-string value passed to `ts.resolveTypeReferenceDirective`, likely by a wrapping package working with an outdated `resolveTypeReferenceDirectives` signature. This is probably not a problem in TS itself.
```

Some kind of incompatibility with latest [typescript package](https://www.npmjs.com/package/typescript?activeTab=versions). Typescript 4.7.2 was released today. Until now the project was using 4.6.4 (there were only pre-releases in 4.7.1 and 4.7.0 series). My workaround is to cap it at `< 4.7.0`.

### Euler
Job [1072861](https://app.circleci.com/pipelines/github/ethereum/solidity/24386/workflows/1d379105-8a89-41e6-88d3-442c5339827d/jobs/1072861) has 3 failing tests with this error message:
```
337 passing (9m)
  3 failing

  1) batch operations
       sub-account transfers:
     Error: VM Exception while processing transaction: reverted with custom error 'BatchDispatchSimulation(<error parameters>)'
        ...
```

This is somehow related to changes in ethers.js. We earlier capped ethers.js for this external test at 5.6.1 in #13027. Removing this older workaround now fixes the problem.

While at it I also removed this workaround from all other external tests except for Gnosis and Uniswap. In #13051 @matheusaaguiar determined that Gnosis is the case that still fails with 5.6.8 and for me Uniswap also fails here without the workaround (see [1073153](https://app.circleci.com/pipelines/github/ethereum/solidity/24397/workflows/555dd7a6-bd3f-4164-b7ef-49646687da25/jobs/1073153)).