### PR TITLE
Fixed typo in abi.encodeWithSignature description

### DIFF
--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -24,7 +24,7 @@ Global Variables
 - ``abi.encodeCall(function functionPointer, (...)) returns (bytes memory)``: ABI-encodes a call to ``functionPointer`` with the arguments found in the
   tuple. Performs a full type-check, ensuring the types match the function signature. Result equals ``abi.encodeWithSelector(functionPointer.selector, (...))``
 - ``abi.encodeWithSignature(string memory signature, ...) returns (bytes memory)``: Equivalent
-  to ``abi.encodeWithSelector(bytes4(keccak256(bytes(signature)), ...)``
+  to ``abi.encodeWithSelector(bytes4(keccak256(bytes(signature))), ...)``
 - ``bytes.concat(...) returns (bytes memory)``: :ref:`Concatenates variable number of
   arguments to one byte array<bytes-concat>`
 - ``string.concat(...) returns (string memory)``: :ref:`Concatenates variable number of


### PR DESCRIPTION
In the description of abi.encodeWithSignature, a right parenthesis is missing in the function argument of abi.encodeWithSelector.

![image](https://user-images.githubusercontent.com/80020902/206095193-4528648c-2d80-431d-9158-9fac3f660143.png)
