### PR TITLE
Removed duplicated link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Report a security vulnerability
-    url: https://github.com/ethereum/solidity/security/policy
-    about: Please review our security policy for more details.
   - name: Initiate a language design or feedback discussion
     url: https://forum.soliditylang.org
     about: Open a thread on the Solidity forum.


### PR DESCRIPTION
Submitting the Security advisory will only show for repo admins, normal users will still have the option to check our security policy.