### PR TITLE
Improved output of formatNumberReadable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,8 @@ Compiler Features:
 Bugfixes:
  * Yul Optimizer: Hash hex and decimal literals according to their value instead of their representation, improving the detection of equivalent functions.
  * Solidity Upgrade Tool ``solidity-upgrade``: Fix the tool returning success code on uncaught exceptions.
+ * SMTChecker: Fix display error for negative integers that are one more than powers of two.
+ * SMTChecker: Improved readability for large integers that are powers of two or almost powers of two in error messages.
 
 
 ### 0.8.17 (2022-09-08)

--- a/libsolutil/CMakeLists.txt
+++ b/libsolutil/CMakeLists.txt
@@ -43,7 +43,7 @@ set(sources
 )
 
 add_library(solutil ${sources})
-target_link_libraries(solutil PUBLIC jsoncpp Boost::boost Boost::filesystem Boost::system range-v3)
+target_link_libraries(solutil PUBLIC jsoncpp Boost::boost Boost::filesystem Boost::system range-v3 fmt::fmt-header-only)
 target_include_directories(solutil PUBLIC "${CMAKE_SOURCE_DIR}")
 add_dependencies(solutil solidity_BuildInfo.h)
 

--- a/libsolutil/StringUtils.h
+++ b/libsolutil/StringUtils.h
@@ -27,6 +27,8 @@
 #include <libsolutil/CommonData.h>
 #include <libsolutil/Numeric.h>
 
+#include <fmt/format.h>
+
 #include <algorithm>
 #include <limits>
 #include <locale>
@@ -101,110 +103,17 @@ std::string joinHumanReadablePrefixed
 		return _separator + joinHumanReadable(_list, _separator, _lastSeparator);
 }
 
-/// Same as @ref formatNumberReadable but only for unsigned numbers
-template <class T>
-inline std::string formatUnsignedNumberReadable (
-	T const& _value,
-	bool _useTruncation = false
-)
-{
-	static_assert(
-		std::is_same<bigint, T>::value || !std::numeric_limits<T>::is_signed,
-		"only unsigned types or bigint supported"
-	); //bigint does not carry sign bit on shift
-
-	// smaller numbers return as decimal
-	if (_value <= 0x1000000)
-		return _value.str();
-
-	HexCase hexcase = HexCase::Mixed;
-	HexPrefix prefix = HexPrefix::Add;
-
-	// when multiple trailing zero bytes, format as N * 2**x
-	int i = 0;
-	T v = _value;
-	for (; (v & 0xff) == 0; v >>= 8)
-		++i;
-	if (i > 2)
-	{
-		// 0x100 yields 2**8 (N is 1 and redundant)
-		if (v == 1)
-			return "2**" + std::to_string(i * 8);
-		return toHex(toCompactBigEndian(v), prefix, hexcase) +
-			" * 2**" +
-			std::to_string(i * 8);
-	}
-
-	// when multiple trailing FF bytes, format as N * 2**x - 1
-	i = 0;
-	for (v = _value; (v & 0xff) == 0xff; v >>= 8)
-		++i;
-	if (i > 2)
-	{
-		// 0xFF yields 2**8 - 1 (v is 0 in that case)
-		if (v == 0)
-			return "2**" + std::to_string(i * 8) + " - 1";
-		return toHex(toCompactBigEndian(T(v + 1)), prefix, hexcase) +
-			" * 2**" + std::to_string(i * 8) +
-			" - 1";
-	}
-
-	std::string str = toHex(toCompactBigEndian(_value), prefix, hexcase);
-	if (_useTruncation)
-	{
-		// return as interior-truncated hex.
-		size_t len = str.size();
-
-		if (len < 24)
-			return str;
-
-		size_t const initialChars = (prefix == HexPrefix::Add) ? 6 : 4;
-		size_t const finalChars = 4;
-		size_t numSkipped = len - initialChars - finalChars;
-
-		return str.substr(0, initialChars) +
-			"...{+" +
-			std::to_string(numSkipped) +
-			" more}..." +
-			str.substr(len-finalChars, len);
-	}
-
-	// otherwise, show whole value.
-	return str;
-}
-
 /// Formats large numbers to be easily readable by humans.
 /// Returns decimal representation for smaller numbers; hex for large numbers.
 /// "Special" numbers, powers-of-two and powers-of-two minus 1, are returned in
 /// formulaic form like 0x01 * 2**24 - 1.
