### PR TITLE
Disable FETCHCONTENT_FULLY_DISCONNECTED on ppa release

### DIFF
--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -217,7 +217,7 @@ override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DTESTS=OFF ${CMAKE_OPTIONS}
+	dh_auto_configure -- -DTESTS=OFF -DFETCHCONTENT_FULLY_DISCONNECTED=OFF ${CMAKE_OPTIONS}
 EOF
 cat <<EOF > debian/copyright
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/13362.

I managed to reproduce the problem locally using a Kinetic docker image, and upon some investigation, it turns out that the problem was related to this [change](
https://salsa.debian.org/debian/debhelper/-/commit/5debbd6171dd2a091dde9ed499d8bb118ed2e1a8) in the `debhelper` package used to build the `.deb`.

The change, released in debhelper version [13.8](https://launchpad.net/debian/+source/debhelper/13.8), enables the cmake [FETCHCONTENT_FULLY_DISCONNECTED](https://cmake.org/cmake/help/latest/module/FetchContent.html#variable:FETCHCONTENT_FULLY_DISCONNECTED) option by default, which prevents cmake from downloading or updating any content and assumes that it is already available. This option was set to `OFF` in all debhelper releases prior to 13.8.

The current `fmtlib` cmake configuration depends on the `FetchContent` module and thus fails to retrieve the package, throwing the chain of linking errors as shown here: https://github.com/ethereum/solidity/issues/13362#issuecomment-1240976092.

This issue only affects kinetic, since all other versions used by our `release_ppa` script rely on the old configuration (where the option was set to `OFF`):
```
focal: debhelper (12.10ubuntu1)
jammy: debhelper (13.6ubuntu1)
kinetic: debhelper (13.9.1ubuntu1)
```

This PR forces the cmake option to be `OFF` again to allow cmake to fetch the content. Another alternative would be to change the current `fmtlib` cmake configuration to not rely on `FetchContent_MakeAvailable` and use `ExternalProject_Add` instead.


