### PR TITLE
Enable highlighting for more code blocks in the docs

### DIFF
--- a/docs/internals/layout_in_storage.rst
+++ b/docs/internals/layout_in_storage.rst
@@ -153,7 +153,7 @@ the :ref:`standard JSON interface <compiler-api>`.  The output is a JSON object 
 element has the following form:
 
 
-.. code::
+.. code-block:: json
 
 
     {
@@ -181,7 +181,7 @@ The given ``type``, in this case ``t_uint256`` represents an element in
 ``types``, which has the form:
 
 
-.. code::
+.. code-block:: json
 
     {
         "encoding": "inplace",
@@ -238,7 +238,7 @@ value and reference types, types that are encoded packed, and nested types.
         bytes b1;
     }
 
-.. code:: json
+.. code-block:: json
 
     {
       "storage": [

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -186,7 +186,9 @@ transactions.
 
 To listen for this event, you could use the following
 JavaScript code, which uses `web3.js <https://github.com/ethereum/web3.js/>`_ to create the ``Coin`` contract object,
-and any user interface calls the automatically generated ``balances`` function from above::
+and any user interface calls the automatically generated ``balances`` function from above:
+
+.. code-block:: javascript
 
     Coin.Sent().watch({}, '', function(error, result) {
         if (!error) {

--- a/docs/natspec-format.rst
+++ b/docs/natspec-format.rst
@@ -183,7 +183,7 @@ other to be used by the developer.
 If the above contract is saved as ``ex1.sol`` then you can generate the
 documentation using:
 
-.. code::
+.. code-block:: shell
 
    solc --userdoc --devdoc ex1.sol
 
@@ -202,7 +202,7 @@ User Documentation
 The above documentation will produce the following user documentation
 JSON file as output:
 
-.. code::
+.. code-block:: json
 
     {
       "version" : 1,
@@ -230,7 +230,7 @@ Developer Documentation
 Apart from the user documentation file, a developer documentation JSON
 file should also be produced and should look like this:
 
-.. code::
+.. code-block:: json
 
     {
       "version" : 1,


### PR DESCRIPTION
Fixes a few code blocks that were missing highlighting. There might be more, these are just those I noticed when preparing feedback on the new highlighter.