### PR TITLE
fix: `bytecodeHash` cannot be set to non-none for `appendCBOR=false`

### DIFF
--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -929,6 +929,13 @@ std::variant<StandardCompiler::InputsAndSettings, Json::Value> StandardCompiler:
 				metadataHash == "bzzr1" ?
 				CompilerStack::MetadataHash::Bzzr1 :
 				CompilerStack::MetadataHash::None;
+		if (ret.metadataFormat == CompilerStack::MetadataFormat::NoMetadata && ret.metadataHash != CompilerStack::MetadataHash::None)
+			return formatFatalError(
+				Error::Type::JSONError,
+				"When the parameter \"appendCBOR\" is set to false, the parameter \"bytecodeHash\" cannot be set to \"" +
+				metadataHash +
+				"\". The parameter \"bytecodeHash\" should either be skipped, or set to \"none\"."
+			);
 	}
 
 	Json::Value outputSelection = settings.get("outputSelection", Json::Value());

--- a/test/cmdlineTests/metadata_append_standard_json_error/args
+++ b/test/cmdlineTests/metadata_append_standard_json_error/args
@@ -1,0 +1,1 @@
+--pretty-json --json-indent 4

--- a/test/cmdlineTests/metadata_append_standard_json_error/input.json
+++ b/test/cmdlineTests/metadata_append_standard_json_error/input.json
@@ -1,0 +1,29 @@
+{
+	"language": "Solidity",
+	"sources":
+	{
+		"A":
+		{
+			"content": "// SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0;\n\ncontract test {}"
+		}
+	},
+	"settings":
+	{
+		"viaIR": true,
+		"optimizer": {
+			"enabled": true
+		},
+		"metadata":
+		{
+			"appendCBOR": false,
+			"bytecodeHash": "ipfs"
+		},
+		"outputSelection":
+		{
+			"A":
+			{
+				"test": ["evm.bytecode"]
+			}
+		}
+	}
+}

--- a/test/cmdlineTests/metadata_append_standard_json_error/output.json
+++ b/test/cmdlineTests/metadata_append_standard_json_error/output.json
@@ -1,0 +1,12 @@
+{
+    "errors":
+    [
+        {
+            "component": "general",
+            "formattedMessage": "When the parameter \"appendCBOR\" is set to false, the parameter \"bytecodeHash\" cannot be set to \"ipfs\". The parameter \"bytecodeHash\" should either be skipped, or set to \"none\".",
+            "message": "When the parameter \"appendCBOR\" is set to false, the parameter \"bytecodeHash\" cannot be set to \"ipfs\". The parameter \"bytecodeHash\" should either be skipped, or set to \"none\".",
+            "severity": "error",
+            "type": "JSONError"
+        }
+    ]
+}


### PR DESCRIPTION
Testing: see `test/cmdlineTests/metadata_append_standard_json_error`

Closes: https://github.com/ethereum/solidity/issues/13628

Did not add a changelog as the feature wasn't released.