### PR TITLE
Revert debian compatibility for ubuntu focal support.

### DIFF
--- a/scripts/deps-ppa/static_z3.sh
+++ b/scripts/deps-ppa/static_z3.sh
@@ -73,16 +73,16 @@ cp "/tmp/${packagename}_${debversion}.orig.tar.gz" ../
 # Create debian package information
 
 mkdir debian
-echo 13 > debian/compat
+echo 9 > debian/compat
 # TODO: the Z3 packages have different build dependencies
 cat <<EOF > debian/control
 Source: z3-static
 Section: science
 Priority: extra
 Maintainer: Daniel Kirchner <daniel@ekpyron.org>
-Build-Depends: debhelper (>= 13.0.0),
+Build-Depends: debhelper (>= 9.0.0),
                cmake,
-               g++ (>= 9.0),
+               g++ (>= 5.0),
                git,
                libgmp-dev,
                dh-python,

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -156,15 +156,15 @@ cp "/tmp/${packagename}_${debversion}.orig.tar.gz" ../
 # Create debian package information
 
 mkdir debian
-echo 13 > debian/compat
+echo 9 > debian/compat
 cat <<EOF > debian/control
 Source: solc
 Section: science
 Priority: extra
 Maintainer: Christian (Buildserver key) <builds@ethereum.org>
-Build-Depends: ${SMTDEPENDENCY}debhelper (>= 13.0.0),
+Build-Depends: ${SMTDEPENDENCY}debhelper (>= 9.0.0),
                cmake,
-               g++ (>= 9.0),
+               g++ (>= 5.0),
                git,
                libgmp-dev,
                libboost-all-dev,


### PR DESCRIPTION
Reverts https://github.com/ethereum/solidity/pull/13781
since it causes issues like https://launchpadlibrarian.net/652849231/buildlog_ubuntu-focal-amd64.solc_1%3A0.8.19-0ubuntu1~focal_BUILDING.txt.gz

A build against the old script works (https://launchpad.net/~ethereum/+archive/ubuntu/ethereum/+build/25613224) - so since upgrading this doesn't actually bring much of a real advantage, we'll downgrade again until we drop focal support.