### PR TITLE
Double number of operations per run for stale action bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -48,4 +48,4 @@ jobs:
           exempt-draft-pr: false
           exempt-all-milestones: true
           remove-stale-when-updated: true
-          operations-per-run: 128
+          operations-per-run: 256


### PR DESCRIPTION
This PR adds a workaround for the issue https://github.com/ethereum/solidity/issues/13986
It should not completely fix the issue though, so I think we should keep the issue open for now until we have a better solution for the problem.