### PR TITLE
fix emit statments being printed on the same line

### DIFF
--- a/test/libsolidity/semanticTests/emit_three_identical_events.sol
+++ b/test/libsolidity/semanticTests/emit_three_identical_events.sol
@@ -1,0 +1,14 @@
+contract C {
+    event Terminated();
+
+    function terminate() external {
+        emit Terminated();
+        emit Terminated();
+        emit Terminated();
+    }
+}
+// ----
+// terminate() ->
+// ~ emit Terminated()
+// ~ emit Terminated()
+// ~ emit Terminated()

--- a/test/libsolidity/semanticTests/emit_two_identical_events.sol
+++ b/test/libsolidity/semanticTests/emit_two_identical_events.sol
@@ -1,0 +1,12 @@
+contract C {
+    event Terminated();
+
+    function terminate() external {
+        emit Terminated();
+        emit Terminated();
+    }
+}
+// ----
+// terminate() ->
+// ~ emit Terminated()
+// ~ emit Terminated()

--- a/test/libsolidity/util/TestFunctionCall.cpp
+++ b/test/libsolidity/util/TestFunctionCall.cpp
@@ -208,12 +208,10 @@ string TestFunctionCall::format(
 		if (!sideEffects.empty())
 		{
 			stream << std::endl;
-			for (string const& effect: sideEffects)
-			{
-				stream << _linePrefix << "// ~ " << effect;
-				if (effect != *sideEffects.rbegin())
-					stream << std::endl;
-			}
+			size_t i = 0;
+			for (; i < sideEffects.size() - 1; ++i)
+				stream << _linePrefix << "// ~ " << sideEffects[i] << std::endl;
+			stream << _linePrefix << "// ~ " << sideEffects[i];
 		}
 
 		stream << formatGasExpectations(_linePrefix, _renderMode == RenderMode::ExpectedValuesActualGas, _interactivePrint);


### PR DESCRIPTION
Rectified issue in TestFunctionCall::Format to ensure emit logs are printed on separate lines. Added two tests to check for proper emit output.  Fixes #13592

I have opened a new pull request here due to when I tried to rebase the last one I made a few mistakes. Old PR: https://github.com/ethereum/solidity/pull/13635