### PR TITLE
Run emscripten builder as current user

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1016,15 +1016,15 @@ jobs:
       - store_artifacts: *artifacts_test_results
       - gitter_notify_failure_unless_pr
 
-  # NOTE: work around to git unsafe repository error by adding /root/project as a safe.directory
-  # See https://github.com/CircleCI-Public/cimg-base/issues/170
   b_ems:
     <<: *base_ems_large
     environment:
       TERM: xterm
       MAKEFLAGS: -j 10
     steps:
-      - run: git config --global --add safe.directory /root/project
+      # NOTE: work around to git unsafe repository error by adding /project as a safe.directory
+      # See https://github.com/CircleCI-Public/cimg-base/issues/170
+      - run: git config --global --add safe.directory /project
       - checkout
       - run:
           name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1016,12 +1016,15 @@ jobs:
       - store_artifacts: *artifacts_test_results
       - gitter_notify_failure_unless_pr
 
+  # NOTE: work around to git unsafe repository error by adding /root/project as a safe.directory
+  # See https://github.com/CircleCI-Public/cimg-base/issues/170
   b_ems:
     <<: *base_ems_large
     environment:
       TERM: xterm
       MAKEFLAGS: -j 10
     steps:
+      - run: git config --global --add safe.directory /root/project
       - checkout
       - run:
           name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,12 @@
 #     - ubu: ubuntu
 #     - ems: Emscripten
 version: 2.1
+
+aliases:
+  - &container_config
+    # default working_directory for all containers.
+    working_directory: &working_directory ~/project
+
 parameters:
   ubuntu-2004-docker-image:
     type: string
@@ -288,6 +294,7 @@ defaults:
   # Base Image Templates
 
   - base_ubuntu1604_clang: &base_ubuntu1604_clang
+      <<: *container_config
       docker:
         - image: << pipeline.parameters.ubuntu-1604-clang-ossfuzz-docker-image >>
       environment:
@@ -302,6 +309,7 @@ defaults:
         MAKEFLAGS: -j 2
 
   - base_ubuntu2004_clang: &base_ubuntu2004_clang
+      <<: *container_config
       docker:
         - image: << pipeline.parameters.ubuntu-2004-clang-docker-image >>
       environment:
@@ -329,6 +337,7 @@ defaults:
         MAKEFLAGS: -j 5
 
   - base_ubuntu2004: &base_ubuntu2004
+      <<: *container_config
       docker:
         - image: << pipeline.parameters.ubuntu-2004-docker-image >>
       environment:
@@ -357,6 +366,7 @@ defaults:
         MAKEFLAGS: -j 10
 
   - base_buildpack_focal_small: &base_buildpack_focal_small
+      <<: *container_config
       docker:
         - image: buildpack-deps:focal
       resource_class: small
@@ -365,6 +375,7 @@ defaults:
         MAKEFLAGS: -j 2
 
   - base_buildpack_latest_small: &base_buildpack_latest_small
+      <<: *container_config
       docker:
         - image: buildpack-deps:latest
       resource_class: small
@@ -373,6 +384,7 @@ defaults:
         MAKEFLAGS: -j 2
 
   - base_archlinux: &base_archlinux
+      <<: *container_config
       docker:
         - image: archlinux:base
       environment:
@@ -380,6 +392,7 @@ defaults:
         MAKEFLAGS: -j 3
 
   - base_archlinux_large: &base_archlinux_large
+      <<: *container_config
       docker:
         - image: archlinux:base
       resource_class: large
@@ -388,22 +401,26 @@ defaults:
         MAKEFLAGS: -j 5
 
   - base_win_powershell: &base_win_powershell
+      <<: *container_config
       executor:
         name: win/default
         shell: powershell.exe
 
   - base_win_powershell_large: &base_win_powershell_large
+      <<: *container_config
       executor:
         name: win/default
         shell: powershell.exe
         size: large
 
   - base_win_cmd: &base_win_cmd
+      <<: *container_config
       executor:
         name: win/default
         shell: cmd.exe
 
   - base_osx: &base_osx
+      <<: *container_config
       macos:
         xcode: "13.2.0"
       environment:
@@ -411,6 +428,7 @@ defaults:
         MAKEFLAGS: -j5
 
   - base_osx_large: &base_osx_large
