### PR TITLE
Add numeric short form in assembly

### DIFF
--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -512,6 +512,8 @@ variant<Literal, Identifier> Parser::parseLiteralOrIdentifier()
 	case Token::FalseLiteral:
 	{
 		LiteralKind kind = LiteralKind::Number;
+		string currLiteral = currentLiteral();
+
 		switch (currentToken())
 		{
 		case Token::StringLiteral:
@@ -519,7 +521,15 @@ variant<Literal, Identifier> Parser::parseLiteralOrIdentifier()
 			kind = LiteralKind::String;
 			break;
 		case Token::Number:
-			if (!isValidNumberLiteral(currentLiteral()))
+			currLiteral.erase(std::remove(currLiteral.begin(), currLiteral.end(), '_'), currLiteral.end());
+			if (currLiteral.find("e") != string::npos || currLiteral.find("E") != string::npos)
+			{
+				istringstream os(currLiteral);
+				double d;
+				os >> d;
+				currLiteral = to_string(d).substr(0, to_string(d).find('.'));
+			}
+			if (!isValidNumberLiteral(currLiteral))
 				fatalParserError(4828_error, "Invalid number literal.");
 			kind = LiteralKind::Number;
 			break;
@@ -534,7 +544,7 @@ variant<Literal, Identifier> Parser::parseLiteralOrIdentifier()
 		Literal literal{
 			createDebugData(),
 			kind,
-			YulString{currentLiteral()},
+			YulString{currLiteral},
 			kind == LiteralKind::Boolean ? m_dialect.boolType : m_dialect.defaultType
 		};
 		advance();

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -522,7 +522,7 @@ variant<Literal, Identifier> Parser::parseLiteralOrIdentifier()
 			break;
 		case Token::Number:
 			currLiteral.erase(std::remove(currLiteral.begin(), currLiteral.end(), '_'), currLiteral.end());
-			if (currLiteral.find("e") != string::npos || currLiteral.find("E") != string::npos)
+			if (currLiteral.find("e") != string::npos && !(boost::starts_with(currLiteral, "0x") || boost::starts_with(currLiteral, "0X")))
 			{
 				istringstream os(currLiteral);
 				double d;

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -522,13 +522,6 @@ variant<Literal, Identifier> Parser::parseLiteralOrIdentifier()
 			break;
 		case Token::Number:
 			currLiteral.erase(std::remove(currLiteral.begin(), currLiteral.end(), '_'), currLiteral.end());
-			if (currLiteral.find("e") != string::npos && !(boost::starts_with(currLiteral, "0x") || boost::starts_with(currLiteral, "0X")))
-			{
-				istringstream os(currLiteral);
-				double d;
-				os >> d;
-				currLiteral = to_string(d).substr(0, to_string(d).find('.'));
-			}
 			if (!isValidNumberLiteral(currLiteral))
 				fatalParserError(4828_error, "Invalid number literal.");
 			kind = LiteralKind::Number;

--- a/test/libsolidity/semanticTests/constants/asm_numerical_underscores.sol
+++ b/test/libsolidity/semanticTests/constants/asm_numerical_underscores.sol
@@ -1,0 +1,40 @@
+contract A {
+    function b() public returns (uint i) {
+        assembly {
+            i := 3_200_000_000
+        }
+    }
+
+    function c() public returns (uint i) {
+        assembly {
+            i := 3200000000
+        }
+    }
+
+    function d() public returns (int i) {
+        assembly {
+            i := 3_200_000_000
+        }
+    }
+
+    function e() public returns (int i) {
+        assembly {
+            i := 32e8
+        }
+    }
+
+    function f() public returns (string memory j) {
+        string memory s = "string_with_underscores";
+        assembly {
+            j := s
+        }
+    }
+}
+// ====
+// compileToEwasm: also
+// ----
+// b() -> 3200000000
+// c() -> 3200000000
+// d() -> 3200000000
+// e() -> 3200000000
+// f() -> 0x20, 23, "string_with_underscores"

--- a/test/libsolidity/semanticTests/constants/asm_numerical_underscores.sol
+++ b/test/libsolidity/semanticTests/constants/asm_numerical_underscores.sol
@@ -16,31 +16,6 @@ contract A {
             i := 3_200_000_000
         }
     }
-
-    function e() public returns (int i) {
-        assembly {
-            i := 32e8
-        }
-    }
-
-    function f() public returns (int h) {
-        assembly {
-            h := 0xBEBC2000
-        }
-    }
-
-    function g() public returns (int h) {
-        assembly {
-            h := 0xbebc2000
-        }
-    }
-
-    function h() public returns (string memory j) {
-        string memory s = "string_with_underscores";
-        assembly {
-            j := s
-        }
-    }
 }
 // ====
 // compileToEwasm: also
@@ -48,7 +23,3 @@ contract A {
 // b() -> 3200000000
 // c() -> 3200000000
 // d() -> 3200000000
-// e() -> 3200000000
-// f() -> 3200000000
-// g() -> 3200000000
-// h() -> 0x20, 23, "string_with_underscores"

--- a/test/libsolidity/semanticTests/constants/asm_numerical_underscores.sol
+++ b/test/libsolidity/semanticTests/constants/asm_numerical_underscores.sol
@@ -23,7 +23,19 @@ contract A {
         }
     }
 
-    function f() public returns (string memory j) {
+    function f() public returns (int h) {
+        assembly {
+            h := 0xBEBC2000
+        }
+    }
+
+    function g() public returns (int h) {
+        assembly {
+            h := 0xbebc2000
+        }
+    }
+
+    function h() public returns (string memory j) {
         string memory s = "string_with_underscores";
         assembly {
             j := s
@@ -37,4 +49,6 @@ contract A {
 // c() -> 3200000000
 // d() -> 3200000000
 // e() -> 3200000000
-// f() -> 0x20, 23, "string_with_underscores"
+// f() -> 3200000000
+// g() -> 3200000000
+// h() -> 0x20, 23, "string_with_underscores"

--- a/test/libyul/yulSyntaxTests/number_literal_3.yul
+++ b/test/libyul/yulSyntaxTests/number_literal_3.yul
@@ -1,2 +1,3 @@
 { let x:u256 := 1e5:u256 }
 // ----
+// ParserError 4828: (16-19): Invalid number literal.

--- a/test/libyul/yulSyntaxTests/number_literal_3.yul
+++ b/test/libyul/yulSyntaxTests/number_literal_3.yul
@@ -1,3 +1,2 @@
 { let x:u256 := 1e5:u256 }
 // ----
-// ParserError 4828: (16-19): Invalid number literal.

--- a/test/libyul/yulSyntaxTests/number_literals_3.yul
+++ b/test/libyul/yulSyntaxTests/number_literals_3.yul
@@ -2,4 +2,3 @@
 	let x := 1e5
 }
 // ----
-// ParserError 4828: (12-15): Invalid number literal.

--- a/test/libyul/yulSyntaxTests/number_literals_3.yul
+++ b/test/libyul/yulSyntaxTests/number_literals_3.yul
@@ -2,3 +2,4 @@
 	let x := 1e5
 }
 // ----
+// ParserError 4828: (12-15): Invalid number literal.


### PR DESCRIPTION
Added functionality for assembly to support underscore's and scientific notation in numeric short form. Fixes #13407

This will now work:
```
contract A {
    function b() public pure {
    uint c;
        assembly {
            c := 3200000000
            c := 3_200_000_000
            c := 1e3
        }
    }
}
```