### PR TITLE
Switch to Gen2 macOS resources on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,14 +296,15 @@ defaults:
 
   - base_osx: &base_osx
       macos:
-        xcode: "13.2.0"
+        xcode: "14.2.0"
+      resource_class: macos.x86.medium.gen2
       environment:
         TERM: xterm
         MAKEFLAGS: -j5
 
   - base_osx_large: &base_osx_large
       macos:
-        xcode: "13.2.0"
+        xcode: "14.2.0"
       resource_class: large
       environment:
         TERM: xterm

--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -52,7 +52,6 @@ function validate_checksum {
 
 if [ ! -f /usr/local/lib/libz3.a ] # if this file does not exists (cache was not restored), rebuild dependencies
 then
-  brew unlink python
   brew install boost
   brew install cmake
   brew install wget


### PR DESCRIPTION
Fixes: #14058 base_osx now has the macos.x86.medium.gen2 tag and base_osx_large has the macos.m1.large.gen1 tag. I believe the updated Gen2 resource is available with the free plan. and the new large resource is coming in at 400 credits per minute