### PR TITLE
[COC] Update contact section in Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,10 +55,8 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at chris@ethereum.org which only goes to
-Christian Reitwiessner or axic@ethereum.org which only goes to Alex Beregszaszi.
-To report an issue involving either of them please email Hudson Jameson at
-hudson@ethereum.org.
+reported by contacting the project team at solidity@ethereum.org.
+To report an issue involving the Solidity team please email José Pedro Cabrita at zepedro@ethereum.org.
 All complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
Updates the ``Enforcement`` section of the Code of Conduct to reflect the current contact email address for the team leads.