### PR TITLE
Pin hardhat version in GP2 external tests

### DIFF
--- a/test/externalTests/gp2.sh
+++ b/test/externalTests/gp2.sh
@@ -69,6 +69,8 @@ function gp2_test
     force_hardhat_unlimited_contract_size "$config_file" "$config_var"
     npm install
 
+    npm install hardhat@2.10.2
+
     # Some dependencies come with pre-built artifacts. We want to build from scratch.
     rm -r node_modules/@gnosis.pm/safe-contracts/build/
 


### PR DESCRIPTION
New hardhat release breaks the GP2 tests as follows:

```
bench/trace/gas.ts:76:38 - error TS2339: Property 'addn' does not exist on type 'bigint'.

76         cumulativeGas: trace.gasUsed.addn(transactionGas),
                                        ~~~~
```
Since [GP2 repository](https://github.com/gnosis/gp-v2-contracts.git) has been archived, I'm pinning the hardhat version to the previous stable one.