### PR TITLE
Placeholder elaboration in function-modifiers.rst

### DIFF
--- a/docs/contracts/function-modifiers.rst
+++ b/docs/contracts/function-modifiers.rst
@@ -111,6 +111,12 @@ whitespace-separated list and are evaluated in the order presented.
 Modifiers cannot implicitly access or change the arguments and return values of functions they modify.
 Their values can only be passed to them explicitly at the point of invocation.
 
+In function modifiers, it is necessary to specify when you want the function to which the modifier is
+applied to be run. The placeholder statement (denoted by a single underscore character ``_``) is used to
+denote where the body of the function being modified should be inserted. Note that the
+placeholder operator is different from using underscores as leading or trailing characters in variable
+names, which is a stylistic choice.
+
 Explicit returns from a modifier or function body only leave the current
 modifier or function body. Return variables are assigned and
 control flow continues after the ``_`` in the preceding modifier.


### PR DESCRIPTION
Hi,

This PR is a continuation of Create placeholders.rst #13239 

Thanks @cameel for the feedback, I have removed the mutex code example and cleaned things up a bit as well as implemented all of the changes in your review.

Looking back on it, I agree with you that placeholders didn't really deserve their own page in the docs. This version just adds two paragraphs to function-modifiers prior to the first mention of the `_` character in the section. This was the area where I feel it best fits within this page.

Please let me know if you have any other recommendations or changes.

Thanks,
Arby