### PR TITLE
docs(resources.rst): update editor extensions

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -43,17 +43,6 @@ Integrated (Ethereum) Development Environments
 Editor Integrations
 ===================
 
-* Atom
-
-    * `Etheratom <https://github.com/0mkara/etheratom>`_
-        Plugin for the Atom editor that features syntax highlighting, compilation and a runtime environment (Backend node & VM compatible).
-
-    * `Atom Solidity Linter <https://atom.io/packages/linter-solidity>`_
-        Plugin for the Atom editor that provides Solidity linting.
-
-    * `Atom Solium Linter <https://atom.io/packages/linter-solium>`_
-        Configurable Solidity linter for Atom using Solium (now Ethlint) as a base.
-
 * Emacs
 
     * `Emacs Solidity <https://github.com/ethereum/emacs-solidity/>`_
@@ -62,31 +51,40 @@ Editor Integrations
 * IntelliJ
 
     * `IntelliJ IDEA plugin <https://plugins.jetbrains.com/plugin/9475-intellij-solidity>`_
-        Solidity plugin for IntelliJ IDEA (and all other JetBrains IDEs)
+        Solidity plugin for IntelliJ IDEA (and all other JetBrains IDEs).
 
-* Sublime
+* Sublime Text
 
     * `Package for SublimeText - Solidity language syntax <https://packagecontrol.io/packages/Ethereum/>`_
         Solidity syntax highlighting for SublimeText editor.
 
 * Vim
 
-    * `Vim Solidity <https://github.com/tomlion/vim-solidity/>`_
-        Plugin for the Vim editor providing syntax highlighting.
+    * `Vim Solidity by Thesis <https://github.com/thesis/vim-solidity/>`_
+        Syntax highlighting for Solidity in Vim.
+
+    * `Vim Solidity by TovarishFin <https://github.com/TovarishFin/vim-solidity>`_
+        Vim syntax file for Solidity.
 
     * `Vim Syntastic <https://github.com/vim-syntastic/syntastic>`_
         Plugin for the Vim editor providing compile checking.
 
-* Visual Studio Code
+* Visual Studio Code (VS Code)
 
-    * `Visual Studio Code extension <https://juan.blanco.ws/solidity-contracts-in-visual-studio-code/>`_
+    * `Ethereum Remix Visual Studio Code extension <https://marketplace.visualstudio.com/items?itemName=RemixProject.ethereum-remix>`_
+        Ethereum Remix extension pack for VS Code
+
+    * `Solidity Visual Studio Code extension, by Juan Blanco <https://juan.blanco.ws/solidity-contracts-in-visual-studio-code/>`_
         Solidity plugin for Microsoft Visual Studio Code that includes syntax highlighting and the Solidity compiler.
+
+    * `Solidity Visual Studio Code extension, by Nomic Foundation <https://marketplace.visualstudio.com/items?itemName=NomicFoundation.hardhat-solidity>`_
+        Solidity and Hardhat support by the Hardhat team, including: syntax highlighting, jump to definition, renames, quick fixes and inline solc warnings and errors.
 
     * `Solidity Visual Auditor extension <https://marketplace.visualstudio.com/items?itemName=tintinweb.solidity-visual-auditor>`_
         Adds security centric syntax and semantic highlighting to Visual Studio Code.
 
-    * `Hardhat + Solidity Visual Studio Code extension <https://marketplace.visualstudio.com/items?itemName=NomicFoundation.hardhat-solidity>`_
-        Solidity and Hardhat support by the Hardhat team.
+    * `Truffle for VS Code <https://marketplace.visualstudio.com/items?itemName=trufflesuite-csi.truffle-vscode>`_
+        Build, debug and deploy smart contracts on Ethereum and EVM-compatible blockchains.
 
 Solidity Tools
 ==============


### PR DESCRIPTION
Update the editor extensions section of the resources page:

1. Remove the Atom section - as Atom is being deprecated on 2022-12-15. See https://github.blog/2022-06-08-sunsetting-atom/
2. Update the vim syntax plugins - add the thesis fork of the tomlion vim syntax highlighter. The thesis fork is maintained.
3. add/rename vscode extensions - add truffle and remix extensions and rename the two Solidity extensions to include the authors.