### PR TITLE
Workaround for the spurious `control reaches end of non-void function` warning in GCC 12.1

### DIFF
--- a/libsmtutil/CVC4Interface.cpp
+++ b/libsmtutil/CVC4Interface.cpp
@@ -19,6 +19,7 @@
 #include <libsmtutil/CVC4Interface.h>
 
 #include <libsolutil/CommonIO.h>
+#include <libsolutil/Exceptions.h>
 
 #include <cvc4/util/bitvector.h>
 
@@ -289,6 +290,9 @@ CVC4::Expr CVC4Interface::toCVC4Expr(Expression const& _expr)
 	}
 
 	smtAssert(false, "");
+
+	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
+	throw exception();
 }
 
 CVC4::Type CVC4Interface::cvc4Sort(Sort const& _sort)

--- a/libsmtutil/CVC4Interface.cpp
+++ b/libsmtutil/CVC4Interface.cpp
@@ -278,7 +278,7 @@ CVC4::Expr CVC4Interface::toCVC4Expr(Expression const& _expr)
 			return m_context.mkExpr(CVC4::kind::APPLY_CONSTRUCTOR, c, arguments);
 		}
 
-		smtAssert(false, "");
+		smtAssert(false);
 	}
 	catch (CVC4::TypeCheckingException const& _e)
 	{
@@ -289,7 +289,7 @@ CVC4::Expr CVC4Interface::toCVC4Expr(Expression const& _expr)
 		smtAssert(false, _e.what());
 	}
 
-	smtAssert(false, "");
+	smtAssert(false);
 
 	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
 	throw exception();

--- a/libsmtutil/Z3Interface.cpp
+++ b/libsmtutil/Z3Interface.cpp
@@ -20,6 +20,7 @@
 
 #include <libsolutil/CommonData.h>
 #include <libsolutil/CommonIO.h>
+#include <libsolutil/Exceptions.h>
 
 #ifdef HAVE_Z3_DLOPEN
 #include <libsmtutil/Z3Loader.h>
@@ -271,6 +272,9 @@ z3::expr Z3Interface::toZ3Expr(Expression const& _expr)
 	}
 
 	smtAssert(false, "");
+
+	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
+	throw exception();
 }
 
 Expression Z3Interface::fromZ3Expr(z3::expr const& _expr)
@@ -379,6 +383,9 @@ Expression Z3Interface::fromZ3Expr(z3::expr const& _expr)
 		return Expression(_expr.decl().name().str(), arguments, fromZ3Sort(_expr.get_sort()));
 
 	smtAssert(false, "");
+
+	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
+	throw exception();
 }
 
 z3::sort Z3Interface::z3Sort(Sort const& _sort)

--- a/libsmtutil/Z3Interface.cpp
+++ b/libsmtutil/Z3Interface.cpp
@@ -264,14 +264,14 @@ z3::expr Z3Interface::toZ3Expr(Expression const& _expr)
 			return constructor(args);
 		}
 
-		smtAssert(false, "");
+		smtAssert(false);
 	}
 	catch (z3::exception const& _e)
 	{
 		smtAssert(false, _e.msg());
 	}
 
-	smtAssert(false, "");
+	smtAssert(false);
 
 	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
 	throw exception();
@@ -382,7 +382,7 @@ Expression Z3Interface::fromZ3Expr(z3::expr const& _expr)
 	)
 		return Expression(_expr.decl().name().str(), arguments, fromZ3Sort(_expr.get_sort()));
 
-	smtAssert(false, "");
+	smtAssert(false);
 
 	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
 	throw exception();

--- a/libsolidity/ast/ASTJsonImporter.cpp
+++ b/libsolidity/ast/ASTJsonImporter.cpp
@@ -229,6 +229,9 @@ ASTPointer<ASTNode> ASTJsonImporter::convertJsonToASTNode(Json::Value const& _js
 		return createDocumentation(_json);
 	else
 		astAssert(false, "Unknown type of ASTNode: " + nodeType);
+
+	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
+	throw exception();
 }
 
 // ============ functions to instantiate the AST-Nodes from Json-Nodes ==============
@@ -1073,6 +1076,9 @@ Visibility ASTJsonImporter::visibility(Json::Value const& _node)
 		return Visibility::External;
 	else
 		astAssert(false, "Unknown visibility declaration");
+
+	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
+	throw exception();
 }
 
 VariableDeclaration::Location ASTJsonImporter::location(Json::Value const& _node)
