### PR TITLE
Disable t_ubu_ossfuzz gitter notifications.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -919,8 +919,6 @@ jobs:
             scripts/regressions.py -o test_results
       - store_test_results: *store_test_results
       - store_artifacts: *artifacts_test_results
-      - gitter_notify_failure_unless_pr
-      - gitter_notify_success_unless_pr
 
   b_archlinux:
     <<: *base_archlinux_large


### PR DESCRIPTION
We've had this job fail every day for years now, posting messages to the channel, without that making us fix it, so the notifications have clearly failed its purpose :-).

We can add them back, when the job is succeeding again, but for now the notifications serve little purpose other than spamming the channel :-).

Pinging @bshastry to be aware of this, in case we merge it.