### PR TITLE
Initialize vars before use

### DIFF
--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -540,8 +540,8 @@ void Scanner::scanToken()
 
 	Token token;
 	// M and N are for the purposes of grabbing different type sizes
-	unsigned m;
-	unsigned n;
+	unsigned m = 0;
+	unsigned n = 0;
 	do
 	{
 		// Remember the position of the next token


### PR DESCRIPTION
Looks like these two vars can be used before initialization. Spotted with GCC 12.