### PR TITLE
Add full stops to error messages

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1601,7 +1601,8 @@ bool TypeChecker::visit(Assignment const& _assignment)
 				" not compatible with types " +
 				t->humanReadableName() +
 				" and " +
-				type(_assignment.rightHandSide())->humanReadableName()
+				type(_assignment.rightHandSide())->humanReadableName() +
+				"."
 			);
 	}
 	return false;
@@ -1723,9 +1724,7 @@ bool TypeChecker::visit(UnaryOperation const& _operation)
 	TypeResult result = type(_operation.subExpression())->unaryOperatorResult(op);
 	if (!result)
 	{
-		string description = "Unary operator " + string(TokenTraits::toString(op)) + " cannot be applied to type " + subExprType->humanReadableName();
-		if (!result.message().empty())
-			description += ". " + result.message();
+		string description = "Unary operator " + string(TokenTraits::toString(op)) + " cannot be applied to type " + subExprType->humanReadableName() + "." + (!result.message().empty() ? " " + result.message() : "");
 		if (modifying)
 			// Cannot just report the error, ignore the unary operator, and continue,
 			// because the sub-expression was already processed with requireLValue()
@@ -1759,8 +1758,8 @@ void TypeChecker::endVisit(BinaryOperation const& _operation)
 			" not compatible with types " +
 			leftType->humanReadableName() +
 			" and " +
-			rightType->humanReadableName() +
-			(!result.message().empty() ? ". " + result.message() : "")
+			rightType->humanReadableName() + "." +
+			(!result.message().empty() ? " " + result.message() : "")
 		);
 		commonType = leftType;
 	}

--- a/test/libsolidity/syntaxTests/abiEncoder/abi_encodeCall_tuple_from_invalid_operator.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/abi_encodeCall_tuple_from_invalid_operator.sol
@@ -15,9 +15,9 @@ contract C {
     }
 }
 // ----
-// TypeError 2271: (284-299): Operator + not compatible with types tuple(int_const 1,int_const 1) and tuple(int_const 2,int_const 2)
+// TypeError 2271: (284-299): Operator + not compatible with types tuple(int_const 1,int_const 1) and tuple(int_const 2,int_const 2).
 // TypeError 9062: (284-299): Expected an inline tuple, not an expression of a tuple type.
-// TypeError 2271: (334-345): Operator / not compatible with types tuple() and tuple()
+// TypeError 2271: (334-345): Operator / not compatible with types tuple() and tuple().
 // TypeError 9062: (334-345): Expected an inline tuple, not an expression of a tuple type.
-// TypeError 4907: (380-383): Unary operator ! cannot be applied to type tuple()
+// TypeError 4907: (380-383): Unary operator ! cannot be applied to type tuple().
 // TypeError 9062: (380-383): Expected an inline tuple, not an expression of a tuple type.

--- a/test/libsolidity/syntaxTests/conversion/implicit_conversion_of_super_in_comparison.sol
+++ b/test/libsolidity/syntaxTests/conversion/implicit_conversion_of_super_in_comparison.sol
@@ -19,9 +19,9 @@ contract C {
     }
 }
 // ----
-// TypeError 2271: (144-157): Operator != not compatible with types type(contract super C) and contract C
-// TypeError 2271: (167-180): Operator != not compatible with types contract C and type(contract super C)
-// TypeError 2271: (254-264): Operator != not compatible with types type(contract super C) and contract C
-// TypeError 2271: (274-284): Operator != not compatible with types contract C and type(contract super C)
-// TypeError 2271: (349-359): Operator != not compatible with types type(contract super C) and contract D
-// TypeError 2271: (369-379): Operator != not compatible with types contract D and type(contract super C)
+// TypeError 2271: (144-157): Operator != not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (167-180): Operator != not compatible with types contract C and type(contract super C).
+// TypeError 2271: (254-264): Operator != not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (274-284): Operator != not compatible with types contract C and type(contract super C).
+// TypeError 2271: (349-359): Operator != not compatible with types type(contract super C) and contract D.
+// TypeError 2271: (369-379): Operator != not compatible with types contract D and type(contract super C).

--- a/test/libsolidity/syntaxTests/conversion/implicit_conversion_of_super_in_operators.sol
+++ b/test/libsolidity/syntaxTests/conversion/implicit_conversion_of_super_in_operators.sol
@@ -30,27 +30,27 @@ contract C {
     }
 }
 // ----
-// TypeError 2271: (49-62): Operator << not compatible with types type(contract super C) and contract C
-// TypeError 2271: (72-85): Operator >> not compatible with types type(contract super C) and contract C
-// TypeError 2271: (95-107): Operator ^ not compatible with types type(contract super C) and contract C
-// TypeError 2271: (117-129): Operator | not compatible with types type(contract super C) and contract C
-// TypeError 2271: (139-151): Operator & not compatible with types type(contract super C) and contract C
-// TypeError 2271: (162-174): Operator * not compatible with types type(contract super C) and contract C
-// TypeError 2271: (184-196): Operator / not compatible with types type(contract super C) and contract C
-// TypeError 2271: (206-218): Operator % not compatible with types type(contract super C) and contract C
-// TypeError 2271: (228-240): Operator - not compatible with types type(contract super C) and contract C
-// TypeError 2271: (250-262): Operator + not compatible with types type(contract super C) and contract C
-// TypeError 2271: (272-285): Operator ** not compatible with types type(contract super C) and contract C
-// TypeError 2271: (296-309): Operator == not compatible with types type(contract super C) and contract C
-// TypeError 2271: (319-332): Operator != not compatible with types type(contract super C) and contract C
-// TypeError 2271: (342-355): Operator >= not compatible with types type(contract super C) and contract C
-// TypeError 2271: (365-378): Operator <= not compatible with types type(contract super C) and contract C
-// TypeError 2271: (388-400): Operator < not compatible with types type(contract super C) and contract C
-// TypeError 2271: (410-422): Operator > not compatible with types type(contract super C) and contract C
-// TypeError 2271: (433-446): Operator || not compatible with types type(contract super C) and contract C
-// TypeError 2271: (456-469): Operator && not compatible with types type(contract super C) and contract C
+// TypeError 2271: (49-62): Operator << not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (72-85): Operator >> not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (95-107): Operator ^ not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (117-129): Operator | not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (139-151): Operator & not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (162-174): Operator * not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (184-196): Operator / not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (206-218): Operator % not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (228-240): Operator - not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (250-262): Operator + not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (272-285): Operator ** not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (296-309): Operator == not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (319-332): Operator != not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (342-355): Operator >= not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (365-378): Operator <= not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (388-400): Operator < not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (410-422): Operator > not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (433-446): Operator || not compatible with types type(contract super C) and contract C.
+// TypeError 2271: (456-469): Operator && not compatible with types type(contract super C) and contract C.
 // TypeError 4247: (480-485): Expression has to be an lvalue.
