### PR TITLE
docs: Replace references to "mining" with "attestation"

### DIFF
--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -304,7 +304,7 @@ These blocks form a linear sequence in time, and that is where the word "blockch
 Blocks are added to the chain at regular intervals, although these intervals may be subject to change in the future.
 For the most up-to-date information, it is recommended to monitor the network, for example, on `Etherscan <https://etherscan.io/chart/blocktime>`_.
 
-As part of the "order selection mechanism" (which is called "mining") it may happen that
+As part of the "order selection mechanism" (which is called "attestation") it may happen that
 blocks are reverted from time to time, but only at the "tip" of the chain. The more
 blocks are added on top of a particular block, the less likely this block will be reverted. So it might be that your transactions
 are reverted and even removed from the blockchain, but the longer you wait, the less

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -304,7 +304,7 @@ These blocks form a linear sequence in time, and that is where the word "blockch
 Blocks are added to the chain at regular intervals, although these intervals may be subject to change in the future.
 For the most up-to-date information, it is recommended to monitor the network, for example, on `Etherscan <https://etherscan.io/chart/blocktime>`_.
 
-As part of the "order selection mechanism" (which is called "attestation") it may happen that
+As part of the "order selection mechanism", which is called `attestation <https://ethereum.org/en/developers/docs/consensus-mechanisms/pos/attestations/>`_, it may happen that
 blocks are reverted from time to time, but only at the "tip" of the chain. The more
 blocks are added on top of a particular block, the less likely this block will be reverted. So it might be that your transactions
 are reverted and even removed from the blockchain, but the longer you wait, the less


### PR DESCRIPTION
Updated mining to attestation, but maybe it doesn't even make sense to put it like this. This is for the maintainers to decide but maybe it'd make sense to remove "(which is called "attestation")" altogether and just add a link to more information about LMD-GHOST.