### PR TITLE
Fix Euler tests by pinning v3-periphery

### DIFF
--- a/test/externalTests/euler.sh
+++ b/test/externalTests/euler.sh
@@ -74,6 +74,9 @@ function euler_test
     force_hardhat_unlimited_contract_size "$config_file"
     npm install
 
+    # TODO: Remove this when https://github.com/Uniswap/v3-periphery/issues/313 gets fixed.
+    npm install @uniswap/v3-periphery@1.4.1
+
     replace_version_pragmas
     neutralize_packaged_contracts
 


### PR DESCRIPTION
New 1.4.2 release is causing issues, and an issue was already opened in the v3-periphery repository. This will likely be fixed fairly soon in the upstream repo.