### PR TITLE
[libsolidity] Refactor Compiler Stack imported source type.

### DIFF
--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -410,7 +410,7 @@ void CompilerStack::importASTs(map<string, Json::Value> const& _sources)
 		m_sources[path] = std::move(source);
 	}
 	m_stackState = ParsedAndImported;
-	m_importedSources = true;
+	m_compilationSourceType = CompilationSourceType::SolidityAST;
 
 	storeContractDefinitions();
 }
@@ -1482,7 +1482,17 @@ string CompilerStack::createMetadata(Contract const& _contract, bool _forIR) con
 {
 	Json::Value meta{Json::objectValue};
 	meta["version"] = 1;
-	meta["language"] = m_importedSources ? "SolidityAST" : "Solidity";
+	string sourceType;
+	switch (m_compilationSourceType)
+	{
+	case CompilationSourceType::Solidity:
+		sourceType = "Solidity";
+		break;
+	case CompilationSourceType::SolidityAST:
+		sourceType = "SolidityAST";
+		break;
+	}
+	meta["language"] = sourceType;
 	meta["compiler"]["version"] = VersionStringStrict;
 
 	/// All the source files (including self), which should be included in the metadata.

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -117,6 +117,13 @@ public:
 		None
 	};
 
+	enum class CompilationSourceType {
+		/// Regular compilation from Solidity source files.
+		Solidity,
+		/// Compilation from an imported Solidity AST.
+		SolidityAST
+	};
+
 	/// Creates a new compiler stack.
 	/// @param _readFile callback used to read files for import statements. Must return
 	/// and must not emit exceptions.
@@ -511,7 +518,7 @@ private:
 	langutil::DebugInfoSelection m_debugInfoSelection = langutil::DebugInfoSelection::Default();
 	bool m_parserErrorRecovery = false;
 	State m_stackState = Empty;
-	bool m_importedSources = false;
+	CompilationSourceType m_compilationSourceType = CompilationSourceType::Solidity;
 	/// Whether or not there has been an error during processing.
 	/// If this is true, the stack will refuse to generate code.
 	bool m_hasError = false;


### PR DESCRIPTION
Refactors `libsolidity/interface/CompilerStack.cpp` to make #12834 more readable.