### PR TITLE
Fix spurious unreachable warning in `SemVerMatcher`

### DIFF
--- a/test/libsolidity/SemVerMatcher.cpp
+++ b/test/libsolidity/SemVerMatcher.cpp
@@ -75,6 +75,9 @@ SemVerMatchExpression parseExpression(string const& _input)
 		// Ignored, since a test case should have a parsable version
 		soltestAssert(false);
 	}
+
+	// FIXME: Workaround for spurious GCC 12.1 warning (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105794)
+	util::unreachable();
 }
 
 }


### PR DESCRIPTION
This is the same false-positive as #13087, but at a new spot. Probably introduced by the recently merged #12797. It only happens in Debug mode and we don't have a CI run for that.

Apparently this is still not fixed in GCC. My original report was closed as a duplicate but it's tracked as [bug#104787](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104787).

### Errors
This is what I'm getting locally without this workaround:
```
test/libsolidity/SemVerMatcher.cpp: In function ‘solidity::langutil::SemVerMatchExpression solidity::frontend::test::SemVerMatcher::{anonymous}::parseExpression(const std::string&)’:
test/libsolidity/SemVerMatcher.cpp:78:1: error: control reaches end of non-void function [-Werror=return-type]
   78 | }
      | ^
cc1plus: all warnings being treated as errors
make[2]: *** [test/CMakeFiles/soltest.dir/build.make:1028: test/CMakeFiles/soltest.dir/libsolidity/SemVerMatcher.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:868: test/CMakeFiles/soltest.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 86%] Built target solc
make: *** [Makefile:136: all] Error 2
```