### PR TITLE
Fix gp2 ext test failing to build, not being able to resolve the the keyv dependency

### DIFF
--- a/scripts/externalTests/update_external_repos.sh
+++ b/scripts/externalTests/update_external_repos.sh
@@ -80,7 +80,6 @@ cd "$target_dir"
 clone_repo brinktrade        brink-core
 clone_repo dapphub           dappsys-monolithic
 clone_repo element-fi        elf-contracts
-clone_repo ensdomains        ens
 clone_repo ensdomains        ens-contracts
 clone_repo euler-xyz         euler-contracts
 clone_repo cowprotocol       contracts                 gp2-contracts
@@ -102,7 +101,6 @@ clone_repo yieldprotocol     yield-liquidator-v2
 sync_branch brink-core                master
 sync_branch dappsys-monolithic        master
 sync_branch elf-contracts             main
-sync_branch ens                       master
 sync_branch ens-contracts             master
 sync_branch euler-contracts           master
 sync_branch gp2-contracts             main

--- a/scripts/externalTests/update_external_repos.sh
+++ b/scripts/externalTests/update_external_repos.sh
@@ -83,7 +83,7 @@ clone_repo element-fi        elf-contracts
 clone_repo ensdomains        ens
 clone_repo ensdomains        ens-contracts
 clone_repo euler-xyz         euler-contracts
-clone_repo gnosis            gp-v2-contracts
+clone_repo cowprotocol       contracts                 gp2-contracts
 clone_repo gnosis            mock-contract
 clone_repo gnosis            util-contracts
 clone_repo JoinColony        colonyNetwork
@@ -105,7 +105,7 @@ sync_branch elf-contracts             main
 sync_branch ens                       master
 sync_branch ens-contracts             master
 sync_branch euler-contracts           master
-sync_branch gp-v2-contracts           main
+sync_branch gp2-contracts             main
 sync_branch mock-contract             master
 sync_branch util-contracts            main
 sync_branch colonyNetwork             develop

--- a/test/externalTests/gp2.sh
+++ b/test/externalTests/gp2.sh
@@ -31,12 +31,12 @@ BINARY_TYPE="$1"
 BINARY_PATH="$(realpath "$2")"
 SELECTED_PRESETS="$3"
 
-function compile_fn { npm run build; }
-function test_fn { npm test; }
+function compile_fn { yarn run build; }
+function test_fn { yarn test; }
 
 function gp2_test
 {
-    local repo="https://github.com/gnosis/gp-v2-contracts.git"
+    local repo="https://github.com/cowprotocol/contracts.git"
     local ref_type=branch
     local ref=main
     local config_file="hardhat.config.ts"
@@ -67,11 +67,11 @@ function gp2_test
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")" "$config_var"
     force_hardhat_unlimited_contract_size "$config_file" "$config_var"
-    npm install
+    yarn
 
     # New hardhat release breaks GP2 tests, and since GP2 repository has been archived, we are pinning hardhat
     # to the previous stable version. See https://github.com/ethereum/solidity/pull/13485
-    npm install hardhat@2.10.2
+    yarn add hardhat@2.10.2
 
     # Some dependencies come with pre-built artifacts. We want to build from scratch.
     rm -r node_modules/@gnosis.pm/safe-contracts/build/


### PR DESCRIPTION
For some reason, `npm install` is not able to resolve some dependencies (namely [keyv](https://github.com/gnosis/gp-v2-contracts/blob/main/yarn.lock#L2570)), and thus the build of gp2 fails.

The CI job report the following error https://app.circleci.com/pipelines/github/ethereum/solidity/26946/workflows/f1a18e69-c5ec-4f7d-84c1-845b7f8abf2e/jobs/1194591?invite=true#step-104-141
```
yarn run v1.22.15
$ tsc && tsc -p tsconfig.lib.esm.json && tsc -p tsconfig.lib.commonjs.json
error TS2688: Cannot find type definition file for 'keyv'.
  The file is in the program because:
    Entry point for implicit type library 'keyv'
```

The [gp2 repo](https://github.com/gnosis/gp-v2-contracts) only contains a `yarn.lock` file and npm versions v7+ should support `yarn.lock` files (https://blog.npmjs.org/post/621733939456933888/npm-v7-series-why-keep-package-lockjson). However, this does not seem to be the case for our CI even though the npm version is 8.1.2.

This PR replaces npm with yarn to resolve the missing dependency and also update the gp2 repository since the original was archived.

Update: I found this issue: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/62793, which refers to the source of the problem, although the solution is still unclear.