### PR TITLE
Workflow to label and comment stale pull requests

### DIFF
--- a/.github/workflows/stale-pull-requests.yml
+++ b/.github/workflows/stale-pull-requests.yml
@@ -1,0 +1,39 @@
+name: Check stale pull requests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * *'
+
+permissions:
+  issues: read
+  pull-requests: write
+
+env:
+  BEFORE_STALE: 14
+  BEFORE_CLOSE: 7
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          debug-only: true
+          # disable issues
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          stale-pr-message: |
+            This pull request is stale because it has been open for ${{ env.BEFORE_STALE }} days with no activity.
+            It will be closed in ${{ env.BEFORE_CLOSE }} days unless the `stale` label is removed.
+          close-pr-message: |
+            This pull request was closed due to a lack of activity for ${{ env.BEFORE_CLOSE }} days after it was stale.
+          stale-pr-label: stale
+          close-pr-label: closed-due-inactivity
+          days-before-pr-stale: ${{ env.BEFORE_STALE }}
+          days-before-pr-close: ${{ env.BEFORE_CLOSE }}
+          exempt-pr-labels: 'external contribution'
+          exempt-draft-pr: true
+          exempt-all-milestones: true
+          remove-stale-when-updated: true
+          operations-per-run: 60


### PR DESCRIPTION
This PR supersedes https://github.com/ethereum/solidity/pull/13499 and address some of the concerns of the issue https://github.com/ethereum/solidity/issues/8969.

It adds a workflow to label PRs as stale after 14 days of inactivity, comments on them, and if they remain inactive for more than 7 days, it closes them. If an update occurs, the label is removed, and the timer restarted.

PRs labeled as `external contribution`, milestones, and draft PRs are ignored.
Issues are ignored (i.e., set to `-1`).
It runs every day at noon.

It is currently set for debugging only and can be triggered manually in the workflow dashboard, so we can check the expected behavior in the workflow logs without affecting the current open PRs.
