### PR TITLE
Add std:: qualifier to move() calls

### DIFF
--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -52,7 +52,7 @@ AssemblyItem const& Assembly::append(AssemblyItem _i)
 {
 	assertThrow(m_deposit >= 0, AssemblyException, "Stack underflow.");
 	m_deposit += static_cast<int>(_i.deposit());
-	m_items.emplace_back(move(_i));
+	m_items.emplace_back(std::move(_i));
 	if (!m_items.back().location().isValid() && m_currentSourceLocation.isValid())
 		m_items.back().setLocation(m_currentSourceLocation);
 	m_items.back().m_modifierDepth = m_currentModifierDepth;
@@ -254,7 +254,7 @@ Json::Value Assembly::assemblyJSON(map<string, unsigned> const& _sourceIndices, 
 		if (!data.empty())
 			jsonItem["value"] = data;
 		jsonItem["source"] = sourceIndex;
-		code.append(move(jsonItem));
+		code.append(std::move(jsonItem));
 
 		if (item.type() == AssemblyItemType::Tag)
 		{
@@ -265,7 +265,7 @@ Json::Value Assembly::assemblyJSON(map<string, unsigned> const& _sourceIndices, 
 			jumpdest["source"] = sourceIndex;
 			if (item.m_modifierDepth != 0)
 				jumpdest["modifierDepth"] = static_cast<int>(item.m_modifierDepth);
-			code.append(move(jumpdest));
+			code.append(std::move(jumpdest));
 		}
 	}
 	if (_includeSourceList)
@@ -464,7 +464,7 @@ map<u256, u256> const& Assembly::optimiseInternal(
 			}
 			if (optimisedItems.size() < m_items.size())
 			{
-				m_items = move(optimisedItems);
+				m_items = std::move(optimisedItems);
 				count++;
 			}
 		}
@@ -478,7 +478,7 @@ map<u256, u256> const& Assembly::optimiseInternal(
 			*this
 		);
 
-	m_tagReplacements = move(tagReplacements);
+	m_tagReplacements = std::move(tagReplacements);
 	return *m_tagReplacements;
 }
 

--- a/libevmasm/CommonSubexpressionEliminator.cpp
+++ b/libevmasm/CommonSubexpressionEliminator.cpp
@@ -48,8 +48,8 @@ vector<AssemblyItem> CommonSubexpressionEliminator::getOptimizedItems()
 	{
 		m_breakingItem = nullptr;
 		m_storeOperations.clear();
-		m_initialState = move(nextInitialState);
-		m_state = move(nextState);
+		m_initialState = std::move(nextInitialState);
+		m_state = std::move(nextState);
 	});
 
 	map<int, Id> initialStackContents;

--- a/libevmasm/ConstantOptimiser.cpp
+++ b/libevmasm/ConstantOptimiser.cpp
@@ -244,8 +244,8 @@ AssemblyItems ComputeMethod::findRepresentation(u256 const& _value)
 			bigint newGas = gasNeeded(newRoutine);
 			if (newGas < bestGas)
 			{
-				bestGas = move(newGas);
-				routine = move(newRoutine);
+				bestGas = std::move(newGas);
+				routine = std::move(newRoutine);
 			}
 		}
 		return routine;

--- a/libevmasm/ControlFlowGraph.cpp
+++ b/libevmasm/ControlFlowGraph.cpp
@@ -236,12 +236,12 @@ void ControlFlowGraph::gatherKnowledge()
 		item.state = _state->copy();
 		item.blocksSeen = _currentItem.blocksSeen;
 		item.blocksSeen.insert(_currentItem.blockId);
-		workQueue.push_back(move(item));
+		workQueue.push_back(std::move(item));
 	};
 
 	while (!workQueue.empty())
 	{
-		WorkQueueItem item = move(workQueue.back());
+		WorkQueueItem item = std::move(workQueue.back());
 		workQueue.pop_back();
 		//@todo we might have to do something like incrementing the sequence number for each JUMPDEST
 		assertThrow(!!item.blockId, OptimizerException, "");

--- a/libevmasm/Inliner.cpp
+++ b/libevmasm/Inliner.cpp
@@ -257,7 +257,7 @@ void Inliner::optimise()
 						if (auto exitItem = shouldInline(*tag, nextItem, *inlinableBlock))
 						{
 							newItems += inlinableBlock->items | ranges::views::drop_last(1);
-							newItems.emplace_back(move(*exitItem));
+							newItems.emplace_back(std::move(*exitItem));
 
 							// We are removing one push tag to the block we inline.
 							--inlinableBlock->pushTagCount;
@@ -277,5 +277,5 @@ void Inliner::optimise()
 		newItems.emplace_back(item);
 	}
 
-	m_items = move(newItems);
+	m_items = std::move(newItems);
 }

--- a/libevmasm/KnownState.cpp
+++ b/libevmasm/KnownState.cpp
@@ -252,7 +252,7 @@ void KnownState::reduceToCommonKnowledge(KnownState const& _other, bool _combine
 		map<int, Id> shiftedStack;
 		for (auto const& stackElement: m_stackElements)
 			shiftedStack[stackElement.first - stackDiff] = stackElement.second;
-		m_stackElements = move(shiftedStack);
+		m_stackElements = std::move(shiftedStack);
 		m_stackHeight = _other.m_stackHeight;
 	}
 
@@ -333,7 +333,7 @@ KnownState::StoreOperation KnownState::storeInStorage(
 	for (auto const& storageItem: m_storageContent)
 		if (m_expressionClasses->knownToBeDifferent(storageItem.first, _slot) || storageItem.second == _value)
 			storageContents.insert(storageItem);
-	m_storageContent = move(storageContents);
+	m_storageContent = std::move(storageContents);
 
 	AssemblyItem item(Instruction::SSTORE, _location);
 	Id id = m_expressionClasses->find(item, {_slot, _value}, true, m_sequenceNumber);
@@ -365,7 +365,7 @@ KnownState::StoreOperation KnownState::storeInMemory(Id _slot, Id _value, Source
 	for (auto const& memoryItem: m_memoryContent)
 		if (m_expressionClasses->knownToBeDifferentBy32(memoryItem.first, _slot))
 			memoryContents.insert(memoryItem);
-	m_memoryContent = move(memoryContents);
+	m_memoryContent = std::move(memoryContents);
 
 	AssemblyItem item(Instruction::MSTORE, _location);
 	Id id = m_expressionClasses->find(item, {_slot, _value}, true, m_sequenceNumber);

--- a/libevmasm/PathGasMeter.cpp
+++ b/libevmasm/PathGasMeter.cpp
@@ -44,7 +44,7 @@ GasMeter::GasConsumption PathGasMeter::estimateMax(
 	auto path = make_unique<GasPath>();
 	path->index = _startIndex;
 	path->state = _state->copy();
-	queue(move(path));
+	queue(std::move(path));
 
 	GasMeter::GasConsumption gas;
 	while (!m_queue.empty() && !gas.isInfinite)
@@ -60,14 +60,14 @@ void PathGasMeter::queue(std::unique_ptr<GasPath>&& _newPath)
 	)
 		return;
 	m_highestGasUsagePerJumpdest[_newPath->index] = _newPath->gas;
-	m_queue[_newPath->index] = move(_newPath);
+	m_queue[_newPath->index] = std::move(_newPath);
 }
 
 GasMeter::GasConsumption PathGasMeter::handleQueueItem()
 {
 	assertThrow(!m_queue.empty(), OptimizerException, "");
 
-	unique_ptr<GasPath> path = move(m_queue.rbegin()->second);
+	unique_ptr<GasPath> path = std::move(m_queue.rbegin()->second);
 	m_queue.erase(--m_queue.end());
 
 	shared_ptr<KnownState> state = path->state;
@@ -129,7 +129,7 @@ GasMeter::GasConsumption PathGasMeter::handleQueueItem()
 			newPath->largestMemoryAccess = meter.largestMemoryAccess();
 			newPath->state = state->copy();
 			newPath->visitedJumpdests = path->visitedJumpdests;
-			queue(move(newPath));
+			queue(std::move(newPath));
 		}
 
 		if (branchStops)

--- a/libsmtutil/CHCSmtLib2Interface.cpp
+++ b/libsmtutil/CHCSmtLib2Interface.cpp
@@ -44,7 +44,7 @@ CHCSmtLib2Interface::CHCSmtLib2Interface(
 ):
 	CHCSolverInterface(_queryTimeout),
 	m_smtlib2(make_unique<SMTLib2Interface>(_queryResponses, _smtCallback, m_queryTimeout)),
-	m_queryResponses(move(_queryResponses)),
+	m_queryResponses(std::move(_queryResponses)),
 	m_smtCallback(_smtCallback)
 {
 	reset();
@@ -195,7 +195,7 @@ void CHCSmtLib2Interface::declareFunction(string const& _name, SortPointer const
 
 void CHCSmtLib2Interface::write(string _data)
 {
-	m_accumulatedOutput += move(_data) + "\n";
+	m_accumulatedOutput += std::move(_data) + "\n";
 }
 
 string CHCSmtLib2Interface::querySolver(string const& _input)

--- a/libsmtutil/SMTLib2Interface.cpp
+++ b/libsmtutil/SMTLib2Interface.cpp
@@ -45,8 +45,8 @@ SMTLib2Interface::SMTLib2Interface(
 	optional<unsigned> _queryTimeout
 ):
 	SolverInterface(_queryTimeout),
-	m_queryResponses(move(_queryResponses)),
-	m_smtCallback(move(_smtCallback))
+	m_queryResponses(std::move(_queryResponses)),
+	m_smtCallback(std::move(_smtCallback))
 {
 	reset();
 }
@@ -264,7 +264,7 @@ string SMTLib2Interface::toSmtLibSort(vector<SortPointer> const& _sorts)
 void SMTLib2Interface::write(string _data)
 {
 	smtAssert(!m_accumulatedOutput.empty(), "");
-	m_accumulatedOutput.back() += move(_data) + "\n";
+	m_accumulatedOutput.back() += std::move(_data) + "\n";
 }
 
 string SMTLib2Interface::checkSatAndGetValuesCommand(vector<Expression> const& _expressionsToEvaluate)

--- a/libsmtutil/SMTPortfolio.cpp
+++ b/libsmtutil/SMTPortfolio.cpp
@@ -41,7 +41,7 @@ SMTPortfolio::SMTPortfolio(
 	SolverInterface(_queryTimeout)
 {
 	if (_enabledSolvers.smtlib2)
-		m_solvers.emplace_back(make_unique<SMTLib2Interface>(move(_smtlib2Responses), move(_smtCallback), m_queryTimeout));
+		m_solvers.emplace_back(make_unique<SMTLib2Interface>(std::move(_smtlib2Responses), std::move(_smtCallback), m_queryTimeout));
 #ifdef HAVE_Z3
 	if (_enabledSolvers.z3 && Z3Interface::available())
 		m_solvers.emplace_back(make_unique<Z3Interface>(m_queryTimeout));

--- a/libsmtutil/Z3CHCInterface.cpp
+++ b/libsmtutil/Z3CHCInterface.cpp
@@ -101,7 +101,7 @@ tuple<CheckResult, Expression, CHCSolverInterface::CexGraph> Z3CHCInterface::que
 		{
 			result = CheckResult::UNSATISFIABLE;
 			auto invariants = m_z3Interface->fromZ3Expr(m_solver.get_answer());
-			return {result, move(invariants), {}};
+			return {result, std::move(invariants), {}};
 		}
 		case z3::check_result::unknown:
 		{

--- a/libsolc/libsolc.cpp
+++ b/libsolc/libsolc.cpp
@@ -56,7 +56,7 @@ string takeOverAllocation(char const* _data)
 	for (auto iter = begin(solidityAllocations); iter != end(solidityAllocations); ++iter)
 		if (iter->data() == _data)
 		{
-			string chunk = move(*iter);
+			string chunk = std::move(*iter);
 			solidityAllocations.erase(iter);
 			return chunk;
 		}
@@ -109,7 +109,7 @@ ReadCallback::Callback wrapReadCallback(CStyleReadFileCallback _readCallback, vo
 string compile(string _input, CStyleReadFileCallback _readCallback, void* _readContext)
 {
 	StandardCompiler compiler(wrapReadCallback(_readCallback, _readContext));
-	return compiler.compile(move(_input));
+	return compiler.compile(std::move(_input));
 }
 
 }

--- a/libsolidity/analysis/DeclarationContainer.cpp
+++ b/libsolidity/analysis/DeclarationContainer.cpp
@@ -210,7 +210,7 @@ void DeclarationContainer::populateHomonyms(back_insert_iterator<Homonyms> _it) 
 		ResolvingSettings settings;
 		settings.recursive = true;
 		settings.alsoInvisible = true;
-		vector<Declaration const*> const& declarations = m_enclosingContainer->resolveName(name, move(settings));
+		vector<Declaration const*> const& declarations = m_enclosingContainer->resolveName(name, std::move(settings));
 		if (!declarations.empty())
 			_it = make_pair(location, declarations);
 	}

--- a/libsolidity/analysis/FunctionCallGraph.cpp
+++ b/libsolidity/analysis/FunctionCallGraph.cpp
@@ -61,7 +61,7 @@ CallGraph FunctionCallGraphBuilder::buildCreationGraph(ContractDefinition const&
 	builder.m_currentNode = CallGraph::SpecialNode::Entry;
 	builder.processQueue();
 
-	return move(builder.m_graph);
+	return std::move(builder.m_graph);
 }
 
 CallGraph FunctionCallGraphBuilder::buildDeployedGraph(
@@ -109,7 +109,7 @@ CallGraph FunctionCallGraphBuilder::buildDeployedGraph(
 	builder.m_currentNode = CallGraph::SpecialNode::Entry;
 	builder.processQueue();
 
-	return move(builder.m_graph);
+	return std::move(builder.m_graph);
 }
 
 bool FunctionCallGraphBuilder::visit(FunctionCall const& _functionCall)

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -184,7 +184,7 @@ vector<Declaration const*> NameAndTypeResolver::nameFromCurrentScope(ASTString c
 	ResolvingSettings settings;
 	settings.recursive = true;
 	settings.alsoInvisible = _includeInvisibles;
-	return m_currentScope->resolveName(_name, move(settings));
+	return m_currentScope->resolveName(_name, std::move(settings));
 }
 
 Declaration const* NameAndTypeResolver::pathFromCurrentScope(vector<ASTString> const& _path) const
@@ -204,7 +204,7 @@ std::vector<Declaration const*> NameAndTypeResolver::pathFromCurrentScopeWithAll
 	settings.recursive = true;
 	settings.alsoInvisible = false;
 	settings.onlyVisibleAsUnqualifiedNames = true;
-	vector<Declaration const*> candidates = m_currentScope->resolveName(_path.front(), move(settings));
+	vector<Declaration const*> candidates = m_currentScope->resolveName(_path.front(), std::move(settings));
 
 	for (size_t i = 1; i < _path.size() && candidates.size() == 1; i++)
 	{

--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -276,7 +276,7 @@ void ReferencesResolver::operator()(yul::Identifier const& _identifier)
 			return;
 		}
 
-	m_yulAnnotation->externalReferences[&_identifier].suffix = move(suffix);
+	m_yulAnnotation->externalReferences[&_identifier].suffix = std::move(suffix);
 	m_yulAnnotation->externalReferences[&_identifier].declaration = declarations.front();
 }
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1639,7 +1639,7 @@ bool TypeChecker::visit(TupleExpression const& _tuple)
 		if (components.size() == 1)
 			_tuple.annotation().type = type(*components[0]);
 		else
-			_tuple.annotation().type = TypeProvider::tuple(move(types));
+			_tuple.annotation().type = TypeProvider::tuple(std::move(types));
 		// If some of the components are not LValues, the error is reported above.
 		_tuple.annotation().isLValue = true;
 		_tuple.annotation().isPure = false;
@@ -1710,7 +1710,7 @@ bool TypeChecker::visit(TupleExpression const& _tuple)
 			if (components.size() == 1)
 				_tuple.annotation().type = type(*components[0]);
 			else
-				_tuple.annotation().type = TypeProvider::tuple(move(types));
+				_tuple.annotation().type = TypeProvider::tuple(std::move(types));
 		}
 
 		_tuple.annotation().isLValue = false;
@@ -2811,8 +2811,8 @@ bool TypeChecker::visit(FunctionCall const& _functionCall)
 		}
 
 		funcCallAnno.type = returnTypes.size() == 1 ?
-			move(returnTypes.front()) :
-			TypeProvider::tuple(move(returnTypes));
+			std::move(returnTypes.front()) :
+			TypeProvider::tuple(std::move(returnTypes));
 
 		break;
 	}

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -239,7 +239,7 @@ vector<ErrorDefinition const*> ContractDefinition::interfaceErrors(bool _require
 		result +=
 			(*annotation().creationCallGraph)->usedErrors +
 			(*annotation().deployedCallGraph)->usedErrors;
-	return util::convertContainer<vector<ErrorDefinition const*>>(move(result));
+	return util::convertContainer<vector<ErrorDefinition const*>>(std::move(result));
 }
 
 vector<pair<util::FixedHash<4>, FunctionTypePointer>> const& ContractDefinition::interfaceFunctionList(bool _includeInheritedFunctions) const

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -358,7 +358,7 @@ public:
 	):
 		Declaration(_id, _location, _unitAlias, std::move(_unitAliasLocation)),
 		m_path(std::move(_path)),
-		m_symbolAliases(move(_symbolAliases))
+		m_symbolAliases(std::move(_symbolAliases))
 	{ }
 
 	void accept(ASTVisitor& _visitor) override;
@@ -1503,7 +1503,7 @@ public:
 	):
 		Statement(_id, _location, _docString),
 		m_dialect(_dialect),
