### PR TITLE
Remove the inaccurate `Type::categoryName()`

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2847,11 +2847,7 @@ bool TypeChecker::visit(FunctionCall const& _functionCall)
 	}
 
 	default:
-		m_errorReporter.fatalTypeError(
-			5704_error,
-			_functionCall.location(),
-			capitalized(Type::categoryName(expressionType->category())) + " is not callable."
-		);
+		m_errorReporter.fatalTypeError(5704_error, _functionCall.location(), "This expression is not callable.");
 		// Unreachable, because fatalTypeError throws. We don't set kind, but that's okay because the switch below
 		// is never reached. And, even if it was, SetOnce would trigger an assertion violation and not UB.
 		funcCallAnno.isPure = argumentsArePure;

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -294,35 +294,6 @@ Type const* Type::commonType(Type const* _a, Type const* _b)
 		return nullptr;
 }
 
-char const* Type::categoryName(Type::Category _category)
-{
-	switch (_category)
-	{
-	case Category::Address: return "address";
-	case Category::Integer: return "integer";
-	case Category::RationalNumber: return "rational number literal";
-	case Category::StringLiteral: return "string literal";
-	case Category::Bool: return "boolean";
-	case Category::FixedPoint: return "fixed-point number";
-	case Category::Array: return "array";
-	case Category::ArraySlice: return "array slice";
-	case Category::FixedBytes: return "fixed-size byte array";
-	case Category::Contract: return "contract";
-	case Category::Struct: return "struct";
-	case Category::Function: return "function";
-	case Category::Enum: return "enum";
-	case Category::UserDefinedValueType: return "user-defined value type";
-	case Category::Tuple: return "tuple";
-	case Category::Mapping: return "mapping";
-	case Category::TypeType: return "type of a type";
-	case Category::Modifier: return "modifier";
-	case Category::Magic: return "magic variable";
-	case Category::Module: return "module";
-	case Category::InaccessibleDynamic: return "inaccessible dynamic value";
-	}
-	util::unreachable();
-}
-
 MemberList const& Type::members(ASTNode const* _currentScope) const
 {
 	if (!m_members[_currentScope])

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -201,8 +201,6 @@ public:
 	static Type const* commonType(Type const* _a, Type const* _b);
 
 	virtual Category category() const = 0;
-	static char const* categoryName(Type::Category _category);
-
 	/// @returns a valid solidity identifier such that two types should compare equal if and
 	/// only if they have the same identifier.
 	/// The identifier should start with "t_".

--- a/libsolutil/StringUtils.h
+++ b/libsolutil/StringUtils.h
@@ -160,15 +160,6 @@ inline std::string toLower(std::string _s)
 	return _s;
 }
 
-/// Returns a copy of the string with the first character converted to its uppercase equivalent.
-/// Uses the classic "C" locale semantics.
-inline std::string capitalized(std::string _s)
-{
-	if (_s.size() > 0)
-		_s[0] = toUpper(_s[0]);
-	return _s;
-}
-
 /// Checks whether _c is a decimal digit character. It uses the classic "C" locale semantics.
 /// @param _c character to be checked
 /// @return true if _c is a decimal digit character, false otherwise

--- a/test/libsolidity/syntaxTests/functionCalls/enum_value_not_callable.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/enum_value_not_callable.sol
@@ -4,4 +4,4 @@ contract C {
     uint a = E.B(1000);
 }
 // ----
-// TypeError 5704: (46-55): Enum is not callable.
+// TypeError 5704: (46-55): This expression is not callable.

--- a/test/libsolidity/syntaxTests/functionCalls/int_not_callable.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/int_not_callable.sol
@@ -5,4 +5,4 @@ contract C
     }
 }
 // ----
-// TypeError 5704: (53-60): Rational number literal is not callable.
+// TypeError 5704: (53-60): This expression is not callable.

--- a/test/libsolidity/syntaxTests/functionCalls/magic_not_callable.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/magic_not_callable.sol
@@ -2,4 +2,4 @@ contract C {
     uint a = msg(1000);
 }
 // ----
