### PR TITLE
Re-implement KnowledgeBase using groups of constantly-spaced variables.

### DIFF
--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -50,7 +50,7 @@ DataFlowAnalyzer::DataFlowAnalyzer(
 ):
 	m_dialect(_dialect),
 	m_functionSideEffects(std::move(_functionSideEffects)),
-	m_knowledgeBase(_dialect, [this](YulString _var) { return variableValue(_var); }),
+	m_knowledgeBase([this](YulString _var) { return variableValue(_var); }),
 	m_analyzeStores(_analyzeStores == MemoryAndStorage::Analyze)
 {
 	if (m_analyzeStores)
@@ -76,7 +76,7 @@ void DataFlowAnalyzer::operator()(ExpressionStatement& _statement)
 			cxx20::erase_if(m_state.environment.storage, mapTuple([&](auto&& key, auto&& value) {
 				return
 					!m_knowledgeBase.knownToBeDifferent(vars->first, key) &&
-					!m_knowledgeBase.knownToBeEqual(vars->second, value);
+					vars->second != value;
 			}));
 			m_state.environment.storage[vars->first] = vars->second;
 			return;

--- a/libyul/optimiser/KnowledgeBase.cpp
+++ b/libyul/optimiser/KnowledgeBase.cpp
@@ -23,7 +23,6 @@
 
 #include <libyul/AST.h>
 #include <libyul/Utilities.h>
-#include <libyul/optimiser/SimplificationRules.h>
 #include <libyul/optimiser/DataFlowAnalyzer.h>
 
 #include <libsolutil/CommonData.h>
@@ -36,37 +35,24 @@ using namespace solidity::yul;
 
 bool KnowledgeBase::knownToBeDifferent(YulString _a, YulString _b)
 {
-	// Try to use the simplification rules together with the
-	// current values to turn `sub(_a, _b)` into a nonzero constant.
-	// If that fails, try `eq(_a, _b)`.
-
 	if (optional<u256> difference = differenceIfKnownConstant(_a, _b))
 		return difference != 0;
-
-	Expression expr2 = simplify(FunctionCall{{}, {{}, "eq"_yulstring}, util::make_vector<Expression>(Identifier{{}, _a}, Identifier{{}, _b})});
-	if (holds_alternative<Literal>(expr2))
-		return valueOfLiteral(std::get<Literal>(expr2)) == 0;
-
 	return false;
 }
 
 optional<u256> KnowledgeBase::differenceIfKnownConstant(YulString _a, YulString _b)
 {
-	// Try to use the simplification rules together with the
-	// current values to turn `sub(_a, _b)` into a constant.
-
-	Expression expr1 = simplify(FunctionCall{{}, {{}, "sub"_yulstring}, util::make_vector<Expression>(Identifier{{}, _a}, Identifier{{}, _b})});
-	if (Literal const* value = get_if<Literal>(&expr1))
-		return valueOfLiteral(*value);
-
-	return {};
+	VariableOffset offA = explore(_a);
+	VariableOffset offB = explore(_b);
+	if (offA.reference == offB.reference)
+		return offA.offset - offB.offset;
+	else
+		return {};
 }
+
 
 bool KnowledgeBase::knownToBeDifferentByAtLeast32(YulString _a, YulString _b)
 {
-	// Try to use the simplification rules together with the
-	// current values to turn `sub(_a, _b)` into a constant whose absolute value is at least 32.
-
 	if (optional<u256> difference = differenceIfKnownConstant(_a, _b))
 		return difference >= 32 && difference <= u256(0) - 32;
 
@@ -80,29 +66,113 @@ bool KnowledgeBase::knownToBeZero(YulString _a)
 
 optional<u256> KnowledgeBase::valueIfKnownConstant(YulString _a)
 {
-	if (AssignedValue const* value = m_variableValues(_a))
-		if (Literal const* literal = get_if<Literal>(value->value))
-			return valueOfLiteral(*literal);
+	VariableOffset offset = explore(_a);
+	if (offset.reference == YulString{})
+		return offset.offset;
+	else
+		return nullopt;
+}
+
+optional<u256> KnowledgeBase::valueIfKnownConstant(Expression const& _expression)
+{
+	if (Identifier const* ident = get_if<Identifier>(&_expression))
+		return valueIfKnownConstant(ident->name);
+	else if (Literal const* lit = get_if<Literal>(&_expression))
+		return valueOfLiteral(*lit);
+	else
+		return {};
+}
+
+KnowledgeBase::VariableOffset KnowledgeBase::explore(YulString _var)
+{
+	// We query the value first so that the variable is reset if it has changed
+	// since the last call.
+	Expression const* value = valueOf(_var);
+	if (VariableOffset const* varOff = util::valueOrNullptr(m_offsets, _var))
+		return *varOff;
+
+	if (value)
+		if (optional<VariableOffset> offset = explore(*value))
+			return setOffset(_var, *offset);
+	return setOffset(_var, VariableOffset{_var, 0});
+
+}
+
+optional<KnowledgeBase::VariableOffset> KnowledgeBase::explore(Expression const& _value)
+{
+	if (Literal const* literal = std::get_if<Literal>(&_value))
+		return VariableOffset{YulString{}, valueOfLiteral(*literal)};
+	else if (Identifier const* identifier = std::get_if<Identifier>(&_value))
+		return explore(identifier->name);
+	else if (FunctionCall const* f = get_if<FunctionCall>(&_value))
+		if (f->functionName.name == "add"_yulstring || f->functionName.name == "sub"_yulstring)
+			if (optional<VariableOffset> a = explore(f->arguments[0]))
+				if (optional<VariableOffset> b = explore(f->arguments[1]))
+				{
+					u256 offset =
+						f->functionName.name == "add"_yulstring ?
+						a->offset + b->offset :
+						a->offset - b->offset;
+					if (a->reference == b->reference)
+						// Offsets relative to the same reference variable
+						return VariableOffset{a->reference, offset};
+					else if (a->reference == YulString{})
+						// a is constant
+						return VariableOffset{b->reference, offset};
+					else if (b->reference == YulString{})
+						// b is constant
+						return VariableOffset{a->reference, offset};
+				}
+
 	return {};
 }
 
-Expression KnowledgeBase::simplify(Expression _expression)
+Expression const* KnowledgeBase::valueOf(YulString _var)
 {
-	m_counter = 0;
-	return simplifyRecursively(std::move(_expression));
+	Expression const* lastValue = m_lastKnownValue[_var];
+	AssignedValue const* assignedValue = m_variableValues(_var);
+	Expression const* currentValue = assignedValue ? assignedValue->value : nullptr;
+	if (lastValue != currentValue)
+		reset(_var);
+	m_lastKnownValue[_var] = currentValue;
+	return currentValue;
 }
 
-Expression KnowledgeBase::simplifyRecursively(Expression _expression)
+void KnowledgeBase::reset(YulString _var)
 {
-	if (m_counter++ > 100)
-		return _expression;
+	m_lastKnownValue.erase(_var);
+	if (VariableOffset const* offset = util::valueOrNullptr(m_offsets, _var))
+	{
+		// Remove var from its group
+		if (offset->reference != YulString{})
+			m_groupMembers[offset->reference].erase(_var);
+		m_offsets.erase(_var);
+	}
+	if (set<YulString>* group = util::valueOrNullptr(m_groupMembers, _var))
+	{
+		// _var was a representative, we might have to find a new one.
+		if (group->empty())
+			m_groupMembers.erase(_var);
+		else
+		{
+			YulString newRepresentative = *group->begin();
+			u256 newOffset = m_offsets[newRepresentative].offset;
+			for (YulString groupMember: *group)
+			{
+				yulAssert(m_offsets[groupMember].reference == _var);
+				m_offsets[groupMember].reference = newRepresentative;
+				m_offsets[newRepresentative].offset -= newOffset;
+			}
+		}
+	}
+}
 
-	if (holds_alternative<FunctionCall>(_expression))
-		for (Expression& arg: std::get<FunctionCall>(_expression).arguments)
-			arg = simplifyRecursively(arg);
-
-	if (auto match = SimplificationRules::findFirstMatch(_expression, m_dialect, m_variableValues))
-		return simplifyRecursively(match->action().toExpression(debugDataOf(_expression), langutil::EVMVersion()));
-
-	return _expression;
+KnowledgeBase::VariableOffset KnowledgeBase::setOffset(YulString _variable, VariableOffset _value)
+{
+	m_offsets[_variable] = _value;
+	// Constants are not tracked in m_groupMembers because
+	// the "representative" can never be reset.
+	if (_value.reference != YulString{})
+		m_groupMembers[_value.reference].insert(_variable);
+	return _value;
 }

--- a/libyul/optimiser/KnowledgeBase.cpp
+++ b/libyul/optimiser/KnowledgeBase.cpp
@@ -71,11 +71,7 @@ bool KnowledgeBase::knownToBeZero(YulString _a)
 
 optional<u256> KnowledgeBase::valueIfKnownConstant(YulString _a)
 {
-	VariableOffset offset = explore(_a);
-	if (offset.reference.empty())
-		return offset.offset;
-	else
-		return nullopt;
+	return explore(_a).absoluteValue();
 }
 
 optional<u256> KnowledgeBase::valueIfKnownConstant(Expression const& _expression)
@@ -129,10 +125,10 @@ optional<KnowledgeBase::VariableOffset> KnowledgeBase::explore(Expression const&
 				if (optional<VariableOffset> b = explore(f->arguments[1]))
 				{
 					u256 offset = a->offset + b->offset;
-					if (a->reference.empty())
+					if (a->isAbsolute())
 						// a is constant
 						return VariableOffset{b->reference, offset};
-					else if (b->reference.empty())
+					else if (b->isAbsolute())
 						// b is constant
 						return VariableOffset{a->reference, offset};
 				}
@@ -144,7 +140,7 @@ optional<KnowledgeBase::VariableOffset> KnowledgeBase::explore(Expression const&
 					u256 offset = a->offset - b->offset;
 					if (a->reference == b->reference)
 						return VariableOffset{YulString{}, offset};
-					else if (b->reference.empty())
+					else if (b->isAbsolute())
 						// b is constant
 						return VariableOffset{a->reference, offset};
 				}
@@ -175,7 +171,7 @@ void KnowledgeBase::reset(YulString _var)
 	if (VariableOffset const* offset = util::valueOrNullptr(m_offsets, _var))
 	{
 		// Remove var from its group
-		if (!offset->reference.empty())
+		if (!offset->isAbsolute())
 			m_groupMembers[offset->reference].erase(_var);
 		m_offsets.erase(_var);
 	}

--- a/libyul/optimiser/KnowledgeBase.h
+++ b/libyul/optimiser/KnowledgeBase.h
@@ -47,6 +47,9 @@ struct AssignedValue;
  * form.
  * The only requirement is that the assigned values are movable expressions.
  *
+ * There is a constructor to provide all SSA values right at the beginning.
+ * If you use this, the KnowledgeBase will be slightly more efficient.
+ *
  * Internally, tries to find groups of variables that have a mutual constant
  * difference and stores these differences always relative to a specific
  * representative variable of the group.
@@ -57,9 +60,13 @@ struct AssignedValue;
 class KnowledgeBase
 {
 public:
+	/// Constructor for arbitrary value callback that allows for variable values
+	/// to change in between calls to functions of this class.
 	KnowledgeBase(std::function<AssignedValue const*(YulString)> _variableValues):
 		m_variableValues(std::move(_variableValues))
 	{}
+	/// Constructor to use if source code is in SSA form and values are constant.
+	KnowledgeBase(std::map<YulString, AssignedValue> const& _ssaValues);
 
 	bool knownToBeDifferent(YulString _a, YulString _b);
 	std::optional<u256> differenceIfKnownConstant(YulString _a, YulString _b);
@@ -91,6 +98,8 @@ private:
 
 	VariableOffset setOffset(YulString _variable, VariableOffset _value);
 
+	/// If true, we can assume that variable values never change and skip some steps.
+	bool m_valuesAreSSA = false;
 	/// Callback to retrieve the current value of a variable.
 	std::function<AssignedValue const*(YulString)> m_variableValues;
 

--- a/libyul/optimiser/KnowledgeBase.h
+++ b/libyul/optimiser/KnowledgeBase.h
@@ -38,32 +38,69 @@ struct AssignedValue;
 
 /**
  * Class that can answer questions about values of variables and their relations.
+ *
+ * Requires a callback that returns the current value of the variable.
+ * The value can change any time during the lifetime of the KnowledgeBase,
+ * it will update its internal data structure accordingly.
+ *
+ * This means that the code the KnowledgeBase is used on does not need to be in SSA
+ * form.
+ * The only requirement is that the assigned values are movable expressions.
+ *
+ * Internally, tries to find groups of variables that have a mutual constant
+ * difference and stores these differences always relative to a specific
+ * representative variable of the group.
+ *
+ * There is a special group which is the constant values. Those use the
+ * empty YulString as representative "variable".
  */
 class KnowledgeBase
 {
 public:
-	KnowledgeBase(
-		Dialect const& _dialect,
-		std::function<AssignedValue const*(YulString)> _variableValues
-	):
-		m_dialect(_dialect),
+	KnowledgeBase(std::function<AssignedValue const*(YulString)> _variableValues):
 		m_variableValues(std::move(_variableValues))
 	{}
 
 	bool knownToBeDifferent(YulString _a, YulString _b);
 	std::optional<u256> differenceIfKnownConstant(YulString _a, YulString _b);
 	bool knownToBeDifferentByAtLeast32(YulString _a, YulString _b);
-	bool knownToBeEqual(YulString _a, YulString _b) const { return _a == _b; }
 	bool knownToBeZero(YulString _a);
 	std::optional<u256> valueIfKnownConstant(YulString _a);
+	std::optional<u256> valueIfKnownConstant(Expression const& _expression);
 
 private:
-	Expression simplify(Expression _expression);
-	Expression simplifyRecursively(Expression _expression);
+	/**
+	 * Constant offset relative to a reference variable, or absolute constant if the
+	 * reference variable is the empty YulString.
+	 */
+	struct VariableOffset
+	{
+		YulString reference;
+		u256 offset;
+	};
 
-	Dialect const& m_dialect;
+	VariableOffset explore(YulString _var);
+	std::optional<VariableOffset> explore(Expression const& _value);
+
+	/// Retrieves the current value of a variable and potentially resets the variable if it is not up to date.
+	Expression const* valueOf(YulString _var);
+
+	/// Resets all information about the variable and removes it from its group,
+	/// potentially finding a new representative.
+	void reset(YulString _var);
+
+	VariableOffset setOffset(YulString _variable, VariableOffset _value);
+
+	/// Callback to retrieve the current value of a variable.
 	std::function<AssignedValue const*(YulString)> m_variableValues;
-	size_t m_counter = 0;
+
+	/// Offsets for each variable to one representative per group.
+	/// The empty string is the representative of the constant value zero.
+	std::map<YulString, VariableOffset> m_offsets;
+	/// Last known value of each variable we queried.
+	std::map<YulString, Expression const*> m_lastKnownValue;
+	/// For each representative, variables that use it to offset from.
+	std::map<YulString, std::set<YulString>> m_groupMembers;
 };
 
 }

--- a/libyul/optimiser/KnowledgeBase.h
+++ b/libyul/optimiser/KnowledgeBase.h
@@ -84,6 +84,19 @@ private:
 	{
 		YulString reference;
 		u256 offset;
+
+		bool isAbsolute() const
+		{
+			return reference.empty();
+		}
+
+		std::optional<u256> absoluteValue() const
+		{
+			if (isAbsolute())
+				return offset;
+			else
+				return std::nullopt;
+		}
 	};
 
 	VariableOffset explore(YulString _var);

--- a/libyul/optimiser/UnusedStoreEliminator.cpp
+++ b/libyul/optimiser/UnusedStoreEliminator.cpp
@@ -104,7 +104,7 @@ UnusedStoreEliminator::UnusedStoreEliminator(
 	m_functionSideEffects(_functionSideEffects),
 	m_controlFlowSideEffects(_controlFlowSideEffects),
 	m_ssaValues(_ssaValues),
-	m_knowledgeBase([this](YulString _var) { return util::valueOrNullptr(m_ssaValues, _var); })
+	m_knowledgeBase(_ssaValues)
 {}
 
 void UnusedStoreEliminator::operator()(FunctionCall const& _functionCall)

--- a/libyul/optimiser/UnusedStoreEliminator.cpp
+++ b/libyul/optimiser/UnusedStoreEliminator.cpp
@@ -174,7 +174,7 @@ void UnusedStoreEliminator::visit(Statement const& _statement)
 			initialState = State::Used;
 			auto startOffset = identifierNameIfSSA(funCall->arguments.at(1));
 			auto length = identifierNameIfSSA(funCall->arguments.at(2));
-			KnowledgeBase knowledge(m_dialect, [this](YulString _var) { return util::valueOrNullptr(m_ssaValues, _var); });
+			KnowledgeBase knowledge([this](YulString _var) { return util::valueOrNullptr(m_ssaValues, _var); });
 			if (length && startOffset)
 			{
 				FunctionCall const* lengthCall = get_if<FunctionCall>(m_ssaValues.at(*length).value);
@@ -267,7 +267,7 @@ bool UnusedStoreEliminator::knownUnrelated(
 	UnusedStoreEliminator::Operation const& _op2
 ) const
 {
-	KnowledgeBase knowledge(m_dialect, [this](YulString _var) { return util::valueOrNullptr(m_ssaValues, _var); });
+	KnowledgeBase knowledge([this](YulString _var) { return util::valueOrNullptr(m_ssaValues, _var); });
 
 	if (_op1.location != _op2.location)
 		return true;
@@ -348,7 +348,7 @@ bool UnusedStoreEliminator::knownCovered(
 		return true;
 	if (_covered.location == Location::Memory)
 	{
-		KnowledgeBase knowledge(m_dialect, [this](YulString _var) { return util::valueOrNullptr(m_ssaValues, _var); });
+		KnowledgeBase knowledge([this](YulString _var) { return util::valueOrNullptr(m_ssaValues, _var); });
 
 		if (_covered.length && knowledge.knownToBeZero(*_covered.length))
 			return true;
@@ -359,7 +359,7 @@ bool UnusedStoreEliminator::knownCovered(
 			return false;
 		optional<u256> coveredLength = knowledge.valueIfKnownConstant(*_covered.length);
 		optional<u256> coveringLength = knowledge.valueIfKnownConstant(*_covering.length);
-		if (knowledge.knownToBeEqual(*_covered.start, *_covering.start))
+		if (*_covered.start == *_covering.start)
 			if (coveredLength && coveringLength && *coveredLength <= *coveringLength)
 				return true;
 		optional<u256> coveredStart = knowledge.valueIfKnownConstant(*_covered.start);

--- a/libyul/optimiser/UnusedStoreEliminator.h
+++ b/libyul/optimiser/UnusedStoreEliminator.h
@@ -27,6 +27,7 @@
 #include <libyul/optimiser/OptimiserStep.h>
 #include <libyul/optimiser/Semantics.h>
 #include <libyul/optimiser/UnusedStoreBase.h>
+#include <libyul/optimiser/KnowledgeBase.h>
 
 #include <libevmasm/SemanticInformation.h>
 
@@ -68,13 +69,7 @@ public:
 		std::map<YulString, ControlFlowSideEffects> _controlFlowSideEffects,
 		std::map<YulString, AssignedValue> const& _ssaValues,
 		bool _ignoreMemory
-	):
-		UnusedStoreBase(_dialect),
-		m_ignoreMemory(_ignoreMemory),
-		m_functionSideEffects(_functionSideEffects),
-		m_controlFlowSideEffects(_controlFlowSideEffects),
-		m_ssaValues(_ssaValues)
-	{}
+	);
 
 	using UnusedStoreBase::operator();
 	void operator()(FunctionCall const& _functionCall) override;
@@ -121,6 +116,8 @@ private:
 	std::map<YulString, AssignedValue> const& m_ssaValues;
 
 	std::map<Statement const*, Operation> m_storeOperations;
+
+	KnowledgeBase mutable m_knowledgeBase;
 };
 
 }

--- a/test/libsolidity/semanticTests/array/copying/function_type_array_to_storage.sol
+++ b/test/libsolidity/semanticTests/array/copying/function_type_array_to_storage.sol
@@ -46,7 +46,7 @@ contract C {
 }
 // ----
 // test() -> 0x20, 0x14, "[a called][b called]"
-// gas irOptimized: 116673
+// gas irOptimized: 116660
 // gas legacy: 119030
 // gas legacyOptimized: 117021
 // test2() -> 0x20, 0x14, "[b called][a called]"

--- a/test/libyul/KnowledgeBaseTest.cpp
+++ b/test/libyul/KnowledgeBaseTest.cpp
@@ -58,7 +58,7 @@ protected:
 		for (auto const& [name, expression]: m_ssaValues.values())
 			m_values[name].value = expression;
 
-		return KnowledgeBase(m_dialect, [this](YulString _var) { return util::valueOrNullptr(m_values, _var); });
+		return KnowledgeBase([this](YulString _var) { return util::valueOrNullptr(m_values, _var); });
 	}
 
 	EVMDialect m_dialect{EVMVersion{}, true};
@@ -83,9 +83,11 @@ BOOST_AUTO_TEST_CASE(basic)
 	BOOST_CHECK(!kb.knownToBeDifferent("a"_yulstring, "b"_yulstring));
 	// This only works if the variable names are the same.
 	// It assumes that SSA+CSE+Simplifier actually replaces the variables.
-	BOOST_CHECK(!kb.knownToBeEqual("a"_yulstring, "b"_yulstring));
 	BOOST_CHECK(!kb.valueIfKnownConstant("a"_yulstring));
 	BOOST_CHECK(kb.valueIfKnownConstant("zero"_yulstring) == u256(0));
+	BOOST_CHECK(kb.differenceIfKnownConstant("a"_yulstring, "b"_yulstring) == u256(0));
+	BOOST_CHECK(kb.differenceIfKnownConstant("a"_yulstring, "c"_yulstring) == u256(0));
+	BOOST_CHECK(kb.valueIfKnownConstant("e"_yulstring) == u256(0));
 }
 
 BOOST_AUTO_TEST_CASE(difference)
@@ -94,7 +96,7 @@ BOOST_AUTO_TEST_CASE(difference)
 		let a := calldataload(0)
 		let b := add(a, 200)
 		let c := add(a, 220)
-		let d := add(c, 12)
+		let d := add(12, c)
 		let e := sub(c, 12)
 	})");
 


### PR DESCRIPTION
Implements first part of #13700 

Benchmarks on Chains.sol:
```
  0.923% (0.19629 s): FullInliner
  1.441% (0.306496 s): UnusedPruner
  1.643% (0.349348 s): EqualStoreEliminator
  2.184% (0.46454 s): SSATransform
  2.311% (0.491574 s): UnusedStoreEliminator
  8.326% (1.770782 s): ExpressionSimplifier
 10.479% (2.228634 s): LoadResolver
 17.932% (3.813814 s): LiteralRematerialiser
 22.204% (4.722373 s): CommonSubexpressionEliminator
 30.263% (6.436332 s): UnusedAssignEliminator
--------------------------------------
    100% (21.268 s)

  0.593% (0.055503 s): ExpressionSplitter
  1.606% (0.15037 s): SSATransform
  1.643% (0.153831 s): UnusedPruner
  1.767% (0.165487 s): UnusedStoreEliminator
  2.739% (0.256452 s): EqualStoreEliminator
  6.024% (0.564127 s): ExpressionSimplifier
 10.905% (1.021125 s): LoadResolver
 13.787% (1.291075 s): LiteralRematerialiser
 21.658% (2.028051 s): CommonSubexpressionEliminator
 36.901% (3.455471 s): UnusedAssignEliminator
--------------------------------------
    100% (9.364 s)

43.5 seconds
```