### PR TITLE
docs: specify memory-safe is available since 0.8.13 for inline assembly

### DIFF
--- a/docs/assembly.rst
+++ b/docs/assembly.rst
@@ -364,8 +364,9 @@ in memory is automatically considered memory-safe and does not need to be annota
     an assembly block as memory-safe, but violate one of the memory assumptions, this **will** lead to incorrect and
     undefined behaviour that cannot easily be discovered by testing.
 
+The annotation was introduced in version 0.8.13 and is not supported by older compilers.
 In case you are developing a library that is meant to be compatible across multiple versions
-of solidity, you can use a special comment to annotate an assembly block as memory-safe:
+of Solidity, you can use a special Natspec comment that has the same effect but is ignored in older versions:
 
 .. code-block:: solidity
 


### PR DESCRIPTION
# What does this PR introduce?

A very simple mention in the **inline-assembly** section in the docs about the new `("memory-safe")` feature.
Since it was introduced recently, I thought it would be good to mention it is available since 0.8.13, as devs using older compiler version like 0.8.7 might not guess it from the docs.

Not sure if it's in your conventions tho to mention the versions number directly in the docs content body.