-// TypeError 7366: (480-493): Operator -= not compatible with types type(contract super C) and contract C
+// TypeError 7366: (480-493): Operator -= not compatible with types type(contract super C) and contract C.
 // TypeError 4247: (503-508): Expression has to be an lvalue.
-// TypeError 7366: (503-516): Operator += not compatible with types type(contract super C) and contract C
+// TypeError 7366: (503-516): Operator += not compatible with types type(contract super C) and contract C.
 // TypeError 1080: (527-546): True expression's type type(contract super C) does not match false expression's type contract C.

--- a/test/libsolidity/syntaxTests/errors/error_incompatible_binary_ops.sol
+++ b/test/libsolidity/syntaxTests/errors/error_incompatible_binary_ops.sol
@@ -27,21 +27,21 @@ contract C {
 }
 
 // ----
-// TypeError 2271: (86-116): Operator << not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool)
-// TypeError 2271: (126-156): Operator >> not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool)
-// TypeError 2271: (166-195): Operator ^ not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool)
-// TypeError 2271: (205-234): Operator | not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool)
-// TypeError 2271: (244-273): Operator & not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool)
-// TypeError 2271: (284-313): Operator * not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool)
-// TypeError 2271: (323-352): Operator / not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool)
-// TypeError 2271: (362-391): Operator % not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool)
-// TypeError 2271: (401-430): Operator + not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool)
-// TypeError 2271: (440-469): Operator - not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool)
-// TypeError 2271: (480-510): Operator == not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool)
-// TypeError 2271: (520-550): Operator != not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool)
-// TypeError 2271: (560-590): Operator >= not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool)
-// TypeError 2271: (600-630): Operator <= not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool)
-// TypeError 2271: (640-669): Operator < not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool)
-// TypeError 2271: (679-708): Operator > not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool)
-// TypeError 2271: (719-749): Operator || not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool)
-// TypeError 2271: (759-789): Operator && not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool)
+// TypeError 2271: (86-116): Operator << not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool).
+// TypeError 2271: (126-156): Operator >> not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool).
+// TypeError 2271: (166-195): Operator ^ not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool).
+// TypeError 2271: (205-234): Operator | not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool).
+// TypeError 2271: (244-273): Operator & not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool).
+// TypeError 2271: (284-313): Operator * not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool).
+// TypeError 2271: (323-352): Operator / not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool).
+// TypeError 2271: (362-391): Operator % not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool).
+// TypeError 2271: (401-430): Operator + not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool).
+// TypeError 2271: (440-469): Operator - not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool).
+// TypeError 2271: (480-510): Operator == not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool).
+// TypeError 2271: (520-550): Operator != not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool).
+// TypeError 2271: (560-590): Operator >= not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool).
+// TypeError 2271: (600-630): Operator <= not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool).
+// TypeError 2271: (640-669): Operator < not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool).
+// TypeError 2271: (679-708): Operator > not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool).
+// TypeError 2271: (719-749): Operator || not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool).
+// TypeError 2271: (759-789): Operator && not compatible with types error MyCustomError(uint256,bool) and error MyCustomError(uint256,bool).

