### PR TITLE
Introduce `pragma experimental solidity`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,10 +5,15 @@ Language Features:
 
 Compiler Features:
  * EWasm: Remove EWasm backend.
+ * Parser: Introduce ``pragma experimental solidity``, which will enable an experimental language mode that in particular has no stability guarantees between non-breaking releases and is not suited for production use.
 
 
 Bugfixes:
  * SMTChecker: Fix encoding of side-effects inside ``if`` and ``ternary conditional``statements in the BMC engine.
+
+
+AST Changes:
+ * AST: Add the ``experimentalSolidity`` field to the ``SourceUnit`` nodes, which indicate whether the experimental parsing mode has been enabled via ``pragma experimental solidity``.
 
 
 ### 0.8.20 (2023-05-10)

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -167,9 +167,14 @@ public:
 		int64_t _id,
 		SourceLocation const& _location,
 		std::optional<std::string> _licenseString,
-		std::vector<ASTPointer<ASTNode>> _nodes
+		std::vector<ASTPointer<ASTNode>> _nodes,
+		bool _experimentalSolidity
 	):
-		ASTNode(_id, _location), m_licenseString(std::move(_licenseString)), m_nodes(std::move(_nodes)) {}
+		ASTNode(_id, _location),
+		m_licenseString(std::move(_licenseString)),
+		m_nodes(std::move(_nodes)),
+		m_experimentalSolidity(_experimentalSolidity)
+	{}
 
 	void accept(ASTVisitor& _visitor) override;
 	void accept(ASTConstVisitor& _visitor) const override;
@@ -180,10 +185,12 @@ public:
 
 	/// @returns a set of referenced SourceUnits. Recursively if @a _recurse is true.
 	std::set<SourceUnit const*> referencedSourceUnits(bool _recurse = false, std::set<SourceUnit const*> _skipList = std::set<SourceUnit const*>()) const;
+	bool experimentalSolidity() const { return m_experimentalSolidity; }
 
 private:
 	std::optional<std::string> m_licenseString;
 	std::vector<ASTPointer<ASTNode>> m_nodes;
