### PR TITLE
Fixed some comments in `Types.h`

### DIFF
--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -802,14 +802,14 @@ public:
 	/// Constructor for a byte array ("bytes") and string.
 	explicit ArrayType(DataLocation _location, bool _isString = false);
 
-	/// Constructor for a dynamically sized array type ("type[]")
+	/// Constructor for a dynamically sized array type ("<type>[]")
 	ArrayType(DataLocation _location, Type const* _baseType):
 		ReferenceType(_location),
 		m_baseType(copyForLocationIfReference(_baseType))
 	{
 	}
 
-	/// Constructor for a fixed-size array type ("type[20]")
+	/// Constructor for a fixed-size array type ("<type>[<length>]")
 	ArrayType(DataLocation _location, Type const* _baseType, u256 _length):
 		ReferenceType(_location),
 		m_baseType(copyForLocationIfReference(_baseType)),


### PR DESCRIPTION
Note sure if `"type[]"` and `"type[20]"` were given as examples or not in the blocks below:

```c++
/// Constructor for a dynamically sized array type ("type[]")
...
/// Constructor for a fixed-size array type ("type[20]")
```

This PR replaces them with their generic form that was also used in a few lines above as a comment for `class ArrayType`:

```c++
/**
 * The type of an array. The flavours are byte array (bytes), statically- (<type>[<length>])
 * and dynamically-sized array (<type>[]).
```