### PR TITLE
Let the nightlies call themselves 'nightly', the return.

### DIFF
--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -28,10 +28,9 @@
 
 set -e
 
-if test -z "$1"; then
-    BUILD_DIR="emscripten_build"
-else
-    BUILD_DIR="$1"
+params=""
+if (( $# != 0 )); then
+    params="$(printf "%q " "${@}")"
 fi
 
 # solbuildpackpusher/solidity-buildpack-deps:emscripten-14
@@ -39,4 +38,4 @@ fi
 # See https://github.blog/2022-04-12-git-security-vulnerability-announced/
 docker run -v "$(pwd):/root/project" -w /root/project \
     solbuildpackpusher/solidity-buildpack-deps@sha256:f1c13f3450d1f2e53ea18ac1ac1a17e932573cb9a5ccd0fd9ef6dd44f6402fa9 \
-    /bin/bash -c "git config --global --add safe.directory /root/project && ./scripts/ci/build_emscripten.sh $BUILD_DIR"
+    /bin/bash -c "git config --global --add safe.directory /root/project && ./scripts/ci/build_emscripten.sh ${params}"

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -2,17 +2,22 @@
 set -ex
 
 ROOTDIR="$(dirname "$0")/../.."
+# shellcheck source=scripts/common.sh
+source "${ROOTDIR}/scripts/common.sh"
+
+prerelease_source="${1:-ci}"
+
 cd "${ROOTDIR}"
 
 # shellcheck disable=SC2166
 if [ "$CIRCLE_BRANCH" = release -o -n "$CIRCLE_TAG" -o -n "$FORCE_RELEASE" ]
 then
-    echo -n "" >prerelease.txt
+    echo -n >prerelease.txt
 else
     # Use last commit date rather than build date to avoid ending up with builds for
     # different platforms having different version strings (and therefore producing different bytecode)
     # if the CI is triggered just before midnight.
-    TZ=UTC git show --quiet --date="format-local:%Y.%-m.%-d" --format="ci.%cd" >prerelease.txt
+    TZ=UTC git show --quiet --date="format-local:%Y.%-m.%-d" --format="${prerelease_source}.%cd" >prerelease.txt
 fi
 
 if [ -n "$CIRCLE_SHA1" ]


### PR DESCRIPTION
Since PR[#10772](https://github.com/ethereum/solidity/pull/10772), nightly builds started to call themselves `ci` during the build. 

This happens because the nightly workflow in the solc-bin repo invokes the `build_emscripten.sh` from the solidity repo, in line [78](https://github.com/ethereum/solc-bin/blob/gh-pages/.github/workflows/nightly-emscripten.yml#L78), after the script set the `prerelease.txt` to the nightly version (line [53](https://github.com/ethereum/solc-bin/blob/gh-pages/.github/workflows/nightly-emscripten.yml#L53)), thus overwriting the `prerelease.txt` created by the workflow. 

The creation of the `prerelease.txt` file was added to the nightly workflow here https://github.com/ethereum/solc-bin/pull/64 to fix the issue when nightly builds were calling themselves `develop`. Now, they want to be `ci`, but we should not allow it!

You can see the error by running:
```javascript
solc.loadRemoteVersion("v0.8.15-nightly.2022.5.27+commit.095cc647", (err, compiler) => {
    console.log(compiler.version())
})
```
Which returns: `0.8.15-ci.2022.5.27+commit.095cc647.Emscripten.clang` 
Instead of: `0.8.15-nightly.2022.5.27+commit.095cc647.Emscripten.clang`

EDITED:
~The PR adds a condition to not modify the `prerelease.txt` file if it is a `nightly` build.~
The PR adds an optional argument to set the release binary name in the `build` script and also modifies the `emscripten_build` script to receive optional parameters for the same purpose. Parameters were used in the latter instead of arguments since the script would have more than one optional argument, requiring the user to provide the first argument even if he only wants to set the second.
The docker script was also modified to forward the parameters to the CI scripts.
If no parameters are given, the script behaves as before.

It should be merged before https://github.com/ethereum/solc-bin/pull/123.