### PR TITLE
Fix a couple of small errors in docs: broken/missing backticks, broken code blocks, bad capitalization

### DIFF
--- a/docs/bugs.rst
+++ b/docs/bugs.rst
@@ -68,7 +68,7 @@ conditions
     If no conditions are given, assume that the bug is present.
 check
     This field contains different checks that report whether the smart contract
-    contains the bug or not. The first type of check are Javascript regular
+    contains the bug or not. The first type of check are JavaScript regular
     expressions that are to be matched against the source code ("source-regex")
     if the bug is present.  If there is no match, then the bug is very likely
     not present. If there is a match, the bug might be present.  For improved

--- a/docs/contracts/events.rst
+++ b/docs/contracts/events.rst
@@ -151,6 +151,6 @@ The output of the above looks like the following (trimmed):
 Additional Resources for Understanding Events
 =============================================
 
-- `Javascript documentation <https://github.com/web3/web3.js/blob/1.x/docs/web3-eth-contract.rst#events>`_
+- `JavaScript documentation <https://github.com/web3/web3.js/blob/1.x/docs/web3-eth-contract.rst#events>`_
 - `Example usage of events <https://github.com/ethchange/smart-exchange/blob/master/lib/contracts/SmartExchange.sol>`_
 - `How to access them in js <https://github.com/ethchange/smart-exchange/blob/master/lib/exchange_transactions.js>`_

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -175,6 +175,7 @@ See especially:
 
 If you want to debug using GDB, make sure you build differently than the "usual".
 For example, you could run the following command in your ``build`` folder:
+
 .. code-block:: bash
 
    cmake -DCMAKE_BUILD_TYPE=Debug ..

--- a/docs/ir-breaking-changes.rst
+++ b/docs/ir-breaking-changes.rst
@@ -174,8 +174,8 @@ hiding new and different behavior in existing code.
 
   The function ``preincr_u8(1)`` returns the following values:
 
-  - Old code generator: 3 (``1 + 2``) but the return value is unspecified in general
-  - New code generator: 4 (``2 + 2``) but the return value is not guaranteed
+  - Old code generator: ``3`` (``1 + 2``) but the return value is unspecified in general
+  - New code generator: ``4`` (``2 + 2``) but the return value is not guaranteed
 
   .. index:: ! evaluation order; function arguments
 

--- a/docs/path-resolution.rst
+++ b/docs/path-resolution.rst
@@ -253,6 +253,7 @@ The compiler resolves the import into a source unit name based on the import pat
 #. We start with the source unit name of the importing source unit.
 #. The last path segment with preceding slashes is removed from the resolved name.
 #. Then, for every segment in the import path, starting from the leftmost one:
+
     - If the segment is ``.``, it is skipped.
     - If the segment is ``..``, the last path segment with preceding slashes is removed from the resolved name.
     - Otherwise, the segment (preceded by a single slash if the resolved name is not empty), is appended to the resolved name.

--- a/docs/smtchecker.rst
+++ b/docs/smtchecker.rst
@@ -834,7 +834,7 @@ option ``--model-checker-solvers {all,cvc4,eld,smtlib2,z3}`` or the JSON option
 
   - if ``solc`` is compiled with it;
   - if a dynamic ``z3`` library of version >=4.8.x is installed in a Linux system (from Solidity 0.7.6);
-  - statically in ``soljson.js`` (from Solidity 0.6.9), that is, the Javascript binary of the compiler.
+  - statically in ``soljson.js`` (from Solidity 0.6.9), that is, the JavaScript binary of the compiler.
 
 .. note::
   z3 version 4.8.16 broke ABI compatibility with previous versions and cannot

--- a/docs/smtchecker.rst
+++ b/docs/smtchecker.rst
@@ -681,7 +681,7 @@ most derived type in case of inheritance.
     }
 
 Note that in function ``property_transfer``, the external calls are
-performed on variable ``t``
+performed on variable ``t``.
 
 Another caveat of this mode are calls to state variables of contract type
 outside the analyzed contract. In the code below, even though ``B`` deploys

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -16,11 +16,11 @@ Many projects will implement their own style guides.  In the event of
 conflicts, project specific style guides take precedence.
 
 The structure and many of the recommendations within this style guide were
-taken from python's
+taken from Python's
 `pep8 style guide <https://peps.python.org/pep-0008/>`_.
 
 The goal of this guide is *not* to be the right way or the best way to write
-Solidity code.  The goal of this guide is *consistency*.  A quote from python's
+Solidity code.  The goal of this guide is *consistency*.  A quote from Python's
 `pep8 <https://peps.python.org/pep-0008/#a-foolish-consistency-is-the-hobgoblin-of-little-minds>`_
 captures this concept well.
 

