### PR TITLE
[solc] Exit code 2 for exceptions.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Language Features:
 
 
 Compiler Features:
+* Commandline Interface: Return exit code ``2`` on uncaught exceptions.
 * Commandline Interface: Add `--no-cbor-metadata` that skips CBOR metadata from getting appended at the end of the bytecode.
 * Standard JSON: Add a boolean field `settings.metadata.appendCBOR` that skips CBOR metadata from getting appended at the end of the bytecode.
 * Yul Optimizer: Allow replacing the previously hard-coded cleanup sequence by specifying custom steps after a colon delimiter (``:``) in the sequence string.
@@ -11,6 +12,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * Solidity Upgrade Tool ``solidity-upgrade``: Fix the tool returning success code on uncaught exceptions.
 
 
 ### 0.8.17 (2022-09-08)

--- a/solc/main.cpp
+++ b/solc/main.cpp
@@ -44,36 +44,24 @@ int main(int argc, char** argv)
 	{
 		cerr << "SMT logic error:" << endl;
 		cerr << boost::diagnostic_information(_exception);
-		return 1;
+		return 2;
 	}
 	catch (langutil::UnimplementedFeatureError const& _exception)
 	{
 		cerr << "Unimplemented feature:" << endl;
 		cerr << boost::diagnostic_information(_exception);
-		return 1;
+		return 2;
 	}
 	catch (langutil::InternalCompilerError const& _exception)
 	{
 		cerr << "Internal compiler error:" << endl;
 		cerr << boost::diagnostic_information(_exception);
-		return 1;
-	}
-	catch (boost::exception const& _exception)
-	{
-		cerr << "Uncaught exception:" << endl;
-		cerr << boost::diagnostic_information(_exception) << endl;
-		return 1;
-	}
-	catch (std::exception const& _exception)
-	{
-		cerr << "Uncaught exception:" << endl;
-		cerr << boost::diagnostic_information(_exception) << endl;
-		return 1;
+		return 2;
 	}
 	catch (...)
 	{
-		cerr << "Uncaught exception" << endl;
+		cerr << "Uncaught exception:" << endl;
 		cerr << boost::current_exception_diagnostic_information() << endl;
-		return 1;
+		return 2;
 	}
 }

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -502,22 +502,22 @@ int main(int argc, char const *argv[])
 	catch (boost::program_options::error const& exception)
 	{
 		cerr << exception.what() << endl;
-		return EXIT_FAILURE;
+		return 2;
 	}
 	catch (std::runtime_error const& exception)
 	{
 		cerr << exception.what() << endl;
-		return EXIT_FAILURE;
+		return 2;
 	}
 	catch (solidity::test::ConfigException const& exception)
 	{
 		cerr << exception.what() << endl;
-		return EXIT_FAILURE;
+		return 2;
 	}
 	catch (...)
 	{
 		cerr << "Unhandled exception caught." << endl;
 		cerr << boost::current_exception_diagnostic_information() << endl;
-		return EXIT_FAILURE;
+		return 2;
 	}
 }

--- a/tools/solidityUpgrade/main.cpp
+++ b/tools/solidityUpgrade/main.cpp
@@ -84,11 +84,15 @@ int main(int argc, char** argv)
 	}
 	catch (boost::exception const& _exception)
 	{
-		cerr << "Exception while processing input: " << boost::diagnostic_information(_exception) << endl;
+		cerr << "Exception while processing input:" << endl;
+		cerr << boost::diagnostic_information(_exception) << endl;
+		return 2;
 	}
 	catch (...)
 	{
-		cerr << "Unknown exception while processing input: " << boost::current_exception_diagnostic_information() << endl;
+		cerr << "Uncaught exception while processing input:" << endl;
+		cerr << boost::current_exception_diagnostic_information() << endl;
+		return 2;
 	}
 
 	return 0;

--- a/tools/yulPhaser/main.cpp
+++ b/tools/yulPhaser/main.cpp
@@ -36,7 +36,7 @@ int main(int argc, char** argv)
 
 		std::cerr << std::endl;
 		std::cerr << "ERROR: " << exception.what() << std::endl;
-		return 1;
+		return 2;
 	}
 	catch (solidity::phaser::BadInput const& exception)
 	{
@@ -45,46 +45,12 @@ int main(int argc, char** argv)
 
 		std::cerr << std::endl;
 		std::cerr << "ERROR: " << exception.what() << std::endl;
-		return 1;
-	}
-	catch (solidity::util::Exception const& exception)
-	{
-		// Something's seriously wrong. Probably a bug in the program or a missing handler (which
-		// is really also a bug). The exception should have been handled gracefully by this point
-		// if it's something that can happen in normal usage. E.g. an error in the input or a
-		// failure of some part of the system that's outside of control of the application (disk,
-		// network, etc.). The bug should be reported and investigated so our job here is just to
-		// provide as much useful information about it as possible.
-
-		std::cerr << std::endl;
-		std::cerr << "UNCAUGHT EXCEPTION!" << std::endl;
-
-		// We can print some useful diagnostic info for this particular exception type.
-		std::cerr << "Location: " << exception.lineInfo() << std::endl;
-
-		char const* const* function = boost::get_error_info<boost::throw_function>(exception);
-		if (function != nullptr)
-			std::cerr << "Function: " << *function << std::endl;
-
-		// Let it crash. The terminate() will print some more stuff useful for debugging like
-		// what() and the actual exception type.
-		throw;
-	}
-	catch (std::exception const&)
-	{
-		// Again, probably a bug but this time it's just plain std::exception so there's no point
-		// in doing anything special. terminate() will do an adequate job.
-		std::cerr << std::endl;
-		std::cerr << "UNCAUGHT EXCEPTION!" << std::endl;
-		throw;
+		return 2;
 	}
 	catch (...)
 	{
-		// Some people don't believe these exist.
-		// I have no idea what this is and it's flying towards me so technically speaking it's an
-		// unidentified flying object.
-		std::cerr << std::endl;
-		std::cerr << "UFO SPOTTED!" << std::endl;
-		throw;
+		std::cerr << "Uncaught exception:" << std::endl;
+		std::cerr << boost::current_exception_diagnostic_information() << std::endl;
+		return 2;
 	}
 }


### PR DESCRIPTION
It could be useful to distinguish normal errors from exceptions. `solc` will now return `0` on success, `1` on normal failures, but `2` on exceptions. 

See https://github.com/ethereum/solidity/pull/13576#issuecomment-1282912101.