### PR TITLE
Revert workaround introduced in euler tests because it is no longer needed

### DIFF
--- a/test/externalTests/euler.sh
+++ b/test/externalTests/euler.sh
@@ -67,10 +67,6 @@ function euler_test
     sed -i "/expectError: 'JUNK_UPGRADE_TEST_FAILURE'/d" test/moduleUpgrade.js
     sed -i "/et\.expect(errMsg)\.to\.contain('e\/collateral-violation');/d" test/flashLoanNative.js
 
-    # One of the tests is currently broken in the upstream, due to changed behavior of chainid in @ethereumjs/vm.
-    # TODO: Remove this when https://github.com/euler-xyz/euler-contracts/issues/119 gets fixed.
-    sed -i 's/domainSeparatorMatch)\.to\.equal(true/domainSeparatorMatch)\.to\.equal(false/g' test/eulStakes.js
-
     neutralize_package_lock
     neutralize_package_json_hooks
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"


### PR DESCRIPTION
This reverts #13047 