### PR TITLE
[DOCS] Remove mentions of Yul being experimental from docs

### DIFF
--- a/docs/yul.rst
+++ b/docs/yul.rst
@@ -9,13 +9,9 @@ Yul
 Yul (previously also called JULIA or IULIA) is an intermediate language that can be
 compiled to bytecode for different backends.
 
-Support for EVM 1.0, EVM 1.5 and Ewasm is planned, and it is designed to
-be a usable common denominator of all three
-platforms. It can already be used in stand-alone mode and
-for "inline assembly" inside Solidity
-and there is an experimental implementation of the Solidity compiler
-that uses Yul as an intermediate language. Yul is a good target for
-high-level optimisation stages that can benefit all target platforms equally.
+It can be used in stand-alone mode and for "inline assembly" inside Solidity.
+The compiler uses Yul as an intermediate language in the IR-based code generator ("new codegen" or "IR-based codegen").
+Yul is a good target for high-level optimisation stages that can benefit all target platforms equally.
 
 Motivation and High-level Description
 =====================================


### PR DESCRIPTION
- Removes Ewasm and EVM 1.5 references
- Updates the text around viaIR to not be called experimental anymore