-/// @a T can be any integer variable, will typically be u160, u256 or bigint.
+/// @a T can be any integer type, will typically be u160, u256 or bigint.
 /// @param _value to be formatted
 /// @param _useTruncation if true, internal truncation is also applied,
 /// like  0x5555...{+56 more}...5555
-/// @example formatNumberReadable((u256)0x7ffffff) = "0x08 * 2**24"
-/// @example formatNumberReadable(-57896044618658097711785492504343953926634992332820282019728792003956564819968) = -0x80 * 2**248
-template <class T>
-inline std::string formatNumberReadable(
-	T const& _value,
-	bool _useTruncation = false
-)
-{
-	static_assert(
-		std::numeric_limits<T>::is_integer,
-		"only integer numbers are supported"
-	);
-
-	if (_value >= 0)
-	{
-		bigint const _v = bigint(_value);
-		return formatUnsignedNumberReadable(_v, _useTruncation);
-	}
-	else
-	{
-		bigint const _abs_value = bigint(-1) * _value;
-		return "-" + formatUnsignedNumberReadable(_abs_value, _useTruncation);
-	}
-}
+/// @example formatNumberReadable((u256)0x7ffffff) = "2**27 - 1"
+/// @example formatNumberReadable(-57896044618658097711785492504343953926634992332820282019728792003956564819968) = -2**255
+std::string formatNumberReadable(bigint const& _value, bool _useTruncation = false);
 
 /// Safely converts an unsigned integer as string into an unsigned int type.
 ///

