### PR TITLE
Changed sed command in `zeppelin.sh` to match renamed test file in openzeppelin project.

### DIFF
--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -109,8 +109,8 @@ function zeppelin_test
     sed -i "s|it(\('divide by 0'\)|it.skip(\1|g" test/utils/math/Math.test.js
     # CAUTION:: The following two sed commands depend on the order of occurrence of the relevant patterns in the mentioned files.
     # Could result in an error in the future.
-    sed -zi "s|it(\('deposit'\)|it.skip(\1|3" test/token/ERC20/extensions/ERC20TokenizedVault.test.js
-    sed -zi "s|it(\('withdraw'\)|it.skip(\1|3" test/token/ERC20/extensions/ERC20TokenizedVault.test.js
+    sed -zi "s|it(\('deposit'\)|it.skip(\1|3" test/token/ERC20/extensions/ERC4626.test.js
+    sed -zi "s|it(\('withdraw'\)|it.skip(\1|3" test/token/ERC20/extensions/ERC4626.test.js
 
     # TODO: Remove this when https://github.com/NomicFoundation/hardhat/issues/2115 gets fixed.
     sed -i "s|describe\(('Polygon-Child'\)|describe.skip\1|g" test/crosschain/CrossChainEnabled.test.js


### PR DESCRIPTION
After the merge of [openzeppelin-contracts#3467](https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3467) file `ERC20TokenizedVault.test.js` was renamed to `ERC4626.test.js`. There are two `sed` commands in the `zeppelin.sh` script which referenced that file and needed to be changed accordingly. 