### PR TITLE
Fix C++ compilation errors on 32-bit Raspbian due to `unsigned` -> `int` conversion

### DIFF
--- a/test/Metadata.cpp
+++ b/test/Metadata.cpp
@@ -136,7 +136,7 @@ private:
 	}
 	bytes readBytes(unsigned length)
 	{
-		bytes ret{m_metadata.begin() + m_pos, m_metadata.begin() + m_pos + length};
+		bytes ret{m_metadata.begin() + static_cast<int>(m_pos), m_metadata.begin() + static_cast<int>(m_pos + length)};
 		m_pos += length;
 		return ret;
 	}

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -141,7 +141,7 @@ namespace
 			ControlFlowGraph cfg(output);
 			AssemblyItems optItems;
 			for (BasicBlock const& block: cfg.optimisedBlocks())
-				copy(output.begin() + block.begin, output.begin() + block.end,
+				copy(output.begin() + static_cast<int>(block.begin), output.begin() + static_cast<int>(block.end),
 					 back_inserter(optItems));
 			output = move(optItems);
 		}

--- a/test/libsolidity/util/TestFileParser.h
+++ b/test/libsolidity/util/TestFileParser.h
@@ -98,7 +98,7 @@ private:
 		void advance(unsigned n = 1)
 		{
 			solAssert(m_char != m_source.end(), "Cannot advance beyond end.");
-			m_char = std::next(m_char, n);
+			m_char = std::next(m_char, static_cast<int>(n));
 		}
 
 		/// Returns the current character or '\0' if at end of input.


### PR DESCRIPTION
Test cases were getting build errors with - simple problems with unsigned vs int - static_cast applied.  

- BOOST_LIB_VERSION "1_79"
- g++ (Raspbian 8.3.0-6+rpi1) 8.3.0
- 5.10.17-v7l+ armv7l GNU/Linux