### PR TITLE
Update emscripten Dockerfile to 3.1.18

### DIFF
--- a/scripts/docker/buildpack-deps/Dockerfile.emscripten
+++ b/scripts/docker/buildpack-deps/Dockerfile.emscripten
@@ -32,8 +32,8 @@
 # apparently this currently breaks due to conflicting compatibility headers.
 # Using $(em-config CACHE)/sysroot/usr seems to work, though, and still has cmake find the
 # dependencies automatically.
-FROM emscripten/emsdk:2.0.33 AS base
-LABEL version="11"
+FROM emscripten/emsdk:3.1.18 AS base
+LABEL version="12"
 
 ADD emscripten.jam /usr/src
 RUN set -ex; \


### PR DESCRIPTION
closes #13122

Just following the steps mentioned in https://github.com/ethereum/solidity/pull/12241. This PR will build a docker image.