### PR TITLE
EVMHost: Add "support" for Blake2f

### DIFF
--- a/test/EVMHost.cpp
+++ b/test/EVMHost.cpp
@@ -253,6 +253,8 @@ evmc::Result EVMHost::call(evmc_message const& _message) noexcept
 		else
 			return precompileALTBN128PairingProduct<EVMC_LONDON>(_message);
 	}
+	else if (_message.recipient == 0x0000000000000000000000000000000000000009_address && m_evmVersion >= langutil::EVMVersion::istanbul())
+		return precompileBlake2f(_message);
 
 	auto const stateBackup = accounts;
 
@@ -1115,6 +1117,12 @@ evmc::Result EVMHost::precompileALTBN128PairingProduct(evmc_message const& _mess
 		}
 	};
 	return precompileGeneric(_message, inputOutput);
+}
+
+evmc::Result EVMHost::precompileBlake2f(evmc_message const&) noexcept
+{
+	// TODO implement
+	return resultWithFailure();
 }
 
 evmc::Result EVMHost::precompileGeneric(

--- a/test/EVMHost.h
+++ b/test/EVMHost.h
@@ -120,6 +120,7 @@ private:
 	static evmc::Result precompileALTBN128G1Mul(evmc_message const& _message) noexcept;
 	template <evmc_revision Revision>
 	static evmc::Result precompileALTBN128PairingProduct(evmc_message const& _message) noexcept;
+	static evmc::Result precompileBlake2f(evmc_message const& _message) noexcept;
 	static evmc::Result precompileGeneric(evmc_message const& _message, std::map<bytes, EVMPrecompileOutput> const& _inOut) noexcept;
 	/// @returns a result object with gas usage and result data taken from @a _data.
 	/// The outcome will be a failure if the limit < required.


### PR DESCRIPTION
This is only a safety measure should any of the future tests depend on it.