--- a/test/libsolidity/smtCheckerTests/operators/division_3.sol
+++ b/test/libsolidity/smtCheckerTests/operators/division_3.sol
@@ -7,4 +7,4 @@ contract C {
 // ====
 // SMTEngine: all
 // ----
-// Warning 4984: (95-100): CHC: Overflow (resulting value larger than 0x80 * 2**248 - 1) happens here.\nCounterexample:\n\nx = (- 57896044618658097711785492504343953926634992332820282019728792003956564819968)\ny = (- 1)\n = 0\n\nTransaction trace:\nC.constructor()\nC.f((- 57896044618658097711785492504343953926634992332820282019728792003956564819968), (- 1))
+// Warning 4984: (95-100): CHC: Overflow (resulting value larger than 2**255 - 1) happens here.\nCounterexample:\n\nx = (- 57896044618658097711785492504343953926634992332820282019728792003956564819968)\ny = (- 1)\n = 0\n\nTransaction trace:\nC.constructor()\nC.f((- 57896044618658097711785492504343953926634992332820282019728792003956564819968), (- 1))

--- a/test/libsolidity/smtCheckerTests/overflow/signed_div_overflow.sol
+++ b/test/libsolidity/smtCheckerTests/overflow/signed_div_overflow.sol
@@ -7,5 +7,5 @@ contract C  {
 // SMTEngine: all
 // SMTIgnoreCex: yes
 // ----
-// Warning 4984: (77-82): CHC: Overflow (resulting value larger than 0x80 * 2**248 - 1) happens here.
+// Warning 4984: (77-82): CHC: Overflow (resulting value larger than 2**255 - 1) happens here.
 // Warning 4281: (77-82): CHC: Division by zero happens here.

--- a/test/libsolidity/smtCheckerTests/overflow/signed_guard_sub_overflow.sol
+++ b/test/libsolidity/smtCheckerTests/overflow/signed_guard_sub_overflow.sol
@@ -8,4 +8,4 @@ contract C  {
 // SMTEngine: all
 // SMTIgnoreOS: macos
 // ----
-// Warning 4984: (96-101): CHC: Overflow (resulting value larger than 0x80 * 2**248 - 1) happens here.\nCounterexample:\n\nx = 57896044618658097711785492504343953926634992332820282019728792003956564819967\ny = (- 1)\n = 0\n\nTransaction trace:\nC.constructor()\nC.f(57896044618658097711785492504343953926634992332820282019728792003956564819967, (- 1))
+// Warning 4984: (96-101): CHC: Overflow (resulting value larger than 2**255 - 1) happens here.\nCounterexample:\n\nx = 57896044618658097711785492504343953926634992332820282019728792003956564819967\ny = (- 1)\n = 0\n\nTransaction trace:\nC.constructor()\nC.f(57896044618658097711785492504343953926634992332820282019728792003956564819967, (- 1))

--- a/test/libsolidity/smtCheckerTests/overflow/signed_guard_sum_overflow.sol
+++ b/test/libsolidity/smtCheckerTests/overflow/signed_guard_sum_overflow.sol
@@ -8,5 +8,5 @@ contract C  {
 // SMTEngine: all
 // SMTIgnoreCex: yes
 // ----
-// Warning 3944: (78-83): CHC: Underflow (resulting value less than -0x80 * 2**248) happens here.
-// Warning 4984: (78-83): CHC: Overflow (resulting value larger than 0x80 * 2**248 - 1) happens here.
+// Warning 3944: (78-83): CHC: Underflow (resulting value less than -2**255) happens here.
+// Warning 4984: (78-83): CHC: Overflow (resulting value larger than 2**255 - 1) happens here.

--- a/test/libsolidity/smtCheckerTests/overflow/signed_mul_overflow.sol
+++ b/test/libsolidity/smtCheckerTests/overflow/signed_mul_overflow.sol
@@ -7,5 +7,5 @@ contract C  {
 // SMTEngine: all
 // SMTIgnoreCex: yes
 // ----
-// Warning 3944: (77-82): CHC: Underflow (resulting value less than -0x80 * 2**248) happens here.
-// Warning 4984: (77-82): CHC: Overflow (resulting value larger than 0x80 * 2**248 - 1) happens here.
+// Warning 3944: (77-82): CHC: Underflow (resulting value less than -2**255) happens here.
+// Warning 4984: (77-82): CHC: Overflow (resulting value larger than 2**255 - 1) happens here.

--- a/test/libsolidity/smtCheckerTests/overflow/signed_sub_overflow.sol
+++ b/test/libsolidity/smtCheckerTests/overflow/signed_sub_overflow.sol
@@ -7,5 +7,5 @@ contract C  {
 // SMTEngine: all
 // SMTIgnoreCex: yes
 // ----
-// Warning 3944: (77-82): CHC: Underflow (resulting value less than -0x80 * 2**248) happens here.
-// Warning 4984: (77-82): CHC: Overflow (resulting value larger than 0x80 * 2**248 - 1) happens here.
+// Warning 3944: (77-82): CHC: Underflow (resulting value less than -2**255) happens here.
+// Warning 4984: (77-82): CHC: Overflow (resulting value larger than 2**255 - 1) happens here.

--- a/test/libsolidity/smtCheckerTests/overflow/signed_sum_overflow.sol
+++ b/test/libsolidity/smtCheckerTests/overflow/signed_sum_overflow.sol
@@ -7,5 +7,5 @@ contract C  {
 // SMTEngine: all
 // SMTIgnoreCex: yes
 // ----
-// Warning 3944: (77-82): CHC: Underflow (resulting value less than -0x80 * 2**248) happens here.
-// Warning 4984: (77-82): CHC: Overflow (resulting value larger than 0x80 * 2**248 - 1) happens here.
+// Warning 3944: (77-82): CHC: Underflow (resulting value less than -2**255) happens here.
+// Warning 4984: (77-82): CHC: Overflow (resulting value larger than 2**255 - 1) happens here.

--- a/test/libsolidity/smtCheckerTests/unchecked/signed_mod.sol
+++ b/test/libsolidity/smtCheckerTests/unchecked/signed_mod.sol
@@ -15,4 +15,4 @@ contract C {
 // SMTEngine: all
 // ----
 // Warning 4281: (85-90): CHC: Division by zero happens here.\nCounterexample:\n\na = 0\nb = 0\n = 0\n\nTransaction trace:\nC.constructor()\nC.f(0, 0)
-// Warning 4984: (242-248): CHC: Overflow (resulting value larger than 0x80 * 2**248 - 1) happens here.\nCounterexample:\n\n_check = true\n = 0\nx = (- 57896044618658097711785492504343953926634992332820282019728792003956564819968)\n\nTransaction trace:\nC.constructor()\nC.g(true)
+// Warning 4984: (242-248): CHC: Overflow (resulting value larger than 2**255 - 1) happens here.\nCounterexample:\n\n_check = true\n = 0\nx = (- 57896044618658097711785492504343953926634992332820282019728792003956564819968)\n\nTransaction trace:\nC.constructor()\nC.g(true)

--- a/test/libsolutil/StringUtils.cpp
+++ b/test/libsolutil/StringUtils.cpp
@@ -107,17 +107,23 @@ BOOST_AUTO_TEST_CASE(test_human_readable_join)
 
 BOOST_AUTO_TEST_CASE(test_format_number_readable)
 {
-	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x8000000)), "0x08 * 2**24");
-	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x80000000)), "0x80 * 2**24");
-	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x800000000)), "0x08 * 2**32");
-	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x8000000000)), "0x80 * 2**32");
-	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x80000000000)), "0x08 * 2**40");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x10000000)), "2**28");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x100000000)), "2**32");
 