@@ -1092,6 +1098,9 @@ VariableDeclaration::Location ASTJsonImporter::location(Json::Value const& _node
 		return VariableDeclaration::Location::CallData;
 	else
 		astAssert(false, "Unknown location declaration");
+
+	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
+	throw exception();
 }
 
 Literal::SubDenomination ASTJsonImporter::subdenomination(Json::Value const& _node)
@@ -1125,6 +1134,9 @@ Literal::SubDenomination ASTJsonImporter::subdenomination(Json::Value const& _no
 		return Literal::SubDenomination::Year;
 	else
 		astAssert(false, "Unknown subdenomination");
+
+	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
+	throw exception();
 }
 
 StateMutability ASTJsonImporter::stateMutability(Json::Value const& _node)
@@ -1142,6 +1154,9 @@ StateMutability ASTJsonImporter::stateMutability(Json::Value const& _node)
 		return StateMutability::Payable;
 	else
 		astAssert(false, "Unknown stateMutability");
+
+	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
+	throw exception();
 }
 
 }

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1653,6 +1653,9 @@ ASTPointer<Statement> Parser::parseSimpleStatement(ASTPointer<ASTString> const& 
 			solAssert(false, "");
 		}
 	}
+
+	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
+	throw exception();
 }
 
 bool Parser::IndexAccessedPath::empty() const

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1637,7 +1637,7 @@ ASTPointer<Statement> Parser::parseSimpleStatement(ASTPointer<ASTString> const& 
 			return parseExpressionStatement(_docString, nodeFactory.createNode<TupleExpression>(components, false));
 		}
 		default:
-			solAssert(false, "");
+			solAssert(false);
 		}
 	}
 	else
@@ -1650,7 +1650,7 @@ ASTPointer<Statement> Parser::parseSimpleStatement(ASTPointer<ASTString> const& 
 		case LookAheadInfo::Expression:
 			return parseExpressionStatement(_docString, expressionFromIndexAccessStructure(iap));
 		default:
-			solAssert(false, "");
+			solAssert(false);
 		}
 	}
 
@@ -1661,9 +1661,8 @@ ASTPointer<Statement> Parser::parseSimpleStatement(ASTPointer<ASTString> const& 
 bool Parser::IndexAccessedPath::empty() const
 {
 	if (!indices.empty())
-	{
-		solAssert(!path.empty(), "");
-	}
+		solAssert(!path.empty());
+
 	return path.empty() && indices.empty();
 }
 

--- a/libyul/AsmJsonImporter.cpp
+++ b/libyul/AsmJsonImporter.cpp
@@ -110,6 +110,9 @@ Statement AsmJsonImporter::createStatement(Json::Value const& _node)
 		return createBlock(_node);
 	else
 		yulAssert(false, "Invalid nodeType as statement");
+
+	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
+	throw exception();
 }
 
 Expression AsmJsonImporter::createExpression(Json::Value const& _node)
@@ -129,6 +132,9 @@ Expression AsmJsonImporter::createExpression(Json::Value const& _node)
 		return createLiteral(_node);
 	else
 		yulAssert(false, "Invalid nodeType as expression");
+
+	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
+	throw exception();
 }
 
 vector<Expression> AsmJsonImporter::createExpressionVector(Json::Value const& _array)

--- a/libyul/backends/evm/StackHelpers.h
+++ b/libyul/backends/evm/StackHelpers.h
@@ -371,6 +371,9 @@ private:
 				return true;
 			}
 		yulAssert(false, "");
+
+		// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
+		throw std::exception();
 	}
 };
 

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -276,6 +276,9 @@ unique_ptr<FitnessMetric> FitnessMetricFactory::build(
 		default:
 			assertThrow(false, solidity::util::Exception, "Invalid MetricAggregatorChoice value.");
 	}
+
+	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
+	throw exception();
 }
 
 PopulationFactory::Options PopulationFactory::Options::fromCommandLine(po::variables_map const& _arguments)


### PR DESCRIPTION
**Depends on #13088**.

GCC 12.1 warns that `control reaches end of non-void function [-Wreturn-type]` in some places where our assertion macros guarantee that this can never happen.

This started happening for me when GCC 12.1 hit the core Arch Linux repos. The problem does not exist on earlier GCC or on Clang. [I have already reported it in GCC](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794) but for now we need a workaround. I added an explicit `throw` to make GCC shut up.