### PR TITLE
Disable more zeppelin test cases in which Hardhat's heuristics break after relaxing inlining.

### DIFF
--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -100,9 +100,16 @@ function zeppelin_test
     sed -i 's|it(\(`reverts when downcasting 2^\${bits} + 1 (\${maxValue.addn(2)})`\)|it.skip(\1|g' test/utils/math/SafeCast.test.js
     sed -i 's|it(\(`reverts when casting [^`]\+`\)|it.skip(\1|g' test/utils/math/SafeCast.test.js
     sed -i "s|it(\('missing value'\)|it.skip(\1|g" test/utils/structs/EnumerableMap.behavior.js
+    sed -i "s|it(\('reverts when queried for non existent token id'\)|it.skip(\1|g" test/token/ERC721/ERC721.behavior.js
+    sed -i "s|it(\('reverts if index is greater than supply'\)|it.skip(\1|g" test/token/ERC721/ERC721.behavior.js
+    sed -i "s|it(\('burns all tokens'\)|it.skip(\1|g" test/token/ERC721/ERC721.behavior.js
+    sed -i "s|it(\('other accounts cannot pause'\)|it.skip(\1|g" test/token/ERC721/presets/ERC721PresetMinterPauserAutoId.test.js
+    sed -i "s|it(\('other accounts cannot unpause'\)|it.skip(\1|g" test/token/ERC721/presets/ERC721PresetMinterPauserAutoId.test.js
+    sed -i "s|it(\('prevents initialization'\)|it.skip(\1|g" test/proxy/utils/Initializable.test.js
 
     # TODO: Remove this when https://github.com/NomicFoundation/hardhat/issues/2115 gets fixed.
     sed -i "s|describe\(('Polygon-Child'\)|describe.skip\1|g" test/crosschain/CrossChainEnabled.test.js
+    sed -i "s|it(\('revert with invalid multi proof #2'\)|it.skip(\1|g" test/utils/cryptography/MerkleProof.test.js
 
     neutralize_package_json_hooks
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"


### PR DESCRIPTION
After [OpenZeppelin/openzeppelin-contracts/commit/65b45726b](https://github.com/OpenZeppelin/openzeppelin-contracts/commit/65b45726b34dafe8fc3ef78c3d4b7b3f404f61ad) and relaxed inlining being enabled some tests were failing, so they were disabled.  
Also disabled one test because of [NomicFoundation/hardhat/#2115](https://github.com/NomicFoundation/hardhat/issues/2115). 