--- a/test/libsolidity/syntaxTests/errors/error_incompatible_operator_for_type.sol
+++ b/test/libsolidity/syntaxTests/errors/error_incompatible_operator_for_type.sol
@@ -12,8 +12,8 @@ contract C {
 
 // ----
 // TypeError 4247: (102-115): Expression has to be an lvalue.
-// TypeError 7366: (102-120): Operator += not compatible with types error MyCustomError(uint256,bool) and int_const 1
+// TypeError 7366: (102-120): Operator += not compatible with types error MyCustomError(uint256,bool) and int_const 1.
 // TypeError 4247: (130-143): Expression has to be an lvalue.
-// TypeError 7366: (130-148): Operator -= not compatible with types error MyCustomError(uint256,bool) and int_const 1
-// TypeError 7366: (158-176): Operator += not compatible with types uint256 and error MyCustomError(uint256,bool)
-// TypeError 7366: (186-204): Operator -= not compatible with types uint256 and error MyCustomError(uint256,bool)
+// TypeError 7366: (130-148): Operator -= not compatible with types error MyCustomError(uint256,bool) and int_const 1.
+// TypeError 7366: (158-176): Operator += not compatible with types uint256 and error MyCustomError(uint256,bool).
+// TypeError 7366: (186-204): Operator -= not compatible with types uint256 and error MyCustomError(uint256,bool).

--- a/test/libsolidity/syntaxTests/errors/error_incompatible_unary_operator.sol
+++ b/test/libsolidity/syntaxTests/errors/error_incompatible_unary_operator.sol
@@ -8,4 +8,4 @@ contract C {
 
 // ----
 // TypeError 4247: (86-99): Expression has to be an lvalue.
-// TypeError 9767: (86-101): Unary operator ++ cannot be applied to type error MyCustomError(uint256,bool)
+// TypeError 9767: (86-101): Unary operator ++ cannot be applied to type error MyCustomError(uint256,bool).

--- a/test/libsolidity/syntaxTests/events/event_incompatible_binary_ops.sol
+++ b/test/libsolidity/syntaxTests/events/event_incompatible_binary_ops.sol
@@ -26,21 +26,21 @@ contract C {
 }
 
 // ----
-// TypeError 2271: (83-113): Operator << not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256)
-// TypeError 2271: (123-153): Operator >> not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256)
-// TypeError 2271: (163-192): Operator ^ not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256)
-// TypeError 2271: (202-231): Operator | not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256)
-// TypeError 2271: (241-270): Operator & not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256)
-// TypeError 2271: (281-310): Operator * not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256)
-// TypeError 2271: (320-349): Operator / not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256)
-// TypeError 2271: (359-388): Operator % not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256)
-// TypeError 2271: (398-427): Operator + not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256)
-// TypeError 2271: (437-466): Operator - not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256)
-// TypeError 2271: (477-507): Operator == not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256)
-// TypeError 2271: (517-547): Operator != not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256)
-// TypeError 2271: (557-587): Operator >= not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256)
-// TypeError 2271: (597-627): Operator <= not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256)
-// TypeError 2271: (637-666): Operator < not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256)
-// TypeError 2271: (676-705): Operator > not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256)
-// TypeError 2271: (716-746): Operator || not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256)
-// TypeError 2271: (756-786): Operator && not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256)
+// TypeError 2271: (83-113): Operator << not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256).
+// TypeError 2271: (123-153): Operator >> not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256).
+// TypeError 2271: (163-192): Operator ^ not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256).
+// TypeError 2271: (202-231): Operator | not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256).
+// TypeError 2271: (241-270): Operator & not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256).
+// TypeError 2271: (281-310): Operator * not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256).
+// TypeError 2271: (320-349): Operator / not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256).
+// TypeError 2271: (359-388): Operator % not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256).
+// TypeError 2271: (398-427): Operator + not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256).
+// TypeError 2271: (437-466): Operator - not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256).
+// TypeError 2271: (477-507): Operator == not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256).
+// TypeError 2271: (517-547): Operator != not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256).
+// TypeError 2271: (557-587): Operator >= not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256).
+// TypeError 2271: (597-627): Operator <= not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256).
+// TypeError 2271: (637-666): Operator < not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256).
+// TypeError 2271: (676-705): Operator > not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256).
+// TypeError 2271: (716-746): Operator || not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256).
+// TypeError 2271: (756-786): Operator && not compatible with types event MyCustomEvent(uint256) and event MyCustomEvent(uint256).

--- a/test/libsolidity/syntaxTests/events/event_incompatible_operator_for_type.sol
+++ b/test/libsolidity/syntaxTests/events/event_incompatible_operator_for_type.sol
@@ -11,8 +11,8 @@ contract C {
 
 // ----
 // TypeError 4247: (99-112): Expression has to be an lvalue.
-// TypeError 7366: (99-117): Operator += not compatible with types event MyCustomEvent(uint256) and int_const 1
+// TypeError 7366: (99-117): Operator += not compatible with types event MyCustomEvent(uint256) and int_const 1.
 // TypeError 4247: (127-140): Expression has to be an lvalue.
-// TypeError 7366: (127-145): Operator -= not compatible with types event MyCustomEvent(uint256) and int_const 1
-// TypeError 7366: (155-173): Operator += not compatible with types uint256 and event MyCustomEvent(uint256)
-// TypeError 7366: (183-201): Operator -= not compatible with types uint256 and event MyCustomEvent(uint256)
+// TypeError 7366: (127-145): Operator -= not compatible with types event MyCustomEvent(uint256) and int_const 1.
+// TypeError 7366: (155-173): Operator += not compatible with types uint256 and event MyCustomEvent(uint256).
+// TypeError 7366: (183-201): Operator -= not compatible with types uint256 and event MyCustomEvent(uint256).

--- a/test/libsolidity/syntaxTests/events/event_incompatible_unary_operator.sol
+++ b/test/libsolidity/syntaxTests/events/event_incompatible_unary_operator.sol
@@ -7,4 +7,4 @@ contract C {
 
 // ----
 // TypeError 4247: (83-96): Expression has to be an lvalue.
-// TypeError 9767: (83-98): Unary operator ++ cannot be applied to type event MyCustomEvent(uint256)
+// TypeError 9767: (83-98): Unary operator ++ cannot be applied to type event MyCustomEvent(uint256).

--- a/test/libsolidity/syntaxTests/functionTypes/comparison_of_function_types_gt_1.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/comparison_of_function_types_gt_1.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError 2271: (73-88): Operator > not compatible with types function () external returns (bool) and function () external returns (bool)
+// TypeError 2271: (73-88): Operator > not compatible with types function () external returns (bool) and function () external returns (bool).

--- a/test/libsolidity/syntaxTests/functionTypes/comparison_of_function_types_gt_2.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/comparison_of_function_types_gt_2.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError 2271: (73-78): Operator > not compatible with types function () returns (bool) and function () returns (bool)
+// TypeError 2271: (73-78): Operator > not compatible with types function () returns (bool) and function () returns (bool).

--- a/test/libsolidity/syntaxTests/functionTypes/comparison_of_function_types_lt_1.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/comparison_of_function_types_lt_1.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError 2271: (73-88): Operator < not compatible with types function () external returns (bool) and function () external returns (bool)
+// TypeError 2271: (73-88): Operator < not compatible with types function () external returns (bool) and function () external returns (bool).

--- a/test/libsolidity/syntaxTests/functionTypes/comparison_of_function_types_lt_2.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/comparison_of_function_types_lt_2.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError 2271: (73-78): Operator < not compatible with types function () returns (bool) and function () returns (bool)
+// TypeError 2271: (73-78): Operator < not compatible with types function () returns (bool) and function () returns (bool).

--- a/test/libsolidity/syntaxTests/functionTypes/comparison_operator_for_external_functions_with_extra_gas_slots.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/comparison_operator_for_external_functions_with_extra_gas_slots.sol
@@ -8,5 +8,5 @@ contract C {
     }
 }
 // ----
-// TypeError 2271: (193-259): Operator == not compatible with types function () external and function () external
-// TypeError 2271: (277-351): Operator == not compatible with types function () external and function () external
+// TypeError 2271: (193-259): Operator == not compatible with types function () external and function () external.
+// TypeError 2271: (277-351): Operator == not compatible with types function () external and function () external.

--- a/test/libsolidity/syntaxTests/functionTypes/comparison_operators_between_internal_and_external_function_pointers.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/comparison_operators_between_internal_and_external_function_pointers.sol
@@ -19,5 +19,5 @@ contract C {
     }
 }
 // ----
-// TypeError 2271: (606-672): Operator != not compatible with types function () and function () external
-// TypeError 2271: (688-741): Operator != not compatible with types function () and function () external
+// TypeError 2271: (606-672): Operator != not compatible with types function () and function () external.
+// TypeError 2271: (688-741): Operator != not compatible with types function () and function () external.

--- a/test/libsolidity/syntaxTests/functionTypes/comparison_operators_external_functions_with_different_parameters.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/comparison_operators_external_functions_with_different_parameters.sol
@@ -21,6 +21,6 @@ contract C {
 // ----
 // TypeError 9574: (249-333): Type function (uint256) external is not implicitly convertible to expected type function () external.
 // TypeError 9574: (343-427): Type function (bool) external is not implicitly convertible to expected type function () external.
-// TypeError 2271: (458-522): Operator == not compatible with types function (uint256) external and function () external
-// TypeError 2271: (538-602): Operator == not compatible with types function (bool) external and function () external
-// TypeError 2271: (726-786): Operator != not compatible with types function (bool) external and function (uint256) external
+// TypeError 2271: (458-522): Operator == not compatible with types function (uint256) external and function () external.
+// TypeError 2271: (538-602): Operator == not compatible with types function (bool) external and function () external.
+// TypeError 2271: (726-786): Operator != not compatible with types function (bool) external and function (uint256) external.

--- a/test/libsolidity/syntaxTests/iceRegressionTests/declarationUnaryTuple/declaration_dec_tuple.sol
+++ b/test/libsolidity/syntaxTests/iceRegressionTests/declarationUnaryTuple/declaration_dec_tuple.sol
@@ -6,4 +6,4 @@ contract C
     }
 }
 // ----
-// TypeError 9767: (59-64): Unary operator -- cannot be applied to type tuple(,)
+// TypeError 9767: (59-64): Unary operator -- cannot be applied to type tuple(,).

--- a/test/libsolidity/syntaxTests/iceRegressionTests/declarationUnaryTuple/declaration_delete_tuple.sol
+++ b/test/libsolidity/syntaxTests/iceRegressionTests/declarationUnaryTuple/declaration_delete_tuple.sol
@@ -7,4 +7,4 @@ contract C
 }
 // ----
 // TypeError 4247: (68-69): Expression has to be an lvalue.
