### PR TITLE
Update the default free memory pointer in Yul.rst

### DIFF
--- a/docs/yul.rst
+++ b/docs/yul.rst
@@ -1162,7 +1162,7 @@ An example Yul Object is shown below:
         code {
             function allocate(size) -> ptr {
                 ptr := mload(0x40)
-                if iszero(ptr) { ptr := 0x60 }
+                if iszero(ptr) { ptr := 0x80 }
                 mstore(0x40, add(ptr, size))
             }
 

--- a/docs/yul.rst
+++ b/docs/yul.rst
@@ -1162,7 +1162,8 @@ An example Yul Object is shown below:
         code {
             function allocate(size) -> ptr {
                 ptr := mload(0x40)
-                if iszero(ptr) { ptr := 0x80 }
+                // Note that Solidity generated IR code reserves memory offset ``0x60`` as well, but a pure Yul object is free to use memory as it chooses.
+                if iszero(ptr) { ptr := 0x60 }
                 mstore(0x40, add(ptr, size))
             }
 
@@ -1191,6 +1192,7 @@ An example Yul Object is shown below:
             code {
                 function allocate(size) -> ptr {
                     ptr := mload(0x40)
+                    // Note that Solidity generated IR code reserves memory offset ``0x60`` as well, but a pure Yul object is free to use memory as it chooses.
                     if iszero(ptr) { ptr := 0x60 }
                     mstore(0x40, add(ptr, size))
                 }


### PR DESCRIPTION
The solidity docs and [Inline assembly memory management](https://docs.soliditylang.org/en/v0.8.15/assembly.html#memory-management) suggest the actual allocate-able memory starts from `0x80`, defaulting the free memory pointer to `0x80`. 

But the above yul example defaults the free memory pointer to `0x60` in initialisation cases which I'm not sure if it's intended.