### PR TITLE
gp2 external test workaround

### DIFF
--- a/test/externalTests/common.sh
+++ b/test/externalTests/common.sh
@@ -235,8 +235,7 @@ function force_truffle_compiler_settings
 function name_hardhat_default_export
 {
     local config_file="$1"
-
-    local import="import {HardhatUserConfig} from 'hardhat/types';"
+    local import="import {HardhatUserConfig} from 'hardhat/types/config';"
     local config="const config: HardhatUserConfig = {"
     sed -i "s|^\s*export\s*default\s*{|${import}\n${config}|g" "$config_file"
     echo "export default config;" >> "$config_file"

--- a/test/externalTests/gp2.sh
+++ b/test/externalTests/gp2.sh
@@ -76,6 +76,9 @@ function gp2_test
     # See https://github.com/cowprotocol/contracts/issues/32
     yarn add @tenderly/hardhat-tenderly@1.1.6
 
+    # Add missing sinon type definitions
+    yarn add @types/sinon
+
     # Some dependencies come with pre-built artifacts. We want to build from scratch.
     rm -r node_modules/@gnosis.pm/safe-contracts/build/
 


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/13960 by adding a workaround to the Gnosis Protocol external tests.
