### PR TITLE
Separate node for every `if` and `case` body in the Yul CFG

### DIFF
--- a/libyul/ControlFlowSideEffectsCollector.cpp
+++ b/libyul/ControlFlowSideEffectsCollector.cpp
@@ -51,9 +51,15 @@ void ControlFlowBuilder::operator()(If const& _if)
 {
 	visit(*_if.condition);
 	ControlFlowNode* node = m_currentNode;
-	(*this)(_if.body);
+
+	ControlFlowNode* ifEnd = newNode();
+	node->successors.emplace_back(ifEnd);
+
 	newConnectedNode();
-	node->successors.emplace_back(m_currentNode);
+	(*this)(_if.body);
+
+	m_currentNode->successors.emplace_back(ifEnd);
+	m_currentNode = ifEnd;
 }
 
 void ControlFlowBuilder::operator()(Switch const& _switch)
@@ -68,8 +74,8 @@ void ControlFlowBuilder::operator()(Switch const& _switch)
 	for (Case const& case_: _switch.cases)
 	{
 		m_currentNode = initialNode;
-		(*this)(case_.body);
 		newConnectedNode();
+		(*this)(case_.body);
 		m_currentNode->successors.emplace_back(finalNode);
 	}
 	m_currentNode = finalNode;
@@ -282,4 +288,3 @@ void ControlFlowSideEffectsCollector::recordReachabilityAndQueue(
 	if (m_processedNodes[&_function].insert(_node).second)
 		m_pendingNodes.at(&_function).push_front(_node);
 }
-


### PR DESCRIPTION
There are errors in the function `void ControlFlowBuilder::operator()(If const& _if)` and function `void ControlFlowBuilder::operator()(Switch const& _switch)` when calculating CFG.
1. In the function `void ControlFlowBuilder::operator()(If const& _if)`, the `if.condition` block is not the same block as the `if.then` block. The original code is calculated as one same block.
2. The switch.expression block are not the same block as all the cases block in cases, the original code is calculated as one same block. This can cause some potential problems during the optimization phase.