### PR TITLE
Tweak wording in value type docs

### DIFF
--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -4,8 +4,7 @@
 Value Types
 ===========
 
-The following types are also called value types because variables of these
-types will always be passed by value, i.e. they are always copied when they
+The following are called value types because their variables will always be passed by value, i.e. they are always copied when they
 are used as function arguments or in assignments.
 
 .. index:: ! bool, ! true, ! false
@@ -47,7 +46,7 @@ access the minimum and maximum value representable by the type.
 
   Integers in Solidity are restricted to a certain range. For example, with ``uint32``, this is ``0`` up to ``2**32 - 1``.
   There are two modes in which arithmetic is performed on these types: The "wrapping" or "unchecked" mode and the "checked" mode.
-  By default, arithmetic is always "checked", which mean that if the result of an operation falls outside the value range
+  By default, arithmetic is always "checked", meaning that if an operation's result falls outside the value range 
   of the type, the call is reverted through a :ref:`failing assertion<assert-and-require>`. You can switch to "unchecked" mode
   using ``unchecked { ... }``. More details can be found in the section about :ref:`unchecked <unchecked>`.
 
@@ -182,7 +181,7 @@ Operators:
 Address
 -------
 
-The address type comes in two flavours, which are largely identical:
+The address type comes in two largely identical flavors:
 
 - ``address``: Holds a 20 byte value (size of an Ethereum address).
 - ``address payable``: Same as ``address``, but with the additional members ``transfer`` and ``send``.
@@ -653,13 +652,13 @@ smallest and respectively largest value of the given enum.
 
 .. _user-defined-value-types:
 
-User Defined Value Types
+User-defined Value Types
 ------------------------
 
-A user defined value type allows creating a zero cost abstraction over an elementary value type.
+A user-defined value type allows creating a zero cost abstraction over an elementary value type.
 This is similar to an alias, but with stricter type requirements.
 
-A user defined value type is defined using ``type C is V``, where ``C`` is the name of the newly
+A user-defined value type is defined using ``type C is V``, where ``C`` is the name of the newly
 introduced type and ``V`` has to be a built-in value type (the "underlying type"). The function
 ``C.wrap`` is used to convert from the underlying type to the custom type. Similarly, the
 function ``C.unwrap`` is used to convert from the custom type to the underlying type.
@@ -680,7 +679,7 @@ type with 18 decimals and a minimal library to do arithmetic operations on the t
     // SPDX-License-Identifier: GPL-3.0
     pragma solidity ^0.8.8;
 
-    // Represent a 18 decimal, 256 bit wide fixed point type using a user defined value type.
+    // Represent a 18 decimal, 256 bit wide fixed point type using a user-defined value type.
     type UFixed256x18 is uint256;
 
     /// A minimal library to do fixed point operations on UFixed256x18.

--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -46,7 +46,7 @@ access the minimum and maximum value representable by the type.
 
   Integers in Solidity are restricted to a certain range. For example, with ``uint32``, this is ``0`` up to ``2**32 - 1``.
   There are two modes in which arithmetic is performed on these types: The "wrapping" or "unchecked" mode and the "checked" mode.
-  By default, arithmetic is always "checked", meaning that if an operation's result falls outside the value range 
+  By default, arithmetic is always "checked", meaning that if an operation's result falls outside the value range
   of the type, the call is reverted through a :ref:`failing assertion<assert-and-require>`. You can switch to "unchecked" mode
   using ``unchecked { ... }``. More details can be found in the section about :ref:`unchecked <unchecked>`.
 


### PR DESCRIPTION
- User-defined were written inconsistently (with/without hyphen)
- Rewording some sentences for user clarity.