### PR TITLE
Update misleading information about OpenZeppelin's ECDSA library

### DIFF
--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -231,8 +231,8 @@ Mathematical and Cryptographic Functions
     for _transaction_ signatures (see `EIP-2 <https://eips.ethereum.org/EIPS/eip-2#specification>`_), but
     the ecrecover function remained unchanged.
 
-    This is usually not a problem unless you require signatures to be unique or
-    use them to identify items. OpenZeppelin have a `ECDSA helper library <https://docs.openzeppelin.com/contracts/2.x/api/cryptography#ECDSA>`_ that you can use as a wrapper for ``ecrecover`` without this issue.
+    This is usually not a problem unless you require signatures to be unique or use them to identify items.
+    OpenZeppelin have a `ECDSA helper library <https://docs.openzeppelin.com/contracts/4.x/api/utils#ECDSA>`_ that you can use as a wrapper for ``ecrecover`` without this issue.
 
 .. note::
 


### PR DESCRIPTION
There were many changes to the ECDSA library in OpenZeppelin's library and referenced functions are no longer safe to use in this manner since 4.1 version of the library.

In short - two versions of the functions which accept signature as `bytes` accept both 65-byte regular signature and 64-byte EIP-2098 signature.