### PR TITLE
CI config tweaks after CircleCI review

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -735,7 +735,7 @@ jobs:
           name: Install Java
           command: |
             sudo apt -q update
-            sudo apt install -y openjdk-16-jdk
+            sudo apt install -y openjdk-17-jdk
       - run:
           name: Run tests
           command: ./scripts/test_antlr_grammar.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,17 +356,9 @@ defaults:
         TERM: xterm
         MAKEFLAGS: -j 10
 
-  - base_buildpack_focal_small: &base_buildpack_focal_small
+  - base_cimg_small: &base_cimg_small
       docker:
-        - image: buildpack-deps:focal
-      resource_class: small
-      environment:
-        TERM: xterm
-        MAKEFLAGS: -j 2
-
-  - base_buildpack_latest_small: &base_buildpack_latest_small
-      docker:
-        - image: buildpack-deps:latest
+        - image: cimg/base:current
       resource_class: small
       environment:
         TERM: xterm
@@ -681,12 +673,14 @@ jobs:
       - gitter_notify_failure_unless_pr
 
   chk_coding_style:
-    <<: *base_buildpack_focal_small
+    <<: *base_cimg_small
     steps:
       - checkout
       - run:
           name: Install shellcheck
-          command: apt -q update && apt install -y shellcheck
+          command: |
+            sudo apt -q update
+            sudo apt install -y shellcheck
       - run:
           name: Check for C++ coding style
           command: ./scripts/check_style.sh
@@ -708,12 +702,14 @@ jobs:
       - gitter_notify_failure_unless_pr
 
   chk_pylint:
-    <<: *base_buildpack_focal_small
+    <<: *base_cimg_small
     steps:
       - checkout
       - run:
           name: Install pip
-          command: apt -q update && apt install -y python3-pip
+          command: |
+            sudo apt -q update
+            sudo apt install -y python3-pip
       - run:
           name: Install pylint and dependencies of the scripts that will be linted
           command: python3 -m pip install
@@ -732,12 +728,14 @@ jobs:
       - gitter_notify_failure_unless_pr
 
   chk_antlr_grammar:
-    <<: *base_buildpack_focal_small
+    <<: *base_cimg_small
     steps:
       - checkout
       - run:
           name: Install Java
-          command: apt -q update && apt install -y openjdk-16-jdk
+          command: |
+            sudo apt -q update
+            sudo apt install -y openjdk-16-jdk
       - run:
           name: Run tests
           command: ./scripts/test_antlr_grammar.sh
@@ -759,14 +757,14 @@ jobs:
       - gitter_notify_failure_unless_pr
 
   chk_proofs:
-    <<: *base_buildpack_latest_small
+    <<: *base_cimg_small
     steps:
       - checkout
       - run:
           name: Z3 python deps
           command: |
-            apt-get -qq update
-            apt-get -qy install python3-pip
+            sudo apt-get -qq update
+            sudo apt-get -qy install python3-pip
             pip3 install --user z3-solver
       - run: *run_proofs
       - gitter_notify_failure_unless_pr
@@ -1405,6 +1403,10 @@ jobs:
 
   b_bytecode_ubu:
     <<: *base_ubuntu2004_small
+    environment:
+      TERM: xterm
+      MAKEFLAGS: -j 2
+      LC_ALL: C
     steps:
       - checkout
       - attach_workspace:
@@ -1414,6 +1416,10 @@ jobs:
 
   b_bytecode_osx:
     <<: *base_osx
+    environment:
+      TERM: xterm
+      MAKEFLAGS: -j 5
+      LC_ALL: C
     steps:
       - checkout
       - attach_workspace:
@@ -1449,6 +1455,7 @@ jobs:
     <<: *base_node_small
     environment:
       SOLC_EMSCRIPTEN: "On"
+      LC_ALL: C
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,11 +527,6 @@ defaults:
       requires:
         - b_win
 
-  - workflow_win_release: &workflow_win_release
-      <<: *workflow_trigger_on_tags
-      requires:
-        - b_win_release
-
   # --------------------------------------------------------------------------
   # Parameterized Job Templates
 
@@ -1373,11 +1368,6 @@ jobs:
             - .\test\*\soltest.exe
       - gitter_notify_failure_unless_pr
 
-  b_win_release:
-    <<: *b_win
-    environment:
-      FORCE_RELEASE: ON
-
   t_win_soltest: &t_win_soltest
     <<: *base_win_powershell
     steps:
@@ -1404,9 +1394,6 @@ jobs:
       - store_test_results: *store_test_results
       - store_artifacts: *artifacts_test_results
       - gitter_notify_failure_unless_pr
