### PR TITLE
Remove unnecessary "Callcode" in the heading

### DIFF
--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -507,7 +507,7 @@ depth limit of a little less than 1000 in practice.
 .. index:: delegatecall, library
 
 Delegatecall and Libraries
-=====================================
+==========================
 
 There exists a special variant of a message call, named **delegatecall**
 which is identical to a message call apart from the fact that

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -504,9 +504,9 @@ operations, loops should be preferred over recursive calls. Furthermore,
 only 63/64th of the gas can be forwarded in a message call, which causes a
 depth limit of a little less than 1000 in practice.
 
-.. index:: delegatecall, callcode, library
+.. index:: delegatecall, library
 
-Delegatecall / Callcode and Libraries
+Delegatecall and Libraries
 =====================================
 
 There exists a special variant of a message call, named **delegatecall**


### PR DESCRIPTION
The heading contains "Callcode", but there is no description of callcode in this section, so it would be easier to understand if it were removed.

An alternative is to add a description of callcode, but since callcode is rarely used today, I think it is better to remove it.