### PR TITLE
Fix NULL dereference in abi.encodeCall check

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ Compiler Features:
 
 Bugfixes:
  * Commandline Interface: Disallow the following options outside of the compiler mode: ``--via-ir``,``--metadata-literal``, ``--metadata-hash``, ``--model-checker-show-unproved``, ``--model-checker-div-mod-no-slacks``, ``--model-checker-engine``, ``--model-checker-invariants``, ``--model-checker-solvers``, ``--model-checker-timeout``, ``--model-checker-contracts``, ``--model-checker-targets``.
+ * Type Checker: Fix null dereference in `abi.encodeCall` type checking of free function.
 
 
 ### 0.8.15 (2022-06-15)

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encodeCall_error_free_function.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encodeCall_error_free_function.sol
@@ -1,0 +1,7 @@
+error E(uint);
+
+function f() {
+    abi.encodeCall(E, (1));
+}
+// ----
+// TypeError 3509: (50-51): Expected regular external function type, or external view on public function. Cannot use errors for abi.encodeCall.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encodeCall_event_free_function.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encodeCall_event_free_function.sol
@@ -1,0 +1,9 @@
+library L {
+    event E(uint);
+}
+
+function f() {
+    abi.encodeCall(L.E, (1));
+}
+// ----
+// TypeError 3509: (68-71): Expected regular external function type, or external view on public function. Cannot use events for abi.encodeCall.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encodeCall_free_func.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encodeCall_free_func.sol
@@ -1,0 +1,7 @@
+function g(uint) {}
+
+function f() {
+    abi.encodeCall(g, (1));
+}
+// ----
+// TypeError 3509: (55-56): Expected regular external function type, or external view on public function. Provided internal function.

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encodeCall_on_lib_func_in_free_func.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encodeCall_on_lib_func_in_free_func.sol
@@ -1,0 +1,9 @@
+library L {
+    function g() external {}
+}
+
+function f() {
+    abi.encodeCall(L.g, (1));
+}
+// ----
+// TypeError 3509: (78-81): Expected regular external function type, or external view on public function. Cannot use library functions for abi.encodeCall.


### PR DESCRIPTION
closes #13266