### PR TITLE
Disabling more OpenZeppelin tests that expect reverts with specific error

### DIFF
--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -106,6 +106,11 @@ function zeppelin_test
     sed -i "s|it(\('other accounts cannot pause'\)|it.skip(\1|g" test/token/ERC721/presets/ERC721PresetMinterPauserAutoId.test.js
     sed -i "s|it(\('other accounts cannot unpause'\)|it.skip(\1|g" test/token/ERC721/presets/ERC721PresetMinterPauserAutoId.test.js
     sed -i "s|it(\('prevents initialization'\)|it.skip(\1|g" test/proxy/utils/Initializable.test.js
+    sed -i "s|it(\('divide by 0'\)|it.skip(\1|g" test/utils/math/Math.test.js
+    # CAUTION:: The following two sed commands depend on the order of occurrence of the relevant patterns in the mentioned files.
+    # Could result in an error in the future.
+    sed -zi "s|it(\('deposit'\)|it.skip(\1|3" test/token/ERC20/extensions/ERC20TokenizedVault.test.js
+    sed -zi "s|it(\('withdraw'\)|it.skip(\1|3" test/token/ERC20/extensions/ERC20TokenizedVault.test.js
 
     # TODO: Remove this when https://github.com/NomicFoundation/hardhat/issues/2115 gets fixed.
     sed -i "s|describe\(('Polygon-Child'\)|describe.skip\1|g" test/crosschain/CrossChainEnabled.test.js


### PR DESCRIPTION
Disabling more zeppline tests that expect reverts with specific errors and they're broken via IR due to Hardhat heuristics.