### PR TITLE
removed a duplicate word from a comment.

### DIFF
--- a/libsolidity/codegen/ContractCompiler.h
+++ b/libsolidity/codegen/ContractCompiler.h
@@ -36,7 +36,7 @@ namespace solidity::frontend
 
 /**
  * Code generator at the contract level. Can be used to generate code for exactly one contract
- * either either in "runtime mode" or "creation mode".
+ * either in "runtime mode" or "creation mode".
  */
 class ContractCompiler: private ASTConstVisitor
 {


### PR DESCRIPTION
One line 39 of `libsolidity/codegen/ContractCompiler.h` there was a duplicate word "either" which was removed.

```diff
- * either either in "runtime mode" or "creation mode".
+ * either in "runtime mode" or "creation mode". 
```