### PR TITLE
Quick fix of prb-math external tests

### DIFF
--- a/test/externalTests/prb-math.sh
+++ b/test/externalTests/prb-math.sh
@@ -39,7 +39,9 @@ function prb_math_test
 {
     local repo="https://github.com/paulrberg/prb-math"
     local ref_type=branch
-    local ref=main
+    # We currently pin the prb-math version to the latest version that support hardhat
+    # Please see here for details: https://github.com/ethereum/solidity/issues/13767
+    local ref=v2.5.0
     local config_file="hardhat.config.ts"
     local config_var="config"
 


### PR DESCRIPTION
As mentioned in issue #13767 prb-math migrated to Foundry, and our current external tests setup does not support Foundry.

This PR adds a workaround pinning the prb-math to its latest version that still supports Hardhat.