+      <<: *container_config
       macos:
         xcode: "13.2.0"
       resource_class: large
@@ -419,6 +437,7 @@ defaults:
         MAKEFLAGS: -j10
 
   - base_ems_large: &base_ems_large
+      <<: *container_config
       docker:
         - image: << pipeline.parameters.emscripten-docker-image >>
       resource_class: large
@@ -427,6 +446,7 @@ defaults:
         MAKEFLAGS: -j 5
 
   - base_python_small: &base_python_small
+      <<: *container_config
       docker:
         - image: circleci/python:3.6
       resource_class: small
@@ -435,6 +455,7 @@ defaults:
         MAKEFLAGS: -j 2
 
   - base_node_small: &base_node_small
+      <<: *container_config
       docker:
         - image: circleci/node
       resource_class: small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1043,9 +1043,9 @@ jobs:
       TERM: xterm
       MAKEFLAGS: -j 10
     steps:
-      # NOTE: work around to git unsafe repository error by adding /project as a safe.directory
+      # NOTE: work around to git unsafe repository error by adding $CIRCLE_WORKING_DIRECTORY as a safe.directory
       # See https://github.com/CircleCI-Public/cimg-base/issues/170
-      - run: git config --global --add safe.directory /project
+      - run: git config --global --add safe.directory ${CIRCLE_WORKING_DIRECTORY}
       - checkout
       - run:
           name: Build

--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -35,8 +35,7 @@ else
 fi
 
 # solbuildpackpusher/solidity-buildpack-deps:emscripten-13
-docker run -v "$(pwd):/home/emscripten/project" \
-    -w /home/emscripten/project \
+docker run -v "$(pwd):/emsdk/project" -w /emsdk/project \
     --user "$(id -u):$(id -g)" \
     solbuildpackpusher/solidity-buildpack-deps@sha256:f1c13f3450d1f2e53ea18ac1ac1a17e932573cb9a5ccd0fd9ef6dd44f6402fa9 \
     ./scripts/ci/build_emscripten.sh "$BUILD_DIR"

--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -35,7 +35,7 @@ else
 fi
 
 # solbuildpackpusher/solidity-buildpack-deps:emscripten-13
-docker run --volume "$(pwd):/emsdk/project" --workdir /emsdk/project \
+docker run --volume "$(pwd):/project" --workdir /project \
     --user "1000:1000" \
     solbuildpackpusher/solidity-buildpack-deps@sha256:f1c13f3450d1f2e53ea18ac1ac1a17e932573cb9a5ccd0fd9ef6dd44f6402fa9 \
-    ./scripts/ci/build_emscripten.sh "$BUILD_DIR"
+    ./scripts/ci/build_emscripten.sh "$BUILD_DIR" /project

--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -35,7 +35,7 @@ else
 fi
 
 # solbuildpackpusher/solidity-buildpack-deps:emscripten-13
-docker run --volume "$(pwd):/project" --workdir /project \
+docker run --volume "$(pwd):${HOME}/project" --workdir "${HOME}/project" \
     --user "1000:1000" \
     solbuildpackpusher/solidity-buildpack-deps@sha256:f1c13f3450d1f2e53ea18ac1ac1a17e932573cb9a5ccd0fd9ef6dd44f6402fa9 \
     ./scripts/ci/build_emscripten.sh "$BUILD_DIR"

--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -34,8 +34,12 @@ else
     BUILD_DIR="$1"
 fi
 
+# set base project directory as the home folder of the emscripten user
+# https://github.com/emscripten-core/emsdk/blob/main/docker/Dockerfile#L81
+EMSCRIPTEN_HOME="/home/emscripten"
+
 # solbuildpackpusher/solidity-buildpack-deps:emscripten-13
-docker run --volume "$(pwd):${HOME}/project" --workdir "${HOME}/project" \
+docker run --volume "$(pwd):${EMSCRIPTEN_HOME}/project" --workdir "${EMSCRIPTEN_HOME}/project" \
     --user "1000:1000" \
     solbuildpackpusher/solidity-buildpack-deps@sha256:f1c13f3450d1f2e53ea18ac1ac1a17e932573cb9a5ccd0fd9ef6dd44f6402fa9 \
     ./scripts/ci/build_emscripten.sh "$BUILD_DIR"

