### PR TITLE
docs: add notice about `address` conversion prior to 0.8.0

### DIFF
--- a/docs/types/conversion.rst
+++ b/docs/types/conversion.rst
@@ -188,6 +188,10 @@ Addresses
 As described in :ref:`address_literals`, hex literals of the correct size that pass the checksum
 test are of ``address`` type. No other literals can be implicitly converted to the ``address`` type.
 
-Explicit conversions from ``bytes20`` or any integer type to ``address`` result in ``address payable``.
+Explicit conversions to ``address`` are allowed only from ``bytes20`` and ``uint160``.
 
-An ``address a`` can be converted to ``address payable`` via ``payable(a)``.
+An ``address a`` can be converted explicitly to ``address payable`` via ``payable(a)``.
+
+.. note::
+    Prior to version 0.8.0, it was possible to explicitly convert from any integer type (of any size, signed or unsigned) to  ``address`` or ``address payable``.
+    Starting with in 0.8.0 only conversion from ``uint160`` is allowed.


### PR DESCRIPTION
# What does this PR introduce?

Prior to Solidity 0.8.0, it was possible to **convert explicitly** any integer type (signed or unsigned) to the `address` type.

For instance, these Solidity code snippets would have compiled up to version 0.7.6:

```solidity
pragma solidity 0.7.6;

contract Address {

    function convertAddress(uint256 a) public pure returns (address) {
        return address(a);
    }

    function convertAddress(uint48 a) public pure returns (address) {
        return address(a);
    }

    function convertAddress(int8 a) public pure returns (address) {
        return address(a);
    }
    
}
```

## Docs changed introduced

This PR aims to clarify the change of behaviour in the Section **Types > Conversion > Address**, specifying that:

- explicit conversion from `uint160` is allowed.
- add a notice about the behaviour of explicit `address` conversion prior to 0.8.0.

Your commit messages should detail why you made your change in addition to what you did (unless it is a tiny change).