-// TypeError 5704: (26-35): Magic variable is not callable.
+// TypeError 5704: (26-35): This expression is not callable.

--- a/test/libsolidity/syntaxTests/functionCalls/mapping_not_callable.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/mapping_not_callable.sol
@@ -3,4 +3,4 @@ contract C {
     uint a = m(1000);
 }
 // ----
-// TypeError 5704: (56-63): Mapping is not callable.
+// TypeError 5704: (56-63): This expression is not callable.

--- a/test/libsolidity/syntaxTests/functionCalls/modifier_not_callable.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/modifier_not_callable.sol
@@ -4,4 +4,4 @@ contract C {
     modifier m(uint) { _; }
 }
 // ----
-// TypeError 5704: (26-33): Modifier is not callable.
+// TypeError 5704: (26-33): This expression is not callable.

--- a/test/libsolidity/syntaxTests/functionCalls/module_not_callable.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/module_not_callable.sol
@@ -6,4 +6,4 @@ contract C {
     uint a = A(1000);
 }
 // ----
-// TypeError 5704: (B.sol:48-55): Module is not callable.
+// TypeError 5704: (B.sol:48-55): This expression is not callable.

--- a/test/libsolidity/syntaxTests/functionCalls/this_not_callable.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/this_not_callable.sol
@@ -6,4 +6,4 @@ contract C {
     }
 }
 // ----
-// TypeError 5704: (72-78): Contract is not callable.
+// TypeError 5704: (72-78): This expression is not callable.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/462_callable_crash.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/462_callable_crash.sol
@@ -6,4 +6,4 @@ contract C {
     }
 }
 // ----
-// TypeError 5704: (90-108): Rational number literal is not callable.
+// TypeError 5704: (90-108): This expression is not callable.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/492_do_not_crash_on_not_lvalue.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/492_do_not_crash_on_not_lvalue.sol
@@ -6,4 +6,4 @@ contract C {
     }
 }
 // ----
-// TypeError 5704: (153-157): Mapping is not callable.
+// TypeError 5704: (153-157): This expression is not callable.

--- a/test/libsolidity/syntaxTests/scoping/state_variable_function_conflict_former_crash.sol
+++ b/test/libsolidity/syntaxTests/scoping/state_variable_function_conflict_former_crash.sol
@@ -11,4 +11,4 @@ contract SomeContract {
 }
 // ----
 // DeclarationError 2333: (106-145): Identifier already declared.
-// TypeError 5704: (185-195): Integer is not callable.
+// TypeError 5704: (185-195): This expression is not callable.

--- a/test/libsolidity/syntaxTests/tupleAssignments/double_storage_crash.sol
+++ b/test/libsolidity/syntaxTests/tupleAssignments/double_storage_crash.sol
@@ -7,4 +7,4 @@ contract CrashContract {
        }
 }
 // ----
-// TypeError 5704: (170-177): Rational number literal is not callable.
+// TypeError 5704: (170-177): This expression is not callable.

--- a/test/libsolidity/syntaxTests/types/function_call_fail.sol
+++ b/test/libsolidity/syntaxTests/types/function_call_fail.sol
@@ -4,4 +4,4 @@ contract C {
     }
 }
 // ----
-// TypeError 5704: (59-63): Rational number literal is not callable.
+// TypeError 5704: (59-63): This expression is not callable.


### PR DESCRIPTION
This PR reverts most of my changes from #14087 and tweaks the error message in a different way, that does not require printing the type.

Discussion for reference: https://github.com/ethereum/solidity/pull/12656#discussion_r1169051859, https://github.com/ethereum/solidity/pull/12656#discussion_r1169057251.

The main problem with `Type::categoryName()` is that for most values it tries to describe the instance of the type, rather than the category - which fits the error message but is not a good formatter for that enum in general. I could fix it, but I actually found a better way to word it independently of its type (compared to https://github.com/ethereum/solidity/pull/14087#discussion_r1156057504), so I'll go with that instead.