### PR TITLE
Uniform naming convention for github labels

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -33,8 +33,8 @@ jobs:
             However, unless the issue is a concrete proposal that can be implemented, we recommend starting a language discussion on the [forum](https://forum.soliditylang.org) instead.
           ascending: true
           stale-issue-label: stale
-          close-issue-label: closed-due-inactivity
-          exempt-issue-labels: 'bug :bug:,epic,roadmap,selected-for-development,must have,must have eventually,SMT'
+          close-issue-label: 'closed due inactivity'
+          exempt-issue-labels: 'bug :bug:,epic,roadmap,selected for development,must have,must have eventually,smt'
           stale-pr-message: |
             This pull request is stale because it has been open for ${{ env.BEFORE_PR_STALE }} days with no activity.
             It will be closed in ${{ env.BEFORE_PR_CLOSE }} days unless the `stale` label is removed.


### PR DESCRIPTION
Related to https://github.com/ethereum/solidity/pull/13970#discussion_r1115832284

I renamed most labels to use a uniform naming convention, so that it's harder to make a mistake in GH actions when refering to them:
- `Feature Request` -> `feature`
- `fuzz-blocker` -> `fuzz blocker`
- `Needs Investigation` -> `needs investigation`
- `solc-bin` -> `solcbin`
- `solc-js` -> `solcjs`
- `via-IR` -> `via ir`

That did not require code changes.

The `hacktoberfest-accepted` was not changed because that's the Hackoberfest requirement.

There are, however, also some labels that existing actions already refer to. This PR updates them. **We should rename those labels and merge the PR simultaneously**.
- `selected-for-development` -> `selected for development`
- `closed-due-inactivity` -> `closed due inactivity`
- `SMT` -> `smt`