+	bool m_experimentalSolidity = false;
 };
 
 /**

--- a/libsolidity/ast/ASTJsonExporter.cpp
+++ b/libsolidity/ast/ASTJsonExporter.cpp
@@ -214,8 +214,11 @@ bool ASTJsonExporter::visit(SourceUnit const& _node)
 {
 	std::vector<pair<string, Json::Value>> attributes = {
 		make_pair("license", _node.licenseString() ? Json::Value(*_node.licenseString()) : Json::nullValue),
-		make_pair("nodes", toJson(_node.nodes()))
+		make_pair("nodes", toJson(_node.nodes())),
 	};
+
+	if (_node.experimentalSolidity())
+		attributes.emplace_back("experimentalSolidity", Json::Value(_node.experimentalSolidity()));
 
 	if (_node.annotation().exportedSymbols.set())
 	{

--- a/libsolidity/ast/ASTJsonImporter.cpp
+++ b/libsolidity/ast/ASTJsonImporter.cpp
@@ -271,11 +271,15 @@ ASTPointer<SourceUnit> ASTJsonImporter::createSourceUnit(Json::Value const& _nod
 	if (_node.isMember("license") && !_node["license"].isNull())
 		license = _node["license"].asString();
 
+	bool experimentalSolidity = false;
+	if (_node.isMember("experimentalSolidity") && !_node["experimentalSolidity"].isNull())
+		experimentalSolidity = _node["experimentalSolidity"].asBool();
+
 	vector<ASTPointer<ASTNode>> nodes;
 	for (auto& child: member(_node, "nodes"))
 		nodes.emplace_back(convertJsonToASTNode(child));
 
-	ASTPointer<SourceUnit> tmp = createASTNode<SourceUnit>(_node, license, nodes);
+	ASTPointer<SourceUnit> tmp = createASTNode<SourceUnit>(_node, license, nodes, experimentalSolidity);
 	tmp->annotation().path = _srcName;
 	return tmp;
 }

--- a/libsolidity/ast/ExperimentalFeatures.h
+++ b/libsolidity/ast/ExperimentalFeatures.h
@@ -32,7 +32,8 @@ enum class ExperimentalFeature
 	ABIEncoderV2, // new ABI encoder that makes use of Yul
 	SMTChecker,
 	Test,
-	TestOnlyAnalysis
+	TestOnlyAnalysis,
+	Solidity
 };
 
 static std::set<ExperimentalFeature> const ExperimentalFeatureWithoutWarning =
@@ -48,6 +49,7 @@ static std::map<std::string, ExperimentalFeature> const ExperimentalFeatureNames
 	{ "SMTChecker", ExperimentalFeature::SMTChecker },
 	{ "__test", ExperimentalFeature::Test },
 	{ "__testOnlyAnalysis", ExperimentalFeature::TestOnlyAnalysis },
+	{ "solidity", ExperimentalFeature::Solidity }
 };
 
 }

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -399,7 +399,7 @@ private:
 	/// @returns the newly loaded sources.
 	StringMap loadMissingSources(SourceUnit const& _ast);
 	std::string applyRemapping(std::string const& _path, std::string const& _context);
-	void resolveImports();
+	bool resolveImports();
 
 	/// Store the contract definitions in m_contracts.
 	void storeContractDefinitions();

--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -89,7 +89,7 @@ private:
 	///@name Parsing functions for the AST nodes
 	void parsePragmaVersion(langutil::SourceLocation const& _location, std::vector<Token> const& _tokens, std::vector<std::string> const& _literals);
 	ASTPointer<StructuredDocumentation> parseStructuredDocumentation();
-	ASTPointer<PragmaDirective> parsePragmaDirective();
+	ASTPointer<PragmaDirective> parsePragmaDirective(bool _finishedParsingTopLevelPragmas);
 	ASTPointer<ImportDirective> parseImportDirective();
 	/// @returns an std::pair<ContractKind, bool>, where
 	/// result.second is set to true, if an abstract contract was parsed, false otherwise.
@@ -227,6 +227,8 @@ private:
 	langutil::EVMVersion m_evmVersion;
 	/// Counter for the next AST node ID
 	int64_t m_currentNodeID = 0;
+	/// Flag that indicates whether experimental mode is enabled in the current source unit
+	bool m_experimentalSolidityEnabledInCurrentSourceUnit = false;
 };
 
 }

--- a/scripts/test_antlr_grammar.sh
+++ b/scripts/test_antlr_grammar.sh
@@ -110,7 +110,7 @@ do
   SOL_FILES+=("$line")
 done < <(
   grep --include "*.sol" -riL -E \
-    "^\/\/ (Syntax|Type|Declaration)Error|^\/\/ ParserError (1684|2837|3716|3997|5333|6275|6281|6933|7319)|^==== Source:" \
+    "^\/\/ (Syntax|Type|Declaration)Error|^\/\/ ParserError (1684|2837|3716|3997|5333|6275|6281|6933|7319|8185)|^==== Source:" \
     "${ROOT_DIR}/test/libsolidity/syntaxTests" \
     "${ROOT_DIR}/test/libsolidity/semanticTests" |
       # Skipping the unicode tests as I couldn't adapt the lexical grammar to recursively counting RLO/LRO/PDF's.

--- a/test/libsolidity/ASTJSON/pragma_experimental_solidity.json
+++ b/test/libsolidity/ASTJSON/pragma_experimental_solidity.json
@@ -1,0 +1,21 @@
+{
+  "absolutePath": "a",
+  "experimentalSolidity": true,
+  "exportedSymbols": {},
+  "id": 2,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "id": 1,
+      "literals":
+      [
+        "experimental",
+        "solidity"
+      ],
+      "nodeType": "PragmaDirective",
+      "src": "0:29:1"
+    }
+  ],
+  "src": "0:30:1"
+}

--- a/test/libsolidity/ASTJSON/pragma_experimental_solidity.sol
+++ b/test/libsolidity/ASTJSON/pragma_experimental_solidity.sol
@@ -1,0 +1,3 @@
+pragma experimental solidity;
+
+// ----

--- a/test/libsolidity/ASTJSON/pragma_experimental_solidity_parseOnly.json
+++ b/test/libsolidity/ASTJSON/pragma_experimental_solidity_parseOnly.json
@@ -1,0 +1,20 @@
+{
+  "absolutePath": "a",
+  "experimentalSolidity": true,
+  "id": 2,
+  "nodeType": "SourceUnit",
+  "nodes":
+  [
+    {
+      "id": 1,
+      "literals":
+      [
+        "experimental",
+        "solidity"
+      ],
+      "nodeType": "PragmaDirective",
+      "src": "0:29:1"
+    }
+  ],
+  "src": "0:30:1"
+}

--- a/test/libsolidity/SolidityTypes.cpp
+++ b/test/libsolidity/SolidityTypes.cpp
@@ -213,7 +213,7 @@ BOOST_AUTO_TEST_CASE(type_identifiers)
 	ModifierDefinition mod(++id, SourceLocation{}, make_shared<string>("modif"), SourceLocation{}, {}, emptyParams, {}, {}, {});
 	BOOST_CHECK_EQUAL(ModifierType(mod).identifier(), "t_modifier$__$");
 
-	SourceUnit su(++id, {}, {}, {});
+	SourceUnit su(++id, {}, {}, {}, {});
 	BOOST_CHECK_EQUAL(ModuleType(su).identifier(), "t_module_7");
 	BOOST_CHECK_EQUAL(MagicType(MagicType::Kind::Block).identifier(), "t_magic_block");
 	BOOST_CHECK_EQUAL(MagicType(MagicType::Kind::Message).identifier(), "t_magic_message");

--- a/test/libsolidity/syntaxTests/pragma/experimental_solidity.sol
+++ b/test/libsolidity/syntaxTests/pragma/experimental_solidity.sol
@@ -1,0 +1,3 @@
+pragma experimental solidity;
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.

--- a/test/libsolidity/syntaxTests/pragma/experimental_solidity_multisource_not_all_enable.sol
+++ b/test/libsolidity/syntaxTests/pragma/experimental_solidity_multisource_not_all_enable.sol
@@ -1,0 +1,24 @@
+==== Source: A.sol ====
+contract A {}
+==== Source: B.sol ====
+pragma experimental solidity;
+import "A.sol";
+contract B {
+    A a;
+}
+==== Source: C.sol ====
+pragma experimental solidity;
+import "A.sol";
+contract C {
+    A a;
+}
+==== Source: D.sol ====
+pragma experimental solidity;
+import "A.sol";
+contract D {
+    A a;
+}
+// ----
+// ParserError 2141: (B.sol:0-29): File declares "pragma experimental solidity". If you want to enable the experimental mode, all source units must include the pragma.
+// ParserError 2141: (C.sol:0-29): File declares "pragma experimental solidity". If you want to enable the experimental mode, all source units must include the pragma.
+// ParserError 2141: (D.sol:0-29): File declares "pragma experimental solidity". If you want to enable the experimental mode, all source units must include the pragma.

--- a/test/libsolidity/syntaxTests/pragma/experimental_solidity_out_of_order_1.sol
+++ b/test/libsolidity/syntaxTests/pragma/experimental_solidity_out_of_order_1.sol
@@ -1,0 +1,5 @@
+contract A {}
+
+pragma experimental solidity;
+// ----
+// ParserError 8185: (45-45): Experimental pragma "solidity" can only be set at the beginning of the source unit.

--- a/test/libsolidity/syntaxTests/pragma/experimental_solidity_out_of_order_2.sol
+++ b/test/libsolidity/syntaxTests/pragma/experimental_solidity_out_of_order_2.sol
@@ -1,0 +1,13 @@
+function f() pure returns (uint)
+{
+    return 1;
+}
+
+pragma experimental solidity;
+
+struct A
+{
+    uint256 x;
+}
+// ----
+// ParserError 8185: (83-89): Experimental pragma "solidity" can only be set at the beginning of the source unit.


### PR DESCRIPTION
Note: *this is still a work in progress*

- [x] Changelog entry (pragma, ast)
- [x] Decide feature name for the experimental pragma (current placeholder is `next`) (decision `pragma experimental solidity`)
- [x] Change pragma from `next` to `solidity`
- [x] Resolve imports in CompilerStack

Fixes: https://github.com/ethereum/solidity/pull/10639#issuecomment-1514836960