### PR TITLE
Allow Public functions in interfaces

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 Language Features:
 * Allow named parameters in mapping types.
+* Allow functions to be declared as public in interfaces.
 
 
 Compiler Features:

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -547,7 +547,7 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 
 		if (_function.isConstructor())
 			m_errorReporter.typeError(6482_error, _function.location(), "Constructor cannot be defined in interfaces.");
-		else if (_function.visibility() != Visibility::External || _function.visibility() != Visibility::Public)
+		else if (_function.visibility() != Visibility::External && _function.visibility() != Visibility::Public)
 			m_errorReporter.typeError(1560_error, _function.location(), "Functions in interfaces must be declared external or public.");
 	}
 	else if (m_currentContract->contractKind() == ContractKind::Library)

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -547,8 +547,8 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 
 		if (_function.isConstructor())
 			m_errorReporter.typeError(6482_error, _function.location(), "Constructor cannot be defined in interfaces.");
-		else if (_function.visibility() != Visibility::External)
-			m_errorReporter.typeError(1560_error, _function.location(), "Functions in interfaces must be declared external.");
+		else if (_function.visibility() != Visibility::External || _function.visibility() != Visibility::Public)
+			m_errorReporter.typeError(1560_error, _function.location(), "Functions in interfaces must be declared external or public.");
 	}
 	else if (m_currentContract->contractKind() == ContractKind::Library)
 		if (_function.isConstructor())

--- a/test/libsolidity/syntaxTests/visibility/interface/function_default.sol
+++ b/test/libsolidity/syntaxTests/visibility/interface/function_default.sol
@@ -3,4 +3,4 @@ interface I {
 }
 // ----
 // SyntaxError 4937: (15-28): No visibility specified. Did you intend to add "external"?
-// TypeError 1560: (15-28): Functions in interfaces must be declared external.
+// TypeError 1560: (15-28): Functions in interfaces must be declared external or public.

--- a/test/libsolidity/syntaxTests/visibility/interface/function_default.sol
+++ b/test/libsolidity/syntaxTests/visibility/interface/function_default.sol
@@ -3,4 +3,3 @@ interface I {
 }
 // ----
 // SyntaxError 4937: (15-28): No visibility specified. Did you intend to add "external"?
-// TypeError 1560: (15-28): Functions in interfaces must be declared external or public.

--- a/test/libsolidity/syntaxTests/visibility/interface/function_internal.sol
+++ b/test/libsolidity/syntaxTests/visibility/interface/function_internal.sol
@@ -2,4 +2,4 @@ interface I {
 	function f() internal;
 }
 // ----
-// TypeError 1560: (15-37): Functions in interfaces must be declared external.
+// TypeError 1560: (15-37): Functions in interfaces must be declared external or public.

--- a/test/libsolidity/syntaxTests/visibility/interface/function_private.sol
+++ b/test/libsolidity/syntaxTests/visibility/interface/function_private.sol
@@ -2,4 +2,4 @@ interface I {
 	function f() private;
 }
 // ----
-// TypeError 1560: (15-36): Functions in interfaces must be declared external.
+// TypeError 1560: (15-36): Functions in interfaces must be declared external or public.

--- a/test/libsolidity/syntaxTests/visibility/interface/function_public.sol
+++ b/test/libsolidity/syntaxTests/visibility/interface/function_public.sol
@@ -2,4 +2,3 @@ interface I {
 	function f() public;
 }
 // ----
-// TypeError 1560: (15-35): Functions in interfaces must be declared external.

--- a/test/libsolidity/syntaxTests/visibility/interface/interface_contract_function_default.sol
+++ b/test/libsolidity/syntaxTests/visibility/interface/interface_contract_function_default.sol
@@ -9,4 +9,3 @@ abstract contract C {
 // ----
 // SyntaxError 4937: (158-171): No visibility specified. Did you intend to add "external"?
 // SyntaxError 4937: (200-215): No visibility specified. Did you intend to add "public"?
-// TypeError 1560: (158-171): Functions in interfaces must be declared external or public.

--- a/test/libsolidity/syntaxTests/visibility/interface/interface_contract_function_default.sol
+++ b/test/libsolidity/syntaxTests/visibility/interface/interface_contract_function_default.sol
@@ -9,4 +9,4 @@ abstract contract C {
 // ----
 // SyntaxError 4937: (158-171): No visibility specified. Did you intend to add "external"?
 // SyntaxError 4937: (200-215): No visibility specified. Did you intend to add "public"?
-// TypeError 1560: (158-171): Functions in interfaces must be declared external.
+// TypeError 1560: (158-171): Functions in interfaces must be declared external or public.


### PR DESCRIPTION
Fixes #13890

- Should "default" visibility be accepted? Is it equivalent to public or do we want public to be explicit?
- I'm not sure why, but some test fail ... can you help me identify why ?