### PR TITLE
docs: Disallow decimal literals with trailing dots

### DIFF
--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -448,8 +448,8 @@ Integer literals are formed from a sequence of digits in the range 0-9.
 They are interpreted as decimals. For example, ``69`` means sixty nine.
 Octal literals do not exist in Solidity and leading zeros are invalid.
 
-Decimal fractional literals are formed by a ``.`` with at least one number on
-one side.  Examples include ``1.``, ``.1`` and ``1.3``.
+Decimal fractional literals are formed by a ``.`` with at least one number after the decimal point.
+Examples include ``.1`` and ``1.3`` (but not ``1.``).
 
 Scientific notation in the form of ``2e10`` is also supported, where the
 mantissa can be fractional but the exponent has to be an integer.


### PR DESCRIPTION
Currently the documentation suggests that a decimal literal can omit the fractional part [1]:

> Decimal fractional literals are formed by a `.` with at least one number on one side. Examples include `1.`, `.1` and `1.3`.

However, commit ac68710 (May 30, 2018) disallowed trailing dots that are not followed by a number [2].

Using decimal literals of the form `1.` will actually result in a `ParserError` and so the docs should not recommend this form.

[1] https://docs.soliditylang.org/en/v0.8.15/types.html#rational-and-integer-literals
[2] https://github.com/ethereum/solidity/commit/ac6871078940f0ae4a47380091fc46ed46a63d0a