### PR TITLE
updated int assembly.rst (Sample program bug fix)

### DIFF
--- a/docs/assembly.rst
+++ b/docs/assembly.rst
@@ -108,7 +108,7 @@ efficient code, for example:
                 for
                     { let end := add(dataElementLocation, mul(len, 0x20)) }
                     lt(dataElementLocation, end)
-                    { data := add(dataElementLocation, 0x20) }
+                    { dataElementLocation := add(dataElementLocation, 0x20) }
                 {
                     sum := add(sum, mload(dataElementLocation))
                 }


### PR DESCRIPTION
fixed for loop bug in VectorSum.sumPureAsm function at line 42
# updated { data := add(dataElementLocation, 0x20) } to ----->  { dataElementLocation := add(dataElementLocation, 0x20) }
 in order to update dataElementLocation after every iteration. (Hence ending the loop)