### PR TITLE
lsp: Fixes initialization phase if `include-paths` was not set at all then also no error should be generated.

### DIFF
--- a/libsolidity/lsp/LanguageServer.cpp
+++ b/libsolidity/lsp/LanguageServer.cpp
@@ -149,25 +149,28 @@ void LanguageServer::changeConfiguration(Json::Value const& _settings)
 {
 	m_settingsObject = _settings;
 	Json::Value jsonIncludePaths = _settings["include-paths"];
-	int typeFailureCount = 0;
 
-	if (jsonIncludePaths && jsonIncludePaths.isArray())
+	if (jsonIncludePaths)
 	{
-		vector<boost::filesystem::path> includePaths;
-		for (Json::Value const& jsonPath: jsonIncludePaths)
+		int typeFailureCount = 0;
+		if (jsonIncludePaths.isArray())
 		{
-			if (jsonPath.isString())
-				includePaths.emplace_back(boost::filesystem::path(jsonPath.asString()));
-			else
-				typeFailureCount++;
+			vector<boost::filesystem::path> includePaths;
+			for (Json::Value const& jsonPath: jsonIncludePaths)
+			{
+				if (jsonPath.isString())
+					includePaths.emplace_back(boost::filesystem::path(jsonPath.asString()));
+				else
+					typeFailureCount++;
+			}
+			m_fileRepository.setIncludePaths(move(includePaths));
 		}
-		m_fileRepository.setIncludePaths(move(includePaths));
-	}
-	else
-		++typeFailureCount;
+		else
+			++typeFailureCount;
 
-	if (typeFailureCount)
-		m_client.trace("Invalid JSON configuration passed. \"include-paths\" must be an array of strings.");
+		if (typeFailureCount)
+			m_client.trace("Invalid JSON configuration passed. \"include-paths\" must be an array of strings.");
+	}
 }
 
 void LanguageServer::compile()


### PR DESCRIPTION

The reason why CI did not fail for that is because it's simply reported as message, and our CI test client does not strictly evaluate trace messages in that regard. I am also not sure that should be done or if that would be overkill. Nevertheless, that's fixing not having `include-paths` specified in the custom settings.