### PR TITLE
Fixes broken layout due to misplacement of open-in-remix link in documentation

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -50,13 +50,18 @@ pre {
 /* Link to Remix IDE shown next to code snippets */
 p.remix-link-container {
     position: relative;
-    right: -100%;        /* Positioned next to the the top-right corner of the code block following it. */
+    font-size: 12px;        /* Positioned next to the the top-right corner of the code block following it. */
+    top: -30px;
 }
 
 a.remix-link {
     position: absolute;  /* Remove it from normal flow not to affect the original position of the snippet. */
-    top: 0.5em;
-    width: 3.236em;      /* Size of the margin (= right-side padding in .wy-nav-content in the current theme). */
+    top: -0.1em;
+    width: 2.1em;      /* Size of the margin (= right-side padding in .wy-nav-content in the current theme). */
+    right: 3px;
+    background: darkgray;
+    border-radius: 4px;
+    padding: 5px;
 }
 
 a.remix-link .link-icon {


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/13948.

I just made some changes in CSS file and the result looks like this.
Let me know is this enough or suggest me something better is needed.

![Screenshot (28)](https://user-images.githubusercontent.com/111430616/217573230-b5d0b00b-74fd-499c-8190-3b3b52f87662.png)