-		m_flags(move(_flags)),
+		m_flags(std::move(_flags)),
 		m_operations(std::move(_operations))
 	{}
 	void accept(ASTVisitor& _visitor) override;

--- a/libsolidity/ast/ASTJsonExporter.cpp
+++ b/libsolidity/ast/ASTJsonExporter.cpp
@@ -336,15 +336,15 @@ bool ASTJsonExporter::visit(UsingForDirective const& _node)
 		{
 			Json::Value functionNode;
 			functionNode["function"] = toJson(*function);
-			functionList.append(move(functionNode));
+			functionList.append(std::move(functionNode));
 		}
-		attributes.emplace_back("functionList", move(functionList));
+		attributes.emplace_back("functionList", std::move(functionList));
 	}
 	else
 		attributes.emplace_back("libraryName", toJson(*_node.functionsOrLibrary().front()));
 	attributes.emplace_back("global", _node.global());
 
-	setJsonNode(_node, "UsingForDirective", move(attributes));
+	setJsonNode(_node, "UsingForDirective", std::move(attributes));
 
 	return false;
 }
@@ -518,7 +518,7 @@ bool ASTJsonExporter::visit(ModifierInvocation const& _node)
 		else if (dynamic_cast<ContractDefinition const*>(declaration))
 			attributes.emplace_back("kind", "baseConstructorSpecifier");
 	}
-	setJsonNode(_node, "ModifierInvocation", move(attributes));
+	setJsonNode(_node, "ModifierInvocation", std::move(attributes));
 	return false;
 }
 
@@ -645,9 +645,9 @@ bool ASTJsonExporter::visit(InlineAssembly const& _node)
 				flags.append(*flag);
 			else
 				flags.append(Json::nullValue);
-		attributes.emplace_back(make_pair("flags", move(flags)));
+		attributes.emplace_back(make_pair("flags", std::move(flags)));
 	}
-	setJsonNode(_node, "InlineAssembly", move(attributes));
+	setJsonNode(_node, "InlineAssembly", std::move(attributes));
 
 	return false;
 }

--- a/libsolidity/ast/ASTJsonImporter.cpp
+++ b/libsolidity/ast/ASTJsonImporter.cpp
@@ -299,7 +299,7 @@ ASTPointer<ImportDirective> ASTJsonImporter::createImportDirective(Json::Value c
 		path,
 		unitAlias,
 		createNameSourceLocation(_node),
-		move(symbolAliases)
+		std::move(symbolAliases)
 	);
 
 	astAssert(_node["absolutePath"].isString(), "Expected 'absolutePath' to be a string!");
@@ -391,7 +391,7 @@ ASTPointer<UsingForDirective> ASTJsonImporter::createUsingForDirective(Json::Val
 
 	return createASTNode<UsingForDirective>(
 		_node,
-		move(functions),
+		std::move(functions),
 		!_node.isMember("libraryName"),
 		_node["typeName"].isNull() ? nullptr  : convertJsonToASTNode<TypeName>(_node["typeName"]),
 		memberAsBool(_node, "global")
@@ -686,7 +686,7 @@ ASTPointer<InlineAssembly> ASTJsonImporter::createInlineAssembly(Json::Value con
 		_node,
 		nullOrASTString(_node, "documentation"),
 		dialect,
-		move(flags),
+		std::move(flags),
 		operations
 	);
 }

--- a/libsolidity/ast/TypeProvider.cpp
+++ b/libsolidity/ast/TypeProvider.cpp
@@ -404,7 +404,7 @@ TupleType const* TypeProvider::tuple(vector<Type const*> members)
 	if (members.empty())
 		return &m_emptyTuple;
 
-	return createAndGet<TupleType>(move(members));
+	return createAndGet<TupleType>(std::move(members));
 }
 
 ReferenceType const* TypeProvider::withLocation(ReferenceType const* _type, DataLocation _location, bool _isPointer)

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -125,7 +125,7 @@ MemberList::Member::Member(Declaration const* _declaration, Type const* _type):
 {}
 
 MemberList::Member::Member(Declaration const* _declaration, Type const* _type, string _name):
-	name(move(_name)),
+	name(std::move(_name)),
 	type(_type),
 	declaration(_declaration)
 {
@@ -305,7 +305,7 @@ MemberList const& Type::members(ASTNode const* _currentScope) const
 		MemberList::MemberMap members = nativeMembers(_currentScope);
 		if (_currentScope)
 			members += boundFunctions(*this, *_currentScope);
-		m_members[_currentScope] = make_unique<MemberList>(move(members));
+		m_members[_currentScope] = make_unique<MemberList>(std::move(members));
 	}
 	return *m_members[_currentScope];
 }
@@ -2737,7 +2737,7 @@ Type const* TupleType::mobileType() const
 		else
 			mobiles.push_back(nullptr);
 	}
-	return TypeProvider::tuple(move(mobiles));
+	return TypeProvider::tuple(std::move(mobiles));
 }
 
 FunctionType::FunctionType(FunctionDefinition const& _function, Kind _kind):

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -199,7 +199,7 @@ void CompilerContext::appendYulUtilityFunctions(OptimiserSettings const& _optimi
 	if (!code.empty())
 	{
 		appendInlineAssembly(
-			yul::reindent("{\n" + move(code) + "\n}"),
+			yul::reindent("{\n" + std::move(code) + "\n}"),
 			{},
 			m_externallyUsedYulFunctions,
 			true,

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -1293,7 +1293,7 @@ bool ContractCompiler::visit(Return const& _return)
 
 		Type const* expectedType;
 		if (expression->annotation().type->category() == Type::Category::Tuple || types.size() != 1)
-			expectedType = TypeProvider::tuple(move(types));
+			expectedType = TypeProvider::tuple(std::move(types));
 		else
 			expectedType = types.front();
 		compileExpression(*expression, expectedType);

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -71,7 +71,7 @@ Type const* closestType(Type const* _type, Type const* _targetType, bool _isShif
 				solAssert(tempComponents[i], "");
 			}
 		}
-		return TypeProvider::tuple(move(tempComponents));
+		return TypeProvider::tuple(std::move(tempComponents));
 	}
 	else
 		return _targetType->dataStoredIn(DataLocation::Storage) ? _type->mobileType() : _targetType;
@@ -391,7 +391,7 @@ bool ExpressionCompiler::visit(TupleExpression const& _tuple)
 				if (_tuple.annotation().willBeWrittenTo)
 				{
 					solAssert(!!m_currentLValue, "");
-					lvalues.push_back(move(m_currentLValue));
+					lvalues.push_back(std::move(m_currentLValue));
 				}
 			}
 			else if (_tuple.annotation().willBeWrittenTo)
@@ -399,9 +399,9 @@ bool ExpressionCompiler::visit(TupleExpression const& _tuple)
 		if (_tuple.annotation().willBeWrittenTo)
 		{
 			if (_tuple.components().size() == 1)
-				m_currentLValue = move(lvalues[0]);
+				m_currentLValue = std::move(lvalues[0]);
 			else
-				m_currentLValue = make_unique<TupleObject>(m_context, move(lvalues));
+				m_currentLValue = make_unique<TupleObject>(m_context, std::move(lvalues));
 		}
 	}
 	return false;

--- a/libsolidity/codegen/ExpressionCompiler.h
+++ b/libsolidity/codegen/ExpressionCompiler.h
@@ -151,7 +151,7 @@ void ExpressionCompiler::setLValue(Expression const& _expression, Arguments cons
 	solAssert(!m_currentLValue, "Current LValue not reset before trying to set new one.");
 	std::unique_ptr<LValueType> lvalue = std::make_unique<LValueType>(m_context, _arguments...);
 	if (_expression.annotation().willBeWrittenTo)
-		m_currentLValue = move(lvalue);
+		m_currentLValue = std::move(lvalue);
 	else
 		lvalue->retrieveValue(_expression.location(), true);
 }

--- a/libsolidity/codegen/LValue.cpp
+++ b/libsolidity/codegen/LValue.cpp
@@ -557,7 +557,7 @@ TupleObject::TupleObject(
 	CompilerContext& _compilerContext,
 	std::vector<std::unique_ptr<LValue>>&& _lvalues
 ):
-	LValue(_compilerContext), m_lvalues(move(_lvalues))
+	LValue(_compilerContext), m_lvalues(std::move(_lvalues))
 {
 }
 

--- a/libsolidity/codegen/MultiUseYulFunctionCollector.cpp
+++ b/libsolidity/codegen/MultiUseYulFunctionCollector.cpp
@@ -33,7 +33,7 @@ using namespace solidity::util;
 
 string MultiUseYulFunctionCollector::requestedFunctions()
 {
-	string result = move(m_code);
+	string result = std::move(m_code);
 	m_code.clear();
 	m_requestedFunctions.clear();
 	return result;
@@ -47,7 +47,7 @@ string MultiUseYulFunctionCollector::createFunction(string const& _name, functio
 		string fun = _creator();
 		solAssert(!fun.empty(), "");
 		solAssert(fun.find("function " + _name + "(") != string::npos, "Function not properly named.");
-		m_code += move(fun);
+		m_code += std::move(fun);
 	}
 	return _name;
 }

--- a/libsolidity/codegen/ir/IRGenerationContext.cpp
+++ b/libsolidity/codegen/ir/IRGenerationContext.cpp
@@ -121,7 +121,7 @@ void IRGenerationContext::addStateVariable(
 	unsigned _byteOffset
 )
 {
-	m_stateVariables[&_declaration] = make_pair(move(_storageOffset), _byteOffset);
+	m_stateVariables[&_declaration] = make_pair(std::move(_storageOffset), _byteOffset);
 }
 
 string IRGenerationContext::newYulVariable()
@@ -137,12 +137,12 @@ void IRGenerationContext::initializeInternalDispatch(InternalDispatchMap _intern
 		for (auto function: functions)
 			enqueueFunctionForCodeGeneration(*function);
 
-	m_internalDispatchMap = move(_internalDispatch);
+	m_internalDispatchMap = std::move(_internalDispatch);
 }
 
 InternalDispatchMap IRGenerationContext::consumeInternalDispatchMap()
 {
-	InternalDispatchMap internalDispatch = move(m_internalDispatchMap);
+	InternalDispatchMap internalDispatch = std::move(m_internalDispatchMap);
 	m_internalDispatchMap.clear();
 	return internalDispatch;
 }

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -113,7 +113,7 @@ pair<string, string> IRGenerator::run(
 	}
 	asmStack.optimize();
 
-	return {move(ir), asmStack.print(m_context.soliditySourceProvider())};
+	return {std::move(ir), asmStack.print(m_context.soliditySourceProvider())};
 }
 
 string IRGenerator::generate(
@@ -214,7 +214,7 @@ string IRGenerator::generate(
 	// NOTE: Function pointers can be passed from creation code via storage variables. We need to
 	// get all the functions they could point to into the dispatch functions even if they're never
 	// referenced by name in the deployed code.
-	m_context.initializeInternalDispatch(move(internalDispatchMap));
+	m_context.initializeInternalDispatch(std::move(internalDispatchMap));
 
 	// Do not register immutables to avoid assignment.
 	t("DeployedObject", IRNames::deployedObject(_contract));
@@ -236,8 +236,8 @@ string IRGenerator::generate(
 
 	solAssert(_contract.annotation().creationCallGraph->get() != nullptr, "");
 	solAssert(_contract.annotation().deployedCallGraph->get() != nullptr, "");
-	verifyCallGraph(collectReachableCallables(**_contract.annotation().creationCallGraph), move(creationFunctionList));
-	verifyCallGraph(collectReachableCallables(**_contract.annotation().deployedCallGraph), move(deployedFunctionList));
+	verifyCallGraph(collectReachableCallables(**_contract.annotation().creationCallGraph), std::move(creationFunctionList));
+	verifyCallGraph(collectReachableCallables(**_contract.annotation().deployedCallGraph), std::move(deployedFunctionList));
 
 	return t.render();
 }
@@ -317,7 +317,7 @@ InternalDispatchMap IRGenerator::generateInternalDispatchFunctions(ContractDefin
 				});
 			}
 
-			templ("cases", move(cases));
+			templ("cases", std::move(cases));
 			return templ.render();
 		});
 	}
@@ -944,7 +944,7 @@ void IRGenerator::generateConstructors(ContractDefinition const& _contract)
 					generateFunctionWithModifierInner(*constructor);
 				}
 			}
-			t("userDefinedConstructorBody", move(body));
+			t("userDefinedConstructorBody", std::move(body));
 
 			return t.render();
 		});
@@ -1117,7 +1117,7 @@ void IRGenerator::resetContext(ContractDefinition const& _contract, ExecutionCon
 		m_context.soliditySourceProvider()
 	);
 	newContext.copyFunctionIDsFrom(m_context);
-	m_context = move(newContext);
+	m_context = std::move(newContext);
 
 	m_context.setMostDerivedContract(_contract);
 	for (auto const& var: ContractType(_contract).stateVariables())

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -827,17 +827,17 @@ bool IRGeneratorForStatements::visit(BinaryOperation const& _binOp)
 				expr = "iszero(" + expr + ")";
 		}
 		else if (op == Token::Equal)
