### PR TITLE
Move new issues to triage

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,61 @@
+name: Add new issues to triage column
+
+on:
+  issues:
+    types:
+      - opened
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  ORGANIZATION: ethereum
+  REPOSITORY: solidity
+  PROJECT_NUMBER: 43
+  DRY_RUN: true
+
+jobs:
+  triage_issues:
+    runs-on: ubuntu-latest
+    if: join(github.event.issue.labels) == ''
+    steps:
+      - name: Retrieve the content of all columns on the board
+        run: |
+          gh api graphql \
+            --raw-field owner="$ORGANIZATION" \
+            --field project_number="$PROJECT_NUMBER" \
+            --raw-field repository_name="$REPOSITORY" \
+            --raw-field query='
+              query($owner: String!, $repository_name: String!, $project_number: Int!) {
+                repository(owner: $owner, name: $repository_name) {
+                  project(number: $project_number) {
+                    columns(first: 10) {
+                      nodes {
+                        id,
+                        name
+                      }
+                    }
+                  }
+                }
+              }' > project_columns.json
+          echo 'COLUMN_ID='$(jq '.data.repository.project.columns.nodes[] | select(.name == "Triage") | .id' project_columns.json) >> $GITHUB_ENV
+          echo 'COLUMN_NAME='$(jq '.data.repository.project.columns.nodes[] | select(.name == "Triage") | .name' project_columns.json) >> $GITHUB_ENV
+
+      - name: Add issue#${{ github.event.issue.number }} to Triage column
+        env:
+          ISSUE_ID: ${{ github.event.issue.node_id }}
+        run: |
+          echo "Adding issue: ${{ github.event.issue.number }} to column $COLUMN_NAME in project $PROJECT_NUMBER"
+          if [[ $DRY_RUN == "false" ]]; then
+            gh api graphql \
+              --silent \
+              --raw-field column=$COLUMN_ID \
+              --raw-field issue=$ISSUE_ID \
+              --raw-field query='
+                mutation($column: ID!, $issue: ID!) {
+                  addProjectCard(input: {
+                    projectColumnId: $column,
+                    contentId: $issue
+                  }) {
+                    clientMutationId
+                  }
+                }'
+          fi


### PR DESCRIPTION
This PR adds a simple workflow to move new issues to the [old project board](https://github.com/ethereum/solidity/projects/43) as mentioned here: https://github.com/ethereum/solidity/issues/8969#issuecomment-1245619135

The workflow adds any new issue not labeled yet to the Triage column. It requires repository, project and org permissions and only works for github `classic` project board. However, it is easy to adjust it to the `projectV2` api when we move to the new GH boards.
It also has a `dry-run` flag, so nothing will be mutated in the boards until we turn it to false.
The `COLUMN_NAME` is only for debugging and will be removed.
