### PR TITLE
Clarify which arrays can be resized with `.pop()` and `.push()`

### DIFF
--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -134,7 +134,9 @@ The numeric index becomes a required parameter for the getter.
 
 Accessing an array past its end causes a failing assertion. Methods ``.push()`` and ``.push(value)`` can be used
 to append a new element at the end of a dynamically-sized array, where ``.push()`` appends a zero-initialized element and returns
-a reference to it.
+a reference to it. Dynamically-sized arrays can only be resized in storage. In memory such arrays can be of arbitrary 
+size but the size cannot be changed once an array is allocated.
+
 
 .. index:: ! string, ! bytes
 

--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -133,7 +133,7 @@ It is possible to mark state variable arrays ``public`` and have Solidity create
 The numeric index becomes a required parameter for the getter.
 
 Accessing an array past its end causes a failing assertion. Methods ``.push()`` and ``.push(value)`` can be used
-to append a new element at the end of the array, where ``.push()`` appends a zero-initialized element and returns
+to append a new element at the end of a dynamically-sized array, where ``.push()`` appends a zero-initialized element and returns
 a reference to it.
 
 .. index:: ! string, ! bytes

--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -134,9 +134,11 @@ The numeric index becomes a required parameter for the getter.
 
 Accessing an array past its end causes a failing assertion. Methods ``.push()`` and ``.push(value)`` can be used
 to append a new element at the end of a dynamically-sized array, where ``.push()`` appends a zero-initialized element and returns
-a reference to it. Dynamically-sized arrays can only be resized in storage. In memory such arrays can be of arbitrary 
-size but the size cannot be changed once an array is allocated.
+a reference to it.
 
+.. note::
+    Dynamically-sized arrays can only be resized in storage.
+    In memory, such arrays can be of arbitrary size but the size cannot be changed once an array is allocated.
 
 .. index:: ! string, ! bytes
 


### PR DESCRIPTION
The docs should specify that members `.push()` and `.pop()` only exist for dynamically sized-arrays. This is done later in the section under the "Array Members" subheading but could cause some initial confusion when not mentioned earlier in the section. 