### PR TITLE
libsolidity: Redundant std::move

### DIFF
--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -923,7 +923,7 @@ public:
 		ASTPointer<ParameterList> const& _returnParameters,
 		ASTPointer<Block> const& _body
 	):
-		CallableDeclaration(_id, _location, _name, std::move(_nameLocation), _visibility, _parameters, _isVirtual, _overrides, _returnParameters),
+		CallableDeclaration(_id, _location, _name, _nameLocation, _visibility, _parameters, _isVirtual, _overrides, _returnParameters),
 		StructurallyDocumented(_documentation),
 		ImplementationOptional(_body != nullptr),
 		m_stateMutability(_stateMutability),


### PR DESCRIPTION
This patch suppresses warnings like this one emitted by GCC 13.0.1 with -Werror:

```
/builddir/build/BUILD/solidity-0.8.18/libsolidity/ast/AST.h: In constructor 'solidity::frontend::FunctionDefinition::FunctionDefinition(int64_t, const solidity::frontend::ASTNode::SourceLocation&, solidity::frontend::ASTPointer<std::__cxx11::basic_string<char> >&, const solidity::frontend::ASTNode::SourceLocation&, solidity::frontend::Visibility, solidity::frontend::StateMutability, bool, solidity::langutil::Token, bool, solidity::frontend::ASTPointer<solidity::frontend::OverrideSpecifier>&, solidity::frontend::ASTPointer<solidity::frontend::StructuredDocumentation>&, solidity::frontend::ASTPointer<solidity::frontend::ParameterList>&, std::vector<std::shared_ptr<solidity::frontend::ModifierInvocation> >, solidity::frontend::ASTPointer<solidity::frontend::ParameterList>&, solidity::frontend::ASTPointer<solidity::frontend::Block>&)':
/builddir/build/BUILD/solidity-0.8.18/libsolidity/ast/AST.h:926:69: error: redundant move in initialization [-Werror=redundant-move]
  926 |                 CallableDeclaration(_id, _location, _name, std::move(_nameLocation), _visibility, _parameters, _isVirtual, _overrides, _returnParameters),
      |                                                            ~~~~~~~~~^~~~~~~~~~~~~~~
/builddir/build/BUILD/solidity-0.8.18/libsolidity/ast/AST.h:926:69: note: remove 'std::move' call
```

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>