### PR TITLE
Fix incompatibilities with Golang parser generation

### DIFF
--- a/docs/grammar/SolidityParser.g4
+++ b/docs/grammar/SolidityParser.g4
@@ -378,7 +378,7 @@ dataLocation: Memory | Storage | Calldata;
  */
 expression:
 	expression LBrack index=expression? RBrack # IndexAccess
-	| expression LBrack start=expression? Colon end=expression? RBrack # IndexRangeAccess
+	| expression LBrack startIndex=expression? Colon endIndex=expression? RBrack # IndexRangeAccess
 	| expression Period (identifier | Address) # MemberAccess
 	| expression LBrace (namedArgument (Comma namedArgument)*)? RBrace # FunctionCallOptions
 	| expression callArgumentList # FunctionCall
@@ -399,7 +399,7 @@ expression:
 	| expression Or expression # OrOperation
 	|<assoc=right> expression Conditional expression Colon expression # Conditional
 	|<assoc=right> expression assignOp expression # Assignment
-	| New typeName # NewExpression
+	| New typeName # NewExpr
 	| tupleExpression # Tuple
 	| inlineArrayExpression # InlineArray
  	| (


### PR DESCRIPTION
Generating a Golang antlr4 parser from the grammar is currently broken due to some idiosyncratic language incompatibilities:
 - `boolean` -> `bool` is not supported (upstreaming a fix here: github.com/antlr/antlr4/pull/4231)
 - Golang generation generates both a `NewExpressionContext` `struct` and `function` in the same package, causing a redeclaration error
 - start / end indexing conflicts with Antlr4 Golang runtime `GetStart` and `GetEnd` methods

This PR fixes the second two by:
 - Renaming `NewExpression` to `NewExpr` which changes the `NewExpressionContext` type to `NewExprContext`
 - Renaming `start` and `end` to `startIndex` and `endIndex`