### PR TITLE
Update debian/compat to version 13

### DIFF
--- a/scripts/deps-ppa/static_z3.sh
+++ b/scripts/deps-ppa/static_z3.sh
@@ -73,16 +73,16 @@ cp "/tmp/${packagename}_${debversion}.orig.tar.gz" ../
 # Create debian package information
 
 mkdir debian
-echo 9 > debian/compat
+echo 13 > debian/compat
 # TODO: the Z3 packages have different build dependencies
 cat <<EOF > debian/control
 Source: z3-static
 Section: science
 Priority: extra
 Maintainer: Daniel Kirchner <daniel@ekpyron.org>
-Build-Depends: debhelper (>= 9.0.0),
+Build-Depends: debhelper (>= 13.0.0),
                cmake,
-               g++ (>= 5.0),
+               g++ (>= 9.0),
                git,
                libgmp-dev,
                dh-python,

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -156,15 +156,15 @@ cp "/tmp/${packagename}_${debversion}.orig.tar.gz" ../
 # Create debian package information
 
 mkdir debian
-echo 9 > debian/compat
+echo 13 > debian/compat
 cat <<EOF > debian/control
 Source: solc
 Section: science
 Priority: extra
 Maintainer: Christian (Buildserver key) <builds@ethereum.org>
-Build-Depends: ${SMTDEPENDENCY}debhelper (>= 9.0.0),
+Build-Depends: ${SMTDEPENDENCY}debhelper (>= 13.0.0),
                cmake,
-               g++ (>= 5.0),
+               g++ (>= 9.0),
                git,
                libgmp-dev,
                libboost-all-dev,


### PR DESCRIPTION

Compat version 13 is currently the recommended one.

An important change introduced in 10 was change of default to target parallel builds

https://github.com/Debian/debhelper/blob/5d1bb29841043d8e47ebbdd043e6cd086cad508e/debhelper.pod#compatibility-levels