### PR TITLE
Fix some deprecated calls with `boost v1.81`

### DIFF
--- a/libsolidity/lsp/LanguageServer.cpp
+++ b/libsolidity/lsp/LanguageServer.cpp
@@ -221,7 +221,7 @@ vector<boost::filesystem::path> LanguageServer::allSolidityFilesFromProject() co
 	// We explicitly decided against including all files from include paths but leave the possibility
 	// open for a future PR to enable such a feature to be optionally enabled (default disabled).
 
-	auto directoryIterator = fs::recursive_directory_iterator(m_fileRepository.basePath(), fs::symlink_option::recurse);
+	auto directoryIterator = fs::recursive_directory_iterator(m_fileRepository.basePath(), fs::directory_options::follow_directory_symlink);
 	for (fs::directory_entry const& dirEntry: directoryIterator)
 		if (
 			dirEntry.path().extension() == ".sol" &&

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -589,7 +589,7 @@ void CommandLineInterface::createFile(string const& _fileName, string const& _da
 
 void CommandLineInterface::createJson(string const& _fileName, string const& _json)
 {
-	createFile(boost::filesystem::basename(_fileName) + string(".json"), _json);
+	createFile(boost::filesystem::path(_fileName).stem().string() + string(".json"), _json);
 }
 
 bool CommandLineInterface::run(int _argc, char const* const* _argv)


### PR DESCRIPTION
A build with `boost v1.81` was not possible due to some deprecation warnings.

```
[ 56%] Building CXX object libsolidity/CMakeFiles/solidity.dir/parsing/DocStringParser.cpp.o
/Users/alex/git/solidity/libsolidity/lsp/LanguageServer.cpp:224:27: error: 'recursive_directory_iterator' is deprecated: Use directory_options instead of symlink_option [-Werror,-Wdeprecated-declarations]
        auto directoryIterator = fs::recursive_directory_iterator(m_fileRepository.basePath(), fs::symlink_option::recurse);
                                 ^
/opt/homebrew/include/boost/filesystem/directory.hpp:576:5: note: 'recursive_directory_iterator' has been explicitly marked deprecated here
    BOOST_FILESYSTEM_DETAIL_DEPRECATED("Use directory_options instead of symlink_option")
    ^
/opt/homebrew/include/boost/filesystem/config.hpp:85:64: note: expanded from macro 'BOOST_FILESYSTEM_DETAIL_DEPRECATED'
#define BOOST_FILESYSTEM_DETAIL_DEPRECATED(msg) __attribute__((deprecated(msg)))
                                                               ^
/Users/alex/git/solidity/libsolidity/lsp/LanguageServer.cpp:224:27: error: 'recursive_directory_iterator' is deprecated: Use directory_options instead of symlink_option [-Werror,-Wdeprecated-declarations]
        auto directoryIterator = fs::recursive_directory_iterator(m_fileRepository.basePath(), fs::symlink_option::recurse);
                                 ^
/opt/homebrew/include/boost/filesystem/directory.hpp:576:5: note: 'recursive_directory_iterator' has been explicitly marked deprecated here
    BOOST_FILESYSTEM_DETAIL_DEPRECATED("Use directory_options instead of symlink_option")
    ^
/opt/homebrew/include/boost/filesystem/config.hpp:85:64: note: expanded from macro 'BOOST_FILESYSTEM_DETAIL_DEPRECATED'
#define BOOST_FILESYSTEM_DETAIL_DEPRECATED(msg) __attribute__((deprecated(msg)))
                                                               ^
2 errors generated.
make[2]: *** [libsolidity/CMakeFiles/solidity.dir/lsp/LanguageServer.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [libsolidity/CMakeFiles/solidity.dir/all] Error 2
make: *** [all] Error 2
```

```
[ 59%] Building CXX object tools/CMakeFiles/phaser.dir/yulPhaser/Population.cpp.o
/Users/alex/git/solidity/solc/CommandLineInterface.cpp:592:32: error: 'basename' is deprecated: Use path::stem() instead [-Werror,-Wdeprecated-declarations]
        createFile(boost::filesystem::basename(_fileName) + string(".json"), _json);
                                      ^
/opt/homebrew/include/boost/filesystem/convenience.hpp:34:1: note: 'basename' has been explicitly marked deprecated here
BOOST_FILESYSTEM_DETAIL_DEPRECATED("Use path::stem() instead")
^
/opt/homebrew/include/boost/filesystem/config.hpp:85:64: note: expanded from macro 'BOOST_FILESYSTEM_DETAIL_DEPRECATED'
#define BOOST_FILESYSTEM_DETAIL_DEPRECATED(msg) __attribute__((deprecated(msg)))
                                                               ^
1 error generated.
make[2]: *** [solc/CMakeFiles/solcli.dir/CommandLineInterface.cpp.o] Error 1
```