### PR TITLE
PeepholeOptimizer: TruthyBooleanComparison

### DIFF
--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -975,6 +975,70 @@ BOOST_AUTO_TEST_CASE(block_deduplicator_loops)
 	BOOST_CHECK_EQUAL(pushTags.size(), 1);
 }
 
+BOOST_AUTO_TEST_CASE(peephole_truthy_equal_comparison)
+{
+	AssemblyItems items{
+		Instruction::ISZERO,
+		Instruction::ISZERO,
+		AssemblyItem(Push, 1),
+		Instruction::EQ,
+	};
+	AssemblyItems expectation{};
+	PeepholeOptimiser peepOpt(items);
+	BOOST_REQUIRE(peepOpt.optimise());
+	BOOST_CHECK_EQUAL_COLLECTIONS(
+		items.begin(), items.end(),
+		expectation.begin(), expectation.end()
+	);
+}
+
+BOOST_AUTO_TEST_CASE(peephole_truthy_inequal_comparison)
+{
+	AssemblyItems items{
+		Instruction::ISZERO,
+		Instruction::ISZERO,
+		AssemblyItem(Push, 1),
+		Instruction::SUB,
+		AssemblyItem(PushTag, 1),
+		Instruction::JUMPI
+	};
+	AssemblyItems expectation{
+		Instruction::ISZERO,
+		AssemblyItem(PushTag, 1),
+		Instruction::JUMPI
+	};
+	PeepholeOptimiser peepOpt(items);
+	BOOST_REQUIRE(peepOpt.optimise());
+	BOOST_CHECK_EQUAL_COLLECTIONS(
+		items.begin(), items.end(),
+		expectation.begin(), expectation.end()
+	);
+}
+
+BOOST_AUTO_TEST_CASE(peephole_reverse_truthy_inequal_comparison)
+{
+	AssemblyItems items{
+		AssemblyItem(Push, 1),
+		Instruction::SWAP1,
+		Instruction::ISZERO,
+		Instruction::ISZERO,
+		Instruction::SUB,
+		AssemblyItem(PushTag, 1),
+		Instruction::JUMPI
+	};
+	AssemblyItems expectation{
+		Instruction::ISZERO,
+		AssemblyItem(PushTag, 1),
+		Instruction::JUMPI
+	};
+	PeepholeOptimiser peepOpt(items);
+	BOOST_REQUIRE(peepOpt.optimise());
+	BOOST_CHECK_EQUAL_COLLECTIONS(
+		items.begin(), items.end(),
+		expectation.begin(), expectation.end()
+	);
+}
+
 BOOST_AUTO_TEST_CASE(clear_unreachable_code)
 {
 	AssemblyItems items{


### PR DESCRIPTION
Closes #13442 

TODO:
- [x] if(a == true) -> if (a) => iszero iszero push1 eq -> ()
- [x]  if(true == a) -> if (a)  => iszero iszero push1 eq -> ()
- [x] if(a == false) -> if (!a) &&  if(false == a) -> if (!a) - already optimized
- [x] if(a != true) -> if(!a) => push1 swap1 iszero iszero sub pushtag jumpi -> iszero pushtag jumpi
- [x] if(true != a) -> if(!a) => iszero iszero push1 sub pushtag jumpi -> iszero pushtag jumpi
- [ ] a == true -> a => complex
- [ ] a != true -> !a =>  complex
- [ ] if (a.send(1) == true) -> if(a.send(1)) => complex
- [x] unit tests
- [ ] Standard JSON tests
- [ ] Update changelog