### PR TITLE
feat(parsing): allow trailing commas in some places

### DIFF
--- a/docs/grammar/SolidityParser.g4
+++ b/docs/grammar/SolidityParser.g4
@@ -102,7 +102,7 @@ namedArgument: name=identifier Colon value=expression;
  * Arguments when calling a function or a similar callable object.
  * The arguments are either given as comma separated list or as map of named arguments.
  */
-callArgumentList: LParen ((expression (Comma expression)*)? | LBrace (namedArgument (Comma namedArgument)*)? RBrace) RParen;
+callArgumentList: LParen ((expression (Comma expression)* Comma?)? | LBrace (namedArgument (Comma namedArgument)* Comma?)? RBrace) RParen;
 /**
  * Qualified name.
  */
@@ -120,7 +120,7 @@ visibility: Internal | External | Private | Public;
 /**
  * A list of parameters, such as function arguments or return values.
  */
-parameterList: parameters+=parameterDeclaration (Comma parameters+=parameterDeclaration)*;
+parameterList: parameters+=parameterDeclaration (Comma parameters+=parameterDeclaration)* Comma?;
 //@doc:inline
 parameterDeclaration: type=typeName location=dataLocation? name=identifier?;
 /**
@@ -150,7 +150,7 @@ stateMutability: Pure | View | Payable;
  * In cases where there are ambiguous declarations in several base contracts being overridden,
  * a complete list of base contracts has to be given.
  */
-overrideSpecifier: Override (LParen overrides+=identifierPath (Comma overrides+=identifierPath)* RParen)?;
+overrideSpecifier: Override (LParen overrides+=identifierPath (Comma overrides+=identifierPath)* Comma? RParen)?;
 /**
  * The definition of contract, library and interface functions.
  * Depending on the context in which the function is defined, further restrictions may apply,
@@ -249,7 +249,7 @@ structMember: type=typeName name=identifier Semicolon;
 /**
  * Definition of an enum. Can occur at top-level within a source unit or within a contract, library or interface.
  */
-enumDefinition:	Enum name=identifier LBrace enumValues+=identifier (Comma enumValues+=identifier)* RBrace;
+enumDefinition:	Enum name=identifier LBrace enumValues+=identifier (Comma enumValues+=identifier)* Comma? RBrace;
 /**
  * Definition of a user defined value type. Can occur at top-level within a source unit or within a contract, library or interface.
  */
@@ -295,7 +295,7 @@ eventParameter: type=typeName Indexed? name=identifier?;
  */
 eventDefinition:
 	Event name=identifier
-	LParen (parameters+=eventParameter (Comma parameters+=eventParameter)*)? RParen
+	LParen (parameters+=eventParameter (Comma parameters+=eventParameter)*)? Comma? RParen
 	Anonymous?
 	Semicolon;
 
@@ -308,14 +308,14 @@ errorParameter: type=typeName name=identifier?;
  */
 errorDefinition:
 	Error name=identifier
-	LParen (parameters+=errorParameter (Comma parameters+=errorParameter)*)? RParen
+	LParen (parameters+=errorParameter (Comma parameters+=errorParameter)*)? Comma? RParen
 	Semicolon;
 
 /**
  * Using directive to bind library functions and free functions to types.
  * Can occur within contracts and libraries and at the file level.
  */
-usingDirective: Using (identifierPath | (LBrace identifierPath (Comma identifierPath)* RBrace)) For (Mul | typeName) Global? Semicolon;
+usingDirective: Using (identifierPath | (LBrace identifierPath (Comma identifierPath)* Comma? RBrace)) For (Mul | typeName) Global? Semicolon;
 /**
  * A type name can be an elementary type, a function type, a mapping type, a user-defined type
  * (e.g. a contract or struct) or an array type.
@@ -349,7 +349,7 @@ expression:
 	expression LBrack index=expression? RBrack # IndexAccess
 	| expression LBrack start=expression? Colon end=expression? RBrack # IndexRangeAccess
 	| expression Period (identifier | Address) # MemberAccess
-	| expression LBrace (namedArgument (Comma namedArgument)*)? RBrace # FunctionCallOptions
+	| expression LBrace (namedArgument (Comma namedArgument)* Comma?)? RBrace # FunctionCallOptions
 	| expression callArgumentList # FunctionCall
 	| Payable callArgumentList # PayableConversion
 	| Type LParen typeName RParen # MetaType
@@ -384,7 +384,7 @@ tupleExpression: LParen (expression? ( Comma expression?)* ) RParen;
 /**
  * An inline array expression denotes a statically sized array of the common type of the contained expressions.
  */
