### PR TITLE
Fix new warnings from pylint 2.14 and adjust pylint config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -700,6 +700,7 @@ jobs:
             deepdiff
             colorama
             requests
+      - run: pylint --version
       - run:
           name: Linting Python Scripts
           command: ./scripts/pylint_all.py

--- a/scripts/gas_diff_stats.py
+++ b/scripts/gas_diff_stats.py
@@ -88,11 +88,11 @@ def collect_statistics(lines) -> (int, int, int, int, int, int):
     diff_kinds = [Diff.Minus, Diff.Plus]
     codegen_kinds = [Kind.IrOptimized, Kind.LegacyOptimized, Kind.Legacy]
     return tuple(
-        sum([
+        sum(
             val
             for (diff_kind, codegen_kind, val) in out
             if diff_kind == _diff_kind and codegen_kind == _codegen_kind
-        ])
+        )
         for _diff_kind in diff_kinds
         for _codegen_kind in codegen_kinds
     )

--- a/scripts/pylintrc
+++ b/scripts/pylintrc
@@ -17,7 +17,6 @@
 # TODO: What could be eliminated in future PRs: invalid-name, pointless-string-statement, redefined-outer-name.
 disable=
     bad-indentation,
-    bad-whitespace,
     duplicate-code,
     invalid-name,
     missing-docstring,


### PR DESCRIPTION
I just noticed that `chk_pylint` is failing in one of my PRs ([1078571](https://app.circleci.com/pipelines/github/ethereum/solidity/24513/workflows/24e787ce-ad27-49eb-b193-3960ee519399/jobs/1078571)). Looks like pylint 2.14 has been released.

```
************* Module /root/project/scripts/pylintrc
scripts/pylintrc:1:0: E0012: Bad option value for --disable. Don't recognize message bad-whitespace. (bad-option-value)
************* Module gas_diff_stats
scripts/gas_diff_stats.py:91:8: R1728: Consider using a generator instead 'sum(val for (diff_kind, codegen_kind, val) in out if diff_kind == _diff_kind and codegen_kind == _codegen_kind)' (consider-using-generator)
```

It's totally right about the generator. As for `bad-whitespace`, I'm not sure if it has been removed just now or if it's been deprecated for some time but this is something that does not make the job fail so it could have been there for quite some time. It also does not appear for me locally. Removing it does not hurt anyway.

I also added an extra CI step to print pylint version. Makes it easier to compare the version in CI with what I'm running locally.