### PR TITLE
Fix for library name updates in isoltest semantics tests.

### DIFF
--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -386,10 +386,7 @@ TestCase::TestResult SemanticTest::runTest(
 			// For convenience, in semantic tests we assume that an unqualified name like `L` is equivalent to one
 			// with an empty source unit name (`:L`). This is fine because the compiler never uses unqualified
 			// names in the Yul code it produces and does not allow `linkersymbol()` at all in inline assembly.
-			if (test.call().signature.find(':') == string::npos)
-				libraries[":" + test.call().signature] = m_contractAddress;
-			else
-				libraries[test.call().signature] = m_contractAddress;
+			libraries[test.call().libraryFile + ":" + test.call().signature] = m_contractAddress;
 			continue;
 		}
 		else

--- a/test/libsolidity/util/SoltestTypes.h
+++ b/test/libsolidity/util/SoltestTypes.h
@@ -268,6 +268,7 @@ struct FunctionValue
 struct FunctionCall
 {
 	/// Signature of the function call, e.g. `f(uint256, uint256)`.
+	/// For a library deployment, this contains the library name.
 	std::string signature;
 	/// Optional value that can be sent with the call.
 	/// Value is expressed in wei, smallest unit of ether
@@ -313,6 +314,8 @@ struct FunctionCall
 	std::vector<std::string> expectedSideEffects{};
 	/// A textual representation of the actual side-effect of the function call.
 	std::vector<std::string> actualSideEffects{};
+	/// File name of the library. Always empty, unless this is a library deployment call.
+	std::string libraryFile{};
 };
 
 using Builtin = std::function<std::optional<bytes>(FunctionCall const&)>;

--- a/test/libsolidity/util/TestFileParser.cpp
+++ b/test/libsolidity/util/TestFileParser.cpp
@@ -107,15 +107,15 @@ vector<solidity::frontend::test::FunctionCall> TestFileParser::parseFunctionCall
 							string libraryName;
 							if (accept(Token::String))
 							{
-								libraryName = m_scanner.currentLiteral();
+								call.libraryFile = m_scanner.currentLiteral();
 								expect(Token::String);
 								expect(Token::Colon);
-								libraryName += ':' + m_scanner.currentLiteral();
+								libraryName += m_scanner.currentLiteral();
 								expect(Token::Identifier);
 							}
 							else if (accept(Token::Colon, true))
 							{
-								libraryName = ':' + m_scanner.currentLiteral();
+								libraryName = m_scanner.currentLiteral();
 								expect(Token::Identifier);
 							}
 							else

--- a/test/libsolidity/util/TestFunctionCall.cpp
+++ b/test/libsolidity/util/TestFunctionCall.cpp
@@ -58,7 +58,10 @@ string TestFunctionCall::format(
 
 		if (m_call.kind == FunctionCall::Kind::Library)
 		{
-			stream << _linePrefix << newline << ws << "library:" << ws << m_call.signature;
+			stream << _linePrefix << newline << ws << "library:" << ws;
+			if (!m_call.libraryFile.empty())
+				stream << "\"" << m_call.libraryFile << "\":";
+			stream << m_call.signature;
 			return;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/13120.

However, this is again only a minimal hot fix for the issue.
What should really be done is to give those different kinds of function calls a proper structure instead of adding more most of the time unused fields and reusing fields with different meaning - e.g. it could be a variant.
And generally, the entire infrastructure here could probably be largely simplified.
Anyways, this adjustment here should fix the issue at hand.