### PR TITLE
Update triage automation to use new project board and github projectV2 API

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -6,55 +6,122 @@ on:
       - opened
 
 env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GH_TOKEN: ${{ secrets.PROJECT_BOARD_AUTOMATION }}
   ORGANIZATION: ethereum
-  REPOSITORY: solidity
-  PROJECT_NUMBER: 43
-  DRY_RUN: false
+  PROJECT_NUMBER: 27 # Solidity Bug Triaging Board
+  # See: https://github.com/orgs/ethereum/projects/27/settings/fields/Status
+  COLUMN_FIELD_NAME: "Status"
+  TRIAGE_COLUMN_NAME: "To Triage"
+  DRY_RUN: true
 
 jobs:
   triage_issues:
     runs-on: ubuntu-latest
     steps:
-      - name: Retrieve the content of all columns on the board
+      - name: Retrieve the content of selected field on the project board
         run: |
           gh api graphql \
-            --raw-field owner="$ORGANIZATION" \
+            --raw-field organization="$ORGANIZATION" \
             --field project_number="$PROJECT_NUMBER" \
-            --raw-field repository_name="$REPOSITORY" \
             --raw-field query='
-              query($owner: String!, $repository_name: String!, $project_number: Int!) {
-                repository(owner: $owner, name: $repository_name) {
-                  project(number: $project_number) {
-                    columns(first: 10) {
+              query($organization: String!, $project_number: Int!) {
+                organization(login: $organization) {
+                  projectV2(number: $project_number) {
+                    id
+                    fields(first: 20) {
                       nodes {
-                        id,
-                        name
+                        ... on ProjectV2Field {
+                          id
+                          name
+                        }
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          name
+                          options {
+                            id
+                            name
+                          }
+                        }
                       }
                     }
                   }
                 }
-              }' > project_columns.json
-          echo 'COLUMN_ID='$(jq '.data.repository.project.columns.nodes[] | select(.name == "Triage") | .id' project_columns.json) >> $GITHUB_ENV
-          echo 'COLUMN_NAME='$(jq '.data.repository.project.columns.nodes[] | select(.name == "Triage") | .name' project_columns.json) >> $GITHUB_ENV
+              }' > single_select_fields.json
+          echo 'PROJECT_ID='$(
+            jq \
+              '.data.organization.projectV2.id' \
+              single_select_fields.json
+          ) >> $GITHUB_ENV
+          echo 'COLUMN_FIELD_ID='$(
+            jq \
+              --arg column_field_name "$COLUMN_FIELD_NAME" \
+              '.data.organization.projectV2.fields.nodes[]
+              | select(.name == $column_field_name)
+              | .id' \
+              single_select_fields.json
+          ) >> $GITHUB_ENV
+          echo 'TRIAGE_COLUMN_ID='$(
+            jq --raw-output \
+              --arg column_field_name "$COLUMN_FIELD_NAME" \
+              --arg triage_column_name "$TRIAGE_COLUMN_NAME" \
+              '.data.organization.projectV2.fields.nodes[]
+              | select(.name == $column_field_name)
+              | .options[]
+              | select(.name == $triage_column_name)
+              | .id' \
+              single_select_fields.json
+          ) >> $GITHUB_ENV
 
-      - name: Add issue#${{ github.event.issue.number }} to Triage column
+      - name: Add issue#${{ github.event.issue.number }} to project
         env:
           ISSUE_ID: ${{ github.event.issue.node_id }}
         run: |
-          echo "Adding issue: ${{ github.event.issue.number }} to column $COLUMN_NAME in project $PROJECT_NUMBER"
-          if [[ $DRY_RUN == "false" ]]; then
+          echo "Adding issue: ${{ github.event.issue.number }} to project ${{ env.PROJECT_NUMBER }}"
+          if [[ $DRY_RUN == 'false' ]]; then
+            echo 'ITEM_ID='$(
+              gh api graphql \
+                --jq '.data.addProjectV2ItemById.item.id' \
+                --raw-field project_id="$PROJECT_ID" \
+                --raw-field issue_id="$ISSUE_ID" \
+                --raw-field query='
+                mutation($project_id: ID!, $issue_id: ID!) {
+                  addProjectV2ItemById(input: {projectId: $project_id, contentId: $issue_id}) {
+                    item {
+                      id
+                    }
+                  }
+                }'
+            ) >> $GITHUB_ENV
+          fi
+
+      - name: Move issue#${{ github.event.issue.number }} to Triage column
+        run: |
+          echo "Moving issue: ${{ github.event.issue.number }} to Triage column in project ${{ env.PROJECT_NUMBER }}"
+          if [[ $DRY_RUN == 'false' ]]; then
             gh api graphql \
               --silent \
-              --raw-field column=$COLUMN_ID \
-              --raw-field issue=$ISSUE_ID \
+              --raw-field project_id="$PROJECT_ID" \
+              --raw-field item_id="$ITEM_ID" \
+              --raw-field column_field_id="$COLUMN_FIELD_ID" \
+              --raw-field column_value_id="$TRIAGE_COLUMN_ID" \
               --raw-field query='
-                mutation($column: ID!, $issue: ID!) {
-                  addProjectCard(input: {
-                    projectColumnId: $column,
-                    contentId: $issue
+                mutation (
+                  $project_id: ID!
+                  $item_id: ID!
+                  $column_field_id: ID!
+                  $column_value_id: String!
+                ) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $project_id
+                    itemId: $item_id
+                    fieldId: $column_field_id
+                    value: {
+                      singleSelectOptionId: $column_value_id
+                    }
                   }) {
-                    clientMutationId
+                    projectV2Item {
+                      id
+                    }
                   }
                 }'
           fi


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/13892

It requires the PAT named `PROJECT_BOARD_AUTOMATION` with the following permissions:
```
repo
read:project
```
