### PR TITLE
Fix null dereference in using for directive when operator name is empty

### DIFF
--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -995,11 +995,17 @@ ASTPointer<UsingForDirective> Parser::parseUsingDirective()
 				Token operator_ = m_scanner->currentToken();
 				if (!util::contains(userDefinableOperators, operator_))
 				{
+					string operatorName;
+					if (!m_scanner->currentLiteral().empty())
+						operatorName = m_scanner->currentLiteral();
+					else if (char const* tokenString = TokenTraits::toString(operator_))
+						operatorName = string(tokenString);
+
 					parserError(
 						4403_error,
 						fmt::format(
 							"Not a user-definable operator: {}. Only the following operators can be user-defined: {}",
-							(!m_scanner->currentLiteral().empty() ? m_scanner->currentLiteral() : string(TokenTraits::toString(operator_))),
+							operatorName,
 							util::joinHumanReadable(userDefinableOperators | ranges::views::transform([](Token _t) { return string{TokenTraits::toString(_t)}; }))
 						)
 					);

--- a/test/libsolidity/syntaxTests/operators/userDefined/operator_parsing_operator_name_empty_string.sol
+++ b/test/libsolidity/syntaxTests/operators/userDefined/operator_parsing_operator_name_empty_string.sol
@@ -1,0 +1,7 @@
+using {f as ''} for uint;
+using {f as ""} for int;
+using {f as hex""} for address;
+// ----
+// ParserError 4403: (12-14): Not a user-definable operator: . Only the following operators can be user-defined: |, &, ^, ~, +, -, *, /, %, ==, !=, <, >, <=, >=
+// ParserError 4403: (38-40): Not a user-definable operator: . Only the following operators can be user-defined: |, &, ^, ~, +, -, *, /, %, ==, !=, <, >, <=, >=
+// ParserError 4403: (63-68): Not a user-definable operator: . Only the following operators can be user-defined: |, &, ^, ~, +, -, *, /, %, ==, !=, <, >, <=, >=


### PR DESCRIPTION
fix #14016 .