### PR TITLE
Close stale issues

### DIFF
--- a/.github/workflows/stale-pull-requests.yml
+++ b/.github/workflows/stale-pull-requests.yml
@@ -1,4 +1,4 @@
-name: Check stale pull requests
+name: Check stale issues and pull requests
 
 on:
   workflow_dispatch:
@@ -6,12 +6,14 @@ on:
     - cron: '0 12 * * *'
 
 permissions:
-  issues: read
+  issues: write
   pull-requests: write
 
 env:
-  BEFORE_STALE: 14
-  BEFORE_CLOSE: 7
+  BEFORE_ISSUE_STALE: 180
+  BEFORE_ISSUE_CLOSE: 0 #FIXME: change to 14 days
+  BEFORE_PR_STALE: 14
+  BEFORE_PR_CLOSE: 7
 
 jobs:
   stale:
@@ -19,19 +21,28 @@ jobs:
     steps:
       - uses: actions/stale@v6
         with:
-          debug-only: false
-          # disable issues
-          days-before-issue-stale: -1
-          days-before-issue-close: -1
+          debug-only: true
+          days-before-issue-stale: ${{ env.BEFORE_ISSUE_STALE }}
+          days-before-issue-close: ${{ env.BEFORE_ISSUE_CLOSE }}
+          stale-issue-message: |
+            This issue has been marked as stale due to inactivity for the last ${{ env.BEFORE_ISSUE_STALE }} days.
+            It will be automatically closed in ${{ env.BEFORE_ISSUE_CLOSE }} days.
+          close-issue-message: |
+            Hi everyone! This issue has been closed due to inactivity.
+            If you think this issue is still relevant in the latest Solidity version and you have something to [contribute](https://docs.soliditylang.org/en/latest/contributing.html), feel free to reopen.
+            However, unless the issue is a concrete proposal that can be implemented, we recommend starting a language discussion on the [forum](https://forum.soliditylang.org) instead.
+          stale-issue-label: stale
+          close-issue-label: closed-due-inactivity
+          exempt-issue-labels: 'bug :bug:,roadmap,selected-for-development,must have'
           stale-pr-message: |
-            This pull request is stale because it has been open for ${{ env.BEFORE_STALE }} days with no activity.
-            It will be closed in ${{ env.BEFORE_CLOSE }} days unless the `stale` label is removed.
+            This pull request is stale because it has been open for ${{ env.BEFORE_PR_STALE }} days with no activity.
+            It will be closed in ${{ env.BEFORE_PR_CLOSE }} days unless the `stale` label is removed.
           close-pr-message: |
-            This pull request was closed due to a lack of activity for ${{ env.BEFORE_CLOSE }} days after it was stale.
+            This pull request was closed due to a lack of activity for ${{ env.BEFORE_PR_CLOSE }} days after it was stale.
           stale-pr-label: stale
           close-pr-label: closed-due-inactivity
-          days-before-pr-stale: ${{ env.BEFORE_STALE }}
-          days-before-pr-close: ${{ env.BEFORE_CLOSE }}
+          days-before-pr-stale: ${{ env.BEFORE_PR_STALE }}
+          days-before-pr-close: ${{ env.BEFORE_PR_CLOSE }}
           exempt-pr-labels: 'external contribution :star:,roadmap,epic'
           exempt-draft-pr: true
           exempt-all-milestones: true


### PR DESCRIPTION
This PR addresses some of the comments made here: https://github.com/ethereum/solidity/issues/13615#issuecomment-1325635999 and in the matrix channel.

It sets the `days-before-issue-close` to 0, forcing issues labeled with `stale` to be immediately closed.
The `days-before-issue-stale` is irrelevant in this case since @NunoFilipeSantos manually added the stale labels, and the action will have up to 180 days to close everything until it starts to label new stale issues.
As the action has a limit of operations per run due to the GitHub rate limit, not all issues will be closed in a single run.
The action excludes stale issues that also have any of the following labels: `bug`, `roadmap`, `must have` and `must have eventually`.
The closed issues will be labeled: `closed-due-inactivity`.
`DEBUG` is currently enabled.

Please see the changes in the first commit here: https://github.com/ethereum/solidity/commit/7ff369a752b07c97b1c495f506f94d22632cf6e2 since I also renamed the action to a more generic name.