-// TypeError 9767: (59-70): Unary operator delete cannot be applied to type tuple(,int_const 0)
+// TypeError 9767: (59-70): Unary operator delete cannot be applied to type tuple(,int_const 0).

--- a/test/libsolidity/syntaxTests/iceRegressionTests/declarationUnaryTuple/declaration_inc_tuple.sol
+++ b/test/libsolidity/syntaxTests/iceRegressionTests/declarationUnaryTuple/declaration_inc_tuple.sol
@@ -6,4 +6,4 @@ contract C
     }
 }
 // ----
-// TypeError 9767: (61-66): Unary operator ++ cannot be applied to type tuple(,)
+// TypeError 9767: (61-66): Unary operator ++ cannot be applied to type tuple(,).

--- a/test/libsolidity/syntaxTests/iceRegressionTests/declarationUnaryTuple/declaration_unary_tuple.sol
+++ b/test/libsolidity/syntaxTests/iceRegressionTests/declarationUnaryTuple/declaration_unary_tuple.sol
@@ -10,11 +10,11 @@ contract C
 }
 // ----
 // SyntaxError 9636: (59-66): Use of unary + is disallowed.
-// TypeError 4907: (59-66): Unary operator + cannot be applied to type tuple(int_const 0,int_const 0)
+// TypeError 4907: (59-66): Unary operator + cannot be applied to type tuple(int_const 0,int_const 0).
 // TypeError 7364: (51-66): Different number of components on the left hand side (1) than on the right hand side (2).
-// TypeError 4907: (84-91): Unary operator - cannot be applied to type tuple(int_const 0,int_const 0)
+// TypeError 4907: (84-91): Unary operator - cannot be applied to type tuple(int_const 0,int_const 0).
 // TypeError 7364: (76-91): Different number of components on the left hand side (1) than on the right hand side (2).
-// TypeError 4907: (111-118): Unary operator ~ cannot be applied to type tuple(int_const 0,int_const 0)
+// TypeError 4907: (111-118): Unary operator ~ cannot be applied to type tuple(int_const 0,int_const 0).
 // TypeError 7364: (101-118): Different number of components on the left hand side (1) than on the right hand side (2).
-// TypeError 4907: (138-145): Unary operator ! cannot be applied to type tuple(int_const 0,int_const 0)
+// TypeError 4907: (138-145): Unary operator ! cannot be applied to type tuple(int_const 0,int_const 0).
 // TypeError 7364: (128-145): Different number of components on the left hand side (1) than on the right hand side (2).

