### PR TITLE
[libevmasm] Add Assembly::OptimiserSettings::translateSettings.

### DIFF
--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -792,3 +792,18 @@ Assembly const* Assembly::subAssemblyById(size_t _subId) const
 	assertThrow(currentAssembly != this, AssemblyException, "");
 	return currentAssembly;
 }
+
+Assembly::OptimiserSettings Assembly::OptimiserSettings::translateSettings(frontend::OptimiserSettings const& _settings, langutil::EVMVersion const& _evmVersion)
+{
+	// Constructing it this way so that we notice changes in the fields.
+	evmasm::Assembly::OptimiserSettings asmSettings{false,  false, false, false, false, false, _evmVersion, 0};
+	asmSettings.runInliner = _settings.runInliner;
+	asmSettings.runJumpdestRemover = _settings.runJumpdestRemover;
+	asmSettings.runPeephole = _settings.runPeephole;
+	asmSettings.runDeduplicate = _settings.runDeduplicate;
+	asmSettings.runCSE = _settings.runCSE;
+	asmSettings.runConstantOptimiser = _settings.runConstantOptimiser;
+	asmSettings.expectedExecutionsPerDeployment = _settings.expectedExecutionsPerDeployment;
+	asmSettings.evmVersion = _evmVersion;
+	return asmSettings;
+}

--- a/libevmasm/Assembly.h
+++ b/libevmasm/Assembly.h
@@ -128,6 +128,8 @@ public:
 		/// This specifies an estimate on how often each opcode in this assembly will be executed,
 		/// i.e. use a small value to optimise for size and a large value to optimise for runtime gas usage.
 		size_t expectedExecutionsPerDeployment = frontend::OptimiserSettings{}.expectedExecutionsPerDeployment;
+
+		static OptimiserSettings translateSettings(frontend::OptimiserSettings const& _settings, langutil::EVMVersion const& _evmVersion);
 	};
 
 	/// Modify and return the current assembly such that creation and execution gas usage

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -572,21 +572,6 @@ void CompilerContext::updateSourceLocation()
 	m_asm->setSourceLocation(m_visitedNodes.empty() ? SourceLocation() : m_visitedNodes.top()->location());
 }
 
-evmasm::Assembly::OptimiserSettings CompilerContext::translateOptimiserSettings(OptimiserSettings const& _settings)
-{
-	// Constructing it this way so that we notice changes in the fields.
-	evmasm::Assembly::OptimiserSettings asmSettings{false,  false, false, false, false, false, m_evmVersion, 0};
-	asmSettings.runInliner = _settings.runInliner;
-	asmSettings.runJumpdestRemover = _settings.runJumpdestRemover;
-	asmSettings.runPeephole = _settings.runPeephole;
-	asmSettings.runDeduplicate = _settings.runDeduplicate;
-	asmSettings.runCSE = _settings.runCSE;
-	asmSettings.runConstantOptimiser = _settings.runConstantOptimiser;
-	asmSettings.expectedExecutionsPerDeployment = _settings.expectedExecutionsPerDeployment;
-	asmSettings.evmVersion = m_evmVersion;
-	return asmSettings;
-}
-
 evmasm::AssemblyItem CompilerContext::FunctionCompilationQueue::entryLabel(
 	Declaration const& _declaration,
 	CompilerContext& _context

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -283,7 +283,7 @@ public:
 	void appendToAuxiliaryData(bytes const& _data) { m_asm->appendToAuxiliaryData(_data); }
 
 	/// Run optimisation step.
-	void optimise(OptimiserSettings const& _settings) { m_asm->optimise(translateOptimiserSettings(_settings)); }
+	void optimise(OptimiserSettings const& _settings) { m_asm->optimise(evmasm::Assembly::OptimiserSettings::translateSettings(_settings, m_evmVersion)); }
 
 	/// @returns the runtime context if in creation mode and runtime context is set, nullptr otherwise.
 	CompilerContext* runtimeContext() const { return m_runtimeContext; }
@@ -313,8 +313,6 @@ public:
 private:
 	/// Updates source location set in the assembly.
 	void updateSourceLocation();
-
-	evmasm::Assembly::OptimiserSettings translateOptimiserSettings(OptimiserSettings const& _settings);
 
 	/**
 	 * Helper class that manages function labels and ensures that referenced functions are

--- a/libyul/YulStack.cpp
+++ b/libyul/YulStack.cpp
@@ -64,27 +64,6 @@ Dialect const& languageToDialect(YulStack::Language _language, EVMVersion _versi
 	return Dialect::yulDeprecated();
 }
 
-// Duplicated from libsolidity/codegen/CompilerContext.cpp
-// TODO: refactor and remove duplication
-evmasm::Assembly::OptimiserSettings translateOptimiserSettings(
-	frontend::OptimiserSettings const& _settings,
-	langutil::EVMVersion _evmVersion
-)
-{
-	// Constructing it this way so that we notice changes in the fields.
-	evmasm::Assembly::OptimiserSettings asmSettings{false,  false, false, false, false, false, _evmVersion, 0};
-	asmSettings.runInliner = _settings.runInliner;
-	asmSettings.runJumpdestRemover = _settings.runJumpdestRemover;
-	asmSettings.runPeephole = _settings.runPeephole;
-	asmSettings.runDeduplicate = _settings.runDeduplicate;
-	asmSettings.runCSE = _settings.runCSE;
-	asmSettings.runConstantOptimiser = _settings.runConstantOptimiser;
-	asmSettings.expectedExecutionsPerDeployment = _settings.expectedExecutionsPerDeployment;
-	asmSettings.evmVersion = _evmVersion;
-
-	return asmSettings;
-}
-
 }
 
 
@@ -289,7 +268,7 @@ YulStack::assembleEVMWithDeployed(optional<string_view> _deployName) const
 	EthAssemblyAdapter adapter(assembly);
 	compileEVM(adapter, m_optimiserSettings.optimizeStackAllocation);
 
-	assembly.optimise(translateOptimiserSettings(m_optimiserSettings, m_evmVersion));
+	assembly.optimise(evmasm::Assembly::OptimiserSettings::translateSettings(m_optimiserSettings, m_evmVersion));
 
 	optional<size_t> subIndex;
 


### PR DESCRIPTION
We had in the past some discussion about having such function.

- https://github.com/ethereum/solidity/pull/10286#issuecomment-827969786
- https://github.com/ethereum/solidity/pull/11550#discussion_r653680572
- https://github.com/ethereum/solidity/pull/12834#discussion_r869153232

I think, at least with the current source, such function is not introducing any additional dependencies. But maybe it is possible to clean up the dependencies. However, I created this PR so that we can discuss this.

@axic @cameel @chriseth 