### PR TITLE
Allow named parameters in mapping types

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.8.18 (unreleased)
 
 Language Features:
+* Allow named parameters in mapping types.
 
 
 Compiler Features:

--- a/docs/grammar/SolidityParser.g4
+++ b/docs/grammar/SolidityParser.g4
@@ -504,7 +504,7 @@ variableDeclarationTuple:
 variableDeclarationStatement: ((variableDeclaration (Assign expression)?) | (variableDeclarationTuple Assign expression)) Semicolon;
 expressionStatement: expression Semicolon;
 
-mappingType: Mapping LParen key=mappingKeyType DoubleArrow value=typeName RParen;
+mappingType: Mapping LParen key=mappingKeyType name=identifier? DoubleArrow value=typeName name=identifier? RParen;
 /**
  * Only elementary types or user defined types are viable as mapping keys.
  */

--- a/docs/types/mapping-types.rst
+++ b/docs/types/mapping-types.rst
@@ -4,12 +4,13 @@
 Mapping Types
 =============
 
-Mapping types use the syntax ``mapping(KeyType => ValueType)`` and variables
-of mapping type are declared using the syntax ``mapping(KeyType => ValueType) VariableName``.
-The ``KeyType`` can be any
-built-in value type, ``bytes``, ``string``, or any contract or enum type. Other user-defined
-or complex types, such as mappings, structs or array types are not allowed.
-``ValueType`` can be any type, including mappings, arrays and structs.
+Mapping types use the syntax ``mapping(KeyType KeyName? => ValueType ValueName?)`` and variables of
+mapping type are declared using the syntax ``mapping(KeyType KeyName? => ValueType ValueName?)
+VariableName``. The ``KeyType`` can be any built-in value type, ``bytes``, ``string``, or any
+contract or enum type. Other user-defined or complex types, such as mappings, structs or array types
+are not allowed. ``ValueType`` can be any type, including mappings, arrays and structs. ``KeyName``
+and ``ValueName`` are optional (so ``mapping(KeyType => ValueType)`` works as well) and can be any
+valid identifier that is not a type.
 
 You can think of mappings as `hash tables <https://en.wikipedia.org/wiki/Hash_table>`_, which are virtually initialised
 such that every possible key exists and is mapped to a value whose
@@ -29,8 +30,10 @@ of contract functions that are publicly visible.
 These restrictions are also true for arrays and structs that contain mappings.
 
 You can mark state variables of mapping type as ``public`` and Solidity creates a
-:ref:`getter <visibility-and-getters>` for you. The ``KeyType`` becomes a parameter for the getter.
-If ``ValueType`` is a value type or a struct, the getter returns ``ValueType``.
+:ref:`getter <visibility-and-getters>` for you. The ``KeyType`` becomes a parameter
+with name ``KeyName`` (if specified) for the getter.
+If ``ValueType`` is a value type or a struct, the getter returns ``ValueType`` with
+name ``ValueName`` (if specified).
 If ``ValueType`` is an array or a mapping, the getter has one parameter for
 each ``KeyType``, recursively.
 
@@ -64,6 +67,25 @@ contract that returns the value at the specified address.
 The example below is a simplified version of an
 `ERC20 token <https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol>`_.
 ``_allowances`` is an example of a mapping type inside another mapping type.
+
+In the example below, the optional ``KeyName`` and ``ValueName`` are provided for the mapping.
+It does not affect any contract functionality or bytecode, it only sets the ``name`` field
+for the inputs and outputs in the ABI for the mapping's getter.
+
+.. code-block:: solidity
+
+    // SPDX-License-Identifier: GPL-3.0
+    pragma solidity ^0.8.18;
+
+    contract MappingExampleWithNames {
+        mapping(address user => uint balance) public balances;
+
+        function update(uint newBalance) public {
+            balances[msg.sender] = newBalance;
+        }
+    }
+
+
 The example below uses ``_allowances`` to record the amount someone else is allowed to withdraw from your account.
 
 .. code-block:: solidity

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -1428,18 +1428,29 @@ public:
 		int64_t _id,
 		SourceLocation const& _location,
 		ASTPointer<TypeName> _keyType,
-		ASTPointer<TypeName> _valueType
+		ASTPointer<ASTString> _keyName,
+		ASTPointer<TypeName> _valueType,
+		ASTPointer<ASTString> _valueName
 	):