-	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x7ffffff)), "0x08 * 2**24 - 1");
-	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x7fffffff)), "0x80 * 2**24 - 1");
-	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x7ffffffff)), "0x08 * 2**32 - 1");
-	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x7fffffffff)), "0x80 * 2**32 - 1");
-	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x7ffffffffff)), "0x08 * 2**40 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x8000000)), "2**27");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x80000000)), "2**31");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x800000000)), "2**35");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x8000000000)), "2**39");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x80000000000)), "2**43");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x7ffffff)), "2**27 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x7fffffff)), "2**31 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x7ffffffff)), "2**35 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x7fffffffff)), "2**39 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x7ffffffffff)), "2**43 - 1");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0xfffffff)), "2**28 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0xffffffff)), "2**32 - 1");
 
 	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x88000000)), "0x88 * 2**24");
 	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x8888888888000000)), "0x8888888888 * 2**24");
@@ -134,13 +140,73 @@ BOOST_AUTO_TEST_CASE(test_format_number_readable)
 	u256 c = (u256)FixedHash<32>(
 		fromHex("0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789")
 	);
-	u256 d = u256(0xAAAAaaaaAAAAaaaa) << 192 |
+	u256 d = u256(0xAAAAaaaaAAAAaaaa) << 192;
+	u256 e = u256(0xAAAAaaaaAAAAaaaa) << 192 |
 		u256(0xFFFFffffFFFFffff) << 128 |
 		u256(0xFFFFffffFFFFffff) << 64 |
 		u256(0xFFFFffffFFFFffff);
 	BOOST_CHECK_EQUAL(formatNumberReadable(b, true), "0x5555...{+56 more}...5555");
 	BOOST_CHECK_EQUAL(formatNumberReadable(c, true), "0xABCD...{+56 more}...6789");
-	BOOST_CHECK_EQUAL(formatNumberReadable(d, true), "0xAAAAaaaaAAAAaaab * 2**192 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(d, true), "0xAAAAaaaaAAAAaaaa * 2**192");
+	BOOST_CHECK_EQUAL(formatNumberReadable(e, true), "0xAAAAaaaaAAAAaaab * 2**192 - 1");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x20000000)), "2**29");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x200000000)), "2**33");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x2000000000)), "2**37");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x20000000000)), "2**41");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x200000000000)), "2**45");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x1FFFFFFF)), "2**29 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x1FFFFFFFF)), "2**33 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x1FFFFFFFFF)), "2**37 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x1FFFFFFFFFF)), "2**41 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x1FFFFFFFFFFF)), "2**45 - 1");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x3000000)), "0x03 * 2**24");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x30000000)), "0x30 * 2**24");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x300000000)), "0x03 * 2**32");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x3000000000)), "0x30 * 2**32");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x2FFFFFF)), "0x03 * 2**24 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x2FFFFFFF)), "0x30 * 2**24 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x2FFFFFFFF)), "0x03 * 2**32 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x2FFFFFFFFF)), "0x30 * 2**32 - 1");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0xA3000000)), "0xa3 * 2**24");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0xA30000000)), "0x0a30 * 2**24");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0xA300000000)), "0xa3 * 2**32");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0xA3000000000)), "0x0a30 * 2**32");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0xA2FFFFFF)), "0xa3 * 2**24 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0xA2FFFFFFF)), "0x0a30 * 2**24 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0xA2FFFFFFFF)), "0xa3 * 2**32 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0xA2FFFFFFFFF)), "0x0a30 * 2**32 - 1");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x3) << 128, true), "0x03 * 2**128");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x3) << 129, true), "0x06 * 2**128");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x3) << 130, true), "0x0c * 2**128");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x3) << 131, true), "0x18 * 2**128");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x3) << 248, true), "0x03 * 2**248");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x3) << 249, true), "0x06 * 2**248");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x3) << 250, true), "0x0c * 2**248");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x3) << 251, true), "0x18 * 2**248");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x9) << 128, true), "0x09 * 2**128");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x9) << 129, true), "0x12 * 2**128");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x9) << 130, true), "0x24 * 2**128");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x9) << 131, true), "0x48 * 2**128");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x9) << 248, true), "0x09 * 2**248");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x9) << 249, true), "0x12 * 2**248");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x9) << 250, true), "0x24 * 2**248");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x9) << 251, true), "0x48 * 2**248");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0)), "0");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x10000)), "65536");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0xFFFF)), "65535");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x1000000)), "16777216");
+	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0xFFFFFF)), "16777215");
 
 	//for codegen/ExpressionCompiler
 	BOOST_CHECK_EQUAL(formatNumberReadable(u256(-1)), "2**256 - 1");
