### PR TITLE
fix(docs): not displaying svg images in PDF

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ extensions = [
     'sphinx_a4doc',
     'html_extra_template_renderer',
     'remix_code_links',
+    'sphinx.ext.imgconverter',
 ]
 
 a4_base_path = os.path.dirname(__file__) + '/grammar'


### PR DESCRIPTION
Since the PDF output feature of Sphinx does not support SVG images by default, the following extension must be enabled.

https://www.sphinx-doc.org/en/master/usage/extensions/imgconverter.html

This PR enables the extension. 

(As discussed in the Matrix channel of the translation community, this issue may be the cause of the failure to build translated documentation, and it is expected that this PR resolves it as well.)

CC: @cameel 


Before this change: 
![image](https://user-images.githubusercontent.com/20497787/230150339-d39b2dd4-2670-4306-8b12-95be8fa0761c.png)

After this change: 
![image](https://user-images.githubusercontent.com/20497787/230150389-62fefcc9-a03d-4dd0-ba27-56875b4e24c1.png)




