### PR TITLE
Fix Pragma: disallow prefixing operators with version ranges

### DIFF
--- a/liblangutil/SemVerHandler.cpp
+++ b/liblangutil/SemVerHandler.cpp
@@ -208,6 +208,13 @@ void SemVerMatchExpressionParser::parseMatchExpression()
 	range.components.push_back(parseMatchComponent());
 	if (currentToken() == Token::Sub)
 	{
+		if(containPrefixingToken()) {
+			solThrow(
+				SemVerError,
+				"You cannot use operators (<, <=, >=, >, ^) with verison ranges (-)."
+			);
+		}
+
 		range.components[0].prefix = Token::GreaterThanOrEqual;
 		nextToken();
 		range.components.push_back(parseMatchComponent());
@@ -323,4 +330,12 @@ void SemVerMatchExpressionParser::nextToken()
 {
 	++m_pos;
 	m_posInside = 0;
+}
+
+bool SemVerMatchExpressionParser::containPrefixingToken() const
+{
+	if (std::find_if(m_tokens.begin(), m_tokens.end(), TokenTraits::isPragmaOp) != m_tokens.end())
+		return true;
+	else
+		return false;
 }

--- a/liblangutil/SemVerHandler.h
+++ b/liblangutil/SemVerHandler.h
@@ -102,6 +102,7 @@ private:
 	char nextChar();
 	Token currentToken() const;
 	void nextToken();
+	bool containPrefixingToken() const;
 
 	std::vector<Token> m_tokens;
 	std::vector<std::string> m_literals;

--- a/liblangutil/Token.h
+++ b/liblangutil/Token.h
@@ -297,6 +297,7 @@ namespace TokenTraits
 		op == Token::Add || op == Token::Mul || op == Token::Equal || op == Token::NotEqual; }
 	constexpr bool isArithmeticOp(Token op) { return Token::Add <= op && op <= Token::Exp; }
 	constexpr bool isCompareOp(Token op) { return Token::Equal <= op && op <= Token::GreaterThanOrEqual; }
+	constexpr bool isPragmaOp(Token op) { return (Token::LessThan <= op && op <= Token::GreaterThanOrEqual) || op == Token::BitXor; }
 
 	constexpr bool isBitOp(Token op) { return (Token::BitOr <= op && op <= Token::BitAnd) || op == Token::BitNot; }
 	constexpr bool isBooleanOp(Token op) { return (Token::Or <= op && op <= Token::And) || op == Token::Not; }


### PR DESCRIPTION
Fixed issue:  #13920 

When pragma is using version ranges (-) it doesn't allow to use prefixing operators (<, <=, >=, >, ^).