-		TypeName(_id, _location), m_keyType(std::move(_keyType)), m_valueType(std::move(_valueType)) {}
+		TypeName(_id, _location),
+		m_keyType(std::move(_keyType)),
+		m_keyName(std::move(_keyName)),
+		m_valueType(std::move(_valueType)),
+		m_valueName(std::move(_valueName))
+	{}
 	void accept(ASTVisitor& _visitor) override;
 	void accept(ASTConstVisitor& _visitor) const override;
 
 	TypeName const& keyType() const { return *m_keyType; }
+	ASTString keyName() const { return *m_keyName; }
 	TypeName const& valueType() const { return *m_valueType; }
+	ASTString valueName() const { return *m_valueName; }
 
 private:
 	ASTPointer<TypeName> m_keyType;
+	ASTPointer<ASTString> m_keyName;
 	ASTPointer<TypeName> m_valueType;
+	ASTPointer<ASTString> m_valueName;
 };
 
 /**

--- a/libsolidity/ast/ASTJsonExporter.cpp
+++ b/libsolidity/ast/ASTJsonExporter.cpp
@@ -598,7 +598,9 @@ bool ASTJsonExporter::visit(Mapping const& _node)
 {
 	setJsonNode(_node, "Mapping", {
 		make_pair("keyType", toJson(_node.keyType())),
+		make_pair("keyName", _node.keyName()),
 		make_pair("valueType", toJson(_node.valueType())),
+		make_pair("valueName", _node.valueName()),
 		make_pair("typeDescriptions", typePointerToJson(_node.annotation().type, true))
 	});
 	return false;

--- a/libsolidity/ast/ASTJsonImporter.cpp
+++ b/libsolidity/ast/ASTJsonImporter.cpp
@@ -648,7 +648,9 @@ ASTPointer<Mapping> ASTJsonImporter::createMapping(Json::Value const&  _node)
 	return createASTNode<Mapping>(
 		_node,
 		convertJsonToASTNode<TypeName>(member(_node, "keyType")),
-		convertJsonToASTNode<TypeName>(member(_node, "valueType"))
+		memberAsASTString(_node, "keyName"),
+		convertJsonToASTNode<TypeName>(member(_node, "valueType")),
+		memberAsASTString(_node, "valueName")
 	);
 }
 

--- a/libsolidity/ast/TypeProvider.cpp
+++ b/libsolidity/ast/TypeProvider.cpp
@@ -571,9 +571,9 @@ MagicType const* TypeProvider::meta(Type const* _type)
 	return createAndGet<MagicType>(_type);
 }
 
-MappingType const* TypeProvider::mapping(Type const* _keyType, Type const* _valueType)
+MappingType const* TypeProvider::mapping(Type const* _keyType, ASTString _keyName, Type const* _valueType, ASTString _valueName)
 {
-	return createAndGet<MappingType>(_keyType, _valueType);
+	return createAndGet<MappingType>(_keyType, _keyName, _valueType, _valueName);
 }
 
 UserDefinedValueType const* TypeProvider::userDefinedValueType(UserDefinedValueTypeDefinition const& _definition)

--- a/libsolidity/ast/TypeProvider.h
+++ b/libsolidity/ast/TypeProvider.h
@@ -195,7 +195,7 @@ public:
 
 	static MagicType const* meta(Type const* _type);
 
-	static MappingType const* mapping(Type const* _keyType, Type const* _valueType);
+	static MappingType const* mapping(Type const* _keyType, ASTString _keyName, Type const* _valueType, ASTString _valueName);
 
 	static UserDefinedValueType const* userDefinedValueType(UserDefinedValueTypeDefinition const& _definition);
 

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2788,14 +2788,16 @@ FunctionType::FunctionType(VariableDeclaration const& _varDecl):
 	m_declaration(&_varDecl)
 {
 	auto returnType = _varDecl.annotation().type;
+	ASTString returnName;
 
 	while (true)
 	{
 		if (auto mappingType = dynamic_cast<MappingType const*>(returnType))
 		{
 			m_parameterTypes.push_back(mappingType->keyType());
-			m_parameterNames.emplace_back("");
+			m_parameterNames.push_back(mappingType->keyName());
 			returnType = mappingType->valueType();
+			returnName = mappingType->valueName();
 		}
 		else if (auto arrayType = dynamic_cast<ArrayType const*>(returnType))
 		{
@@ -2834,7 +2836,7 @@ FunctionType::FunctionType(VariableDeclaration const& _varDecl):
 			DataLocation::Memory,
 			returnType
 		));
-		m_returnParameterNames.emplace_back("");
+		m_returnParameterNames.emplace_back(returnName);
 	}
 
 	solAssert(

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1510,8 +1510,8 @@ private:
 class MappingType: public CompositeType
 {
 public:
-	MappingType(Type const* _keyType, Type const* _valueType):
-		m_keyType(_keyType), m_valueType(_valueType) {}
+	MappingType(Type const* _keyType, ASTString _keyName, Type const* _valueType, ASTString _valueName):
+		m_keyType(_keyType), m_keyName(_keyName), m_valueType(_valueType), m_valueName(_valueName) {}
 
 	Category category() const override { return Category::Mapping; }
 
@@ -1531,14 +1531,18 @@ public:
 	std::vector<std::tuple<std::string, Type const*>> makeStackItems() const override;
 
 	Type const* keyType() const { return m_keyType; }
+	ASTString keyName() const { return m_keyName; }
 	Type const* valueType() const { return m_valueType; }
+	ASTString valueName() const { return m_valueName; }
 
 protected:
 	std::vector<Type const*> decomposition() const override { return {m_valueType}; }
 
 private:
 	Type const* m_keyType;
+	ASTString m_keyName;
 	Type const* m_valueType;
+	ASTString m_valueName;
 };
 
 /**

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1187,11 +1187,21 @@ ASTPointer<Mapping> Parser::parseMapping()
 	}
 	else
 		fatalParserError(1005_error, "Expected elementary type name or identifier for mapping key type");
+	ASTPointer<ASTString> keyName;
+	if (m_scanner->currentToken() == Token::Identifier)
+		keyName = getLiteralAndAdvance();
+	else
+		keyName = make_shared<ASTString>("");
 	expectToken(Token::DoubleArrow);
 	ASTPointer<TypeName> valueType = parseTypeName();
+	ASTPointer<ASTString> valueName;
+	if (m_scanner->currentToken() == Token::Identifier)
+		valueName = getLiteralAndAdvance();
+	else
+		valueName = make_shared<ASTString>("");
 	nodeFactory.markEndPosition();
 	expectToken(Token::RParen);
-	return nodeFactory.createNode<Mapping>(keyType, valueType);
+	return nodeFactory.createNode<Mapping>(keyType, keyName, valueType, valueName);
 }
 
 ASTPointer<ParameterList> Parser::parseParameterList(

--- a/test/libsolidity/ABIJson/mapping.sol
+++ b/test/libsolidity/ABIJson/mapping.sol
@@ -1,0 +1,77 @@
+contract test {
+    mapping(address owner => mapping(address spender => uint value)) public allowance;
+    mapping(bytes32 => address sender) public commits;
+    mapping(bytes32 => bytes32) public something;
+}
+// ----
+//     :test
+// [
+//   {
+//     "inputs":
+//     [
+//       {
+//         "internalType": "address",
+//         "name": "owner",
+//         "type": "address"
+//       },
+//       {
+//         "internalType": "address",
+//         "name": "spender",
+//         "type": "address"
+//       }
+//     ],
+//     "name": "allowance",
+//     "outputs":
+//     [
+//       {
+//         "internalType": "uint256",
+//         "name": "value",
+//         "type": "uint256"
+//       }
+//     ],
+//     "stateMutability": "view",
+//     "type": "function"
+//   },
+//   {
+//     "inputs":
+//     [
+//       {
+//         "internalType": "bytes32",
+//         "name": "",
+//         "type": "bytes32"
+//       }
+//     ],
+//     "name": "commits",
+//     "outputs":
+//     [
+//       {
+//         "internalType": "address",
+//         "name": "sender",
+//         "type": "address"
+//       }
+//     ],
+//     "stateMutability": "view",
+//     "type": "function"
+//   },
+//   {
+//     "inputs":
+//     [
+//       {
+//         "internalType": "bytes32",
+//         "name": "",
+//         "type": "bytes32"
+//       }
+//     ],
+//     "name": "something",
+//     "outputs":
+//     [
+//       {
+//         "internalType": "bytes32",
+//         "name": "",
+//         "type": "bytes32"
+//       }
+//     ],
+//     "stateMutability": "view",
+//     "type": "function"
+//   }
+// ]

--- a/test/libsolidity/ASTJSON/address_payable.json
+++ b/test/libsolidity/ASTJSON/address_payable.json
@@ -48,6 +48,7 @@
           "typeName":
           {
             "id": 3,
+            "keyName": "",
             "keyType":
             {
               "id": 1,
@@ -67,6 +68,7 @@
               "typeIdentifier": "t_mapping$_t_address_$_t_address_payable_$",
               "typeString": "mapping(address => address payable)"
             },
+            "valueName": "",
             "valueType":
             {
               "id": 2,

--- a/test/libsolidity/ASTJSON/address_payable_parseOnly.json
+++ b/test/libsolidity/ASTJSON/address_payable_parseOnly.json
@@ -29,6 +29,7 @@
           "typeName":
           {
             "id": 3,
+            "keyName": "",
             "keyType":
             {
               "id": 1,
@@ -40,6 +41,7 @@
             "nodeType": "Mapping",
             "src": "17:35:1",
             "typeDescriptions": {},
+            "valueName": "",
             "valueType":
             {
               "id": 2,

--- a/test/libsolidity/ASTJSON/mappings.json
+++ b/test/libsolidity/ASTJSON/mappings.json
@@ -79,6 +79,7 @@
           "typeName":
           {
             "id": 8,
+            "keyName": "",
             "keyType":
             {
               "id": 6,
@@ -110,6 +111,7 @@
               "typeIdentifier": "t_mapping$_t_contract$_C_$19_$_t_bool_$",
               "typeString": "mapping(contract C => bool)"
             },
+            "valueName": "",
             "valueType":
             {
               "id": 7,
@@ -144,6 +146,7 @@
           "typeName":
           {
             "id": 12,
+            "keyName": "",
             "keyType":
             {
               "id": 10,
@@ -163,6 +166,7 @@
               "typeIdentifier": "t_mapping$_t_address_$_t_bool_$",
               "typeString": "mapping(address => bool)"
             },
+            "valueName": "",
             "valueType":
             {
               "id": 11,
@@ -197,6 +201,7 @@
           "typeName":
           {
             "id": 17,
+            "keyName": "",
             "keyType":
             {
               "id": 15,
@@ -228,6 +233,7 @@
               "typeIdentifier": "t_mapping$_t_enum$_E_$4_$_t_bool_$",
               "typeString": "mapping(enum C.E => bool)"
             },
+            "valueName": "",
             "valueType":
             {
               "id": 16,

--- a/test/libsolidity/ASTJSON/mappings_parseOnly.json
+++ b/test/libsolidity/ASTJSON/mappings_parseOnly.json
@@ -60,6 +60,7 @@
           "typeName":
           {
             "id": 8,
+            "keyName": "",
             "keyType":
             {
               "id": 6,
@@ -81,6 +82,7 @@
             "nodeType": "Mapping",
             "src": "40:18:1",
             "typeDescriptions": {},
+            "valueName": "",
             "valueType":
             {
               "id": 7,
@@ -106,6 +108,7 @@
           "typeName":
           {
             "id": 12,
+            "keyName": "",
             "keyType":
             {
               "id": 10,
@@ -117,6 +120,7 @@
             "nodeType": "Mapping",
             "src": "66:24:1",
             "typeDescriptions": {},
+            "valueName": "",
             "valueType":
             {
               "id": 11,
@@ -142,6 +146,7 @@
           "typeName":
           {
             "id": 17,
+            "keyName": "",
             "keyType":
             {
               "id": 15,
@@ -163,6 +168,7 @@
             "nodeType": "Mapping",
             "src": "98:18:1",
             "typeDescriptions": {},
+            "valueName": "",
             "valueType":
             {
               "id": 16,

--- a/test/libsolidity/ASTJSON/userDefinedValueType.json
+++ b/test/libsolidity/ASTJSON/userDefinedValueType.json
@@ -287,6 +287,7 @@
           "typeName":
           {
             "id": 25,
+            "keyName": "",
             "keyType":
             {
               "id": 22,
@@ -318,6 +319,7 @@
               "typeIdentifier": "t_mapping$_t_userDefinedValueType$_MyAddress_$18_$_t_userDefinedValueType$_MyUInt_$20_$",
               "typeString": "mapping(C.MyAddress => C.MyUInt)"
             },
+            "valueName": "",
             "valueType":
             {
               "id": 24,

--- a/test/libsolidity/ASTJSON/userDefinedValueType_parseOnly.json
+++ b/test/libsolidity/ASTJSON/userDefinedValueType_parseOnly.json
@@ -213,6 +213,7 @@
           "typeName":
           {
             "id": 25,
+            "keyName": "",
             "keyType":
             {
               "id": 22,
@@ -234,6 +235,7 @@
             "nodeType": "Mapping",
             "src": "169:28:1",
             "typeDescriptions": {},
+            "valueName": "",
             "valueType":
             {
               "id": 24,

--- a/test/libsolidity/SolidityTypes.cpp
+++ b/test/libsolidity/SolidityTypes.cpp
@@ -97,12 +97,16 @@ BOOST_AUTO_TEST_CASE(storage_layout_mapping)
 		{"first", TypeProvider::fromElementaryTypeName("uint128")},
 		{"second", TypeProvider::mapping(
 			TypeProvider::fromElementaryTypeName("uint8"),
-			TypeProvider::fromElementaryTypeName("uint8")
+			"",
+			TypeProvider::fromElementaryTypeName("uint8"),
+			""
 		)},
 		{"third", TypeProvider::fromElementaryTypeName("uint16")},
 		{"final", TypeProvider::mapping(
 			TypeProvider::fromElementaryTypeName("uint8"),
-			TypeProvider::fromElementaryTypeName("uint8")
+			"",
+			TypeProvider::fromElementaryTypeName("uint8"),
+			""
 		)},
 	}));
 	BOOST_REQUIRE_EQUAL(u256(4), members.storageSize());
@@ -199,8 +203,8 @@ BOOST_AUTO_TEST_CASE(type_identifiers)
 	FunctionType metaFun(TypePointers{keccak256fun}, TypePointers{s.type()}, strings{""}, strings{""});
 	BOOST_CHECK_EQUAL(metaFun.identifier(), "t_function_internal_nonpayable$_t_function_keccak256_nonpayable$__$returns$__$_$returns$_t_type$_t_struct$_Struct_$3_storage_ptr_$_$");
 
-	Type const* m = TypeProvider::mapping(TypeProvider::fromElementaryTypeName("bytes32"), s.type());
-	MappingType m2(TypeProvider::fromElementaryTypeName("uint64"), m);
+	Type const* m = TypeProvider::mapping(TypeProvider::fromElementaryTypeName("bytes32"), "", s.type(), "");
+	MappingType m2(TypeProvider::fromElementaryTypeName("uint64"), "", m, "");
 	BOOST_CHECK_EQUAL(m2.identifier(), "t_mapping$_t_uint64_$_t_mapping$_t_bytes32_$_t_type$_t_struct$_Struct_$3_storage_ptr_$_$_$");
 
 	// TypeType is tested with contract

--- a/test/libsolidity/errorRecoveryTests/do_not_delete_at_error.sol
+++ b/test/libsolidity/errorRecoveryTests/do_not_delete_at_error.sol
@@ -10,4 +10,6 @@ contract Error2 {
 	mapping (address => uint balances; // missing ) before "balances"
 }
 // ----
-// ParserError 6635: (417-425): Expected ')' but got identifier
+// ParserError 6635: (425-426): Expected ')' but got ';'
+// ParserError 6635: (425-426): Expected identifier but got ';'
+// ParserError 6635: (458-459): Expected ';' but got '}'

--- a/test/libsolidity/errorRecoveryTests/error_to_eos.sol
+++ b/test/libsolidity/errorRecoveryTests/error_to_eos.sol
@@ -17,7 +17,8 @@ contract SendCoin {
 }
 
 // ----
-// ParserError 6635: (212-220): Expected ')' but got identifier
-// ParserError 6635: (220-221): Expected ';' but got ')'
-// ParserError 9182: (220-221): Function, variable, struct or modifier declaration expected.
-// Warning 3796: (235-236): Recovered in ContractDefinition at '}'.
+// ParserError 6635: (235-236): Expected identifier but got '}'
+// ParserError 6635: (276-284): Expected ';' but got 'contract'
+// ParserError 9182: (276-284): Function, variable, struct or modifier declaration expected.
+// Warning 3796: (572-573): Recovered in ContractDefinition at '}'.
+// ParserError 7858: (574-575): Expected pragma, import directive or contract/interface/library/struct/enum/constant/function/error definition.

--- a/test/libsolidity/semanticTests/getters/mapping_with_names.sol
+++ b/test/libsolidity/semanticTests/getters/mapping_with_names.sol
@@ -1,0 +1,9 @@
+contract C {
+    mapping(uint a => mapping(uint b => uint c)) public x;
+    constructor() {
+        x[1][2] = 3;
+    }
+}
+// ----
+// x(uint256,uint256): 1, 2 -> 3
+// x(uint256,uint256): 0, 0 -> 0

--- a/test/libsolidity/syntaxTests/natspec/invalid/return_param_amount_differs2.sol
+++ b/test/libsolidity/syntaxTests/natspec/invalid/return_param_amount_differs2.sol
@@ -13,3 +13,4 @@ contract Thing is IThing {
 
     mapping(uint256=>Value) public override value;
 }
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_1.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_1.sol
@@ -1,0 +1,4 @@
+contract test {
+    mapping(address user => bytes32 ipfs) names;
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_2.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_2.sol
@@ -1,0 +1,4 @@
+contract test {
+    mapping(address => bytes32 ipfs) names;
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_3.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_3.sol
@@ -1,0 +1,4 @@
+contract test {
+    mapping(address user => bytes32) names;
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_5.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_5.sol
@@ -1,0 +1,4 @@
+contract test {
+    mapping(address owner => mapping(address spender => bytes32[] notes)) names;
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_6.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_6.sol
@@ -1,0 +1,5 @@
+contract test {
+    mapping(address uint => bytes32 ipfs) names;
+}
+// ----
+// ParserError 2314: (36-40): Expected '=>' but got 'uint'

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_7.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_7.sol
@@ -1,0 +1,4 @@
+contract test {
+    mapping(address owner => bytes32[] note) notes;
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_8.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_8.sol
@@ -1,0 +1,4 @@
+contract test {
+    mapping(address => mapping(address => address) hello) world;
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_conflict_1.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_conflict_1.sol
@@ -1,0 +1,5 @@
+contract test {
+    address owner;
+    mapping(address owner => bytes32 ipfs) names;
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_conflict_2.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_conflict_2.sol
@@ -1,0 +1,5 @@
+contract test {
+    mapping(address owner => address owner) owner;
+}
+// ----
+// DeclarationError 1809: (20-59): Conflicting parameter name "owner" in mapping.

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_conflict_3.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_conflict_3.sol
@@ -1,0 +1,7 @@
+contract test {
+    mapping(address owner => mapping(address owner => address owner)) owner;
+}
+// ----
+// DeclarationError 1809: (45-84): Conflicting parameter name "owner" in mapping.
+// DeclarationError 1809: (20-85): Conflicting parameter name "owner" in mapping.
+// DeclarationError 1809: (20-85): Conflicting parameter name "owner" in mapping.

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_conflict_4.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_conflict_4.sol
@@ -1,0 +1,5 @@
+contract test {
+    mapping(address owner => mapping(address owner => address hello)) world;
+}
+// ----
+// DeclarationError 1809: (20-85): Conflicting parameter name "owner" in mapping.

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_conflict_5.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_conflict_5.sol
@@ -1,0 +1,5 @@
+contract test {
+    mapping(address owner => mapping(address hello => address owner)) world;
+}
+// ----
+// DeclarationError 1809: (20-85): Conflicting parameter name "owner" in mapping.

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_conflict_6.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_conflict_6.sol
@@ -1,0 +1,5 @@
+contract test {
+    mapping(address hello => mapping(address owner => address owner)) world;
+}
+// ----
+// DeclarationError 1809: (45-84): Conflicting parameter name "owner" in mapping.

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_param_1.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_param_1.sol
@@ -1,0 +1,6 @@
+contract test {
+    function _main(mapping(uint name1 => uint name2) storage map) internal {
+        map[1] = 2;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_param_2.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_param_2.sol
@@ -1,0 +1,6 @@
+contract test {
+    function _main(mapping(uint name1 => uint) storage map) internal {
+        map[1] = 2;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_param_3.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_param_3.sol
@@ -1,0 +1,6 @@
+contract test {
+    function _main(mapping(uint => uint name2) storage map) internal {
+        map[1] = 2;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_param_4.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_param_4.sol
@@ -1,0 +1,6 @@
+contract test {
+    function _main(mapping(uint name1 => mapping(uint name2 => uint name3) name4) storage map) internal {
+        map[1][2] = 3;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_param_5.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_param_5.sol
@@ -1,0 +1,6 @@
+contract test {
+    function _main(mapping(uint name1 => uint[] name2) storage map) internal {
+        map[1].push(2);
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_param_6.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_param_6.sol
@@ -1,0 +1,7 @@
+contract test {
+    function _main(mapping(uint nameSame => mapping(uint name2 => mapping(uint nameSame => uint name3) name4) name5) storage map) internal {
+        map[1][2][3] = 4;
+    }
+}
+// ----
+// DeclarationError 1809: (35-132): Conflicting parameter name "nameSame" in mapping.

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_param_7.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_param_7.sol
@@ -1,0 +1,6 @@
+contract test {
+    function _main(mapping(uint name1 => mapping(uint name2 => mapping(uint name3 => uint name4) name5) name6) storage map) internal {
+        map[1][2][3] = 4;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_type_param_1.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_type_param_1.sol
@@ -1,0 +1,4 @@
+contract test {
+    function(mapping(uint name1 => uint name2) storage) internal stateVariableName;
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_type_param_2.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_type_param_2.sol
@@ -1,0 +1,4 @@
+contract test {
+    function(mapping(uint name1 => uint) storage) internal stateVariableName;
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_type_param_3.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_type_param_3.sol
@@ -1,0 +1,4 @@
+contract test {
+    function(mapping(uint => uint name2) storage) internal stateVariableName;
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_type_param_4.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_type_param_4.sol
@@ -1,0 +1,4 @@
+contract test {
+    function(mapping(uint name1 => mapping(uint name2 => uint name3) name4) storage) internal stateVariableName;
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_type_param_5.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_type_param_5.sol
@@ -1,0 +1,4 @@
+contract test {
+    function(mapping(uint name1 => uint[] name2) storage) internal stateVariableName;
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_type_param_6.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_type_param_6.sol
@@ -1,0 +1,5 @@
+contract test {
+    function(mapping(uint nameSame => mapping(uint name2 => mapping(uint nameSame => uint name3) name4) name5) storage) internal stateVariableName;
+}
+// ----
+// DeclarationError 1809: (29-126): Conflicting parameter name "nameSame" in mapping.

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_type_param_7.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_func_type_param_7.sol
@@ -1,0 +1,4 @@
+contract test {
+    function(mapping(uint name1 => mapping(uint name2 => mapping(uint name3 => uint name4) name5) name6) storage) internal stateVariableName;
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_local_1.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_local_1.sol
@@ -1,0 +1,9 @@
+contract test {
+    mapping(uint name1 => uint name2) map;
+
+    function main() external {
+        mapping(uint name3 => uint name4) storage _map = map;
+        _map[1] = 2;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_local_2.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_local_2.sol
@@ -1,0 +1,9 @@
+contract test {
+    mapping(uint name1 => uint) map;
+
+    function main() external {
+        mapping(uint => uint name4) storage _map = map;
+        _map[1] = 2;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_local_3.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_local_3.sol
@@ -1,0 +1,9 @@
+contract test {
+    mapping(uint => uint name2) map;
+
+    function main() external {
+        mapping(uint name3 => uint) storage _map = map;
+        _map[1] = 2;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_local_4.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_local_4.sol
@@ -1,0 +1,9 @@
+contract test {
+    mapping(uint name1 => mapping(uint name2 => uint name3) name4) map;
+
+    function main() external {
+        mapping(uint name5 => uint name6) storage _map = map[1];
+        _map[1] = 2;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_local_5.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_local_5.sol
@@ -1,0 +1,9 @@
+contract test {
+    mapping(uint name1 => uint[] name4) map;
+
+    function main() external {
+        mapping(uint name5 => uint[] name6) storage _map = map;
+        _map[1].push(2);
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_local_6.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_local_6.sol
@@ -1,0 +1,10 @@
+contract test {
+    mapping(uint name1 => mapping(uint name2 => uint name3) name4) map;
+
+    function main() external {
+        mapping(uint nameSame => mapping(uint name2 => uint nameSame) name4) storage _map = map;
+        _map[1][2] = 3;
+    }
+}
+// ----
+// DeclarationError 1809: (128-196): Conflicting parameter name "nameSame" in mapping.

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_local_7.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_local_7.sol
@@ -1,0 +1,11 @@
+contract test {
+    mapping(uint nameSame => mapping(uint name1 => mapping(uint nameSame => uint name3) name6) name4) map;
+
+    function main() external {
+        mapping(uint nameSame => mapping(uint name1 => mapping(uint nameSame => uint name3) name6) name4) storage _map = map;
+        _map[1][2][3] = 4;
+    }
+}
+// ----
+// DeclarationError 1809: (20-117): Conflicting parameter name "nameSame" in mapping.
+// DeclarationError 1809: (163-260): Conflicting parameter name "nameSame" in mapping.

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_local_8.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_local_8.sol
@@ -1,0 +1,9 @@
+contract test {
+    mapping(uint name1 => mapping(uint name2 => mapping(uint name3 => uint name4) name5) name6) map;
+
+    function main() external {
+        mapping(uint name1 => mapping(uint name2 => mapping(uint name3 => uint name4) name5) name6) storage _map = map;
+        _map[1][2][3] = 4;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_nested_1.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_nested_1.sol
@@ -1,0 +1,4 @@
+contract test {
+    mapping(address owner => mapping(address spender => bytes32 note)) names;
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_nested_2.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_nested_2.sol
@@ -1,0 +1,4 @@
+contract test {
+    mapping(address => mapping(address spender => bytes32 note)) names;
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_nested_3.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_nested_3.sol
@@ -1,0 +1,4 @@
+contract test {
+    mapping(address owner => mapping(address => bytes32 note)) names;
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_nested_4.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_nested_4.sol
@@ -1,0 +1,4 @@
+contract test {
+    mapping(address owner => mapping(address spender => bytes32)) names;
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_nested_5.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_nested_5.sol
@@ -1,0 +1,5 @@
+contract test {
+    mapping(address owner => mapping(address spender => bytes32 note));
+}
+// ----
+// ParserError 2314: (86-87): Expected identifier but got ';'

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_nested_6.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_nested_6.sol
@@ -1,0 +1,5 @@
+contract test {
+    mapping(uint nameSame => mapping(uint name1 => mapping(uint nameSame => uint name2) name3) name4) name5;
+}
+// ----
+// DeclarationError 1809: (20-117): Conflicting parameter name "nameSame" in mapping.

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_nested_7.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_nested_7.sol
@@ -1,0 +1,5 @@
+contract test {
+    mapping(uint nameSame => mapping(uint name1 => mapping(uint nameSame => uint name3) name6) name4) public name5;
+}
+// ----
+// DeclarationError 1809: (20-117): Conflicting parameter name "nameSame" in mapping.

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_nested_8.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_nested_8.sol
@@ -1,0 +1,4 @@
+contract test {
+    mapping(uint name1 => mapping(uint name2 => mapping(uint name3 => uint name4) name5) name6) public name7;
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_struct_member_1.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_struct_member_1.sol
@@ -1,0 +1,6 @@
+contract test {
+    struct Person {
+        mapping(uint phone => uint calls) friends;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_struct_member_2.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_struct_member_2.sol
@@ -1,0 +1,6 @@
+contract test {
+    struct Person {
+        mapping(uint phone => uint) friends;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_struct_member_3.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_struct_member_3.sol
@@ -1,0 +1,6 @@
+contract test {
+    struct Person {
+        mapping(uint => uint calls) friends;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_struct_member_4.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_struct_member_4.sol
@@ -1,0 +1,6 @@
+contract test {
+    struct Person {
+        mapping(uint phone => mapping(uint call => uint time) callTimes) friends;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_struct_member_5.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_struct_member_5.sol
@@ -1,0 +1,6 @@
+contract test {
+    struct Person {
+        mapping(uint phone => uint[] calls) friends;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_struct_member_6.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_struct_member_6.sol
@@ -1,0 +1,7 @@
+contract test {
+    struct Person {
+        mapping(uint nameSame => mapping(uint name1 => mapping(uint nameSame => uint name2) name3) name4) name5;
+    }
+}
+// ----
+// DeclarationError 1809: (44-141): Conflicting parameter name "nameSame" in mapping.

--- a/test/libsolidity/syntaxTests/parsing/mapping_with_names_struct_member_7.sol
+++ b/test/libsolidity/syntaxTests/parsing/mapping_with_names_struct_member_7.sol
@@ -1,0 +1,6 @@
+contract test {
+    struct Person {
+        mapping(uint name1 => mapping(uint name2 => mapping(uint name3 => uint name4) name5) name6) name7;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/userDefinedValueType/mapping_key.sol
+++ b/test/libsolidity/syntaxTests/userDefinedValueType/mapping_key.sol
@@ -2,3 +2,4 @@ type MyInt is int;
 contract C {
     mapping(MyInt => int) m;
 }
+// ----


### PR DESCRIPTION
Closes #11407

- Allows providing an optional name/identifier just after the key type and the value type.
- Identifier defaults to empty string "".
- The optional identifier if provided is set to the "name" field in JSON ABI.
- Test cases are added for parser and ABI generator

Please let me know of any changes that are needed.