### PR TITLE
Fixed deprecated github actions that the solc-bin PR check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,7 @@ defaults:
   - base_archlinux_large: &base_archlinux_large
       docker:
         - image: archlinux:base
-      resource_class: large
+      resource_class: macos.m1.large.gen1
       environment:
         TERM: xterm
         MAKEFLAGS: -j 5
@@ -281,7 +281,7 @@ defaults:
   - base_ems_large: &base_ems_large
       docker:
         - image: << pipeline.parameters.emscripten-docker-image >>
-      resource_class: large
+      resource_class: macos.m1.large.gen1
       environment:
         TERM: xterm
         MAKEFLAGS: -j 5
@@ -304,7 +304,7 @@ defaults:
   - base_osx_large: &base_osx_large
       macos:
         xcode: "13.2.0"
-      resource_class: large
+      resource_class: macos.m1.large.gen1
       environment:
         TERM: xterm
         MAKEFLAGS: -j10
@@ -370,7 +370,7 @@ defaults:
 
   - base_ubuntu2204_clang_large: &base_ubuntu2204_clang_large
       <<: *base_ubuntu2204_clang
-      resource_class: large
+      resource_class: macos.m1.large.gen1
       environment:
         TERM: xterm
         CC: clang
@@ -386,7 +386,7 @@ defaults:
 
   - base_ubuntu2204_large: &base_ubuntu2204_large
       <<: *base_ubuntu2204
-      resource_class: large
+      resource_class: macos.m1.large.gen1
       environment:
         TERM: xterm
         MAKEFLAGS: -j 5
@@ -412,7 +412,7 @@ defaults:
       executor:
         name: win/default
         shell: powershell.exe
-        size: large
+        size: macos.m1.large.gen1
 
   # --------------------------------------------------------------------------
   # Workflow Templates
@@ -528,7 +528,7 @@ defaults:
       name: t_native_test_ext_zeppelin
       project: zeppelin
       binary_type: native
-      resource_class: large
+      resource_class: macos.m1.large.gen1
 
   - job_native_test_ext_ens: &job_native_test_ext_ens
       <<: *requires_b_ubu_static
@@ -549,7 +549,7 @@ defaults:
       name: t_native_test_ext_euler
       project: euler
       binary_type: native
-      resource_class: medium
+      resource_class: macos.x86.medium.gen2
 
   - job_native_test_ext_yield_liquidator: &job_native_test_ext_yield_liquidator
       <<: *requires_b_ubu_static
@@ -562,7 +562,7 @@ defaults:
       name: t_native_test_ext_bleeps
       project: bleeps
       binary_type: native
-      resource_class: medium
+      resource_class: macos.x86.medium.gen2
 
   - job_native_test_ext_pool_together: &job_native_test_ext_pool_together
       <<: *requires_b_ubu_static
@@ -597,7 +597,7 @@ defaults:
       name: t_native_test_ext_elementfi
       project: elementfi
       binary_type: native
-      resource_class: medium
+      resource_class: macos.x86.medium.gen2
 
   - job_native_test_ext_brink: &job_native_test_ext_brink
       <<: *requires_b_ubu_static
@@ -612,7 +612,7 @@ defaults:
       project: chainlink
       binary_type: native
       image: cimg/node:16.18
-      resource_class: large # Tests run out of memory on a smaller machine
+      resource_class: macos.m1.large.gen1 # Tests run out of memory on a smaller machine
 
   - job_native_test_ext_gp2: &job_native_test_ext_gp2
       <<: *requires_b_ubu_static
@@ -627,7 +627,7 @@ defaults:
       project: colony
       binary_type: solcjs
       image: cimg/node:14.20
-      resource_class: medium
+      resource_class: macos.x86.medium.gen2
       python2: true
 
   - job_b_ubu_asan_clang: &job_b_ubu_asan_clang

--- a/.github/workflows/buildpack-deps.yml
+++ b/.github/workflows/buildpack-deps.yml
@@ -26,7 +26,7 @@ jobs:
         image_variant: [emscripten, ubuntu.clang.ossfuzz, ubuntu2004, ubuntu2204.clang, ubuntu2204]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Have changed from actions/checkout@v2 to actions/checkout@v3 which should eliminate the warning message. actions/setup-python and actions/upload-artifact are not found within the .github folder.