-			expr = "eq(" + move(args) + ")";
+			expr = "eq(" + std::move(args) + ")";
 		else if (op == Token::NotEqual)
-			expr = "iszero(eq(" + move(args) + "))";
+			expr = "iszero(eq(" + std::move(args) + "))";
 		else if (op == Token::GreaterThanOrEqual)
-			expr = "iszero(" + string(isSigned ? "slt(" : "lt(") + move(args) + "))";
+			expr = "iszero(" + string(isSigned ? "slt(" : "lt(") + std::move(args) + "))";
 		else if (op == Token::LessThanOrEqual)
-			expr = "iszero(" + string(isSigned ? "sgt(" : "gt(") + move(args) + "))";
+			expr = "iszero(" + string(isSigned ? "sgt(" : "gt(") + std::move(args) + "))";
 		else if (op == Token::GreaterThan)
-			expr = (isSigned ? "sgt(" : "gt(") + move(args) + ")";
+			expr = (isSigned ? "sgt(" : "gt(") + std::move(args) + ")";
 		else if (op == Token::LessThan)
-			expr = (isSigned ? "slt(" : "lt(") + move(args) + ")";
+			expr = (isSigned ? "slt(" : "lt(") + std::move(args) + ")";
 		else
 			solAssert(false, "Unknown comparison operator.");
 		define(_binOp) << expr << "\n";
@@ -1109,7 +1109,7 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 			messageArgumentType
 		);
 
-		appendCode() << move(requireOrAssertFunction) << "(" << IRVariable(*arguments[0]).name();
+		appendCode() << std::move(requireOrAssertFunction) << "(" << IRVariable(*arguments[0]).name();
 		if (messageArgumentType && messageArgumentType->sizeOnStack() > 0)
 			appendCode() << ", " << IRVariable(*arguments[1]).commaSeparatedList();
 		appendCode() << ")\n";

--- a/libsolidity/formal/ArraySlicePredicate.cpp
+++ b/libsolidity/formal/ArraySlicePredicate.cpp
@@ -86,6 +86,6 @@ pair<bool, ArraySlicePredicate::SliceData const&> ArraySlicePredicate::create(So
 
 	return {false, m_slicePredicates[tupleName] = {
 		{&slice, &header, &loop},
-		{move(rule1), move(rule2), move(rule3), move(rule4)}
+		{std::move(rule1), std::move(rule2), std::move(rule3), std::move(rule4)}
 	}};
 }

--- a/libsolidity/formal/BMC.cpp
+++ b/libsolidity/formal/BMC.cpp
@@ -76,7 +76,7 @@ void BMC::analyze(SourceUnit const& _source, map<ASTNode const*, set<Verificatio
 
 	SMTEncoder::resetSourceAnalysis();
 
-	m_solvedTargets = move(_solvedTargets);
+	m_solvedTargets = std::move(_solvedTargets);
 	m_context.setSolver(m_interface.get());
 	m_context.reset();
 	m_context.setAssertionAccumulation(true);
@@ -686,7 +686,7 @@ pair<vector<smtutil::Expression>, vector<string>> BMC::modelExpressions()
 				expressionName = m_charStreamProvider.charStream(*uf->location().sourceName).text(
 					uf->location()
 				);
-			expressionNames.push_back(move(expressionName));
+			expressionNames.push_back(std::move(expressionName));
 		}
 
 	return {expressionsToEvaluate, expressionNames};
@@ -888,7 +888,7 @@ void BMC::addVerificationTarget(
 	if (_type == VerificationTargetType::ConstantCondition)
 		checkVerificationTarget(target);
 	else
-		m_verificationTargets.emplace_back(move(target));
+		m_verificationTargets.emplace_back(std::move(target));
 }
 
 /// Solving.
@@ -964,7 +964,7 @@ void BMC::checkCondition(
 			message.str(),
 			SecondarySourceLocation().append(modelMessage.str(), SourceLocation{})
 			.append(SMTEncoder::callStackMessage(_callStack))
-			.append(move(secondaryLocation))
+			.append(std::move(secondaryLocation))
 		);
 		break;
 	}

--- a/libsolidity/formal/CHC.cpp
+++ b/libsolidity/formal/CHC.cpp
@@ -1422,7 +1422,7 @@ vector<smtutil::Expression> CHC::currentStateVariables(ContractDefinition const&
 smtutil::Expression CHC::currentEqualInitialVarsConstraints(vector<VariableDeclaration const*> const& _vars) const
 {
 	return fold(_vars, smtutil::Expression(true), [this](auto&& _conj, auto _var) {
-		return move(_conj) && currentValue(*_var) == m_context.variable(*_var)->valueAtIndex(0);
+		return std::move(_conj) && currentValue(*_var) == m_context.variable(*_var)->valueAtIndex(0);
 	});
 }
 
@@ -1566,7 +1566,7 @@ tuple<CheckResult, smtutil::Expression, CHCSolverInterface::CexGraph> CHC::query
 			tie(resultNoOpt, invariantNoOpt, cexNoOpt) = m_interface->query(_query);
 
 			if (resultNoOpt == CheckResult::SATISFIABLE)
-				cex = move(cexNoOpt);
+				cex = std::move(cexNoOpt);
 
 			spacer->setSpacerOptions(true);
 		}
@@ -1817,7 +1817,7 @@ void CHC::checkAndReportTarget(
 			predicates.insert(pred);
 		map<Predicate const*, set<string>> invariants = collectInvariants(invariant, predicates, m_settings.invariants);
 		for (auto pred: invariants | ranges::views::keys)
-			m_invariants[pred] += move(invariants.at(pred));
+			m_invariants[pred] += std::move(invariants.at(pred));
 	}
 	else if (result == CheckResult::SATISFIABLE)
 	{

--- a/libsolidity/formal/EncodingContext.cpp
+++ b/libsolidity/formal/EncodingContext.cpp
@@ -211,5 +211,5 @@ void EncodingContext::addAssertion(smtutil::Expression const& _expr)
 	if (m_assertions.empty())
 		m_assertions.push_back(_expr);
 	else
-		m_assertions.back() = _expr && move(m_assertions.back());
+		m_assertions.back() = _expr && std::move(m_assertions.back());
 }

--- a/libsolidity/formal/EncodingContext.h
+++ b/libsolidity/formal/EncodingContext.h
@@ -63,7 +63,7 @@ public:
 	smtutil::Expression newVariable(std::string _name, smtutil::SortPointer _sort)
 	{
 		solAssert(m_solver, "");
-		return m_solver->newVariable(move(_name), move(_sort));
+		return m_solver->newVariable(std::move(_name), std::move(_sort));
 	}
 
 	struct IdCompare

--- a/libsolidity/formal/Invariants.cpp
+++ b/libsolidity/formal/Invariants.cpp
@@ -55,9 +55,9 @@ map<Predicate const*, set<string>> collectInvariants(
 				auto arg0 = _expr->arguments.at(0);
 				auto arg1 = _expr->arguments.at(1);
 				if (starts_with(arg0.name, t))
-					equalities.insert({arg0.name, {arg0, move(arg1)}});
+					equalities.insert({arg0.name, {arg0, std::move(arg1)}});
 				else if (starts_with(arg1.name, t))
-					equalities.insert({arg1.name, {arg1, move(arg0)}});
+					equalities.insert({arg1.name, {arg1, std::move(arg0)}});
 			}
 		for (auto const& arg: _expr->arguments)
 			_addChild(&arg);

--- a/libsolidity/formal/ModelChecker.cpp
+++ b/libsolidity/formal/ModelChecker.cpp
@@ -38,7 +38,7 @@ ModelChecker::ModelChecker(
 	ReadCallback::Callback const& _smtCallback
 ):
 	m_errorReporter(_errorReporter),
-	m_settings(move(_settings)),
+	m_settings(std::move(_settings)),
 	m_context(),
 	m_bmc(m_context, m_uniqueErrorReporter, _smtlib2Responses, _smtCallback, m_settings, _charStreamProvider),
 	m_chc(m_context, m_uniqueErrorReporter, _smtlib2Responses, _smtCallback, m_settings, _charStreamProvider)

--- a/libsolidity/formal/Predicate.cpp
+++ b/libsolidity/formal/Predicate.cpp
@@ -50,13 +50,13 @@ Predicate const* Predicate::create(
 	vector<ScopeOpener const*> _scopeStack
 )
 {
-	smt::SymbolicFunctionVariable predicate{_sort, move(_name), _context};
+	smt::SymbolicFunctionVariable predicate{_sort, std::move(_name), _context};
 	string functorName = predicate.currentName();
 	solAssert(!m_predicates.count(functorName), "");
 	return &m_predicates.emplace(
 		std::piecewise_construct,
 		std::forward_as_tuple(functorName),
-		std::forward_as_tuple(move(predicate), _type, _node, _contractContext, move(_scopeStack))
+		std::forward_as_tuple(std::move(predicate), _type, _node, _contractContext, std::move(_scopeStack))
 	).first->second;
 }
 
@@ -67,7 +67,7 @@ Predicate::Predicate(
 	ContractDefinition const* _contractContext,
 	vector<ScopeOpener const*> _scopeStack
 ):
-	m_predicate(move(_predicate)),
+	m_predicate(std::move(_predicate)),
 	m_type(_type),
 	m_node(_node),
 	m_contractContext(_contractContext),

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -2977,7 +2977,7 @@ set<FunctionDefinition const*, ASTNode::CompareByID> const& SMTEncoder::contract
 					resolvedFunctions.insert(baseFunction);
 			}
 		}
-		m_contractFunctions.emplace(&_contract, move(resolvedFunctions));
+		m_contractFunctions.emplace(&_contract, std::move(resolvedFunctions));
 	}
 	return m_contractFunctions.at(&_contract);
 }
@@ -2991,7 +2991,7 @@ set<FunctionDefinition const*, ASTNode::CompareByID> const& SMTEncoder::contract
 			for (auto const* baseFun: base->definedFunctions())
 				allFunctions.insert(baseFun);
 
-		m_contractFunctionsWithoutVirtual.emplace(&_contract, move(allFunctions));
+		m_contractFunctionsWithoutVirtual.emplace(&_contract, std::move(allFunctions));
 
 	}
 	return m_contractFunctionsWithoutVirtual.at(&_contract);

--- a/libsolidity/formal/SymbolicState.cpp
+++ b/libsolidity/formal/SymbolicState.cpp
@@ -32,8 +32,8 @@ BlockchainVariable::BlockchainVariable(
 	map<string, smtutil::SortPointer> _members,
 	EncodingContext& _context
 ):