-
-  t_win_release_soltest:
-    <<: *t_win_soltest
 
   b_bytecode_ubu:
     <<: *base_ubuntu2004_small
@@ -1639,9 +1626,7 @@ workflows:
 
       # Windows build and tests
       - b_win: *workflow_trigger_on_tags
-      - b_win_release: *workflow_trigger_on_tags
       - t_win_soltest: *workflow_win
-      - t_win_release_soltest: *workflow_win_release
 
       # Bytecode comparison:
       - b_bytecode_ubu:
@@ -1674,7 +1659,7 @@ workflows:
           requires:
             - b_ubu_static
             - b_osx
-            - b_win_release
+            - b_win
             - b_ems
 
   nightly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -428,7 +428,7 @@ defaults:
 
   - base_python_small: &base_python_small
       docker:
-        - image: circleci/python:3.6
+        - image: cimg/python:3.6
       resource_class: small
       environment:
         TERM: xterm
@@ -436,7 +436,7 @@ defaults:
 
   - base_node_small: &base_node_small
       docker:
-        - image: circleci/node
+        - image: cimg/node:current
       resource_class: small
       environment:
         TERM: xterm
@@ -537,98 +537,97 @@ defaults:
       project: colony
       binary_type: solcjs
       compile_only: 1
-      nodejs_version: '14'
+      nodejs_version: '14.20'
+      python2: true
 
   - job_native_test_ext_gnosis: &job_native_test_ext_gnosis
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_gnosis
       project: gnosis
       binary_type: native
-      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
-      nodejs_version: '16'
+      nodejs_version: '16.18'
   - job_native_test_ext_zeppelin: &job_native_test_ext_zeppelin
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_zeppelin
       project: zeppelin
       binary_type: native
-      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
-      nodejs_version: '16'
+      nodejs_version: '16.18'
       resource_class: large
   - job_native_test_ext_ens: &job_native_test_ext_ens
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_ens
       project: ens
       binary_type: native
-      nodejs_version: '16'
+      nodejs_version: '16.18'
   - job_native_test_ext_trident: &job_native_test_ext_trident
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_trident
       project: trident
       binary_type: native
-      nodejs_version: '16'
+      nodejs_version: '16.18'
   - job_native_test_ext_euler: &job_native_test_ext_euler
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_euler
       project: euler
       binary_type: native
-      nodejs_version: '16'
+      nodejs_version: '16.18'
       resource_class: medium
   - job_native_test_ext_yield_liquidator: &job_native_test_ext_yield_liquidator
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_yield_liquidator
       project: yield-liquidator
       binary_type: native
-      nodejs_version: '16'
+      nodejs_version: '16.18'
   - job_native_test_ext_bleeps: &job_native_test_ext_bleeps
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_bleeps
       project: bleeps
       binary_type: native
-      nodejs_version: '16'
+      nodejs_version: '16.18'
       resource_class: medium
   - job_native_test_ext_pool_together: &job_native_test_ext_pool_together
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_pool_together
       project: pool-together
       binary_type: native
-      nodejs_version: '16'
+      nodejs_version: '16.18'
   - job_native_test_ext_perpetual_pools: &job_native_test_ext_perpetual_pools
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_perpetual_pools
       project: perpetual-pools
       binary_type: native
-      nodejs_version: '16'
+      nodejs_version: '16.18'
   - job_native_test_ext_uniswap: &job_native_test_ext_uniswap
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_uniswap
       project: uniswap
       binary_type: native
-      nodejs_version: '16'
+      nodejs_version: '16.18'
   - job_native_test_ext_prb_math: &job_native_test_ext_prb_math
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_prb_math
       project: prb-math
       binary_type: native
-      nodejs_version: '16'
+      nodejs_version: '16.18'
   - job_native_test_ext_elementfi: &job_native_test_ext_elementfi
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_elementfi
       project: elementfi
       binary_type: native
-      nodejs_version: '16'
+      nodejs_version: '16.18'
       resource_class: medium
   - job_native_test_ext_brink: &job_native_test_ext_brink
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_brink
       project: brink
       binary_type: native
-      nodejs_version: '16'
+      nodejs_version: '16.18'
   - job_native_test_ext_chainlink: &job_native_test_ext_chainlink
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_chainlink
       project: chainlink
       binary_type: native
-      nodejs_version: '16'
+      nodejs_version: '16.18'
       resource_class: large # Tests run out of memory on a smaller machine
   - job_native_test_ext_gp2: &job_native_test_ext_gp2
       <<: *workflow_ubuntu2004_static
