### PR TITLE
Properly distinguish team members and external contributors

### DIFF
--- a/.github/workflows/welcome-external-pr.yml
+++ b/.github/workflows/welcome-external-pr.yml
@@ -23,15 +23,13 @@ jobs:
           gh api graphql \
             --raw-field organization="$ORGANIZATION" \
             --raw-field query='
-              query($organization: String!, $cursor: String) {
+              query($organization: String!) {
                 organization(login: $organization) {
-                  membersWithRole(first: 100, after: $cursor) {
-                    pageInfo {
-                      hasNextPage,
-                      endCursor
-                    }
-                    nodes {
-                      login
+                  team(slug: "Solidity") {
+                    members(first: 100) {
+                      nodes {
+                        login
+                      }
                     }
                   }
                 }
@@ -39,7 +37,7 @@ jobs:
           echo "CONTRIBUTOR_IS_ORG_MEMBER=$(
             jq \
               --arg contributor $CONTRIBUTOR \
-              '.data.organization.membersWithRole | any(.nodes[].login; . == $contributor)' \
+              '.data.organization.team.members | any(.nodes[].login; . == $contributor)' \
               org_members.json
           )" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
This PR fixes the `welcome-external-pr` workflow to detect team members properly. The previous version did not handle pagination and consequently could produce false negatives, as can be seen here: https://github.com/ethereum/solidity/pull/13675#issuecomment-1301045747
The pagination was removed since it does not make sense for the size of the Solidity team, and a better endpoint was used, as suggested by @ekpyron.

