### PR TITLE
Update sphinx-a4doc version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@
 sphinx_rtd_theme>=0.5.2
 
 pygments-lexer-solidity>=0.7.0
-sphinx-a4doc==1.3.0
+sphinx-a4doc>=1.6.0
 
 # Sphinx 2.1.0 is the oldest version that accepts a lexer class in add_lexer()
 sphinx>=2.1.0, <6.0


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/13820 by updating the minimum `sphinx-a4doc` version to `1.6.0`. The [issue](https://github.com/taminomara/sphinx-a4doc/issues/16) was fixed upstream.