### PR TITLE
Emit PUSH0 as junk in evm code transform, if available.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ Compiler Features:
  * Optimizer: Re-implement simplified version of UnusedAssignEliminator and UnusedStoreEliminator. It can correctly remove some unused assignments in deeply nested loops that were ignored by the old version.
  * SMTChecker: Properties that are proved safe are now reported explicitly at the end of the analysis. By default, only the number of safe properties is shown. The CLI option ``--model-checker-show-proved-safe`` and the JSON option ``settings.modelChecker.showProvedSafe`` can be enabled to show the full list of safe properties.
  * SMTChecker: Group all messages about unsupported language features in a single warning. The CLI option ``--model-checker-show-unsupported`` and the JSON option ``settings.modelChecker.showUnsupported`` can be enabled to show the full list.
+ * Yul EVM Code Transform: If available, use ``push0`` instead of ``codesize`` to produce an arbitrary value on stack in order to create equal stack heights between branches.
 
 
 Bugfixes:

--- a/libyul/backends/evm/AbstractAssembly.h
+++ b/libyul/backends/evm/AbstractAssembly.h
@@ -117,6 +117,9 @@ public:
 
 	/// Mark this assembly as invalid. Any attempt to request bytecode from it should throw.
 	virtual void markAsInvalid() = 0;
+
+	/// @returns the EVM version the assembly targets.
+	virtual langutil::EVMVersion evmVersion() const = 0;
 };
 
 enum class IdentifierContext { LValue, RValue, VariableDeclaration, NonExternal };

--- a/libyul/backends/evm/EthAssemblyAdapter.cpp
+++ b/libyul/backends/evm/EthAssemblyAdapter.cpp
@@ -181,6 +181,11 @@ void EthAssemblyAdapter::markAsInvalid()
 	m_assembly.markAsInvalid();
 }
 
+langutil::EVMVersion EthAssemblyAdapter::evmVersion() const
+{
+	return m_assembly.evmVersion();
+}
+
 EthAssemblyAdapter::LabelID EthAssemblyAdapter::assemblyTagToIdentifier(evmasm::AssemblyItem const& _tag)
 {
 	u256 id = _tag.data();

--- a/libyul/backends/evm/EthAssemblyAdapter.h
+++ b/libyul/backends/evm/EthAssemblyAdapter.h
@@ -67,6 +67,9 @@ public:
 
 	void markAsInvalid() override;
 
+	langutil::EVMVersion evmVersion() const override;
+
+
 private:
 	static LabelID assemblyTagToIdentifier(evmasm::AssemblyItem const& _tag);
 	void appendJumpInstruction(evmasm::Instruction _instruction, JumpType _jumpType);

--- a/libyul/backends/evm/NoOutputAssembly.h
+++ b/libyul/backends/evm/NoOutputAssembly.h
@@ -77,6 +77,8 @@ public:
 
 	void markAsInvalid() override {}
 
+	langutil::EVMVersion evmVersion() const override { return m_evmVersion; }
+
 private:
 	int m_stackHeight = 0;
 	langutil::EVMVersion m_evmVersion;

--- a/libyul/backends/evm/OptimizedEVMCodeTransform.cpp
+++ b/libyul/backends/evm/OptimizedEVMCodeTransform.cpp
@@ -351,7 +351,10 @@ void OptimizedEVMCodeTransform::createStackLayout(std::shared_ptr<DebugData cons
 				[&](JunkSlot const&)
 				{
 					// Note: this will always be popped, so we can push anything.
-					m_assembly.appendInstruction(evmasm::Instruction::CODESIZE);
+					if (m_assembly.evmVersion().hasPush0())
+						m_assembly.appendConstant(0);
+					else
+						m_assembly.appendInstruction(evmasm::Instruction::CODESIZE);
 				}
 			}, _slot);
 		},


### PR DESCRIPTION
Part of https://github.com/ethereum/solidity/issues/14073

Changes the code transform towards producing a less-weird ``PUSH0`` instead of ``CODESIZE`` - this doesn't make much of a difference other than aesthetics (``codesize`` occurring in these cases was a bit weird).