### PR TITLE
Fix GCC compilation errors due to Boost 1.79 update

### DIFF
--- a/libevmasm/GasMeter.cpp
+++ b/libevmasm/GasMeter.cpp
@@ -184,7 +184,7 @@ GasMeter::GasConsumption GasMeter::estimateMax(AssemblyItem const& _item, bool _
 				if (*value)
 				{
 					// Note: msb() counts from 0 and throws on 0 as input.
-					unsigned const significantByteCount  = (boost::multiprecision::msb(*value) + 1 + 7) / 8;
+					unsigned const significantByteCount  = (static_cast<unsigned>(boost::multiprecision::msb(*value)) + 1u + 7u) / 8u;
 					gas += GasCosts::expByteGas(m_evmVersion) * significantByteCount;
 				}
 			}

--- a/libsolidity/analysis/ConstantEvaluator.cpp
+++ b/libsolidity/analysis/ConstantEvaluator.cpp
@@ -49,7 +49,7 @@ bool fitsPrecisionExp(bigint const& _base, bigint const& _exp)
 
 	size_t const bitsMax = 4096;
 
-	unsigned mostSignificantBaseBit = boost::multiprecision::msb(_base);
+	size_t mostSignificantBaseBit = static_cast<size_t>(boost::multiprecision::msb(_base));
 	if (mostSignificantBaseBit == 0) // _base == 1
 		return true;
 	if (mostSignificantBaseBit > bitsMax) // _base >= 2 ^ 4096

--- a/libsolutil/Numeric.cpp
+++ b/libsolutil/Numeric.cpp
@@ -31,7 +31,7 @@ bool solidity::fitsPrecisionBaseX(bigint const& _mantissa, double _log2OfBase, u
 
 	size_t const bitsMax = 4096;
 
-	unsigned mostSignificantMantissaBit = boost::multiprecision::msb(_mantissa);
+	size_t mostSignificantMantissaBit = static_cast<size_t>(boost::multiprecision::msb(_mantissa));
 	if (mostSignificantMantissaBit > bitsMax) // _mantissa >= 2 ^ 4096
 		return false;
 

--- a/libsolutil/Numeric.h
+++ b/libsolutil/Numeric.h
@@ -33,6 +33,9 @@
 #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 12)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overread"
+#pragma GCC diagnostic ignored "-Waggressive-loop-optimizations"
 #endif
 #include <boost/multiprecision/cpp_int.hpp>
 #if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 12)

--- a/test/FilesystemUtils.cpp
+++ b/test/FilesystemUtils.cpp
@@ -20,6 +20,8 @@
 
 #include <test/libsolidity/util/SoltestErrors.h>
 
+#include <fstream>
+
 using namespace std;
 using namespace solidity;
 using namespace solidity::test;

--- a/test/yulPhaser/AlgorithmRunner.cpp
+++ b/test/yulPhaser/AlgorithmRunner.cpp
@@ -31,6 +31,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/tools/output_test_stream.hpp>
 
+#include <fstream>
 #include <regex>
 #include <sstream>
 

--- a/test/yulPhaser/Phaser.cpp
+++ b/test/yulPhaser/Phaser.cpp
@@ -30,6 +30,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
+#include <fstream>
 
 using namespace std;
 using namespace solidity::test;


### PR DESCRIPTION
Replaces and closes #13090.

Attempt to fix https://app.circleci.com/pipelines/github/ethereum/solidity/24748/workflows/e6c3ff3b-a9f2-4832-aa2f-d64b66f03c5b/jobs/1089693