### PR TITLE
Release checklist tweaks and clarifications

### DIFF
--- a/ReleaseChecklist.md
+++ b/ReleaseChecklist.md
@@ -33,7 +33,9 @@
        Set the target to the ``develop`` branch and the tag to the new version, e.g. ``v0.8.5``.
        Include the following warning: ``**The release is still in progress and the binaries may not yet be available from all sources.**``.
        Don't publish it yet - click the ``Save draft`` button instead.
- - [ ] Thank voluntary contributors in the GitHub release notes (use ``git shortlog --summary --email v0.5.3..origin/develop``).
+ - [ ] Thank voluntary contributors in the GitHub release notes.
+       Use ``scripts/list_contributors.sh v<previous version>`` to get initial list of names.
+       Remove different variants of the same name manually before using the output.
  - [ ] Check that all tests on the latest commit in ``develop`` are green.
  - [ ] Click the ``Publish release`` button on the release page, creating the tag.
  - [ ] Wait for the CI runs on the tag itself.

--- a/ReleaseChecklist.md
+++ b/ReleaseChecklist.md
@@ -12,15 +12,34 @@
  - [ ] Access to the [solidity_lang Twitter account](https://twitter.com/solidity_lang).
  - [ ] [Reddit](https://www.reddit.com) account that is at least 10 days old with a minimum of 20 comment karma (``/r/ethereum`` requirements).
 
+### Pre-flight checks
+At least a day before the release:
+ - [ ] Run ``make linkcheck`` from within ``docs/`` and fix any broken links it finds.
+       Ignore false positives caused by ``href`` anchors and dummy links not meant to work.
+ - [ ] Make sure that all merged PRs that should have changelog entries do have them.
+ - [ ] Rerun CI on the top commits of main branches in all repositories that do not have daily activity by creating a test branch or PR:
+      - [ ] ``solc-js``
+      - [ ] ``solc-bin`` (make sure the bytecode comparison check did run)
+      - [ ] ``homebrew-ethereum``
+ - [ ] (Optional) Create a prerelease in our Ubuntu PPA by following the steps in the PPA section below on ``develop`` rather than on a tag.
+       This is recommended especially when dealing with PPA for the first time, when we add a new Ubuntu version or when the PPA scripts were modified in this release cycle.
+ - [ ] Verify that the release tarball of ``solc-js`` works.
+       Bump version locally, add ``soljson.js`` from CI, build it, compare the file structure with the previous version, install it locally and try to use it.
+
+### Drafts
+At least a day before the release:
+ - [ ] Create a draft PR to sort the changelog.
+ - [ ] Create draft PRs to bump version in ``solidity`` and ``solc-js``.
+ - [ ] Create a draft of the release on github.
+ - [ ] Create a draft PR to update soliditylang.org.
+ - [ ] Create drafts of blog posts.
+ - [ ] Prepare drafts of Twitter, Reddit and Solidity Forum announcements.
+
 ### Blog Post
  - [ ] Create a post on [solidity-blog](https://github.com/ethereum/solidity-blog) in the ``Releases`` category and explain some of the new features or concepts.
  - [ ] Create a post on [solidity-blog](https://github.com/ethereum/solidity-blog) in the ``Security Alerts`` category in case of important bug(s).
 
-### Documentation check
- - [ ] Run ``make linkcheck`` from within ``docs/`` and fix any broken links it finds. Ignore false positives caused by ``href`` anchors and dummy links not meant to work.
-
 ### Changelog
- - [ ] Make sure that all merged PRs that should have changelog entries do have them.
  - [ ] Sort the changelog entries alphabetically and correct any errors you notice. Commit it.
  - [ ] Update the changelog to include a release date.
  - [ ] Run ``scripts/update_bugs_by_version.py`` to regenerate ``bugs_by_version.json`` from the changelog and ``bugs.json``.

--- a/ReleaseChecklist.md
+++ b/ReleaseChecklist.md
@@ -81,11 +81,15 @@ At least a day before the release:
  - [ ] Create ``.release_ppa_auth`` at the root of your local Solidity checkout and set ``LAUNCHPAD_EMAIL`` and ``LAUNCHPAD_KEYID`` to your key's email and key id.
  - [ ] Double-check that the ``DISTRIBUTIONS`` list in ``scripts/release_ppa.sh`` and ``scripts/deps-ppa/static_z3.sh`` contains the most recent versions of Ubuntu.
  - [ ] Make sure the [``~ethereum/cpp-build-deps`` PPA repository](https://launchpad.net/~ethereum/+archive/ubuntu/cpp-build-deps) contains ``libz3-static-dev builds`` for all current versions of Ubuntu.
-       If not, run ``scripts/deps-ppa/static_z3.sh`` and wait for the builds to succeed before continuing.
+       Note that it may be included in the ``z3-static`` multipackage (follow the ``View package details`` link to check).
+       If not present, run ``scripts/deps-ppa/static_z3.sh`` and wait for the builds to succeed before continuing.
  - [ ] Run ``scripts/release_ppa.sh v$VERSION`` to create the PPA release.
- - [ ] Wait for the [``~ethereum/ethereum-static`` PPA](https://launchpad.net/~ethereum/+archive/ubuntu/ethereum-static) build to be finished and published for *all platforms*.
+       This will create a single package containing static binary for older Ubuntu versions in the [``~ethereum/ethereum-static`` PPA](https://launchpad.net/~ethereum/+archive/ubuntu/ethereum-static)
+       and separate packages with dynamically-linked binaries for recent versions (those listed in ``DISTRIBUTIONS``) in the [``~ethereum/ethereum`` PPA](https://launchpad.net/~ethereum/+archive/ubuntu/ethereum).
+ - [ ] Wait for the build to be finished and published for *all architectures* (currently we only build for ``amd64``, but we may add ``arm`` in the future).
        **SERIOUSLY: DO NOT PROCEED EARLIER!!!**
-       *After* the static builds are *published*, copy the static package to the [``~ethereum/ethereum`` PPA](https://launchpad.net/~ethereum/+archive/ubuntu/ethereum)
+ - [ ] *After* the package with the static build is *published*, use it to create packages for older Ubuntu versions.
+       Copy the static package to the [``~ethereum/ethereum`` PPA](https://launchpad.net/~ethereum/+archive/ubuntu/ethereum)
        for the destination series ``Trusty``, ``Xenial`` and ``Bionic`` while selecting ``Copy existing binaries``.
 
 ### Release solc-js

--- a/ReleaseChecklist.md
+++ b/ReleaseChecklist.md
@@ -7,6 +7,7 @@
  - [ ] DockerHub account with push rights to the [``solc`` image](https://hub.docker.com/r/ethereum/solc).
  - [ ] Lauchpad (Ubuntu One) account with a membership in the ["Ethereum" team](https://launchpad.net/~ethereum) and
        a gnupg key for your email in the ``ethereum.org`` domain (has to be version 1, gpg2 won't work).
+ - [ ] Ubuntu/Debian dependencies of the PPA scripts: ``devscripts``, ``debhelper``, ``dput``, ``git``, ``wget``, ``ca-certificates``.
  - [ ] [npm Registry](https://www.npmjs.com) account added as a collaborator for the [``solc`` package](https://www.npmjs.com/package/solc).
  - [ ] Access to the [solidity_lang Twitter account](https://twitter.com/solidity_lang).
  - [ ] [Reddit](https://www.reddit.com) account that is at least 10 days old with a minimum of 20 comment karma (``/r/ethereum`` requirements).

--- a/ReleaseChecklist.md
+++ b/ReleaseChecklist.md
@@ -58,9 +58,9 @@
 
 ### PPA
  - [ ] Create ``.release_ppa_auth`` at the root of your local Solidity checkout and set ``LAUNCHPAD_EMAIL`` and ``LAUNCHPAD_KEYID`` to your key's email and key id.
- - [ ] Double-check that the ``DISTRIBUTIONS`` list in ``scripts/release_ppa.sh`` and ``scripts/deps-ppa/static-z3.sh`` contains the most recent versions of Ubuntu.
+ - [ ] Double-check that the ``DISTRIBUTIONS`` list in ``scripts/release_ppa.sh`` and ``scripts/deps-ppa/static_z3.sh`` contains the most recent versions of Ubuntu.
  - [ ] Make sure the [``~ethereum/cpp-build-deps`` PPA repository](https://launchpad.net/~ethereum/+archive/ubuntu/cpp-build-deps) contains ``libz3-static-dev builds`` for all current versions of Ubuntu.
-       If not, run ``scripts/deps-ppa/static-z3.sh`` and wait for the builds to succeed before continuing.
+       If not, run ``scripts/deps-ppa/static_z3.sh`` and wait for the builds to succeed before continuing.
  - [ ] Run ``scripts/release_ppa.sh v$VERSION`` to create the PPA release.
  - [ ] Wait for the [``~ethereum/ethereum-static`` PPA](https://launchpad.net/~ethereum/+archive/ubuntu/ethereum-static) build to be finished and published for *all platforms*.
        **SERIOUSLY: DO NOT PROCEED EARLIER!!!**

--- a/scripts/list_contributors.sh
+++ b/scripts/list_contributors.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# ------------------------------------------------------------------------------
+# Creates a list containing names of people who contributed to the project, for use
+# in release notes. The names come from the author field on the commits between
+# the current revision and the one specified as argument.
+#
+# Note that the output often requires extra manual processing to remove entries
+# that refer to the same person (diacritics vs no diacritics, name vs nickname, etc.).
+#
+# Usage:
+#    <script name>.sh <revision>
+#
+# ------------------------------------------------------------------------------
+# This file is part of solidity.
+#
+# solidity is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# solidity is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with solidity.  If not, see <http://www.gnu.org/licenses/>
+#
+# (c) 2023 solidity contributors.
+#------------------------------------------------------------------------------
+
+set -euo pipefail
+
+script_dir=$(dirname "$0")
+# shellcheck source=scripts/common.sh
+source "${script_dir}/common.sh"
+
+(( $# == 1)) || fail "Wrong number of arguments. Usage: $0 <revision>."
+
+revision="$1"
+
+# NOTE: Commas are removed from any names containing them. It would look confusing otherwise, given
+# that the list is delimited by commas. Hopefully no contributor uses a comma as their nickname.
+git shortlog --summary "${revision}..origin/develop" |
+    cut --field 2 |
+    tr --delete , |
+    sort |
+    uniq |
+    paste --serial --delimiter=, |
+    sed -e 's/,/, /g'


### PR DESCRIPTION
- Access to a Debian/Ubuntu machine is a prerequisite for updating the PPA.
- A script to simplify compiling a list of contributors.
- More details about the purpose of PPA steps.
- New sections with things we should be doing before the release detect typical problems early and not have to spend too much time on wording the communication on the release day.