### PR TITLE
Issue warning for unitialized for-loop initialization expression

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Language Features:
 
 
 Compiler Features:
+ * Static Analyzer: Issue warning for uninitialized for-loop initialization expression.
  * TypeChecker: Support using library constants in initializers of other constants.
  * Yul IR Code Generation: Improved copy routines for arrays with packed storage layout.
  * Yul Optimizer: Add rule to convert `mod(mul(X, Y), A)` into `mulmod(X, Y, A)`, if `A` is a power of two.

--- a/libsolidity/analysis/StaticAnalyzer.cpp
+++ b/libsolidity/analysis/StaticAnalyzer.cpp
@@ -135,6 +135,17 @@ void StaticAnalyzer::endVisit(FunctionDefinition const&)
 	m_currentFunction = nullptr;
 }
 
+bool StaticAnalyzer::visit(ForStatement const& _forStatement) {
+	if (auto var = dynamic_cast<VariableDeclarationStatement const*>(_forStatement.initializationExpression()))
+		if (!var->initialValue())
+			m_errorReporter.warning(
+				4716_error,
+				var->location(),
+				"Uninitialized variable in for-loop initialization expression."
+			);
+	return true;
+}
+
 bool StaticAnalyzer::visit(Identifier const& _identifier)
 {
 	if (m_currentFunction)

--- a/libsolidity/analysis/StaticAnalyzer.h
+++ b/libsolidity/analysis/StaticAnalyzer.h
@@ -65,6 +65,7 @@ private:
 	bool visit(FunctionDefinition const& _function) override;
 	void endVisit(FunctionDefinition const& _function) override;
 
+	bool visit(ForStatement const& _forStatement) override;
 	bool visit(ExpressionStatement const& _statement) override;
 	bool visit(VariableDeclaration const& _variable) override;
 	bool visit(Identifier const& _identifier) override;

--- a/test/libsolidity/syntaxTests/uninitialized/for_init_expression_empty.sol
+++ b/test/libsolidity/syntaxTests/uninitialized/for_init_expression_empty.sol
@@ -1,0 +1,10 @@
+contract C {
+    function foo() pure public returns (int) {
+        for (; true;) {
+            int i = 42;
+            return i + 1;
+        }
+        return 0;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/uninitialized/for_init_expression_literal.sol
+++ b/test/libsolidity/syntaxTests/uninitialized/for_init_expression_literal.sol
@@ -1,0 +1,11 @@
+contract C {
+    function foo() pure public returns (int) {
+        for (42; true;) {
+            int i = 42;
+            return i + 1;
+        }
+        return 0;
+    }
+}
+// ----
+// Warning 6133: (73-75): Statement has no effect.

--- a/test/libsolidity/syntaxTests/uninitialized/for_init_expression_uninit_unused.sol
+++ b/test/libsolidity/syntaxTests/uninitialized/for_init_expression_uninit_unused.sol
@@ -1,0 +1,12 @@
+contract C {
+    function foo() pure public returns (int) {
+        for (int i; true;) {
+            int i = i;
+            return i + 1;
+        }
+        return 0;
+    }
+}
+// ----
+// Warning 2519: (101-106): This declaration shadows an existing declaration.
+// Warning 4716: (73-78): Uninitialized variable in for-loop initialization expression.


### PR DESCRIPTION
A simple check that addresses #13214.

New tests are added.