### PR TITLE
Better way to annotate unreachability in C++

### DIFF
--- a/libsmtutil/CVC4Interface.cpp
+++ b/libsmtutil/CVC4Interface.cpp
@@ -292,7 +292,7 @@ CVC4::Expr CVC4Interface::toCVC4Expr(Expression const& _expr)
 	smtAssert(false);
 
 	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
-	throw exception();
+	util::unreachable();
 }
 
 CVC4::Type CVC4Interface::cvc4Sort(Sort const& _sort)

--- a/libsmtutil/Z3Interface.cpp
+++ b/libsmtutil/Z3Interface.cpp
@@ -274,7 +274,7 @@ z3::expr Z3Interface::toZ3Expr(Expression const& _expr)
 	smtAssert(false);
 
 	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
-	throw exception();
+	util::unreachable();
 }
 
 Expression Z3Interface::fromZ3Expr(z3::expr const& _expr)
@@ -385,7 +385,7 @@ Expression Z3Interface::fromZ3Expr(z3::expr const& _expr)
 	smtAssert(false);
 
 	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
-	throw exception();
+	util::unreachable();
 }
 
 z3::sort Z3Interface::z3Sort(Sort const& _sort)

--- a/libsolidity/ast/ASTJsonImporter.cpp
+++ b/libsolidity/ast/ASTJsonImporter.cpp
@@ -231,7 +231,7 @@ ASTPointer<ASTNode> ASTJsonImporter::convertJsonToASTNode(Json::Value const& _js
 		astAssert(false, "Unknown type of ASTNode: " + nodeType);
 
 	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
-	throw exception();
+	util::unreachable();
 }
 
 // ============ functions to instantiate the AST-Nodes from Json-Nodes ==============
@@ -1078,7 +1078,7 @@ Visibility ASTJsonImporter::visibility(Json::Value const& _node)
 		astAssert(false, "Unknown visibility declaration");
 
 	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
-	throw exception();
+	util::unreachable();
 }
 
 VariableDeclaration::Location ASTJsonImporter::location(Json::Value const& _node)
@@ -1100,7 +1100,7 @@ VariableDeclaration::Location ASTJsonImporter::location(Json::Value const& _node
 		astAssert(false, "Unknown location declaration");
 
 	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
-	throw exception();
+	util::unreachable();
 }
 
 Literal::SubDenomination ASTJsonImporter::subdenomination(Json::Value const& _node)
@@ -1136,7 +1136,7 @@ Literal::SubDenomination ASTJsonImporter::subdenomination(Json::Value const& _no
 		astAssert(false, "Unknown subdenomination");
 
 	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
-	throw exception();
+	util::unreachable();
 }
 
 StateMutability ASTJsonImporter::stateMutability(Json::Value const& _node)
@@ -1156,7 +1156,7 @@ StateMutability ASTJsonImporter::stateMutability(Json::Value const& _node)
 		astAssert(false, "Unknown stateMutability");
 
 	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
-	throw exception();
+	util::unreachable();
 }
 
 }

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1655,7 +1655,7 @@ ASTPointer<Statement> Parser::parseSimpleStatement(ASTPointer<ASTString> const& 
 	}
 
 	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
-	throw exception();
+	util::unreachable();
 }
 
 bool Parser::IndexAccessedPath::empty() const

--- a/libsolutil/Assertions.h
+++ b/libsolutil/Assertions.h
@@ -40,6 +40,28 @@ namespace solidity::util
 #define ETH_FUNC __func__
 #endif
 
+#if defined(__GNUC__)
+// GCC 4.8+, Clang, Intel and other compilers compatible with GCC (-std=c++0x or above)
+[[noreturn]] inline __attribute__((always_inline)) void unreachable()
+{
+	__builtin_unreachable();
+}
+
+#elif defined(_MSC_VER) // MSVC
+
+[[noreturn]] __forceinline void unreachable()
+{
+	__assume(false);
+}
+
+#else
+
+[[noreturn]] inline void unreachable()
+{
+	solThrow(Exception, "Unreachable");
+}
+#endif
+
 namespace assertions
 {
 

--- a/libyul/AsmJsonImporter.cpp
+++ b/libyul/AsmJsonImporter.cpp
@@ -112,7 +112,7 @@ Statement AsmJsonImporter::createStatement(Json::Value const& _node)
 		yulAssert(false, "Invalid nodeType as statement");
 
 	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
-	throw exception();
+	util::unreachable();
 }
 
 Expression AsmJsonImporter::createExpression(Json::Value const& _node)
@@ -134,7 +134,7 @@ Expression AsmJsonImporter::createExpression(Json::Value const& _node)
 		yulAssert(false, "Invalid nodeType as expression");
 
 	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
-	throw exception();
+	util::unreachable();
 }
 
 vector<Expression> AsmJsonImporter::createExpressionVector(Json::Value const& _array)

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -278,7 +278,7 @@ unique_ptr<FitnessMetric> FitnessMetricFactory::build(
 	}
 
 	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
-	throw exception();
+	util::unreachable();
 }
 
 PopulationFactory::Options PopulationFactory::Options::fromCommandLine(po::variables_map const& _arguments)


### PR DESCRIPTION
At first my code (after OS upgrade) wasn't compiling anymore so I fixed it an then realized @cameel was faster in fixing (or working around) what GCC 12 is reporting.

I think however, that the above suggested way is probably the better way, generally, and also for future-use. What do you think @cameel ?

PR relates to #13087.