@@ -154,17 +220,23 @@ BOOST_AUTO_TEST_CASE(test_format_number_readable)
 
 BOOST_AUTO_TEST_CASE(test_format_number_readable_signed)
 {
-	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x8000000)), "-0x08 * 2**24");
-	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x80000000)), "-0x80 * 2**24");
-	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x800000000)), "-0x08 * 2**32");
-	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x8000000000)), "-0x80 * 2**32");
-	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x80000000000)), "-0x08 * 2**40");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x10000000)), "-2**28");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x100000000)), "-2**32");
 
-	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x7ffffff)), "-0x08 * 2**24 - 1");
-	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x7fffffff)), "-0x80 * 2**24 - 1");
-	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x7ffffffff)), "-0x08 * 2**32 - 1");
-	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x7fffffffff)), "-0x80 * 2**32 - 1");
-	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x7ffffffffff)), "-0x08 * 2**40 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x8000000)), "-2**27");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x80000000)), "-2**31");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x800000000)), "-2**35");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x8000000000)), "-2**39");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x80000000000)), "-2**43");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x7ffffff)), "-2**27 + 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x7fffffff)), "-2**31 + 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x7ffffffff)), "-2**35 + 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x7fffffffff)), "-2**39 + 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x7ffffffffff)), "-2**43 + 1");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0xfffffff)), "-2**28 + 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0xffffffff)), "-2**32 + 1");
 
 	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x88000000)), "-0x88 * 2**24");
 	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x8888888888000000)), "-0x8888888888 * 2**24");
@@ -190,23 +262,77 @@ BOOST_AUTO_TEST_CASE(test_format_number_readable_signed)
 
 	BOOST_CHECK_EQUAL(formatNumberReadable(b, true), "-0x5555...{+56 more}...5555");
 	BOOST_CHECK_EQUAL(formatNumberReadable(c, true), "-0x0BCD...{+56 more}...6789");
