### PR TITLE
LSP: Fixes URL decoding incoming file names.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Compiler Features:
 * Standard JSON: Add a boolean field `settings.metadata.appendCBOR` that skips CBOR metadata from getting appended at the end of the bytecode.
 * Yul Optimizer: Allow replacing the previously hard-coded cleanup sequence by specifying custom steps after a colon delimiter (``:``) in the sequence string.
 * Language Server: Add basic document hover support.
+* Language Server: Fixes URL decoding of incoming file names.
 
 
 Bugfixes:
@@ -23,6 +24,7 @@ Important Bugfixes:
 
 Compiler Features:
  * Code Generator: More efficient overflow checks for multiplication.
+ * Yul Optimizer: Simplify the starting offset of zero-length operations to zero.
  * Language Server: Analyze all files in a project by default (can be customized by setting ``'file-load-strategy'`` to ``'directly-opened-and-on-import'`` in LSP settings object).
  * Yul Optimizer: Simplify the starting offset of zero-length operations to zero.
 

--- a/libsolidity/lsp/FileRepository.cpp
+++ b/libsolidity/lsp/FileRepository.cpp
@@ -73,23 +73,23 @@ string FileRepository::sourceUnitNameToUri(string const& _sourceUnitName) const
 	else if (_sourceUnitName.find("file://") == 0)
 		return _sourceUnitName;
 	else if (regex_search(_sourceUnitName, windowsDriveLetterPath))
-		return "file:///" + _sourceUnitName;
+		return "file:///" + util::encodeURI(_sourceUnitName);
 	else if (
 		auto const resolvedPath = tryResolvePath(_sourceUnitName);
 		resolvedPath.message().empty()
 	)
-		return "file://" + ensurePathIsUnixLike(resolvedPath.get().generic_string());
+		return "file://" + util::encodeURI(ensurePathIsUnixLike(resolvedPath.get().generic_string()));
 	else if (m_basePath.generic_string() != "/")
-		return "file://" + m_basePath.generic_string() + "/" + _sourceUnitName;
+		return "file://" + util::encodeURI(m_basePath.generic_string() + "/" + _sourceUnitName);
 	else
 		// Avoid double-/ in case base-path itself is simply a UNIX root filesystem root.
-		return "file:///" + _sourceUnitName;
+		return "file:///" + util::encodeURI(_sourceUnitName);
 }
 
 string FileRepository::uriToSourceUnitName(string const& _path) const
 {
 	lspRequire(boost::algorithm::starts_with(_path, "file://"), ErrorCode::InternalError, "URI must start with file://");
-	return stripFileUriSchemePrefix(_path);
+	return stripFileUriSchemePrefix(util::decodeURI(_path));
 }
 
 void FileRepository::setSourceByUri(string const& _uri, string _source)

--- a/libsolidity/lsp/LanguageServer.cpp
+++ b/libsolidity/lsp/LanguageServer.cpp
@@ -396,7 +396,7 @@ void LanguageServer::handleInitialize(MessageID _id, Json::Value const& _args)
 			ErrorCode::InvalidParams,
 			"rootUri only supports file URI scheme."
 		);
-		rootPath = stripFileUriSchemePrefix(rootPath);
+		rootPath = stripFileUriSchemePrefix(util::decodeURI(rootPath));
 	}
 	else if (Json::Value rootPath = _args["rootPath"])
 		rootPath = rootPath.asString();
