### PR TITLE
Run triage action on all new issues independent of the presence of labels

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -15,7 +15,6 @@ env:
 jobs:
   triage_issues:
     runs-on: ubuntu-latest
-    if: join(github.event.issue.labels) == ''
     steps:
       - name: Retrieve the content of all columns on the board
         run: |


### PR DESCRIPTION
As commented here: https://github.com/ethereum/solidity/pull/13970#discussion_r1107534077 we will create issues based on predefined templates that already label some of them. So we need to update the triage action to run on all open issues, even if they already have some label added during creation. 