-	m_name(move(_name)),
-	m_members(move(_members)),
+	m_name(std::move(_name)),
+	m_members(std::move(_members)),
 	m_context(_context)
 {
 	vector<string> members;
@@ -94,12 +94,12 @@ smtutil::Expression SymbolicState::balance() const
 
 smtutil::Expression SymbolicState::balance(smtutil::Expression _address) const
 {
-	return smtutil::Expression::select(balances(), move(_address));
+	return smtutil::Expression::select(balances(), std::move(_address));
 }
 
 smtutil::Expression SymbolicState::blockhash(smtutil::Expression _blockNumber) const
 {
-	return smtutil::Expression::select(m_tx.member("blockhash"), move(_blockNumber));
+	return smtutil::Expression::select(m_tx.member("blockhash"), std::move(_blockNumber));
 }
 
 void SymbolicState::newBalances()
@@ -114,13 +114,13 @@ void SymbolicState::transfer(smtutil::Expression _from, smtutil::Expression _to,
 {
 	unsigned indexBefore = m_state.index();
 	addBalance(_from, 0 - _value);
-	addBalance(_to, move(_value));
+	addBalance(_to, std::move(_value));
 	unsigned indexAfter = m_state.index();
 	solAssert(indexAfter > indexBefore, "");
 	m_state.newVar();
 	/// Do not apply the transfer operation if _from == _to.
 	auto newState = smtutil::Expression::ite(
-		move(_from) == move(_to),
+		std::move(_from) == std::move(_to),
 		m_state.value(indexBefore),
 		m_state.value(indexAfter)
 	);
@@ -132,7 +132,7 @@ void SymbolicState::addBalance(smtutil::Expression _address, smtutil::Expression
 	auto newBalances = smtutil::Expression::store(
 		balances(),
 		_address,
-		balance(_address) + move(_value)
+		balance(_address) + std::move(_value)
 	);
 	m_state.assignMember("balances", newBalances);
 }
@@ -322,7 +322,7 @@ void SymbolicState::buildABIFunctions(set<FunctionCall const*> const& _abiFuncti
 		functions[name] = functionSort;
 	}
 
-	m_abi = make_unique<BlockchainVariable>("abi", move(functions), m_context);
+	m_abi = make_unique<BlockchainVariable>("abi", std::move(functions), m_context);
 }
 
 smtutil::Expression SymbolicState::abiFunction(frontend::FunctionCall const* _funCall)

--- a/libsolidity/formal/SymbolicVariables.cpp
+++ b/libsolidity/formal/SymbolicVariables.cpp
@@ -38,7 +38,7 @@ SymbolicVariable::SymbolicVariable(
 ):
 	m_type(_type),
 	m_originalType(_originalType),
-	m_uniqueName(move(_uniqueName)),
+	m_uniqueName(std::move(_uniqueName)),
 	m_context(_context),
 	m_ssa(make_unique<SSAVariable>())
 {
@@ -52,8 +52,8 @@ SymbolicVariable::SymbolicVariable(
 	string _uniqueName,
 	EncodingContext& _context
 ):
-	m_sort(move(_sort)),
-	m_uniqueName(move(_uniqueName)),
+	m_sort(std::move(_sort)),
+	m_uniqueName(std::move(_uniqueName)),
 	m_context(_context),
 	m_ssa(make_unique<SSAVariable>())
 {
@@ -108,7 +108,7 @@ SymbolicBoolVariable::SymbolicBoolVariable(
 	string _uniqueName,
 	EncodingContext& _context
 ):
-	SymbolicVariable(_type, _type, move(_uniqueName), _context)
+	SymbolicVariable(_type, _type, std::move(_uniqueName), _context)
 {
 	solAssert(m_type->category() == frontend::Type::Category::Bool, "");
 }
@@ -119,7 +119,7 @@ SymbolicIntVariable::SymbolicIntVariable(
 	string _uniqueName,
 	EncodingContext& _context
 ):
-	SymbolicVariable(_type, _originalType, move(_uniqueName), _context)
+	SymbolicVariable(_type, _originalType, std::move(_uniqueName), _context)
 {
 	solAssert(isNumber(*m_type), "");
 }
@@ -128,7 +128,7 @@ SymbolicAddressVariable::SymbolicAddressVariable(
 	string _uniqueName,
 	EncodingContext& _context
 ):
-	SymbolicIntVariable(TypeProvider::uint(160), TypeProvider::uint(160), move(_uniqueName), _context)
+	SymbolicIntVariable(TypeProvider::uint(160), TypeProvider::uint(160), std::move(_uniqueName), _context)
 {
 }
 
@@ -138,7 +138,7 @@ SymbolicFixedBytesVariable::SymbolicFixedBytesVariable(
 	string _uniqueName,
 	EncodingContext& _context
 ):
-	SymbolicIntVariable(TypeProvider::uint(_numBytes * 8), _originalType, move(_uniqueName), _context)
+	SymbolicIntVariable(TypeProvider::uint(_numBytes * 8), _originalType, std::move(_uniqueName), _context)
 {
 }
 
@@ -147,7 +147,7 @@ SymbolicFunctionVariable::SymbolicFunctionVariable(
 	string _uniqueName,
 	EncodingContext& _context
 ):
-	SymbolicVariable(_type, _type, move(_uniqueName), _context),
+	SymbolicVariable(_type, _type, std::move(_uniqueName), _context),
 	m_declaration(m_context.newVariable(currentName(), m_sort))
 {
 	solAssert(m_type->category() == frontend::Type::Category::Function, "");
@@ -158,7 +158,7 @@ SymbolicFunctionVariable::SymbolicFunctionVariable(
 	string _uniqueName,
 	EncodingContext& _context
 ):
-	SymbolicVariable(move(_sort), move(_uniqueName), _context),
+	SymbolicVariable(std::move(_sort), std::move(_uniqueName), _context),
 	m_declaration(m_context.newVariable(currentName(), m_sort))
 {
 	solAssert(m_sort->kind == Kind::Function, "");
@@ -219,7 +219,7 @@ SymbolicEnumVariable::SymbolicEnumVariable(
 	string _uniqueName,
 	EncodingContext& _context
 ):
-	SymbolicVariable(_type, _type, move(_uniqueName), _context)
+	SymbolicVariable(_type, _type, std::move(_uniqueName), _context)
 {
 	solAssert(isEnum(*m_type), "");
 }
@@ -229,7 +229,7 @@ SymbolicTupleVariable::SymbolicTupleVariable(
 	string _uniqueName,
 	EncodingContext& _context
 ):
-	SymbolicVariable(_type, _type, move(_uniqueName), _context)
+	SymbolicVariable(_type, _type, std::move(_uniqueName), _context)
 {
 	solAssert(isTuple(*m_type), "");
 }
@@ -239,7 +239,7 @@ SymbolicTupleVariable::SymbolicTupleVariable(
 	string _uniqueName,
 	EncodingContext& _context
 ):
-	SymbolicVariable(move(_sort), move(_uniqueName), _context)
+	SymbolicVariable(std::move(_sort), std::move(_uniqueName), _context)
 {
 	solAssert(m_sort->kind == Kind::Tuple, "");
 }
@@ -288,7 +288,7 @@ SymbolicArrayVariable::SymbolicArrayVariable(
 	string _uniqueName,
 	EncodingContext& _context
 ):
-	SymbolicVariable(_type, _originalType, move(_uniqueName), _context),
+	SymbolicVariable(_type, _originalType, std::move(_uniqueName), _context),
 	m_pair(
 		smtSort(*_type),
 		m_uniqueName + "_length_pair",
@@ -303,7 +303,7 @@ SymbolicArrayVariable::SymbolicArrayVariable(
 	string _uniqueName,
 	EncodingContext& _context
 ):
-	SymbolicVariable(move(_sort), move(_uniqueName), _context),
+	SymbolicVariable(std::move(_sort), std::move(_uniqueName), _context),
 	m_pair(
 		std::make_shared<TupleSort>(
 			"array_length_pair",
@@ -346,7 +346,7 @@ SymbolicStructVariable::SymbolicStructVariable(
 	string _uniqueName,
 	EncodingContext& _context
 ):
-	SymbolicVariable(_type, _type, move(_uniqueName), _context)
+	SymbolicVariable(_type, _type, std::move(_uniqueName), _context)
 {
 	solAssert(isNonRecursiveStruct(*m_type), "");
 	auto const* structType = dynamic_cast<StructType const*>(_type);

--- a/libsolidity/interface/ABI.cpp
+++ b/libsolidity/interface/ABI.cpp
@@ -134,7 +134,7 @@ Json::Value ABI::generate(ContractDefinition const& _contractDef)
 				formatType(p->name(), *type, *p->annotation().type, false)
 			);
 		}
-		abi.emplace(move(errorJson));
+		abi.emplace(std::move(errorJson));
 	}
 
 	Json::Value abiJson{Json::arrayValue};

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -208,7 +208,7 @@ void CompilerStack::setRemappings(vector<ImportRemapper::Remapping> _remappings)
 		solThrow(CompilerError, "Must set remappings before parsing.");
 	for (auto const& remapping: _remappings)
 		solAssert(!remapping.prefix.empty(), "");
-	m_importRemapper.setRemappings(move(_remappings));
+	m_importRemapper.setRemappings(std::move(_remappings));
 }
 
 void CompilerStack::setViaIR(bool _viaIR)
@@ -407,7 +407,7 @@ void CompilerStack::importASTs(map<string, Json::Value> const& _sources)
 			src.first,
 			true // imported from AST
 		);
-		m_sources[path] = move(source);
+		m_sources[path] = std::move(source);
 	}
 	m_stackState = ParsedAndImported;
 	m_importedSources = true;
@@ -793,7 +793,7 @@ Json::Value CompilerStack::generatedSources(string const& _contractName, bool _r
 				sources[0]["name"] = sourceName;
 				sources[0]["id"] = sourceIndex;
 				sources[0]["language"] = "Yul";
-				sources[0]["contents"] = move(source);
+				sources[0]["contents"] = std::move(source);
 
 			}
 		}

--- a/libsolidity/interface/ImportRemapper.cpp
+++ b/libsolidity/interface/ImportRemapper.cpp
@@ -35,7 +35,7 @@ void ImportRemapper::setRemappings(vector<Remapping> _remappings)
 {
 	for (auto const& remapping: _remappings)
 		solAssert(!remapping.prefix.empty(), "");
-	m_remappings = move(_remappings);
+	m_remappings = std::move(_remappings);
 }
 
 SourceUnitName ImportRemapper::apply(ImportPath const& _path, string const& _context) const

--- a/libsolidity/interface/Natspec.cpp
+++ b/libsolidity/interface/Natspec.cpp
@@ -92,7 +92,7 @@ Json::Value Natspec::userDocumentation(ContractDefinition const& _contractDef)
 		{
 			Json::Value errorDoc{Json::objectValue};
 			errorDoc["notice"] = value;
-			doc["errors"][error->functionType(true)->externalSignature()].append(move(errorDoc));
+			doc["errors"][error->functionType(true)->externalSignature()].append(std::move(errorDoc));
 		}
 	}
 
@@ -140,10 +140,10 @@ Json::Value Natspec::devDocumentation(ContractDefinition const& _contractDef)
 			);
 
 			if (!jsonReturn.empty())
-				method["returns"] = move(jsonReturn);
+				method["returns"] = std::move(jsonReturn);
 
 			if (!method.empty())
-				doc["methods"][it.second->externalSignature()] = move(method);
+				doc["methods"][it.second->externalSignature()] = std::move(method);
 		}
 	}
 
@@ -230,7 +230,7 @@ Json::Value Natspec::extractCustomDoc(multimap<string, DocTag> const& _tags)
 		return Json::nullValue;
 	Json::Value result{Json::objectValue};
 	for (auto& [tag, value]: concatenated)
-		result[tag] = move(value);
+		result[tag] = std::move(value);
 	return result;
 }
 

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -403,7 +403,7 @@ Json::Value collectEVMObject(
 	if (_runtimeObject && _artifactRequested("immutableReferences"))
 		output["immutableReferences"] = formatImmutableReferences(_object.immutableReferences);
 	if (_artifactRequested("generatedSources"))
-		output["generatedSources"] = move(_generatedSources);
+		output["generatedSources"] = std::move(_generatedSources);
 	return output;
 }
 
@@ -966,7 +966,7 @@ std::variant<StandardCompiler::InputsAndSettings, Json::Value> StandardCompiler:
 			if (sourceContracts[source].empty())
 				return formatFatalError("JSONError", "Source contracts must be a non-empty array.");
 		}
-		ret.modelCheckerSettings.contracts = {move(sourceContracts)};
+		ret.modelCheckerSettings.contracts = {std::move(sourceContracts)};
 	}
 
 	if (modelCheckerSettings.isMember("divModNoSlacks"))
@@ -1076,7 +1076,7 @@ Json::Value StandardCompiler::compileSolidity(StandardCompiler::InputsAndSetting
 	compilerStack.setViaIR(_inputsAndSettings.viaIR);
 	compilerStack.setEVMVersion(_inputsAndSettings.evmVersion);
 	compilerStack.setParserErrorRecovery(_inputsAndSettings.parserErrorRecovery);
-	compilerStack.setRemappings(move(_inputsAndSettings.remappings));
+	compilerStack.setRemappings(std::move(_inputsAndSettings.remappings));
 	compilerStack.setOptimiserSettings(std::move(_inputsAndSettings.optimiserSettings));
 	compilerStack.setRevertStringBehaviour(_inputsAndSettings.revertStrings);
 	if (_inputsAndSettings.debugInfoSelection.has_value())
@@ -1582,7 +1582,7 @@ Json::Value StandardCompiler::formatFunctionDebugData(
 			fun["entryPoint"] = Json::nullValue;
 		fun["parameterSlots"] = Json::UInt64(info.params);
 		fun["returnSlots"] = Json::UInt64(info.returns);
-		ret[name] = move(fun);
+		ret[name] = std::move(fun);
 	}
 
 	return ret;

--- a/libsolidity/interface/StorageLayout.cpp
+++ b/libsolidity/interface/StorageLayout.cpp
@@ -40,8 +40,8 @@ Json::Value StorageLayout::generate(ContractDefinition const& _contractDef)
 		variables.append(generate(*var, slot, offset));
 
 	Json::Value layout;
-	layout["storage"] = move(variables);
-	layout["types"] = move(m_types);
+	layout["storage"] = std::move(variables);
+	layout["types"] = std::move(m_types);
 	return layout;
 }
 
@@ -81,7 +81,7 @@ void StorageLayout::generate(Type const* _type)
 			auto const& offsets = structType->storageOffsetsOfMember(member->name());
 			members.append(generate(*member, offsets.first, offsets.second));
 		}
-		typeInfo["members"] = move(members);
+		typeInfo["members"] = std::move(members);
 		typeInfo["encoding"] = "inplace";
 	}
 	else if (auto mappingType = dynamic_cast<MappingType const*>(_type))

--- a/libsolidity/lsp/FileRepository.cpp
+++ b/libsolidity/lsp/FileRepository.cpp
@@ -62,7 +62,7 @@ string FileRepository::sourceUnitNameToUri(string const& _sourceUnitName) const
 		if (!regex_search(inputPath, windowsDriveLetterPath))
 			return inputPath;
 		else
-			return "/" + move(inputPath);
+			return "/" + std::move(inputPath);
 	};
 
 	if (m_sourceUnitNamesToUri.count(_sourceUnitName))
@@ -124,7 +124,7 @@ Result<boost::filesystem::path> FileRepository::tryResolvePath(std::string const
 		boost::filesystem::path canonicalPath = boost::filesystem::path(prefix) / boost::filesystem::path(_strippedSourceUnitName);
 
 		if (boost::filesystem::exists(canonicalPath))
-			candidates.push_back(move(canonicalPath));
+			candidates.push_back(std::move(canonicalPath));
 	}
 
 	if (candidates.empty())
@@ -169,7 +169,7 @@ frontend::ReadCallback::Result FileRepository::readFile(string const& _kind, str
 		auto contents = readFileAsString(resolvedPath.get());
 		solAssert(m_sourceCodes.count(_sourceUnitName) == 0, "");
 		m_sourceCodes[_sourceUnitName] = contents;
-		return ReadCallback::Result{true, move(contents)};
+		return ReadCallback::Result{true, std::move(contents)};
 	}
 	catch (std::exception const& _exception)
 	{

--- a/libsolidity/lsp/GotoDefinition.cpp
+++ b/libsolidity/lsp/GotoDefinition.cpp
@@ -44,13 +44,13 @@ void GotoDefinition::operator()(MessageID _id, Json::Value const& _args)
 		// Handles all expressions that can have one or more declaration annotation.
 		if (auto const* declaration = referencedDeclaration(expression))
 			if (auto location = declarationLocation(declaration))
-				locations.emplace_back(move(location.value()));
+				locations.emplace_back(std::move(location.value()));
 	}
 	else if (auto const* identifierPath = dynamic_cast<IdentifierPath const*>(sourceNode))
 	{
 		if (auto const* declaration = identifierPath->annotation().referencedDeclaration)
 			if (auto location = declarationLocation(declaration))
-				locations.emplace_back(move(location.value()));
+				locations.emplace_back(std::move(location.value()));
 	}
 	else if (auto const* importDirective = dynamic_cast<ImportDirective const*>(sourceNode))
 	{

--- a/libsolidity/lsp/LanguageServer.cpp
+++ b/libsolidity/lsp/LanguageServer.cpp
@@ -202,7 +202,7 @@ void LanguageServer::changeConfiguration(Json::Value const& _settings)
 				else
 					typeFailureCount++;
 			}
-			m_fileRepository.setIncludePaths(move(includePaths));
+			m_fileRepository.setIncludePaths(std::move(includePaths));
 		}
 		else
 			++typeFailureCount;
@@ -289,7 +289,7 @@ void LanguageServer::compileAndUpdateDiagnostics()
 		string message = error->typeName() + ":";
 		if (string const* comment = error->comment())
 			message += " " + *comment;
-		jsonDiag["message"] = move(message);
+		jsonDiag["message"] = std::move(message);
 		jsonDiag["range"] = toRange(*location);
 
 		if (auto const* secondary = error->secondarySourceLocation())
@@ -318,8 +318,8 @@ void LanguageServer::compileAndUpdateDiagnostics()
 		params["uri"] = m_fileRepository.sourceUnitNameToUri(sourceUnitName);
 		if (!diagnostics.empty())
 			m_nonemptyDiagnostics.insert(sourceUnitName);
-		params["diagnostics"] = move(diagnostics);
-		m_client.notify("textDocument/publishDiagnostics", move(params));
+		params["diagnostics"] = std::move(diagnostics);
+		m_client.notify("textDocument/publishDiagnostics", std::move(params));
 	}
 }
 
@@ -418,7 +418,7 @@ void LanguageServer::handleInitialize(MessageID _id, Json::Value const& _args)
 	replyArgs["capabilities"]["semanticTokensProvider"]["full"] = true; // XOR requests.full.delta = true
 	replyArgs["capabilities"]["renameProvider"] = true;
 
-	m_client.reply(_id, move(replyArgs));
+	m_client.reply(_id, std::move(replyArgs));
 }
 
 void LanguageServer::handleInitialized(MessageID, Json::Value const&)
@@ -480,7 +480,7 @@ void LanguageServer::handleTextDocumentDidOpen(Json::Value const& _args)
 	string text = _args["textDocument"]["text"].asString();
 	string uri = _args["textDocument"]["uri"].asString();
 	m_openFiles.insert(uri);
-	m_fileRepository.setSourceByUri(uri, move(text));
+	m_fileRepository.setSourceByUri(uri, std::move(text));
 	compileAndUpdateDiagnostics();
 }
 
@@ -516,10 +516,10 @@ void LanguageServer::handleTextDocumentDidChange(Json::Value const& _args)
 			);
 
 			string buffer = m_fileRepository.sourceUnits().at(sourceUnitName);
