### PR TITLE
Reduce duplication in AST helpers for finding try/catch clauses

### DIFF
--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -29,6 +29,8 @@
 #include <libsolidity/ast/TypeProvider.h>
 #include <libsolutil/Keccak256.h>
 
+#include <range/v3/view/tail.hpp>
+
 #include <boost/algorithm/string.hpp>
 
 #include <functional>
@@ -37,6 +39,17 @@
 using namespace std;
 using namespace solidity;
 using namespace solidity::frontend;
+
+namespace
+{
+TryCatchClause const* findClause(vector<ASTPointer<TryCatchClause>> const& _clauses, optional<string> _errorName = {})
+{
+	for (auto const& clause: ranges::views::tail(_clauses))
+		if (_errorName.has_value() ? clause->errorName() == _errorName : clause->errorName().empty())
+			return clause.get();
+	return nullptr;
+}
+}
 
 ASTNode::ASTNode(int64_t _id, SourceLocation _location):
 	m_id(static_cast<size_t>(_id)),
@@ -981,26 +994,14 @@ TryCatchClause const* TryStatement::successClause() const
 	return m_clauses[0].get();
 }
 
-TryCatchClause const* TryStatement::panicClause() const
-{
-	for (size_t i = 1; i < m_clauses.size(); ++i)
-		if (m_clauses[i]->errorName() == "Panic")
-			return m_clauses[i].get();
-	return nullptr;
+TryCatchClause const* TryStatement::panicClause() const {
+	return findClause(m_clauses, "Panic");
 }
 
-TryCatchClause const* TryStatement::errorClause() const
-{
-	for (size_t i = 1; i < m_clauses.size(); ++i)
-		if (m_clauses[i]->errorName() == "Error")
-			return m_clauses[i].get();
-	return nullptr;
+TryCatchClause const* TryStatement::errorClause() const {
+	return findClause(m_clauses, "Error");
 }
 
-TryCatchClause const* TryStatement::fallbackClause() const
-{
-	for (size_t i = 1; i < m_clauses.size(); ++i)
-		if (m_clauses[i]->errorName().empty())
-			return m_clauses[i].get();
-	return nullptr;
+TryCatchClause const* TryStatement::fallbackClause() const {
+	return findClause(m_clauses);
 }


### PR DESCRIPTION
* Using helper function: `checkForClause` in anonymous namespace, condensed some duplicate code.
* Preferred range-v3 function `tail`, to range-for-loop through data-array starting from index=`1`.