### PR TITLE
User defined literal suffix parallel work

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1277,16 +1277,20 @@ pair<RationalNumberType const*, RationalNumberType const*> RationalNumberType::m
 	rational unsignedMantissa = abs(m_value);
 
 	if (unsignedMantissa > maxMantissa)
-		return {nullptr, nullptr};
+		return {nullptr, TypeProvider::rationalNumber(-exponent)};
 
 	while (unsignedMantissa.denominator() != 1)
 	{
 		unsignedMantissa *= 10;
 		--exponent;
 
-		// FIXME: What happens when exponent in scientific notation is max uint?
-		if (unsignedMantissa > maxMantissa || exponent > maxUint)
+		if (exponent > maxUint && unsignedMantissa > maxMantissa)
 			return {nullptr, nullptr};
+		// FIXME: What happens when exponent in scientific notation is max uint?
+		if (exponent > maxUint)
+			return {TypeProvider::rationalNumber(unsignedMantissa), nullptr};
+		if (unsignedMantissa > maxMantissa)
+			return {nullptr, TypeProvider::rationalNumber(-exponent)};
 	}
 
 	return {

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -607,7 +607,8 @@ public:
 	/// base-10 exponent, such that the number is equal to `mantissa * 10**-exponent`.
 	/// @returns Pair of non-null pointers representing the types of the literals corresponding to
 	/// mantissa and exponent if the resulting mantissa and exponent both fit in 256 bits.
-	/// A pair of null pointers otherwise.
+	/// If either of these values does not fit in 256 bits, its value in the pair is null.
+	/// Otherwise, Pair of null pointers.
 	std::pair<RationalNumberType const*, RationalNumberType const*> mantissaExponent() const;
 
 	/// @returns true if the value is negative.

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -2664,6 +2664,7 @@ void ExpressionCompiler::appendInternalFunctionCall(
 				assert(rationalNumberType);
 
 				auto&& [mantissa, exponent] = rationalNumberType->mantissaExponent();
+				solAssert(mantissa && exponent);
 				m_context << mantissa->literalValue(nullptr);
 				utils().convertType(*mantissa, *parameterTypes.at(0));
 				m_context << exponent->literalValue(nullptr);

--- a/test/libsolidity/syntaxTests/literalSuffixes/parameters/exponent_out_of_range.sol
+++ b/test/libsolidity/syntaxTests/literalSuffixes/parameters/exponent_out_of_range.sol
@@ -19,10 +19,10 @@ contract C {
     }
 }
 // ----
-// TypeError 5503: (338-347): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function.
-// TypeError 5503: (357-367): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function.
-// TypeError 5503: (377-388): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function.
-// TypeError 5503: (399-480): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function.
-// TypeError 5503: (502-584): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function.
-// TypeError 5503: (605-688): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function.
+// TypeError 5503: (338-347): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function. Mantissa is out of range of the largest supported integer type.
+// TypeError 5503: (357-367): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function. Mantissa is out of range of the largest supported integer type.
+// TypeError 5503: (377-388): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function. Mantissa is out of range of the largest supported integer type.
+// TypeError 5503: (399-480): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function. Mantissa is out of range of the largest supported integer type.
+// TypeError 5503: (502-584): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function. Mantissa is out of range of the largest supported integer type.
+// TypeError 5503: (605-688): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function. Mantissa is out of range of the largest supported integer type.
 // TypeError 8838: (748-757): The type of the literal cannot be converted to the parameters of the suffix function.

--- a/test/libsolidity/syntaxTests/literalSuffixes/parameters/integer_out_of_range.sol
+++ b/test/libsolidity/syntaxTests/literalSuffixes/parameters/integer_out_of_range.sol
@@ -21,5 +21,5 @@ contract C {
 // TypeError 8838: (396-405): The type of the literal cannot be converted to the parameter of the suffix function.
 // TypeError 8838: (415-424): The type of the literal cannot be converted to the parameter of the suffix function.
 // TypeError 8838: (434-516): The type of the literal cannot be converted to the parameter of the suffix function.
-// TypeError 5503: (536-619): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function.
+// TypeError 5503: (536-619): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function. Mantissa is out of range of the largest supported integer type.
 // TypeError 8838: (536-619): The type of the literal cannot be converted to the parameter of the suffix function.

--- a/test/libsolidity/syntaxTests/literalSuffixes/parameters/mantissa_out_of_range.sol
+++ b/test/libsolidity/syntaxTests/literalSuffixes/parameters/mantissa_out_of_range.sol
@@ -37,16 +37,16 @@ contract C {
 // TypeError 8838: (591-600): The type of the literal cannot be converted to the parameters of the suffix function.
 // TypeError 8838: (610-619): The type of the literal cannot be converted to the parameters of the suffix function.
 // TypeError 8838: (629-711): The type of the literal cannot be converted to the parameters of the suffix function.
-// TypeError 5503: (731-814): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function.
+// TypeError 5503: (731-814): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function. Mantissa is out of range of the largest supported integer type.
 // TypeError 8838: (835-842): The type of the literal cannot be converted to the parameters of the suffix function.
 // TypeError 8838: (852-859): The type of the literal cannot be converted to the parameters of the suffix function.
 // TypeError 8838: (869-879): The type of the literal cannot be converted to the parameters of the suffix function.
 // TypeError 8838: (889-899): The type of the literal cannot be converted to the parameters of the suffix function.
 // TypeError 8838: (909-992): The type of the literal cannot be converted to the parameters of the suffix function.
-// TypeError 5503: (1022-1106): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function.
+// TypeError 5503: (1022-1106): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function. Mantissa is out of range of the largest supported integer type.
 // TypeError 8838: (1137-1147): The type of the literal cannot be converted to the parameters of the suffix function.
 // TypeError 8838: (1157-1167): The type of the literal cannot be converted to the parameters of the suffix function.
 // TypeError 8838: (1177-1190): The type of the literal cannot be converted to the parameters of the suffix function.
 // TypeError 8838: (1200-1213): The type of the literal cannot be converted to the parameters of the suffix function.
-// TypeError 5503: (1223-1309): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function.
-// TypeError 5503: (1339-1426): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function.
+// TypeError 5503: (1223-1309): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function. Mantissa is out of range of the largest supported integer type.
+// TypeError 5503: (1339-1426): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function. Mantissa is out of range of the largest supported integer type.

--- a/test/libsolidity/syntaxTests/literalSuffixes/suffixableLiterals/invalid_suffixed_decimal_mantissa_too_large.sol
+++ b/test/libsolidity/syntaxTests/literalSuffixes/suffixableLiterals/invalid_suffixed_decimal_mantissa_too_large.sol
@@ -9,4 +9,4 @@ contract C {
     Decimal x = 0.115792089237316195423570985008687907853269984665640564039457584007913129639936 suffix; // 2**256 * 10**-78
 }
 // ----
-// TypeError 5503: (211-298): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function.
+// TypeError 5503: (211-298): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function. Mantissa is out of range of the largest supported integer type.

--- a/test/libsolidity/syntaxTests/literalSuffixes/suffixableLiterals/invalid_suffixed_integer_too_large.sol
+++ b/test/libsolidity/syntaxTests/literalSuffixes/suffixableLiterals/invalid_suffixed_integer_too_large.sol
@@ -5,7 +5,7 @@ contract C {
     uint y = 999999999999999999999999999999999999999999999999999999999999999999999999999999 suffix;
 }
 // ----
-// TypeError 5503: (92-106): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function.
+// TypeError 5503: (92-106): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function. Mantissa is out of range of the largest supported integer type.
 // TypeError 8838: (92-106): The type of the literal cannot be converted to the parameter of the suffix function.
-// TypeError 5503: (121-206): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function.
+// TypeError 5503: (121-206): This fractional number cannot be decomposed into a mantissa and decimal exponent that fit the range of parameters of any possible suffix function. Mantissa is out of range of the largest supported integer type.
 // TypeError 8838: (121-206): The type of the literal cannot be converted to the parameter of the suffix function.


### PR DESCRIPTION
Draft PR used to work in parallel with #12656 .  

- [x] Disallow suffixes with zero or more than one return value.
- [x] Disallow suffixes with storage and calldata return values.
- [x] Disallow signed exponent for decimal suffixes.
- [x] Fix: Suffixed values are not disallowed as array sizes even though they're not constants.
- [ ] Fix: Suffixes not detected as function calls by control flow graph (no "unreachable code" warning).
- [ ] More detailed error message for exponent/mantissa out of range.
- [ ] Include suffix definition as a secondary location in errors.
- [ ] Grammar update.
- [ ] Fix failing command line tests.
- [ ] When no suffix definition found, check if there are any non-suffix definitions and list them in error message.