### PR TITLE
Add Natspec devdoc inheritance support for events

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Language Features:
 Compiler Features:
 * Commandline Interface: Return exit code ``2`` on uncaught exceptions.
 * Commandline Interface: Add `--no-cbor-metadata` that skips CBOR metadata from getting appended at the end of the bytecode.
+* Natspec: Add event Natspec inheritance for devdoc.
 * Standard JSON: Add a boolean field `settings.metadata.appendCBOR` that skips CBOR metadata from getting appended at the end of the bytecode.
 * Yul Optimizer: Allow replacing the previously hard-coded cleanup sequence by specifying custom steps after a colon delimiter (``:``) in the sequence string.
 * Language Server: Add basic document hover support.

--- a/libsolidity/interface/Natspec.cpp
+++ b/libsolidity/interface/Natspec.cpp
@@ -168,7 +168,7 @@ Json::Value Natspec::devDocumentation(ContractDefinition const& _contractDef)
 			));
 	}
 
-	for (auto const& event: _contractDef.events())
+	for (auto const& event: _contractDef.definedInterfaceEvents())
 		if (auto devDoc = devDocumentation(event->annotation().docTags); !devDoc.empty())
 			doc["events"][event->functionType(true)->externalSignature()] = devDoc;
 

--- a/test/libsolidity/SolidityNatspecJSON.cpp
+++ b/test/libsolidity/SolidityNatspecJSON.cpp
@@ -485,6 +485,64 @@ BOOST_AUTO_TEST_CASE(event)
 	checkNatspec(sourceCode, "ERC20", userDoc, true);
 }
 
+BOOST_AUTO_TEST_CASE(event_inheritance)
+{
+	char const* sourceCode = R"(
+		contract ERC20 {
+			/// @notice This event is emitted when a transfer occurs.
+			/// @param from The source account.
+			/// @param to The destination account.
+			/// @param amount The amount.
+			/// @dev A test case!
+			event Transfer(address indexed from, address indexed to, uint amount);
+		}
+
+		contract A is ERC20 {
+		}
+
+		contract B is A {
+		}
+	)";
+
+	char const* devDoc = R"ABCDEF(
+	{
+		"events":
+		{
+			"Transfer(address,address,uint256)":
+			{
+				"details": "A test case!",
+				"params":
+				{
+					"amount": "The amount.",
+					"from": "The source account.",
+					"to": "The destination account."
+				}
+			}
+		},
+		"methods": {}
+	}
+	)ABCDEF";
+	checkNatspec(sourceCode, "ERC20", devDoc, false);
+	checkNatspec(sourceCode, "A", devDoc, false);
+	checkNatspec(sourceCode, "B", devDoc, false);
+
+	char const* userDoc = R"ABCDEF(
+	{
+		"events":
+		{
+			"Transfer(address,address,uint256)":
+			{
+				"notice": "This event is emitted when a transfer occurs."
+			}
+		},
+		"methods": {}
+	}
+	)ABCDEF";
+	checkNatspec(sourceCode, "ERC20", userDoc, true);
+	checkNatspec(sourceCode, "A", userDoc, true);
+	checkNatspec(sourceCode, "B", userDoc, true);
+}
+
 BOOST_AUTO_TEST_CASE(dev_desc_after_nl)
 {
 	char const* sourceCode = R"(


### PR DESCRIPTION
closes #13199

For some reason, event's Natspec is inherited in userdoc but not devdoc. Not sure if it's on purpose.