### PR TITLE
Fixes to build with boost-1.79.0 and Clang on FreeBSD

### DIFF
--- a/libevmasm/GasMeter.cpp
+++ b/libevmasm/GasMeter.cpp
@@ -184,7 +184,7 @@ GasMeter::GasConsumption GasMeter::estimateMax(AssemblyItem const& _item, bool _
 				if (*value)
 				{
 					// Note: msb() counts from 0 and throws on 0 as input.
-					unsigned const significantByteCount  = (boost::multiprecision::msb(*value) + 1 + 7) / 8;
+					unsigned const significantByteCount  = (unsigned)((boost::multiprecision::msb(*value) + 1 + 7) / 8);
 					gas += GasCosts::expByteGas(m_evmVersion) * significantByteCount;
 				}
 			}

--- a/libsolidity/analysis/ConstantEvaluator.cpp
+++ b/libsolidity/analysis/ConstantEvaluator.cpp
@@ -49,7 +49,7 @@ bool fitsPrecisionExp(bigint const& _base, bigint const& _exp)
 
 	size_t const bitsMax = 4096;
 
-	unsigned mostSignificantBaseBit = boost::multiprecision::msb(_base);
+	auto mostSignificantBaseBit = boost::multiprecision::msb(_base);
 	if (mostSignificantBaseBit == 0) // _base == 1
 		return true;
 	if (mostSignificantBaseBit > bitsMax) // _base >= 2 ^ 4096

--- a/libsolutil/Numeric.cpp
+++ b/libsolutil/Numeric.cpp
@@ -31,7 +31,7 @@ bool solidity::fitsPrecisionBaseX(bigint const& _mantissa, double _log2OfBase, u
 
 	size_t const bitsMax = 4096;
 
-	unsigned mostSignificantMantissaBit = boost::multiprecision::msb(_mantissa);
+	auto mostSignificantMantissaBit = boost::multiprecision::msb(_mantissa);
 	if (mostSignificantMantissaBit > bitsMax) // _mantissa >= 2 ^ 4096
 		return false;
 


### PR DESCRIPTION
It was failing with messages like this:
> error: implicit conversion loses integer precision: 'typename std::enable_if<number_category<cpp_int_backend<0, 0, boost::multiprecision::signed_magnitude, boost::multiprecision::unchecked, allocator<unsigned long long>>>::value == number_kind_integer, std::size_t>::type' (aka 'unsigned long') to 'unsigned int'