--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -36,10 +36,10 @@ fi
 
 # set base project directory as the home folder of the emscripten user
 # https://github.com/emscripten-core/emsdk/blob/main/docker/Dockerfile#L81
-EMSCRIPTEN_HOME="/home/emscripten"
+PROJECT_DIR="/home/emscripten/project"
 
 # solbuildpackpusher/solidity-buildpack-deps:emscripten-13
-docker run --volume "$(pwd):${EMSCRIPTEN_HOME}/project" --workdir "${EMSCRIPTEN_HOME}/project" \
+docker run --volume "$(pwd):${PROJECT_DIR}" --workdir "${PROJECT_DIR}" \
     --user "1000:1000" \
     solbuildpackpusher/solidity-buildpack-deps@sha256:f1c13f3450d1f2e53ea18ac1ac1a17e932573cb9a5ccd0fd9ef6dd44f6402fa9 \
-    ./scripts/ci/build_emscripten.sh "$BUILD_DIR"
+    ${PROJECT_DIR}/scripts/ci/build_emscripten.sh "$BUILD_DIR"

--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -35,7 +35,7 @@ else
 fi
 
 # solbuildpackpusher/solidity-buildpack-deps:emscripten-13
-docker run -v "$(pwd):/emsdk/project" -w /emsdk/project \
+docker run --volume "$(pwd):/emsdk/project" --workdir /emsdk/project \
     --user "1000:1000" \
     solbuildpackpusher/solidity-buildpack-deps@sha256:f1c13f3450d1f2e53ea18ac1ac1a17e932573cb9a5ccd0fd9ef6dd44f6402fa9 \
     ./scripts/ci/build_emscripten.sh "$BUILD_DIR"

--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -36,6 +36,6 @@ fi
 
 # solbuildpackpusher/solidity-buildpack-deps:emscripten-13
 docker run -v "$(pwd):/emsdk/project" -w /emsdk/project \
-    --user "$(id -u):$(id -g)" \
+    --user "1000:1000" \
     solbuildpackpusher/solidity-buildpack-deps@sha256:f1c13f3450d1f2e53ea18ac1ac1a17e932573cb9a5ccd0fd9ef6dd44f6402fa9 \
     ./scripts/ci/build_emscripten.sh "$BUILD_DIR"

--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -35,6 +35,8 @@ else
 fi
 
 # solbuildpackpusher/solidity-buildpack-deps:emscripten-13
-docker run -v "$(pwd):/root/project" -w /root/project \
+docker run -v "$(pwd):/home/emscripten/project" \
+    -w /home/emscripten/project \
+    --user "$(id -u):$(id -g)" \
     solbuildpackpusher/solidity-buildpack-deps@sha256:f1c13f3450d1f2e53ea18ac1ac1a17e932573cb9a5ccd0fd9ef6dd44f6402fa9 \
     ./scripts/ci/build_emscripten.sh "$BUILD_DIR"

--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -38,4 +38,4 @@ fi
 docker run --volume "$(pwd):/project" --workdir /project \
     --user "1000:1000" \
     solbuildpackpusher/solidity-buildpack-deps@sha256:f1c13f3450d1f2e53ea18ac1ac1a17e932573cb9a5ccd0fd9ef6dd44f6402fa9 \
-    ./scripts/ci/build_emscripten.sh "$BUILD_DIR" /project
+    ./scripts/ci/build_emscripten.sh "$BUILD_DIR"

--- a/scripts/ci/build_emscripten.sh
+++ b/scripts/ci/build_emscripten.sh
@@ -40,10 +40,7 @@ else
 	BUILD_DIR="$1"
 fi
 
-apt-get update
-apt-get install lz4 --no-install-recommends
-
-WORKSPACE=/root/project
+WORKSPACE=/home/emscripten/project
 
 cd $WORKSPACE
 

--- a/scripts/ci/build_emscripten.sh
+++ b/scripts/ci/build_emscripten.sh
@@ -40,9 +40,9 @@ else
 	BUILD_DIR="$1"
 fi
 
-WORKSPACE="${2:-/root/project}"
+WORKSPACE=/project
 
