### PR TITLE
Fix dark mode bug

### DIFF
--- a/docs/_static/js/toggle.js
+++ b/docs/_static/js/toggle.js
@@ -4,15 +4,16 @@ document.addEventListener('DOMContentLoaded', function() {
         var mode = (isDay ? "Day" : "Night");
         localStorage.setItem("css-mode", mode);
 
-        var daysheet = $('link[href="_static/pygments.css"]')[0].sheet;
+        var url_root = DOCUMENTATION_OPTIONS.URL_ROOT == "./" ? "" : DOCUMENTATION_OPTIONS.URL_ROOT;
+        var daysheet = $(`link[href="${url_root}_static/pygments.css"]`)[0].sheet;
         daysheet.disabled = !isDay;
 
-        var nightsheet = $('link[href="_static/css/dark.css"]')[0];
+        var nightsheet = $(`link[href="${url_root}_static/css/dark.css"]`)[0];
         if (!isDay && nightsheet === undefined) {
             var element = document.createElement("link");
             element.setAttribute("rel", "stylesheet");
             element.setAttribute("type", "text/css");
-            element.setAttribute("href", "_static/css/dark.css");
+            element.setAttribute("href", `${url_root}_static/css/dark.css`);
             document.getElementsByTagName("head")[0].appendChild(element);
             return;
         }


### PR DESCRIPTION
Solidity document has a bug that dark mode is not applied to pages under the `internals` directory.
For example: 
https://docs.soliditylang.org/en/v0.8.15/internals/layout_in_calldata.html

This is due to improper handling of relative paths.
Fixed using the url root retrieved from "documentations options" in sphinx.
https://github.com/sphinx-doc/sphinx/blob/95b81831b19727a3a933e387b1bc6c1053c3aadd/sphinx/themes/basic/static/documentation_options.js_t#L2