-			buffer.replace(static_cast<size_t>(change->start), static_cast<size_t>(change->end - change->start), move(text));
-			text = move(buffer);
+			buffer.replace(static_cast<size_t>(change->start), static_cast<size_t>(change->end - change->start), std::move(text));
+			text = std::move(buffer);
 		}
-		m_fileRepository.setSourceByUri(uri, move(text));
+		m_fileRepository.setSourceByUri(uri, std::move(text));
 	}
 
 	compileAndUpdateDiagnostics();

--- a/libsolidity/lsp/Transport.cpp
+++ b/libsolidity/lsp/Transport.cpp
@@ -67,7 +67,7 @@ optional<Json::Value> Transport::receive()
 		return nullopt;
 	}
 
-	return {move(jsonMessage)};
+	return {std::move(jsonMessage)};
 }
 
 void Transport::trace(std::string _message, Json::Value _extra)
@@ -76,9 +76,9 @@ void Transport::trace(std::string _message, Json::Value _extra)
 	{
 		Json::Value params;
 		if (_extra.isObject())
-			params = move(_extra);
-		params["message"] = move(_message);
-		notify("$/logTrace", move(params));
+			params = std::move(_extra);
+		params["message"] = std::move(_message);
+		notify("$/logTrace", std::move(params));
 	}
 }
 
@@ -101,30 +101,30 @@ optional<map<string, string>> Transport::parseHeaders()
 		if (!headers.emplace(boost::trim_copy(name), boost::trim_copy(value)).second)
 			return nullopt;
 	}
-	return {move(headers)};
+	return {std::move(headers)};
 }
 
 void Transport::notify(string _method, Json::Value _message)
 {
 	Json::Value json;
-	json["method"] = move(_method);
-	json["params"] = move(_message);
-	send(move(json));
+	json["method"] = std::move(_method);
+	json["params"] = std::move(_message);
+	send(std::move(json));
 }
 
 void Transport::reply(MessageID _id, Json::Value _message)
 {
 	Json::Value json;
-	json["result"] = move(_message);
-	send(move(json), _id);
+	json["result"] = std::move(_message);
+	send(std::move(json), _id);
 }
 
 void Transport::error(MessageID _id, ErrorCode _code, string _message)
 {
 	Json::Value json;
 	json["error"]["code"] = static_cast<int>(_code);
-	json["error"]["message"] = move(_message);
-	send(move(json), _id);
+	json["error"]["message"] = std::move(_message);
+	send(std::move(json), _id);
 }
 
 void Transport::send(Json::Value _json, MessageID _id)

--- a/libsolidity/parsing/DocStringParser.cpp
+++ b/libsolidity/parsing/DocStringParser.cpp
@@ -116,7 +116,7 @@ multimap<string, DocTag> DocStringParser::parse()
 			currPos = nlPos + 1;
 		}
 	}
-	return move(m_docTags);
+	return std::move(m_docTags);
 }
 
 DocStringParser::iter DocStringParser::parseDocTagLine(iter _pos, iter _end, bool _appending)

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -274,7 +274,7 @@ ASTPointer<ImportDirective> Parser::parseImportDirective()
 					expectToken(Token::As);
 					tie(alias, aliasLocation) = expectIdentifierWithLocation();
 				}
-				symbolAliases.emplace_back(ImportDirective::SymbolAlias{move(id), move(alias), aliasLocation});
+				symbolAliases.emplace_back(ImportDirective::SymbolAlias{std::move(id), std::move(alias), aliasLocation});
 				if (m_scanner->currentToken() != Token::Comma)
 					break;
 				advance();
@@ -302,7 +302,7 @@ ASTPointer<ImportDirective> Parser::parseImportDirective()
 		fatalParserError(6326_error, "Import path cannot be empty.");
 	nodeFactory.markEndPosition();
 	expectToken(Token::Semicolon);
-	return nodeFactory.createNode<ImportDirective>(path, unitAlias, unitAliasLocation, move(symbolAliases));
+	return nodeFactory.createNode<ImportDirective>(path, unitAlias, unitAliasLocation, std::move(symbolAliases));
 }
 
 std::pair<ContractKind, bool> Parser::parseContractKind()
@@ -496,7 +496,7 @@ ASTPointer<OverrideSpecifier> Parser::parseOverrideSpecifier()
 		expectToken(Token::RParen);
 	}
 
-	return nodeFactory.createNode<OverrideSpecifier>(move(overrides));
+	return nodeFactory.createNode<OverrideSpecifier>(std::move(overrides));
 }
 
 StateMutability Parser::parseStateMutability()
@@ -686,7 +686,7 @@ ASTPointer<StructDefinition> Parser::parseStructDefinition()
 	}
 	nodeFactory.markEndPosition();
 	expectToken(Token::RBrace);
-	return nodeFactory.createNode<StructDefinition>(move(name), move(nameLocation), move(members));
+	return nodeFactory.createNode<StructDefinition>(std::move(name), std::move(nameLocation), std::move(members));
 }
 
 ASTPointer<EnumValue> Parser::parseEnumValue()
@@ -918,7 +918,7 @@ pair<ASTPointer<ASTString>, SourceLocation> Parser::expectIdentifierWithLocation
 	SourceLocation nameLocation = currentLocation();
 	ASTPointer<ASTString> name = expectIdentifierToken();
 
-	return {move(name), move(nameLocation)};
+	return {std::move(name), std::move(nameLocation)};
 }
 
 ASTPointer<EventDefinition> Parser::parseEventDefinition()
@@ -957,7 +957,7 @@ ASTPointer<ErrorDefinition> Parser::parseErrorDefinition()
 	ASTPointer<ParameterList> parameters = parseParameterList({});
 	nodeFactory.markEndPosition();
 	expectToken(Token::Semicolon);
-	return nodeFactory.createNode<ErrorDefinition>(name, move(nameLocation), documentation, parameters);
+	return nodeFactory.createNode<ErrorDefinition>(name, std::move(nameLocation), documentation, parameters);
 }
 
 ASTPointer<UsingForDirective> Parser::parseUsingDirective()
@@ -996,7 +996,7 @@ ASTPointer<UsingForDirective> Parser::parseUsingDirective()
 	}
 	nodeFactory.markEndPosition();
 	expectToken(Token::Semicolon);
-	return nodeFactory.createNode<UsingForDirective>(move(functions), usesBraces, typeName, global);
+	return nodeFactory.createNode<UsingForDirective>(std::move(functions), usesBraces, typeName, global);
 }
 
 ASTPointer<ModifierInvocation> Parser::parseModifierInvocation()
@@ -1014,7 +1014,7 @@ ASTPointer<ModifierInvocation> Parser::parseModifierInvocation()
 	}
 	else
 		nodeFactory.setEndPositionFromNode(name);
-	return nodeFactory.createNode<ModifierInvocation>(name, move(arguments));
+	return nodeFactory.createNode<ModifierInvocation>(name, std::move(arguments));
 }
 
 ASTPointer<Identifier> Parser::parseIdentifier()
@@ -1052,7 +1052,7 @@ ASTPointer<UserDefinedValueTypeDefinition> Parser::parseUserDefinedValueTypeDefi
 	expectToken(Token::Semicolon);
 	return nodeFactory.createNode<UserDefinedValueTypeDefinition>(
 		name,
-		move(nameLocation),
+		std::move(nameLocation),
 		typeName
 	);
 }
@@ -1377,7 +1377,7 @@ ASTPointer<InlineAssembly> Parser::parseInlineAssembly(ASTPointer<ASTString> con
 		BOOST_THROW_EXCEPTION(FatalError());
 
 	location.end = nativeLocationOf(*block).end;
-	return make_shared<InlineAssembly>(nextID(), location, _docString, dialect, move(flags), block);
+	return make_shared<InlineAssembly>(nextID(), location, _docString, dialect, std::move(flags), block);
 }
 
 ASTPointer<IfStatement> Parser::parseIfStatement(ASTPointer<ASTString> const& _docString)
@@ -1710,9 +1710,9 @@ pair<Parser::LookAheadInfo, Parser::IndexAccessedPath> Parser::tryParseIndexAcce
 	IndexAccessedPath iap = parseIndexAccessedPath();
 
 	if (m_scanner->currentToken() == Token::Identifier || TokenTraits::isLocationSpecifier(m_scanner->currentToken()))
-		return make_pair(LookAheadInfo::VariableDeclaration, move(iap));
+		return make_pair(LookAheadInfo::VariableDeclaration, std::move(iap));
 	else
-		return make_pair(LookAheadInfo::Expression, move(iap));
+		return make_pair(LookAheadInfo::Expression, std::move(iap));
 }
 
 ASTPointer<VariableDeclarationStatement> Parser::parseVariableDeclarationStatement(

--- a/libsolutil/Whiskers.cpp
+++ b/libsolutil/Whiskers.cpp
@@ -32,7 +32,7 @@ using namespace std;
 using namespace solidity::util;
 
 Whiskers::Whiskers(string _template):
-	m_template(move(_template))
+	m_template(std::move(_template))
 {
 }
 
@@ -41,7 +41,7 @@ Whiskers& Whiskers::operator()(string _parameter, string _value)
 	checkParameterValid(_parameter);
 	checkParameterUnknown(_parameter);
 	checkTemplateContainsTags(_parameter, {""});
-	m_parameters[move(_parameter)] = move(_value);
+	m_parameters[std::move(_parameter)] = std::move(_value);
 	return *this;
 }
 
@@ -50,7 +50,7 @@ Whiskers& Whiskers::operator()(string _parameter, bool _value)
 	checkParameterValid(_parameter);
 	checkParameterUnknown(_parameter);
 	checkTemplateContainsTags(_parameter, {"?", "/"});
-	m_conditions[move(_parameter)] = _value;
+	m_conditions[std::move(_parameter)] = _value;
 	return *this;
 }
 
@@ -65,7 +65,7 @@ Whiskers& Whiskers::operator()(
 	for (auto const& element: _values)
 		for (auto const& val: element)
 			checkParameterValid(val.first);
-	m_listParameters[move(_listParameter)] = move(_values);
+	m_listParameters[std::move(_listParameter)] = std::move(_values);
 	return *this;
 }
 

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -88,7 +88,7 @@ void Parser::updateLocationEndFrom(
 			DebugData updatedDebugData = *_debugData;
 			updatedDebugData.nativeLocation.end = _location.end;
 			updatedDebugData.originLocation.end = _location.end;
-			_debugData = make_shared<DebugData const>(move(updatedDebugData));
+			_debugData = make_shared<DebugData const>(std::move(updatedDebugData));
 			break;
 		}
 		case UseSourceLocationFrom::LocationOverride:
@@ -98,7 +98,7 @@ void Parser::updateLocationEndFrom(
 		{
 			DebugData updatedDebugData = *_debugData;
 			updatedDebugData.nativeLocation.end = _location.end;
-			_debugData = make_shared<DebugData const>(move(updatedDebugData));
+			_debugData = make_shared<DebugData const>(std::move(updatedDebugData));
 			break;
 		}
 	}
@@ -246,7 +246,7 @@ optional<pair<string_view, SourceLocation>> Parser::parseSrcComment(
 	{
 		shared_ptr<string const> sourceName = m_sourceNames->at(static_cast<unsigned>(sourceIndex.value()));
 		solAssert(sourceName, "");
-		return {{tail, SourceLocation{start.value(), end.value(), move(sourceName)}}};
+		return {{tail, SourceLocation{start.value(), end.value(), std::move(sourceName)}}};
 	}
 	return {{tail, SourceLocation{}}};
 }
@@ -313,7 +313,7 @@ Statement Parser::parseStatement()
 		_if.condition = make_unique<Expression>(parseExpression());
 		_if.body = parseBlock();
 		updateLocationEndFrom(_if.debugData, nativeLocationOf(_if.body));
-		return Statement{move(_if)};
+		return Statement{std::move(_if)};
 	}
 	case Token::Switch:
 	{
@@ -331,7 +331,7 @@ Statement Parser::parseStatement()
 		if (_switch.cases.empty())
 			fatalParserError(2418_error, "Switch statement without any cases.");
 		updateLocationEndFrom(_switch.debugData, nativeLocationOf(_switch.cases.back().body));
-		return Statement{move(_switch)};
+		return Statement{std::move(_switch)};
 	}
 	case Token::For:
 		return parseForLoop();
@@ -371,7 +371,7 @@ Statement Parser::parseStatement()
 	case Token::LParen:
 	{
 		Expression expr = parseCall(std::move(elementary));
-		return ExpressionStatement{debugDataOf(expr), move(expr)};
+		return ExpressionStatement{debugDataOf(expr), std::move(expr)};
 	}
 	case Token::Comma:
 	case Token::AssemblyAssign:
@@ -414,7 +414,7 @@ Statement Parser::parseStatement()
 		assignment.value = make_unique<Expression>(parseExpression());
 		updateLocationEndFrom(assignment.debugData, nativeLocationOf(*assignment.value));
 
-		return Statement{move(assignment)};
+		return Statement{std::move(assignment)};
 	}
 	default:
 		fatalParserError(6913_error, "Call or assignment expected.");
@@ -485,11 +485,11 @@ Expression Parser::parseExpression()
 					nativeLocationOf(_identifier),
 					"Builtin function \"" + _identifier.name.str() + "\" must be called."
 				);
-			return move(_identifier);
+			return std::move(_identifier);
 		},
 		[&](Literal& _literal) -> Expression
 		{
-			return move(_literal);
+			return std::move(_literal);
 		}
 	}, operation);
 }

--- a/libyul/AsmPrinter.cpp
+++ b/libyul/AsmPrinter.cpp
@@ -197,7 +197,7 @@ string AsmPrinter::operator()(ForLoop const& _forLoop)
 		delim = ' ';
 	return
 		locationComment +
-		("for " + move(pre) + delim + move(condition) + delim + move(post) + "\n") +
+		("for " + std::move(pre) + delim + std::move(condition) + delim + std::move(post) + "\n") +
 		(*this)(_forLoop.body);
 }
 

--- a/libyul/ControlFlowSideEffectsCollector.cpp
+++ b/libyul/ControlFlowSideEffectsCollector.cpp
@@ -92,7 +92,7 @@ void ControlFlowBuilder::operator()(FunctionDefinition const& _function)
 
 	m_currentNode->successors.emplace_back(flow.exit);
 
-	m_functionFlows[&_function] = move(flow);
+	m_functionFlows[&_function] = std::move(flow);
 
 	m_leave = nullptr;
 }

--- a/libyul/ObjectParser.cpp
+++ b/libyul/ObjectParser.cpp
@@ -88,7 +88,7 @@ shared_ptr<Object> ObjectParser::parseObject(Object* _containingObject)
 
 	expectToken(Token::LBrace);
 
-	ret->code = parseCode(move(sourceNameMapping));
+	ret->code = parseCode(std::move(sourceNameMapping));
 
 	while (currentToken() != Token::RBrace)
 	{
@@ -113,7 +113,7 @@ shared_ptr<Block> ObjectParser::parseCode(optional<SourceNameMap> _sourceNames)
 		fatalParserError(4846_error, "Expected keyword \"code\".");
 	advance();
 
-	return parseBlock(move(_sourceNames));
+	return parseBlock(std::move(_sourceNames));
 }
 
 optional<SourceNameMap> ObjectParser::tryParseSourceNameMapping() const