-cd "$WORKSPACE"
+cd $WORKSPACE
 
 # shellcheck disable=SC2166
 if [[ "$CIRCLE_BRANCH" = release || -n "$CIRCLE_TAG" || -n "$FORCE_RELEASE" || "$(git tag --points-at HEAD 2>/dev/null)" == v* ]]

--- a/scripts/ci/build_emscripten.sh
+++ b/scripts/ci/build_emscripten.sh
@@ -40,7 +40,7 @@ else
 	BUILD_DIR="$1"
 fi
 
-WORKSPACE=/home/emscripten/project
+WORKSPACE=/emsdk/project
 
 cd $WORKSPACE
 

--- a/scripts/ci/build_emscripten.sh
+++ b/scripts/ci/build_emscripten.sh
@@ -40,9 +40,9 @@ else
 	BUILD_DIR="$1"
 fi
 
-WORKSPACE=${2:-/root/project}
+WORKSPACE="${2:-/root/project}"
 
-cd $WORKSPACE
+cd "$WORKSPACE"
 
 # shellcheck disable=SC2166
 if [[ "$CIRCLE_BRANCH" = release || -n "$CIRCLE_TAG" || -n "$FORCE_RELEASE" || "$(git tag --points-at HEAD 2>/dev/null)" == v* ]]

--- a/scripts/ci/build_emscripten.sh
+++ b/scripts/ci/build_emscripten.sh
@@ -40,7 +40,7 @@ else
 	BUILD_DIR="$1"
 fi
 
-WORKSPACE=/emsdk/project
+WORKSPACE=${2:-/root/project}
 
 cd $WORKSPACE
 

--- a/scripts/ci/build_emscripten.sh
+++ b/scripts/ci/build_emscripten.sh
@@ -40,9 +40,9 @@ else
 	BUILD_DIR="$1"
 fi
 
-WORKSPACE=/project
+WORKSPACE="${HOME}/project"
 
-cd $WORKSPACE
+cd "$WORKSPACE"
 
 # shellcheck disable=SC2166
 if [[ "$CIRCLE_BRANCH" = release || -n "$CIRCLE_TAG" || -n "$FORCE_RELEASE" || "$(git tag --points-at HEAD 2>/dev/null)" == v* ]]

--- a/scripts/ci/build_ossfuzz.sh
+++ b/scripts/ci/build_ossfuzz.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ROOTDIR="/root/project"
+ROOTDIR="/project"
 BUILDDIR="${ROOTDIR}/build"
 mkdir -p "${BUILDDIR}" && mkdir -p "$BUILDDIR/deps"
 

--- a/scripts/ci/build_ossfuzz.sh
+++ b/scripts/ci/build_ossfuzz.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ROOTDIR="/project"
+ROOTDIR="${HOME}/project"
 BUILDDIR="${ROOTDIR}/build"
 mkdir -p "${BUILDDIR}" && mkdir -p "$BUILDDIR/deps"
 

--- a/scripts/ci/docker_upgrade.sh
+++ b/scripts/ci/docker_upgrade.sh
@@ -51,16 +51,16 @@ docker build "scripts/docker/${IMAGE_NAME}" --file "scripts/docker/${IMAGE_NAME}
 
 echo "-- test_docker @ '${PWD}'"
 
-# NOTE: Since /root/project/ is a dir from outside the container and the owner of the files is different,
+# NOTE: Since /project/ is a dir from outside the container and the owner of the files is different,
 # git show in the script refuses to work. It must be marked as safe to use first.
 # See https://github.blog/2022-04-12-git-security-vulnerability-announced/
 docker run \
   --rm \
-  --volume "${PWD}:/root/project" \
+  --volume "${PWD}:/project" \
   "${IMAGE_NAME}" \
   bash -c "
-    git config --global --add safe.directory /root/project &&
-    /root/project/scripts/ci/${IMAGE_NAME}_test_${IMAGE_VARIANT}.sh
+    git config --global --add safe.directory /project &&
+    /project/scripts/ci/${IMAGE_NAME}_test_${IMAGE_VARIANT}.sh
   "
 
 echo "-- push_docker"

--- a/scripts/ci/docker_upgrade.sh
+++ b/scripts/ci/docker_upgrade.sh
@@ -51,7 +51,7 @@ docker build "scripts/docker/${IMAGE_NAME}" --file "scripts/docker/${IMAGE_NAME}
 
 echo "-- test_docker @ '${PWD}'"
 
