### PR TITLE
Add default value for CIRCLE_TAG

### DIFF
--- a/scripts/ci/notification/matrix_notification.sh
+++ b/scripts/ci/notification/matrix_notification.sh
@@ -72,7 +72,7 @@ function format_predefined_message() {
 # Set message environment variables based on CI backend
 if [[ "$CIRCLECI" = true ]] ; then
     BRANCH="$CIRCLE_BRANCH"
-    TAG="$CIRCLE_TAG"
+    TAG="${CIRCLE_TAG:-}"
     BUILD_URL="$CIRCLE_BUILD_URL"
     BUILD_NUM="$CIRCLE_BUILD_NUM"
     WORKFLOW_NAME="$(circleci_workflow_name)"


### PR DESCRIPTION
Adds a default value for `CIRCLE_TAG` since it may not be present always as observed here: https://github.com/ethereum/solidity/pull/14090#issuecomment-1518058193