### PR TITLE
Skipping benchmark diff when previous run failed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1257,12 +1257,17 @@ jobs:
               pr_id=$(echo "$CIRCLE_PULL_REQUEST" | sed 's|\(.*\)\/||')
               scripts_dir=../../../scripts
 
-              "${scripts_dir}/externalTests/download_benchmarks.py" --base-of-pr "$pr_id"
+              # Our main goal here is to provide new benchmarks, the diff is optional. When benchmarks from
+              # the previous run are not available for whatever reason, we still succeed and just skip the diff.
+              # download_benchmarks.py exits with status 2 in that case.
+              if "${scripts_dir}/externalTests/download_benchmarks.py" --base-of-pr "$pr_id" || [[ $? == 2 ]]; then
+                echo 'export SKIP_BENCHMARK_DIFF=true' >> $BASH_ENV
+              fi
             fi
       - run:
           name: Diff benchmarks
           command: |
-            if [[ $CIRCLE_PULL_REQUEST != "" ]]; then
+            if [[ $CIRCLE_PULL_REQUEST != "" && $SKIP_BENCHMARK_DIFF != "true" ]]; then
               cd reports/externalTests/
               mkdir diff/
               scripts_dir=../../scripts


### PR DESCRIPTION
This is a fix for the failure of `c_ext_benchmarks` that we observed in #13092.

Currently `download_benchmarks.py` fails when benchmarks on the base branch are not available for whatever reason. They may be unavailable either because `c_ext_benchmarks` on that branch failed (or did not run because of a failure of a dependency) or because the workflow is still in progress. This is what we want for CLI usage, since not being able to provide the benchmarks is technically a failure of the script. When running in CI, however, we only really want the job to fail in a situation where it's a fixable issue that requires attention. For example if we have a syntax error in the script, the job should fail but if the previous benchmark predictably is not (and will not be) available, we should just skip the diff and still provide the current benchmark so that the next run can use it.

This PR updates `download_benchmarks.py` so that it can signal what exactly happened via its exit code and makes `c_ext_benchmarks` job in CI use the code to decide whether to skip diffing or not. The script will also now print more concrete error messages when the job is not successful.

One further improvement we might make would be to retry the script if the workflow on the base branch is still running. For now I just went with the simplest solution: the script fails. This is actually the one situation where failing makes sense because the failure is transient and you can later use "Restart from failed" option in CircleCI to rerun just the benchmark job.