### PR TITLE
Remove std qualifier from string in Metadata tests

### DIFF
--- a/test/libsolidity/Metadata.cpp
+++ b/test/libsolidity/Metadata.cpp
@@ -54,10 +54,10 @@ map<string, string> requireParsedCBORMetadata(bytes const& _bytecode, CompilerSt
 optional<string> compileAndCheckLicenseMetadata(string const& _contractName, char const* _sourceCode)
 {
 	CompilerStack compilerStack;
-	compilerStack.setSources({{"A.sol", std::string(_sourceCode)}});
+	compilerStack.setSources({{"A.sol", _sourceCode}});
 	BOOST_REQUIRE_MESSAGE(compilerStack.compile(), "Compiling contract failed");
 
-	std::string const& serialisedMetadata = compilerStack.metadata(_contractName);
+	string const& serialisedMetadata = compilerStack.metadata(_contractName);
 	Json::Value metadata;
 	BOOST_REQUIRE(util::jsonParseStrict(serialisedMetadata, metadata));
 	BOOST_CHECK(solidity::test::isValidMetadata(metadata));
@@ -101,13 +101,13 @@ BOOST_AUTO_TEST_CASE(metadata_stamp)
 		{
 			CompilerStack compilerStack;
 			compilerStack.setMetadataFormat(metadataFormat);
-			compilerStack.setSources({{"", std::string(sourceCode)}});
+			compilerStack.setSources({{"", sourceCode}});
 			compilerStack.setEVMVersion(solidity::test::CommonOptions::get().evmVersion());
 			compilerStack.setOptimiserSettings(solidity::test::CommonOptions::get().optimize);
 			compilerStack.setMetadataHash(metadataHash);
 			BOOST_REQUIRE_MESSAGE(compilerStack.compile(), "Compiling contract failed");
 			bytes const& bytecode = compilerStack.runtimeObject("test").bytecode;
-			std::string const& metadata = compilerStack.metadata("test");
+			string const& metadata = compilerStack.metadata("test");
 			BOOST_CHECK(solidity::test::isValidMetadata(metadata));
 
 			auto const cborMetadata = requireParsedCBORMetadata(bytecode, metadataFormat);
@@ -174,13 +174,13 @@ BOOST_AUTO_TEST_CASE(metadata_stamp_experimental)
 		{
 			CompilerStack compilerStack;
 			compilerStack.setMetadataFormat(metadataFormat);
-			compilerStack.setSources({{"", std::string(sourceCode)}});
+			compilerStack.setSources({{"", sourceCode}});
 			compilerStack.setEVMVersion(solidity::test::CommonOptions::get().evmVersion());
 			compilerStack.setOptimiserSettings(solidity::test::CommonOptions::get().optimize);
 			compilerStack.setMetadataHash(metadataHash);
 			BOOST_REQUIRE_MESSAGE(compilerStack.compile(), "Compiling contract failed");
 			bytes const& bytecode = compilerStack.runtimeObject("test").bytecode;
-			std::string const& metadata = compilerStack.metadata("test");
+			string const& metadata = compilerStack.metadata("test");
 			BOOST_CHECK(solidity::test::isValidMetadata(metadata));
 
 			auto const cborMetadata = requireParsedCBORMetadata(bytecode, metadataFormat);
@@ -242,14 +242,14 @@ BOOST_AUTO_TEST_CASE(metadata_relevant_sources)
 		}
 	)";
 	compilerStack.setSources({
-		{"A", std::string(sourceCodeA)},
-		{"B", std::string(sourceCodeB)},
+		{"A", sourceCodeA},
+		{"B", sourceCodeB},
 	});
 	compilerStack.setEVMVersion(solidity::test::CommonOptions::get().evmVersion());
 	compilerStack.setOptimiserSettings(solidity::test::CommonOptions::get().optimize);
 	BOOST_REQUIRE_MESSAGE(compilerStack.compile(), "Compiling contract failed");
 
-	std::string const& serialisedMetadata = compilerStack.metadata("A");
+	string const& serialisedMetadata = compilerStack.metadata("A");
 	Json::Value metadata;
 	BOOST_REQUIRE(util::jsonParseStrict(serialisedMetadata, metadata));
 	BOOST_CHECK(solidity::test::isValidMetadata(metadata));
@@ -282,15 +282,15 @@ BOOST_AUTO_TEST_CASE(metadata_relevant_sources_imports)
 		}
 	)";
 	compilerStack.setSources({
-		{"A", std::string(sourceCodeA)},
-		{"B", std::string(sourceCodeB)},
-		{"C", std::string(sourceCodeC)}
+		{"A", sourceCodeA},
+		{"B", sourceCodeB},
+		{"C", sourceCodeC}
 	});
 	compilerStack.setEVMVersion(solidity::test::CommonOptions::get().evmVersion());
 	compilerStack.setOptimiserSettings(solidity::test::CommonOptions::get().optimize);
 	BOOST_REQUIRE_MESSAGE(compilerStack.compile(), "Compiling contract failed");
 
