### PR TITLE
Literal-related documentation and index tweaks

### DIFF
--- a/docs/contracts/functions.rst
+++ b/docs/contracts/functions.rst
@@ -277,7 +277,7 @@ This behaviour is also in line with the ``STATICCALL`` opcode.
 Special Functions
 =================
 
-.. index:: ! receive ether function, function;receive ! receive
+.. index:: ! receive ether function, function;receive, ! receive
 
 .. _receive-ether-function:
 

--- a/docs/contracts/functions.rst
+++ b/docs/contracts/functions.rst
@@ -1,4 +1,4 @@
-.. index:: ! functions
+.. index:: ! functions, ! function;free
 
 .. _functions:
 

--- a/docs/contracts/using-for.rst
+++ b/docs/contracts/using-for.rst
@@ -1,4 +1,4 @@
-.. index:: ! using for, library, ! operator; user-defined
+.. index:: ! using for, library, ! operator;user-defined, function;free
 
 .. _using-for:
 

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -173,7 +173,6 @@ parameters from the function declaration, but can be in arbitrary order.
         function set(uint key, uint value) public {
             data[key] = value;
         }
-
     }
 
 Omitted Names in Function Definitions

--- a/docs/types/conversion.rst
+++ b/docs/types/conversion.rst
@@ -130,6 +130,7 @@ If the array is shorter than the target type, it will be padded with zeros at th
         }
     }
 
+.. index:: ! literal;conversion, literal;rational, literal;hexadecimal number
 .. _types-conversion-literals:
 
 Conversions between Literals and Elementary Types
@@ -151,6 +152,8 @@ that is large enough to represent it without truncation:
     Prior to version 0.8.0, any decimal or hexadecimal number literals could be explicitly
     converted to an integer type. From 0.8.0, such explicit conversions are as strict as implicit
     conversions, i.e., they are only allowed if the literal fits in the resulting range.
+
+.. index:: literal;string, literal;hexadecimal
 
 Fixed-Size Byte Arrays
 ----------------------
@@ -181,6 +184,8 @@ if their number of characters matches the size of the bytes type:
     bytes2 d = hex"123"; // not allowed
     bytes2 e = "x"; // not allowed
     bytes2 f = "xyz"; // not allowed
+
+.. index:: literal;address
 
 Addresses
 ---------

--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -235,7 +235,7 @@ with the :ref:`default value<default-value>`.
         }
     }
 
-.. index:: ! array;literals, ! inline;arrays
+.. index:: ! literal;array, ! inline;arrays
 
 Array Literals
 ^^^^^^^^^^^^^^

--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -588,7 +588,8 @@ of the hexadecimal sequence.
 Multiple hexadecimal literals separated by whitespace are concatenated into a single literal:
 ``hex"00112233" hex"44556677"`` is equivalent to ``hex"0011223344556677"``
 
-Hexadecimal literals behave like :ref:`string literals <string_literals>` and have the same convertibility restrictions.
+Hexadecimal literals in some ways behave like :ref:`string literals <string_literals>` but are not
+implicitly convertible to the ``string`` type.
 
 .. index:: enum
 

--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -423,7 +423,7 @@ Dynamically-sized byte array
 ``string``:
     Dynamically-sized UTF-8-encoded string, see :ref:`arrays`. Not a value-type!
 
-.. index:: address, literal;address
+.. index:: address, ! literal;address
 
 .. _address_literals:
 
@@ -439,7 +439,7 @@ an error. You can prepend (for integer types) or append (for bytesNN types) zero
 .. note::
     The mixed-case address checksum format is defined in `EIP-55 <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md>`_.
 
-.. index:: literal, literal;rational
+.. index:: integer, rational number, ! literal;rational
 
 .. _rational_literals:
 
@@ -517,7 +517,7 @@ regardless of the type of the right (exponent) operand.
     uint128 a = 1;
     uint128 b = 2.5 + a + 0.5;
 
-.. index:: literal, literal;string, string
+.. index:: ! literal;string, string
 .. _string_literals:
 
 String Literals and Types
@@ -564,6 +564,8 @@ character sequence ``abcdef``.
 Any Unicode line terminator which is not a newline (i.e. LF, VF, FF, CR, NEL, LS, PS) is considered to
 terminate the string literal. Newline only terminates the string literal if it is not preceded by a ``\``.
 
+.. index:: ! literal;unicode
+
 Unicode Literals
 ----------------
 
@@ -574,7 +576,7 @@ They also support the very same escape sequences as regular string literals.
 
     string memory a = unicode"Hello 😃";
 
-.. index:: literal, bytes
+.. index:: ! literal;hexadecimal, bytes
 
 Hexadecimal Literals
 --------------------

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -1,8 +1,10 @@
+.. index:: ! denomination
+
 **************************************
 Units and Globally Available Variables
 **************************************
 
-.. index:: wei, finney, szabo, gwei, ether
+.. index:: ! wei, ! finney, ! szabo, ! gwei, ! ether, ! denomination;ether
 
 Ether Units
 ===========
@@ -21,7 +23,7 @@ The only effect of the subdenomination suffix is a multiplication by a power of 
 .. note::
     The denominations ``finney`` and ``szabo`` have been removed in version 0.7.0.
 
-.. index:: time, seconds, minutes, hours, days, weeks, years
+.. index:: ! seconds, ! minutes, ! hours, ! days, ! weeks, ! years, ! denomination;time
 
 Time Units
 ==========
@@ -52,7 +54,7 @@ interpret a function parameter in days, you can in the following way:
 
     function f(uint start, uint daysAfter) public {
         if (block.timestamp >= start + daysAfter * 1 days) {
-          // ...
+            // ...
         }
     }
 

--- a/docs/yul.rst
+++ b/docs/yul.rst
@@ -166,6 +166,8 @@ Inside a code block, the following elements can be used
 Multiple syntactical elements can follow each other simply separated by
 whitespace, i.e. there is no terminating ``;`` or newline required.
 
+.. index:: ! literal;in Yul
+
 Literals
 --------
 


### PR DESCRIPTION
Extracted from #14121 so that there we can focus strictly on the new docs without the noise form cleanup/refactors.

The PR makes index entries more consistent, fixes the entry for `receive` and also rewords the part of the description of hexadecimal string literals that seems to be untrue.