### PR TITLE
Workaround for Hardhat no longer accepting unreleased solc versions in `HARDHAT_TESTS_SOLC_VERSION`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1200,7 +1200,10 @@ jobs:
       - run:
           name: Run hardhat-core test suite
           command: |
-            HARDHAT_TESTS_SOLC_VERSION=$(scripts/get_version.sh)
+            # Since a recent release, Hardhat no longer accepts unreleased versions in this variable.
+            # TODO: Remove the hack when https://github.com/NomicFoundation/hardhat/issues/3295 is fixed.
+            #HARDHAT_TESTS_SOLC_VERSION=$(scripts/get_version.sh)
+            HARDHAT_TESTS_SOLC_VERSION=0.8.16
             export HARDHAT_TESTS_SOLC_VERSION
 
             # NOTE: This is expected to work without running `yarn build` first.


### PR DESCRIPTION
Temporary workaround for https://github.com/NomicFoundation/hardhat/issues/3295.

`t_ems_ext_hardhat` is failing in all our PRs now. All tests in the suite fail with an errors like this (from [1198229](https://app.circleci.com/pipelines/github/ethereum/solidity/27026/workflows/5de23979-ad27-45d3-a053-0fd3f5c2d1b0/jobs/1198229)):
```
1) Stack traces
       Use compiler at /tmp/workspace/soljson.js with version 0.8.18
         0_8
           abi-v2
             call-failing-function
               Without optimizations
                 test-files/0_8/abi-v2/call-failing-function:
     HardhatError: HH11: An internal invariant was violated: Trying to get a compiler before it was downloaded
      at assertHardhatInvariant (/home/circleci/project/hardhat/packages/hardhat-core/src/internal/core/errors.ts:272:11)
      at CompilerDownloader.getCompiler (/home/circleci/project/hardhat/packages/hardhat-core/src/internal/solidity/compiler/downloader.ts:196:27)
      at getCompilerForVersion (/home/circleci/project/hardhat/packages/hardhat-core/test/internal/hardhat-network/stack-traces/compilation.ts:132:20)
      at compileFiles (/home/circleci/project/hardhat/packages/hardhat-core/test/internal/hardhat-network/stack-traces/compilation.ts:101:20)
      at compileIfNecessary (/home/circleci/project/hardhat/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts:238:43)
      at runTest (/home/circleci/project/hardhat/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts:409:43)
      at Context.func (/home/circleci/project/hardhat/packages/hardhat-core/test/internal/hardhat-network/stack-traces/test.ts:135:5)
```

The patch hard-codes the version to the last released one, which at least makes Hardhat not reject the version outright. Hopefully there's not much hard-coded specifically for 0.8.17 inside Hardhat. We should remove this as soon as the upstream issue is fixed.