### PR TITLE
update docker images with z3 4.11.2

### DIFF
--- a/scripts/docker/buildpack-deps/Dockerfile.emscripten
+++ b/scripts/docker/buildpack-deps/Dockerfile.emscripten
@@ -33,7 +33,7 @@
 # Using $(em-config CACHE)/sysroot/usr seems to work, though, and still has cmake find the
 # dependencies automatically.
 FROM emscripten/emsdk:3.1.19 AS base
-LABEL version="13"
+LABEL version="14"
 
 ADD emscripten.jam /usr/src
 RUN set -ex && \
@@ -42,7 +42,7 @@ RUN set -ex && \
 	apt-get install lz4 --no-install-recommends && \
 	\
 	cd /usr/src && \
-	git clone https://github.com/Z3Prover/z3.git -b z3-4.11.0 --depth 1 && \
+	git clone https://github.com/Z3Prover/z3.git -b z3-4.11.2 --depth 1 && \
 	cd z3 && \
 	mkdir build && \
 	cd build && \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu1604.clang.ossfuzz
@@ -22,7 +22,7 @@
 # (c) 2016-2021 solidity contributors.
 #------------------------------------------------------------------------------
 FROM gcr.io/oss-fuzz-base/base-clang:latest as base
-LABEL version="20"
+LABEL version="21"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -61,7 +61,7 @@ RUN set -ex; \
 
 # Z3
 RUN set -ex; \
-    git clone --depth 1 -b z3-4.11.0 https://github.com/Z3Prover/z3.git \
+    git clone --depth 1 -b z3-4.11.2 https://github.com/Z3Prover/z3.git \
     /usr/src/z3; \
     cd /usr/src/z3; \
     mkdir build; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:focal AS base
-LABEL version="15"
+LABEL version="16"
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004.clang
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004.clang
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:focal AS base
-LABEL version="15"
+LABEL version="16"
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
The flow in updating z3 is the following:

1. Someone needs to push new PPA builds with the new version, in https://launchpad.net/~ethereum/+archive/ubuntu/cpp-build-deps/+packages
2. When they are built, open a PR (PR1) like this one bumping the dockerfile versions and updating the z3 version where applicable
3. When the new images are built, the bot will post the 4 new hashes here. In a different PR (PR2) (now this was done in https://github.com/ethereum/solidity/pull/13740):
    - Update the docker hashes
    - Update the z3 version in `.circleci/osx_install_dependencies.sh`
    - Update the SMT tests
4. Merge PR2
5. Rebase PR1, merge PR1.
6. Done