### PR TITLE
Fix dark mode in grammar

### DIFF
--- a/docs/_static/css/dark.css
+++ b/docs/_static/css/dark.css
@@ -633,3 +633,22 @@ code.docutils.literal.notranslate {
 a.remix-link {
     filter: invert(1); /* The icon is black. In dark mode we want it white. */
 }
+
+
+/* Grammar */
+
+.railroad-diagram {
+    fill: white;
+}
+
+.railroad-diagram path {
+    stroke: white;
+}
+
+.railroad-diagram rect {
+    stroke: white;
+}
+
+.a4 .sig-name {
+    background-color: transparent !important;
+}


### PR DESCRIPTION
Before this change:
![image](https://user-images.githubusercontent.com/20497787/230540269-1bbc4ca8-e0ec-4811-a18e-af967a5f3278.png)

After this change:
![image](https://user-images.githubusercontent.com/20497787/230540322-a2d390a7-4e1f-4404-a72e-f88dbd3b4834.png)
