### PR TITLE
Remove more workarounds from gnosis ext test

### DIFF
--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -73,13 +73,8 @@ function gnosis_safe_test
     # them for other presets but that's fine - we want same code run for benchmarks to be comparable.
     # TODO: Remove this when Hardhat adjusts heuristics for IR (https://github.com/nomiclabs/hardhat/issues/3365).
     sed -i "s|\(it\)\(('should not allow to call setup on singleton'\)|\1.skip\2|g" test/core/Safe.Setup.spec.ts
-    sed -i 's|\(it\)\(("changes the expected storage slot without touching the most important ones"\)|\1.skip\2|g' test/libraries/SignMessageLib.spec.ts
     sed -i "s|\(it\)\(('can be used only via DELEGATECALL opcode'\)|\1.skip\2|g" test/libraries/SignMessageLib.spec.ts
-    sed -i 's|\(describe\)\(("Upgrade from Safe 1.1.1"\)|\1.skip\2|g' test/migration/UpgradeFromSafe111.spec.ts
-    sed -i 's|\(describe\)\(("Upgrade from Safe 1.2.0"\)|\1.skip\2|g' test/migration/UpgradeFromSafe120.spec.ts
-    sed -i "s|it\(('should enforce delegatecall'\)|it.skip\1|g" test/accessors/SimulateTxAccessor.spec.ts
     sed -i "s|it\(('can only be called from Safe itself'\)|it.skip\1|g" test/libraries/Migration.spec.ts
-    sed -i "s|it\(('should enforce delegatecall to MultiSend'\)|it.skip\1|g" test/libraries/MultiSend.spec.ts
 
     neutralize_package_lock
     neutralize_package_json_hooks


### PR DESCRIPTION
As mentioned here https://github.com/ethereum/solidity/pull/13878#pullrequestreview-1253082426, I found some more workarounds in the current gnosis external test that we could remove. Sadly I was a bit late to comment on the PR before it got merged.