### PR TITLE
Unskip test from elementfi external test

### DIFF
--- a/test/externalTests/elementfi.sh
+++ b/test/externalTests/elementfi.sh
@@ -87,10 +87,6 @@ function elementfi_test
     sed -i 's|bytes32(uint256(pool))|bytes32(uint256(uint160(pool)))|g' vault/PoolRegistry.sol
     popd
 
-    # The test suite uses forked Mainnet and an expiration period that's too short.
-    # TODO: Remove when https://github.com/element-fi/elf-contracts/issues/243 is fixed.
-    sed -i 's|^\s*require(_expiration - block\.timestamp < _unitSeconds);\s*$||g' contracts/ConvergentCurvePool.sol
-
     # Disable tests that won't pass on the ir presets due to Hardhat heuristics. Note that this also disables
     # them for other presets but that's fine - we want same code run for benchmarks to be comparable.
     # TODO: Remove this when Hardhat adjusts heuristics for IR (https://github.com/nomiclabs/hardhat/issues/2115).


### PR DESCRIPTION
Upstream issue was resolved, therefore removing the test skip
https://github.com/element-fi/elf-contracts/issues/243