### PR TITLE
libsolutil: Add missing `cstdint` include to fix a warning on GCC 13

### DIFF
--- a/liblangutil/EVMVersion.h
+++ b/liblangutil/EVMVersion.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <string>
 

--- a/libsolutil/Common.h
+++ b/libsolutil/Common.h
@@ -42,11 +42,12 @@
 
 #include <boost/version.hpp>
 
+#include <cstdint>
+#include <functional>
 #include <map>
+#include <string>
 #include <utility>
 #include <vector>
-#include <functional>
-#include <string>
 
 namespace solidity
 {


### PR DESCRIPTION
This helps suppressing the following message during compilation:

```
/builddir/build/BUILD/solidity-0.8.18/libsolutil/Common.h:55:27: error: 'uint8_t' was not declared in this scope
   55 | using bytes = std::vector<uint8_t>;
      |                           ^~~~~~~
/builddir/build/BUILD/solidity-0.8.18/libsolutil/Common.h:49:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   48 | #include <functional>
  +++ |+#include <cstdint>
   49 | #include <string>
```

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>