### PR TITLE
Correct the return values in the example with multiple modifier placeholders in `ir-breaking-changes.rst`

### DIFF
--- a/docs/ir-breaking-changes.rst
+++ b/docs/ir-breaking-changes.rst
@@ -122,8 +122,8 @@ hiding new and different behavior in existing code.
           modifier mod() { _; _; }
       }
 
-  If you execute ``f(0)`` in the old code generator, it will return ``2``, while
-  it will return ``1`` when using the new code generator.
+  If you execute ``f(0)`` in the old code generator, it will return ``1``, while
+  it will return ``0`` when using the new code generator.
 
   .. code-block:: solidity
 


### PR DESCRIPTION
Fix errors in the doc