### PR TITLE
Reverse lookup for DataFlowAnalyzer

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Language Features:
 
 
 Compiler Features:
+ * Optimizer: Introduced an optimized variable assignment map to improve the performance of Yul optimizer steps that rely on data flow analysis.
 
 
 Bugfixes:

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -183,6 +183,8 @@ add_library(yul
 	optimiser/UnusedPruner.h
 	optimiser/VarDeclInitializer.cpp
 	optimiser/VarDeclInitializer.h
+	optimiser/VariableAssignmentMap.cpp
+	optimiser/VariableAssignmentMap.h
 	optimiser/VarNameCleaner.cpp
 	optimiser/VarNameCleaner.h
 )

--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -270,7 +270,7 @@ void DataFlowAnalyzer::handleAssignment(std::set<YulString> const& _variables, E
 	auto const& referencedVariables = movableChecker.referencedVariables();
 	for (auto const& name: _variables)
 	{
-		m_state.references[name] = referencedVariables;
+		m_state.references.set(name, referencedVariables);
 		if (!_isDeclaration)
 		{
 			// assignment to slot denoted by "name"
@@ -353,9 +353,8 @@ void DataFlowAnalyzer::clearValues(std::set<YulString> _variables)
 	// Also clear variables that reference variables to be cleared.
 	std::set<YulString> referencingVariables;
 	for (auto const& variableToClear: _variables)
-		for (auto const& [ref, names]: m_state.references)
-			if (names.count(variableToClear))
-				referencingVariables.emplace(ref);
+		if (auto&& references = m_state.references.getReversedOrNullptr(variableToClear))
+			referencingVariables += *references;
 
 	// Clear the value and update the reference relation.
 	for (auto const& name: _variables + referencingVariables)

--- a/libyul/optimiser/DataFlowAnalyzer.h
+++ b/libyul/optimiser/DataFlowAnalyzer.h
@@ -25,6 +25,7 @@
 
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/optimiser/KnowledgeBase.h>
+#include <libyul/optimiser/VariableAssignmentMap.h>
 #include <libyul/YulString.h>
 #include <libyul/AST.h> // Needed for m_zero below.
 #include <libyul/SideEffects.h>
@@ -104,7 +105,7 @@ public:
 
 	/// @returns the current value of the given variable, if known - always movable.
 	AssignedValue const* variableValue(YulString _variable) const { return util::valueOrNullptr(m_state.value, _variable); }
-	std::set<YulString> const* references(YulString _variable) const { return util::valueOrNullptr(m_state.references, _variable); }
+	std::set<YulString> const* references(YulString _variable) const { return m_state.references.getOrderedOrNullptr(_variable); }
 	std::map<YulString, AssignedValue> const& allValues() const { return m_state.value; }
 	std::optional<YulString> storageValue(YulString _key) const;
 	std::optional<YulString> memoryValue(YulString _key) const;
@@ -179,9 +180,9 @@ private:
 	{
 		/// Current values of variables, always movable.
 		std::map<YulString, AssignedValue> value;
-		/// m_references[a].contains(b) <=> the current expression assigned to a references b
-		std::unordered_map<YulString, std::set<YulString>> references;
-
+		/// references.m_ordered[a].contains(b) <=> the current expression assigned to a references b
+		/// references.m_reversed[b].contains(a) <=> b from current expression assigned to a is references by a
+		VariableAssignmentMap references;
 		Environment environment;
 	};
 

--- a/libyul/optimiser/VariableAssignmentMap.cpp
+++ b/libyul/optimiser/VariableAssignmentMap.cpp
@@ -1,0 +1,39 @@
+#include <libyul/optimiser/VariableAssignmentMap.h>
+
+using std::set;
+using namespace solidity::yul;
+
+void VariableAssignmentMap::set(YulString const& _variable, std::set<YulString> const& _references)
+{
+	erase(_variable);
+	m_ordered[_variable] = _references;
+	for (auto&& reference: _references)
+		m_reversed[reference].emplace(_variable);
+}
+
+void VariableAssignmentMap::erase(YulString const& _variable)
+{
+	for (auto&& reference: m_ordered[_variable])
+		if (m_reversed.find(reference) != m_reversed.end())
+		{
+			if (m_reversed[reference].size() > 1)
+				m_reversed[reference].erase(_variable);
+			else
+				// Only fully remove an entry if no variables other than _variable
+				// are contained in the set pointed to by reference.
+				m_reversed.erase(reference);
+		}
+	m_ordered.erase(_variable);
+}
+
+set<YulString> const* VariableAssignmentMap::getOrderedOrNullptr(YulString const& _variable) const
+{
+	auto&& it = m_ordered.find(_variable);
+	return (it != m_ordered.end()) ? &it->second : nullptr;
+}
+
+set<YulString> const* VariableAssignmentMap::getReversedOrNullptr(YulString const& _variable) const
+{
+	auto&& it = m_reversed.find(_variable);
+	return (it != m_reversed.end()) ? &it->second : nullptr;
+}

--- a/libyul/optimiser/VariableAssignmentMap.h
+++ b/libyul/optimiser/VariableAssignmentMap.h
@@ -1,0 +1,85 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <libyul/YulString.h>
+
+#include <set>
+#include <unordered_map>
+
+namespace solidity::yul
+{
+
+/**
+ * Class that implements a reverse lookup for an ``unordered_map<YulString, set<YulString>>`` by wrapping the
+ * two such maps - one ordered, and one reversed, e.g.
+ *
+ *  m_ordered           m_reversed
+ *  f -> (g,)           g -> (f,)
+ *  c -> (b,d,e,)       d -> (c,)
+ *  a -> (b,c,)         c -> (a,)
+ *                      e -> (c,)
+ *                      b -> (a,c,)
+ *
+ * The above example will from here onwards be referenced as ```Ref 1```.
+ *
+ * This allows us to have simultaneously managed insertion and deletion via a single interface, instead of manually
+ * managing this at the point of usage (see ``DataFlowAnalyzer``).
+ */
+class VariableAssignmentMap
+{
+public:
+	VariableAssignmentMap() = default;
+	/**
+	 * Insert a set of values for the provided key ``_variable`` into ``m_ordered`` and ``m_reversed``.
+	 * This method will erase all references of ``_variable`` from both sets before performing the insertion,
+	 * akin to container assignment with subscript operator, i.e. container[index] = value.
+	 * For example, if ``_variable`` is ``x`` and ``_references`` is ``{"y", "z"}``, the following would be added to ``Ref 1``:
+	 *
+	 * m_ordered        m_reversed
+	 * x -> (y, z,)     y -> (x,)
+	 *                  y -> (z,)
+	 *
+	 * @param _variable current expression variable
+	 * @param _references all referenced variables in the expression assigned to ``_variable``
+	 */
+	void set(YulString const& _variable, std::set<YulString> const& _references);
+
+	/**
+	 * Erase entries in both maps based on provided ``_variable``. The behaviour is the same as ``set("x", {})``.
+	 * For example, after deleting ``c`` for ``Ref 1``, ``Ref 1`` would contain the following:
+	 *
+	 *  m_ordered           m_reversed
+	 *  f -> (g,)           g -> (f,)
+	 *  a -> (b,c,)         c -> (a,)
+	 *                      b -> (a,)
+	 *
+	 * @param _variable variable to erase
+	 */
+	void erase(YulString const& _variable);
+	std::set<YulString> const* getOrderedOrNullptr(YulString const& _variable) const;
+	std::set<YulString> const* getReversedOrNullptr(YulString const& _variable) const;
+
+private:
+	/// m_ordered[a].contains[b] <=> the current expression assigned to ``a`` references ``b``
+	std::unordered_map<YulString, std::set<YulString>> m_ordered;
+	/// m_reversed[b].contains[a] <=> the current expression assigned to ``a`` references ``b``
+	std::unordered_map<YulString, std::set<YulString>> m_reversed;
+};
+
+} // solidity::yul


### PR DESCRIPTION
Part of https://github.com/ethereum/solidity/issues/13719 and https://github.com/ethereum/solidity/issues/13822.

Benchmarking is run on the [contract](https://gist.github.com/chriseth/def56b241b480fa2bc52d173fdc8e451).

Mostly helps with CSE (`CommonSubexpressionEleminator`) and `LiteralRematerialiser`, `LoadResolver` and `ExpressionSimplifier`, i.e. steps that inherit from and thus rely on the `DataFlowAnalyzer`. The results are as follows:

This PR is essentially a rework of @chriseth's [Improve DataFlowAnalyzer PR](https://github.com/ethereum/solidity/pull/13823/files#diff-42ab9538e190e995d9019d40d1a7cd57bcce79e729158981cfad1b29bd07d0a0), which includes many other improvements (of which I think all were merged already in separate PRs).
The question here is whether we'd prefer the approach here (where the in-order and reverse lookup are wrapped in a separate class), or in Chris' PR, where the reverse lookup is just added to the `DataFlowAnalyzer::State` object and then used directly from there.

## develop (baseline)
```
======================================
  0.000% (8e-06 s): FunctionGrouper
  0.001% (1.4e-05 s): VarDeclInitializer
  0.001% (2.3e-05 s): ForLoopInitRewriter
  0.003% (8.1e-05 s): FunctionHoister
  0.017% (0.000421 s): ExpressionInliner
  0.035% (0.00085 s): UnusedFunctionParameterPruner
  0.075% (0.001829 s): ForLoopConditionIntoBody
  0.077% (0.001873 s): ForLoopConditionOutOfBody
  0.082% (0.002001 s): SSAReverser
  0.093% (0.002263 s): StructuralSimplifier
  0.135% (0.003282 s): BlockFlattener
  0.148% (0.003606 s): CircularReferencesPruner
  0.223% (0.00542 s): ExpressionJoiner
  0.235% (0.005713 s): EquivalentFunctionCombiner
  0.313% (0.007626 s): Rematerialiser
  0.335% (0.008165 s): LoopInvariantCodeMotion
  0.561% (0.013661 s): FunctionSpecializer
  0.845% (0.020568 s): ExpressionSplitter
  0.902% (0.021972 s): ConditionalUnsimplifier
  0.961% (0.023401 s): ConditionalSimplifier
  1.059% (0.025783 s): ControlFlowSimplifier
  1.072% (0.026108 s): DeadCodeEliminator
  1.551% (0.037774 s): EqualStoreEliminator
  3.646% (0.088806 s): FullInliner
  3.853% (0.09384 s): UnusedStoreEliminator
  4.819% (0.117355 s): UnusedPruner
  7.358% (0.179209 s): SSATransform
  7.365% (0.179365 s): UnusedAssignEliminator
  9.883% (0.240684 s): ExpressionSimplifier
 11.218% (0.273217 s): LoadResolver
 16.676% (0.40613 s): LiteralRematerialiser
 26.459% (0.644396 s): CommonSubexpressionEliminator
--------------------------------------
    100% (2.435 s)
```
## with reverse lookup (this)
```
Performance metrics of optimizer steps
======================================
  0.001% (1e-05 s): FunctionGrouper
  0.001% (2.1e-05 s): VarDeclInitializer
  0.002% (2.9e-05 s): ForLoopInitRewriter
  0.006% (9.3e-05 s): FunctionHoister
  0.026% (0.00041 s): ExpressionInliner
  0.053% (0.000846 s): UnusedFunctionParameterPruner
  0.113% (0.001798 s): ForLoopConditionIntoBody
  0.125% (0.001986 s): ForLoopConditionOutOfBody
  0.134% (0.002124 s): SSAReverser
  0.146% (0.002312 s): StructuralSimplifier
  0.183% (0.002902 s): BlockFlattener
  0.228% (0.003604 s): CircularReferencesPruner
  0.332% (0.005263 s): ExpressionJoiner
  0.336% (0.005319 s): Rematerialiser
  0.367% (0.005814 s): EquivalentFunctionCombiner
  0.514% (0.008142 s): LoopInvariantCodeMotion
  0.963% (0.015248 s): FunctionSpecializer
  1.211% (0.019182 s): EqualStoreEliminator
  1.309% (0.020744 s): ExpressionSplitter
  1.360% (0.021539 s): ConditionalUnsimplifier
  1.429% (0.022642 s): ConditionalSimplifier
  1.634% (0.02588 s): ControlFlowSimplifier
  1.656% (0.026226 s): DeadCodeEliminator
  5.166% (0.081833 s): FullInliner
  5.865% (0.092911 s): UnusedStoreEliminator
  7.376% (0.116846 s): UnusedPruner
  8.498% (0.134622 s): LoadResolver
  8.557% (0.135551 s): ExpressionSimplifier
  9.066% (0.143613 s): LiteralRematerialiser
 11.084% (0.175588 s): SSATransform
 11.256% (0.178307 s): UnusedAssignEliminator
 21.004% (0.332742 s): CommonSubexpressionEliminator
--------------------------------------
    100% (1.584 s)
```