### PR TITLE
Fix `b_ubu_ubsan_clang` running the address sanitizer instead of the undefined behavior sanitizer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -650,7 +650,7 @@ defaults:
   - job_b_ubu_ubsan_clang: &job_b_ubu_ubsan_clang
       <<: *workflow_trigger_on_tags
       name: b_ubu_ubsan_clang
-      cmake_options: -DSANITIZE=address
+      cmake_options: -DSANITIZE=undefined
 
 # -----------------------------------------------------------------------------------------------
 jobs:


### PR DESCRIPTION
Looks like #11896 broke the undefined behavior sanitizer we run in nightly. It made the `ubsan` job run the address sanitizer instead. It's probably the reason why #14001 did not make nightly fail after we merged it.