### PR TITLE
Fix a few typos in docstrings, comments and variable names

### DIFF
--- a/test/libsolidity/AnalysisFramework.h
+++ b/test/libsolidity/AnalysisFramework.h
@@ -72,7 +72,7 @@ protected:
 	std::vector<std::string> m_warningsToFilter = {"This is a pre-release compiler version"};
 	std::vector<std::string> m_messagesToCut = {"Source file requires different compiler version (current compiler is"};
 
-	/// @returns reference to lazy-instanciated CompilerStack.
+	/// @returns reference to lazy-instantiated CompilerStack.
 	solidity::frontend::CompilerStack& compiler()
 	{
 		if (!m_compiler)
@@ -80,7 +80,7 @@ protected:
 		return *m_compiler;
 	}
 
-	/// @returns reference to lazy-instanciated CompilerStack.
+	/// @returns reference to lazy-instantiated CompilerStack.
 	solidity::frontend::CompilerStack const& compiler() const
 	{
 		if (!m_compiler)

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -1538,7 +1538,7 @@ BOOST_AUTO_TEST_CASE(struct_referencing)
 				s.a = 4;
 				return s;
 			}
-			// argument-dependant lookup tests
+			// argument-dependent lookup tests
 			function a(I.S memory) public pure returns (uint) { return 1; }
 			function a(S memory) public pure returns (uint) { return 2; }
 		}

--- a/test/libsolidity/semanticTests/externalContracts/snark.sol
+++ b/test/libsolidity/semanticTests/externalContracts/snark.sol
@@ -164,10 +164,10 @@ contract Test {
 		Pairing.G1Point memory p2;
 		p1.X = 1; p1.Y = 2;
 		p2.X = 1; p2.Y = 2;
-		Pairing.G1Point memory explict_sum = Pairing.add(p1, p2);
+		Pairing.G1Point memory explicit_sum = Pairing.add(p1, p2);
 		Pairing.G1Point memory scalar_prod = Pairing.mul(p1, 2);
-		return (explict_sum.X == scalar_prod.X &&
-			explict_sum.Y == scalar_prod.Y);
+		return (explicit_sum.X == scalar_prod.X &&
+			explicit_sum.Y == scalar_prod.Y);
 	}
 	function g() public returns (bool) {
 		Pairing.G1Point memory x = Pairing.add(Pairing.P1(), Pairing.negate(Pairing.P1()));

--- a/test/libsolidity/semanticTests/structs/struct_referencing.sol
+++ b/test/libsolidity/semanticTests/structs/struct_referencing.sol
@@ -15,7 +15,7 @@ library L {
         s.a = 4;
         return s;
     }
-    // argument-dependant lookup tests
+    // argument-dependent lookup tests
     function a(I.S memory) public pure returns (uint) { return 1; }
     function a(S memory) public pure returns (uint) { return 2; }
 }

--- a/test/tools/ossfuzz/protoToAbiV2.cpp
+++ b/test/tools/ossfuzz/protoToAbiV2.cpp
@@ -944,7 +944,7 @@ string TypeVisitor::visit(StructType const& _type)
 		structDefinition(_type);
 		// Set last dyn param if struct contains a dyn param e.g., bytes, array etc.
 		m_isLastDynParamRightPadded = DynParamVisitor().visit(_type);
-		// If top-level struct is a non-emtpy struct, assign the name S<suffix>
+		// If top-level struct is a non-empty struct, assign the name S<suffix>
 		m_baseType = s_structTypeName + to_string(m_structStartCounter);
 	}
 	else


### PR DESCRIPTION
Hi,

This PR will fix : 

- 2 typos in `test/libsolidity/AnalysisFramework.h`
- 1 typo in `test/libsolidity/SolidityEndToEndTest.cpp`
- 3 typos in `test/libsolidity/semanticTests/externalContracts/snark.sol`
- 1 typo in `test/libsolidity/semanticTests/structs/struct_referencing.sol`
- 1 typo in `test/tools/ossfuzz/protoToAbiV2.cpp`



Ciao! :robot: