### PR TITLE
Explicitly use derived operator from base class

### DIFF
--- a/libsmtutil/Sorts.h
+++ b/libsmtutil/Sorts.h
@@ -57,6 +57,7 @@ struct IntSort: public Sort
 		isSigned(_signed)
 	{}
 
+	using Sort::operator==;
 	bool operator==(IntSort const& _other) const
 	{
 		return Sort::operator==(_other) && isSigned == _other.isSigned;
@@ -72,6 +73,7 @@ struct BitVectorSort: public Sort
 		size(_size)
 	{}
 
+	using Sort::operator==;
 	bool operator==(BitVectorSort const& _other) const
 	{
 		return Sort::operator==(_other) && size == _other.size;

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -786,6 +786,7 @@ public:
 	/// if the type has an interfaceType.
 	virtual BoolResult validForLocation(DataLocation _loc) const = 0;
 
+	using Type::operator==;
 	bool operator==(ReferenceType const& _other) const
 	{
 		return location() == _other.location() && isPointer() == _other.isPointer();


### PR DESCRIPTION
Thus suppress the following issue when compiling with -Werror=overloaded-virtual:

```
In file included from /builddir/build/BUILD/solidity-0.8.18/libsmtutil/SolverInterface.h:22,
                 from /builddir/build/BUILD/solidity-0.8.18/libsmtutil/CHCSolverInterface.h:25,
                 from /builddir/build/BUILD/solidity-0.8.18/libsmtutil/CHCSmtLib2Interface.h:25,
                 from /builddir/build/BUILD/solidity-0.8.18/libsmtutil/CHCSmtLib2Interface.cpp:19:
/builddir/build/BUILD/solidity-0.8.18/libsmtutil/Sorts.h:47:22: error: 'virtual bool solidity::smtutil::Sort::operator==(const solidity::smtutil::Sort&) const' was hidden [-Werror=overloaded-virtual=]
   47 |         virtual bool operator==(Sort const& _other) const { return kind == _other.kind; }
      |                      ^~~~~~~~
/builddir/build/BUILD/solidity-0.8.18/libsmtutil/Sorts.h:60:14: note:   by 'bool solidity::smtutil::IntSort::operator==(const solidity::smtutil::IntSort&) const'
   60 |         bool operator==(IntSort const& _other) const
      |              ^~~~~~~~
/builddir/build/BUILD/solidity-0.8.18/libsmtutil/Sorts.h:47:22: error: 'virtual bool solidity::smtutil::Sort::operator==(const solidity::smtutil::Sort&) const' was hidden [-Werror=overloaded-virtual=]
   47 |         virtual bool operator==(Sort const& _other) const { return kind == _other.kind; }
      |                      ^~~~~~~~
/builddir/build/BUILD/solidity-0.8.18/libsmtutil/Sorts.h:75:14: note:   by 'bool solidity::smtutil::BitVectorSort::operator==(const solidity::smtutil::BitVectorSort&) const'
   75 |         bool operator==(BitVectorSort const& _other) const
      |              ^~~~~~~~
```

```
In file included from /builddir/build/BUILD/solidity-0.8.18/libsolidity/ast/AST.h:27,
                 from /builddir/build/BUILD/solidity-0.8.18/libsolidity/ast/ASTVisitor.h:26,
                 from /builddir/build/BUILD/solidity-0.8.18/libsolidity/analysis/ConstantEvaluator.h:26,
                 from /builddir/build/BUILD/solidity-0.8.18/libsolidity/analysis/ConstantEvaluator.cpp:24:
/builddir/build/BUILD/solidity-0.8.18/libsolidity/ast/Types.h:221:22: error: 'virtual bool solidity::frontend::Type::operator==(const solidity::frontend::Type&) const' was hidden [-Werror=overloaded-virtual=]
  221 |         virtual bool operator==(Type const& _other) const { return category() == _other.category(); }
      |                      ^~~~~~~~
/builddir/build/BUILD/solidity-0.8.18/libsolidity/ast/Types.h:774:14: note:   by 'bool solidity::frontend::ReferenceType::operator==(const solidity::frontend::ReferenceType&) const'
  774 |         bool operator==(ReferenceType const& _other) const
      |              ^~~~~~~~
In file included from /builddir/build/BUILD/solidity-0.8.18/libsolidity/ast/AST.h:27,
                 from /builddir/build/BUILD/solidity-0.8.18/libsolidity/analysis/ContractLevelChecker.cpp:25:
/builddir/build/BUILD/solidity-0.8.18/libsolidity/ast/Types.h:221:22: error: 'virtual bool solidity::frontend::Type::operator==(const solidity::frontend::Type&) const' was hidden [-Werror=overloaded-virtual=]
  221 |         virtual bool operator==(Type const& _other) const { return category() == _other.category(); }
      |                      ^~~~~~~~
/builddir/build/BUILD/solidity-0.8.18/libsolidity/ast/Types.h:774:14: note:   by 'bool solidity::frontend::ReferenceType::operator==(const solidity::frontend::ReferenceType&) const'
  774 |         bool operator==(ReferenceType const& _other) const
      |              ^~~~~~~~
```