### PR TITLE
[.clang-format ] Update prohibited property 'AlignEscapedNewlinesLeft'.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,7 @@ Language: Cpp
 BasedOnStyle: LLVM
 AccessModifierOffset: -4
 AlignAfterOpenBracket: AlwaysBreak
-AlignEscapedNewlinesLeft: true
+AlignEscapedNewlines: Left
 AlwaysBreakAfterReturnType: None
 AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false


### PR DESCRIPTION
- 'AlignEscapedNewlines' set to 'Left' is now the correct property.

I just saw that `AlignEscapedNewlinesLeft` is an prohibited property nowadays.  It seem to got implemented before LLVM 5.0. However, I'm not able to find now the correct commit. See https://github.com/llvm/llvm-project/issues/31808#issuecomment-980976885. I was not able to find the related revision `r302428` in the current GitHub repository. It seem to have got merged after [LLVM 4.0.1-rc1](https://github.com/llvm/llvm-project/releases/tag/llvmorg-4.0.1-rc1) and before [LLVM 4.0.1-rc2](https://github.com/llvm/llvm-project/releases/tag/llvmorg-4.0.1-rc2) not sure what happened there. 