-inlineArrayExpression: LBrack (expression ( Comma expression)* ) RBrack;
+inlineArrayExpression: LBrack (expression ( Comma expression)* Comma?) RBrack;
 
 /**
  * Besides regular non-keyword Identifiers, some keywords like 'from' and 'error' can also be used as identifiers.

--- a/docs/grammar/SolidityParser.g4
+++ b/docs/grammar/SolidityParser.g4
@@ -46,7 +46,7 @@ path: NonEmptyStringLiteral;
 /**
  * List of aliases for symbols to be imported.
  */
-symbolAliases: LBrace aliases+=importAliases (Comma aliases+=importAliases)* RBrace;
+symbolAliases: LBrace aliases+=importAliases (Comma aliases+=importAliases)* Comma? RBrace;
 
 /**
  * Top-level definition of a contract.

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -490,6 +490,9 @@ ASTPointer<OverrideSpecifier> Parser::parseOverrideSpecifier()
 				break;
 
 			expectToken(Token::Comma);
+
+			if (currentToken() == Token::RParen)
+				break;
 		}
 
 		nodeFactory.markEndPosition();
@@ -977,6 +980,10 @@ ASTPointer<UsingForDirective> Parser::parseUsingDirective()
 			functions.emplace_back(parseIdentifierPath());
 		}
 		while (m_scanner->currentToken() == Token::Comma);
+
+		if (currentToken() == Token::Comma)
+			advance();
+
 		expectToken(Token::RBrace);
 	}
 	else

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -712,7 +712,7 @@ ASTPointer<EnumDefinition> Parser::parseEnumDefinition()
 		if (m_scanner->currentToken() == Token::RBrace)
 			break;
 		expectToken(Token::Comma);
-		if (m_scanner->currentToken() != Token::Identifier)
+		if (m_scanner->currentToken() != Token::Identifier && m_scanner->peekNextToken() != Token::RBrace)
 			fatalParserError(1612_error, "Expected identifier after ','");
 	}
 	if (members.empty())
@@ -2032,7 +2032,10 @@ ASTPointer<Expression> Parser::parsePrimaryExpression()
 				if (m_scanner->currentToken() != Token::Comma && m_scanner->currentToken() != oppositeToken)
 					components.push_back(parseExpression());
 				else if (isArray)
-					parserError(4799_error, "Expected expression (inline array elements cannot be omitted).");
+					if (m_scanner->currentToken() == oppositeToken)
+						break;
+					else
+						parserError(4799_error, "Expected expression (inline array elements cannot be omitted).");
 				else
 					components.push_back(ASTPointer<Expression>());
 

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1207,7 +1207,10 @@ ASTPointer<ParameterList> Parser::parseParameterList(
 		while (m_scanner->currentToken() != Token::RParen)
 		{
 			if (m_scanner->currentToken() == Token::Comma && m_scanner->peekNextToken() == Token::RParen)
-				fatalParserError(7591_error, "Unexpected trailing comma in parameter list.");
+			{
+				advance();
+				break;
+			}
 			expectToken(Token::Comma);
 			parameters.push_back(parseVariableDeclaration(options));
 		}
@@ -2125,7 +2128,6 @@ Parser::FunctionCallArguments Parser::parseNamedArguments()
 			m_scanner->peekNextToken() == Token::RBrace
 		)
 		{
-			parserError(2074_error, "Unexpected trailing comma.");
 			advance();
 		}
 

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -277,6 +277,11 @@ ASTPointer<ImportDirective> Parser::parseImportDirective()
 				symbolAliases.emplace_back(ImportDirective::SymbolAlias{move(id), move(alias), aliasLocation});
 				if (m_scanner->currentToken() != Token::Comma)
 					break;
+				else if (m_scanner->peekNextToken() == Token::RBrace)
+				{
+					advance();
+					break;
+				}
 				advance();
 			}
 			expectToken(Token::RBrace);
@@ -491,7 +496,7 @@ ASTPointer<OverrideSpecifier> Parser::parseOverrideSpecifier()
 
 			expectToken(Token::Comma);
 
-			if (currentToken() == Token::RParen)
+			if (m_scanner->currentToken() == Token::RParen)
 				break;
 		}
 
@@ -981,7 +986,7 @@ ASTPointer<UsingForDirective> Parser::parseUsingDirective()
 		}
 		while (m_scanner->currentToken() == Token::Comma);
 
-		if (currentToken() == Token::Comma)
+		if (m_scanner->currentToken() == Token::Comma)
 			advance();
 
 		expectToken(Token::RBrace);

--- a/test/libsolidity/syntaxTests/inheritance/override/override_multiple_fail1.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/override_multiple_fail1.sol
@@ -1,8 +1,0 @@
-contract A {
-	function foo() internal returns (uint256);
-}
-contract X {
-	int public override(A,) testvar;
-}
-// ----
-// ParserError 2314: (95-96): Expected identifier but got ')'

--- a/test/libsolidity/syntaxTests/inheritance/override/override_multiple_trailing_comma.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/override_multiple_trailing_comma.sol
@@ -1,0 +1,7 @@
+abstract contract A {
+	function foo() internal virtual returns (uint256);
+}
+abstract contract X is A {
+	function foo() internal override(A,) virtual returns (uint256);
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/array_trailing_comma.sol
+++ b/test/libsolidity/syntaxTests/parsing/array_trailing_comma.sol
@@ -1,0 +1,4 @@
+contract c {
+    function test() public pure returns (uint8[3] memory arr) { arr = [1, 2, 3, ]; }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/enum_declaration_identifier_expected.sol
+++ b/test/libsolidity/syntaxTests/parsing/enum_declaration_identifier_expected.sol
@@ -1,0 +1,5 @@
+contract c {
+	enum foo { WARNING, 1, }
+}
+// ----
+// ParserError 1612: (34-35): Expected identifier after ','

--- a/test/libsolidity/syntaxTests/parsing/enum_declaration_trailing_comma.sol
+++ b/test/libsolidity/syntaxTests/parsing/enum_declaration_trailing_comma.sol
@@ -1,0 +1,5 @@
+contract c {
+	enum foo { WARNING,}
+}
+// ----
+

--- a/test/libsolidity/syntaxTests/parsing/import_aliases_trailing_comma.sol
+++ b/test/libsolidity/syntaxTests/parsing/import_aliases_trailing_comma.sol
@@ -1,0 +1,5 @@
+==== Source: a ====
+contract A {}
+==== Source: b ====
+import {A as AliasedA, } from "a";
+// ----

--- a/test/libsolidity/syntaxTests/parsing/malformed_enum_declaration.sol
+++ b/test/libsolidity/syntaxTests/parsing/malformed_enum_declaration.sol
@@ -1,5 +1,0 @@
-contract c {
-	enum foo { WARNING,}
-}
-// ----
-// ParserError 1612: (33-34): Expected identifier after ','

--- a/test/libsolidity/syntaxTests/parsing/multiple_event_arg_trailing_comma.sol
+++ b/test/libsolidity/syntaxTests/parsing/multiple_event_arg_trailing_comma.sol
@@ -1,6 +1,4 @@
 contract test {
     event Test(uint a, uint b,);
-    function(uint a) {}
 }
 // ----
-// ParserError 7591: (45-46): Unexpected trailing comma in parameter list.

--- a/test/libsolidity/syntaxTests/parsing/multiple_function_param_trailing_comma.sol
+++ b/test/libsolidity/syntaxTests/parsing/multiple_function_param_trailing_comma.sol
@@ -1,5 +1,5 @@
 contract test {
-	function(uint a, uint b,) {}
+	function Test(uint a, uint b,) public {}
 }
 // ----
-// ParserError 7591: (40-41): Unexpected trailing comma in parameter list.
+

--- a/test/libsolidity/syntaxTests/parsing/multiple_modifier_arg_trailing_comma.sol
+++ b/test/libsolidity/syntaxTests/parsing/multiple_modifier_arg_trailing_comma.sol
@@ -1,6 +1,4 @@
 contract test {
     modifier modTest(uint a, uint b,) { _; }
-    function(uint a) {}
 }
 // ----
-// ParserError 7591: (51-52): Unexpected trailing comma in parameter list.

--- a/test/libsolidity/syntaxTests/parsing/multiple_return_param_trailing_comma.sol
+++ b/test/libsolidity/syntaxTests/parsing/multiple_return_param_trailing_comma.sol
@@ -1,5 +1,4 @@
 contract test {
-    function() returns (uint a, uint b,) {}
+    function Test() public returns (uint a, uint b,) {}
 }
 // ----
-// ParserError 7591: (54-55): Unexpected trailing comma in parameter list.

--- a/test/libsolidity/syntaxTests/parsing/single_event_arg_trailing_comma.sol
+++ b/test/libsolidity/syntaxTests/parsing/single_event_arg_trailing_comma.sol
@@ -1,6 +1,4 @@
 contract test {
 	event Test(uint a,);
-	function(uint a) {}
 }
 // ----
-// ParserError 7591: (34-35): Unexpected trailing comma in parameter list.

--- a/test/libsolidity/syntaxTests/parsing/single_function_param_trailing_comma.sol
+++ b/test/libsolidity/syntaxTests/parsing/single_function_param_trailing_comma.sol
@@ -1,5 +1,4 @@
 contract test {
-	function(uint a,) {}
+	function Test(uint a,) public {}
 }
 // ----
-// ParserError 7591: (32-33): Unexpected trailing comma in parameter list.

--- a/test/libsolidity/syntaxTests/parsing/single_modifier_arg_trailing_comma.sol
+++ b/test/libsolidity/syntaxTests/parsing/single_modifier_arg_trailing_comma.sol
@@ -1,6 +1,4 @@
 contract test {
 	modifier modTest(uint a,) { _; }
-	function(uint a) {}
 }
 // ----
-// ParserError 7591: (40-41): Unexpected trailing comma in parameter list.

--- a/test/libsolidity/syntaxTests/parsing/single_return_param_trailing_comma.sol
+++ b/test/libsolidity/syntaxTests/parsing/single_return_param_trailing_comma.sol
@@ -1,5 +1,4 @@
 contract test {
-	function() returns (uint a,) {}
+	function Test() public returns (uint a,) {}
 }
 // ----
-// ParserError 7591: (43-44): Unexpected trailing comma in parameter list.

--- a/test/libsolidity/syntaxTests/parsing/trailing_comma_in_named_args.sol
+++ b/test/libsolidity/syntaxTests/parsing/trailing_comma_in_named_args.sol
@@ -1,6 +1,5 @@
 contract test {
-	function a(uint a, uint b, uint c) returns (uint r) { r = a * 100 + b * 10 + c * 1; }
-	function b() returns (uint r) { r = a({a: 1, b: 2, c: 3, }); }
+	function test1(uint a, uint b, uint c) public pure returns (uint r) { r = a * 100 + b * 10 + c * 1; }
+	function test2() public pure returns (uint r) { r = test1({a: 1, b: 2, c: 3, }); }
 }
 // ----
-// ParserError 2074: (159-160): Unexpected trailing comma.


### PR DESCRIPTION
Partially resolves https://github.com/ethereum/solidity/issues/2991

Allowing trailing commas everywhere wouldn't be possible for the current state of Solidity syntax since it has tuples with empty elements that can be interpreted ambiguously with trailing commas:
```solidity
contract C {
	function f() public pure {
		(uint a,) = (uint(1),);
	}
}
```
Should we parse `(uint(1),)` as one element tuple or as two elements tuple with NULL as second element? It seems like a breaking change but I'd be happy to be wrong.

---

What isn't a breaking change is allowing trailing commas in:
1. Function/modifier/event/error/try/catch parameters, return parameters
2. Function call arguments
3. Enum definitions
4. Inline array definitions
5. Using directives
6. Override specifiers
7. Import aliases

We can start with it, making life easier for some refactorings and unifying this trailing comma rule across other languages that allow it.