--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -257,7 +257,7 @@ reverts on failure.
 
 * ``send``
 
-Send is the low-level counterpart of ``transfer``. If the execution fails, the current contract will not stop with an exception, but ``send`` will return ``false``.
+``send`` is the low-level counterpart of ``transfer``. If the execution fails, the current contract will not stop with an exception, but ``send`` will return ``false``.
 
 .. warning::
     There are some dangers in using ``send``: The transfer fails if the call stack depth is at 1024

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -636,6 +636,6 @@ Error Types
 10. ``Exception``: Unknown failure during compilation - this should be reported as an issue.
 11. ``CompilerError``: Invalid use of the compiler stack - this should be reported as an issue.
 12. ``FatalError``: Fatal error not processed correctly - this should be reported as an issue.
-13. ``YulException``: Error during Yul Code generation - this should be reported as an issue.
+13. ``YulException``: Error during Yul code generation - this should be reported as an issue.
 14. ``Warning``: A warning, which didn't stop the compilation, but should be addressed if possible.
 15. ``Info``: Information that the compiler thinks the user might find useful, but is not dangerous and does not necessarily need to be addressed.

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -160,7 +160,7 @@ at each version. Backward compatibility is not guaranteed between each version.
    - It is possible to access dynamic data returned from function calls.
    - ``revert`` opcode introduced, which means that ``revert()`` will not waste gas.
 - ``constantinople``
-   - Opcodes ``create2`, ``extcodehash``, ``shl``, ``shr`` and ``sar`` are available in assembly.
+   - Opcodes ``create2``, ``extcodehash``, ``shl``, ``shr`` and ``sar`` are available in assembly.
    - Shifting operators use shifting opcodes and thus need less gas.
 - ``petersburg``
    - The compiler behaves the same way as with constantinople.

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -15,7 +15,7 @@ Using the Commandline Compiler
 Basic Usage
 -----------
 
-One of the build targets of the Solidity repository is ``solc``, the solidity commandline compiler.
+One of the build targets of the Solidity repository is ``solc``, the Solidity commandline compiler.
 Using ``solc --help`` provides you with an explanation of all options. The compiler can produce various outputs, ranging from simple binaries and assembly over an abstract syntax tree (parse tree) to estimations of gas usage.
 If you only want to compile a single file, you run it as ``solc --bin sourceFile.sol`` and it will print the binary. If you want to get some of the more advanced output variants of ``solc``, it is probably better to tell it to output everything to separate files using ``solc -o outputDirectory --bin --ast-compact-json --asm sourceFile.sol``.
 


### PR DESCRIPTION
#### Fix the missing backquote in `create2`

```diff
-   - Opcodes ``create2`, ``extcodehash``, ``shl``, ``shr`` and ``sar`` are available in assembly.
+   - Opcodes ``create2``, ``extcodehash``, ``shl``, ``shr`` and ``sar`` are available in assembly.
```

#### Fix the code block not rendered

![image](https://user-images.githubusercontent.com/20497787/228267879-ef0733d4-5a2b-453e-b4e8-9fd6ea55dcb2.png)

```diff
 For example, you could run the following command in your ``build`` folder:
+
 .. code-block:: bash
```

#### Wrap numbers in backquotes

```diff
-  - Old code generator: 3 (``1 + 2``) but the return value is unspecified in general
-  - New code generator: 4 (``2 + 2``) but the return value is not guaranteed
+  - Old code generator: ``3`` (``1 + 2``) but the return value is unspecified in general
+  - New code generator: ``4`` (``2 + 2``) but the return value is not guaranteed
```

#### Fix the missing dot

```diff
-performed on variable ``t``
+performed on variable ``t``.
```

#### Fix unnecessary capitalization

```diff
-13. ``YulException``: Error during Yul Code generation - this should be reported as an issue.
+13. ``YulException``: Error during Yul code generation - this should be reported as an issue.
```

#### Fix the style of the bullet points

![image](https://user-images.githubusercontent.com/20497787/228267464-c6778ca2-ccbb-4a4b-8259-36045c447596.png)

```diff
 #. Then, for every segment in the import path, starting from the leftmost one:
+
     - If the segment is ``.``, it is skipped.
```

#### Consolidate languages into formal names
- python -> Python
- Javascript -> JavaScript
- solidity -> Solidity

#### Use the function name

```diff
-Send is the low-level counterpart of ``transfer``. If the execution fails, the current contract will not stop with an exception, but ``send`` will return ``false``.
+``send`` is the low-level counterpart of ``transfer``. If the execution fails, the current contract will not stop with an exception, but ``send`` will return ``false``.
```