### PR TITLE
Fix UTF-8 sequence validation when used with array literals.

### DIFF
--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -144,6 +144,7 @@ private:
 	void endVisit(TryStatement const& _tryStatement) override;
 	bool visit(WhileStatement const& _whileStatement) override;
 	bool visit(ForStatement const& _forStatement) override;
+	bool visit(Return const& _return) override;
 	void endVisit(Return const& _return) override;
 	void endVisit(EmitStatement const& _emit) override;
 	void endVisit(RevertStatement const& _revert) override;

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -287,6 +287,9 @@ struct ExpressionAnnotation: ASTAnnotation
 	/// Note that even the simplest expressions, like `(f)()`, result in an indirect call even if they consist of
 	/// values known at compilation time.
 	bool calledDirectly = false;
+
+	// Types that expression result is assigned to.
+	std::vector<Type const*> resultExpectedTypes;
 };
 
 struct IdentifierAnnotation: ExpressionAnnotation

--- a/test/libsolidity/semanticTests/array/copying/cleanup_during_multi_element_per_slot_copy.sol
+++ b/test/libsolidity/semanticTests/array/copying/cleanup_during_multi_element_per_slot_copy.sol
@@ -16,7 +16,7 @@ contract C {
 }
 // ----
 // constructor()
-// gas irOptimized: 237351
+// gas irOptimized: 224415
 // gas legacy: 221315
-// gas legacyOptimized: 185247
+// gas legacyOptimized: 208995
 // f() -> 0

--- a/test/libsolidity/semanticTests/array/function_type_inline_array_to_memory_array.sol
+++ b/test/libsolidity/semanticTests/array/function_type_inline_array_to_memory_array.sol
@@ -1,9 +1,7 @@
 contract C {
-    function externalDefault() external returns(uint) { return 11; }
     function externalView() external view returns(uint) { return 12; }
     function externalPure() external pure returns(uint) { return 13; }
 
-    function internalDefault() internal returns(uint) { return 21; }
     function internalView() internal view returns(uint) { return 22; }
     function internalPure() internal pure returns(uint) { return 23; }
 
@@ -41,9 +39,6 @@ contract C {
     }
 }
 // ----
-// TypeError 7407: (760-779): Type function () view external returns (uint256)[1] memory is not implicitly convertible to expected type function () external returns (uint256)[1] memory.
-// TypeError 7407: (812-826): Type function () view returns (uint256)[1] memory is not implicitly convertible to expected type function () returns (uint256)[1] memory.
-// TypeError 7407: (1230-1249): Type function () pure external returns (uint256)[1] memory is not implicitly convertible to expected type function () external returns (uint256)[1] memory.
-// TypeError 7407: (1282-1296): Type function () pure returns (uint256)[1] memory is not implicitly convertible to expected type function () returns (uint256)[1] memory.
-// TypeError 7407: (1688-1707): Type function () pure external returns (uint256)[1] memory is not implicitly convertible to expected type function () external returns (uint256)[1] memory.
-// TypeError 7407: (1737-1751): Type function () pure returns (uint256)[1] memory is not implicitly convertible to expected type function () returns (uint256)[1] memory.
+// testViewToDefault() -> 12, 22
+// testPureToDefault() -> 13, 23
+// testPureToView() -> 13, 23

--- a/test/libsolidity/semanticTests/functionTypes/function_implicit_conversion.sol
+++ b/test/libsolidity/semanticTests/functionTypes/function_implicit_conversion.sol
@@ -1,0 +1,41 @@
+contract C {
+    function externalView() external view returns(uint) { return 12; }
+    function externalPure() external pure returns(uint) { return 13; }
+
+    function internalView() internal view returns(uint) { return 22; }
+    function internalPure() internal pure returns(uint) { return 23; }
+
+    function testViewToDefault() public returns (uint, uint) {
+        function () external returns(uint) externalDefault;
+        function () internal returns(uint) internalDefault;
+
+        externalDefault = this.externalView;
+        internalDefault = internalView;
+
+        return (externalDefault(), internalDefault());
+    }
+
+    function testPureToDefault() public returns (uint, uint) {
+        function () external returns(uint) externalDefault;
+        function () internal returns(uint) internalDefault;
+
+        externalDefault = this.externalPure;
+        internalDefault = internalPure;
+
+        return (externalDefault(), internalDefault());
+    }
+
+    function testPureToView() public returns (uint, uint) {
+        function () external view returns(uint) externalView;
+        function () internal view returns(uint) internalView;
+
+        externalView = this.externalPure;
+        internalView = internalPure;
+
+        return (externalView(), internalView());
+    }
+}
+// ----
+// testViewToDefault() -> 12, 22
+// testPureToDefault() -> 13, 23
+// testPureToView() -> 13, 23

--- a/test/libsolidity/semanticTests/various/skip_dynamic_types_for_structs.sol
+++ b/test/libsolidity/semanticTests/various/skip_dynamic_types_for_structs.sol
@@ -20,6 +20,6 @@ contract C {
 
 // ----
 // g() -> 2, 6
-// gas irOptimized: 178637
+// gas irOptimized: 178634
 // gas legacy: 180945
 // gas legacyOptimized: 179460

--- a/test/libsolidity/syntaxTests/conversion/implicit_conversion_from_array_of_string_literals_to_calldata_string.sol
+++ b/test/libsolidity/syntaxTests/conversion/implicit_conversion_from_array_of_string_literals_to_calldata_string.sol
@@ -6,4 +6,9 @@ contract C {
     }
 }
 // ----
