### PR TITLE
 Print settings options such evmVersion and optimize in isoltest/soltest failed test logs.

### DIFF
--- a/test/Common.h
+++ b/test/Common.h
@@ -81,6 +81,12 @@ struct CommonOptions
 	// Throws a ConfigException on error
 	virtual void validate() const;
 
+	/// @returns string with a key=value list of the options separated by comma
+	/// Ex.: "evmVersion=london, optimize=true, useABIEncoderV1=false"
+	virtual std::string toString(std::vector<std::string> const& _selectedOptions) const;
+	/// Helper to print the value of settings used
+	virtual void printSelectedOptions(std::ostream& _stream, std::string const& _linePrefix, std::vector<std::string> const& _selectedOptions) const;
+
 	static CommonOptions const& get();
 	static void setSingleton(std::unique_ptr<CommonOptions const>&& _instance);
 

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -315,6 +315,14 @@ TestCase::TestResult SemanticTest::run(ostream& _stream, string const& _linePref
 				throw;
 		}
 	}
+
+	if (result != TestResult::Success)
+		solidity::test::CommonOptions::get().printSelectedOptions(
+			_stream,
+			_linePrefix,
+			{"evmVersion", "optimize", "useABIEncoderV1", "batch"}
+		);
+
 	return result;
 }
 


### PR DESCRIPTION
Resolves #13065.