### PR TITLE
Moved Keywords section from 'Cheatsheet' to 'Units and Globally Available Variables'

### DIFF
--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -112,13 +112,3 @@ Modifiers
 - ``override``: States that this function, modifier or public state variable changes
   the behaviour of a function or modifier in a base contract.
 
-Reserved Keywords
-=================
-
-These keywords are reserved in Solidity. They might become part of the syntax in the future:
-
-``after``, ``alias``, ``apply``, ``auto``, ``byte``, ``case``, ``copyof``, ``default``,
-``define``, ``final``, ``implements``, ``in``, ``inline``, ``let``, ``macro``, ``match``,
-``mutable``, ``null``, ``of``, ``partial``, ``promise``, ``reference``, ``relocatable``,
-``sealed``, ``sizeof``, ``static``, ``supports``, ``switch``, ``typedef``, ``typeof``,
-``var``.

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -384,3 +384,14 @@ The following properties are available for an integer type ``T``:
 
 ``type(T).max``
     The largest value representable by type ``T``.
+
+Reserved Keywords
+=================
+
+These keywords are reserved in Solidity. They might become part of the syntax in the future:
+
+``after``, ``alias``, ``apply``, ``auto``, ``byte``, ``case``, ``copyof``, ``default``,
+``define``, ``final``, ``implements``, ``in``, ``inline``, ``let``, ``macro``, ``match``,
+``mutable``, ``null``, ``of``, ``partial``, ``promise``, ``reference``, ``relocatable``,
+``sealed``, ``sizeof``, ``static``, ``supports``, ``switch``, ``typedef``, ``typeof``,
+``var``.


### PR DESCRIPTION
Part of https://github.com/ethereum/solidity/issues/12934.
Moved the list of keywords to "Units and Globally Available Variables" from "CheatSheet"