### PR TITLE
Fix internal error in multiple wrong options for SMTChecker natspec

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -24,6 +24,7 @@ Bugfixes:
  * SMTChecker: Fix display error for negative integers that are one more than powers of two.
  * SMTChecker: Improved readability for large integers that are powers of two or almost powers of two in error messages.
  * SMTChecker: Fix internal error when a public library function is called internally.
+ * SMTChecker: Fix internal error on multiple wrong SMTChecker natspec entries.
 
 
 ### 0.8.17 (2022-09-08)

--- a/libsolidity/formal/CHC.cpp
+++ b/libsolidity/formal/CHC.cpp
@@ -1102,14 +1102,18 @@ set<CHC::CHCNatspecOption> CHC::smtNatspecTags(FunctionDefinition const& _functi
 {
 	set<CHC::CHCNatspecOption> options;
 	string smtStr = "custom:smtchecker";
+	bool errorSeen = false;
 	for (auto const& [tag, value]: _function.annotation().docTags)
 		if (tag == smtStr)
 		{
 			string const& content = value.content;
 			if (auto option = natspecOptionFromString(content))
 				options.insert(*option);
-			else
+			else if (!errorSeen)
+			{
+				errorSeen = true;
 				m_errorReporter.warning(3130_error, _function.location(), "Unknown option for \"" + smtStr + "\": \"" + content + "\"");
+			}
 		}
 	return options;
 }

--- a/test/libsolidity/smtCheckerTests/natspec/natspec_smtchecker_multi_errors_1.sol
+++ b/test/libsolidity/smtCheckerTests/natspec/natspec_smtchecker_multi_errors_1.sol
@@ -1,0 +1,10 @@
+contract C {
+    /// @custom:smtchecker b
+    /// @custom:smtchecker
+    /// @custom:smtchecker a b c
+    function f() internal {}
+}
+
+contract D is C {}
+// ----
+// Warning 3130: (106-130): Unknown option for "custom:smtchecker": "b"


### PR DESCRIPTION
Fix https://github.com/ethereum/solidity/issues/13732

The ideal fix would be adding source location to DocTags so we could point exactly to the wrong tag, but that's quite a lot of overhead. This is a quite niche feature and the current error reporting in this PR should be enough.