### PR TITLE
[DOCS] Update copyright year and description

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Solidity'
-project_copyright = '2016-2021, Ethereum'
+project_copyright = '2016-2023, The solidity Authors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,7 +63,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Solidity'
-project_copyright = '2016-2023, The solidity Authors'
+project_copyright = '2016-2023, The Solidity Authors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
This change updates the year from 2021 to 2023.

Additionally I propose to change the copyright description from ``Ethereum`` to ``The solidity Authors``.
This is more accurate and descriptive.

Alternatively we could also use ``The Solidity Team``.

Geth does it in a similar fashion, see the [footer in their docs](https://geth.ethereum.org/docs).

<img width="280" alt="image" src="https://user-images.githubusercontent.com/41991517/214850851-93afe014-bd3a-40f3-9334-ac5388d73ab6.png">
