### PR TITLE
Add git `safe.directory` workaround in emscripten build script

### DIFF
--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -35,6 +35,8 @@ else
 fi
 
 # solbuildpackpusher/solidity-buildpack-deps:emscripten-13
+# NOTE: Without `safe.directory` git would assume it's not safe to operate on /root/project since it's owned by a different user.
+# See https://github.blog/2022-04-12-git-security-vulnerability-announced/
 docker run -v "$(pwd):/root/project" -w /root/project \
     solbuildpackpusher/solidity-buildpack-deps@sha256:f1c13f3450d1f2e53ea18ac1ac1a17e932573cb9a5ccd0fd9ef6dd44f6402fa9 \
-    ./scripts/ci/build_emscripten.sh "$BUILD_DIR"
+    /bin/bash -c "git config --global --add safe.directory /root/project && ./scripts/ci/build_emscripten.sh $BUILD_DIR"

--- a/scripts/ci/build_emscripten.sh
+++ b/scripts/ci/build_emscripten.sh
@@ -40,12 +40,9 @@ else
 	BUILD_DIR="$1"
 fi
 
-apt-get update
-apt-get install lz4 --no-install-recommends
-
 WORKSPACE=/root/project
 
-cd $WORKSPACE
+cd "$WORKSPACE"
 
 # shellcheck disable=SC2166
 if [[ "$CIRCLE_BRANCH" = release || -n "$CIRCLE_TAG" || -n "$FORCE_RELEASE" || "$(git tag --points-at HEAD 2>/dev/null)" == v* ]]


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/13506 by adding [safe.directory](https://github.blog/2022-04-12-git-security-vulnerability-announced/) git configuration to prevent errors when git traverses files with different ownership.

The binaries match since no changes were made in the building paths.
```
diff soljson.js soljson-ci.js -s    
Files soljson.js and soljson-ci.js are identical
```
```
CI version: 0.8.18-ci.2022.9.14+commit.f0f40cf2.Emscripten.clang
Local version: 0.8.18-ci.2022.9.14+commit.f0f40cf2.Emscripten.clang
```

We still need to investigate the feasibility of the `add-nightly-and-push` action in the solc-bin workflow with branch protection enabled, as mentioned here: https://github.com/ethereum/solidity/issues/13506#issuecomment-1245668362