### PR TITLE
Update naming of Mainnet

### DIFF
--- a/liblangutil/EVMVersion.h
+++ b/liblangutil/EVMVersion.h
@@ -34,7 +34,7 @@ namespace solidity::langutil
 
 /**
  * A version specifier of the EVM we want to compile to.
- * Defaults to the latest version deployed on Ethereum mainnet at the time of compiler release.
+ * Defaults to the latest version deployed on Ethereum Mainnet at the time of compiler release.
  */
 class EVMVersion:
 	boost::less_than_comparable<EVMVersion>,

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -1285,7 +1285,7 @@ void CompilerStack::assemble(
 			"Contract code size is "s +
 			to_string(compiledContract.runtimeObject.bytecode.size()) +
 			" bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). "
-			"This contract may not be deployable on mainnet. "
+			"This contract may not be deployable on Mainnet. "
 			"Consider enabling the optimizer (with a low \"runs\" value!), "
 			"turning off revert strings, or using libraries."
 		);

--- a/test/externalTests/elementfi.sh
+++ b/test/externalTests/elementfi.sh
@@ -43,7 +43,7 @@ function elementfi_test
     local config_var=config
 
     local compile_only_presets=(
-        # ElementFi's test suite is hard-coded for mainnet forked via alchemy.io.
+        # ElementFi's test suite is hard-coded for Mainnet forked via alchemy.io.
         # Locally we can only compile.
         #ir-no-optimize           # Compilation fails with "YulException: Variable var_amount_9311 is 10 slot(s) too deep inside the stack."
         #ir-optimize-evm-only     # Compilation fails with "YulException: Variable var_amount_9311 is 10 slot(s) too deep inside the stack."
@@ -87,7 +87,7 @@ function elementfi_test
     sed -i 's|bytes32(uint256(pool))|bytes32(uint256(uint160(pool)))|g' vault/PoolRegistry.sol
     popd
 
-    # The test suite uses forked mainnet and an expiration period that's too short.
+    # The test suite uses forked Mainnet and an expiration period that's too short.
     # TODO: Remove when https://github.com/element-fi/elf-contracts/issues/243 is fixed.
     sed -i 's|^\s*require(_expiration - block\.timestamp < _unitSeconds);\s*$||g' contracts/ConvergentCurvePool.sol
 

--- a/test/libsolidity/syntaxTests/bytecode_too_large.sol
+++ b/test/libsolidity/syntaxTests/bytecode_too_large.sol
@@ -9,4 +9,4 @@ contract test {
 // ====
 // EVMVersion: >byzantium
 // ----
-// Warning 5574: (21-27154): Contract code size is 27199 bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on mainnet. Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.
+// Warning 5574: (21-27154): Contract code size is 27199 bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on Mainnet. Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.

--- a/test/libsolidity/syntaxTests/bytecode_too_large_abiencoder_v1.sol
+++ b/test/libsolidity/syntaxTests/bytecode_too_large_abiencoder_v1.sol
@@ -9,4 +9,4 @@ contract test {
 // ====
 // EVMVersion: >byzantium
 // ----
-// Warning 5574: (21-27154): Contract code size is 27209 bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on mainnet. Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.
+// Warning 5574: (21-27154): Contract code size is 27209 bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on Mainnet. Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.

--- a/test/libsolidity/syntaxTests/bytecode_too_large_byzantium.sol
+++ b/test/libsolidity/syntaxTests/bytecode_too_large_byzantium.sol
@@ -7,4 +7,4 @@ contract test {
 // ====
 // EVMVersion: =byzantium
 // ----
-// Warning 5574: (0-27133): Contract code size is 27227 bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on mainnet. Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.
+// Warning 5574: (0-27133): Contract code size is 27227 bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on Mainnet. Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.


### PR DESCRIPTION
Achieves compliance with https://eips.ethereum.org/EIPS/eip-2228