### PR TITLE
Fix warning about DOWNLOAD_EXTRACT_TIMESTAMP on CMake 3.24

### DIFF
--- a/cmake/EthPolicy.cmake
+++ b/cmake/EthPolicy.cmake
@@ -20,4 +20,9 @@ macro (eth_policy)
 		# Allow selecting MSVC runtime library using CMAKE_MSVC_RUNTIME_LIBRARY.
 		cmake_policy(SET CMP0091 NEW)
 	endif()
+
+	# Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
+	if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+		cmake_policy(SET CMP0135 NEW)
+	endif()
 endmacro()


### PR DESCRIPTION
This pull request is made to fix the issue https://github.com/ethereum/solidity/issues/13421

From CMake 3.24, the CMP0135 policy behavior should be specified when using ExternalProject_Add function.

This is the CMP0135
documentation: https://cmake.org/cmake/help/latest/policy/CMP0135.html#policy:CMP0135
> _New in version 3.24._
> 
> When using the URL download method with the [ExternalProject_Add()](https://cmake.org/cmake/help/latest/module/ExternalProject.html#command:externalproject_add) command, CMake 3.23 and below sets the timestamps of the extracted contents to the same as the timestamps in the archive. When the URL changes, the new archive is downloaded and extracted, but the timestamps of the extracted contents might not be newer than the previous contents. Anything that depends on the extracted contents might not be rebuilt, even though the contents may change.
> 
> CMake 3.24 and above prefers to set the timestamps of all extracted contents to the time of the extraction. This ensures that anything that depends on the extracted contents will be rebuilt whenever the URL changes.
> 
> The DOWNLOAD_EXTRACT_TIMESTAMP option to the [ExternalProject_Add()](https://cmake.org/cmake/help/latest/module/ExternalProject.html#command:externalproject_add) command can be used to explicitly specify how timestamps should be handled. When DOWNLOAD_EXTRACT_TIMESTAMP is not given, this policy controls the default behavior. The OLD behavior for this policy is to restore the timestamps from the archive. The NEW behavior sets the timestamps of extracted contents to the time of extraction.
> 
> This policy was introduced in CMake version 3.24. CMake version 3.24.1 warns when the policy is not set and uses OLD behavior. Use the [cmake_policy()](https://cmake.org/cmake/help/latest/command/cmake_policy.html#command:cmake_policy) command to set it to OLD or NEW explicitly.

I think we should use NEW behavior for this policy to make sure the dependencies will be rebuilt whenever the URL changes.
