### PR TITLE
Disable zeppelin tests that detect wrong revert reason

### DIFF
--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -70,6 +70,7 @@ function zeppelin_test
     sed -i "s|it(\('reverts \)|it.skip(\1|g" structs/EnumerableSet.behavior.js
     popd
 
+
     # In some cases Hardhat does not detect revert reasons properly via IR.
     # TODO: Remove this when https://github.com/NomicFoundation/hardhat/issues/2453 gets fixed.
     sed -i "s|it(\('reverts if the current value is 0'\)|it.skip(\1|g" test/utils/Counters.test.js
@@ -111,6 +112,11 @@ function zeppelin_test
     # Could result in an error in the future.
     sed -zi "s|it(\('deposit'\)|it.skip(\1|3" test/token/ERC20/extensions/ERC4626.test.js
     sed -zi "s|it(\('withdraw'\)|it.skip(\1|3" test/token/ERC20/extensions/ERC4626.test.js
+
+    # Here only the testToInt(248) and testToInt(256) cases fail so change the loop range to skip them
+    sed -i "s|range(8, 256, 8)\(.forEach(bits => testToInt(bits));\)|range(8, 240, 8)\1|" test/utils/math/SafeCast.test.js
+
+
 
     # TODO: Remove this when https://github.com/NomicFoundation/hardhat/issues/2115 gets fixed.
     sed -i "s|describe\(('Polygon-Child'\)|describe.skip\1|g" test/crosschain/CrossChainEnabled.test.js


### PR DESCRIPTION
Example of a failing test: https://app.circleci.com/pipelines/github/ethereum/solidity/25359/workflows/d917e214-0762-4caa-8f46-b7fba63e7e61/jobs/1117784
This will avoid the wrong revert reason detection like these:
* Received: Transaction reverted: function was called with incorrect parameters
* Expected: SafeCast: value doesn't fit in 248 bits

Related: https://github.com/NomicFoundation/hardhat/issues/2453