### PR TITLE
renames lspAssert() to lspRequire + documentation

### DIFF
--- a/libsolidity/lsp/FileRepository.cpp
+++ b/libsolidity/lsp/FileRepository.cpp
@@ -88,7 +88,7 @@ string FileRepository::sourceUnitNameToUri(string const& _sourceUnitName) const
 
 string FileRepository::uriToSourceUnitName(string const& _path) const
 {
-	lspAssert(boost::algorithm::starts_with(_path, "file://"), ErrorCode::InternalError, "URI must start with file://");
+	lspRequire(boost::algorithm::starts_with(_path, "file://"), ErrorCode::InternalError, "URI must start with file://");
 	return stripFileUriSchemePrefix(_path);
 }
 

--- a/libsolidity/lsp/LanguageServer.cpp
+++ b/libsolidity/lsp/LanguageServer.cpp
@@ -183,7 +183,7 @@ void LanguageServer::changeConfiguration(Json::Value const& _settings)
 		else if (text == "directly-opened-and-on-import")
 			m_fileLoadStrategy = FileLoadStrategy::DirectlyOpenedAndOnImported;
 		else
-			lspAssert(false, ErrorCode::InvalidParams, "Invalid file load strategy: " + text);
+			lspRequire(false, ErrorCode::InvalidParams, "Invalid file load strategy: " + text);
 	}
 
 	m_settingsObject = _settings;
@@ -366,7 +366,7 @@ bool LanguageServer::run()
 
 void LanguageServer::requireServerInitialized()
 {
-	lspAssert(
+	lspRequire(
 		m_state == State::Initialized,
 		ErrorCode::ServerNotInitialized,
 		"Server is not properly initialized."
@@ -375,7 +375,7 @@ void LanguageServer::requireServerInitialized()
 
 void LanguageServer::handleInitialize(MessageID _id, Json::Value const& _args)
 {
-	lspAssert(
+	lspRequire(
 		m_state == State::Started,
 		ErrorCode::RequestFailed,
 		"Initialize called at the wrong time."
@@ -389,7 +389,7 @@ void LanguageServer::handleInitialize(MessageID _id, Json::Value const& _args)
 	if (Json::Value uri = _args["rootUri"])
 	{
 		rootPath = uri.asString();
-		lspAssert(
+		lspRequire(
 			boost::starts_with(rootPath, "file://"),
 			ErrorCode::InvalidParams,
 			"rootUri only supports file URI scheme."
@@ -471,7 +471,7 @@ void LanguageServer::handleTextDocumentDidOpen(Json::Value const& _args)
 {
 	requireServerInitialized();
 
-	lspAssert(
+	lspRequire(
 		_args["textDocument"],
 		ErrorCode::RequestFailed,
 		"Text document parameter missing."
@@ -492,14 +492,14 @@ void LanguageServer::handleTextDocumentDidChange(Json::Value const& _args)
 
 	for (Json::Value jsonContentChange: _args["contentChanges"])
 	{
-		lspAssert(
+		lspRequire(
 			jsonContentChange.isObject(),
 			ErrorCode::RequestFailed,
 			"Invalid content reference."
 		);
 
 		string const sourceUnitName = m_fileRepository.uriToSourceUnitName(uri);
-		lspAssert(
+		lspRequire(
 			m_fileRepository.sourceUnits().count(sourceUnitName),
 			ErrorCode::RequestFailed,
 			"Unknown file: " + uri
@@ -509,7 +509,7 @@ void LanguageServer::handleTextDocumentDidChange(Json::Value const& _args)
 		if (jsonContentChange["range"].isObject()) // otherwise full content update
 		{
 			optional<SourceLocation> change = parseRange(m_fileRepository, sourceUnitName, jsonContentChange["range"]);
-			lspAssert(
+			lspRequire(
 				change && change->hasText(),
 				ErrorCode::RequestFailed,
 				"Invalid source range: " + util::jsonCompactPrint(jsonContentChange["range"])
@@ -529,7 +529,7 @@ void LanguageServer::handleTextDocumentDidClose(Json::Value const& _args)
 {
 	requireServerInitialized();
 
-	lspAssert(
+	lspRequire(
 		_args["textDocument"],
 		ErrorCode::RequestFailed,
 		"Text document parameter missing."

--- a/libsolidity/lsp/Transport.h
+++ b/libsolidity/lsp/Transport.h
@@ -71,7 +71,14 @@ private:
 	ErrorCode m_code;
 };
 
-#define lspAssert(condition, errorCode, errorMessage) \
+/**
+ * Ensures precondition check is valid.
+ * This is supposed to be a recoverable error, that means, if the condition fails to be valid,
+ * an exception is being raised to be thrown out of the current request handlers
+ * of the current LSP's client RPC call and this will cause the current request to fail
+ * with the given error code - but subsequent calls shall be able to continue.
+ */
+#define lspRequire(condition, errorCode, errorMessage) \
 	if (!(condition)) \
 	{ \
 		BOOST_THROW_EXCEPTION( \


### PR DESCRIPTION
Closes #13539. Requires lsp-find-all-refs to be merged first.