### PR TITLE
`build.sh` needs --install flag to install systemwide, `install.sh` installs pre-built binaries

### DIFF
--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -63,7 +63,7 @@ Global Variables
   with arbitrary precision and does not wrap around at ``2**256``. Assert that ``k != 0`` starting from version 0.5.0.
 - ``this`` (current contract's type): the current contract, explicitly convertible to ``address`` or ``address payable``
 - ``super``: the contract one level higher in the inheritance hierarchy
-- ``selfdestruct(address payable recipient)``: destroy the current contract, sending its funds to the given address
+-  ``selfdestruct(address payable recipient)``: (**Deprecated**) destroy the current contract and transfer its remaining funds to the specified recipient address (deprecated starting from Solidity 0.8.0, use transfer or send instead)
 - ``<address>.balance`` (``uint256``): balance of the :ref:`address` in Wei
 - ``<address>.code`` (``bytes memory``): code at the :ref:`address` (can be empty)
 - ``<address>.codehash`` (``bytes32``): the codehash of the :ref:`address`

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,7 +11,7 @@ else
 fi
 
 if [[ "$(git tag --points-at HEAD 2>/dev/null)" == v* ]]; then
-	touch "${ROOTDIR}/prerelease.txt"
+    touch "${ROOTDIR}/prerelease.txt"
 fi
 
 mkdir -p "${BUILDDIR}"
@@ -20,7 +20,13 @@ cd "${BUILDDIR}"
 cmake .. -DCMAKE_BUILD_TYPE="$BUILD_TYPE" "${@:2}"
 make -j2
 
-if [[ "${CI}" == "" ]]; then
-	echo "Installing ..."
-	sudo make install
+if [[ "$#" -gt 1 && "$2" == "--install" ]]; then
+    echo "Build complete. Installing ..."
+    if [[ "${CI}" == "" ]]; then
+        sudo make install
+    else
+        make install
+    fi
+else
+    echo "Build complete. Use --install flag to install."
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -e
+
+if [[ "$#" -eq 0 ]]; then
+    echo "Usage: $0 --from=<build_directory>"
+    exit 1
+fi
+
+BUILD_DIR=""
+for arg in "$@"; do
+    case $arg in
+        --from=*)
+        BUILD_DIR="${arg#*=}"
+        ;;
+        *)
+        echo "Invalid argument: $arg"
+        exit 1
+        ;;
+    esac
+done
+
+if [[ ! -d "$BUILD_DIR" ]]; then
+    echo "Error: Build directory '$BUILD_DIR' does not exist."
+    exit 1
+fi
+
+cd "$BUILD_DIR"
+
+if [[ ! -f "Makefile" ]]; then
+    echo "Error: Makefile not found in build directory."
+    exit 1
+fi
+
+if [[ "${CI}" == "" ]]; then
+    sudo make install
+else
+    make install
+fi
+
+echo "Installation complete."


### PR DESCRIPTION
Solves https://github.com/ethereum/solidity/issues/14012

`build.sh` needs an `--install` flag to install binaries system-wide.
`install.sh` can now install pre-built binaries, but needs a `--from=<BUILD DIRECTORY>` flag.