### PR TITLE
`update_bugs_by_version.py`: don't fail when the list gets updated

### DIFF
--- a/scripts/update_bugs_by_version.py
+++ b/scripts/update_bugs_by_version.py
@@ -8,7 +8,6 @@
 
 import json
 import re
-import sys
 from pathlib import Path
 
 def comp(version_string):
@@ -35,7 +34,9 @@ for key, value in versions.items():
             continue
         value['bugs'] += [bug['name']]
 
-new_contents = json.dumps(versions, sort_keys=True, indent=4, separators=(',', ': '))
-old_contents = (root_path / 'docs/bugs_by_version.json').read_text(encoding='utf8')
-(root_path / 'docs/bugs_by_version.json').write_text(new_contents, encoding='utf8')
-sys.exit(old_contents != new_contents)
+(root_path / 'docs/bugs_by_version.json').write_text(json.dumps(
+    versions,
+    sort_keys=True,
+    indent=4,
+    separators=(',', ': ')
+), encoding='utf8')

--- a/scripts/update_bugs_by_version.py
+++ b/scripts/update_bugs_by_version.py
@@ -6,20 +6,20 @@
 # This makes it possible to use this script as part of CI to check
 # that the list is up to date.
 
-import os
 import json
 import re
 import sys
+from pathlib import Path
 
 def comp(version_string):
     return [int(c) for c in version_string.split('.')]
 
-path = os.path.dirname(os.path.realpath(__file__))
-with open(path + '/../docs/bugs.json', encoding='utf8') as bugsFile:
-    bugs = json.load(bugsFile)
+root_path = Path(__file__).resolve().parent.parent
+
+bugs = json.loads((root_path / 'docs/bugs.json').read_text(encoding='utf8'))
 
 versions = {}
-with open(path + '/../Changelog.md', encoding='utf8') as changelog:
+with (root_path / 'Changelog.md').open(encoding='utf8') as changelog:
     for line in changelog:
         m = re.search(r'^### (\S+) \((\d+-\d+-\d+)\)$', line)
         if m:
@@ -36,8 +36,6 @@ for key, value in versions.items():
         value['bugs'] += [bug['name']]
 
 new_contents = json.dumps(versions, sort_keys=True, indent=4, separators=(',', ': '))
-with open(path + '/../docs/bugs_by_version.json', 'r', encoding='utf8') as bugs_by_version:
-    old_contents = bugs_by_version.read()
-with open(path + '/../docs/bugs_by_version.json', 'w', encoding='utf8') as bugs_by_version:
-    bugs_by_version.write(new_contents)
+old_contents = (root_path / 'docs/bugs_by_version.json').read_text(encoding='utf8')
+(root_path / 'docs/bugs_by_version.json').write_text(new_contents, encoding='utf8')
 sys.exit(old_contents != new_contents)

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -355,7 +355,7 @@ function test_via_ir_equivalence()
 
     for yul_file in $(find . -name "${output_file_prefix}*.yul" | sort -V); do
         bin_output_two_stage+=$(
-	    msg_on_error --no-stderr "$SOLC" --strict-assembly --bin "${optimizer_flags[@]}" "$yul_file" |
+        msg_on_error --no-stderr "$SOLC" --strict-assembly --bin "${optimizer_flags[@]}" "$yul_file" |
                 sed '/^Binary representation:$/d' |
                 sed '/^=======/d'
         )
@@ -375,8 +375,13 @@ function test_via_ir_equivalence()
 
 ## RUN
 
-echo "Checking that the bug list is up to date..."
-"$REPO_ROOT"/scripts/update_bugs_by_version.py
+SOLTMPDIR=$(mktemp -d)
+printTask "Checking that the bug list is up to date..."
+cp "${REPO_ROOT}/docs/bugs_by_version.json" "${SOLTMPDIR}/original_bugs_by_version.json"
+"${REPO_ROOT}/scripts/update_bugs_by_version.py"
+diff --unified "${SOLTMPDIR}/original_bugs_by_version.json" "${REPO_ROOT}/docs/bugs_by_version.json" || \
+    fail "The bug list in bugs_by_version.json was out of date and has been updated. Please investigate and submit a bugfix if necessary."
+rm -r "$SOLTMPDIR"
 
 printTask "Testing unknown options..."
 (


### PR DESCRIPTION
The script fails if the file gets updated, which is fine for testing but confusing when you run it manually. I changed the script so that the diffing happens only in CLI tests.

Also, refactored the script to use pathlib.