@@ -432,11 +432,11 @@ void LanguageServer::handleInitialized(MessageID, Json::Value const&)
 
 void LanguageServer::semanticTokensFull(MessageID _id, Json::Value const& _args)
 {
-	auto uri = _args["textDocument"]["uri"];
+	auto uri = _args["textDocument"]["uri"].asString();
 
 	compile();
 
-	auto const sourceName = m_fileRepository.uriToSourceUnitName(uri.as<string>());
+	auto const sourceName = m_fileRepository.uriToSourceUnitName(uri);
 	SourceUnit const& ast = m_compilerStack.ast(sourceName);
 	m_compilerStack.charStream(sourceName);
 	Json::Value data = SemanticTokensBuilder().build(ast, m_compilerStack.charStream(sourceName));

--- a/libsolutil/CMakeLists.txt
+++ b/libsolutil/CMakeLists.txt
@@ -43,7 +43,7 @@ set(sources
 )
 
 add_library(solutil ${sources})
-target_link_libraries(solutil PUBLIC jsoncpp Boost::boost Boost::filesystem Boost::system range-v3)
+target_link_libraries(solutil PUBLIC jsoncpp Boost::boost Boost::filesystem Boost::system range-v3 fmt::fmt-header-only)
 target_include_directories(solutil PUBLIC "${CMAKE_SOURCE_DIR}")
 add_dependencies(solutil solidity_BuildInfo.h)
 

--- a/libsolutil/StringUtils.h
+++ b/libsolutil/StringUtils.h
@@ -50,6 +50,13 @@ std::string quotedAlternativesList(std::vector<std::string> const& suggestions);
 /// If @a _startSuffix == @a _endSuffix, the empty string is returned.
 std::string suffixedVariableNameList(std::string const& _baseName, size_t _startSuffix, size_t _endSuffix);
 
+/// Decodes a URI with respect to %XX notation.
+/// No URI-validity verification is performed but simply the URI decoded into non-escaping characters.
+std::string decodeURI(std::string const& _uri);
+
+/// Encodes a string into a URI conform notation.
+std::string encodeURI(std::string const& _uri);
+
 /// Joins collection of strings into one string with separators between, last separator can be different.
 /// @param _list collection of strings to join
 /// @param _separator defaults to ", "

--- a/test/libsolutil/StringUtils.cpp
+++ b/test/libsolutil/StringUtils.cpp
@@ -210,6 +210,38 @@ BOOST_AUTO_TEST_CASE(test_format_number_readable_signed)
 	);
 }
 
+BOOST_AUTO_TEST_CASE(test_encodeURI)
+{
+	BOOST_CHECK_EQUAL(util::encodeURI(""), "");
+	BOOST_CHECK_EQUAL(util::encodeURI(" "), "%20");
+	BOOST_CHECK_EQUAL(util::encodeURI("%"), "%25");
+	BOOST_CHECK_EQUAL(util::encodeURI("Hello World."), "Hello%20World.");
+	BOOST_CHECK_EQUAL(util::encodeURI("\x01\x02\x7F"), "%01%02%7F");
+	BOOST_CHECK_EQUAL(util::encodeURI("C:\\readme.md"), "C:%5Creadme.md");
+	BOOST_CHECK_EQUAL(util::encodeURI("C:/readme.md"), "C:/readme.md");
+	BOOST_CHECK_EQUAL(util::encodeURI("/var/log"), "/var/log");
+}
+
+BOOST_AUTO_TEST_CASE(test_decodeURI)
+{
+	BOOST_CHECK_EQUAL(util::decodeURI(""), "");
+	BOOST_CHECK_EQUAL(util::decodeURI(""), "");
+	BOOST_CHECK_EQUAL(util::decodeURI(" ")," ");
+	BOOST_CHECK_EQUAL(util::decodeURI("%25"), "%");
+	BOOST_CHECK_EQUAL(util::decodeURI("Hello%20World."), "Hello World.");
+	BOOST_CHECK_EQUAL(util::decodeURI("Hello World."), "Hello World.");
+	BOOST_CHECK_EQUAL(util::decodeURI("%01%02%7F"), "\x01\x02\x7F");
+	BOOST_CHECK_EQUAL(util::decodeURI("C%3A%5Creadme.md"), "C:\\readme.md");
+	BOOST_CHECK_EQUAL(util::decodeURI("C:/readme.md"), "C:/readme.md");
+
+	// Decoding failure cases (there's not really a standard for that).
+	BOOST_CHECK_EQUAL(util::decodeURI("%"), "");
+	BOOST_CHECK_EQUAL(util::decodeURI("%ZZ"), "ZZ");
+	BOOST_CHECK_EQUAL(util::decodeURI("%7Ge"), "7Ge");
+	BOOST_CHECK_EQUAL(util::decodeURI("%2F%2%2F"), "/2/");
+	BOOST_CHECK_EQUAL(util::decodeURI("%1G/%7G/%FG"), "1G/7G/FG");
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }


### PR DESCRIPTION
This fixes #13035. 

On Windows platform, it is much more likely to hit, as we did not URL decode the incoming URL, and thus, the files (nor the base path, if specified as `rootUri`) could not be opened nor traversed.

### Checklist

- [x] fix URL decoding/encoding
- [x] Changelog entry
- [x] tests