@@ -636,14 +635,15 @@ defaults:
       project: gp2
       binary_type: native
       # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
-      nodejs_version: '16'
+      nodejs_version: '16.18'
   - job_ems_test_ext_colony: &job_ems_test_ext_colony
       <<: *workflow_emscripten
       name: t_ems_test_ext_colony
       project: colony
       binary_type: solcjs
-      nodejs_version: '14'
+      nodejs_version: '14.20'
       resource_class: medium
+      python2: true
 
   - job_b_ubu_asan_clang: &job_b_ubu_asan_clang
       <<: *workflow_trigger_on_tags
@@ -1178,7 +1178,7 @@ jobs:
   t_ems_ext_hardhat:
     <<: *base_node_small
     docker:
-      - image: circleci/node:16
+      - image: cimg/node:16.18
     environment:
       TERM: xterm
       HARDHAT_TESTS_SOLC_PATH: /tmp/workspace/soljson.js
@@ -1217,12 +1217,15 @@ jobs:
         default: 0
       nodejs_version:
         type: string
-        default: latest
+        default: current
       resource_class:
         type: string
         default: small
+      python2:
+        type: boolean
+        default: false
     docker:
-      - image: circleci/node:<<parameters.nodejs_version>>
+      - image: cimg/node:<<parameters.nodejs_version>>
     resource_class: <<parameters.resource_class>>
     # NOTE: Each external test runs up to 6 independent settings presets. If parallelism is higher than
     # actual preset count, some runs will exit immediately. If it's lower, some runs will get more than one preset.
@@ -1238,7 +1241,18 @@ jobs:
           name: Install lsof
           command: |
             # lsof is used by Colony in its stop-blockchain-client.sh script
+            sudo apt update
             sudo apt-get --quiet --assume-yes --no-install-recommends install lsof