--- a/test/libsolidity/syntaxTests/literalOperations/division_by_zero.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/division_by_zero.sol
@@ -2,4 +2,4 @@ contract C {
     uint constant a = 1 / 0;
 }
 // ----
-// TypeError 2271: (35-40): Operator / not compatible with types int_const 1 and int_const 0
+// TypeError 2271: (35-40): Operator / not compatible with types int_const 1 and int_const 0.

--- a/test/libsolidity/syntaxTests/literalOperations/division_by_zero_complex.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/division_by_zero_complex.sol
@@ -2,4 +2,4 @@ contract C {
     uint constant a = 1 / ((1+3)-4);
 }
 // ----
-// TypeError 2271: (35-48): Operator / not compatible with types int_const 1 and int_const 0
+// TypeError 2271: (35-48): Operator / not compatible with types int_const 1 and int_const 0.

--- a/test/libsolidity/syntaxTests/literalOperations/mod_zero.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/mod_zero.sol
@@ -2,4 +2,4 @@ contract C {
     uint constant b3 = 1 % 0;
 }
 // ----
-// TypeError 2271: (36-41): Operator % not compatible with types int_const 1 and int_const 0
+// TypeError 2271: (36-41): Operator % not compatible with types int_const 1 and int_const 0.

--- a/test/libsolidity/syntaxTests/literalOperations/mod_zero_complex.sol
+++ b/test/libsolidity/syntaxTests/literalOperations/mod_zero_complex.sol
@@ -2,4 +2,4 @@ contract C {
     uint constant b3 = 1 % (-4+((2)*2));
 }
 // ----
-// TypeError 2271: (36-52): Operator % not compatible with types int_const 1 and int_const 0
+// TypeError 2271: (36-52): Operator % not compatible with types int_const 1 and int_const 0.

--- a/test/libsolidity/syntaxTests/metaTypes/integer_err.sol
+++ b/test/libsolidity/syntaxTests/metaTypes/integer_err.sol
@@ -12,4 +12,4 @@ contract Test {
 // ----
 // TypeError 9574: (59-89): Type int256 is not implicitly convertible to expected type uint8.
 // TypeError 9574: (99-127): Type int256 is not implicitly convertible to expected type uint256.
-// TypeError 2271: (142-169): Operator == not compatible with types int256 and int_const 1157...(70 digits omitted)...9935
+// TypeError 2271: (142-169): Operator == not compatible with types int256 and int_const 1157...(70 digits omitted)...9935.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/011_type_conversion_for_comparison_invalid.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/011_type_conversion_for_comparison_invalid.sol
@@ -2,4 +2,4 @@ contract test {
     function f() public { int32(2) == uint64(2); }
 }
 // ----
-// TypeError 2271: (42-63): Operator == not compatible with types int32 and uint64
+// TypeError 2271: (42-63): Operator == not compatible with types int32 and uint64.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/025_comparison_of_mapping_types.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/025_comparison_of_mapping_types.sol
@@ -6,4 +6,4 @@ contract C {
     }
 }
 // ----
-// TypeError 2271: (147-153): Operator == not compatible with types mapping(uint256 => uint256) and mapping(uint256 => uint256)
+// TypeError 2271: (147-153): Operator == not compatible with types mapping(uint256 => uint256) and mapping(uint256 => uint256).

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/112_exp_operator_exponent_too_big.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/112_exp_operator_exponent_too_big.sol
@@ -2,4 +2,4 @@ contract test {
     function f() public returns (uint d) { return 2 ** 10000000000; }
 }
 // ----
-// TypeError 2271: (66-82): Operator ** not compatible with types int_const 2 and int_const 10000000000
+// TypeError 2271: (66-82): Operator ** not compatible with types int_const 2 and int_const 10000000000.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/196_integer_boolean_or.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/196_integer_boolean_or.sol
@@ -1,3 +1,3 @@
 contract test { fallback() external { uint x = 1; uint y = 2; x || y; } }
 // ----
-// TypeError 2271: (62-68): Operator || not compatible with types uint256 and uint256
+// TypeError 2271: (62-68): Operator || not compatible with types uint256 and uint256.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/197_integer_boolean_and.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/197_integer_boolean_and.sol
@@ -1,3 +1,3 @@
 contract test { fallback() external { uint x = 1; uint y = 2; x && y; } }
 // ----
-// TypeError 2271: (62-68): Operator && not compatible with types uint256 and uint256
+// TypeError 2271: (62-68): Operator && not compatible with types uint256 and uint256.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/198_integer_boolean_not.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/198_integer_boolean_not.sol
@@ -1,3 +1,3 @@
 contract test { fallback() external { uint x = 1; !x; } }
 // ----
-// TypeError 4907: (50-52): Unary operator ! cannot be applied to type uint256
+// TypeError 4907: (50-52): Unary operator ! cannot be applied to type uint256.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/202_bytes_reference_compare_operators.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/202_bytes_reference_compare_operators.sol
@@ -1,3 +1,3 @@
 contract test { bytes a; bytes b; fallback() external { a == b; } }
 // ----
-// TypeError 2271: (56-62): Operator == not compatible with types bytes storage ref and bytes storage ref
+// TypeError 2271: (56-62): Operator == not compatible with types bytes storage ref and bytes storage ref.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/203_struct_reference_compare_operators.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/203_struct_reference_compare_operators.sol
@@ -7,4 +7,4 @@ contract test {
   }
 }
 // ----
-// TypeError 2271: (79-85): Operator == not compatible with types struct test.s storage ref and struct test.s storage ref
+// TypeError 2271: (79-85): Operator == not compatible with types struct test.s storage ref and struct test.s storage ref.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/213_no_delete_on_storage_pointers.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/213_no_delete_on_storage_pointers.sol
@@ -6,4 +6,4 @@ contract C {
     }
 }
 // ----
