### PR TITLE
Optimize multiplicity map

### DIFF
--- a/libyul/backends/evm/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/StackLayoutGenerator.cpp
@@ -172,7 +172,7 @@ Stack createIdealLayout(Stack const& _operationOutput, Stack const& _post, Calla
 		vector<variant<PreviousSlot, StackSlot>>& layout;
 		Stack const& post;
 		std::set<StackSlot> outputs;
-		std::map<StackSlot, int> multiplicity;
+		Multiplicity multiplicity;
 		Callable generateSlotOnTheFly;
 		ShuffleOperations(
 			vector<variant<PreviousSlot, StackSlot>>& _layout,


### PR DESCRIPTION
@hrkrshnn 

**Rationale:**

Right now, the `std::map<StackSlot, int>` uses a vtable generated by `std::variant` in the lookup.

This causes a lot of extra overhead in the tight inner loops of the map's lookup.

Instead, we can just perform the indirection once per lookup and forward to a specialized map for the corresponding type.

This greatly reduces the compile time from 15.x seconds to 9.x seconds on the [StdCheatsSafe example (a.k.a. Chains.sol)](https://gist.github.com/chriseth/def56b241b480fa2bc52d173fdc8e451):

`time ./solc/solc --bin -o output StdCheatsSafe.sol --via-ir --optimize --optimize-runs=1000000 --overwrite`

**Comments:**

For better performance, we could use a custom open addressing map fine-tuned for storage of `uintptr_t`s.

Not all data types are best suited for open addressing. Literals (u256s) perform better in a `std::map`, as they occupy multiple 64-bit words.
