### PR TITLE
Migrate yulStackShuffling tests to isoltest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -149,6 +149,7 @@ set(libyul_sources
     libyul/StackLayoutGeneratorTest.cpp
     libyul/StackLayoutGeneratorTest.h
     libyul/StackShufflingTest.cpp
+    libyul/StackShufflingTest.h
     libyul/SyntaxTest.h
     libyul/SyntaxTest.cpp
     libyul/YulInterpreterTest.cpp

--- a/test/InteractiveTests.h
+++ b/test/InteractiveTests.h
@@ -35,6 +35,7 @@
 #include <test/libyul/ControlFlowSideEffectsTest.h>
 #include <test/libyul/FunctionSideEffects.h>
 #include <test/libyul/StackLayoutGeneratorTest.h>
+#include <test/libyul/StackShufflingTest.h>
 #include <test/libyul/SyntaxTest.h>
 
 #include <boost/filesystem.hpp>
@@ -64,6 +65,7 @@ Testsuite const g_interactiveTestsuites[] = {
 	{"Yul Object Compiler",    "libyul",      "objectCompiler",        false, false, &yul::test::ObjectCompilerTest::create},
 	{"Yul Control Flow Graph", "libyul",      "yulControlFlowGraph",   false, false, &yul::test::ControlFlowGraphTest::create},
 	{"Yul Stack Layout",       "libyul",      "yulStackLayout",        false, false, &yul::test::StackLayoutGeneratorTest::create},
+	{"Yul Stack Shuffling",    "libyul",      "yulStackShuffling",     false, false, &yul::test::StackShufflingTest::create},
 	{"Control Flow Side Effects","libyul",    "controlFlowSideEffects",false, false, &yul::test::ControlFlowSideEffectsTest::create},
 	{"Function Side Effects",  "libyul",      "functionSideEffects",   false, false, &yul::test::FunctionSideEffects::create},
 	{"Yul Syntax",             "libyul",      "yulSyntaxTests",        false, false, &yul::test::SyntaxTest::create},

--- a/test/TestCase.cpp
+++ b/test/TestCase.cpp
@@ -51,7 +51,7 @@ void TestCase::printUpdatedSettings(std::ostream& _stream, std::string const& _l
 bool TestCase::isTestFilename(boost::filesystem::path const& _filename)
 {
 	string extension = _filename.extension().string();
-	return (extension == ".sol" || extension == ".yul") &&
+	return (extension == ".sol" || extension == ".yul" || extension == ".stack") &&
 		   !boost::starts_with(_filename.string(), "~") &&
 			!boost::starts_with(_filename.string(), ".");
 }

--- a/test/libyul/StackShufflingTest.h
+++ b/test/libyul/StackShufflingTest.h
@@ -1,0 +1,47 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <test/TestCase.h>
+
+#include <libyul/backends/evm/ControlFlowGraph.h>
+
+using namespace solidity::frontend::test;
+
+namespace solidity::yul::test
+{
+
+class StackShufflingTest: public TestCase
+{
+public:
+	static std::unique_ptr<TestCase> create(Config const& _config)
+	{
+		return std::make_unique<StackShufflingTest>(_config.filename);
+	}
+	explicit StackShufflingTest(std::string const& _filename);
+	TestResult run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
+private:
+	bool parse(std::string const& _source);
+
+	Stack m_sourceStack;
+	Stack m_targetStack;
+	std::map<YulString, yul::FunctionCall> m_functions;
+	std::map<YulString, Scope::Variable> m_variables;
+};
+}

--- a/test/libyul/yulStackShuffling/swap_cycle.stack
+++ b/test/libyul/yulStackShuffling/swap_cycle.stack
@@ -1,0 +1,22 @@
+[ v0 v1 v2 v3 v4 v5 v6 v7 v9 v10 v11 v12 v13 v14 v15 v16 RET RET v5 ]
+[ v1 v0 v2 v3 v4 v5 v6 v7 v9 v10 v11 v12 v13 v14 v15 v16 RET JUNK JUNK ]
+// ----
+// [ v0 v1 v2 v3 v4 v5 v6 v7 v9 v10 v11 v12 v13 v14 v15 v16 RET RET v5 ]
+// POP
+// [ v0 v1 v2 v3 v4 v5 v6 v7 v9 v10 v11 v12 v13 v14 v15 v16 RET RET ]
+// SWAP16
+// [ v0 RET v2 v3 v4 v5 v6 v7 v9 v10 v11 v12 v13 v14 v15 v16 RET v1 ]
+// SWAP16
+// [ v0 v1 v2 v3 v4 v5 v6 v7 v9 v10 v11 v12 v13 v14 v15 v16 RET RET ]
+// POP
+// [ v0 v1 v2 v3 v4 v5 v6 v7 v9 v10 v11 v12 v13 v14 v15 v16 RET ]
+// SWAP15
+// [ v0 RET v2 v3 v4 v5 v6 v7 v9 v10 v11 v12 v13 v14 v15 v16 v1 ]
+// SWAP16
+// [ v1 RET v2 v3 v4 v5 v6 v7 v9 v10 v11 v12 v13 v14 v15 v16 v0 ]
+// SWAP15
+// [ v1 v0 v2 v3 v4 v5 v6 v7 v9 v10 v11 v12 v13 v14 v15 v16 RET ]
+// PUSH JUNK
+// [ v1 v0 v2 v3 v4 v5 v6 v7 v9 v10 v11 v12 v13 v14 v15 v16 RET JUNK ]
+// PUSH JUNK
+// [ v1 v0 v2 v3 v4 v5 v6 v7 v9 v10 v11 v12 v13 v14 v15 v16 RET JUNK JUNK ]

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(isoltest
 	../libyul/FunctionSideEffects.cpp
 	../libyul/ObjectCompilerTest.cpp
 	../libyul/SyntaxTest.cpp
+	../libyul/StackShufflingTest.cpp
 	../libyul/StackLayoutGeneratorTest.cpp
 	../libyul/YulOptimizerTest.cpp
 	../libyul/YulOptimizerTestCommon.cpp

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -76,7 +76,7 @@ public:
 		boost::replace_all(filter, "/", "\\/");
 		boost::replace_all(filter, "*", ".*");
 
-		m_filterExpression = regex{"(" + filter + "(\\.sol|\\.yul))"};
+		m_filterExpression = regex{"(" + filter + "(\\.sol|\\.yul|\\.stack))"};
 	}
 
 	bool matches(fs::path const& _path, string const& _name) const


### PR DESCRIPTION
This PR is a first attempt to create a easy way to analyze the current stack shuffling algorithm. It migrates an old boost test to the `isoltest` format for stack layouts.

The format consists of two source entries each one representing the initial stack and the target stack layout respectively.
Then it logs the steps used by `createStackLayout` as the output of the test, showing the current stack layout followed by the operation performed that resulted in the next stack layout until the target layout is reached.