-// TypeError 9767: (97-105): Unary operator delete cannot be applied to type uint256[] storage pointer
+// TypeError 9767: (97-105): Unary operator delete cannot be applied to type uint256[] storage pointer.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/308_rational_unary_plus_operation.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/308_rational_unary_plus_operation.sol
@@ -7,4 +7,4 @@ contract test {
 }
 // ----
 // SyntaxError 9636: (70-75): Use of unary + is disallowed.
-// TypeError 4907: (70-75): Unary operator + cannot be applied to type rational_const 13 / 4
+// TypeError 4907: (70-75): Unary operator + cannot be applied to type rational_const 13 / 4.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/329_rational_as_exponent_value_signed.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/329_rational_as_exponent_value_signed.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// TypeError 2271: (60-69): Operator ** not compatible with types int_const 2 and rational_const -11 / 5
+// TypeError 2271: (60-69): Operator ** not compatible with types int_const 2 and rational_const -11 / 5.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/330_rational_as_exponent_value_unsigned.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/330_rational_as_exponent_value_unsigned.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// TypeError 2271: (61-69): Operator ** not compatible with types int_const 3 and rational_const 5 / 2
+// TypeError 2271: (61-69): Operator ** not compatible with types int_const 3 and rational_const 5 / 2.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/331_rational_as_exponent_half.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/331_rational_as_exponent_half.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// TypeError 2271: (50-60): Operator ** not compatible with types int_const 2 and rational_const 1 / 2
+// TypeError 2271: (50-60): Operator ** not compatible with types int_const 2 and rational_const 1 / 2.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/332_rational_as_exponent_value_neg_quarter.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/332_rational_as_exponent_value_neg_quarter.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// TypeError 2271: (50-62): Operator ** not compatible with types int_const 42 and rational_const -1 / 4
+// TypeError 2271: (50-62): Operator ** not compatible with types int_const 42 and rational_const -1 / 4.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/338_rational_bitnot_unary_operation.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/338_rational_bitnot_unary_operation.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// TypeError 4907: (50-61): Unary operator ~ cannot be applied to type fixed128x18
+// TypeError 4907: (50-61): Unary operator ~ cannot be applied to type fixed128x18.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/339_rational_bitor_binary_operation.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/339_rational_bitor_binary_operation.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// TypeError 2271: (50-64): Operator | not compatible with types fixed128x18 and int_const 3
+// TypeError 2271: (50-64): Operator | not compatible with types fixed128x18 and int_const 3.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/340_rational_bitxor_binary_operation.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/340_rational_bitxor_binary_operation.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// TypeError 2271: (50-65): Operator ^ not compatible with types fixed128x18 and int_const 3
+// TypeError 2271: (50-65): Operator ^ not compatible with types fixed128x18 and int_const 3.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/341_rational_bitand_binary_operation.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/341_rational_bitand_binary_operation.sol
@@ -4,4 +4,4 @@ contract test {
     }
 }
 // ----
-// TypeError 2271: (50-65): Operator & not compatible with types fixed128x18 and int_const 3
+// TypeError 2271: (50-65): Operator & not compatible with types fixed128x18 and int_const 3.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/368_shift_constant_left_negative_rvalue.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/368_shift_constant_left_negative_rvalue.sol
@@ -2,4 +2,4 @@ contract C {
     uint public a = 0x42 << -8;
 }
 // ----
-// TypeError 2271: (33-43): Operator << not compatible with types int_const 66 and int_const -8
+// TypeError 2271: (33-43): Operator << not compatible with types int_const 66 and int_const -8.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/369_shift_constant_right_negative_rvalue.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/369_shift_constant_right_negative_rvalue.sol
@@ -2,4 +2,4 @@ contract C {
     uint public a = 0x42 >> -8;
 }
 // ----
-// TypeError 2271: (33-43): Operator >> not compatible with types int_const 66 and int_const -8
+// TypeError 2271: (33-43): Operator >> not compatible with types int_const 66 and int_const -8.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/370_shift_constant_left_excessive_rvalue.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/370_shift_constant_left_excessive_rvalue.sol
@@ -2,4 +2,4 @@ contract C {
     uint public a = 0x42 << 0x100000000;
 }
 // ----
-// TypeError 2271: (33-52): Operator << not compatible with types int_const 66 and int_const 4294967296
+// TypeError 2271: (33-52): Operator << not compatible with types int_const 66 and int_const 4294967296.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/371_shift_constant_right_excessive_rvalue.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/371_shift_constant_right_excessive_rvalue.sol
@@ -2,4 +2,4 @@ contract C {
     uint public a = 0x42 >> 0x100000000;
 }
 // ----
-// TypeError 2271: (33-52): Operator >> not compatible with types int_const 66 and int_const 4294967296
+// TypeError 2271: (33-52): Operator >> not compatible with types int_const 66 and int_const 4294967296.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/372_shift_constant_right_fractional.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/372_shift_constant_right_fractional.sol
@@ -2,4 +2,4 @@ contract C {
     uint public a = 0x42 >> (1 / 2);
 }
 // ----
-// TypeError 2271: (33-48): Operator >> not compatible with types int_const 66 and rational_const 1 / 2
+// TypeError 2271: (33-48): Operator >> not compatible with types int_const 66 and rational_const 1 / 2.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/compoundAssignment/incomp_types.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/compoundAssignment/incomp_types.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError 7366: (72-83): Operator += not compatible with types uint256 and tuple(int_const 1,int_const 1)
+// TypeError 7366: (72-83): Operator += not compatible with types uint256 and tuple(int_const 1,int_const 1).

--- a/test/libsolidity/syntaxTests/parsing/unary_plus_expression.sol
+++ b/test/libsolidity/syntaxTests/parsing/unary_plus_expression.sol
@@ -6,4 +6,4 @@ contract test {
 }
 // ----
 // SyntaxError 9636: (70-72): Use of unary + is disallowed.