+// TypeError 6069: (123-126): Type literal_string "h" is not implicitly convertible to expected type string calldata.
+// TypeError 6069: (128-131): Type literal_string "e" is not implicitly convertible to expected type string calldata.
+// TypeError 6069: (133-136): Type literal_string "l" is not implicitly convertible to expected type string calldata.
+// TypeError 6069: (138-141): Type literal_string "l" is not implicitly convertible to expected type string calldata.
+// TypeError 6069: (143-146): Type literal_string "o" is not implicitly convertible to expected type string calldata.
 // TypeError 6359: (122-147): Return argument type string memory[5] memory is not implicitly convertible to expected type (type of first return variable) string calldata[5] calldata.

--- a/test/libsolidity/syntaxTests/inline_arrays/inline_array_with_invalid_utf8_sequences.sol
+++ b/test/libsolidity/syntaxTests/inline_arrays/inline_array_with_invalid_utf8_sequences.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f() public pure {
+        string[2] memory a2 = [string(bytes(hex'74000001')), string(bytes(hex'c0a80101'))];
+        string[2] memory a1 = [hex'74000001', hex'c0a80101'];
+    }
+}
+// ----
+// TypeError 6069: (182-195): Type literal_string hex"c0a80101" is not implicitly convertible to expected type string memory. Contains invalid UTF-8 sequence at position 4.

--- a/test/libsolidity/syntaxTests/inline_arrays/inline_array_with_invalid_utf8_sequences_index_access.sol
+++ b/test/libsolidity/syntaxTests/inline_arrays/inline_array_with_invalid_utf8_sequences_index_access.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        string memory s = [hex'74000001', hex'c0a80101'][1];
+    }
+}
+// ----
+// TypeError 6069: (86-99): Type literal_string hex"c0a80101" is not implicitly convertible to expected type string memory. Contains invalid UTF-8 sequence at position 4.

--- a/test/libsolidity/syntaxTests/inline_arrays/inline_array_with_invalid_utf8_sequences_storage.sol
+++ b/test/libsolidity/syntaxTests/inline_arrays/inline_array_with_invalid_utf8_sequences_storage.sol
@@ -1,0 +1,5 @@
+contract C {
+    string[2] data = [hex'74000001', hex'c0a80101'];
+}
+// ----
+// TypeError 6069: (50-63): Type literal_string hex"c0a80101" is not implicitly convertible to expected type string storage ref. Contains invalid UTF-8 sequence at position 4.

--- a/test/libsolidity/syntaxTests/inline_arrays/invalid_types_in_inline_array.sol
+++ b/test/libsolidity/syntaxTests/inline_arrays/invalid_types_in_inline_array.sol
@@ -4,4 +4,6 @@ contract C {
     }
 }
 // ----
+// TypeError 6069: (71-76): Type literal_string "foo" is not implicitly convertible to expected type uint256.
+// TypeError 6069: (78-82): Type bool is not implicitly convertible to expected type uint256.
 // TypeError 6378: (66-83): Unable to deduce common type for array elements.

--- a/test/libsolidity/syntaxTests/inline_arrays/multidimensional_inline_array_with_invalid_utf8_sequences.sol
+++ b/test/libsolidity/syntaxTests/inline_arrays/multidimensional_inline_array_with_invalid_utf8_sequences.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        string[2][2] memory a1 = [['foo', 'bar'], [hex'74000001', hex'c0a80101']];
+    }
+}
+// ----
+// TypeError 6069: (110-123): Type literal_string hex"c0a80101" is not implicitly convertible to expected type string memory. Contains invalid UTF-8 sequence at position 4.

--- a/test/libsolidity/syntaxTests/inline_arrays/nested_inline_array_with_invalid_utf8_sequences_index_access.sol
+++ b/test/libsolidity/syntaxTests/inline_arrays/nested_inline_array_with_invalid_utf8_sequences_index_access.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        string[2] memory s = [['foo', 'bar'], [hex'74000001', hex'c0a80101']][1];
+    }
+}
+// ----
+// TypeError 6069: (106-119): Type literal_string hex"c0a80101" is not implicitly convertible to expected type string memory. Contains invalid UTF-8 sequence at position 4.

--- a/test/libsolidity/syntaxTests/inline_arrays/return_inline_array_with_invalid_utf8_sequences.sol
+++ b/test/libsolidity/syntaxTests/inline_arrays/return_inline_array_with_invalid_utf8_sequences.sol
@@ -1,0 +1,11 @@
+contract C {
+    function f() public pure returns (string[2] memory) {
+        return [string(bytes(hex'74000001')), string(bytes(hex'c0a80101'))];
+    }
+
+    function g() public pure returns (string[2] memory) {
+        return [hex'74000001', hex'c0a80101'];
+    }
+}
+// ----
+// TypeError 6069: (244-257): Type literal_string hex"c0a80101" is not implicitly convertible to expected type string memory. Contains invalid UTF-8 sequence at position 4.

--- a/test/libsolidity/syntaxTests/inline_arrays/return_multidimensional_inline_array_with_invalid_utf8_sequences.sol
+++ b/test/libsolidity/syntaxTests/inline_arrays/return_multidimensional_inline_array_with_invalid_utf8_sequences.sol
@@ -1,0 +1,7 @@
+contract C {
+    function g() public pure returns (string[2][2] memory) {
+        return [['foo', 'bar'], [hex'74000001', hex'c0a80101']];
+    }
+}
+// ----
+// TypeError 6069: (122-135): Type literal_string hex"c0a80101" is not implicitly convertible to expected type string memory. Contains invalid UTF-8 sequence at position 4.


### PR DESCRIPTION
PR extends ExpressionAnnotation with new field that is used to keep variable types that expression results are eventually assigned to. So that, inline array components are converted directly to the final type without intermediate steps that relies on type deduction with mobile types usage. That allows to use all information about inline array components (e.g. literals) to decide if implicit conversion is possible or not.