### PR TITLE
docs/grammer: Fix the writing of unicodeStringLiteral rules.

### DIFF
--- a/docs/grammar/SolidityLexer.g4
+++ b/docs/grammar/SolidityLexer.g4
@@ -198,9 +198,7 @@ fragment EscapeSequence:
 /**
  * A single quoted string literal allowing arbitrary unicode characters.
  */
-UnicodeStringLiteral:
-	'unicode"' DoubleQuotedUnicodeStringCharacter* '"'
-	| 'unicode\'' SingleQuotedUnicodeStringCharacter* '\'';
+UnicodeStringLiteral: 'unicode' (('"' DoubleQuotedUnicodeStringCharacter* '"') | ('\'' SingleQuotedUnicodeStringCharacter* '\''));
 //@doc:inline
 fragment DoubleQuotedUnicodeStringCharacter: ~["\r\n\\] | EscapeSequence;
 //@doc:inline


### PR DESCRIPTION
UnicodeStringLiteral rules can be written with a common prefix
like HexString 

ref
https://github.com/ethereum/solidity/blob/ef6ff2f05550e4386f2fec7753a44fe39a124488/docs/grammar/SolidityLexer.g4#L213