### PR TITLE
Make plus operator binary only

### DIFF
--- a/liblangutil/Token.h
+++ b/liblangutil/Token.h
@@ -300,7 +300,7 @@ namespace TokenTraits
 
 	constexpr bool isBitOp(Token op) { return (Token::BitOr <= op && op <= Token::BitAnd) || op == Token::BitNot; }
 	constexpr bool isBooleanOp(Token op) { return (Token::Or <= op && op <= Token::And) || op == Token::Not; }
-	constexpr bool isUnaryOp(Token op) { return (Token::Not <= op && op <= Token::Delete) || op == Token::Add || op == Token::Sub; }
+	constexpr bool isUnaryOp(Token op) { return (Token::Not <= op && op <= Token::Delete) || op == Token::Sub; }
 	constexpr bool isCountOp(Token op) { return op == Token::Inc || op == Token::Dec; }
 	constexpr bool isShiftOp(Token op) { return (Token::SHL <= op) && (op <= Token::SHR); }
 	constexpr bool isVariableVisibilitySpecifier(Token op) { return op == Token::Public || op == Token::Private || op == Token::Internal; }

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -4035,9 +4035,7 @@ void TypeChecker::endVisit(UsingForDirective const& _usingFor)
 
 			bool identicalFirstTwoParameters = (parameterCount < 2 || *parameterTypes.at(0) == *parameterTypes.at(1));
 			bool isUnaryOnlyOperator = (!TokenTraits::isBinaryOp(operator_.value()) && TokenTraits::isUnaryOp(operator_.value()));
-			bool isBinaryOnlyOperator =
-				(TokenTraits::isBinaryOp(operator_.value()) && !TokenTraits::isUnaryOp(operator_.value())) ||
-				operator_.value() == Token::Add;
+			bool isBinaryOnlyOperator = (TokenTraits::isBinaryOp(operator_.value()) && !TokenTraits::isUnaryOp(operator_.value()));
 			bool firstParameterMatchesUsingFor = parameterCount == 0 || *usingForType == *parameterTypes.front();
 
 			optional<string> wrongParametersMessage;

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -2084,7 +2084,10 @@ public:
 		m_subExpression(std::move(_subExpression)),
 		m_isPrefix(_isPrefix)
 	{
-		solAssert(TokenTraits::isUnaryOp(_operator), "");
+		// NOTE: Unary plus is disallowed but only at the analysis stage.
+		// If you use `--stop-after parsing`, you can still get an AST with UnaryOperation node
+		// representing the unary plus.
+		solAssert(TokenTraits::isUnaryOp(_operator) || _operator == Token::Add);
 	}
 	void accept(ASTVisitor& _visitor) override;
 	void accept(ASTConstVisitor& _visitor) const override;

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1862,7 +1862,11 @@ ASTPointer<Expression> Parser::parseUnaryExpression(
 	ASTNodeFactory nodeFactory = _partiallyParsedExpression ?
 		ASTNodeFactory(*this, _partiallyParsedExpression) : ASTNodeFactory(*this);
 	Token token = m_scanner->currentToken();
-	if (!_partiallyParsedExpression && (TokenTraits::isUnaryOp(token) || TokenTraits::isCountOp(token)))
+	if (!_partiallyParsedExpression && (
+		TokenTraits::isUnaryOp(token) ||
+		TokenTraits::isCountOp(token) ||
+		token == Token::Add
+	))
 	{
 		// prefix expression
 		advance();


### PR DESCRIPTION
Part of #13718.
Originally requested in https://github.com/ethereum/solidity/pull/13790#discussion_r1113063168.

One of the quirks we noticed when implementing user-defined operators was that `TokenTraits::isUnaryOp()` treats `+` as a unary operator, even though the use of unary plus is an error in Solidity. This is an attempt to straighten this out.