### PR TITLE
Fix dynamic array spec

### DIFF
--- a/docs/abi-spec.rst
+++ b/docs/abi-spec.rst
@@ -193,7 +193,7 @@ on the type of ``X`` being
 
   ``enc(X) = enc(k) enc((X[0], ..., X[k-1]))``
 
-  i.e. it is encoded as if it were an array of static size ``k``, prefixed with
+  i.e. it is encoded as if it were a tuple with ``k`` elements of the same type (resp. an array of static size ``k``), prefixed with
   the number of elements.
 
 - ``bytes``, of length ``k`` (which is assumed to be of type ``uint256``):

--- a/docs/abi-spec.rst
+++ b/docs/abi-spec.rst
@@ -191,7 +191,7 @@ on the type of ``X`` being
 
 - ``T[]`` where ``X`` has ``k`` elements (``k`` is assumed to be of type ``uint256``):
 
-  ``enc(X) = enc(k) enc([X[0], ..., X[k-1]])``
+  ``enc(X) = enc(k) enc(([X[0], ..., X[k-1]]))``
 
   i.e. it is encoded as if it were an array of static size ``k``, prefixed with
   the number of elements.

--- a/docs/abi-spec.rst
+++ b/docs/abi-spec.rst
@@ -191,7 +191,7 @@ on the type of ``X`` being
 
 - ``T[]`` where ``X`` has ``k`` elements (``k`` is assumed to be of type ``uint256``):
 
-  ``enc(X) = enc(k) enc(([X[0], ..., X[k-1]]))``
+  ``enc(X) = enc(k) enc((X[0], ..., X[k-1]))``
 
   i.e. it is encoded as if it were an array of static size ``k``, prefixed with
   the number of elements.


### PR DESCRIPTION
Fixes dynamic array spec. 
Elements should be encoded as tuple so everything after `enc(k)` should be same as for fixed size array above