### PR TITLE
Updated outputCompilationResults() for issue 4617

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -1154,7 +1154,7 @@ void CommandLineInterface::outputCompilationResults()
 		handleNatspec(false, contract);
 	} // end of contracts iteration
 
-	if (!m_hasOutput ^ (contracts.size() < 1))
+	if (!m_hasOutput ^ (contracts.size()<1))
 	{
 		if (!m_options.output.dir.empty())
 			sout() << "Compiler run successful. Artifact(s) can be found in directory " << m_options.output.dir << "." << endl;

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -1154,15 +1154,15 @@ void CommandLineInterface::outputCompilationResults()
 		handleNatspec(false, contract);
 	} // end of contracts iteration
 
-	if (!m_hasOutput || (contracts.size()<1))
+	if (!m_hasOutput)
 	{
 		if (!m_options.output.dir.empty())
 			sout() << "Compiler run successful. Artifact(s) can be found in directory " << m_options.output.dir << "." << endl;
-		else if(contracts.size()<1)
-			sout() << "Compiler run successful. No contracts to compile. " << endl;
 		else
 			serr() << "Compiler run successful, no output requested." << endl;
 	}
+	else if(contracts.size() < 1)
+			sout() << "Compiler run successful. No contracts to compile. " << endl;
 }
 
 }

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -1161,7 +1161,7 @@ void CommandLineInterface::outputCompilationResults()
 		else
 			serr() << "Compiler run successful, no output requested." << endl;
 	}
-	else if(contracts.size() < 1)
+	else if (contracts.size() < 1)
 			sout() << "Compiler run successful. No contracts to compile. " << endl;
 }
 

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -1154,7 +1154,7 @@ void CommandLineInterface::outputCompilationResults()
 		handleNatspec(false, contract);
 	} // end of contracts iteration
 
-	if (!m_hasOutput ^ (contracts.size()<1))
+	if (!m_hasOutput || (contracts.size()<1))
 	{
 		if (!m_options.output.dir.empty())
 			sout() << "Compiler run successful. Artifact(s) can be found in directory " << m_options.output.dir << "." << endl;

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -1158,7 +1158,7 @@ void CommandLineInterface::outputCompilationResults()
 	{
 		if (!m_options.output.dir.empty())
 			sout() << "Compiler run successful. Artifact(s) can be found in directory " << m_options.output.dir << "." << endl;
-		else if(contracts.size() < 1)
+		else if(contracts.size()<1)
 			sout() << "Compiler run successful. No contracts to compile. " << endl;
 		else
 			serr() << "Compiler run successful, no output requested." << endl;


### PR DESCRIPTION
Updated outputCompilationResults() to appropriately report when there are no contracts to compile. As requested in issue #4617 (https://github.com/ethereum/solidity/issues/4617) the needsHumanTargetedStdout check was removed so the header is printed for all contracts regardless of options presented. The needsHumanTargetedStdout was then deleted as it was not used anywhere else.