@@ -156,7 +156,7 @@ optional<SourceNameMap> ObjectParser::tryParseSourceNameMapping() const
 
 		Token const next = scanner.next();
 		if (next == Token::EOS)
-			return {move(sourceNames)};
+			return {std::move(sourceNames)};
 		if (next != Token::Comma)
 			break;
 		scanner.next();
@@ -172,7 +172,7 @@ optional<SourceNameMap> ObjectParser::tryParseSourceNameMapping() const
 
 shared_ptr<Block> ObjectParser::parseBlock(optional<SourceNameMap> _sourceNames)
 {
-	Parser parser(m_errorReporter, m_dialect, move(_sourceNames));
+	Parser parser(m_errorReporter, m_dialect, std::move(_sourceNames));
 	shared_ptr<Block> block = parser.parseInline(m_scanner);
 	yulAssert(block || m_errorReporter.hasErrors(), "Invalid block but no error!");
 	return block;

--- a/libyul/backends/evm/ConstantOptimiser.cpp
+++ b/libyul/backends/evm/ConstantOptimiser.cpp
@@ -130,7 +130,7 @@ Representation const& RepresentationFinder::findRepresentation(u256 const& _valu
 
 	if (numberEncodingSize(~_value) < numberEncodingSize(_value))
 		// Negated is shorter to represent
-		routine = min(move(routine), represent("not"_yulstring, findRepresentation(~_value)));
+		routine = min(std::move(routine), represent("not"_yulstring, findRepresentation(~_value)));
 
 	// Decompose value into a * 2**k + b where abs(b) << 2**k
 	for (unsigned bits = 255; bits > 8 && m_maxSteps > 0; --bits)
@@ -171,10 +171,10 @@ Representation const& RepresentationFinder::findRepresentation(u256 const& _valu
 
 		if (m_maxSteps > 0)
 			m_maxSteps--;
-		routine = min(move(routine), move(newRoutine));
+		routine = min(std::move(routine), std::move(newRoutine));
 	}
 	yulAssert(MiniEVMInterpreter{m_dialect}.eval(*routine.expression) == _value, "Invalid expression generated.");
-	return m_cache[_value] = move(routine);
+	return m_cache[_value] = std::move(routine);
 }
 
 Representation RepresentationFinder::represent(u256 const& _value) const

--- a/libyul/backends/evm/ControlFlowGraph.h
+++ b/libyul/backends/evm/ControlFlowGraph.h
@@ -236,7 +236,7 @@ struct CFG
 
 	BasicBlock& makeBlock(std::shared_ptr<DebugData const> _debugData)
 	{
-		return blocks.emplace_back(BasicBlock{move(_debugData), {}, {}});
+		return blocks.emplace_back(BasicBlock{std::move(_debugData), {}, {}});
 	}
 };
 

--- a/libyul/backends/evm/ControlFlowGraphBuilder.cpp
+++ b/libyul/backends/evm/ControlFlowGraphBuilder.cpp
@@ -532,7 +532,7 @@ Stack const& ControlFlowGraphBuilder::visitFunctionCall(FunctionCall const& _cal
 				return TemporarySlot{_call, _i};
 			}) | ranges::to<Stack>,
 			// operation
-			move(builtinCall)
+			std::move(builtinCall)
 		}).output;
 	}
 	else
@@ -607,8 +607,8 @@ void ControlFlowGraphBuilder::makeConditionalJump(
 {
 	yulAssert(m_currentBlock, "");
 	m_currentBlock->exit = CFG::BasicBlock::ConditionalJump{
-		move(_debugData),
-		move(_condition),
+		std::move(_debugData),
+		std::move(_condition),
 		&_nonZero,
 		&_zero
 	};
@@ -624,7 +624,7 @@ void ControlFlowGraphBuilder::jump(
 )
 {
 	yulAssert(m_currentBlock, "");
-	m_currentBlock->exit = CFG::BasicBlock::Jump{move(_debugData), &_target, backwards};
+	m_currentBlock->exit = CFG::BasicBlock::Jump{std::move(_debugData), &_target, backwards};
 	_target.entries.emplace_back(m_currentBlock);
 	m_currentBlock = &_target;
 }

--- a/libyul/backends/evm/EVMCodeTransform.cpp
+++ b/libyul/backends/evm/EVMCodeTransform.cpp
@@ -64,9 +64,9 @@ CodeTransform::CodeTransform(
 	m_builtinContext(_builtinContext),
 	m_allowStackOpt(_allowStackOpt),
 	m_useNamedLabelsForFunctions(_useNamedLabelsForFunctions),
-	m_identifierAccessCodeGen(move(_identifierAccessCodeGen)),
-	m_context(move(_context)),
-	m_delayedReturnVariables(move(_delayedReturnVariables)),
+	m_identifierAccessCodeGen(std::move(_identifierAccessCodeGen)),
+	m_context(std::move(_context)),
+	m_delayedReturnVariables(std::move(_delayedReturnVariables)),
 	m_functionExitLabel(_functionExitLabel)
 {
 	if (!m_context)
@@ -406,11 +406,11 @@ void CodeTransform::operator()(FunctionDefinition const& _function)
 	if (!m_allowStackOpt)
 		subTransform.setupReturnVariablesAndFunctionExit();
 
-	subTransform.m_assignedNamedLabels = move(m_assignedNamedLabels);
+	subTransform.m_assignedNamedLabels = std::move(m_assignedNamedLabels);
 
 	subTransform(_function.body);
 
-	m_assignedNamedLabels = move(subTransform.m_assignedNamedLabels);
+	m_assignedNamedLabels = std::move(subTransform.m_assignedNamedLabels);
 
 	m_assembly.setSourceLocation(originLocationOf(_function));
 	if (!subTransform.m_stackErrors.empty())

--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -383,7 +383,7 @@ BuiltinFunctionForEVM const* EVMDialect::verbatimFunction(size_t _arguments, siz
 			}
 		).second;
 		builtinFunction.isMSize = true;
-		function = make_shared<BuiltinFunctionForEVM const>(move(builtinFunction));
+		function = make_shared<BuiltinFunctionForEVM const>(std::move(builtinFunction));
 	}
 	return function.get();
 }

--- a/libyul/backends/evm/EthAssemblyAdapter.cpp
+++ b/libyul/backends/evm/EthAssemblyAdapter.cpp
@@ -96,7 +96,7 @@ void EthAssemblyAdapter::appendLinkerSymbol(std::string const& _linkerSymbol)
 
 void EthAssemblyAdapter::appendVerbatim(bytes _data, size_t _arguments, size_t _returnVariables)
 {
-	m_assembly.appendVerbatim(move(_data), _arguments, _returnVariables);
+	m_assembly.appendVerbatim(std::move(_data), _arguments, _returnVariables);
 }
 
 void EthAssemblyAdapter::appendJump(int _stackDiffAfter, JumpType _jumpType)

--- a/libyul/backends/evm/OptimizedEVMCodeTransform.cpp
+++ b/libyul/backends/evm/OptimizedEVMCodeTransform.cpp
@@ -61,7 +61,7 @@ vector<StackTooDeepError> OptimizedEVMCodeTransform::run(
 	optimizedCodeTransform(*dfg->entry);
 	for (Scope::Function const* function: dfg->functions)
 		optimizedCodeTransform(dfg->functionInfo.at(function));
-	return move(optimizedCodeTransform.m_stackErrors);
+	return std::move(optimizedCodeTransform.m_stackErrors);
 }
 
 void OptimizedEVMCodeTransform::operator()(CFG::FunctionCall const& _call)
@@ -459,7 +459,7 @@ void OptimizedEVMCodeTransform::operator()(CFG::BasicBlock const& _block)
 			{
 				// Restore the stack afterwards for the non-zero case below.
 				ScopeGuard stackRestore([storedStack = m_stack, this]() {
-					m_stack = move(storedStack);
+					m_stack = std::move(storedStack);
 					m_assembly.setStackHeight(static_cast<int>(m_stack.size()));
 				});
 

--- a/libyul/backends/evm/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/StackLayoutGenerator.cpp
@@ -65,7 +65,7 @@ map<YulString, vector<StackLayoutGenerator::StackTooDeep>> StackLayoutGenerator:
 	stackTooDeepErrors[YulString{}] = reportStackTooDeep(_cfg, YulString{});
 	for (auto const& function: _cfg.functions)
 		if (auto errors = reportStackTooDeep(_cfg, function->name); !errors.empty())
-			stackTooDeepErrors[function->name] = move(errors);
+			stackTooDeepErrors[function->name] = std::move(errors);
 	return stackTooDeepErrors;
 }
 
@@ -324,8 +324,8 @@ Stack StackLayoutGenerator::propagateStackThroughBlock(Stack _exitStack, CFG::Ba
 		Stack newStack = propagateStackThroughOperation(stack, operation, _aggressiveStackCompression);
 		if (!_aggressiveStackCompression && !findStackTooDeep(newStack, stack).empty())
 			// If we had stack errors, run again with aggressive stack compression.
-			return propagateStackThroughBlock(move(_exitStack), _block, true);
-		stack = move(newStack);
+			return propagateStackThroughBlock(std::move(_exitStack), _block, true);
+		stack = std::move(newStack);
 	}
 
 	return stack;
@@ -715,13 +715,13 @@ void StackLayoutGenerator::fillInJunk(CFG::BasicBlock const& _block)
 		util::BreadthFirstSearch<CFG::BasicBlock const*> breadthFirstSearch{{_entry}};
 		breadthFirstSearch.run([&](CFG::BasicBlock const* _block, auto _addChild) {
 			auto& blockInfo = m_layout.blockInfos.at(_block);
-			blockInfo.entryLayout = Stack{_numJunk, JunkSlot{}} + move(blockInfo.entryLayout);
+			blockInfo.entryLayout = Stack{_numJunk, JunkSlot{}} + std::move(blockInfo.entryLayout);
 			for (auto const& operation: _block->operations)
 			{
 				auto& operationEntryLayout = m_layout.operationEntryLayout.at(&operation);
-				operationEntryLayout = Stack{_numJunk, JunkSlot{}} + move(operationEntryLayout);
+				operationEntryLayout = Stack{_numJunk, JunkSlot{}} + std::move(operationEntryLayout);
 			}
-			blockInfo.exitLayout = Stack{_numJunk, JunkSlot{}} + move(blockInfo.exitLayout);
+			blockInfo.exitLayout = Stack{_numJunk, JunkSlot{}} + std::move(blockInfo.exitLayout);
 
 			std::visit(util::GenericVisitor{
 				[&](CFG::BasicBlock::MainExit const&) {},

--- a/libyul/backends/wasm/EVMToEwasmTranslator.cpp
+++ b/libyul/backends/wasm/EVMToEwasmTranslator.cpp
@@ -92,7 +92,7 @@ Object EVMToEwasmTranslator::run(Object const& _object)
 
 	Object ret;
 	ret.name = _object.name;
-	ret.code = make_shared<Block>(move(ast));
+	ret.code = make_shared<Block>(std::move(ast));
 	ret.debugData = _object.debugData;
 	ret.analysisInfo = make_shared<AsmAnalysisInfo>();
 

--- a/libyul/backends/wasm/TextTransform.cpp
+++ b/libyul/backends/wasm/TextTransform.cpp
@@ -90,7 +90,7 @@ string TextTransform::run(wasm::Module const& _module)
 	ret += "\n";
 	for (auto const& f: _module.functions)
 		ret += transform(f) + "\n";
-	return move(ret) + ")\n";
+	return std::move(ret) + ")\n";
 }
 
 string TextTransform::operator()(wasm::Literal const& _literal)
@@ -159,7 +159,7 @@ string TextTransform::operator()(wasm::If const& _if)
 string TextTransform::operator()(wasm::Loop const& _loop)
 {
 	string label = _loop.labelName.empty() ? "" : " $" + _loop.labelName;
-	return "(loop" + move(label) + "\n" + indented(joinTransformed(_loop.statements, '\n')) + ")\n";
+	return "(loop" + std::move(label) + "\n" + indented(joinTransformed(_loop.statements, '\n')) + ")\n";
 }
 
 string TextTransform::operator()(wasm::Branch const& _branch)
@@ -180,7 +180,7 @@ string TextTransform::operator()(wasm::Return const&)
 string TextTransform::operator()(wasm::Block const& _block)
 {
 	string label = _block.labelName.empty() ? "" : " $" + _block.labelName;
-	return "(block" + move(label) + "\n" + indented(joinTransformed(_block.statements, '\n')) + "\n)\n";
+	return "(block" + std::move(label) + "\n" + indented(joinTransformed(_block.statements, '\n')) + "\n)\n";
 }
 
 string TextTransform::indented(string const& _in)
@@ -230,7 +230,7 @@ string TextTransform::joinTransformed(vector<wasm::Expression> const& _expressio
 		string t = visit(e);
 		if (!t.empty() && !ret.empty() && ret.back() != '\n')
 			ret += _separator;
-		ret += move(t);
+		ret += std::move(t);
 	}
 	return ret;
 }

--- a/libyul/backends/wasm/WasmDialect.cpp
+++ b/libyul/backends/wasm/WasmDialect.cpp
@@ -269,7 +269,7 @@ void WasmDialect::addFunction(
 	vector<optional<LiteralKind>> _literalArguments
 )
 {
-	YulString name{move(_name)};
+	YulString name{std::move(_name)};
 	BuiltinFunction& f = m_functions[name];
 	f.name = name;
 	f.parameters = std::move(_params);

--- a/libyul/optimiser/ConditionalSimplifier.h
+++ b/libyul/optimiser/ConditionalSimplifier.h
@@ -64,7 +64,7 @@ private:
 		Dialect const& _dialect,
 		std::map<YulString, ControlFlowSideEffects> _sideEffects
 	):
-		m_dialect(_dialect), m_functionSideEffects(move(_sideEffects))
+		m_dialect(_dialect), m_functionSideEffects(std::move(_sideEffects))
 	{}
 	Dialect const& m_dialect;
 	std::map<YulString, ControlFlowSideEffects> m_functionSideEffects;

--- a/libyul/optimiser/DeadCodeEliminator.h
+++ b/libyul/optimiser/DeadCodeEliminator.h
@@ -63,7 +63,7 @@ private:
 	DeadCodeEliminator(
 		Dialect const& _dialect,
 		std::map<YulString, ControlFlowSideEffects> _sideEffects
-	): m_dialect(_dialect), m_functionSideEffects(move(_sideEffects)) {}
+	): m_dialect(_dialect), m_functionSideEffects(std::move(_sideEffects)) {}
 
 	Dialect const& m_dialect;
 	std::map<YulString, ControlFlowSideEffects> m_functionSideEffects;

--- a/libyul/optimiser/ForLoopInitRewriter.cpp
+++ b/libyul/optimiser/ForLoopInitRewriter.cpp
@@ -40,7 +40,7 @@ void ForLoopInitRewriter::operator()(Block& _block)
 				(*this)(forLoop.post);
 				vector<Statement> rewrite;
 				swap(rewrite, forLoop.pre.statements);
-				rewrite.emplace_back(move(forLoop));
+				rewrite.emplace_back(std::move(forLoop));
 				return { std::move(rewrite) };
 			}
 			else

--- a/libyul/optimiser/FunctionSpecializer.cpp
+++ b/libyul/optimiser/FunctionSpecializer.cpp
@@ -65,7 +65,7 @@ void FunctionSpecializer::operator()(FunctionCall& _f)
 
 	if (ranges::any_of(arguments, [](auto& _a) { return _a.has_value(); }))
 	{
-		YulString oldName = move(_f.functionName.name);
+		YulString oldName = std::move(_f.functionName.name);
 		auto newName = m_nameDispenser.newName(oldName);
 
 		m_oldToNewMap[oldName].emplace_back(make_pair(newName, arguments));
@@ -106,12 +106,12 @@ FunctionDefinition FunctionSpecializer::specialize(
 				VariableDeclaration{
 					_f.debugData,
 					vector<TypedName>{newFunction.parameters[index]},
-					make_unique<Expression>(move(*argument))
+					make_unique<Expression>(std::move(*argument))
 				}
 			);
 
 	newFunction.body.statements =
-		move(missingVariableDeclarations) + move(newFunction.body.statements);
+		std::move(missingVariableDeclarations) + std::move(newFunction.body.statements);
 
 	// Only take those indices that cannot be specialized, i.e., whose value is `nullopt`.
 	newFunction.parameters =
@@ -120,7 +120,7 @@ FunctionDefinition FunctionSpecializer::specialize(
 			applyMap(_arguments, [&](auto const& _v) { return !_v; })
 		);
 
-	newFunction.name = move(_newName);
+	newFunction.name = std::move(_newName);
 
 	return newFunction;
 }
@@ -146,10 +146,10 @@ void FunctionSpecializer::run(OptimiserStepContext& _context, Block& _ast)
 					f.m_oldToNewMap.at(functionDefinition.name),
 					[&](auto& _p) -> Statement
 					{
-						return f.specialize(functionDefinition, move(_p.first), move(_p.second));
+						return f.specialize(functionDefinition, std::move(_p.first), std::move(_p.second));
 					}
 				);
