### PR TITLE
Suppress libcln in nightly asan jobs

### DIFF
--- a/.circleci/cln-asan.supp
+++ b/.circleci/cln-asan.supp
@@ -1,0 +1,1 @@
+leak:*libcln*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1094,6 +1094,9 @@ jobs:
     environment:
       TERM: xterm
       ASAN_OPTIONS: check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2
+      # Suppress CLN memory leak.
+      # See: https://github.com/ethereum/solidity/issues/13891 for details.
+      LSAN_OPTIONS: suppressions=.circleci/cln-asan.supp
     <<: *steps_cmdline_tests
 
   t_ubu_asan_soltest:
@@ -1104,6 +1107,9 @@ jobs:
       OPTIMIZE: 0
       SOLTEST_FLAGS: --no-smt
       ASAN_OPTIONS: check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2
+      # Suppress CLN memory leak.
+      # See: https://github.com/ethereum/solidity/issues/13891 for details.
+      LSAN_OPTIONS: suppressions=.circleci/cln-asan.supp
     <<: *steps_soltest
 
   t_ubu_asan_clang_soltest:


### PR DESCRIPTION
Workaround to https://github.com/ethereum/solidity/issues/13891 by suppressing CLN memory leak errors in `t_ubu_asan_soltest` and `t_ubu_asan_cli`.

I tested it in a local docker image based on the current develop branch (commit `206e7cf`) with `-DSANITIZE=address` and `ASAN_OPTIONS="check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2"` as done by the CI.