### PR TITLE
Code reshuffling before custom operators

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1751,7 +1751,9 @@ bool TypeChecker::visit(UnaryOperation const& _operation)
 	else
 		_operation.annotation().type = result.get();
 	_operation.annotation().isConstant = false;
-	_operation.annotation().isPure = !modifying && *_operation.subExpression().annotation().isPure;
+	_operation.annotation().isPure =
+		!modifying &&
+		*_operation.subExpression().annotation().isPure;
 	_operation.annotation().isLValue = false;
 
 	return false;
@@ -3750,8 +3752,9 @@ void TypeChecker::endVisit(UsingForDirective const& _usingFor)
 			solAssert(m_errorReporter.hasErrors());
 			return;
 		}
-		solAssert(_usingFor.typeName()->annotation().type);
-		if (Declaration const* typeDefinition = _usingFor.typeName()->annotation().type->typeDefinition())
+		Type const* usingForType = _usingFor.typeName()->annotation().type;
+		solAssert(usingForType);
+		if (Declaration const* typeDefinition = usingForType->typeDefinition())
 		{
 			if (typeDefinition->scope() != m_currentSourceUnit)
 				m_errorReporter.typeError(
@@ -3785,10 +3788,12 @@ void TypeChecker::endVisit(UsingForDirective const& _usingFor)
 		return;
 	}
 
-	solAssert(_usingFor.typeName()->annotation().type);
+	Type const* usingForType = _usingFor.typeName()->annotation().type;
+	solAssert(usingForType);
+
 	Type const* normalizedType = TypeProvider::withLocationIfReference(
 		DataLocation::Storage,
-		_usingFor.typeName()->annotation().type
+		usingForType
 	);
 	solAssert(normalizedType);
 
@@ -3824,7 +3829,7 @@ void TypeChecker::endVisit(UsingForDirective const& _usingFor)
 					"The function \"{}\" cannot be bound to the type \"{}\" because the type cannot "
 					"be implicitly converted to the first argument of the function (\"{}\"){}",
 					joinHumanReadable(path->path(), "."),
-					_usingFor.typeName()->annotation().type->toString(true /* withoutDataLocation */),
+					usingForType->toString(true /* withoutDataLocation */),
 					functionType->selfType()->humanReadableName(),
 					result.message().empty() ? "." : ": " +  result.message()
 				)

--- a/libsolidity/analysis/ViewPureChecker.h
+++ b/libsolidity/analysis/ViewPureChecker.h
@@ -73,6 +73,8 @@ private:
 		std::optional<langutil::SourceLocation> const& _nestedLocation = {}
 	);
 
+	void reportFunctionCallMutability(StateMutability _mutability, langutil::SourceLocation const& _location);
+
 	/// Determines the mutability of modifier if not already cached.
 	MutabilityAndLocation const& modifierMutability(ModifierDefinition const& _modifier);
 


### PR DESCRIPTION
Another refactor PR extracted from #12362.

A bunch of trivial changes that move code around, extract common helpers, add helper variables or rename stuff. They don't add much on their own but they're still not wrong even without the operator PR and I want them merged separately to reduce the size of that PR. There are no functional changes here so I think this bit is also easier to review separately than mixed with all the actual changes.