### PR TITLE
[Documentation] Change text to be hyperlink

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -80,10 +80,8 @@ Finally, please make sure you respect the `coding style
 for this project. Also, even though we do CI testing, please test your code and
 ensure that it builds locally before submitting a pull request.
 
-We highly recommend going through our `review checklist <https://github.com/ethereum/solidity/blob/develop/ReviewChecklist.md>`
-before submitting the pull request.
-We thoroughly review every PR and will help you get it right, but there are many
-common problems that can be easily avoided, making the review much smoother.
+We highly recommend going through our `review checklist <https://github.com/ethereum/solidity/blob/develop/ReviewChecklist.md>`_ before submitting the pull request.
+We thoroughly review every PR and will help you get it right, but there are many common problems that can be easily avoided, making the review much smoother.
 
 Thank you for your help!
 


### PR DESCRIPTION
The documentation link incorrectly displays in the text along with the angled brackets. I believe this is incorrect, and should be a standard markdown hyperlink. The error also disrupts the spacing of the line.  My small PR fixes both issues.

![eth-docs](https://user-images.githubusercontent.com/38789408/198944119-81885bf1-8084-4436-ac5b-11a1fa21ecce.png)
