### PR TITLE
allow setting remappings on lsp server init

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Compiler Features:
 * Standard JSON: Add a boolean field `settings.metadata.appendCBOR` that skips CBOR metadata from getting appended at the end of the bytecode.
 * Yul Optimizer: Allow replacing the previously hard-coded cleanup sequence by specifying custom steps after a colon delimiter (``:``) in the sequence string.
 * Language Server: Add basic document hover support.
+* Language Server: Add configuration option to apply custom remappings via ``remappings`` in the LSP settings object.
 
 
 Bugfixes:

--- a/libsolidity/lsp/FileRepository.cpp
+++ b/libsolidity/lsp/FileRepository.cpp
@@ -16,6 +16,7 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
+#include <libsolidity/interface/ImportRemapper.h>
 #include <libsolidity/lsp/FileRepository.h>
 #include <libsolidity/lsp/Transport.h>
 #include <libsolidity/lsp/Utils.h>
@@ -43,15 +44,21 @@ using solidity::util::readFileAsString;
 using solidity::util::joinHumanReadable;
 using solidity::util::Result;
 
-FileRepository::FileRepository(boost::filesystem::path _basePath, std::vector<boost::filesystem::path> _includePaths):
+FileRepository::FileRepository(boost::filesystem::path _basePath, std::vector<boost::filesystem::path> _includePaths, vector<frontend::ImportRemapper::Remapping> _remappings):
 	m_basePath(std::move(_basePath)),
-	m_includePaths(std::move(_includePaths))
+	m_includePaths(std::move(_includePaths)),
+	m_remappings(std::move(_remappings))
 {
 }
 
 void FileRepository::setIncludePaths(std::vector<boost::filesystem::path> _paths)
 {
 	m_includePaths = std::move(_paths);
+}
+
+void FileRepository::setRemappings(vector<frontend::ImportRemapper::Remapping> _remappings)
+{
+	m_remappings = std::move(_remappings);
 }
 
 string FileRepository::sourceUnitNameToUri(string const& _sourceUnitName) const

--- a/libsolidity/lsp/FileRepository.h
+++ b/libsolidity/lsp/FileRepository.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <libsolidity/interface/FileReader.h>
+#include <libsolidity/interface/ImportRemapper.h>
 #include <libsolutil/Result.h>
 
 #include <string>
@@ -29,10 +30,13 @@ namespace solidity::lsp
 class FileRepository
 {
 public:
-	FileRepository(boost::filesystem::path _basePath, std::vector<boost::filesystem::path> _includePaths);
+	FileRepository(boost::filesystem::path _basePath, std::vector<boost::filesystem::path> _includePaths, std::vector<frontend::ImportRemapper::Remapping> _remappings);
 
 	std::vector<boost::filesystem::path> const& includePaths() const noexcept { return m_includePaths; }
 	void setIncludePaths(std::vector<boost::filesystem::path> _paths);
+
+	std::vector<frontend::ImportRemapper::Remapping> const& remappings() const noexcept { return m_remappings; }
+	void setRemappings(std::vector<frontend::ImportRemapper::Remapping> _remappings);
 
 	boost::filesystem::path const& basePath() const { return m_basePath; }
 
@@ -63,6 +67,9 @@ private:
 
 	/// Additional directories used for resolving relative paths in imports.
 	std::vector<boost::filesystem::path> m_includePaths;
+
+	/// Remappings of imports.
+	std::vector<frontend::ImportRemapper::Remapping> m_remappings;
 
 	/// Mapping of source unit names to their URIs as understood by the client.
 	StringMap m_sourceUnitNamesToUri;


### PR DESCRIPTION
### What

enables client's of the lsp server to configure remappings during the initialisation command.

we already allow configuring import-paths through the initialisation, so hopefully this is not controversial.

the format expected to be passed in from the initialise json is:

```
{ 
  "remappings": [
      {context: "", prefix: "foo", target: "bar"},
      ...
  ]
}
```

### Why

Because without being able to set remappings, the lsp-server throws errors for any project that requires them.

### Related

* https://github.com/ethereum/solidity/issues/12603
* https://github.com/ethereum/solidity/pull/12994