### PR TITLE
Add Dockerfile for Legacy builds and cli shim helper. 

### DIFF
--- a/scripts/Dockerfile_legacy
+++ b/scripts/Dockerfile_legacy
@@ -1,0 +1,90 @@
+FROM ubuntu:14.04
+
+WORKDIR "/home"
+RUN sudo apt-get -y update
+RUN sudo apt-get -y install language-pack-en-base wget unzip
+RUN sudo dpkg-reconfigure locales
+RUN sudo apt-get -y install software-properties-common
+RUN sudo add-apt-repository -y ppa:george-edison55/cmake-3.x
+
+### need to update apt to ignore gpg checks
+### ubuntu 14.04 is using some old TLS encryption that dosen't share a cyper with modern repositories
+### https://askubuntu.com/questions/74345/how-do-i-bypass-ignore-the-gpg-signature-checks-of-apt
+#RUN wget --no-check-certificate -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+#RUN sudo add-apt-repository "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7 main"
+
+## these repos were used in legacy build instructions
+## and seem to no longer exist
+# RUN sudo add-apt-repository -y ppa:ethereum/ethereum-qt
+# RUN sudo add-apt-repository -y ppa:ethereum/ethereum
+# RUN sudo add-apt-repository -y ppa:ethereum/ethereum-dev
+
+
+RUN sudo apt-get -y update
+RUN sudo apt-get -y upgrade
+
+RUN sudo apt-get -y install build-essential git cmake libboost-all-dev libgmp-dev \
+libleveldb-dev libminiupnpc-dev libreadline-dev libncurses5-dev libcurl4-openssl-dev \
+libmicrohttpd-dev libjsoncpp-dev libargtable2-dev \
+libedit-dev mesa-common-dev ocl-icd-libopencl1 opencl-headers \
+ocl-icd-dev qtbase5-dev qt5-default qtdeclarative5-dev libqt5webkit5-dev \
+libv8-3.14-dev
+
+## these are failing to install and will need to be manually compiled
+# libqt5webengine5-dev libcryptopp-dev libv8-dev libjson-rpc-cpp-dev llvm-3.7-dev libgoogle-perftools-dev
+
+RUN git clone https://github.com/ethereum/cpp-ethereum-cmake
+WORKDIR "/home/cpp-ethereum-cmake"
+RUN git checkout 412c066ef83525c6d48217398fc200964df5737f
+
+## Manually build cryptopp 562
+WORKDIR "/home/"
+RUN mkdir cryptopp562
+WORKDIR "/home/cryptopp562"
+RUN wget --no-check-certificate https://cryptopp.com/cryptopp562.zip
+RUN unzip cryptopp562.zip
+# edit makefile to uncomment and enable -fPIC
+RUN sed -i 's/# CXXFLAGS += -fPIC/CXXFLAGS += -fPIC/g' GNUmakefile
+RUN make
+RUN sudo make install
+
+WORKDIR "/home/"
+RUN git clone --depth 1 --branch v2.2.2 https://github.com/gflags/gflags.git
+WORKDIR "/home/gflags"
+RUN cmake .
+RUN make
+RUN make install
+
+WORKDIR "/home/"
+RUN git clone --depth 1 --branch 2.7.fb https://github.com/facebook/rocksdb.git
+WORKDIR "/home/rocksdb"
+RUN make
+
+WORKDIR "/home/"
+RUN git clone --depth 1 --branch v0.4 https://github.com/cinemast/libjson-rpc-cpp.git
+WORKDIR "/home/libjson-rpc-cpp"
+RUN cmake .
+RUN make
+RUN make install
+
+WORKDIR "/home/"
+RUN git clone https://github.com/ethereumproject/cpp-ethereum.git
+WORKDIR "/home/cpp-ethereum"
+RUN git checkout tags/foundationwallet
+RUN cmake \
+    -DGUI=off \
+    -DROCKSDB_INCLUDE_DIR=/home/rocksdb/include \
+    -DROCKSDB_LIBRARY=/home/rocksdb \
+    .
+RUN make
+
+WORKDIR "/home/"
+RUN git clone --depth 1 --branch v0.1.2 https://github.com/ethereum/solidity.git
+WORKDIR "/home/solidity"
+# Need to patch CMAKELists
+RUN echo "set(CMAKE_CXX_FLAGS \"${CMAKE_CXX_FLAGS} -I${CMAKE_CURRENT_SOURCE_DIR}\")" > CMakeLists.txt
+RUN mkdir build
+WORKDIR "/home/solidity/build"
+RUN cmake ../
+RUN make
+ENTRYPOINT ["/home/cpp-ethereum/solc/solc"]

