### PR TITLE
Add workflow to label and comment stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,14 +16,18 @@ jobs:
       - uses: actions/stale@v5
         with:
           debug-only: true
-          stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. It will be closed in 7 days unless the `stale` label is removed.'
+          stale-issue-message: |
+            This issue is stale because it has been open for 30 days with no activity.
+            It will be closed in 7 days unless the `stale` label is removed.
           stale-issue-label: stale
-          stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. It will be closed in 7 days unless the `stale` label is removed.'
+          stale-pr-message: |
+            This pull request is stale because it has been open for 30 days with no activity.
+            It will be closed in 7 days unless the `stale` label is removed.
           stale-pr-label: stale
           days-before-stale: 30
           days-before-close: 7
           remove-stale-when-updated: true
-          exempt-issue-labels: 'keep'
+          exempt-issue-labels: 'roadmap,must have,must have eventually,should have,nice to have'
           exempt-draft-pr: true
+          exempt-all-milestones: true
           operations-per-run: 60
-

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,18 +16,18 @@ jobs:
       - uses: actions/stale@v5
         with:
           debug-only: true
-          stale-issue-message: |
-            This issue is stale because it has been open for 30 days with no activity.
-            It will be closed in 7 days unless the `stale` label is removed.
-          stale-issue-label: stale
+          # disable issues
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
           stale-pr-message: |
             This pull request is stale because it has been open for 30 days with no activity.
             It will be closed in 7 days unless the `stale` label is removed.
           stale-pr-label: stale
-          days-before-stale: 30
-          days-before-close: 7
-          remove-stale-when-updated: true
-          exempt-issue-labels: 'roadmap,must have,must have eventually,should have,nice to have'
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          exempt-pr-labels: 'roadmap,must have,must have eventually,should have,nice to have,external contribution'
           exempt-draft-pr: true
           exempt-all-milestones: true
+          remove-stale-when-updated: true
           operations-per-run: 60
+          start-date: "2022-09-13"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: '0 12 * * *'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -12,7 +16,6 @@ jobs:
       - uses: actions/stale@v5
         with:
           debug-only: true
-          repo-token: ${{ secrets.PROJECT_BOARD_AUTOMATION }}
           stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. It will be closed in 7 days unless the `stale` label is removed.'
           stale-issue-label: stale
           stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. It will be closed in 7 days unless the `stale` label is removed.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,9 +13,9 @@ jobs:
         with:
           debug-only: true
           repo-token: ${{ secrets.PROJECT_BOARD_AUTOMATION }}
-          stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. It will be closed in 7 days unless the stale label is removed.'
+          stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. It will be closed in 7 days unless the `stale` label is removed.'
           stale-issue-label: stale
-          stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. It will be closed in 7 days unless the stale label is removed.'
+          stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. It will be closed in 7 days unless the `stale` label is removed.'
           stale-pr-label: stale
           days-before-stale: 30
           days-before-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: Check stale issues and pull requests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          debug-only: true
+          repo-token: ${{ secrets.PROJECT_BOARD_AUTOMATION }}
+          stale-issue-message: 'This issue is stale because it has been open for 30 days with no activity. It will be closed in 7 days unless the stale label is removed.'
+          stale-issue-label: stale
+          stale-pr-message: 'This pull request is stale because it has been open for 30 days with no activity. It will be closed in 7 days unless the stale label is removed.'
+          stale-pr-label: stale
+          days-before-stale: 30
+          days-before-close: 7
+          remove-stale-when-updated: true
+          exempt-issue-labels: 'keep'
+          exempt-draft-pr: true
+          operations-per-run: 60
+


### PR DESCRIPTION
This PR address some of the concerns of the issue https://github.com/ethereum/solidity/issues/8969.

It adds a workflow to label an issue or PR as stale after 30 days of inactivity, comments on them, and if they remain inactive for more 7 days it closes them. If an update occurs, the label is removed, and the timer restarted. The action can also be prevented by using the label `keep`.

It is currently set for debugging only, and can be trigger manually in the workflow dashboard, so we can check the expected behavior in the workflow logs without affecting the current open issues and PRs.