### PR TITLE
Report when no contracts to compile

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -48,7 +48,6 @@
 #include <libevmasm/GasMeter.h>
 
 #include <liblangutil/Exceptions.h>
-#include <liblangutil/Scanner.h>
 #include <liblangutil/SourceReferenceFormatter.h>
 
 #include <libsmtutil/Exceptions.h>
@@ -1193,8 +1192,10 @@ void CommandLineInterface::outputCompilationResults()
 	{
 		if (!m_options.output.dir.empty())
 			sout() << "Compiler run successful. Artifact(s) can be found in directory " << m_options.output.dir << "." << endl;
+		else if (contracts.empty())
+			sout() << "Compiler run successful. No contracts to compile." << endl;
 		else
-			serr() << "Compiler run successful, no output requested." << endl;
+			sout() << "Compiler run successful. No output generated." << endl;
 	}
 }
 

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -225,6 +225,11 @@ EOF
         sed -i.bak -e 's/ Consider adding "pragma .*$//' "$stderr_path"
         sed -i.bak -e 's/\(Unimplemented feature error.* in \).*$/\1<FILENAME REMOVED>/' "$stderr_path"
         sed -i.bak -e 's/"version":[ ]*"[^"]*"/"version": "<VERSION REMOVED>"/' "$stdout_path"
+    if [[ $stdout_expectation_file != "" &&  $stderr_expectation_file != "" ]]
+    then
+        sed -i.bak -e '/^Compiler run successful\. No contracts to compile\.$/d' "$stdout_path"
+        sed -i.bak -e '/^Compiler run successful\. No output generated\.$/d' "$stdout_path"
+    fi
 
         # Remove bytecode (but not linker references). Since non-JSON output is unstructured,
         # use metadata markers for detection to have some confidence that it's actually bytecode

--- a/test/cmdlineTests/no_contract_combined_json/args
+++ b/test/cmdlineTests/no_contract_combined_json/args
@@ -1,0 +1,1 @@
+--combined-json ast --pretty-json --json-indent 4

--- a/test/cmdlineTests/no_contract_combined_json/input.sol
+++ b/test/cmdlineTests/no_contract_combined_json/input.sol
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;

--- a/test/cmdlineTests/no_contract_combined_json/output
+++ b/test/cmdlineTests/no_contract_combined_json/output
@@ -1,0 +1,36 @@
+{
+    "sourceList":
+    [
+        "no_contract_combined_json/input.sol"
+    ],
+    "sources":
+    {
+        "no_contract_combined_json/input.sol":
+        {
+            "AST":
+            {
+                "absolutePath": "no_contract_combined_json/input.sol",
+                "exportedSymbols": {},
+                "id": 2,
+                "license": "GPL-3.0",
+                "nodeType": "SourceUnit",
+                "nodes":
+                [
+                    {
+                        "id": 1,
+                        "literals":
+                        [
+                            "solidity",
+                            ">=",
+                            "0.0"
+                        ],
+                        "nodeType": "PragmaDirective",
+                        "src": "36:22:0"
+                    }
+                ],
+                "src": "36:22:0"
+            }
+        }
+    },
+    "version": "<VERSION REMOVED>"
+}


### PR DESCRIPTION
This pull request provides the functionality and updates the test cases necessary to address https://github.com/ethereum/solidity/issues/4617.

The issue requests the output from solc be updated to specify when no contract was supplied and print the header  when ewasm, ir or ir-optimized is specified without altering the current functionality when only abstract contracts etc are provided.

The test cases were updated to accept the new output as previously the tests would check that no output was provided in these conditions. Additionally 2 new test cases were added to cmdline tests, one to test no contract outputs the correct statement and one to check a file containing a number of abstract contracts and interfaces produces no output.

This replaces the current PR [here](https://github.com/ethereum/solidity/pull/13606) duet to the fact that was done on the develop branch.