### PR TITLE
Clarify that a contract without `receive` can still receive Ether through payable function calls

### DIFF
--- a/docs/contracts/functions.rst
+++ b/docs/contracts/functions.rst
@@ -297,7 +297,7 @@ on plain Ether transfers (e.g. via ``.send()`` or ``.transfer()``). If no such
 function exists, but a payable :ref:`fallback function <fallback-function>`
 exists, the fallback function will be called on a plain Ether transfer. If
 neither a receive Ether nor a payable fallback function is present, the
-contract cannot receive Ether through regular transactions and throws an
+contract cannot receive Ether through a transaction that does not represent a payable function call and throws an
 exception.
 
 In the worst case, the ``receive`` function can only rely on 2300 gas being


### PR DESCRIPTION
The receive function documentation is slightly inaccurate currently as a contract can still receive Ether through payable functions even if no receive or payable fallback function is present.