### PR TITLE
Unpin v4-core dependency and neutralize packaged contracts

### DIFF
--- a/test/externalTests/pool-together.sh
+++ b/test/externalTests/pool-together.sh
@@ -69,15 +69,13 @@ function pool_together_test
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")" "$config_var"
     yarn install
 
-    # TODO: Remove this when https://github.com/pooltogether/v4-core/issues/287 gets fixed.
-    npm install @pooltogether/pooltogether-rng-contracts@1.4.0
-
     # These come with already compiled artifacts. We want them recompiled with latest compiler.
     rm -r node_modules/@pooltogether/yield-source-interface/artifacts/
     rm -r node_modules/@pooltogether/uniform-random-number/artifacts/
     rm -r node_modules/@pooltogether/owner-manager-contracts/artifacts/
 
     replace_version_pragmas
+    neutralize_packaged_contracts
 
     for preset in $SELECTED_PRESETS; do
         hardhat_run_test "$config_file" "$preset" "${compile_only_presets[*]}" compile_fn test_fn "$config_var"


### PR DESCRIPTION
As we've previously [pinned the v4-core version](https://github.com/ethereum/solidity/pull/13806) in pooltogether external tests, and reported an [issue](https://github.com/pooltogether/v4-core/issues/287), which has been resolved - I am removing the version pin. However, when doing so, we get the following error:
```
Wrong compiler version detected
```
This is a know issue, and we have `neutralize_packaged_contracts` for that precise reason.