-				return move(out) + make_vector<Statement>(move(functionDefinition));
+				return std::move(out) + make_vector<Statement>(std::move(functionDefinition));
 			}
 		}
 

--- a/libyul/optimiser/KnowledgeBase.cpp
+++ b/libyul/optimiser/KnowledgeBase.cpp
@@ -89,7 +89,7 @@ optional<u256> KnowledgeBase::valueIfKnownConstant(YulString _a)
 Expression KnowledgeBase::simplify(Expression _expression)
 {
 	m_counter = 0;
-	return simplifyRecursively(move(_expression));
+	return simplifyRecursively(std::move(_expression));
 }
 
 Expression KnowledgeBase::simplifyRecursively(Expression _expression)

--- a/libyul/optimiser/NameDispenser.cpp
+++ b/libyul/optimiser/NameDispenser.cpp
@@ -37,7 +37,7 @@ using namespace solidity::util;
 NameDispenser::NameDispenser(Dialect const& _dialect, Block const& _ast, set<YulString> _reservedNames):
 	NameDispenser(_dialect, NameCollector(_ast).names() + _reservedNames)
 {
-	m_reservedNames = move(_reservedNames);
+	m_reservedNames = std::move(_reservedNames);
 }
 
 NameDispenser::NameDispenser(Dialect const& _dialect, set<YulString> _usedNames):

--- a/libyul/optimiser/NameSimplifier.cpp
+++ b/libyul/optimiser/NameSimplifier.cpp
@@ -111,7 +111,7 @@ void NameSimplifier::findSimplification(YulString const& _name)
 	{
 		YulString newName{name};
 		m_context.dispenser.markUsed(newName);
-		m_translations[_name] = move(newName);
+		m_translations[_name] = std::move(newName);
 	}
 }
 

--- a/libyul/optimiser/ReasoningBasedSimplifier.cpp
+++ b/libyul/optimiser/ReasoningBasedSimplifier.cpp
@@ -71,7 +71,7 @@ void ReasoningBasedSimplifier::operator()(If& _if)
 	{
 		Literal trueCondition = m_dialect.trueLiteral();
 		trueCondition.debugData = debugDataOf(*_if.condition);
-		_if.condition = make_unique<yul::Expression>(move(trueCondition));
+		_if.condition = make_unique<yul::Expression>(std::move(trueCondition));
 	}
 	else
 	{
@@ -83,7 +83,7 @@ void ReasoningBasedSimplifier::operator()(If& _if)
 		{
 			Literal falseCondition = m_dialect.zeroLiteralForType(m_dialect.boolType);
 			falseCondition.debugData = debugDataOf(*_if.condition);
-			_if.condition = make_unique<yul::Expression>(move(falseCondition));
+			_if.condition = make_unique<yul::Expression>(std::move(falseCondition));
 			_if.body = yul::Block{};
 			// Nothing left to be done.
 			return;

--- a/libyul/optimiser/StackCompressor.cpp
+++ b/libyul/optimiser/StackCompressor.cpp
@@ -176,7 +176,7 @@ void eliminateVariables(
 		varsToEliminate += chooseVarsToEliminate(candidates[functionName], static_cast<size_t>(numVariables));
 	}
 
-	Rematerialiser::run(_dialect, _ast, move(varsToEliminate));
+	Rematerialiser::run(_dialect, _ast, std::move(varsToEliminate));
 	// Do not remove functions.
 	set<YulString> allFunctions = NameCollector{_ast, NameCollector::OnlyFunctions}.names();
 	UnusedPruner::runUntilStabilised(_dialect, _ast, _allowMSizeOptimization, nullptr, allFunctions);

--- a/libyul/optimiser/UnusedFunctionParameterPruner.cpp
+++ b/libyul/optimiser/UnusedFunctionParameterPruner.cpp
@@ -118,7 +118,7 @@ void UnusedFunctionParameterPruner::run(OptimiserStepContext& _context, Block& _
 				originalFunction.returnVariables =
 					filter(originalFunction.returnVariables, used.second);
 
-				return make_vector<Statement>(move(originalFunction), move(linkingFunction));
+				return make_vector<Statement>(std::move(originalFunction), std::move(linkingFunction));
 			}
 		}
 

--- a/libyul/optimiser/UnusedStoreEliminator.cpp
+++ b/libyul/optimiser/UnusedStoreEliminator.cpp
@@ -186,7 +186,7 @@ void UnusedStoreEliminator::visit(Statement const& _statement)
 		m_stores[YulString{}].insert({&_statement, initialState});
 		vector<Operation> operations = operationsFromFunctionCall(*funCall);
 		yulAssert(operations.size() == 1, "");
-		m_storeOperations[&_statement] = move(operations.front());
+		m_storeOperations[&_statement] = std::move(operations.front());
 	}
 }
 

--- a/test/CommonSyntaxTest.cpp
+++ b/test/CommonSyntaxTest.cpp
@@ -245,10 +245,10 @@ vector<SyntaxTestError> CommonSyntaxTest::parseExpectations(istream& _stream)
 
 		string errorMessage(it, line.end());
 		expectations.emplace_back(SyntaxTestError{
-			move(errorType),
-			move(errorId),
-			move(errorMessage),
-			move(sourceName),
+			std::move(errorType),
+			std::move(errorId),
+			std::move(errorMessage),
+			std::move(sourceName),
 			locationStart,
 			locationEnd
 		});

--- a/test/EVMHost.cpp
+++ b/test/EVMHost.cpp
@@ -50,7 +50,7 @@ evmc::VM& EVMHost::getVM(string const& _path)
 		if (vm && errorCode == EVMC_LOADER_SUCCESS)
 		{
 			if (vm.get_capabilities() & (EVMC_CAPABILITY_EVM1 | EVMC_CAPABILITY_EWASM))
-				vms[_path] = make_unique<evmc::VM>(evmc::VM(move(vm)));
+				vms[_path] = make_unique<evmc::VM>(evmc::VM(std::move(vm)));
 			else
 				cerr << "VM loaded neither supports EVM1 nor EWASM" << endl;
 		}

--- a/test/Metadata.cpp
+++ b/test/Metadata.cpp
@@ -162,7 +162,7 @@ std::optional<map<string, string>> parseCBORMetadata(bytes const& _metadata)
 		{
 			string key = parser.readKey();
 			string value = parser.readValue();
-			ret[move(key)] = move(value);
+			ret[std::move(key)] = std::move(value);
 		}
 		return ret;
 	}

--- a/test/TestCaseReader.cpp
+++ b/test/TestCaseReader.cpp
@@ -194,7 +194,7 @@ pair<SourceMap, size_t> TestCaseReader::parseSourcesAndSettingsWithLineNumber(is
 	}
 	// Register the last source as the main one
 	sources[currentSourceName] = currentSource;
-	return {{move(sources), move(externalSources), move(currentSourceName)}, lineNumber};
+	return {{std::move(sources), std::move(externalSources), std::move(currentSourceName)}, lineNumber};
 }
 
 string TestCaseReader::parseSimpleExpectations(istream& _file)

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -143,7 +143,7 @@ namespace
 			for (BasicBlock const& block: cfg.optimisedBlocks())
 				copy(output.begin() + static_cast<int>(block.begin), output.begin() + static_cast<int>(block.end),
 					 back_inserter(optItems));
-			output = move(optItems);
+			output = std::move(optItems);
 		}
 		return output;
 	}

--- a/test/liblangutil/Scanner.cpp
+++ b/test/liblangutil/Scanner.cpp
@@ -150,11 +150,11 @@ struct TestScanner
 {
 	unique_ptr<CharStream> stream;
 	unique_ptr<Scanner> scanner;
-	explicit TestScanner(string _text) { reset(move(_text)); }
+	explicit TestScanner(string _text) { reset(std::move(_text)); }
 
 	void reset(std::string _text)
 	{
-		stream = make_unique<CharStream>(move(_text), "");
+		stream = make_unique<CharStream>(std::move(_text), "");
 		scanner = make_unique<Scanner>(*stream);
 	}
 

--- a/test/libsolidity/GasTest.cpp
+++ b/test/libsolidity/GasTest.cpp
@@ -58,7 +58,7 @@ void GasTest::parseExpectations(std::istream& _stream)
 		{
 			string kind = line.substr(3, line.length() - 4);
 			boost::trim(kind);
-			currentKind = &m_expectations[move(kind)];
+			currentKind = &m_expectations[std::move(kind)];
 		}
 		else if (!currentKind)
 			BOOST_THROW_EXCEPTION(runtime_error("No function kind specified. Expected \"creation:\", \"external:\" or \"internal:\"."));

--- a/test/libsolidity/SMTCheckerTest.cpp
+++ b/test/libsolidity/SMTCheckerTest.cpp
@@ -77,7 +77,7 @@ SMTCheckerTest::SMTCheckerTest(string const& _filename): SyntaxTest(_filename, E
 		return filtered;
 	};
 	if (m_modelCheckerSettings.invariants.invariants.empty())
-		m_expectations = removeInv(move(m_expectations));
+		m_expectations = removeInv(std::move(m_expectations));
 
 	auto const& ignoreInv = m_reader.stringSetting("SMTIgnoreInv", "yes");
 	if (ignoreInv == "no")

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -61,7 +61,7 @@ SemanticTest::SemanticTest(
 	m_sideEffectHooks(makeSideEffectHooks()),
 	m_enforceCompileToEwasm(_enforceCompileToEwasm),
 	m_enforceGasCost(_enforceGasCost),
-	m_enforceGasCostMinValue(move(_enforceGasCostMinValue))
+	m_enforceGasCostMinValue(std::move(_enforceGasCostMinValue))
 {
 	static set<string> const compileViaYulAllowedValues{"also", "true", "false"};
 	static set<string> const yulRunTriggers{"also", "true"};
@@ -457,14 +457,14 @@ TestCase::TestResult SemanticTest::runTest(
 				success = false;
 
 			test.setFailure(!m_transactionSuccessful);
-			test.setRawBytes(move(output));
+			test.setRawBytes(std::move(output));
 			test.setContractABI(m_compiler.contractABI(m_compiler.lastContractName(m_sources.mainSourceFile)));
 		}
 
 		vector<string> effects;
 		for (SideEffectHook const& hook: m_sideEffectHooks)
 			effects += hook(test.call());
-		test.setSideEffects(move(effects));
+		test.setSideEffects(std::move(effects));
 
 		success &= test.call().expectedSideEffects == test.call().actualSideEffects;
 	}

--- a/test/libsolidity/SolidityExecutionFramework.cpp
+++ b/test/libsolidity/SolidityExecutionFramework.cpp
@@ -109,7 +109,7 @@ bytes SolidityExecutionFramework::multiSourceCompileContract(
 				try
 				{
 					asmStack.optimize();
-					obj = move(*asmStack.assemble(yul::YulStack::Machine::EVM).bytecode);
+					obj = std::move(*asmStack.assemble(yul::YulStack::Machine::EVM).bytecode);
 					obj.link(_libraryAddresses);
 					break;
 				}

--- a/test/libsolidity/util/TestFileParser.cpp
+++ b/test/libsolidity/util/TestFileParser.cpp
@@ -178,7 +178,7 @@ vector<solidity::frontend::test::FunctionCall> TestFileParser::parseFunctionCall
 						accept(Token::Newline, true);
 						call.expectedSideEffects = parseFunctionCallSideEffects();
 
-						calls.emplace_back(move(call));
+						calls.emplace_back(std::move(call));
 					}
 				}
 				catch (TestParserError const& _e)

--- a/test/libyul/ObjectParser.cpp
+++ b/test/libyul/ObjectParser.cpp
@@ -122,7 +122,7 @@ tuple<optional<SourceNameMap>, ErrorList> tryGetSourceLocationMapping(string _so
 	ErrorReporter reporter(errors);
 	Dialect const& dialect = yul::EVMDialect::strictAssemblyForEVM(EVMVersion::berlin());
 	ObjectParser objectParser{reporter, dialect};
-	CharStream stream(move(source), "");
+	CharStream stream(std::move(source), "");
 	auto object = objectParser.parse(make_shared<Scanner>(stream), false);
 	BOOST_REQUIRE(object && object->debugData);
 	return {object->debugData->sourceNames, std::move(errors)};

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -65,7 +65,7 @@ shared_ptr<Block> parse(string const& _source, Dialect const& _dialect, ErrorRep
 		auto parserResult = yul::Parser(
 			errorReporter,
 			_dialect,
-			move(indicesToSourceNames)
+			std::move(indicesToSourceNames)
 		).parse(stream);
 		if (parserResult)
 		{

--- a/test/solc/Common.cpp
+++ b/test/solc/Common.cpp
@@ -91,5 +91,5 @@ string test::stripPreReleaseWarning(string const& _stderrContent)
 	};
 
 	string output = regex_replace(_stderrContent, preReleaseWarningRegex, "");
-	return regex_replace(move(output), noOutputRegex, "");
+	return regex_replace(std::move(output), noOutputRegex, "");
 }

--- a/test/yulPhaser/FitnessMetrics.cpp
+++ b/test/yulPhaser/FitnessMetrics.cpp
@@ -64,7 +64,7 @@ protected:
 	Program optimisedProgram(Program _program) const
 	{
 		[[maybe_unused]] size_t originalSize = _program.codeSize(m_weights);
-		Program result = move(_program);
+		Program result = std::move(_program);
 		result.optimise(m_chromosome.optimisationSteps());
 
 		// Make sure that the program and the chromosome we have chosen are suitable for the test

--- a/test/yulPhaser/ProgramCache.cpp
+++ b/test/yulPhaser/ProgramCache.cpp
@@ -52,7 +52,7 @@ protected:
 
 	Program optimisedProgram(Program _program, string _abbreviatedOptimisationSteps) const
 	{
-		Program result = move(_program);
+		Program result = std::move(_program);
 		result.optimise(Chromosome::genesToSteps(_abbreviatedOptimisationSteps));
 		return result;
 	}

--- a/test/yulPhaser/TestHelpers.cpp
+++ b/test/yulPhaser/TestHelpers.cpp
@@ -30,7 +30,7 @@ using namespace solidity::phaser::test;
 
 function<Mutation> phaser::test::wholeChromosomeReplacement(Chromosome _newChromosome)
 {
-	return [_newChromosome = move(_newChromosome)](Chromosome const&) { return _newChromosome; };
+	return [_newChromosome = std::move(_newChromosome)](Chromosome const&) { return _newChromosome; };
 }
 
 function<Mutation> phaser::test::geneSubstitution(size_t _geneIndex, string _geneValue)

--- a/tools/yulPhaser/Chromosome.cpp
+++ b/tools/yulPhaser/Chromosome.cpp
@@ -43,7 +43,7 @@ Chromosome Chromosome::makeRandom(size_t _length)
 	for (size_t i = 0; i < _length; ++i)
 		steps.push_back(randomOptimisationStep());
 
-	return Chromosome(move(steps));
+	return Chromosome(std::move(steps));
 }
 
 ostream& phaser::operator<<(ostream& _stream, Chromosome const& _chromosome)

--- a/tools/yulPhaser/GeneticAlgorithms.cpp
+++ b/tools/yulPhaser/GeneticAlgorithms.cpp
@@ -71,7 +71,7 @@ Population RandomAlgorithm::runNextRound(Population _population)
 	size_t replacementCount = _population.individuals().size() - elitePopulation.individuals().size();
 
 	return
-		move(elitePopulation) +
+		std::move(elitePopulation) +
 		Population::makeRandom(
 			_population.fitnessMetric(),
 			replacementCount,

--- a/tools/yulPhaser/Mutations.cpp
+++ b/tools/yulPhaser/Mutations.cpp
@@ -44,7 +44,7 @@ function<Mutation> phaser::geneRandomisation(double _chance)
 				gene
 			);
 
-		return Chromosome(move(genes));
+		return Chromosome(std::move(genes));
 	};
 }
 
