### PR TITLE
Optimize integer overflow checks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Language Features:
 
 Compiler Features:
  * Assembler: Use ``push0`` for placing ``0`` in the stack for EVM versions starting from "Shanghai". This decreases the deployment costs.
+ * Code Generator: More efficient overflow checks for integer addition and subtraction.
  * EVM: Set default EVM version to "Shanghai".
  * EVM: Support for the EVM Version "Shanghai".
  * NatSpec: Add support for NatSpec documentation in ``enum`` definitions.

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -628,10 +628,8 @@ string YulUtilFunctions::overflowCheckedIntAddFunction(IntegerType const& _type)
 					<?256bit>
 						// overflow, if x >= 0 and sum < y
 						// underflow, if x < 0 and sum >= y
-						if or(
-							and(iszero(slt(x, 0)), slt(sum, y)),
-							and(slt(x, 0), iszero(slt(sum, y)))
-						) { <panic>() }
+						// combine both conditions using xor
+						if xor(slt(x, 0), slt(sum, y)) { <panic>() }
 					<!256bit>
 						if or(
 							sgt(sum, <maxValue>),
@@ -829,11 +827,9 @@ string YulUtilFunctions::overflowCheckedIntSubFunction(IntegerType const& _type)
 				<?signed>
 					<?256bit>
 						// underflow, if y >= 0 and diff > x
-						// overflow, if y < 0 and diff < x
-						if or(
-							and(iszero(slt(y, 0)), sgt(diff, x)),
-							and(slt(y, 0), slt(diff, x))
-						) { <panic>() }
+						// overflow, if y < 0 and diff <= x
+						// combine both conditions using xor
+						if xor(slt(y, 0), slt(x, diff)) { <panic>() }
 					<!256bit>
 						if or(
 							slt(diff, <minValue>),

--- a/test/cmdlineTests/standard_debug_info_in_evm_asm_via_ir_location/output.json
+++ b/test/cmdlineTests/standard_debug_info_in_evm_asm_via_ir_location/output.json
@@ -326,8 +326,6 @@ sub_0: assembly {
       swap1
       dup2
       slt
-      0x01
-      and
       tag_14
       jumpi
         /* \"C\":79:428  contract C... */
@@ -351,15 +349,7 @@ sub_0: assembly {
       slt
       swap2
       slt
-      swap1
-      dup1
-      iszero
-      dup3
-      and
-      swap2
-      iszero
-      and
-      or
+      xor
       tag_38
       jumpi
       jump\t// out
@@ -433,8 +423,6 @@ sub_0: assembly {
   swap1
   dup2
   slt
-  0x01
-  and
   tag_7
   jumpi
   0x00
@@ -715,8 +703,6 @@ sub_0: assembly {
       swap1
       dup2
       slt
-      0x01
-      and
       tag_14
       jumpi
         /* \"D\":91:166  contract D is C(3)... */
@@ -740,15 +726,7 @@ sub_0: assembly {
       slt
       swap2
       slt
-      swap1
-      dup1
-      iszero
-      dup3
-      and
-      swap2
-      iszero
-      and
-      or
+      xor
       tag_38
       jumpi
       jump\t// out

--- a/test/cmdlineTests/standard_debug_info_in_yul_location/output.json
+++ b/test/cmdlineTests/standard_debug_info_in_yul_location/output.json
@@ -365,10 +365,8 @@ object \"C_54\" {
 
                 // overflow, if x >= 0 and sum < y
                 // underflow, if x < 0 and sum >= y
-                if or(
-                    and(iszero(slt(x, 0)), slt(sum, y)),
-                    and(slt(x, 0), iszero(slt(sum, y)))
-                ) { panic_error_0x11() }
+                // combine both conditions using xor
+                if xor(slt(x, 0), slt(sum, y)) { panic_error_0x11() }
 
             }
 
@@ -667,7 +665,7 @@ object \"C_54\" {
                         let _4 := loadimmutable(\"8\")
                         /// @src 0:79:435  \"contract C...\"
                         let sum := add(/** @src 0:124:126  \"41\" */ 0x29, /** @src 0:79:435  \"contract C...\" */ _4)
-                        if and(1, slt(sum, _4))
+                        if slt(sum, _4)
                         {
                             mstore(_3, shl(224, 0x4e487b71))
                             mstore(4, 0x11)
@@ -754,9 +752,7 @@ object \"C_54\" {
             function checked_add_int256(x, y) -> sum
             {
                 sum := add(x, y)
-                let _1 := slt(sum, y)
-                let _2 := slt(x, 0)
-                if or(and(iszero(_2), _1), and(_2, iszero(_1)))
+                if xor(slt(x, 0), slt(sum, y))
                 {
                     mstore(0, shl(224, 0x4e487b71))
                     mstore(4, 0x11)
@@ -910,10 +906,8 @@ object \"D_72\" {
 
             // overflow, if x >= 0 and sum < y
             // underflow, if x < 0 and sum >= y
-            if or(
-                and(iszero(slt(x, 0)), slt(sum, y)),
-                and(slt(x, 0), iszero(slt(sum, y)))
-            ) { panic_error_0x11() }
+            // combine both conditions using xor
+            if xor(slt(x, 0), slt(sum, y)) { panic_error_0x11() }
 
         }
 
@@ -1204,10 +1198,8 @@ object \"D_72\" {
 
                 // overflow, if x >= 0 and sum < y
                 // underflow, if x < 0 and sum >= y
-                if or(
-                    and(iszero(slt(x, 0)), slt(sum, y)),
-                    and(slt(x, 0), iszero(slt(sum, y)))
-                ) { panic_error_0x11() }
+                // combine both conditions using xor
+                if xor(slt(x, 0), slt(sum, y)) { panic_error_0x11() }
 
             }
 
@@ -1479,7 +1471,7 @@ object \"D_72\" {
             mstore(128, 0x2a)
             /// @src 1:91:166  \"contract D is C(3)...\"
             let sum := add(/** @src 1:107:108  \"3\" */ 0x03, /** @src 1:91:166  \"contract D is C(3)...\" */ value)
-            if and(1, slt(sum, value))
+            if slt(sum, value)
             {
                 mstore(/** @src -1:-1:-1 */ 0, /** @src 1:91:166  \"contract D is C(3)...\" */ shl(224, 0x4e487b71))
                 mstore(4, 0x11)
@@ -1513,7 +1505,7 @@ object \"D_72\" {
                         let _4 := loadimmutable(\"8\")
                         /// @src 1:91:166  \"contract D is C(3)...\"
                         let sum := add(/** @src 0:124:126  \"41\" */ 0x29, /** @src 1:91:166  \"contract D is C(3)...\" */ _4)
-                        if and(1, slt(sum, _4))
+                        if slt(sum, _4)
                         {
                             mstore(_3, shl(224, 0x4e487b71))
                             mstore(4, 0x11)
@@ -1600,9 +1592,7 @@ object \"D_72\" {
             function checked_add_int256(x, y) -> sum
             {
                 sum := add(x, y)
-                let _1 := slt(sum, y)
-                let _2 := slt(x, 0)
-                if or(and(iszero(_2), _1), and(_2, iszero(_1)))
+                if xor(slt(x, 0), slt(sum, y))
                 {
                     mstore(0, shl(224, 0x4e487b71))
                     mstore(4, 0x11)

--- a/test/formal/opcodes.py
+++ b/test/formal/opcodes.py
@@ -51,6 +51,9 @@ def AND(x, y):
 def OR(x, y):
 	return x | y
 
+def XOR(x, y):
+	return x ^ y
+
 def NOT(x):
 	return ~(x)
 

--- a/test/libsolidity/semanticTests/externalContracts/ramanujan_pi.sol
+++ b/test/libsolidity/semanticTests/externalContracts/ramanujan_pi.sol
@@ -33,10 +33,10 @@ contract test {
 }
 // ----
 // constructor()
-// gas irOptimized: 424583
-// gas legacy: 631753
-// gas legacyOptimized: 459425
+// gas irOptimized: 421127
+// gas legacy: 629586
+// gas legacyOptimized: 455753
 // prb_pi() -> 3141592656369545286
 // gas irOptimized: 57478
-// gas legacy: 101655
+// gas legacy: 101307
 // gas legacyOptimized: 75735

--- a/test/libsolidity/semanticTests/externalContracts/strings.sol
+++ b/test/libsolidity/semanticTests/externalContracts/strings.sol
@@ -49,9 +49,9 @@ contract test {
 }
 // ----
 // constructor()
-// gas irOptimized: 636074
-// gas legacy: 1065857
-// gas legacyOptimized: 725207
+// gas irOptimized: 634778
+// gas legacy: 1063913
+// gas legacyOptimized: 723257
 // toSlice(string): 0x20, 11, "hello world" -> 11, 0xa0
 // gas irOptimized: 22660
 // gas legacy: 23190


### PR DESCRIPTION
The arithmetic checks for integer addition and subtraction can be optimized.

Idea:
```solidity
function checkedAddInt(int256 a, int256 b) public pure returns (int256 c) {
    unchecked {
        c = a + b;

        bool overflow;

        assembly {
            // If `a >= 0`, then the sum `c = a + b` can't be less than `b`.
            // If `a <  0`, then the sum `c = a + b` can't be greater than `b`.
            // We combine these two conditions into one using `xor`.
            overflow := xor(slt(a, 0), slt(c, b))
        }

        if (overflow) arithmeticError();
    }
}
```

This saves somewhere between 30-31 gas depending on the optimization setting.