### PR TITLE
Improve error messages for wrong constructor arguments

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * ContractLevelChecker: Properly distinguish the case of missing base constructor arguments from having an unimplemented base function.
  * SMTChecker: Fix internal error when using the custom NatSpec annotation to abstract free functions.
  * TypeChecker: Also allow external library functions in ``using for``.
  * SMTChecker: Fix internal error caused by unhandled ``z3`` expressions that come from the solver when bitwise operators are used.

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -365,7 +365,7 @@ void TypeChecker::endVisit(InheritanceSpecifier const& _inheritance)
 				toString(arguments->size()) +
 				" arguments given but expected " +
 				toString(parameterTypes.size()) +
-				". Remove parentheses if you do not want to provide arguments here."
+				(arguments->size() == 0 ? ". Remove parentheses if you do not want to provide arguments here." : "")
 			);
 		}
 		for (size_t i = 0; i < std::min(arguments->size(), parameterTypes.size()); ++i)

--- a/test/libsolidity/syntaxTests/constructor/abstract_creation_forward_reference.sol
+++ b/test/libsolidity/syntaxTests/constructor/abstract_creation_forward_reference.sol
@@ -12,4 +12,4 @@ contract Parent {
 contract Child is Parent {
 }
 // ----
-// TypeError 3656: (226-254): Contract "Child" should be marked as abstract.
+// TypeError 3415: (226-254): No arguments passed to the base constructor. Specify the arguments or mark "Child" as abstract.

--- a/test/libsolidity/syntaxTests/constructor/base_constructor_missing_arguments.sol
+++ b/test/libsolidity/syntaxTests/constructor/base_constructor_missing_arguments.sol
@@ -12,14 +12,14 @@ contract I is C { constructor() {} }
 contract J is C { constructor() C {} }
 contract K is C { constructor() C() {} }
 // ----
-// TypeError 3656: (47-67): Contract "D" should be marked as abstract.
-// TypeError 3656: (68-106): Contract "E" should be marked as abstract.
+// TypeError 3415: (47-67): No arguments passed to the base constructor. Specify the arguments or mark "D" as abstract.
+// TypeError 3415: (68-106): No arguments passed to the base constructor. Specify the arguments or mark "E" as abstract.
 // DeclarationError 1563: (141-142): Modifier-style base constructor call without arguments.
-// TypeError 3656: (107-147): Contract "F" should be marked as abstract.
-// TypeError 3656: (192-210): Contract "H" should be marked as abstract.
-// TypeError 3656: (211-247): Contract "I" should be marked as abstract.
+// TypeError 3415: (107-147): No arguments passed to the base constructor. Specify the arguments or mark "F" as abstract.
+// TypeError 3415: (192-210): No arguments passed to the base constructor. Specify the arguments or mark "H" as abstract.
+// TypeError 3415: (211-247): No arguments passed to the base constructor. Specify the arguments or mark "I" as abstract.
 // DeclarationError 1563: (280-281): Modifier-style base constructor call without arguments.
-// TypeError 3656: (248-286): Contract "J" should be marked as abstract.
+// TypeError 3415: (248-286): No arguments passed to the base constructor. Specify the arguments or mark "J" as abstract.
 // TypeError 7927: (61-64): Wrong argument count for constructor call: 0 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
 // TypeError 7927: (82-85): Wrong argument count for constructor call: 0 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
 // TypeError 7927: (121-124): Wrong argument count for constructor call: 0 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.

--- a/test/libsolidity/syntaxTests/constructor/base_constructor_missing_arguments.sol
+++ b/test/libsolidity/syntaxTests/constructor/base_constructor_missing_arguments.sol
@@ -1,0 +1,30 @@
+contract C {
+    constructor(uint, bool) {}
+}
+
+contract D is C() {}
+contract E is C() { constructor() {} }
+contract F is C() { constructor() C {} }
+contract G is C() { constructor() C() {} }
+
+contract H is C {}
+contract I is C { constructor() {} }
+contract J is C { constructor() C {} }
+contract K is C { constructor() C() {} }
+// ----
+// TypeError 3656: (47-67): Contract "D" should be marked as abstract.
+// TypeError 3656: (68-106): Contract "E" should be marked as abstract.
+// DeclarationError 1563: (141-142): Modifier-style base constructor call without arguments.
+// TypeError 3656: (107-147): Contract "F" should be marked as abstract.
+// TypeError 3656: (192-210): Contract "H" should be marked as abstract.
+// TypeError 3656: (211-247): Contract "I" should be marked as abstract.
+// DeclarationError 1563: (280-281): Modifier-style base constructor call without arguments.
+// TypeError 3656: (248-286): Contract "J" should be marked as abstract.
+// TypeError 7927: (61-64): Wrong argument count for constructor call: 0 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 7927: (82-85): Wrong argument count for constructor call: 0 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 7927: (121-124): Wrong argument count for constructor call: 0 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 2973: (141-142): Wrong argument count for modifier invocation: 0 arguments given but expected 2.
+// TypeError 7927: (162-165): Wrong argument count for constructor call: 0 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 2973: (182-185): Wrong argument count for modifier invocation: 0 arguments given but expected 2.
+// TypeError 2973: (280-281): Wrong argument count for modifier invocation: 0 arguments given but expected 2.
+// TypeError 2973: (319-322): Wrong argument count for modifier invocation: 0 arguments given but expected 2.

--- a/test/libsolidity/syntaxTests/constructor/base_constructor_missing_arguments_abstract_inheritance_list_empty_parens.sol
+++ b/test/libsolidity/syntaxTests/constructor/base_constructor_missing_arguments_abstract_inheritance_list_empty_parens.sol
@@ -1,0 +1,16 @@
+abstract contract C {
+    constructor(uint, bool) {}
+}
+
+abstract contract D is C() {}
+abstract contract E is C() { constructor() {} }
+abstract contract F is C() { constructor() C {} }
+abstract contract G is C() { constructor() C() {} }
+// ----
+// DeclarationError 1563: (177-178): Modifier-style base constructor call without arguments.
+// TypeError 7927: (79-82): Wrong argument count for constructor call: 0 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 7927: (109-112): Wrong argument count for constructor call: 0 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 7927: (157-160): Wrong argument count for constructor call: 0 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 2973: (177-178): Wrong argument count for modifier invocation: 0 arguments given but expected 2.
+// TypeError 7927: (207-210): Wrong argument count for constructor call: 0 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 2973: (227-230): Wrong argument count for modifier invocation: 0 arguments given but expected 2.

--- a/test/libsolidity/syntaxTests/constructor/base_constructor_missing_arguments_abstract_lists_omitted.sol
+++ b/test/libsolidity/syntaxTests/constructor/base_constructor_missing_arguments_abstract_lists_omitted.sol
@@ -1,0 +1,6 @@
+abstract contract C {
+    constructor(uint, bool) {}
+}
+
+abstract contract D is C {}
+abstract contract E is C { constructor() {} }

--- a/test/libsolidity/syntaxTests/constructor/base_constructor_missing_arguments_abstract_modifier_init.sol
+++ b/test/libsolidity/syntaxTests/constructor/base_constructor_missing_arguments_abstract_modifier_init.sol
@@ -1,0 +1,8 @@
+abstract contract C {
+    constructor(uint, bool) {}
+}
+
+abstract contract D is C { constructor() C {} }
+// ----
+// DeclarationError 1563: (97-98): Modifier-style base constructor call without arguments.
+// TypeError 2973: (97-98): Wrong argument count for modifier invocation: 0 arguments given but expected 2.

--- a/test/libsolidity/syntaxTests/constructor/base_constructor_missing_arguments_abstract_modifier_init_empty_list.sol
+++ b/test/libsolidity/syntaxTests/constructor/base_constructor_missing_arguments_abstract_modifier_init_empty_list.sol
@@ -1,0 +1,7 @@
+abstract contract C {
+    constructor(uint, bool) {}
+}
+
+abstract contract D is C { constructor() C() {} }
+// ----
+// TypeError 2973: (97-100): Wrong argument count for modifier invocation: 0 arguments given but expected 2.

--- a/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_inheritance_and_modifier_lists.sol
+++ b/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_inheritance_and_modifier_lists.sol
@@ -1,0 +1,13 @@
+contract C {
+    constructor(uint, bool) {}
+}
+
+contract D is C(1, true, "a") { constructor() C(1, true, "a") {} }
+contract E is C(1) { constructor() C(1) {} }
+// ----
+// DeclarationError 3364: (93-108): Base constructor arguments given twice.
+// DeclarationError 3364: (149-153): Base constructor arguments given twice.
+// TypeError 7927: (61-76): Wrong argument count for constructor call: 3 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 2973: (93-108): Wrong argument count for modifier invocation: 3 arguments given but expected 2.
+// TypeError 7927: (128-132): Wrong argument count for constructor call: 1 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 2973: (149-153): Wrong argument count for modifier invocation: 1 arguments given but expected 2.

--- a/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_inheritance_and_modifier_lists.sol
+++ b/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_inheritance_and_modifier_lists.sol
@@ -7,7 +7,7 @@ contract E is C(1) { constructor() C(1) {} }
 // ----
 // DeclarationError 3364: (93-108): Base constructor arguments given twice.
 // DeclarationError 3364: (149-153): Base constructor arguments given twice.
-// TypeError 7927: (61-76): Wrong argument count for constructor call: 3 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 7927: (61-76): Wrong argument count for constructor call: 3 arguments given but expected 2
 // TypeError 2973: (93-108): Wrong argument count for modifier invocation: 3 arguments given but expected 2.
-// TypeError 7927: (128-132): Wrong argument count for constructor call: 1 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 7927: (128-132): Wrong argument count for constructor call: 1 arguments given but expected 2
 // TypeError 2973: (149-153): Wrong argument count for modifier invocation: 1 arguments given but expected 2.

--- a/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_inheritance_list.sol
+++ b/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_inheritance_list.sol
@@ -5,5 +5,5 @@ contract C {
 contract D is C(1, true, "a") {}
 contract E is C(1) {}
 // ----
-// TypeError 7927: (61-76): Wrong argument count for constructor call: 3 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
-// TypeError 7927: (94-98): Wrong argument count for constructor call: 1 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 7927: (61-76): Wrong argument count for constructor call: 3 arguments given but expected 2
+// TypeError 7927: (94-98): Wrong argument count for constructor call: 1 arguments given but expected 2

--- a/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_inheritance_list.sol
+++ b/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_inheritance_list.sol
@@ -1,0 +1,9 @@
+contract C {
+    constructor(uint, bool) {}
+}
+
+contract D is C(1, true, "a") {}
+contract E is C(1) {}
+// ----
+// TypeError 7927: (61-76): Wrong argument count for constructor call: 3 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 7927: (94-98): Wrong argument count for constructor call: 1 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.

--- a/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_inheritance_list_abstract.sol
+++ b/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_inheritance_list_abstract.sol
@@ -5,5 +5,5 @@ abstract contract C {
 abstract contract D is C(1, true, "a") {}
 abstract contract E is C(1) {}
 // ----
-// TypeError 7927: (79-94): Wrong argument count for constructor call: 3 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
-// TypeError 7927: (121-125): Wrong argument count for constructor call: 1 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 7927: (79-94): Wrong argument count for constructor call: 3 arguments given but expected 2
+// TypeError 7927: (121-125): Wrong argument count for constructor call: 1 arguments given but expected 2

--- a/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_inheritance_list_abstract.sol
+++ b/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_inheritance_list_abstract.sol
@@ -1,0 +1,9 @@
+abstract contract C {
+    constructor(uint, bool) {}
+}
+
+abstract contract D is C(1, true, "a") {}
+abstract contract E is C(1) {}
+// ----
+// TypeError 7927: (79-94): Wrong argument count for constructor call: 3 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 7927: (121-125): Wrong argument count for constructor call: 1 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.

--- a/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_inheritance_list_empty_parens_and_modifier_list.sol
+++ b/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_inheritance_list_empty_parens_and_modifier_list.sol
@@ -1,0 +1,11 @@
+contract C {
+    constructor(uint, bool) {}
+}
+
+contract D is C() { constructor() C(1, true, "a") {} }
+contract E is C() { constructor() C(1) {} }
+// ----
+// TypeError 7927: (61-64): Wrong argument count for constructor call: 0 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 2973: (81-96): Wrong argument count for modifier invocation: 3 arguments given but expected 2.
+// TypeError 7927: (116-119): Wrong argument count for constructor call: 0 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 2973: (136-140): Wrong argument count for modifier invocation: 1 arguments given but expected 2.

--- a/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_inheritance_list_with_derived_constructor.sol
+++ b/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_inheritance_list_with_derived_constructor.sol
@@ -5,5 +5,5 @@ contract C {
 contract D is C(1, true, "a") { constructor() {} }
 contract E is C(1) { constructor() {} }
 // ----
-// TypeError 7927: (61-76): Wrong argument count for constructor call: 3 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
-// TypeError 7927: (112-116): Wrong argument count for constructor call: 1 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 7927: (61-76): Wrong argument count for constructor call: 3 arguments given but expected 2
+// TypeError 7927: (112-116): Wrong argument count for constructor call: 1 arguments given but expected 2

--- a/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_inheritance_list_with_derived_constructor.sol
+++ b/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_inheritance_list_with_derived_constructor.sol
@@ -1,0 +1,9 @@
+contract C {
+    constructor(uint, bool) {}
+}
+
+contract D is C(1, true, "a") { constructor() {} }
+contract E is C(1) { constructor() {} }
+// ----
+// TypeError 7927: (61-76): Wrong argument count for constructor call: 3 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 7927: (112-116): Wrong argument count for constructor call: 1 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.

--- a/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_modifier_list.sol
+++ b/test/libsolidity/syntaxTests/constructor/base_constructor_wrong_arg_count_modifier_list.sol
@@ -1,0 +1,9 @@
+contract C {
+    constructor(uint, bool) {}
+}
+
+contract D is C { constructor() C(1, true, "a") {} }
+contract E is C { constructor() C(1) {} }
+// ----
+// TypeError 2973: (79-94): Wrong argument count for modifier invocation: 3 arguments given but expected 2.
+// TypeError 2973: (132-136): Wrong argument count for modifier invocation: 1 arguments given but expected 2.

--- a/test/libsolidity/syntaxTests/constructor/constructor_visibility.sol
+++ b/test/libsolidity/syntaxTests/constructor/constructor_visibility.sol
@@ -9,5 +9,5 @@ contract B is A {
   }
 }
 // ----
-// TypeError 3656: (124-303): Contract "B" should be marked as abstract.
+// TypeError 3415: (124-303): No arguments passed to the base constructor. Specify the arguments or mark "B" as abstract.
 // TypeError 9640: (252-256): Explicit type conversion not allowed from "string memory" to "contract A".

--- a/test/libsolidity/syntaxTests/inheritance/too_few_base_arguments.sol
+++ b/test/libsolidity/syntaxTests/inheritance/too_few_base_arguments.sol
@@ -6,5 +6,5 @@ contract Derived2 is Base {
   constructor() Base(2) { }
 }
 // ----
-// TypeError 7927: (67-74): Wrong argument count for constructor call: 1 arguments given but expected 2. Remove parentheses if you do not want to provide arguments here.
+// TypeError 7927: (67-74): Wrong argument count for constructor call: 1 arguments given but expected 2
 // TypeError 2973: (123-130): Wrong argument count for modifier invocation: 1 arguments given but expected 2.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/061_missing_base_constructor_arguments.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/061_missing_base_constructor_arguments.sol
@@ -1,4 +1,4 @@
 contract A { constructor(uint a) { } }
 contract B is A { }
 // ----
-// TypeError 3656: (39-58): Contract "B" should be marked as abstract.
+// TypeError 3415: (39-58): No arguments passed to the base constructor. Specify the arguments or mark "B" as abstract.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/062_base_constructor_arguments_override.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/062_base_constructor_arguments_override.sol
@@ -1,4 +1,4 @@
 contract A { constructor(uint a) { } }
 contract B is A { constructor(bytes4 a, bytes28 b) { } }
 // ----
-// TypeError 3656: (39-58): Contract "B" should be marked as abstract.
+// TypeError 3415: (39-95): No arguments passed to the base constructor. Specify the arguments or mark "B" as abstract.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/062_base_constructor_arguments_override.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/062_base_constructor_arguments_override.sol
@@ -1,4 +1,4 @@
 contract A { constructor(uint a) { } }
-contract B is A { }
+contract B is A { constructor(bytes4 a, bytes28 b) { } }
 // ----
 // TypeError 3656: (39-58): Contract "B" should be marked as abstract.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/525_reject_interface_constructors.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/525_reject_interface_constructors.sol
@@ -1,4 +1,4 @@
 interface I {}
 contract C is I(2) {}
 // ----
-// TypeError 7927: (29-33): Wrong argument count for constructor call: 1 arguments given but expected 0. Remove parentheses if you do not want to provide arguments here.
+// TypeError 7927: (29-33): Wrong argument count for constructor call: 1 arguments given but expected 0


### PR DESCRIPTION
Fixes #13824.

This tweaks error messages in two cases:
- Now a better error message is reported when arguments for base contract constructor are not given.
    - Until now it resulted in an error implying that the constructor is an unimplemented method.
    - The treatment of this class of errors was inconsistent. When an empty argument list was given on the modifier list of the constructor, a proper error about wrong number of arguments was issued. Same in case of wrong but non-zero number of arguments. Only specifically an empty argument list on an inheritance list had this effect.
    - Due to this the constructor will no longer appear in the `unimplementedDeclarations` annotation. Not sure if I should list this as an AST change but I think we do not expose the AST in case of compilation errors (unless via Standard JSON?) so it should not affect tooling.
- Removed the hint to remove the argument list from the constructor when the list is non-empty. A non-empty list clearly indicates that the intention was to perform initialization.