-# NOTE: Since /project/ is a dir from outside the container and the owner of the files is different,
+# NOTE: Since ~/project is a dir from outside the container and the owner of the files is different,
 # git show in the script refuses to work. It must be marked as safe to use first.
 # See https://github.blog/2022-04-12-git-security-vulnerability-announced/
 docker run \

--- a/scripts/ci/docker_upgrade.sh
+++ b/scripts/ci/docker_upgrade.sh
@@ -56,11 +56,11 @@ echo "-- test_docker @ '${PWD}'"
 # See https://github.blog/2022-04-12-git-security-vulnerability-announced/
 docker run \
   --rm \
-  --volume "${PWD}:/project" \
+  --volume "${PWD}:${HOME}/project" \
   "${IMAGE_NAME}" \
   bash -c "
-    git config --global --add safe.directory /project &&
-    /project/scripts/ci/${IMAGE_NAME}_test_${IMAGE_VARIANT}.sh
+    git config --global --add safe.directory ${HOME}/project &&
+    ${HOME}/project/scripts/ci/${IMAGE_NAME}_test_${IMAGE_VARIANT}.sh
   "
 
 echo "-- push_docker"

--- a/scripts/wasm-rebuild/docker-scripts/rebuild_tags.sh
+++ b/scripts/wasm-rebuild/docker-scripts/rebuild_tags.sh
@@ -183,14 +183,14 @@ function process_tag
 cd /tmp
 
 echo "Check out solidity repository..."
-if [ -d /project ]; then
+if [ -d "${HOME}/project" ]; then
   echo "Solidity repo checkout already exists."
 else
-  git clone "${SOLIDITY_REPO_URL}" /project --quiet
+  git clone "${SOLIDITY_REPO_URL}" "${HOME}/project" --quiet
 fi
 
 echo "Extract bytecode comparison scripts from v0.6.1..."
-cd /project
+cd "${HOME}/project"
 git checkout v0.6.1 --quiet
 cp scripts/bytecodecompare/storebytecode.sh /tmp
 # shellcheck disable=SC2016
@@ -212,7 +212,7 @@ ln -sf /emsdk_portable/emscripten/sdk/ /emsdk_portable/
 ln -sf sdk /emsdk_portable/emscripten/bin
 ln -sf /emsdk_portable/emscripten/bin/* /usr/local/bin
 rm -rf /src
-ln -sf /project /src
+ln -sf "${HOME}/project" /src
 
 echo "Install dependencies and upgrade system packages."
 apt-get -qq update >/dev/null 2>&1

--- a/scripts/wasm-rebuild/docker-scripts/rebuild_tags.sh
+++ b/scripts/wasm-rebuild/docker-scripts/rebuild_tags.sh
@@ -183,14 +183,14 @@ function process_tag
 cd /tmp
 
 echo "Check out solidity repository..."
-if [ -d /root/project ]; then
+if [ -d /project ]; then
   echo "Solidity repo checkout already exists."
 else
-  git clone "${SOLIDITY_REPO_URL}" /root/project --quiet
+  git clone "${SOLIDITY_REPO_URL}" /project --quiet
 fi
 
 echo "Extract bytecode comparison scripts from v0.6.1..."
-cd /root/project
+cd /project
 git checkout v0.6.1 --quiet
 cp scripts/bytecodecompare/storebytecode.sh /tmp
 # shellcheck disable=SC2016
@@ -212,7 +212,7 @@ ln -sf /emsdk_portable/emscripten/sdk/ /emsdk_portable/
 ln -sf sdk /emsdk_portable/emscripten/bin
 ln -sf /emsdk_portable/emscripten/bin/* /usr/local/bin
 rm -rf /src
-ln -sf /root/project /src
+ln -sf /project /src
 
 echo "Install dependencies and upgrade system packages."
 apt-get -qq update >/dev/null 2>&1


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/13506.

The PR changes the current behavior of running the `build_emscripten` as root to be run as the current user. It, in turn, also fixes the git error when traversing files with different ownership without the need to change the default [safe.directory](https://github.blog/2022-04-12-git-security-vulnerability-announced/) configuration.