### PR TITLE
Update ambiguous CVC4::BitVector ctor call

### DIFF
--- a/libsmtutil/CVC4Interface.cpp
+++ b/libsmtutil/CVC4Interface.cpp
@@ -239,7 +239,7 @@ CVC4::Expr CVC4Interface::toCVC4Expr(Expression const& _expr)
 				m_context.mkExpr(
 					CVC4::kind::EQUAL,
 					m_context.mkExpr(CVC4::kind::BITVECTOR_EXTRACT, extractOp, arguments[0]),
-					m_context.mkConst(CVC4::BitVector(1, size_t(0)))
+					m_context.mkConst(CVC4::BitVector(1, uint64_t{0}))
 				),
 				nat,
 				m_context.mkExpr(


### PR DESCRIPTION
In [CVC4Interface.cpp](https://github.com/ethereum/solidity/blob/b12b845739d7dfd540e7eef624b39052f0ab8a7d/libsmtutil/CVC4Interface.cpp) we have the following call

https://github.com/ethereum/solidity/blob/b12b845739d7dfd540e7eef624b39052f0ab8a7d/libsmtutil/CVC4Interface.cpp#L242

but it the CVC4 [bitvector.h](https://github.com/CVC4/CVC4-archived/blob/40eac7f0529176bcc8464d6c4c8804fbde628c2b/src/util/bitvector.h) there are two constructors that make this call ambiguous:

```
  BitVector(unsigned size, uint32_t z) : d_size(size), d_value(z)
  {
    d_value = d_value.modByPow2(size);
  }

  BitVector(unsigned size, uint64_t z) : d_size(size), d_value(z)
  {
    d_value = d_value.modByPow2(size);
  }

```

I suggest putting an explicit cast to make the call unambiguous.

Env:
MacOS 12.5
Apple clang version 14.0.0 (clang-1400.0.29.102)
Target: x86_64-apple-darwin21.6.0
Thread model: posix