### PR TITLE
Use directory_options instead of deprecated symlink_option

### DIFF
--- a/libsolidity/lsp/LanguageServer.cpp
+++ b/libsolidity/lsp/LanguageServer.cpp
@@ -221,7 +221,7 @@ vector<boost::filesystem::path> LanguageServer::allSolidityFilesFromProject() co
 	// We explicitly decided against including all files from include paths but leave the possibility
 	// open for a future PR to enable such a feature to be optionally enabled (default disabled).
 
-	auto directoryIterator = fs::recursive_directory_iterator(m_fileRepository.basePath(), fs::symlink_option::recurse);
+	auto directoryIterator = fs::recursive_directory_iterator(m_fileRepository.basePath(), fs::directory_options::follow_directory_symlink);
 	for (fs::directory_entry const& dirEntry: directoryIterator)
 		if (
 			dirEntry.path().extension() == ".sol" &&

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -589,7 +589,7 @@ void CommandLineInterface::createFile(string const& _fileName, string const& _da
 
 void CommandLineInterface::createJson(string const& _fileName, string const& _json)
 {
-	createFile(boost::filesystem::basename(_fileName) + string(".json"), _json);
+	createFile(boost::filesystem::path(_fileName).stem().string() + string(".json"), _json);
 }
 
 bool CommandLineInterface::run(int _argc, char const* const* _argv)


### PR DESCRIPTION
This should fix the `b_osx` build, since we kinda need that one.