### PR TITLE
[DOCS] Translations: Updated links and adding new language repos

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -12,7 +12,7 @@ In particular, we appreciate support in the following areas:
   `"good first issue" <https://github.com/ethereum/solidity/labels/good%20first%20issue>`_ which are
   meant as introductory issues for external contributors.
 * Improving the documentation.
-* Translating the documentation into more languages.
+* `Translating <https://github.com/solidity-docs>`_ the documentation into more languages.
 * Responding to questions from other users on `StackExchange
   <https://ethereum.stackexchange.com>`_ and the `Solidity Gitter Chat
   <https://gitter.im/ethereum/solidity>`_.
@@ -416,7 +416,7 @@ local slang and references, making your language as clear to all readers as poss
 .. note::
 
     While the official Solidity documentation is written in English, there are community contributed :ref:`translations`
-    in other languages available. Please refer to the `translation guide <https://github.com/solidity-docs/translation-guide>`_
+    in other languages available. Please refer to the `translation guide <https://github.com/solidity-docs#solidity-documentation-translation-guide>`_
     for information on how to contribute to the community translations.
 
 Title Case for Headings

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -95,17 +95,20 @@ version stands as a reference.
 You can switch between languages by clicking on the flyout menu in the bottom-left corner
 and selecting the preferred language.
 
+* `Chinese <https://github.com/solidity-docs/zh-cn-chinese/>`_
 * `French <https://docs.soliditylang.org/fr/latest/>`_
 * `Indonesian <https://github.com/solidity-docs/id-indonesian>`_
-* `Persian <https://github.com/solidity-docs/fa-persian>`_
 * `Japanese <https://github.com/solidity-docs/ja-japanese>`_
 * `Korean <https://github.com/solidity-docs/ko-korean>`_
-* `Chinese <https://github.com/solidity-docs/zh-cn-chinese/>`_
+* `Persian <https://github.com/solidity-docs/fa-persian>`_
+* `Russian <https://github.com/solidity-docs/ru-russian>`_
+* `Spanish <https://github.com/solidity-docs/es-spanish>`_
+* `Turkish <https://github.com/solidity-docs/tr-turkish>`_
 
 .. note::
 
-   We recently set up a new GitHub organization and translation workflow to help streamline the
-   community efforts. Please refer to the `translation guide <https://github.com/solidity-docs/translation-guide>`_
+   We set up a GitHub organization and translation workflow to help streamline the
+   community efforts. Please refer to the translation guide in the `solidity-docs org <https://github.com/solidity-docs>`_
    for information on how to start a new language or contribute to the community translations.
 
 Contents


### PR DESCRIPTION
- Updating broken links to the translation guide (https://github.com/solidity-docs#solidity-documentation-translation-guide)
- Adding links to new language repos