### PR TITLE
event and error selectors are now allowed to be compile time constants

### DIFF
--- a/test/libsolidity/syntaxTests/errors/error_selector_as_constant.sol
+++ b/test/libsolidity/syntaxTests/errors/error_selector_as_constant.sol
@@ -1,0 +1,7 @@
+contract C {
+    error Er();
+    function f() external {}
+    bytes4 constant errorSelector = Er.selector;
+}
+// ----
+// TypeError 8349: (95-106): Initial value for constant variable has to be compile-time constant.

--- a/test/libsolidity/syntaxTests/events/event_selector_as_constant.sol
+++ b/test/libsolidity/syntaxTests/events/event_selector_as_constant.sol
@@ -1,0 +1,8 @@
+contract C {
+    event Ev();
+    function f() external {}
+
+    bytes32 constant eventSelector = Ev.selector;
+}
+// ----
+// TypeError 8349: (96-107): Initial value for constant variable has to be compile-time constant.


### PR DESCRIPTION
closes #13137 