### PR TITLE
Fix compiler version check in hardhat artifacts json

### DIFF
--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -357,8 +357,8 @@ function hardhat_verify_compiler_version
     local build_info_files
     build_info_files=$(find . -path '*artifacts/build-info/*.json')
     for build_info_file in $build_info_files; do
-        grep '"solcVersion": "'"${solc_version}"'"' --with-filename "$build_info_file" || fail "Wrong compiler version detected in ${build_info_file}."
-        grep '"solcLongVersion": "'"${full_solc_version}"'"' --with-filename "$build_info_file" || fail "Wrong compiler version detected in ${build_info_file}."
+        grep '"solcVersion":[[:blank:]]*"'"${solc_version}"'"' --with-filename "$build_info_file" || fail "Wrong compiler version detected in ${build_info_file}."
+        grep '"solcLongVersion":[[:blank:]]*"'"${full_solc_version}"'"' --with-filename "$build_info_file" || fail "Wrong compiler version detected in ${build_info_file}."
     done
 }
 

--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -108,6 +108,8 @@ function zeppelin_test
     sed -i "s|it(\('other accounts cannot unpause'\)|it.skip(\1|g" test/token/ERC721/presets/ERC721PresetMinterPauserAutoId.test.js
     sed -i "s|it(\('prevents initialization'\)|it.skip(\1|g" test/proxy/utils/Initializable.test.js
     sed -i "s|it(\('divide by 0'\)|it.skip(\1|g" test/utils/math/Math.test.js
+    sed -i "s|it(\('pending owner resets after renouncing ownership'\)|it.skip(\1|g" test/access/Ownable2Step.test.js
+    sed -i "s|it(\('guards transfer against invalid user'\)|it.skip(\1|g" test/access/Ownable2Step.test.js
     # CAUTION:: The following two sed commands depend on the order of occurrence of the relevant patterns in the mentioned files.
     # Could result in an error in the future.
     sed -zi "s|it(\('deposit'\)|it.skip(\1|3" test/token/ERC20/extensions/ERC4626.test.js


### PR DESCRIPTION
There was a new hardhat release a few days ago, and it seems they now pack their artifacts json more tightly, i.e.
`"param": "value"` -> `"param":"value"`.

And also disabled a couple of Zeppelin tests due to [#2453](https://github.com/NomicFoundation/hardhat/issues/2453) (again).

`bleeps`, `gp2` and `yield_liquidator` will be addressed in subsequent PRs, as they're not required, and thus not blocking merging.