--- a/scripts/solc_shim_legacy
+++ b/scripts/solc_shim_legacy
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+NEWARGS=("$@")
+ARGLEN="${#NEWARGS[@]}"
+LASTARG=$(($ARGLEN-1))
+COMMANDSTR=("sudo" "docker" "run")
+
+echo -e "Args before processing len:${ARGLEN} ${NEWARGS[@]}";
+
+for i in "${!NEWARGS[@]}"
+do
+    if [[ "${NEWARGS[$i]}" == "--combined-json" ]]
+    then
+        echo -e "found --combined-json flag at $i\n"
+        NEXT=$(($i+1))
+        echo -e "what is next value? $NEXT  ${NEWARGS[$NEXT]}"
+        if [[ "${NEWARGS[$NEXT]}" == "abi" ]]
+        then
+            echo -e "following arg is abi \n"
+            NEWARGS[$NEXT]="json-abi"
+        fi
+    fi
+done
+
+# If last argumnent is a file path
+# mount it into the container as a volume
+# so solc can process in the container
+if [[ -e  ${NEWARGS[$LASTARG]} ]]
+then
+    echo -e "Last arg is a file ${NEWARGS[$LASTARG]}"
+    ARGPATH="${NEWARGS[$LASTARG]}"
+    FULLPATH=$(realpath $ARGPATH)
+    NEWARGS[$LASTARG]=$FULLPATH
+    COMMANDSTR+=("-v")
+    COMMANDSTR+=("${FULLPATH}:${FULLPATH}")
+fi
+COMMANDSTR+=("solidity-legacy")
+
+echo -e "FinalCommand: ${COMMANDSTR[@]} ${NEWARGS[@]}"
+eval "${COMMANDSTR[@]} ${NEWARGS[@]}"


### PR DESCRIPTION
This PR adds a "Legacy Dockerfile" in `scripts/Dockerfile_legacy`. This Dockerfile is an attempt to reproduce legacy solidity environments to examine ancient versions of solidity. The Dockerfile can be used to build a container that includes a `solc` executable with:

`docker build -f ./scripts/Dockerfile_legacy -t solidity-legacy .`

the container can then be used to invoke the `solc` executable:

```
docker run solidity-legac --version
solc, the solidity compiler commandline interface
Version: 0.1.0-cd6e4fd4/Release-Linux/g++/int
```

This PR also includes a bash shim that can be moved into `$PATH` to act as a proxy to the Docker container.

Creation of this Dockerfile and reproduction of the legacy environment was part of a research exercise to audit some deployed legacy contracts. The audit was looking specifically at a contract compiled with `v0.1.2` of solidity. Its not clear that this Dockerfile 100% accurately reproduces the `v0.1.2` build but comparing some deployed bytecode with output from this executable did produce a match.

I'm sharing this work in hopes it will be useful to others and maybe prompt further collaboration Its not clear what the source of truth is for the legacy source code. It appears that code was manually duplicate copied between multiple repositories at the time like: 
* https://github.com/ethereumproject/cpp-ethereum 
* https://github.com/ethereum/aleth 
* https://github.com/ethereum/cpp-ethereum-cmake 
and
* https://github.com/ethereum/solidity 

This docker file attempts to build from the `ethereum/solidity` repo but I think it is actually building from `cpp-ethereum` they seem circular dependant. Hopefully this will be helpful for anyone else doing research.
