### PR TITLE
Meetings on Mondays and Wednesdays now happen at the same time

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -30,8 +30,7 @@ Team Calls
 If you have issues or pull requests to discuss, or are interested in hearing what
 the team and contributors are working on, you can join our public team calls:
 
-- Mondays at 3pm CET/CEST.
-- Wednesdays at 2pm CET/CEST.
+- Mondays and Wednesdays at 3pm CET/CEST.
 
 Both calls take place on `Jitsi <https://meet.ethereum.org/solidity>`_.
 


### PR DESCRIPTION
As discussed in the meeting on 24/08/2022, the schedule update for the meetings is to be reflected in the docs