### PR TITLE
Fix missing keyword `unicode` in grammar

### DIFF
--- a/docs/grammar/SolidityLexer.g4
+++ b/docs/grammar/SolidityLexer.g4
@@ -90,6 +90,7 @@ Try: 'try';
 Type: 'type';
 Ufixed: 'ufixed' | ('ufixed' [1-9][0-9]+ 'x' [1-9][0-9]+);
 Unchecked: 'unchecked';
+Unicode: 'unicode';
 /**
  * Sized unsigned integer types.
  * uint is an alias of uint256.

--- a/test/libsolidity/syntaxTests/freeFunctions/invalid_function_named_unicode.sol
+++ b/test/libsolidity/syntaxTests/freeFunctions/invalid_function_named_unicode.sol
@@ -1,0 +1,4 @@
+function unicode() returns {}
+
+// ----
+// ParserError 2314: (9-16): Expected identifier but got 'ILLEGAL'

--- a/test/libsolidity/syntaxTests/parsing/invalid_variable_named_unicode.sol
+++ b/test/libsolidity/syntaxTests/parsing/invalid_variable_named_unicode.sol
@@ -1,0 +1,6 @@
+contract C
+{
+    string unicode = "abc";
+}
+// ----
+// ParserError 2314: (24-31): Expected identifier but got 'ILLEGAL'


### PR DESCRIPTION
While working in #14054, we discovered that the grammar was missing `unicode` as a keyword of the language.
This fixes it and adds test cases. 