@@ -57,7 +57,7 @@ function<Mutation> phaser::geneDeletion(double _chance)
 			if (!SimulationRNG::bernoulliTrial(_chance))
 				genes.push_back(gene);
 
-		return Chromosome(move(genes));
+		return Chromosome(std::move(genes));
 	};
 }
 
@@ -77,7 +77,7 @@ function<Mutation> phaser::geneAddition(double _chance)
 				genes.push_back(Chromosome::randomGene());
 		}
 
-		return Chromosome(move(genes));
+		return Chromosome(std::move(genes));
 	};
 }
 
@@ -102,7 +102,7 @@ function<Mutation> phaser::mutationSequence(vector<function<Mutation>> _mutation
 	{
 		Chromosome mutatedChromosome = _chromosome;
 		for (size_t i = 0; i < _mutations.size(); ++i)
-			mutatedChromosome = _mutations[i](move(mutatedChromosome));
+			mutatedChromosome = _mutations[i](std::move(mutatedChromosome));
 
 		return mutatedChromosome;
 	};

--- a/tools/yulPhaser/PairSelections.h
+++ b/tools/yulPhaser/PairSelections.h
@@ -107,7 +107,7 @@ class PairMosaicSelection: public PairSelection
 {
 public:
 	explicit PairMosaicSelection(std::vector<std::tuple<size_t, size_t>> _pattern, double _selectionSize = 1.0):
-		m_pattern(move(_pattern)),
+		m_pattern(std::move(_pattern)),
 		m_selectionSize(_selectionSize)
 	{
 		assert(m_pattern.size() > 0 || _selectionSize == 0.0);

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -239,8 +239,8 @@ unique_ptr<FitnessMetric> FitnessMetricFactory::build(
 		{
 			for (size_t i = 0; i < _programs.size(); ++i)
 				metrics.push_back(make_unique<ProgramSize>(
-					_programCaches[i] != nullptr ? optional<Program>{} : move(_programs[i]),
-					move(_programCaches[i]),
+					_programCaches[i] != nullptr ? optional<Program>{} : std::move(_programs[i]),
+					std::move(_programCaches[i]),
 					_weights,
 					_options.chromosomeRepetitions
 				));
@@ -251,8 +251,8 @@ unique_ptr<FitnessMetric> FitnessMetricFactory::build(
 		{
 			for (size_t i = 0; i < _programs.size(); ++i)
 				metrics.push_back(make_unique<RelativeProgramSize>(
-					_programCaches[i] != nullptr ? optional<Program>{} : move(_programs[i]),
-					move(_programCaches[i]),
+					_programCaches[i] != nullptr ? optional<Program>{} : std::move(_programs[i]),
+					std::move(_programCaches[i]),
 					_options.relativeMetricScale,
 					_weights,
 					_options.chromosomeRepetitions
@@ -266,13 +266,13 @@ unique_ptr<FitnessMetric> FitnessMetricFactory::build(
 	switch (_options.metricAggregator)
 	{
 		case MetricAggregatorChoice::Average:
-			return make_unique<FitnessMetricAverage>(move(metrics));
+			return make_unique<FitnessMetricAverage>(std::move(metrics));
 		case MetricAggregatorChoice::Sum:
-			return make_unique<FitnessMetricSum>(move(metrics));
+			return make_unique<FitnessMetricSum>(std::move(metrics));
 		case MetricAggregatorChoice::Maximum:
-			return make_unique<FitnessMetricMaximum>(move(metrics));
+			return make_unique<FitnessMetricMaximum>(std::move(metrics));
 		case MetricAggregatorChoice::Minimum:
-			return make_unique<FitnessMetricMinimum>(move(metrics));
+			return make_unique<FitnessMetricMinimum>(std::move(metrics));
 		default:
 			assertThrow(false, solidity::util::Exception, "Invalid MetricAggregatorChoice value.");
 	}
@@ -309,7 +309,7 @@ Population PopulationFactory::build(
 	for (size_t populationSize: _options.randomPopulation)
 		combinedSize += populationSize;
 
-	population = move(population) + buildRandom(
+	population = std::move(population) + buildRandom(
 		combinedSize,
 		_options.minChromosomeLength,
 		_options.maxChromosomeLength,
@@ -317,7 +317,7 @@ Population PopulationFactory::build(
 	);
 
 	for (string const& populationFilePath: _options.populationFromFile)
-		population = move(population) + buildFromFile(populationFilePath, _fitnessMetric);
+		population = std::move(population) + buildFromFile(populationFilePath, _fitnessMetric);
 
 	return population;
 }
@@ -331,7 +331,7 @@ Population PopulationFactory::buildFromStrings(
 	for (string const& geneSequence: _geneSequences)
 		chromosomes.emplace_back(geneSequence);
 
-	return Population(move(_fitnessMetric), move(chromosomes));
+	return Population(std::move(_fitnessMetric), std::move(chromosomes));
 }
 
 Population PopulationFactory::buildRandom(
@@ -342,7 +342,7 @@ Population PopulationFactory::buildRandom(
 )
 {
 	return Population::makeRandom(
-		move(_fitnessMetric),
+		std::move(_fitnessMetric),
 		_populationSize,
 		_minChromosomeLength,
 		_maxChromosomeLength
@@ -354,7 +354,7 @@ Population PopulationFactory::buildFromFile(
 	shared_ptr<FitnessMetric> _fitnessMetric
 )
 {
-	return buildFromStrings(readLinesFromFile(_filePath), move(_fitnessMetric));
+	return buildFromStrings(readLinesFromFile(_filePath), std::move(_fitnessMetric));
 }
 
 ProgramCacheFactory::Options ProgramCacheFactory::Options::fromCommandLine(po::variables_map const& _arguments)
@@ -371,7 +371,7 @@ vector<shared_ptr<ProgramCache>> ProgramCacheFactory::build(
 {
 	vector<shared_ptr<ProgramCache>> programCaches;
 	for (Program& program: _programs)
-		programCaches.push_back(_options.programCacheEnabled ? make_shared<ProgramCache>(move(program)) : nullptr);
+		programCaches.push_back(_options.programCacheEnabled ? make_shared<ProgramCache>(std::move(program)) : nullptr);
 
 	return programCaches;
 }
@@ -400,7 +400,7 @@ vector<Program> ProgramFactory::build(Options const& _options)
 		}
 
 		get<Program>(programOrErrors).optimise(Chromosome(_options.prefix).optimisationSteps());
-		inputPrograms.push_back(move(get<Program>(programOrErrors)));
+		inputPrograms.push_back(std::move(get<Program>(programOrErrors)));
 	}
 
 	return inputPrograms;
@@ -823,12 +823,12 @@ void Phaser::runPhaser(po::variables_map const& _arguments)
 		programCaches,
 		codeWeights
 	);
-	Population population = PopulationFactory::build(populationOptions, move(fitnessMetric));
+	Population population = PopulationFactory::build(populationOptions, std::move(fitnessMetric));
 
 	if (_arguments["mode"].as<PhaserMode>() == PhaserMode::RunAlgorithm)
-		runAlgorithm(_arguments, move(population), move(programCaches));
+		runAlgorithm(_arguments, std::move(population), std::move(programCaches));
 	else
-		printOptimisedProgramsOrASTs(_arguments, population, move(programs), _arguments["mode"].as<PhaserMode>());
+		printOptimisedProgramsOrASTs(_arguments, population, std::move(programs), _arguments["mode"].as<PhaserMode>());
 }
 
 void Phaser::runAlgorithm(
@@ -844,7 +844,7 @@ void Phaser::runAlgorithm(
 		_population.individuals().size()
 	);
 
-	AlgorithmRunner algorithmRunner(move(_population), move(_programCaches), buildAlgorithmRunnerOptions(_arguments), cout);
+	AlgorithmRunner algorithmRunner(std::move(_population), std::move(_programCaches), buildAlgorithmRunnerOptions(_arguments), cout);
 	algorithmRunner.run(*geneticAlgorithm);
 }
 

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -68,7 +68,7 @@ Population Population::makeRandom(
 	for (size_t i = 0; i < _size; ++i)
 		chromosomes.push_back(Chromosome::makeRandom(_chromosomeLengthGenerator()));
 
-	return Population(move(_fitnessMetric), move(chromosomes));
+	return Population(std::move(_fitnessMetric), std::move(chromosomes));
 }
 
 Population Population::makeRandom(
@@ -79,7 +79,7 @@ Population Population::makeRandom(
 )
 {
 	return makeRandom(
-		move(_fitnessMetric),
+		std::move(_fitnessMetric),
 		_size,
 		std::bind(uniformChromosomeLength, _minChromosomeLength, _maxChromosomeLength)
 	);
@@ -112,7 +112,7 @@ Population Population::crossover(PairSelection const& _selection, function<Cross
 			m_individuals[i].chromosome,
 			m_individuals[j].chromosome
 		);
-		crossedIndividuals.emplace_back(move(childChromosome), *m_fitnessMetric);
+		crossedIndividuals.emplace_back(std::move(childChromosome), *m_fitnessMetric);
 	}
 
 	return Population(m_fitnessMetric, crossedIndividuals);
@@ -132,8 +132,8 @@ tuple<Population, Population> Population::symmetricCrossoverWithRemainder(
 			m_individuals[i].chromosome,
 			m_individuals[j].chromosome
 		);
-		crossedIndividuals.emplace_back(move(get<0>(children)), *m_fitnessMetric);
-		crossedIndividuals.emplace_back(move(get<1>(children)), *m_fitnessMetric);
+		crossedIndividuals.emplace_back(std::move(get<0>(children)), *m_fitnessMetric);
+		crossedIndividuals.emplace_back(std::move(get<1>(children)), *m_fitnessMetric);
 		indexSelected[i] = true;
 		indexSelected[j] = true;
 	}
@@ -159,7 +159,7 @@ Population operator+(Population _a, Population _b)
 	assert(_a.m_fitnessMetric == _b.m_fitnessMetric);
 
 	using ::operator+; // Import the std::vector concat operator from CommonData.h
-	return Population(_a.m_fitnessMetric, move(_a.m_individuals) + move(_b.m_individuals));
+	return Population(_a.m_fitnessMetric, std::move(_a.m_individuals) + std::move(_b.m_individuals));
 }
 
 }
@@ -193,7 +193,7 @@ vector<Individual> Population::chromosomesToIndividuals(
 {
 	vector<Individual> individuals;
 	for (auto& chromosome: _chromosomes)
-		individuals.emplace_back(move(chromosome), _fitnessMetric);
+		individuals.emplace_back(std::move(chromosome), _fitnessMetric);
 
 	return individuals;
 }

--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -102,7 +102,7 @@ variant<Program, ErrorList> Program::load(CharStream& _sourceCode)
 
 void Program::optimise(vector<string> const& _optimisationSteps)
 {
-	m_ast = applyOptimisationSteps(m_dialect, m_nameDispenser, move(m_ast), _optimisationSteps);
+	m_ast = applyOptimisationSteps(m_dialect, m_nameDispenser, std::move(m_ast), _optimisationSteps);
 }
 
 ostream& phaser::operator<<(ostream& _stream, Program const& _program)
@@ -153,7 +153,7 @@ variant<unique_ptr<Block>, ErrorList> Program::parseObject(Dialect const& _diale
 	// to refactor ObjectParser and Object to use unique_ptr instead).
 	auto astCopy = make_unique<Block>(get<Block>(ASTCopier{}(*selectedObject->code)));
 
-	return variant<unique_ptr<Block>, ErrorList>(move(astCopy));
+	return variant<unique_ptr<Block>, ErrorList>(std::move(astCopy));
 }
 
 variant<unique_ptr<AsmAnalysisInfo>, ErrorList> Program::analyzeAST(Dialect const& _dialect, Block const& _ast)
@@ -168,7 +168,7 @@ variant<unique_ptr<AsmAnalysisInfo>, ErrorList> Program::analyzeAST(Dialect cons
 		return errors;
 
 	assert(errorReporter.errors().empty());
-	return variant<unique_ptr<AsmAnalysisInfo>, ErrorList>(move(analysisInfo));
+	return variant<unique_ptr<AsmAnalysisInfo>, ErrorList>(std::move(analysisInfo));
 }
 
 unique_ptr<Block> Program::disambiguateAST(

--- a/tools/yulPhaser/Selections.h
+++ b/tools/yulPhaser/Selections.h
@@ -86,7 +86,7 @@ class MosaicSelection: public Selection
 {
 public:
 	explicit MosaicSelection(std::vector<size_t> _pattern, double _selectionSize = 1.0):
-		m_pattern(move(_pattern)),
+		m_pattern(std::move(_pattern)),
 		m_selectionSize(_selectionSize)
 	{
 		assert(m_pattern.size() > 0 || _selectionSize == 0.0);


### PR DESCRIPTION
Starting with clang-16, ``unqualified-std-cast-call`` will be enabled by default, which will warn for every unqualified ``move()`` call.

I wrote this code while trying to get the ems dockerimage update to work but ultimately decided for a different approach, namely adding the ``-Wno-unqualified-std-cast-call`` flag.

If we don't merge this PR we can only use clang-16 (and any later) with that flag.

So, if we want that, feel free to merge, if not, close.