### PR TITLE
Update issue selector, and remove auto labeling

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,17 @@
 blank_issues_enabled: false
 contact_links:
   - name: Bug Report
-    url: https://github.com/ethereum/solidity/issues/new?template=bug_report.md&projects=ethereum/solidity/43&labels=bug+%3Abug%3A
-    about: Bug reports about the Solidity Compiler.
+    url: https://github.com/ethereum/solidity/issues/new?template=bug_report.md&projects=ethereum/solidity/43
+    about: Bug reports for the Solidity Compiler.
   - name: Documentation Issue
-    url: https://github.com/ethereum/solidity/issues/new?template=documentation_issue.md&projects=ethereum/solidity/43&labels=documentation+%3Abook%3A
+    url: https://github.com/ethereum/solidity/issues/new?template=documentation_issue.md&projects=ethereum/solidity/43
     about: Solidity documentation.
   - name: Feature Request
-    url: https://github.com/ethereum/solidity/issues/new?template=feature_request.md&projects=ethereum/solidity/43&labels=feature
+    url: https://github.com/ethereum/solidity/issues/new?template=feature_request.md&projects=ethereum/solidity/43
     about: Solidity language or infrastructure feature requests.
   - name: Report a security vulnerability
     url: https://github.com/ethereum/solidity/security/policy
     about: Please review our security policy for more details.
+  - name: Initiate a language design or feedback discussion
+    url: https://forum.soliditylang.org
+    about: Open a thread on the Solidity forum.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,6 +10,8 @@ name: Feature Request
     - [Solidity chat](https://gitter.im/ethereum/solidity)
     - [Stack Overflow](https://ethereum.stackexchange.com/)
 - Ensure the issue isn't already reported (check `feature` and `language design` labels).
+- If you feel uncertain about your feature request, perhaps it's better to open a language design or feedback forum thread via the issue selector, or by going to the forum directly.
+    - [Solidity forum](https://forum.soliditylang.org/)
 
 *Delete the above section and the instructions in the sections below before submitting*
 -->


### PR DESCRIPTION
References #13408

Note: linking directly to URLs that would open a specific discussion doesn't seem possible, so I've only been able to link to the forum itself.