### PR TITLE
fix sphinx version to 5.* since 6.0 is not supported by code

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,4 +7,4 @@ pygments-lexer-solidity>=0.7.0
 sphinx-a4doc==1.3.0
 
 # Sphinx 2.1.0 is the oldest version that accepts a lexer class in add_lexer()
-sphinx>=2.1.0
+sphinx>=2.1.0, <6.0


### PR DESCRIPTION
sphinx 6.0.0 was released several hours ago (https://github.com/sphinx-doc/sphinx/releases/tag/v6.0.0) and it is not supported by current code: example of filed docs build https://app.circleci.com/pipelines/github/ethereum/solidity/27991/workflows/8f12532e-1234-4041-80c3-e6d395958a30/jobs/1242177

I propose to fix version to 5.* as temporary fast solution