### PR TITLE
Silence version check and up node heap limit for Zeppelin tests

### DIFF
--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -345,7 +345,7 @@ function truffle_verify_compiler_version
     local full_solc_version="$2"
 
     printLog "Verify that the correct version (${solc_version}/${full_solc_version}) of the compiler was used to compile the contracts..."
-    grep "$full_solc_version" --with-filename --recursive build/contracts || fail "Wrong compiler version detected."
+    grep "$full_solc_version" --recursive --quiet build/contracts || fail "Wrong compiler version detected."
 }
 
 function hardhat_verify_compiler_version
@@ -357,8 +357,8 @@ function hardhat_verify_compiler_version
     local build_info_files
     build_info_files=$(find . -path '*artifacts/build-info/*.json')
     for build_info_file in $build_info_files; do
-        grep '"solcVersion":[[:blank:]]*"'"${solc_version}"'"' --with-filename "$build_info_file" || fail "Wrong compiler version detected in ${build_info_file}."
-        grep '"solcLongVersion":[[:blank:]]*"'"${full_solc_version}"'"' --with-filename "$build_info_file" || fail "Wrong compiler version detected in ${build_info_file}."
+        grep '"solcVersion":[[:blank:]]*"'"${solc_version}"'"' --quiet "$build_info_file" || fail "Wrong compiler version detected in ${build_info_file}."
+        grep '"solcLongVersion":[[:blank:]]*"'"${full_solc_version}"'"' --quiet "$build_info_file" || fail "Wrong compiler version detected in ${build_info_file}."
     done
 }
 

--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -23,6 +23,8 @@
 # shellcheck disable=SC2016
 
 set -e
+# Temporary(?) fix to up the heap limit for node in order to prevent 'out of heap errors'
+export NODE_OPTIONS="--max-old-space-size=4096"
 
 source scripts/common.sh
 source test/externalTests/common.sh


### PR DESCRIPTION
The version check greps in `externalTests/common.sh` end up printing a ton of output to `stdout`, which pollutes stdout and reduces visibility in cause of failures. Also up the heap limit for node in order to prevent the root cause of the failures:
```
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```