### PR TITLE
Update Solidity scripts to remove unencrypted git protocol

### DIFF
--- a/scripts/deps-ppa/static_z3.sh
+++ b/scripts/deps-ppa/static_z3.sh
@@ -89,7 +89,7 @@ Build-Depends: debhelper (>= 9.0.0),
                python3
 Standards-Version: 3.9.6
 Homepage: https://github.com/Z3Prover/z3
-Vcs-Git: git://github.com/Z3Prover/z3.git
+Vcs-Git: https://github.com/Z3Prover/z3.git
 Vcs-Browser: https://github.com/Z3Prover/z3
 
 Package: z3-static

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -173,7 +173,7 @@ Build-Depends: ${SMTDEPENDENCY}debhelper (>= 9.0.0),
                scons
 Standards-Version: 3.9.5
 Homepage: https://ethereum.org
-Vcs-Git: git://github.com/ethereum/solidity.git
+Vcs-Git: https://github.com/ethereum/solidity.git
 Vcs-Browser: https://github.com/ethereum/solidity
 
 Package: solc


### PR DESCRIPTION
### Description

GitHub has updated Git protocol security, and the usage of the unencrypted git protocol has been retired permanently on March 15th 2022. But, there are few instances of such in Solidity scripts file for Vcs-Git. Hence, may lead to bunch of unauthenticated git protocol errors.

### Proposed Solution

Use https protocol in place of unencrypted git protocol

`git://github.com/ethereum/solidity.git` should be changed to
`https://github.com/ethereum/solidity.git`


### Reference

https://github.blog/2021-09-01-improving-git-protocol-security-github/

Fixes  #14019