-// TypeError 4907: (70-72): Unary operator + cannot be applied to type uint256
+// TypeError 4907: (70-72): Unary operator + cannot be applied to type uint256.

--- a/test/libsolidity/syntaxTests/shifts/shift_singed_rvalue.sol
+++ b/test/libsolidity/syntaxTests/shifts/shift_singed_rvalue.sol
@@ -7,5 +7,5 @@ contract C {
     }
 }
 // ----
-// TypeError 2271: (89-95): Operator >> not compatible with types int256 and int256
-// TypeError 2271: (179-193): Operator >> not compatible with types int256 and int256
+// TypeError 2271: (89-95): Operator >> not compatible with types int256 and int256.
+// TypeError 2271: (179-193): Operator >> not compatible with types int256 and int256.

--- a/test/libsolidity/syntaxTests/types/bool_ops.sol
+++ b/test/libsolidity/syntaxTests/types/bool_ops.sol
@@ -32,22 +32,22 @@ contract C {
     }
 }
 // ----
-// TypeError 2271: (231-236): Operator > not compatible with types bool and bool
-// TypeError 2271: (250-255): Operator < not compatible with types bool and bool
-// TypeError 2271: (269-275): Operator >= not compatible with types bool and bool
-// TypeError 2271: (289-295): Operator <= not compatible with types bool and bool
-// TypeError 2271: (309-314): Operator & not compatible with types bool and bool
-// TypeError 2271: (328-333): Operator | not compatible with types bool and bool
-// TypeError 2271: (347-352): Operator ^ not compatible with types bool and bool
-// TypeError 4907: (366-368): Unary operator ~ cannot be applied to type bool
-// TypeError 4907: (382-384): Unary operator ~ cannot be applied to type bool
-// TypeError 2271: (398-403): Operator + not compatible with types bool and bool
-// TypeError 2271: (417-422): Operator - not compatible with types bool and bool
-// TypeError 4907: (436-438): Unary operator - cannot be applied to type bool
-// TypeError 4907: (452-454): Unary operator - cannot be applied to type bool
-// TypeError 2271: (468-473): Operator * not compatible with types bool and bool
-// TypeError 2271: (487-492): Operator / not compatible with types bool and bool
-// TypeError 2271: (506-512): Operator ** not compatible with types bool and bool
-// TypeError 2271: (526-531): Operator % not compatible with types bool and bool
-// TypeError 2271: (545-551): Operator << not compatible with types bool and bool
-// TypeError 2271: (565-571): Operator >> not compatible with types bool and bool
+// TypeError 2271: (231-236): Operator > not compatible with types bool and bool.
+// TypeError 2271: (250-255): Operator < not compatible with types bool and bool.
+// TypeError 2271: (269-275): Operator >= not compatible with types bool and bool.
+// TypeError 2271: (289-295): Operator <= not compatible with types bool and bool.
+// TypeError 2271: (309-314): Operator & not compatible with types bool and bool.
+// TypeError 2271: (328-333): Operator | not compatible with types bool and bool.
+// TypeError 2271: (347-352): Operator ^ not compatible with types bool and bool.
+// TypeError 4907: (366-368): Unary operator ~ cannot be applied to type bool.
+// TypeError 4907: (382-384): Unary operator ~ cannot be applied to type bool.
+// TypeError 2271: (398-403): Operator + not compatible with types bool and bool.
+// TypeError 2271: (417-422): Operator - not compatible with types bool and bool.
+// TypeError 4907: (436-438): Unary operator - cannot be applied to type bool.
+// TypeError 4907: (452-454): Unary operator - cannot be applied to type bool.
+// TypeError 2271: (468-473): Operator * not compatible with types bool and bool.
+// TypeError 2271: (487-492): Operator / not compatible with types bool and bool.
+// TypeError 2271: (506-512): Operator ** not compatible with types bool and bool.
+// TypeError 2271: (526-531): Operator % not compatible with types bool and bool.
+// TypeError 2271: (545-551): Operator << not compatible with types bool and bool.
+// TypeError 2271: (565-571): Operator >> not compatible with types bool and bool.

--- a/test/libsolidity/syntaxTests/types/hex_literal_bitnot.sol
+++ b/test/libsolidity/syntaxTests/types/hex_literal_bitnot.sol
@@ -2,4 +2,4 @@ contract C {
     bytes32 b = ~hex"00ff11";
 }
 // ----
-// TypeError 4907: (29-41): Unary operator ~ cannot be applied to type literal_string hex"00ff11"
+// TypeError 4907: (29-41): Unary operator ~ cannot be applied to type literal_string hex"00ff11".

--- a/test/libsolidity/syntaxTests/types/rational_number_bitshift_limit.sol
+++ b/test/libsolidity/syntaxTests/types/rational_number_bitshift_limit.sol
@@ -8,6 +8,6 @@ contract c {
 }
 // ----
 // TypeError 7407: (71-80): Type int_const 5221...(1225 digits omitted)...5168 is not implicitly convertible to expected type int256. Literal is too large to fit in int256.
-// TypeError 2271: (133-142): Operator << not compatible with types int_const 1 and int_const 4096
-// TypeError 2271: (169-182): Operator << not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const 2
+// TypeError 2271: (133-142): Operator << not compatible with types int_const 1 and int_const 4096.
+// TypeError 2271: (169-182): Operator << not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const 2.
 // TypeError 7407: (169-182): Type int_const 1000...(1226 digits omitted)...0000 is not implicitly convertible to expected type int256. Literal is too large to fit in int256.

--- a/test/libsolidity/syntaxTests/types/rational_number_exp_limit_fail.sol
+++ b/test/libsolidity/syntaxTests/types/rational_number_exp_limit_fail.sol
@@ -19,29 +19,29 @@ contract c {
     }
 }
 // ----