-	BOOST_CHECK_EQUAL(formatNumberReadable(d, true), "-0x5555555555555556 * 2**192 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(d, true), "-0x5555555555555556 * 2**192 + 1");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x20000000)), "-2**29");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x200000000)), "-2**33");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x2000000000)), "-2**37");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x20000000000)), "-2**41");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x200000000000)), "-2**45");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x1FFFFFFF)), "-2**29 + 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x1FFFFFFFF)), "-2**33 + 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x1FFFFFFFFF)), "-2**37 + 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x1FFFFFFFFFF)), "-2**41 + 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x1FFFFFFFFFFF)), "-2**45 + 1");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x3000000)), "-0x03 * 2**24");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x30000000)), "-0x30 * 2**24");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x300000000)), "-0x03 * 2**32");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x3000000000)), "-0x30 * 2**32");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x2FFFFFF)), "-0x03 * 2**24 + 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x2FFFFFFF)), "-0x30 * 2**24 + 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x2FFFFFFFF)), "-0x03 * 2**32 + 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x2FFFFFFFFF)), "-0x30 * 2**32 + 1");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0xA3000000)), "-0xa3 * 2**24");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0xA30000000)), "-0x0a30 * 2**24");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0xA300000000)), "-0xa3 * 2**32");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0xA3000000000)), "-0x0a30 * 2**32");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0xA2FFFFFF)), "-0xa3 * 2**24 + 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0xA2FFFFFFF)), "-0x0a30 * 2**24 + 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0xA2FFFFFFFF)), "-0xa3 * 2**32 + 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0xA2FFFFFFFFF)), "-0x0a30 * 2**32 + 1");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable(((-1) * s256(0x3)) << 128, true), "-0x03 * 2**128");
+	BOOST_CHECK_EQUAL(formatNumberReadable(((-1) * s256(0x3)) << 129, true), "-0x06 * 2**128");
+	BOOST_CHECK_EQUAL(formatNumberReadable(((-1) * s256(0x3)) << 130, true), "-0x0c * 2**128");
+	BOOST_CHECK_EQUAL(formatNumberReadable(((-1) * s256(0x3)) << 131, true), "-0x18 * 2**128");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable(((-1) * s256(0x3)) << 248, true), "-0x03 * 2**248");
+	BOOST_CHECK_EQUAL(formatNumberReadable(((-1) * s256(0x3)) << 249, true), "-0x06 * 2**248");
+	BOOST_CHECK_EQUAL(formatNumberReadable(((-1) * s256(0x3)) << 250, true), "-0x0c * 2**248");
+	BOOST_CHECK_EQUAL(formatNumberReadable(((-1) * s256(0x3)) << 251, true), "-0x18 * 2**248");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable(((-1) * s256(0x9)) << 128, true), "-0x09 * 2**128");
+	BOOST_CHECK_EQUAL(formatNumberReadable(((-1) * s256(0x9)) << 129, true), "-0x12 * 2**128");
+	BOOST_CHECK_EQUAL(formatNumberReadable(((-1) * s256(0x9)) << 130, true), "-0x24 * 2**128");
+	BOOST_CHECK_EQUAL(formatNumberReadable(((-1) * s256(0x9)) << 131, true), "-0x48 * 2**128");
+
+	BOOST_CHECK_EQUAL(formatNumberReadable(((-1) * s256(0x9)) << 248, true), "-0x09 * 2**248");
+	BOOST_CHECK_EQUAL(formatNumberReadable(((-1) * s256(0x9)) << 249, true), "-0x12 * 2**248");
+	BOOST_CHECK_EQUAL(formatNumberReadable(((-1) * s256(0x9)) << 250, true), "-0x24 * 2**248");
+	BOOST_CHECK_EQUAL(formatNumberReadable(((-1) * s256(0x9)) << 251, true), "-0x48 * 2**248");
 
 	BOOST_CHECK_EQUAL(formatNumberReadable(s256(-1)), "-1");
 	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x10000)), "-65536");
 	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0xFFFF)), "-65535");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x1000000)), "-16777216");
+	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0xFFFFFF)), "-16777215");
 
 	BOOST_CHECK_EQUAL(
 		formatNumberReadable(
 			frontend::IntegerType(256, frontend::IntegerType::Modifier::Signed).minValue()
 		),
-		"-0x80 * 2**248"
+		"-2**255"
 	);
 	BOOST_CHECK_EQUAL(
 		formatNumberReadable(
 			frontend::IntegerType(256, frontend::IntegerType::Modifier::Signed).maxValue()
 		),
-		"0x80 * 2**248 - 1"
+		"2**255 - 1"
 	);
 }
 


### PR DESCRIPTION
Follow up to issue #9601 and pull request #13163.
Based on advice by @cameel in the conversation in issue.
Previously `formatNumberReadable(57896044618658097711785492504343953926634992332820282019728792003956564819968) `would equal to `0x80 * 2 ** 248`, but now it equals to `2 ** 255`.
Also, there was a bug in the test case `test_format_number_readable_signed` in `test/StringUtils.cpp`. `formatNumberReadable(-0xffffffff)` should be equal to `-2 ** 32 + 1` but previously it was tested to be equal to `-2 ** 32 - 1`. The new version of `formatNumberReadable` fixes this problem. 