### PR TITLE
Strict assembly fuzzer: Change optimization setting from full to minimal

### DIFF
--- a/test/tools/ossfuzz/strictasm_assembly_ossfuzz.cpp
+++ b/test/tools/ossfuzz/strictasm_assembly_ossfuzz.cpp
@@ -41,7 +41,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 		langutil::EVMVersion(),
 		nullopt,
 		YulStack::Language::StrictAssembly,
-		solidity::frontend::OptimiserSettings::full(),
+		solidity::frontend::OptimiserSettings::minimal(),
 		langutil::DebugInfoSelection::All()
 	);
 


### PR DESCRIPTION
I'm not sure what the `full` optimization setting does when YulStack is not used for optimization (only parsing).