+      - when:
+          condition: << parameters.python2 >>
+          steps:
+            - run:
+                name: Install Python 2 and make it the default
+                command: |
+                  # python is used by node-gyp to build native modules (needed for Colony).
+                  # In the 14.x image node-gyp still requires Python 2.
+                  sudo apt install python2 --assume-yes --no-install-recommends
+                  sudo update-alternatives --install /usr/bin/python python /usr/bin/python2 1
       - when:
           condition:
             equal: [<< parameters.binary_type >>, "solcjs"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,10 +390,10 @@ defaults:
         shell: powershell.exe
         size: large
 
-  - base_win_cmd: &base_win_cmd
+  - base_win_bash: &base_win_bash
       executor:
         name: win/default
-        shell: cmd.exe
+        shell: bash.exe
 
   - base_osx: &base_osx
       macos:
@@ -1428,7 +1428,9 @@ jobs:
           label: "osx"
 
   b_bytecode_win:
-    <<: *base_win_cmd
+    <<: *base_win_bash
+    environment:
+      LC_ALL: C
     steps:
       # NOTE: For bytecode generation we need the input files to be byte-for-byte identical on all
       # platforms so line ending conversions must absolutely be disabled.
@@ -1436,10 +1438,10 @@ jobs:
       - checkout
       - attach_workspace:
           at: build
-      - run: mkdir test-cases\
-      - run: cd test-cases\ && python ..\scripts\isolate_tests.py ..\test\
-      - run: cd test-cases\ && python ..\scripts\bytecodecompare\prepare_report.py ..\build\solc\Release\solc.exe --interface standard-json --report-file ..\bytecode-report-windows-json.txt
-      - run: cd test-cases\ && python ..\scripts\bytecodecompare\prepare_report.py ..\build\solc\Release\solc.exe --interface cli --report-file ..\bytecode-report-windows-cli.txt
+      - run: mkdir test-cases/
+      - run: cd test-cases/ && python ../scripts/isolate_tests.py ../test/
+      - run: cd test-cases/ && python ../scripts/bytecodecompare/prepare_report.py ../build/solc/Release/solc.exe --interface standard-json --report-file ../bytecode-report-windows-json.txt
+      - run: cd test-cases/ && python ../scripts/bytecodecompare/prepare_report.py ../build/solc/Release/solc.exe --interface cli --report-file ../bytecode-report-windows-cli.txt
       - store_artifacts:
           path: bytecode-report-windows-json.txt
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -472,10 +472,10 @@ defaults:
       requires:
         - b_ubu_clang
 
-  - workflow_ubuntu2004_release: &workflow_ubuntu2004_release
+  - workflow_ubuntu2004_force_release: &workflow_ubuntu2004_force_release
       <<: *workflow_trigger_on_tags
       requires:
-        - b_ubu_release
+        - b_ubu_force_release
 
   - workflow_ubuntu2004_static: &workflow_ubuntu2004_static
       <<: *workflow_trigger_on_tags
@@ -847,7 +847,7 @@ jobs:
       CMAKE_OPTIONS: << parameters.cmake_options >>
     <<: *steps_build
 
-  b_ubu_release: &b_ubu_release
+  b_ubu_force_release: &b_ubu_force_release
     <<: *b_ubu
     environment:
       FORCE_RELEASE: ON
@@ -1093,16 +1093,16 @@ jobs:
       SOLTEST_FLAGS: --no-smt
     <<: *steps_soltest
 
-  t_ubu_release_soltest_all: &t_ubu_release_soltest_all
+  t_ubu_force_release_soltest_all: &t_ubu_force_release_soltest_all
     # NOTE: This definition is identical to t_ubu_soltest_all but in the workflow we make it depend on
-    # a different job (b_ubu_release) so the workspace it attaches contains a different executable.
+    # a different job (b_ubu_force_release) so the workspace it attaches contains a different executable.
     <<: *t_ubu_soltest_all
 
   t_ubu_cli: &t_ubu_cli
     <<: *base_ubuntu2004_small
     <<: *steps_cmdline_tests
 
-  t_ubu_release_cli: &t_ubu_release_cli
+  t_ubu_force_release_cli: &t_ubu_force_release_cli
     <<: *t_ubu_cli
 
   t_ubu_locale:
@@ -1590,9 +1590,9 @@ workflows:
       - t_ubu_lsp: *workflow_ubuntu2004
 
       # Ubuntu fake release build and tests
-      - b_ubu_release: *workflow_trigger_on_tags
-      - t_ubu_release_cli: *workflow_ubuntu2004_release
-      - t_ubu_release_soltest_all: *workflow_ubuntu2004_release
+      - b_ubu_force_release: *workflow_trigger_on_tags
+      - t_ubu_force_release_cli: *workflow_ubuntu2004_force_release
+      - t_ubu_force_release_soltest_all: *workflow_ubuntu2004_force_release
 
       # Emscripten build and tests that take 15 minutes or less
       - b_ems: *workflow_trigger_on_tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -551,14 +551,13 @@ defaults:
       name: t_native_test_ext_zeppelin
       project: zeppelin
       binary_type: native
-      nodejs_version: '16.18'
       resource_class: large
   - job_native_test_ext_ens: &job_native_test_ext_ens
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_ens
       project: ens
       binary_type: native
-      nodejs_version: '16.18'
+      nodejs_version: '18.11'
   - job_native_test_ext_trident: &job_native_test_ext_trident
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_trident
@@ -570,20 +569,17 @@ defaults:
       name: t_native_test_ext_euler
       project: euler
       binary_type: native
-      nodejs_version: '16.18'
       resource_class: medium
   - job_native_test_ext_yield_liquidator: &job_native_test_ext_yield_liquidator
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_yield_liquidator
       project: yield-liquidator
       binary_type: native
-      nodejs_version: '16.18'
   - job_native_test_ext_bleeps: &job_native_test_ext_bleeps
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_bleeps
       project: bleeps
       binary_type: native
-      nodejs_version: '16.18'
       resource_class: medium
   - job_native_test_ext_pool_together: &job_native_test_ext_pool_together
       <<: *workflow_ubuntu2004_static
@@ -596,7 +592,7 @@ defaults:
       name: t_native_test_ext_perpetual_pools
       project: perpetual-pools
       binary_type: native
-      nodejs_version: '16.18'
+      nodejs_version: '18.11'
   - job_native_test_ext_uniswap: &job_native_test_ext_uniswap
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_uniswap
@@ -608,20 +604,19 @@ defaults:
       name: t_native_test_ext_prb_math
       project: prb-math
       binary_type: native
-      nodejs_version: '16.18'
+      nodejs_version: '18.11'
   - job_native_test_ext_elementfi: &job_native_test_ext_elementfi
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_elementfi
       project: elementfi
       binary_type: native
-      nodejs_version: '16.18'
       resource_class: medium
   - job_native_test_ext_brink: &job_native_test_ext_brink
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_brink
       project: brink
       binary_type: native
-      nodejs_version: '16.18'
+      nodejs_version: '18.11'
   - job_native_test_ext_chainlink: &job_native_test_ext_chainlink
       <<: *workflow_ubuntu2004_static
       name: t_native_test_ext_chainlink
@@ -634,8 +629,7 @@ defaults:
       name: t_native_test_ext_gp2
       project: gp2
       binary_type: native
-      # NOTE: Tests crash on nodejs 17: "Error: error:0308010C:digital envelope routines::unsupported"
-      nodejs_version: '16.18'
+      nodejs_version: '18.11'
   - job_ems_test_ext_colony: &job_ems_test_ext_colony
       <<: *workflow_emscripten
       name: t_ems_test_ext_colony
@@ -1178,7 +1172,7 @@ jobs:
   t_ems_ext_hardhat:
     <<: *base_node_small
     docker:
-      - image: cimg/node:16.18
+      - image: cimg/node:18.11
     environment:
       TERM: xterm
       HARDHAT_TESTS_SOLC_PATH: /tmp/workspace/soljson.js

--- a/.circleci/soltest.sh
+++ b/.circleci/soltest.sh
@@ -92,7 +92,7 @@ do
 done
 
 # wait for individual processes to get their exit status
-for pid in ${PIDs[*]}
+for pid in "${PIDs[@]}"
 do
     wait "$pid"
 done

--- a/scripts/bytecodecompare/storebytecode.sh
+++ b/scripts/bytecodecompare/storebytecode.sh
@@ -35,6 +35,9 @@ REPO_ROOT=$(pwd) # make it absolute
 
 BUILD_DIR="${1:-${REPO_ROOT}/build}"
 
+# Set locale to C to prevent it from affecting glob sort order.
+export LC_ALL=C
+
 echo "Compiling all test contracts into bytecode..."
 TMPDIR=$(mktemp -d)
 (

--- a/scripts/solc-bin/bytecode_reports_for_modified_binaries.sh
+++ b/scripts/solc-bin/bytecode_reports_for_modified_binaries.sh
@@ -104,6 +104,9 @@ tmp_dir=$(mktemp -d -t bytecode-reports-XXXXXX)
 solcjs_dir="$tmp_dir/solcjs"
 script_dir="$solidity_dir/scripts"
 
+# Set locale to C to prevent it from affecting glob sort order.
+export LC_ALL=C
+
 cd "$tmp_dir"
 
 git clone https://github.com/ethereum/solc-js.git "$solcjs_dir"


### PR DESCRIPTION
~Depends on #13063.~ Merged.

This is a bunch of CI tweaks addressing some of the [feeback we received in CircleCI's config review](https://gist.github.com/jenny-miggin/9578d2e52b383b3787e265c80e5f6b03). Here's an overview of what I'm changing:
1) I think that `b_win` job is superfluous given that we have `b_win_release` as well. They pretty much always fail or succeed together and for some reason `b_win` is actually sometimes not showing all compiler errors in its output and `b_win_release` does not have this problem. We're doing just fine with one job for macOS so I think we can do with one for Windows. macOS and Windows jobs are also the ones we're paying the most for so removing this is is going to be a big saving.
    - ~While at it I noticed that `b_osx` is actually running a release config, just like `b_win_release` so I also renamed it to `b_osx_release`.~ **EDIT 2022-10-24**: I misunderstood that. It was called `b_win_release` because it's built with `FORCE_RELEASE=ON`, not because it's a release build. All our macOS and Windows builds are release builds. So instead I'm now leaving it as is and renaming `b_ubu_release` to `b_ubu_force_release` to make this distinction clearer.
    - **2022-10-24**: I'm now removing `b_win_release` and leaving `b_win` in instead. We can't use `b_win_release` for bytecode comparison since it won't match version string of other, non-force-release binaries.
2) CircleCI has deprecated some of the images we're using (see [Legacy Convenience Image Deprecation](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034)) so I'm switching to alternatives:
    - `cimg/node` instead `circleci/node`. The downside here is that the tags for major node.js versions like 12, 14, 16, etc. are no longer available and it doesn't looks like they'll come back anytime soon (https://github.com/CircleCI-Public/cimg-node/issues/130). ~For now I had to specify it down to patch version.~ And we'll have to remember about keeping them up to date now. **EDIT** It's actually possible to specify it only down to minor version which improves the situation a little.
    - `cimg/base` instead of `circleci/buildpack-deps`. In some cases we were using specifically `circleci/buildpack-deps:focal` and this tag is not available for `cimg/base` but this was for jobs like pylint or grammar so I don't think this matters.
        - This actually revealed a small problem with our bytecode report scripts. Looks like the new image has a different default locale, which affects the sort order for Bash globs and for Python's `sorted()`. This affects cases like `input_sol.sol` vs `in_sol.sol` and makes the comparison fail. To fix this I explicitly set locale to `C` whenever we use these scripts.

There are two more things that require more work and are not urgent so I only created issues for them:
- #13057
- #13056