-	std::string const& serialisedMetadata = compilerStack.metadata("C");
+	string const& serialisedMetadata = compilerStack.metadata("C");
 	Json::Value metadata;
 	BOOST_REQUIRE(util::jsonParseStrict(serialisedMetadata, metadata));
 	BOOST_CHECK(solidity::test::isValidMetadata(metadata));
@@ -313,7 +313,7 @@ BOOST_AUTO_TEST_CASE(metadata_useLiteralContent)
 	auto check = [](char const* _src, bool _literal)
 	{
 		CompilerStack compilerStack;
-		compilerStack.setSources({{"", std::string(_src)}});
+		compilerStack.setSources({{"", _src}});
 		compilerStack.setEVMVersion(solidity::test::CommonOptions::get().evmVersion());
 		compilerStack.setOptimiserSettings(solidity::test::CommonOptions::get().optimize);
 		compilerStack.useMetadataLiteralSources(_literal);
@@ -347,7 +347,7 @@ BOOST_AUTO_TEST_CASE(metadata_viair)
 	auto check = [](char const* _src, bool _viaIR)
 	{
 		CompilerStack compilerStack;
-		compilerStack.setSources({{"", std::string(_src)}});
+		compilerStack.setSources({{"", _src}});
 		compilerStack.setEVMVersion(solidity::test::CommonOptions::get().evmVersion());
 		compilerStack.setOptimiserSettings(solidity::test::CommonOptions::get().optimize);
 		compilerStack.setViaIR(_viaIR);
@@ -388,11 +388,11 @@ BOOST_AUTO_TEST_CASE(metadata_revert_strings)
 		contract A {
 		}
 	)";
-	compilerStack.setSources({{"A", std::string(sourceCodeA)}});
+	compilerStack.setSources({{"A", sourceCodeA}});
 	compilerStack.setRevertStringBehaviour(RevertStrings::Strip);
 	BOOST_REQUIRE_MESSAGE(compilerStack.compile(), "Compiling contract failed");
 
-	std::string const& serialisedMetadata = compilerStack.metadata("A");
+	string const& serialisedMetadata = compilerStack.metadata("A");
 	Json::Value metadata;
 	BOOST_REQUIRE(util::jsonParseStrict(serialisedMetadata, metadata));
 	BOOST_CHECK(solidity::test::isValidMetadata(metadata));
@@ -424,13 +424,13 @@ BOOST_AUTO_TEST_CASE(metadata_optimiser_sequence)
 		optimizerSettings.yulOptimiserSteps = _optimizerSequence;
 		optimizerSettings.yulOptimiserCleanupSteps = _optimizerCleanupSequence;
 		CompilerStack compilerStack;
-		compilerStack.setSources({{"", std::string(sourceCode)}});
+		compilerStack.setSources({{"", sourceCode}});
 		compilerStack.setEVMVersion(solidity::test::CommonOptions::get().evmVersion());
 		compilerStack.setOptimiserSettings(optimizerSettings);
 
 		BOOST_REQUIRE_MESSAGE(compilerStack.compile(), "Compiling contract failed");
 
-		std::string const& serialisedMetadata = compilerStack.metadata("C");
+		string const& serialisedMetadata = compilerStack.metadata("C");
 		Json::Value metadata;
 		BOOST_REQUIRE(util::jsonParseStrict(serialisedMetadata, metadata));
 		BOOST_CHECK(solidity::test::isValidMetadata(metadata));


### PR DESCRIPTION
Addresses [this](https://github.com/ethereum/solidity/pull/13376/files#r967370541) comment from another PR. Removes the `std::` qualifier from `std::string`, and also removes and explicit `std::string()` initialization where an implicit conversion from `char*` would suffice.