-// TypeError 2271: (71-112): Operator ** not compatible with types int_const 1797...(301 digits omitted)...7216 and int_const 4
+// TypeError 2271: (71-112): Operator ** not compatible with types int_const 1797...(301 digits omitted)...7216 and int_const 4.
 // TypeError 7407: (71-112): Type int_const 1797...(301 digits omitted)...7216 is not implicitly convertible to expected type int256. Literal is too large to fit in int256.
-// TypeError 2271: (135-151): Operator ** not compatible with types int_const 4 and int_const 1157...(70 digits omitted)...9936
+// TypeError 2271: (135-151): Operator ** not compatible with types int_const 4 and int_const 1157...(70 digits omitted)...9936.
 // TypeError 7407: (126-169): Type int_const 1340...(147 digits omitted)...4096 is not implicitly convertible to expected type int256. Literal is too large to fit in int256.
-// TypeError 2271: (201-217): Operator ** not compatible with types int_const 4 and int_const 1340...(147 digits omitted)...4096
-// TypeError 2271: (183-219): Operator ** not compatible with types int_const 4 and int_const -115...(71 digits omitted)...9936
-// TypeError 2271: (233-244): Operator ** not compatible with types int_const 2 and int_const 1000...(1226 digits omitted)...0000
-// TypeError 2271: (258-270): Operator ** not compatible with types int_const -2 and int_const 1000...(1226 digits omitted)...0000
-// TypeError 2271: (284-296): Operator ** not compatible with types int_const 2 and int_const -100...(1227 digits omitted)...0000
-// TypeError 2271: (310-323): Operator ** not compatible with types int_const -2 and int_const -100...(1227 digits omitted)...0000
-// TypeError 2271: (337-348): Operator ** not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const 2
+// TypeError 2271: (201-217): Operator ** not compatible with types int_const 4 and int_const 1340...(147 digits omitted)...4096.
+// TypeError 2271: (183-219): Operator ** not compatible with types int_const 4 and int_const -115...(71 digits omitted)...9936.
+// TypeError 2271: (233-244): Operator ** not compatible with types int_const 2 and int_const 1000...(1226 digits omitted)...0000.
+// TypeError 2271: (258-270): Operator ** not compatible with types int_const -2 and int_const 1000...(1226 digits omitted)...0000.
+// TypeError 2271: (284-296): Operator ** not compatible with types int_const 2 and int_const -100...(1227 digits omitted)...0000.
+// TypeError 2271: (310-323): Operator ** not compatible with types int_const -2 and int_const -100...(1227 digits omitted)...0000.
+// TypeError 2271: (337-348): Operator ** not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const 2.
 // TypeError 7407: (337-348): Type int_const 1000...(1226 digits omitted)...0000 is not implicitly convertible to expected type int256. Literal is too large to fit in int256.
-// TypeError 2271: (362-374): Operator ** not compatible with types int_const -100...(1227 digits omitted)...0000 and int_const 2
+// TypeError 2271: (362-374): Operator ** not compatible with types int_const -100...(1227 digits omitted)...0000 and int_const 2.
 // TypeError 7407: (362-374): Type int_const -100...(1227 digits omitted)...0000 is not implicitly convertible to expected type int256. Literal is too large to fit in int256.
-// TypeError 2271: (388-400): Operator ** not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const -2
+// TypeError 2271: (388-400): Operator ** not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const -2.
 // TypeError 7407: (388-400): Type int_const 1000...(1226 digits omitted)...0000 is not implicitly convertible to expected type int256. Literal is too large to fit in int256.
-// TypeError 2271: (414-427): Operator ** not compatible with types int_const -100...(1227 digits omitted)...0000 and int_const -2
+// TypeError 2271: (414-427): Operator ** not compatible with types int_const -100...(1227 digits omitted)...0000 and int_const -2.
 // TypeError 7407: (414-427): Type int_const -100...(1227 digits omitted)...0000 is not implicitly convertible to expected type int256. Literal is too large to fit in int256.
-// TypeError 2271: (441-457): Operator ** not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const 1000...(1226 digits omitted)...0000
+// TypeError 2271: (441-457): Operator ** not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const 1000...(1226 digits omitted)...0000.
 // TypeError 7407: (441-457): Type int_const 1000...(1226 digits omitted)...0000 is not implicitly convertible to expected type int256. Literal is too large to fit in int256.
-// TypeError 2271: (471-488): Operator ** not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const -100...(1227 digits omitted)...0000
+// TypeError 2271: (471-488): Operator ** not compatible with types int_const 1000...(1226 digits omitted)...0000 and int_const -100...(1227 digits omitted)...0000.
 // TypeError 7407: (471-488): Type int_const 1000...(1226 digits omitted)...0000 is not implicitly convertible to expected type int256. Literal is too large to fit in int256.
-// TypeError 2271: (502-519): Operator ** not compatible with types int_const -100...(1227 digits omitted)...0000 and int_const 1000...(1226 digits omitted)...0000
+// TypeError 2271: (502-519): Operator ** not compatible with types int_const -100...(1227 digits omitted)...0000 and int_const 1000...(1226 digits omitted)...0000.
 // TypeError 7407: (502-519): Type int_const -100...(1227 digits omitted)...0000 is not implicitly convertible to expected type int256. Literal is too large to fit in int256.
-// TypeError 2271: (533-551): Operator ** not compatible with types int_const -100...(1227 digits omitted)...0000 and int_const -100...(1227 digits omitted)...0000
+// TypeError 2271: (533-551): Operator ** not compatible with types int_const -100...(1227 digits omitted)...0000 and int_const -100...(1227 digits omitted)...0000.
 // TypeError 7407: (533-551): Type int_const -100...(1227 digits omitted)...0000 is not implicitly convertible to expected type int256. Literal is too large to fit in int256.


### PR DESCRIPTION
This change moves the addition of full stops (periods, dots) from  #12362. So far, full stops were added to 4907, 9767, 7366 and 2271. 