### PR TITLE
fix: global state object in yul formal specification

### DIFF
--- a/docs/yul.rst
+++ b/docs/yul.rst
@@ -663,10 +663,10 @@ We will use a destructuring notation for the AST nodes.
     E(G, L, <var_1, ..., var_n := rhs>: Assignment) =
         let G1, L1, v1, ..., vn = E(G, L, rhs)
         let L2 be a copy of L1 where L2[$var_i] = vi for i = 1, ..., n
-        G, L2, regular
+        G1, L2, regular
     E(G, L, <for { i1, ..., in } condition post body>: ForLoop) =
         if n >= 1:
-            let G1, L, mode = E(G, L, i1, ..., in)
+            let G1, L1, mode = E(G, L, i1, ..., in)
             // mode has to be regular or leave due to the syntactic restrictions
             if mode is leave then
                 G1, L1 restricted to variables of L, leave
@@ -686,7 +686,7 @@ We will use a destructuring notation for the AST nodes.
                 else:
                     G3, L3, mode = E(G2, L2, post)
                     if mode is leave:
-                        G2, L3, leave
+                        G3, L3, leave
                     otherwise
                         E(G3, L3, for {} condition post body)
     E(G, L, break: BreakContinue) =


### PR DESCRIPTION
This PR is about the [yul formal specification](https://docs.soliditylang.org/en/v0.8.15/yul.html#formal-specification).

The following points seems to be small issues in the specification:
- line 666, the original specification says that the storage variables cannot be modified in assignments. The following test suggests otherwise
```solidity
    function testYulDropGlobalInAssignment() public {
        uint y;
        assembly {
            let value := 2
            function storeAndReturn(a) -> res {
                sstore(x.slot, a)
                res := a
            }
            y := storeAndReturn(3)
        }
        assertEq(x, y); // does not drop the x value in storage after assigning y
    }
```
- line 669, the original specification seems to have a typo in it because `L1` is used later but is not defined
- line 689, the original specification says that the storage is not modified in the post of a loop if the resulting mode is `leave`. The following test suggests otherwise
```solidity
    function testYulDropGlobalInPostWhenLeave() public {
        assembly {
            function storeAndLeave() {
                for { } true { sstore(x.slot, 5) leave } {}
            }
            storeAndLeave()
        }
        assertEq(x, 5); // does not drop the x value in storage after leaving in the post of the loop
    }
```