### PR TITLE
Add support for Yul ASTs output

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,8 +4,12 @@ Language Features:
 
 
 Compiler Features:
+ * Commandline Interface: Add ``--ast-compact-json`` output in assembler mode.
+ * Commandline Interface: Add ``--ir-ast-json`` and ``--ir-optimized-ast-json`` outputs for Solidity input, providing AST in compact JSON format for IR and optimized IR.
  * EWasm: Remove EWasm backend.
  * Parser: Introduce ``pragma experimental solidity``, which will enable an experimental language mode that in particular has no stability guarantees between non-breaking releases and is not suited for production use.
+ * Standard JSON Interface: Add ``ast`` file-level output for Yul input.
+ * Standard JSON Interface: Add ``irAst`` and ``irOptimizedAst`` contract-level outputs for Solidity input, providing AST in compact JSON format for IR and optimized IR.
 
 
 Bugfixes:

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -390,7 +390,9 @@ Input Description
         //   userdoc - User documentation (natspec)
         //   metadata - Metadata
         //   ir - Yul intermediate representation of the code before optimization
+        //   irAst - AST of Yul intermediate representation of the code before optimization
         //   irOptimized - Intermediate representation after optimization
+        //   irOptimizedAst - AST of intermediate representation after optimization
         //   storageLayout - Slots, offsets and types of the contract's state variables.
         //   evm.assembly - New assembly format
         //   evm.legacyAssembly - Old-style assembly format in JSON
@@ -536,8 +538,14 @@ Output Description
             "userdoc": {},
             // Developer documentation (natspec)
             "devdoc": {},
-            // Intermediate representation (string)
+            // Intermediate representation before optimization (string)
             "ir": "",
+            // AST of intermediate representation before optimization
+            "irAst":  {/* ... */},
+            // Intermediate representation after optimization (string)
+            "irOptimized": "",
+            // AST of intermediate representation after optimization
+            "irOptimizedAst": {/* ... */},
             // See the Storage Layout documentation.
             "storageLayout": {"storage": [/* ... */], "types": {/* ... */} },
             // EVM-related outputs

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -40,6 +40,8 @@
 
 #include <liblangutil/SourceReferenceFormatter.h>
 
+#include <json/json.h>
+
 #include <sstream>
 #include <variant>
 
@@ -87,7 +89,7 @@ set<CallableDeclaration const*, ASTNode::CompareByID> collectReachableCallables(
 
 }
 
-pair<string, string> IRGenerator::run(
+tuple<string, Json::Value, string, Json::Value> IRGenerator::run(
 	ContractDefinition const& _contract,
 	bytes const& _cborMetadata,
 	map<ContractDefinition const*, string_view const> const& _otherYulSources
@@ -112,9 +114,11 @@ pair<string, string> IRGenerator::run(
 			);
 		solAssert(false, ir + "\n\nInvalid IR generated:\n" + errorMessage + "\n");
 	}
+	Json::Value irAst = asmStack.astJson();
 	asmStack.optimize();
+	Json::Value irOptAst = asmStack.astJson();
 
-	return {std::move(ir), asmStack.print(m_context.soliditySourceProvider())};
+	return {std::move(ir), std::move(irAst), asmStack.print(m_context.soliditySourceProvider()), std::move(irOptAst)};
 }
 
 string IRGenerator::generate(

--- a/libsolidity/codegen/ir/IRGenerator.h
+++ b/libsolidity/codegen/ir/IRGenerator.h
@@ -32,6 +32,8 @@
 #include <liblangutil/CharStreamProvider.h>
 #include <liblangutil/EVMVersion.h>
 
+#include <json/json.h>
+
 #include <string>
 
 namespace solidity::frontend
@@ -70,7 +72,7 @@ public:
 
 	/// Generates and returns the IR code, in unoptimized and optimized form
 	/// (or just pretty-printed, depending on the optimizer settings).
-	std::pair<std::string, std::string> run(
+	std::tuple<std::string, Json::Value, std::string, Json::Value> run(
 		ContractDefinition const& _contract,
 		bytes const& _cborMetadata,
 		std::map<ContractDefinition const*, std::string_view const> const& _otherYulSources

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -883,12 +883,28 @@ string const& CompilerStack::yulIR(string const& _contractName) const
 	return contract(_contractName).yulIR;
 }
 
+Json::Value const& CompilerStack::yulIRAst(string const& _contractName) const
+{
+	if (m_stackState != CompilationSuccessful)
+		solThrow(CompilerError, "Compilation was not successful.");
+
+	return contract(_contractName).yulIRAst;
+}
+
 string const& CompilerStack::yulIROptimized(string const& _contractName) const
 {
 	if (m_stackState != CompilationSuccessful)
 		solThrow(CompilerError, "Compilation was not successful.");
 
 	return contract(_contractName).yulIROptimized;
+}
+
+Json::Value const& CompilerStack::yulIROptimizedAst(string const& _contractName) const
+{
+	if (m_stackState != CompilationSuccessful)
+		solThrow(CompilerError, "Compilation was not successful.");
+
+	return contract(_contractName).yulIROptimizedAst;
 }
 
 evmasm::LinkerObject const& CompilerStack::object(string const& _contractName) const
@@ -1445,7 +1461,13 @@ void CompilerStack::generateIR(ContractDefinition const& _contract)
 		m_debugInfoSelection,
 		this
 	);
-	tie(compiledContract.yulIR, compiledContract.yulIROptimized) = generator.run(
+
+	tie(
+		compiledContract.yulIR,
+		compiledContract.yulIRAst,
+		compiledContract.yulIROptimized,
+		compiledContract.yulIROptimizedAst
+	) = generator.run(
 		_contract,
 		createCBORMetadata(compiledContract, /* _forIR */ true),
 		otherYulSources

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -276,8 +276,14 @@ public:
 	/// @returns the IR representation of a contract.
 	std::string const& yulIR(std::string const& _contractName) const;
 
+	/// @returns the IR representation of a contract AST in format.
+	Json::Value const& yulIRAst(std::string const& _contractName) const;
+
 	/// @returns the optimized IR representation of a contract.
 	std::string const& yulIROptimized(std::string const& _contractName) const;
+
+	/// @returns the optimized IR representation of a contract AST in JSON format.
+	Json::Value const& yulIROptimizedAst(std::string const& _contractName) const;
 
 	/// @returns the assembled object for a contract.
 	evmasm::LinkerObject const& object(std::string const& _contractName) const;
@@ -380,6 +386,8 @@ private:
 		evmasm::LinkerObject runtimeObject; ///< Runtime object.
 		std::string yulIR; ///< Yul IR code.
 		std::string yulIROptimized; ///< Optimized Yul IR code.
+		Json::Value yulIRAst; ///< JSON AST of Yul IR code.
+		Json::Value yulIROptimizedAst; ///< JSON AST of optimized Yul IR code.
 		util::LazyInit<std::string const> metadata; ///< The metadata json that will be hashed into the chain.
 		util::LazyInit<Json::Value const> abi;
 		util::LazyInit<Json::Value const> storageLayout;

--- a/libyul/AsmJsonConverter.cpp
+++ b/libyul/AsmJsonConverter.cpp
@@ -33,7 +33,7 @@ namespace solidity::yul
 
 Json::Value AsmJsonConverter::operator()(Block const& _node) const
 {
-	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulBlock");
+	Json::Value ret = createAstNode(originLocationOf(_node), nativeLocationOf(_node), "YulBlock");
 	ret["statements"] = vectorOfVariantsToJson(_node.statements);
 	return ret;
 }
@@ -41,7 +41,7 @@ Json::Value AsmJsonConverter::operator()(Block const& _node) const
 Json::Value AsmJsonConverter::operator()(TypedName const& _node) const
 {
 	yulAssert(!_node.name.empty(), "Invalid variable name.");
-	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulTypedName");
+	Json::Value ret = createAstNode(originLocationOf(_node), nativeLocationOf(_node), "YulTypedName");
 	ret["name"] = _node.name.str();
 	ret["type"] = _node.type.str();
 	return ret;
@@ -49,7 +49,7 @@ Json::Value AsmJsonConverter::operator()(TypedName const& _node) const
 
 Json::Value AsmJsonConverter::operator()(Literal const& _node) const
 {
-	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulLiteral");
+	Json::Value ret = createAstNode(originLocationOf(_node), nativeLocationOf(_node), "YulLiteral");
 	switch (_node.kind)
 	{
 	case LiteralKind::Number:
@@ -76,7 +76,7 @@ Json::Value AsmJsonConverter::operator()(Literal const& _node) const
 Json::Value AsmJsonConverter::operator()(Identifier const& _node) const
 {
 	yulAssert(!_node.name.empty(), "Invalid identifier");
-	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulIdentifier");
+	Json::Value ret = createAstNode(originLocationOf(_node), nativeLocationOf(_node), "YulIdentifier");
 	ret["name"] = _node.name.str();
 	return ret;
 }
@@ -84,7 +84,7 @@ Json::Value AsmJsonConverter::operator()(Identifier const& _node) const
 Json::Value AsmJsonConverter::operator()(Assignment const& _node) const
 {
 	yulAssert(_node.variableNames.size() >= 1, "Invalid assignment syntax");
-	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulAssignment");
+	Json::Value ret = createAstNode(originLocationOf(_node), nativeLocationOf(_node), "YulAssignment");
 	for (auto const& var: _node.variableNames)
 		ret["variableNames"].append((*this)(var));
 	ret["value"] = _node.value ? std::visit(*this, *_node.value) : Json::nullValue;
@@ -93,7 +93,7 @@ Json::Value AsmJsonConverter::operator()(Assignment const& _node) const
 
 Json::Value AsmJsonConverter::operator()(FunctionCall const& _node) const
 {
-	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulFunctionCall");
+	Json::Value ret = createAstNode(originLocationOf(_node), nativeLocationOf(_node), "YulFunctionCall");
 	ret["functionName"] = (*this)(_node.functionName);
 	ret["arguments"] = vectorOfVariantsToJson(_node.arguments);
 	return ret;
@@ -101,14 +101,14 @@ Json::Value AsmJsonConverter::operator()(FunctionCall const& _node) const
 
 Json::Value AsmJsonConverter::operator()(ExpressionStatement const& _node) const
 {
-	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulExpressionStatement");
+	Json::Value ret = createAstNode(originLocationOf(_node), nativeLocationOf(_node), "YulExpressionStatement");
 	ret["expression"] = std::visit(*this, _node.expression);
 	return ret;
 }
 
 Json::Value AsmJsonConverter::operator()(VariableDeclaration const& _node) const
 {
-	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulVariableDeclaration");
+	Json::Value ret = createAstNode(originLocationOf(_node), nativeLocationOf(_node), "YulVariableDeclaration");
 	for (auto const& var: _node.variables)
 		ret["variables"].append((*this)(var));
 
@@ -120,7 +120,7 @@ Json::Value AsmJsonConverter::operator()(VariableDeclaration const& _node) const
 Json::Value AsmJsonConverter::operator()(FunctionDefinition const& _node) const
 {
 	yulAssert(!_node.name.empty(), "Invalid function name.");
-	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulFunctionDefinition");
+	Json::Value ret = createAstNode(originLocationOf(_node), nativeLocationOf(_node), "YulFunctionDefinition");
 	ret["name"] = _node.name.str();
 	for (auto const& var: _node.parameters)
 		ret["parameters"].append((*this)(var));
@@ -133,7 +133,7 @@ Json::Value AsmJsonConverter::operator()(FunctionDefinition const& _node) const
 Json::Value AsmJsonConverter::operator()(If const& _node) const
 {
 	yulAssert(_node.condition, "Invalid if condition.");
-	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulIf");
+	Json::Value ret = createAstNode(originLocationOf(_node), nativeLocationOf(_node), "YulIf");
 	ret["condition"] = std::visit(*this, *_node.condition);
 	ret["body"] = (*this)(_node.body);
 	return ret;
@@ -142,7 +142,7 @@ Json::Value AsmJsonConverter::operator()(If const& _node) const
 Json::Value AsmJsonConverter::operator()(Switch const& _node) const
 {
 	yulAssert(_node.expression, "Invalid expression pointer.");
-	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulSwitch");
+	Json::Value ret = createAstNode(originLocationOf(_node), nativeLocationOf(_node), "YulSwitch");
 	ret["expression"] = std::visit(*this, *_node.expression);
 	for (auto const& var: _node.cases)
 		ret["cases"].append((*this)(var));
@@ -151,7 +151,7 @@ Json::Value AsmJsonConverter::operator()(Switch const& _node) const
 
 Json::Value AsmJsonConverter::operator()(Case const& _node) const
 {
-	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulCase");
+	Json::Value ret = createAstNode(originLocationOf(_node), nativeLocationOf(_node), "YulCase");
 	ret["value"] = _node.value ? (*this)(*_node.value) : "default";
 	ret["body"] = (*this)(_node.body);
 	return ret;
@@ -160,7 +160,7 @@ Json::Value AsmJsonConverter::operator()(Case const& _node) const
 Json::Value AsmJsonConverter::operator()(ForLoop const& _node) const
 {
 	yulAssert(_node.condition, "Invalid for loop condition.");
-	Json::Value ret = createAstNode(nativeLocationOf(_node), "YulForLoop");
+	Json::Value ret = createAstNode(originLocationOf(_node), nativeLocationOf(_node), "YulForLoop");
 	ret["pre"] = (*this)(_node.pre);
 	ret["condition"] = std::visit(*this, *_node.condition);
 	ret["post"] = (*this)(_node.post);
@@ -170,27 +170,30 @@ Json::Value AsmJsonConverter::operator()(ForLoop const& _node) const
 
 Json::Value AsmJsonConverter::operator()(Break const& _node) const
 {
-	return createAstNode(nativeLocationOf(_node), "YulBreak");
+	return createAstNode(originLocationOf(_node), nativeLocationOf(_node), "YulBreak");
 }
 
 Json::Value AsmJsonConverter::operator()(Continue const& _node) const
 {
-	return createAstNode(nativeLocationOf(_node), "YulContinue");
+	return createAstNode(originLocationOf(_node), nativeLocationOf(_node), "YulContinue");
 }
 
 Json::Value AsmJsonConverter::operator()(Leave const& _node) const
 {
-	return createAstNode(nativeLocationOf(_node), "YulLeave");
+	return createAstNode(originLocationOf(_node), nativeLocationOf(_node), "YulLeave");
 }
 
-Json::Value AsmJsonConverter::createAstNode(langutil::SourceLocation const& _location, string _nodeType) const
+Json::Value AsmJsonConverter::createAstNode(langutil::SourceLocation const& _originLocation, langutil::SourceLocation const& _nativeLocation, string _nodeType) const
 {
 	Json::Value ret{Json::objectValue};
 	ret["nodeType"] = std::move(_nodeType);
-	int length = -1;
-	if (_location.start >= 0 && _location.end >= 0)
-		length = _location.end - _location.start;
-	ret["src"] = to_string(_location.start) + ":" + to_string(length) + ":" + (m_sourceIndex.has_value() ? to_string(m_sourceIndex.value()) : "-1");
+	auto srcLocation = [&](int start, int end) -> string
+	{
+		int length = (start >= 0 && end >= 0 && end >= start) ? end - start : -1;
+		return to_string(start) + ":" + to_string(length) + ":" + (m_sourceIndex.has_value() ? to_string(m_sourceIndex.value()) : "-1");
+	};
+	ret["src"] = srcLocation(_originLocation.start, _originLocation.end);
+	ret["nativeSrc"] = srcLocation(_nativeLocation.start, _nativeLocation.end);
 	return ret;
 }
 

--- a/libyul/AsmJsonConverter.h
+++ b/libyul/AsmJsonConverter.h
@@ -62,7 +62,7 @@ public:
 	Json::Value operator()(Label const& _node) const;
 
 private:
-	Json::Value createAstNode(langutil::SourceLocation const& _location, std::string _nodeType) const;
+	Json::Value createAstNode(langutil::SourceLocation const& _originLocation, langutil::SourceLocation const& _nativeLocation, std::string _nodeType) const;
 	template <class T>
 	Json::Value vectorOfVariantsToJson(std::vector<T> const& vec) const;
 

--- a/libyul/Object.h
+++ b/libyul/Object.h
@@ -32,12 +32,12 @@
 #include <memory>
 #include <set>
 #include <limits>
+#include <json/json.h>
 
 namespace solidity::yul
 {
 struct Dialect;
 struct AsmAnalysisInfo;
-
 
 using SourceNameMap = std::map<unsigned, std::shared_ptr<std::string const>>;
 
@@ -58,6 +58,7 @@ struct ObjectNode
 		langutil::DebugInfoSelection const& _debugInfoSelection,
 		langutil::CharStreamProvider const* _soliditySourceProvider
 	) const = 0;
+	virtual Json::Value toJson() const = 0;
 };
 
 /**
@@ -74,6 +75,7 @@ struct Data: public ObjectNode
 		langutil::DebugInfoSelection const& _debugInfoSelection,
 		langutil::CharStreamProvider const* _soliditySourceProvider
 	) const override;
+	Json::Value toJson() const override;
 };
 
 
@@ -95,7 +97,8 @@ public:
 		langutil::DebugInfoSelection const& _debugInfoSelection = langutil::DebugInfoSelection::Default(),
 		langutil::CharStreamProvider const* _soliditySourceProvider = nullptr
 	) const;
-
+	/// @returns a compact JSON representation of the AST.
+	Json::Value toJson() const;
 	/// @returns the set of names of data objects accessible from within the code of
 	/// this object, including the name of object itself
 	/// Handles all names containing dots as reserved identifiers, not accessible as data.

--- a/libyul/YulStack.cpp
+++ b/libyul/YulStack.cpp
@@ -31,10 +31,11 @@
 #include <libyul/backends/evm/EVMMetrics.h>
 #include <libyul/ObjectParser.h>
 #include <libyul/optimiser/Suite.h>
-
 #include <libevmasm/Assembly.h>
 #include <liblangutil/Scanner.h>
+
 #include <boost/algorithm/string.hpp>
+
 #include <optional>
 
 using namespace std;
@@ -268,6 +269,13 @@ string YulStack::print(
 	yulAssert(m_parserResult, "");
 	yulAssert(m_parserResult->code, "");
 	return m_parserResult->toString(&languageToDialect(m_language, m_evmVersion), m_debugInfoSelection, _soliditySourceProvider) + "\n";
+}
+
+Json::Value YulStack::astJson() const
+{
+	yulAssert(m_parserResult, "");
+	yulAssert(m_parserResult->code, "");
+	return  m_parserResult->toJson();
 }
 
 shared_ptr<Object> YulStack::parserResult() const

--- a/libyul/YulStack.h
+++ b/libyul/YulStack.h
@@ -33,6 +33,8 @@
 
 #include <libevmasm/LinkerObject.h>
 
+#include <json/json.h>
+
 #include <memory>
 #include <string>
 
@@ -130,7 +132,7 @@ public:
 	std::string print(
 		langutil::CharStreamProvider const* _soliditySourceProvider = nullptr
 	) const;
-
+	Json::Value astJson() const;
 	/// Return the parsed and analyzed object.
 	std::shared_ptr<Object> parserResult() const;
 

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -101,7 +101,9 @@ private:
 	void handleBinary(std::string const& _contract);
 	void handleOpcode(std::string const& _contract);
 	void handleIR(std::string const& _contract);
+	void handleIRAst(std::string const& _contract);
 	void handleIROptimized(std::string const& _contract);
+	void handleIROptimizedAst(std::string const& _contract);
 	void handleBytecode(std::string const& _contract);
 	void handleSignatureHashes(std::string const& _contract);
 	void handleMetadata(std::string const& _contract);

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -461,7 +461,8 @@ void CommandLineParser::parseOutputSelection()
 		static set<string> const assemblerModeOutputs = {
 			CompilerOutputs::componentName(&CompilerOutputs::asm_),
 			CompilerOutputs::componentName(&CompilerOutputs::binary),
-			CompilerOutputs::componentName(&CompilerOutputs::irOptimized)
+			CompilerOutputs::componentName(&CompilerOutputs::irOptimized),
+			CompilerOutputs::componentName(&CompilerOutputs::astCompactJson),
 		};
 
 		switch (_mode)
@@ -735,7 +736,9 @@ General Information)").c_str(),
 		(CompilerOutputs::componentName(&CompilerOutputs::binaryRuntime).c_str(), "Binary of the runtime part of the contracts in hex.")
 		(CompilerOutputs::componentName(&CompilerOutputs::abi).c_str(), "ABI specification of the contracts.")
 		(CompilerOutputs::componentName(&CompilerOutputs::ir).c_str(), "Intermediate Representation (IR) of all contracts.")
-		(CompilerOutputs::componentName(&CompilerOutputs::irOptimized).c_str(), "Optimized intermediate Representation (IR) of all contracts.")
+		(CompilerOutputs::componentName(&CompilerOutputs::irAstJson).c_str(), "AST of Intermediate Representation (IR) of all contracts in a compact JSON format.")
+		(CompilerOutputs::componentName(&CompilerOutputs::irOptimized).c_str(), "Optimized Intermediate Representation (IR) of all contracts.")
+		(CompilerOutputs::componentName(&CompilerOutputs::irOptimizedAstJson).c_str(), "AST of optimized Intermediate Representation (IR) of all contracts in a compact JSON format.")
 		(CompilerOutputs::componentName(&CompilerOutputs::signatureHashes).c_str(), "Function signature hashes of the contracts.")
 		(CompilerOutputs::componentName(&CompilerOutputs::natspecUser).c_str(), "Natspec user documentation of all contracts.")
 		(CompilerOutputs::componentName(&CompilerOutputs::natspecDev).c_str(), "Natspec developer documentation of all contracts.")
@@ -991,7 +994,9 @@ void CommandLineParser::processArgs()
 	array<string, 9> const conflictingWithStopAfter{
 		CompilerOutputs::componentName(&CompilerOutputs::binary),
 		CompilerOutputs::componentName(&CompilerOutputs::ir),
+		CompilerOutputs::componentName(&CompilerOutputs::irAstJson),
 		CompilerOutputs::componentName(&CompilerOutputs::irOptimized),
+		CompilerOutputs::componentName(&CompilerOutputs::irOptimizedAstJson),
 		g_strGas,
 		CompilerOutputs::componentName(&CompilerOutputs::asm_),
 		CompilerOutputs::componentName(&CompilerOutputs::asmJson),

--- a/solc/CommandLineParser.h
+++ b/solc/CommandLineParser.h
@@ -77,7 +77,9 @@ struct CompilerOutputs
 			{"bin-runtime", &CompilerOutputs::binaryRuntime},
 			{"abi", &CompilerOutputs::abi},
 			{"ir", &CompilerOutputs::ir},
+			{"ir-ast-json", &CompilerOutputs::irAstJson},
 			{"ir-optimized", &CompilerOutputs::irOptimized},
+			{"ir-optimized-ast-json", &CompilerOutputs::irOptimizedAstJson},
 			{"hashes", &CompilerOutputs::signatureHashes},
 			{"userdoc", &CompilerOutputs::natspecUser},
 			{"devdoc", &CompilerOutputs::natspecDev},
@@ -95,7 +97,9 @@ struct CompilerOutputs
 	bool binaryRuntime = false;
 	bool abi = false;
 	bool ir = false;
+	bool irAstJson = false;
 	bool irOptimized = false;
+	bool irOptimizedAstJson = false;
 	bool signatureHashes = false;
 	bool natspecUser = false;
 	bool natspecDev = false;

--- a/test/cmdlineTests/ast_ir/args
+++ b/test/cmdlineTests/ast_ir/args
@@ -1,0 +1,1 @@
+--ir-ast-json --ir-optimized-ast-json --optimize --pretty-json --json-indent 4

--- a/test/cmdlineTests/ast_ir/input.sol
+++ b/test/cmdlineTests/ast_ir/input.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+
+contract C {}

--- a/test/cmdlineTests/ast_ir/output
+++ b/test/cmdlineTests/ast_ir/output
@@ -1,0 +1,1078 @@
+IR AST:
+{
+    "code":
+    {
+        "block":
+        {
+            "nativeSrc": "59:790:0",
+            "nodeType": "YulBlock",
+            "src": "-1:-1:0",
+            "statements":
+            [
+                {
+                    "expression":
+                    {
+                        "arguments":
+                        [
+                            {
+                                "kind": "number",
+                                "nativeSrc": "118:2:0",
+                                "nodeType": "YulLiteral",
+                                "src": "60:13:0",
+                                "type": "",
+                                "value": "64"
+                            },
+                            {
+                                "arguments":
+                                [
+                                    {
+                                        "kind": "number",
+                                        "nativeSrc": "134:3:0",
+                                        "nodeType": "YulLiteral",
+                                        "src": "60:13:0",
+                                        "type": "",
+                                        "value": "128"
+                                    }
+                                ],
+                                "functionName":
+                                {
+                                    "name": "memoryguard",
+                                    "nativeSrc": "122:11:0",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "60:13:0"
+                                },
+                                "nativeSrc": "122:16:0",
+                                "nodeType": "YulFunctionCall",
+                                "src": "60:13:0"
+                            }
+                        ],
+                        "functionName":
+                        {
+                            "name": "mstore",
+                            "nativeSrc": "111:6:0",
+                            "nodeType": "YulIdentifier",
+                            "src": "60:13:0"
+                        },
+                        "nativeSrc": "111:28:0",
+                        "nodeType": "YulFunctionCall",
+                        "src": "60:13:0"
+                    },
+                    "nativeSrc": "111:28:0",
+                    "nodeType": "YulExpressionStatement",
+                    "src": "60:13:0"
+                },
+                {
+                    "body":
+                    {
+                        "nativeSrc": "163:83:0",
+                        "nodeType": "YulBlock",
+                        "src": "60:13:0",
+                        "statements":
+                        [
+                            {
+                                "expression":
+                                {
+                                    "arguments": [],
+                                    "functionName":
+                                    {
+                                        "name": "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb",
+                                        "nativeSrc": "165:77:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "60:13:0"
+                                    },
+                                    "nativeSrc": "165:79:0",
+                                    "nodeType": "YulFunctionCall",
+                                    "src": "60:13:0"
+                                },
+                                "nativeSrc": "165:79:0",
+                                "nodeType": "YulExpressionStatement",
+                                "src": "60:13:0"
+                            }
+                        ]
+                    },
+                    "condition":
+                    {
+                        "arguments": [],
+                        "functionName":
+                        {
+                            "name": "callvalue",
+                            "nativeSrc": "151:9:0",
+                            "nodeType": "YulIdentifier",
+                            "src": "60:13:0"
+                        },
+                        "nativeSrc": "151:11:0",
+                        "nodeType": "YulFunctionCall",
+                        "src": "60:13:0"
+                    },
+                    "nativeSrc": "148:98:0",
+                    "nodeType": "YulIf",
+                    "src": "60:13:0"
+                },
+                {
+                    "expression":
+                    {
+                        "arguments": [],
+                        "functionName":
+                        {
+                            "name": "constructor_C_2",
+                            "nativeSrc": "256:15:0",
+                            "nodeType": "YulIdentifier",
+                            "src": "60:13:0"
+                        },
+                        "nativeSrc": "256:17:0",
+                        "nodeType": "YulFunctionCall",
+                        "src": "60:13:0"
+                    },
+                    "nativeSrc": "256:17:0",
+                    "nodeType": "YulExpressionStatement",
+                    "src": "60:13:0"
+                },
+                {
+                    "nativeSrc": "283:30:0",
+                    "nodeType": "YulVariableDeclaration",
+                    "src": "60:13:0",
+                    "value":
+                    {
+                        "arguments": [],
+                        "functionName":
+                        {
+                            "name": "allocate_unbounded",
+                            "nativeSrc": "293:18:0",
+                            "nodeType": "YulIdentifier",
+                            "src": "60:13:0"
+                        },
+                        "nativeSrc": "293:20:0",
+                        "nodeType": "YulFunctionCall",
+                        "src": "60:13:0"
+                    },
+                    "variables":
+                    [
+                        {
+                            "name": "_1",
+                            "nativeSrc": "287:2:0",
+                            "nodeType": "YulTypedName",
+                            "src": "60:13:0",
+                            "type": ""
+                        }
+                    ]
+                },
+                {
+                    "expression":
+                    {
+                        "arguments":
+                        [
+                            {
+                                "name": "_1",
+                                "nativeSrc": "331:2:0",
+                                "nodeType": "YulIdentifier",
+                                "src": "60:13:0"
+                            },
+                            {
+                                "arguments":
+                                [
+                                    {
+                                        "hexValue": "435f325f6465706c6f796564",
+                                        "kind": "string",
+                                        "nativeSrc": "346:14:0",
+                                        "nodeType": "YulLiteral",
+                                        "src": "60:13:0",
+                                        "type": "",
+                                        "value": "C_2_deployed"
+                                    }
+                                ],
+                                "functionName":
+                                {
+                                    "name": "dataoffset",
+                                    "nativeSrc": "335:10:0",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "60:13:0"
+                                },
+                                "nativeSrc": "335:26:0",
+                                "nodeType": "YulFunctionCall",
+                                "src": "60:13:0"
+                            },
+                            {
+                                "arguments":
+                                [
+                                    {
+                                        "hexValue": "435f325f6465706c6f796564",
+                                        "kind": "string",
+                                        "nativeSrc": "372:14:0",
+                                        "nodeType": "YulLiteral",
+                                        "src": "60:13:0",
+                                        "type": "",
+                                        "value": "C_2_deployed"
+                                    }
+                                ],
+                                "functionName":
+                                {
+                                    "name": "datasize",
+                                    "nativeSrc": "363:8:0",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "60:13:0"
+                                },
+                                "nativeSrc": "363:24:0",
+                                "nodeType": "YulFunctionCall",
+                                "src": "60:13:0"
+                            }
+                        ],
+                        "functionName":
+                        {
+                            "name": "codecopy",
+                            "nativeSrc": "322:8:0",
+                            "nodeType": "YulIdentifier",
+                            "src": "60:13:0"
+                        },
+                        "nativeSrc": "322:66:0",
+                        "nodeType": "YulFunctionCall",
+                        "src": "60:13:0"
+                    },
+                    "nativeSrc": "322:66:0",
+                    "nodeType": "YulExpressionStatement",
+                    "src": "60:13:0"
+                },
+                {
+                    "expression":
+                    {
+                        "arguments":
+                        [
+                            {
+                                "name": "_1",
+                                "nativeSrc": "405:2:0",
+                                "nodeType": "YulIdentifier",
+                                "src": "60:13:0"
+                            },
+                            {
+                                "arguments":
+                                [
+                                    {
+                                        "hexValue": "435f325f6465706c6f796564",
+                                        "kind": "string",
+                                        "nativeSrc": "418:14:0",
+                                        "nodeType": "YulLiteral",
+                                        "src": "60:13:0",
+                                        "type": "",
+                                        "value": "C_2_deployed"
+                                    }
+                                ],
+                                "functionName":
+                                {
+                                    "name": "datasize",
+                                    "nativeSrc": "409:8:0",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "60:13:0"
+                                },
+                                "nativeSrc": "409:24:0",
+                                "nodeType": "YulFunctionCall",
+                                "src": "60:13:0"
+                            }
+                        ],
+                        "functionName":
+                        {
+                            "name": "return",
+                            "nativeSrc": "398:6:0",
+                            "nodeType": "YulIdentifier",
+                            "src": "60:13:0"
+                        },
+                        "nativeSrc": "398:36:0",
+                        "nodeType": "YulFunctionCall",
+                        "src": "60:13:0"
+                    },
+                    "nativeSrc": "398:36:0",
+                    "nodeType": "YulExpressionStatement",
+                    "src": "60:13:0"
+                },
+                {
+                    "body":
+                    {
+                        "nativeSrc": "484:43:0",
+                        "nodeType": "YulBlock",
+                        "src": "60:13:0",
+                        "statements":
+                        [
+                            {
+                                "nativeSrc": "498:19:0",
+                                "nodeType": "YulAssignment",
+                                "src": "60:13:0",
+                                "value":
+                                {
+                                    "arguments":
+                                    [
+                                        {
+                                            "kind": "number",
+                                            "nativeSrc": "514:2:0",
+                                            "nodeType": "YulLiteral",
+                                            "src": "60:13:0",
+                                            "type": "",
+                                            "value": "64"
+                                        }
+                                    ],
+                                    "functionName":
+                                    {
+                                        "name": "mload",
+                                        "nativeSrc": "508:5:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "60:13:0"
+                                    },
+                                    "nativeSrc": "508:9:0",
+                                    "nodeType": "YulFunctionCall",
+                                    "src": "60:13:0"
+                                },
+                                "variableNames":
+                                [
+                                    {
+                                        "name": "memPtr",
+                                        "nativeSrc": "498:6:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "60:13:0"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "name": "allocate_unbounded",
+                    "nativeSrc": "444:83:0",
+                    "nodeType": "YulFunctionDefinition",
+                    "returnVariables":
+                    [
+                        {
+                            "name": "memPtr",
+                            "nativeSrc": "477:6:0",
+                            "nodeType": "YulTypedName",
+                            "src": "60:13:0",
+                            "type": ""
+                        }
+                    ],
+                    "src": "60:13:0"
+                },
+                {
+                    "body":
+                    {
+                        "nativeSrc": "626:36:0",
+                        "nodeType": "YulBlock",
+                        "src": "60:13:0",
+                        "statements":
+                        [
+                            {
+                                "expression":
+                                {
+                                    "arguments":
+                                    [
+                                        {
+                                            "kind": "number",
+                                            "nativeSrc": "647:1:0",
+                                            "nodeType": "YulLiteral",
+                                            "src": "60:13:0",
+                                            "type": "",
+                                            "value": "0"
+                                        },
+                                        {
+                                            "kind": "number",
+                                            "nativeSrc": "650:1:0",
+                                            "nodeType": "YulLiteral",
+                                            "src": "60:13:0",
+                                            "type": "",
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "functionName":
+                                    {
+                                        "name": "revert",
+                                        "nativeSrc": "640:6:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "60:13:0"
+                                    },
+                                    "nativeSrc": "640:12:0",
+                                    "nodeType": "YulFunctionCall",
+                                    "src": "60:13:0"
+                                },
+                                "nativeSrc": "640:12:0",
+                                "nodeType": "YulExpressionStatement",
+                                "src": "60:13:0"
+                            }
+                        ]
+                    },
+                    "name": "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb",
+                    "nativeSrc": "537:125:0",
+                    "nodeType": "YulFunctionDefinition",
+                    "src": "60:13:0"
+                },
+                {
+                    "body":
+                    {
+                        "nativeSrc": "741:59:0",
+                        "nodeType": "YulBlock",
+                        "src": "60:13:0",
+                        "statements": []
+                    },
+                    "name": "constructor_C_2",
+                    "nativeSrc": "714:86:0",
+                    "nodeType": "YulFunctionDefinition",
+                    "src": "60:13:0"
+                }
+            ]
+        },
+        "nodeType": "YulCode"
+    },
+    "name": "C_2",
+    "nodeType": "YulObject",
+    "subObjects":
+    [
+        {
+            "code":
+            {
+                "block":
+                {
+                    "nativeSrc": "929:588:0",
+                    "nodeType": "YulBlock",
+                    "src": "-1:-1:0",
+                    "statements":
+                    [
+                        {
+                            "expression":
+                            {
+                                "arguments":
+                                [
+                                    {
+                                        "kind": "number",
+                                        "nativeSrc": "996:2:0",
+                                        "nodeType": "YulLiteral",
+                                        "src": "60:13:0",
+                                        "type": "",
+                                        "value": "64"
+                                    },
+                                    {
+                                        "arguments":
+                                        [
+                                            {
+                                                "kind": "number",
+                                                "nativeSrc": "1012:3:0",
+                                                "nodeType": "YulLiteral",
+                                                "src": "60:13:0",
+                                                "type": "",
+                                                "value": "128"
+                                            }
+                                        ],
+                                        "functionName":
+                                        {
+                                            "name": "memoryguard",
+                                            "nativeSrc": "1000:11:0",
+                                            "nodeType": "YulIdentifier",
+                                            "src": "60:13:0"
+                                        },
+                                        "nativeSrc": "1000:16:0",
+                                        "nodeType": "YulFunctionCall",
+                                        "src": "60:13:0"
+                                    }
+                                ],
+                                "functionName":
+                                {
+                                    "name": "mstore",
+                                    "nativeSrc": "989:6:0",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "60:13:0"
+                                },
+                                "nativeSrc": "989:28:0",
+                                "nodeType": "YulFunctionCall",
+                                "src": "60:13:0"
+                            },
+                            "nativeSrc": "989:28:0",
+                            "nodeType": "YulExpressionStatement",
+                            "src": "60:13:0"
+                        },
+                        {
+                            "expression":
+                            {
+                                "arguments": [],
+                                "functionName":
+                                {
+                                    "name": "revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74",
+                                    "nativeSrc": "1031:77:0",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "60:13:0"
+                                },
+                                "nativeSrc": "1031:79:0",
+                                "nodeType": "YulFunctionCall",
+                                "src": "60:13:0"
+                            },
+                            "nativeSrc": "1031:79:0",
+                            "nodeType": "YulExpressionStatement",
+                            "src": "60:13:0"
+                        },
+                        {
+                            "body":
+                            {
+                                "nativeSrc": "1177:77:0",
+                                "nodeType": "YulBlock",
+                                "src": "60:13:0",
+                                "statements":
+                                [
+                                    {
+                                        "nativeSrc": "1195:44:0",
+                                        "nodeType": "YulAssignment",
+                                        "src": "60:13:0",
+                                        "value":
+                                        {
+                                            "arguments":
+                                            [
+                                                {
+                                                    "kind": "number",
+                                                    "nativeSrc": "1228:3:0",
+                                                    "nodeType": "YulLiteral",
+                                                    "src": "60:13:0",
+                                                    "type": "",
+                                                    "value": "224"
+                                                },
+                                                {
+                                                    "name": "value",
+                                                    "nativeSrc": "1233:5:0",
+                                                    "nodeType": "YulIdentifier",
+                                                    "src": "60:13:0"
+                                                }
+                                            ],
+                                            "functionName":
+                                            {
+                                                "name": "shr",
+                                                "nativeSrc": "1224:3:0",
+                                                "nodeType": "YulIdentifier",
+                                                "src": "60:13:0"
+                                            },
+                                            "nativeSrc": "1224:15:0",
+                                            "nodeType": "YulFunctionCall",
+                                            "src": "60:13:0"
+                                        },
+                                        "variableNames":
+                                        [
+                                            {
+                                                "name": "newValue",
+                                                "nativeSrc": "1195:8:0",
+                                                "nodeType": "YulIdentifier",
+                                                "src": "60:13:0"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "name": "shift_right_224_unsigned",
+                            "nativeSrc": "1124:130:0",
+                            "nodeType": "YulFunctionDefinition",
+                            "parameters":
+                            [
+                                {
+                                    "name": "value",
+                                    "nativeSrc": "1158:5:0",
+                                    "nodeType": "YulTypedName",
+                                    "src": "60:13:0",
+                                    "type": ""
+                                }
+                            ],
+                            "returnVariables":
+                            [
+                                {
+                                    "name": "newValue",
+                                    "nativeSrc": "1168:8:0",
+                                    "nodeType": "YulTypedName",
+                                    "src": "60:13:0",
+                                    "type": ""
+                                }
+                            ],
+                            "src": "60:13:0"
+                        },
+                        {
+                            "body":
+                            {
+                                "nativeSrc": "1308:51:0",
+                                "nodeType": "YulBlock",
+                                "src": "60:13:0",
+                                "statements":
+                                [
+                                    {
+                                        "nativeSrc": "1326:19:0",
+                                        "nodeType": "YulAssignment",
+                                        "src": "60:13:0",
+                                        "value":
+                                        {
+                                            "arguments":
+                                            [
+                                                {
+                                                    "kind": "number",
+                                                    "nativeSrc": "1342:2:0",
+                                                    "nodeType": "YulLiteral",
+                                                    "src": "60:13:0",
+                                                    "type": "",
+                                                    "value": "64"
+                                                }
+                                            ],
+                                            "functionName":
+                                            {
+                                                "name": "mload",
+                                                "nativeSrc": "1336:5:0",
+                                                "nodeType": "YulIdentifier",
+                                                "src": "60:13:0"
+                                            },
+                                            "nativeSrc": "1336:9:0",
+                                            "nodeType": "YulFunctionCall",
+                                            "src": "60:13:0"
+                                        },
+                                        "variableNames":
+                                        [
+                                            {
+                                                "name": "memPtr",
+                                                "nativeSrc": "1326:6:0",
+                                                "nodeType": "YulIdentifier",
+                                                "src": "60:13:0"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "name": "allocate_unbounded",
+                            "nativeSrc": "1268:91:0",
+                            "nodeType": "YulFunctionDefinition",
+                            "returnVariables":
+                            [
+                                {
+                                    "name": "memPtr",
+                                    "nativeSrc": "1301:6:0",
+                                    "nodeType": "YulTypedName",
+                                    "src": "60:13:0",
+                                    "type": ""
+                                }
+                            ],
+                            "src": "60:13:0"
+                        },
+                        {
+                            "body":
+                            {
+                                "nativeSrc": "1462:44:0",
+                                "nodeType": "YulBlock",
+                                "src": "60:13:0",
+                                "statements":
+                                [
+                                    {
+                                        "expression":
+                                        {
+                                            "arguments":
+                                            [
+                                                {
+                                                    "kind": "number",
+                                                    "nativeSrc": "1487:1:0",
+                                                    "nodeType": "YulLiteral",
+                                                    "src": "60:13:0",
+                                                    "type": "",
+                                                    "value": "0"
+                                                },
+                                                {
+                                                    "kind": "number",
+                                                    "nativeSrc": "1490:1:0",
+                                                    "nodeType": "YulLiteral",
+                                                    "src": "60:13:0",
+                                                    "type": "",
+                                                    "value": "0"
+                                                }
+                                            ],
+                                            "functionName":
+                                            {
+                                                "name": "revert",
+                                                "nativeSrc": "1480:6:0",
+                                                "nodeType": "YulIdentifier",
+                                                "src": "60:13:0"
+                                            },
+                                            "nativeSrc": "1480:12:0",
+                                            "nodeType": "YulFunctionCall",
+                                            "src": "60:13:0"
+                                        },
+                                        "nativeSrc": "1480:12:0",
+                                        "nodeType": "YulExpressionStatement",
+                                        "src": "60:13:0"
+                                    }
+                                ]
+                            },
+                            "name": "revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74",
+                            "nativeSrc": "1373:133:0",
+                            "nodeType": "YulFunctionDefinition",
+                            "src": "60:13:0"
+                        }
+                    ]
+                },
+                "nodeType": "YulCode"
+            },
+            "name": "C_2_deployed",
+            "nodeType": "YulObject",
+            "subObjects":
+            [
+                {
+                    "nodeType": "YulData",
+                    "value": "<BYTECODE REMOVED>"
+                }
+            ]
+        }
+    ]
+}
+Optimized IR AST:
+{
+    "code":
+    {
+        "block":
+        {
+            "nativeSrc": "59:790:0",
+            "nodeType": "YulBlock",
+            "src": "-1:-1:0",
+            "statements":
+            [
+                {
+                    "nativeSrc": "59:790:0",
+                    "nodeType": "YulBlock",
+                    "src": "-1:-1:0",
+                    "statements":
+                    [
+                        {
+                            "nativeSrc": "122:16:0",
+                            "nodeType": "YulVariableDeclaration",
+                            "src": "60:13:0",
+                            "value":
+                            {
+                                "arguments":
+                                [
+                                    {
+                                        "kind": "number",
+                                        "nativeSrc": "134:3:0",
+                                        "nodeType": "YulLiteral",
+                                        "src": "60:13:0",
+                                        "type": "",
+                                        "value": "0x80"
+                                    }
+                                ],
+                                "functionName":
+                                {
+                                    "name": "memoryguard",
+                                    "nativeSrc": "122:11:0",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "60:13:0"
+                                },
+                                "nativeSrc": "122:16:0",
+                                "nodeType": "YulFunctionCall",
+                                "src": "60:13:0"
+                            },
+                            "variables":
+                            [
+                                {
+                                    "name": "_1",
+                                    "nativeSrc": "122:16:0",
+                                    "nodeType": "YulTypedName",
+                                    "src": "60:13:0",
+                                    "type": ""
+                                }
+                            ]
+                        },
+                        {
+                            "expression":
+                            {
+                                "arguments":
+                                [
+                                    {
+                                        "kind": "number",
+                                        "nativeSrc": "118:2:0",
+                                        "nodeType": "YulLiteral",
+                                        "src": "60:13:0",
+                                        "type": "",
+                                        "value": "64"
+                                    },
+                                    {
+                                        "name": "_1",
+                                        "nativeSrc": "122:16:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "60:13:0"
+                                    }
+                                ],
+                                "functionName":
+                                {
+                                    "name": "mstore",
+                                    "nativeSrc": "111:6:0",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "60:13:0"
+                                },
+                                "nativeSrc": "111:28:0",
+                                "nodeType": "YulFunctionCall",
+                                "src": "60:13:0"
+                            },
+                            "nativeSrc": "111:28:0",
+                            "nodeType": "YulExpressionStatement",
+                            "src": "60:13:0"
+                        },
+                        {
+                            "body":
+                            {
+                                "nativeSrc": "163:83:0",
+                                "nodeType": "YulBlock",
+                                "src": "60:13:0",
+                                "statements":
+                                [
+                                    {
+                                        "expression":
+                                        {
+                                            "arguments":
+                                            [
+                                                {
+                                                    "kind": "number",
+                                                    "nativeSrc": "650:1:0",
+                                                    "nodeType": "YulLiteral",
+                                                    "src": "60:13:0",
+                                                    "type": "",
+                                                    "value": "0"
+                                                },
+                                                {
+                                                    "kind": "number",
+                                                    "nativeSrc": "650:1:0",
+                                                    "nodeType": "YulLiteral",
+                                                    "src": "60:13:0",
+                                                    "type": "",
+                                                    "value": "0"
+                                                }
+                                            ],
+                                            "functionName":
+                                            {
+                                                "name": "revert",
+                                                "nativeSrc": "640:6:0",
+                                                "nodeType": "YulIdentifier",
+                                                "src": "60:13:0"
+                                            },
+                                            "nativeSrc": "640:12:0",
+                                            "nodeType": "YulFunctionCall",
+                                            "src": "60:13:0"
+                                        },
+                                        "nativeSrc": "640:12:0",
+                                        "nodeType": "YulExpressionStatement",
+                                        "src": "60:13:0"
+                                    }
+                                ]
+                            },
+                            "condition":
+                            {
+                                "arguments": [],
+                                "functionName":
+                                {
+                                    "name": "callvalue",
+                                    "nativeSrc": "151:9:0",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "60:13:0"
+                                },
+                                "nativeSrc": "151:11:0",
+                                "nodeType": "YulFunctionCall",
+                                "src": "60:13:0"
+                            },
+                            "nativeSrc": "148:98:0",
+                            "nodeType": "YulIf",
+                            "src": "60:13:0"
+                        },
+                        {
+                            "nativeSrc": "363:24:0",
+                            "nodeType": "YulVariableDeclaration",
+                            "src": "60:13:0",
+                            "value":
+                            {
+                                "arguments":
+                                [
+                                    {
+                                        "hexValue": "435f325f6465706c6f796564",
+                                        "kind": "string",
+                                        "nativeSrc": "372:14:0",
+                                        "nodeType": "YulLiteral",
+                                        "src": "60:13:0",
+                                        "type": "",
+                                        "value": "C_2_deployed"
+                                    }
+                                ],
+                                "functionName":
+                                {
+                                    "name": "datasize",
+                                    "nativeSrc": "363:8:0",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "60:13:0"
+                                },
+                                "nativeSrc": "363:24:0",
+                                "nodeType": "YulFunctionCall",
+                                "src": "60:13:0"
+                            },
+                            "variables":
+                            [
+                                {
+                                    "name": "_2",
+                                    "nativeSrc": "363:24:0",
+                                    "nodeType": "YulTypedName",
+                                    "src": "60:13:0",
+                                    "type": ""
+                                }
+                            ]
+                        },
+                        {
+                            "expression":
+                            {
+                                "arguments":
+                                [
+                                    {
+                                        "name": "_1",
+                                        "nativeSrc": "331:2:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "60:13:0"
+                                    },
+                                    {
+                                        "arguments":
+                                        [
+                                            {
+                                                "hexValue": "435f325f6465706c6f796564",
+                                                "kind": "string",
+                                                "nativeSrc": "346:14:0",
+                                                "nodeType": "YulLiteral",
+                                                "src": "60:13:0",
+                                                "type": "",
+                                                "value": "C_2_deployed"
+                                            }
+                                        ],
+                                        "functionName":
+                                        {
+                                            "name": "dataoffset",
+                                            "nativeSrc": "335:10:0",
+                                            "nodeType": "YulIdentifier",
+                                            "src": "60:13:0"
+                                        },
+                                        "nativeSrc": "335:26:0",
+                                        "nodeType": "YulFunctionCall",
+                                        "src": "60:13:0"
+                                    },
+                                    {
+                                        "name": "_2",
+                                        "nativeSrc": "363:24:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "60:13:0"
+                                    }
+                                ],
+                                "functionName":
+                                {
+                                    "name": "codecopy",
+                                    "nativeSrc": "322:8:0",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "60:13:0"
+                                },
+                                "nativeSrc": "322:66:0",
+                                "nodeType": "YulFunctionCall",
+                                "src": "60:13:0"
+                            },
+                            "nativeSrc": "322:66:0",
+                            "nodeType": "YulExpressionStatement",
+                            "src": "60:13:0"
+                        },
+                        {
+                            "expression":
+                            {
+                                "arguments":
+                                [
+                                    {
+                                        "name": "_1",
+                                        "nativeSrc": "405:2:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "60:13:0"
+                                    },
+                                    {
+                                        "name": "_2",
+                                        "nativeSrc": "409:24:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "60:13:0"
+                                    }
+                                ],
+                                "functionName":
+                                {
+                                    "name": "return",
+                                    "nativeSrc": "398:6:0",
+                                    "nodeType": "YulIdentifier",
+                                    "src": "60:13:0"
+                                },
+                                "nativeSrc": "398:36:0",
+                                "nodeType": "YulFunctionCall",
+                                "src": "60:13:0"
+                            },
+                            "nativeSrc": "398:36:0",
+                            "nodeType": "YulExpressionStatement",
+                            "src": "60:13:0"
+                        }
+                    ]
+                }
+            ]
+        },
+        "nodeType": "YulCode"
+    },
+    "name": "C_2",
+    "nodeType": "YulObject",
+    "subObjects":
+    [
+        {
+            "code":
+            {
+                "block":
+                {
+                    "nativeSrc": "929:588:0",
+                    "nodeType": "YulBlock",
+                    "src": "-1:-1:0",
+                    "statements":
+                    [
+                        {
+                            "nativeSrc": "929:588:0",
+                            "nodeType": "YulBlock",
+                            "src": "-1:-1:0",
+                            "statements":
+                            [
+                                {
+                                    "expression":
+                                    {
+                                        "arguments":
+                                        [
+                                            {
+                                                "kind": "number",
+                                                "nativeSrc": "1490:1:0",
+                                                "nodeType": "YulLiteral",
+                                                "src": "60:13:0",
+                                                "type": "",
+                                                "value": "0"
+                                            },
+                                            {
+                                                "kind": "number",
+                                                "nativeSrc": "1490:1:0",
+                                                "nodeType": "YulLiteral",
+                                                "src": "60:13:0",
+                                                "type": "",
+                                                "value": "0"
+                                            }
+                                        ],
+                                        "functionName":
+                                        {
+                                            "name": "revert",
+                                            "nativeSrc": "1480:6:0",
+                                            "nodeType": "YulIdentifier",
+                                            "src": "60:13:0"
+                                        },
+                                        "nativeSrc": "1480:12:0",
+                                        "nodeType": "YulFunctionCall",
+                                        "src": "60:13:0"
+                                    },
+                                    "nativeSrc": "1480:12:0",
+                                    "nodeType": "YulExpressionStatement",
+                                    "src": "60:13:0"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "nodeType": "YulCode"
+            },
+            "name": "C_2_deployed",
+            "nodeType": "YulObject",
+            "subObjects":
+            [
+                {
+                    "nodeType": "YulData",
+                    "value": "<BYTECODE REMOVED>"
+                }
+            ]
+        }
+    ]
+}

--- a/test/cmdlineTests/combined_json_generated_sources/output
+++ b/test/cmdlineTests/combined_json_generated_sources/output
@@ -9,6 +9,7 @@
         {
           "ast":
           {
+            "nativeSrc": "0:1856:1",
             "nodeType": "YulBlock",
             "src": "0:1856:1",
             "statements":
@@ -16,11 +17,13 @@
               {
                 "body":
                 {
+                  "nativeSrc": "47:35:1",
                   "nodeType": "YulBlock",
                   "src": "47:35:1",
                   "statements":
                   [
                     {
+                      "nativeSrc": "57:19:1",
                       "nodeType": "YulAssignment",
                       "src": "57:19:1",
                       "value":
@@ -29,6 +32,7 @@
                         [
                           {
                             "kind": "number",
+                            "nativeSrc": "73:2:1",
                             "nodeType": "YulLiteral",
                             "src": "73:2:1",
                             "type": "",
@@ -38,9 +42,11 @@
                         "functionName":
                         {
                           "name": "mload",
+                          "nativeSrc": "67:5:1",
                           "nodeType": "YulIdentifier",
                           "src": "67:5:1"
                         },
+                        "nativeSrc": "67:9:1",
                         "nodeType": "YulFunctionCall",
                         "src": "67:9:1"
                       },
@@ -48,6 +54,7 @@
                       [
                         {
                           "name": "memPtr",
+                          "nativeSrc": "57:6:1",
                           "nodeType": "YulIdentifier",
                           "src": "57:6:1"
                         }
@@ -56,11 +63,13 @@
                   ]
                 },
                 "name": "allocate_unbounded",
+                "nativeSrc": "7:75:1",
                 "nodeType": "YulFunctionDefinition",
                 "returnVariables":
                 [
                   {
                     "name": "memPtr",
+                    "nativeSrc": "40:6:1",
                     "nodeType": "YulTypedName",
                     "src": "40:6:1",
                     "type": ""
@@ -71,6 +80,7 @@
               {
                 "body":
                 {
+                  "nativeSrc": "177:28:1",
                   "nodeType": "YulBlock",
                   "src": "177:28:1",
                   "statements":
@@ -82,6 +92,7 @@
                         [
                           {
                             "kind": "number",
+                            "nativeSrc": "194:1:1",
                             "nodeType": "YulLiteral",
                             "src": "194:1:1",
                             "type": "",
@@ -89,6 +100,7 @@
                           },
                           {
                             "kind": "number",
+                            "nativeSrc": "197:1:1",
                             "nodeType": "YulLiteral",
                             "src": "197:1:1",
                             "type": "",
@@ -98,24 +110,29 @@
                         "functionName":
                         {
                           "name": "revert",
+                          "nativeSrc": "187:6:1",
                           "nodeType": "YulIdentifier",
                           "src": "187:6:1"
                         },
+                        "nativeSrc": "187:12:1",
                         "nodeType": "YulFunctionCall",
                         "src": "187:12:1"
                       },
+                      "nativeSrc": "187:12:1",
                       "nodeType": "YulExpressionStatement",
                       "src": "187:12:1"
                     }
                   ]
                 },
                 "name": "revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b",
+                "nativeSrc": "88:117:1",
                 "nodeType": "YulFunctionDefinition",
                 "src": "88:117:1"
               },
               {
                 "body":
                 {
+                  "nativeSrc": "300:28:1",
                   "nodeType": "YulBlock",
                   "src": "300:28:1",
                   "statements":
@@ -127,6 +144,7 @@
                         [
                           {
                             "kind": "number",
+                            "nativeSrc": "317:1:1",
                             "nodeType": "YulLiteral",
                             "src": "317:1:1",
                             "type": "",
@@ -134,6 +152,7 @@
                           },
                           {
                             "kind": "number",
+                            "nativeSrc": "320:1:1",
                             "nodeType": "YulLiteral",
                             "src": "320:1:1",
                             "type": "",
@@ -143,24 +162,29 @@
                         "functionName":
                         {
                           "name": "revert",
+                          "nativeSrc": "310:6:1",
                           "nodeType": "YulIdentifier",
                           "src": "310:6:1"
                         },
+                        "nativeSrc": "310:12:1",
                         "nodeType": "YulFunctionCall",
                         "src": "310:12:1"
                       },
+                      "nativeSrc": "310:12:1",
                       "nodeType": "YulExpressionStatement",
                       "src": "310:12:1"
                     }
                   ]
                 },
                 "name": "revert_error_c1322bf8034eace5e0b5c7295db60986aa89aae5e0ea0873e4689e076861a5db",
+                "nativeSrc": "211:117:1",
                 "nodeType": "YulFunctionDefinition",
                 "src": "211:117:1"
               },
               {
                 "body":
                 {
+                  "nativeSrc": "423:28:1",
                   "nodeType": "YulBlock",
                   "src": "423:28:1",
                   "statements":
@@ -172,6 +196,7 @@
                         [
                           {
                             "kind": "number",
+                            "nativeSrc": "440:1:1",
                             "nodeType": "YulLiteral",
                             "src": "440:1:1",
                             "type": "",
@@ -179,6 +204,7 @@
                           },
                           {
                             "kind": "number",
+                            "nativeSrc": "443:1:1",
                             "nodeType": "YulLiteral",
                             "src": "443:1:1",
                             "type": "",
@@ -188,24 +214,29 @@
                         "functionName":
                         {
                           "name": "revert",
+                          "nativeSrc": "433:6:1",
                           "nodeType": "YulIdentifier",
                           "src": "433:6:1"
                         },
+                        "nativeSrc": "433:12:1",
                         "nodeType": "YulFunctionCall",
                         "src": "433:12:1"
                       },
+                      "nativeSrc": "433:12:1",
                       "nodeType": "YulExpressionStatement",
                       "src": "433:12:1"
                     }
                   ]
                 },
                 "name": "revert_error_1b9f4a0a5773e33b91aa01db23bf8c55fce1411167c872835e7fa00a4f17d46d",
+                "nativeSrc": "334:117:1",
                 "nodeType": "YulFunctionDefinition",
                 "src": "334:117:1"
               },
               {
                 "body":
                 {
+                  "nativeSrc": "546:28:1",
                   "nodeType": "YulBlock",
                   "src": "546:28:1",
                   "statements":
@@ -217,6 +248,7 @@
                         [
                           {
                             "kind": "number",
+                            "nativeSrc": "563:1:1",
                             "nodeType": "YulLiteral",
                             "src": "563:1:1",
                             "type": "",
@@ -224,6 +256,7 @@
                           },
                           {
                             "kind": "number",
+                            "nativeSrc": "566:1:1",
                             "nodeType": "YulLiteral",
                             "src": "566:1:1",
                             "type": "",
@@ -233,24 +266,29 @@
                         "functionName":
                         {
                           "name": "revert",
+                          "nativeSrc": "556:6:1",
                           "nodeType": "YulIdentifier",
                           "src": "556:6:1"
                         },
+                        "nativeSrc": "556:12:1",
                         "nodeType": "YulFunctionCall",
                         "src": "556:12:1"
                       },
+                      "nativeSrc": "556:12:1",
                       "nodeType": "YulExpressionStatement",
                       "src": "556:12:1"
                     }
                   ]
                 },
                 "name": "revert_error_15abf5612cd996bc235ba1e55a4a30ac60e6bb601ff7ba4ad3f179b6be8d0490",
+                "nativeSrc": "457:117:1",
                 "nodeType": "YulFunctionDefinition",
                 "src": "457:117:1"
               },
               {
                 "body":
                 {
+                  "nativeSrc": "669:28:1",
                   "nodeType": "YulBlock",
                   "src": "669:28:1",
                   "statements":
@@ -262,6 +300,7 @@
                         [
                           {
                             "kind": "number",
+                            "nativeSrc": "686:1:1",
                             "nodeType": "YulLiteral",
                             "src": "686:1:1",
                             "type": "",
@@ -269,6 +308,7 @@
                           },
                           {
                             "kind": "number",
+                            "nativeSrc": "689:1:1",
                             "nodeType": "YulLiteral",
                             "src": "689:1:1",
                             "type": "",
@@ -278,24 +318,29 @@
                         "functionName":
                         {
                           "name": "revert",
+                          "nativeSrc": "679:6:1",
                           "nodeType": "YulIdentifier",
                           "src": "679:6:1"
                         },
+                        "nativeSrc": "679:12:1",
                         "nodeType": "YulFunctionCall",
                         "src": "679:12:1"
                       },
+                      "nativeSrc": "679:12:1",
                       "nodeType": "YulExpressionStatement",
                       "src": "679:12:1"
                     }
                   ]
                 },
                 "name": "revert_error_81385d8c0b31fffe14be1da910c8bd3a80be4cfa248e04f42ec0faea3132a8ef",
+                "nativeSrc": "580:117:1",
                 "nodeType": "YulFunctionDefinition",
                 "src": "580:117:1"
               },
               {
                 "body":
                 {
+                  "nativeSrc": "810:478:1",
                   "nodeType": "YulBlock",
                   "src": "810:478:1",
                   "statements":
@@ -303,6 +348,7 @@
                     {
                       "body":
                       {
+                        "nativeSrc": "859:83:1",
                         "nodeType": "YulBlock",
                         "src": "859:83:1",
                         "statements":
@@ -314,12 +360,15 @@
                               "functionName":
                               {
                                 "name": "revert_error_1b9f4a0a5773e33b91aa01db23bf8c55fce1411167c872835e7fa00a4f17d46d",
+                                "nativeSrc": "861:77:1",
                                 "nodeType": "YulIdentifier",
                                 "src": "861:77:1"
                               },
+                              "nativeSrc": "861:79:1",
                               "nodeType": "YulFunctionCall",
                               "src": "861:79:1"
                             },
+                            "nativeSrc": "861:79:1",
                             "nodeType": "YulExpressionStatement",
                             "src": "861:79:1"
                           }
@@ -337,11 +386,13 @@
                                 [
                                   {
                                     "name": "offset",
+                                    "nativeSrc": "838:6:1",
                                     "nodeType": "YulIdentifier",
                                     "src": "838:6:1"
                                   },
                                   {
                                     "kind": "number",
+                                    "nativeSrc": "846:4:1",
                                     "nodeType": "YulLiteral",
                                     "src": "846:4:1",
                                     "type": "",
@@ -351,14 +402,17 @@
                                 "functionName":
                                 {
                                   "name": "add",
+                                  "nativeSrc": "834:3:1",
                                   "nodeType": "YulIdentifier",
                                   "src": "834:3:1"
                                 },
+                                "nativeSrc": "834:17:1",
                                 "nodeType": "YulFunctionCall",
                                 "src": "834:17:1"
                               },
                               {
                                 "name": "end",
+                                "nativeSrc": "853:3:1",
                                 "nodeType": "YulIdentifier",
                                 "src": "853:3:1"
                               }
@@ -366,9 +420,11 @@
                             "functionName":
                             {
                               "name": "slt",
+                              "nativeSrc": "830:3:1",
                               "nodeType": "YulIdentifier",
                               "src": "830:3:1"
                             },
+                            "nativeSrc": "830:27:1",
                             "nodeType": "YulFunctionCall",
                             "src": "830:27:1"
                           }
@@ -376,16 +432,20 @@
                         "functionName":
                         {
                           "name": "iszero",
+                          "nativeSrc": "823:6:1",
                           "nodeType": "YulIdentifier",
                           "src": "823:6:1"
                         },
+                        "nativeSrc": "823:35:1",
                         "nodeType": "YulFunctionCall",
                         "src": "823:35:1"
                       },
+                      "nativeSrc": "820:122:1",
                       "nodeType": "YulIf",
                       "src": "820:122:1"
                     },
                     {
+                      "nativeSrc": "951:30:1",
                       "nodeType": "YulAssignment",
                       "src": "951:30:1",
                       "value":
@@ -394,6 +454,7 @@
                         [
                           {
                             "name": "offset",
+                            "nativeSrc": "974:6:1",
                             "nodeType": "YulIdentifier",
                             "src": "974:6:1"
                           }
@@ -401,9 +462,11 @@
                         "functionName":
                         {
                           "name": "calldataload",
+                          "nativeSrc": "961:12:1",
                           "nodeType": "YulIdentifier",
                           "src": "961:12:1"
                         },
+                        "nativeSrc": "961:20:1",
                         "nodeType": "YulFunctionCall",
                         "src": "961:20:1"
                       },
@@ -411,6 +474,7 @@
                       [
                         {
                           "name": "length",
+                          "nativeSrc": "951:6:1",
                           "nodeType": "YulIdentifier",
                           "src": "951:6:1"
                         }
@@ -419,6 +483,7 @@
                     {
                       "body":
                       {
+                        "nativeSrc": "1024:83:1",
                         "nodeType": "YulBlock",
                         "src": "1024:83:1",
                         "statements":
@@ -430,12 +495,15 @@
                               "functionName":
                               {
                                 "name": "revert_error_15abf5612cd996bc235ba1e55a4a30ac60e6bb601ff7ba4ad3f179b6be8d0490",
+                                "nativeSrc": "1026:77:1",
                                 "nodeType": "YulIdentifier",
                                 "src": "1026:77:1"
                               },
+                              "nativeSrc": "1026:79:1",
                               "nodeType": "YulFunctionCall",
                               "src": "1026:79:1"
                             },
+                            "nativeSrc": "1026:79:1",
                             "nodeType": "YulExpressionStatement",
                             "src": "1026:79:1"
                           }
@@ -447,11 +515,13 @@
                         [
                           {
                             "name": "length",
+                            "nativeSrc": "996:6:1",
                             "nodeType": "YulIdentifier",
                             "src": "996:6:1"
                           },
                           {
                             "kind": "number",
+                            "nativeSrc": "1004:18:1",
                             "nodeType": "YulLiteral",
                             "src": "1004:18:1",
                             "type": "",
@@ -461,16 +531,20 @@
                         "functionName":
                         {
                           "name": "gt",
+                          "nativeSrc": "993:2:1",
                           "nodeType": "YulIdentifier",
                           "src": "993:2:1"
                         },
+                        "nativeSrc": "993:30:1",
                         "nodeType": "YulFunctionCall",
                         "src": "993:30:1"
                       },
+                      "nativeSrc": "990:117:1",
                       "nodeType": "YulIf",
                       "src": "990:117:1"
                     },
                     {
+                      "nativeSrc": "1116:29:1",
                       "nodeType": "YulAssignment",
                       "src": "1116:29:1",
                       "value":
@@ -479,11 +553,13 @@
                         [
                           {
                             "name": "offset",
+                            "nativeSrc": "1132:6:1",
                             "nodeType": "YulIdentifier",
                             "src": "1132:6:1"
                           },
                           {
                             "kind": "number",
+                            "nativeSrc": "1140:4:1",
                             "nodeType": "YulLiteral",
                             "src": "1140:4:1",
                             "type": "",
@@ -493,9 +569,11 @@
                         "functionName":
                         {
                           "name": "add",
+                          "nativeSrc": "1128:3:1",
                           "nodeType": "YulIdentifier",
                           "src": "1128:3:1"
                         },
+                        "nativeSrc": "1128:17:1",
                         "nodeType": "YulFunctionCall",
                         "src": "1128:17:1"
                       },
@@ -503,6 +581,7 @@
                       [
                         {
                           "name": "arrayPos",
+                          "nativeSrc": "1116:8:1",
                           "nodeType": "YulIdentifier",
                           "src": "1116:8:1"
                         }
@@ -511,6 +590,7 @@
                     {
                       "body":
                       {
+                        "nativeSrc": "1199:83:1",
                         "nodeType": "YulBlock",
                         "src": "1199:83:1",
                         "statements":
@@ -522,12 +602,15 @@
                               "functionName":
                               {
                                 "name": "revert_error_81385d8c0b31fffe14be1da910c8bd3a80be4cfa248e04f42ec0faea3132a8ef",
+                                "nativeSrc": "1201:77:1",
                                 "nodeType": "YulIdentifier",
                                 "src": "1201:77:1"
                               },
+                              "nativeSrc": "1201:79:1",
                               "nodeType": "YulFunctionCall",
                               "src": "1201:79:1"
                             },
+                            "nativeSrc": "1201:79:1",
                             "nodeType": "YulExpressionStatement",
                             "src": "1201:79:1"
                           }
@@ -542,6 +625,7 @@
                             [
                               {
                                 "name": "arrayPos",
+                                "nativeSrc": "1164:8:1",
                                 "nodeType": "YulIdentifier",
                                 "src": "1164:8:1"
                               },
@@ -550,11 +634,13 @@
                                 [
                                   {
                                     "name": "length",
+                                    "nativeSrc": "1178:6:1",
                                     "nodeType": "YulIdentifier",
                                     "src": "1178:6:1"
                                   },
                                   {
                                     "kind": "number",
+                                    "nativeSrc": "1186:4:1",
                                     "nodeType": "YulLiteral",
                                     "src": "1186:4:1",
                                     "type": "",
@@ -564,9 +650,11 @@
                                 "functionName":
                                 {
                                   "name": "mul",
+                                  "nativeSrc": "1174:3:1",
                                   "nodeType": "YulIdentifier",
                                   "src": "1174:3:1"
                                 },
+                                "nativeSrc": "1174:17:1",
                                 "nodeType": "YulFunctionCall",
                                 "src": "1174:17:1"
                               }
@@ -574,14 +662,17 @@
                             "functionName":
                             {
                               "name": "add",
+                              "nativeSrc": "1160:3:1",
                               "nodeType": "YulIdentifier",
                               "src": "1160:3:1"
                             },
+                            "nativeSrc": "1160:32:1",
                             "nodeType": "YulFunctionCall",
                             "src": "1160:32:1"
                           },
                           {
                             "name": "end",
+                            "nativeSrc": "1194:3:1",
                             "nodeType": "YulIdentifier",
                             "src": "1194:3:1"
                           }
@@ -589,29 +680,35 @@
                         "functionName":
                         {
                           "name": "gt",
+                          "nativeSrc": "1157:2:1",
                           "nodeType": "YulIdentifier",
                           "src": "1157:2:1"
                         },
+                        "nativeSrc": "1157:41:1",
                         "nodeType": "YulFunctionCall",
                         "src": "1157:41:1"
                       },
+                      "nativeSrc": "1154:128:1",
                       "nodeType": "YulIf",
                       "src": "1154:128:1"
                     }
                   ]
                 },
                 "name": "abi_decode_t_array$_t_uint256_$dyn_calldata_ptr",
+                "nativeSrc": "720:568:1",
                 "nodeType": "YulFunctionDefinition",
                 "parameters":
                 [
                   {
                     "name": "offset",
+                    "nativeSrc": "777:6:1",
                     "nodeType": "YulTypedName",
                     "src": "777:6:1",
                     "type": ""
                   },
                   {
                     "name": "end",
+                    "nativeSrc": "785:3:1",
                     "nodeType": "YulTypedName",
                     "src": "785:3:1",
                     "type": ""
@@ -621,12 +718,14 @@
                 [
                   {
                     "name": "arrayPos",
+                    "nativeSrc": "793:8:1",
                     "nodeType": "YulTypedName",
                     "src": "793:8:1",
                     "type": ""
                   },
                   {
                     "name": "length",
+                    "nativeSrc": "803:6:1",
                     "nodeType": "YulTypedName",
                     "src": "803:6:1",
                     "type": ""
@@ -637,6 +736,7 @@
               {
                 "body":
                 {
+                  "nativeSrc": "1395:458:1",
                   "nodeType": "YulBlock",
                   "src": "1395:458:1",
                   "statements":
@@ -644,6 +744,7 @@
                     {
                       "body":
                       {
+                        "nativeSrc": "1441:83:1",
                         "nodeType": "YulBlock",
                         "src": "1441:83:1",
                         "statements":
@@ -655,12 +756,15 @@
                               "functionName":
                               {
                                 "name": "revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b",
+                                "nativeSrc": "1443:77:1",
                                 "nodeType": "YulIdentifier",
                                 "src": "1443:77:1"
                               },
+                              "nativeSrc": "1443:79:1",
                               "nodeType": "YulFunctionCall",
                               "src": "1443:79:1"
                             },
+                            "nativeSrc": "1443:79:1",
                             "nodeType": "YulExpressionStatement",
                             "src": "1443:79:1"
                           }
@@ -675,11 +779,13 @@
                             [
                               {
                                 "name": "dataEnd",
+                                "nativeSrc": "1416:7:1",
                                 "nodeType": "YulIdentifier",
                                 "src": "1416:7:1"
                               },
                               {
                                 "name": "headStart",
+                                "nativeSrc": "1425:9:1",
                                 "nodeType": "YulIdentifier",
                                 "src": "1425:9:1"
                               }
@@ -687,14 +793,17 @@
                             "functionName":
                             {
                               "name": "sub",
+                              "nativeSrc": "1412:3:1",
                               "nodeType": "YulIdentifier",
                               "src": "1412:3:1"
                             },
+                            "nativeSrc": "1412:23:1",
                             "nodeType": "YulFunctionCall",
                             "src": "1412:23:1"
                           },
                           {
                             "kind": "number",
+                            "nativeSrc": "1437:2:1",
                             "nodeType": "YulLiteral",
                             "src": "1437:2:1",
                             "type": "",
@@ -704,21 +813,26 @@
                         "functionName":
                         {
                           "name": "slt",
+                          "nativeSrc": "1408:3:1",
                           "nodeType": "YulIdentifier",
                           "src": "1408:3:1"
                         },
+                        "nativeSrc": "1408:32:1",
                         "nodeType": "YulFunctionCall",
                         "src": "1408:32:1"
                       },
+                      "nativeSrc": "1405:119:1",
                       "nodeType": "YulIf",
                       "src": "1405:119:1"
                     },
                     {
+                      "nativeSrc": "1534:312:1",
                       "nodeType": "YulBlock",
                       "src": "1534:312:1",
                       "statements":
                       [
                         {
+                          "nativeSrc": "1549:45:1",
                           "nodeType": "YulVariableDeclaration",
                           "src": "1549:45:1",
                           "value":
@@ -730,11 +844,13 @@
                                 [
                                   {
                                     "name": "headStart",
+                                    "nativeSrc": "1580:9:1",
                                     "nodeType": "YulIdentifier",
                                     "src": "1580:9:1"
                                   },
                                   {
                                     "kind": "number",
+                                    "nativeSrc": "1591:1:1",
                                     "nodeType": "YulLiteral",
                                     "src": "1591:1:1",
                                     "type": "",
@@ -744,9 +860,11 @@
                                 "functionName":
                                 {
                                   "name": "add",
+                                  "nativeSrc": "1576:3:1",
                                   "nodeType": "YulIdentifier",
                                   "src": "1576:3:1"
                                 },
+                                "nativeSrc": "1576:17:1",
                                 "nodeType": "YulFunctionCall",
                                 "src": "1576:17:1"
                               }
@@ -754,9 +872,11 @@
                             "functionName":
                             {
                               "name": "calldataload",
+                              "nativeSrc": "1563:12:1",
                               "nodeType": "YulIdentifier",
                               "src": "1563:12:1"
                             },
+                            "nativeSrc": "1563:31:1",
                             "nodeType": "YulFunctionCall",
                             "src": "1563:31:1"
                           },
@@ -764,6 +884,7 @@
                           [
                             {
                               "name": "offset",
+                              "nativeSrc": "1553:6:1",
                               "nodeType": "YulTypedName",
                               "src": "1553:6:1",
                               "type": ""
@@ -773,6 +894,7 @@
                         {
                           "body":
                           {
+                            "nativeSrc": "1641:83:1",
                             "nodeType": "YulBlock",
                             "src": "1641:83:1",
                             "statements":
@@ -784,12 +906,15 @@
                                   "functionName":
                                   {
                                     "name": "revert_error_c1322bf8034eace5e0b5c7295db60986aa89aae5e0ea0873e4689e076861a5db",
+                                    "nativeSrc": "1643:77:1",
                                     "nodeType": "YulIdentifier",
                                     "src": "1643:77:1"
                                   },
+                                  "nativeSrc": "1643:79:1",
                                   "nodeType": "YulFunctionCall",
                                   "src": "1643:79:1"
                                 },
+                                "nativeSrc": "1643:79:1",
                                 "nodeType": "YulExpressionStatement",
                                 "src": "1643:79:1"
                               }
@@ -801,11 +926,13 @@
                             [
                               {
                                 "name": "offset",
+                                "nativeSrc": "1613:6:1",
                                 "nodeType": "YulIdentifier",
                                 "src": "1613:6:1"
                               },
                               {
                                 "kind": "number",
+                                "nativeSrc": "1621:18:1",
                                 "nodeType": "YulLiteral",
                                 "src": "1621:18:1",
                                 "type": "",
@@ -815,16 +942,20 @@
                             "functionName":
                             {
                               "name": "gt",
+                              "nativeSrc": "1610:2:1",
                               "nodeType": "YulIdentifier",
                               "src": "1610:2:1"
                             },
+                            "nativeSrc": "1610:30:1",
                             "nodeType": "YulFunctionCall",
                             "src": "1610:30:1"
                           },
+                          "nativeSrc": "1607:117:1",
                           "nodeType": "YulIf",
                           "src": "1607:117:1"
                         },
                         {
+                          "nativeSrc": "1738:98:1",
                           "nodeType": "YulAssignment",
                           "src": "1738:98:1",
                           "value":
@@ -836,11 +967,13 @@
                                 [
                                   {
                                     "name": "headStart",
+                                    "nativeSrc": "1808:9:1",
                                     "nodeType": "YulIdentifier",
                                     "src": "1808:9:1"
                                   },
                                   {
                                     "name": "offset",
+                                    "nativeSrc": "1819:6:1",
                                     "nodeType": "YulIdentifier",
                                     "src": "1819:6:1"
                                   }
@@ -848,14 +981,17 @@
                                 "functionName":
                                 {
                                   "name": "add",
+                                  "nativeSrc": "1804:3:1",
                                   "nodeType": "YulIdentifier",
                                   "src": "1804:3:1"
                                 },
+                                "nativeSrc": "1804:22:1",
                                 "nodeType": "YulFunctionCall",
                                 "src": "1804:22:1"
                               },
                               {
                                 "name": "dataEnd",
+                                "nativeSrc": "1828:7:1",
                                 "nodeType": "YulIdentifier",
                                 "src": "1828:7:1"
                               }
@@ -863,9 +999,11 @@
                             "functionName":
                             {
                               "name": "abi_decode_t_array$_t_uint256_$dyn_calldata_ptr",
+                              "nativeSrc": "1756:47:1",
                               "nodeType": "YulIdentifier",
                               "src": "1756:47:1"
                             },
+                            "nativeSrc": "1756:80:1",
                             "nodeType": "YulFunctionCall",
                             "src": "1756:80:1"
                           },
@@ -873,11 +1011,13 @@
                           [
                             {
                               "name": "value0",
+                              "nativeSrc": "1738:6:1",
                               "nodeType": "YulIdentifier",
                               "src": "1738:6:1"
                             },
                             {
                               "name": "value1",
+                              "nativeSrc": "1746:6:1",
                               "nodeType": "YulIdentifier",
                               "src": "1746:6:1"
                             }
@@ -888,17 +1028,20 @@
                   ]
                 },
                 "name": "abi_decode_tuple_t_array$_t_uint256_$dyn_calldata_ptr",
+                "nativeSrc": "1294:559:1",
                 "nodeType": "YulFunctionDefinition",
                 "parameters":
                 [
                   {
                     "name": "headStart",
+                    "nativeSrc": "1357:9:1",
                     "nodeType": "YulTypedName",
                     "src": "1357:9:1",
                     "type": ""
                   },
                   {
                     "name": "dataEnd",
+                    "nativeSrc": "1368:7:1",
                     "nodeType": "YulTypedName",
                     "src": "1368:7:1",
                     "type": ""
@@ -908,12 +1051,14 @@
                 [
                   {
                     "name": "value0",
+                    "nativeSrc": "1380:6:1",
                     "nodeType": "YulTypedName",
                     "src": "1380:6:1",
                     "type": ""
                   },
                   {
                     "name": "value1",
+                    "nativeSrc": "1388:6:1",
                     "nodeType": "YulTypedName",
                     "src": "1388:6:1",
                     "type": ""

--- a/test/cmdlineTests/standard_generatedSources/output.json
+++ b/test/cmdlineTests/standard_generatedSources/output.json
@@ -19,6 +19,7 @@
                             {
                                 "ast":
                                 {
+                                    "nativeSrc": "0:3989:1",
                                     "nodeType": "YulBlock",
                                     "src": "0:3989:1",
                                     "statements":
@@ -26,11 +27,13 @@
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "47:35:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "47:35:1",
                                                 "statements":
                                                 [
                                                     {
+                                                        "nativeSrc": "57:19:1",
                                                         "nodeType": "YulAssignment",
                                                         "src": "57:19:1",
                                                         "value":
@@ -39,6 +42,7 @@
                                                             [
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "73:2:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "73:2:1",
                                                                     "type": "",
@@ -48,9 +52,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "mload",
+                                                                "nativeSrc": "67:5:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "67:5:1"
                                                             },
+                                                            "nativeSrc": "67:9:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "67:9:1"
                                                         },
@@ -58,6 +64,7 @@
                                                         [
                                                             {
                                                                 "name": "memPtr",
+                                                                "nativeSrc": "57:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "57:6:1"
                                                             }
@@ -66,11 +73,13 @@
                                                 ]
                                             },
                                             "name": "allocate_unbounded",
+                                            "nativeSrc": "7:75:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "returnVariables":
                                             [
                                                 {
                                                     "name": "memPtr",
+                                                    "nativeSrc": "40:6:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "40:6:1",
                                                     "type": ""
@@ -81,6 +90,7 @@
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "177:28:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "177:28:1",
                                                 "statements":
@@ -92,6 +102,7 @@
                                                             [
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "194:1:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "194:1:1",
                                                                     "type": "",
@@ -99,6 +110,7 @@
                                                                 },
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "197:1:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "197:1:1",
                                                                     "type": "",
@@ -108,24 +120,29 @@
                                                             "functionName":
                                                             {
                                                                 "name": "revert",
+                                                                "nativeSrc": "187:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "187:6:1"
                                                             },
+                                                            "nativeSrc": "187:12:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "187:12:1"
                                                         },
+                                                        "nativeSrc": "187:12:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "187:12:1"
                                                     }
                                                 ]
                                             },
                                             "name": "revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b",
+                                            "nativeSrc": "88:117:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "src": "88:117:1"
                                         },
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "300:28:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "300:28:1",
                                                 "statements":
@@ -137,6 +154,7 @@
                                                             [
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "317:1:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "317:1:1",
                                                                     "type": "",
@@ -144,6 +162,7 @@
                                                                 },
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "320:1:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "320:1:1",
                                                                     "type": "",
@@ -153,24 +172,29 @@
                                                             "functionName":
                                                             {
                                                                 "name": "revert",
+                                                                "nativeSrc": "310:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "310:6:1"
                                                             },
+                                                            "nativeSrc": "310:12:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "310:12:1"
                                                         },
+                                                        "nativeSrc": "310:12:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "310:12:1"
                                                     }
                                                 ]
                                             },
                                             "name": "revert_error_c1322bf8034eace5e0b5c7295db60986aa89aae5e0ea0873e4689e076861a5db",
+                                            "nativeSrc": "211:117:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "src": "211:117:1"
                                         },
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "423:28:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "423:28:1",
                                                 "statements":
@@ -182,6 +206,7 @@
                                                             [
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "440:1:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "440:1:1",
                                                                     "type": "",
@@ -189,6 +214,7 @@
                                                                 },
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "443:1:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "443:1:1",
                                                                     "type": "",
@@ -198,29 +224,35 @@
                                                             "functionName":
                                                             {
                                                                 "name": "revert",
+                                                                "nativeSrc": "433:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "433:6:1"
                                                             },
+                                                            "nativeSrc": "433:12:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "433:12:1"
                                                         },
+                                                        "nativeSrc": "433:12:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "433:12:1"
                                                     }
                                                 ]
                                             },
                                             "name": "revert_error_1b9f4a0a5773e33b91aa01db23bf8c55fce1411167c872835e7fa00a4f17d46d",
+                                            "nativeSrc": "334:117:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "src": "334:117:1"
                                         },
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "505:54:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "505:54:1",
                                                 "statements":
                                                 [
                                                     {
+                                                        "nativeSrc": "515:38:1",
                                                         "nodeType": "YulAssignment",
                                                         "src": "515:38:1",
                                                         "value":
@@ -232,11 +264,13 @@
                                                                     [
                                                                         {
                                                                             "name": "value",
+                                                                            "nativeSrc": "533:5:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "533:5:1"
                                                                         },
                                                                         {
                                                                             "kind": "number",
+                                                                            "nativeSrc": "540:2:1",
                                                                             "nodeType": "YulLiteral",
                                                                             "src": "540:2:1",
                                                                             "type": "",
@@ -246,9 +280,11 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "add",
+                                                                        "nativeSrc": "529:3:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "529:3:1"
                                                                     },
+                                                                    "nativeSrc": "529:14:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "529:14:1"
                                                                 },
@@ -257,6 +293,7 @@
                                                                     [
                                                                         {
                                                                             "kind": "number",
+                                                                            "nativeSrc": "549:2:1",
                                                                             "nodeType": "YulLiteral",
                                                                             "src": "549:2:1",
                                                                             "type": "",
@@ -266,9 +303,11 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "not",
+                                                                        "nativeSrc": "545:3:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "545:3:1"
                                                                     },
+                                                                    "nativeSrc": "545:7:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "545:7:1"
                                                                 }
@@ -276,9 +315,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "and",
+                                                                "nativeSrc": "525:3:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "525:3:1"
                                                             },
+                                                            "nativeSrc": "525:28:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "525:28:1"
                                                         },
@@ -286,6 +327,7 @@
                                                         [
                                                             {
                                                                 "name": "result",
+                                                                "nativeSrc": "515:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "515:6:1"
                                                             }
@@ -294,11 +336,13 @@
                                                 ]
                                             },
                                             "name": "round_up_to_mul_of_32",
+                                            "nativeSrc": "457:102:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "value",
+                                                    "nativeSrc": "488:5:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "488:5:1",
                                                     "type": ""
@@ -308,6 +352,7 @@
                                             [
                                                 {
                                                     "name": "result",
+                                                    "nativeSrc": "498:6:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "498:6:1",
                                                     "type": ""
@@ -318,6 +363,7 @@
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "593:152:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "593:152:1",
                                                 "statements":
@@ -329,6 +375,7 @@
                                                             [
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "610:1:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "610:1:1",
                                                                     "type": "",
@@ -336,6 +383,7 @@
                                                                 },
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "613:77:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "613:77:1",
                                                                     "type": "",
@@ -345,12 +393,15 @@
                                                             "functionName":
                                                             {
                                                                 "name": "mstore",
+                                                                "nativeSrc": "603:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "603:6:1"
                                                             },
+                                                            "nativeSrc": "603:88:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "603:88:1"
                                                         },
+                                                        "nativeSrc": "603:88:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "603:88:1"
                                                     },
@@ -361,6 +412,7 @@
                                                             [
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "707:1:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "707:1:1",
                                                                     "type": "",
@@ -368,6 +420,7 @@
                                                                 },
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "710:4:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "710:4:1",
                                                                     "type": "",
@@ -377,12 +430,15 @@
                                                             "functionName":
                                                             {
                                                                 "name": "mstore",
+                                                                "nativeSrc": "700:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "700:6:1"
                                                             },
+                                                            "nativeSrc": "700:15:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "700:15:1"
                                                         },
+                                                        "nativeSrc": "700:15:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "700:15:1"
                                                     },
@@ -393,6 +449,7 @@
                                                             [
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "731:1:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "731:1:1",
                                                                     "type": "",
@@ -400,6 +457,7 @@
                                                                 },
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "734:4:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "734:4:1",
                                                                     "type": "",
@@ -409,29 +467,35 @@
                                                             "functionName":
                                                             {
                                                                 "name": "revert",
+                                                                "nativeSrc": "724:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "724:6:1"
                                                             },
+                                                            "nativeSrc": "724:15:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "724:15:1"
                                                         },
+                                                        "nativeSrc": "724:15:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "724:15:1"
                                                     }
                                                 ]
                                             },
                                             "name": "panic_error_0x41",
+                                            "nativeSrc": "565:180:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "src": "565:180:1"
                                         },
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "794:238:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "794:238:1",
                                                 "statements":
                                                 [
                                                     {
+                                                        "nativeSrc": "804:58:1",
                                                         "nodeType": "YulVariableDeclaration",
                                                         "src": "804:58:1",
                                                         "value":
@@ -440,6 +504,7 @@
                                                             [
                                                                 {
                                                                     "name": "memPtr",
+                                                                    "nativeSrc": "826:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "826:6:1"
                                                                 },
@@ -448,6 +513,7 @@
                                                                     [
                                                                         {
                                                                             "name": "size",
+                                                                            "nativeSrc": "856:4:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "856:4:1"
                                                                         }
@@ -455,9 +521,11 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "round_up_to_mul_of_32",
+                                                                        "nativeSrc": "834:21:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "834:21:1"
                                                                     },
+                                                                    "nativeSrc": "834:27:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "834:27:1"
                                                                 }
@@ -465,9 +533,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "add",
+                                                                "nativeSrc": "822:3:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "822:3:1"
                                                             },
+                                                            "nativeSrc": "822:40:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "822:40:1"
                                                         },
@@ -475,6 +545,7 @@
                                                         [
                                                             {
                                                                 "name": "newFreePtr",
+                                                                "nativeSrc": "808:10:1",
                                                                 "nodeType": "YulTypedName",
                                                                 "src": "808:10:1",
                                                                 "type": ""
@@ -484,6 +555,7 @@
                                                     {
                                                         "body":
                                                         {
+                                                            "nativeSrc": "973:22:1",
                                                             "nodeType": "YulBlock",
                                                             "src": "973:22:1",
                                                             "statements":
@@ -495,12 +567,15 @@
                                                                         "functionName":
                                                                         {
                                                                             "name": "panic_error_0x41",
+                                                                            "nativeSrc": "975:16:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "975:16:1"
                                                                         },
+                                                                        "nativeSrc": "975:18:1",
                                                                         "nodeType": "YulFunctionCall",
                                                                         "src": "975:18:1"
                                                                     },
+                                                                    "nativeSrc": "975:18:1",
                                                                     "nodeType": "YulExpressionStatement",
                                                                     "src": "975:18:1"
                                                                 }
@@ -515,11 +590,13 @@
                                                                     [
                                                                         {
                                                                             "name": "newFreePtr",
+                                                                            "nativeSrc": "916:10:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "916:10:1"
                                                                         },
                                                                         {
                                                                             "kind": "number",
+                                                                            "nativeSrc": "928:18:1",
                                                                             "nodeType": "YulLiteral",
                                                                             "src": "928:18:1",
                                                                             "type": "",
@@ -529,9 +606,11 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "gt",
+                                                                        "nativeSrc": "913:2:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "913:2:1"
                                                                     },
+                                                                    "nativeSrc": "913:34:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "913:34:1"
                                                                 },
@@ -540,11 +619,13 @@
                                                                     [
                                                                         {
                                                                             "name": "newFreePtr",
+                                                                            "nativeSrc": "952:10:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "952:10:1"
                                                                         },
                                                                         {
                                                                             "name": "memPtr",
+                                                                            "nativeSrc": "964:6:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "964:6:1"
                                                                         }
@@ -552,9 +633,11 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "lt",
+                                                                        "nativeSrc": "949:2:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "949:2:1"
                                                                     },
+                                                                    "nativeSrc": "949:22:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "949:22:1"
                                                                 }
@@ -562,12 +645,15 @@
                                                             "functionName":
                                                             {
                                                                 "name": "or",
+                                                                "nativeSrc": "910:2:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "910:2:1"
                                                             },
+                                                            "nativeSrc": "910:62:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "910:62:1"
                                                         },
+                                                        "nativeSrc": "907:88:1",
                                                         "nodeType": "YulIf",
                                                         "src": "907:88:1"
                                                     },
@@ -578,6 +664,7 @@
                                                             [
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "1011:2:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "1011:2:1",
                                                                     "type": "",
@@ -585,6 +672,7 @@
                                                                 },
                                                                 {
                                                                     "name": "newFreePtr",
+                                                                    "nativeSrc": "1015:10:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "1015:10:1"
                                                                 }
@@ -592,29 +680,35 @@
                                                             "functionName":
                                                             {
                                                                 "name": "mstore",
+                                                                "nativeSrc": "1004:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1004:6:1"
                                                             },
+                                                            "nativeSrc": "1004:22:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "1004:22:1"
                                                         },
+                                                        "nativeSrc": "1004:22:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "1004:22:1"
                                                     }
                                                 ]
                                             },
                                             "name": "finalize_allocation",
+                                            "nativeSrc": "751:281:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "memPtr",
+                                                    "nativeSrc": "780:6:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "780:6:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "size",
+                                                    "nativeSrc": "788:4:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "788:4:1",
                                                     "type": ""
@@ -625,11 +719,13 @@
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "1079:88:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "1079:88:1",
                                                 "statements":
                                                 [
                                                     {
+                                                        "nativeSrc": "1089:30:1",
                                                         "nodeType": "YulAssignment",
                                                         "src": "1089:30:1",
                                                         "value":
@@ -638,9 +734,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "allocate_unbounded",
+                                                                "nativeSrc": "1099:18:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1099:18:1"
                                                             },
+                                                            "nativeSrc": "1099:20:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "1099:20:1"
                                                         },
@@ -648,6 +746,7 @@
                                                         [
                                                             {
                                                                 "name": "memPtr",
+                                                                "nativeSrc": "1089:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1089:6:1"
                                                             }
@@ -660,11 +759,13 @@
                                                             [
                                                                 {
                                                                     "name": "memPtr",
+                                                                    "nativeSrc": "1148:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "1148:6:1"
                                                                 },
                                                                 {
                                                                     "name": "size",
+                                                                    "nativeSrc": "1156:4:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "1156:4:1"
                                                                 }
@@ -672,23 +773,28 @@
                                                             "functionName":
                                                             {
                                                                 "name": "finalize_allocation",
+                                                                "nativeSrc": "1128:19:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1128:19:1"
                                                             },
+                                                            "nativeSrc": "1128:33:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "1128:33:1"
                                                         },
+                                                        "nativeSrc": "1128:33:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "1128:33:1"
                                                     }
                                                 ]
                                             },
                                             "name": "allocate_memory",
+                                            "nativeSrc": "1038:129:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "size",
+                                                    "nativeSrc": "1063:4:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "1063:4:1",
                                                     "type": ""
@@ -698,6 +804,7 @@
                                             [
                                                 {
                                                     "name": "memPtr",
+                                                    "nativeSrc": "1072:6:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "1072:6:1",
                                                     "type": ""
@@ -708,6 +815,7 @@
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "1255:229:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "1255:229:1",
                                                 "statements":
@@ -715,6 +823,7 @@
                                                     {
                                                         "body":
                                                         {
+                                                            "nativeSrc": "1360:22:1",
                                                             "nodeType": "YulBlock",
                                                             "src": "1360:22:1",
                                                             "statements":
@@ -726,12 +835,15 @@
                                                                         "functionName":
                                                                         {
                                                                             "name": "panic_error_0x41",
+                                                                            "nativeSrc": "1362:16:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "1362:16:1"
                                                                         },
+                                                                        "nativeSrc": "1362:18:1",
                                                                         "nodeType": "YulFunctionCall",
                                                                         "src": "1362:18:1"
                                                                     },
+                                                                    "nativeSrc": "1362:18:1",
                                                                     "nodeType": "YulExpressionStatement",
                                                                     "src": "1362:18:1"
                                                                 }
@@ -743,11 +855,13 @@
                                                             [
                                                                 {
                                                                     "name": "length",
+                                                                    "nativeSrc": "1332:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "1332:6:1"
                                                                 },
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "1340:18:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "1340:18:1",
                                                                     "type": "",
@@ -757,16 +871,20 @@
                                                             "functionName":
                                                             {
                                                                 "name": "gt",
+                                                                "nativeSrc": "1329:2:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1329:2:1"
                                                             },
+                                                            "nativeSrc": "1329:30:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "1329:30:1"
                                                         },
+                                                        "nativeSrc": "1326:56:1",
                                                         "nodeType": "YulIf",
                                                         "src": "1326:56:1"
                                                     },
                                                     {
+                                                        "nativeSrc": "1392:25:1",
                                                         "nodeType": "YulAssignment",
                                                         "src": "1392:25:1",
                                                         "value":
@@ -775,11 +893,13 @@
                                                             [
                                                                 {
                                                                     "name": "length",
+                                                                    "nativeSrc": "1404:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "1404:6:1"
                                                                 },
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "1412:4:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "1412:4:1",
                                                                     "type": "",
@@ -789,9 +909,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "mul",
+                                                                "nativeSrc": "1400:3:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1400:3:1"
                                                             },
+                                                            "nativeSrc": "1400:17:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "1400:17:1"
                                                         },
@@ -799,12 +921,14 @@
                                                         [
                                                             {
                                                                 "name": "size",
+                                                                "nativeSrc": "1392:4:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1392:4:1"
                                                             }
                                                         ]
                                                     },
                                                     {
+                                                        "nativeSrc": "1454:23:1",
                                                         "nodeType": "YulAssignment",
                                                         "src": "1454:23:1",
                                                         "value":
@@ -813,11 +937,13 @@
                                                             [
                                                                 {
                                                                     "name": "size",
+                                                                    "nativeSrc": "1466:4:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "1466:4:1"
                                                                 },
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "1472:4:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "1472:4:1",
                                                                     "type": "",
@@ -827,9 +953,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "add",
+                                                                "nativeSrc": "1462:3:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1462:3:1"
                                                             },
+                                                            "nativeSrc": "1462:15:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "1462:15:1"
                                                         },
@@ -837,6 +965,7 @@
                                                         [
                                                             {
                                                                 "name": "size",
+                                                                "nativeSrc": "1454:4:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1454:4:1"
                                                             }
@@ -845,11 +974,13 @@
                                                 ]
                                             },
                                             "name": "array_allocation_size_t_array$_t_uint256_$dyn_memory_ptr",
+                                            "nativeSrc": "1173:311:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "length",
+                                                    "nativeSrc": "1239:6:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "1239:6:1",
                                                     "type": ""
@@ -859,6 +990,7 @@
                                             [
                                                 {
                                                     "name": "size",
+                                                    "nativeSrc": "1250:4:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "1250:4:1",
                                                     "type": ""
@@ -869,6 +1001,7 @@
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "1579:28:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "1579:28:1",
                                                 "statements":
@@ -880,6 +1013,7 @@
                                                             [
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "1596:1:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "1596:1:1",
                                                                     "type": "",
@@ -887,6 +1021,7 @@
                                                                 },
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "1599:1:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "1599:1:1",
                                                                     "type": "",
@@ -896,34 +1031,41 @@
                                                             "functionName":
                                                             {
                                                                 "name": "revert",
+                                                                "nativeSrc": "1589:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1589:6:1"
                                                             },
+                                                            "nativeSrc": "1589:12:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "1589:12:1"
                                                         },
+                                                        "nativeSrc": "1589:12:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "1589:12:1"
                                                     }
                                                 ]
                                             },
                                             "name": "revert_error_81385d8c0b31fffe14be1da910c8bd3a80be4cfa248e04f42ec0faea3132a8ef",
+                                            "nativeSrc": "1490:117:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "src": "1490:117:1"
                                         },
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "1658:32:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "1658:32:1",
                                                 "statements":
                                                 [
                                                     {
+                                                        "nativeSrc": "1668:16:1",
                                                         "nodeType": "YulAssignment",
                                                         "src": "1668:16:1",
                                                         "value":
                                                         {
                                                             "name": "value",
+                                                            "nativeSrc": "1679:5:1",
                                                             "nodeType": "YulIdentifier",
                                                             "src": "1679:5:1"
                                                         },
@@ -931,6 +1073,7 @@
                                                         [
                                                             {
                                                                 "name": "cleaned",
+                                                                "nativeSrc": "1668:7:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1668:7:1"
                                                             }
@@ -939,11 +1082,13 @@
                                                 ]
                                             },
                                             "name": "cleanup_t_uint256",
+                                            "nativeSrc": "1613:77:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "value",
+                                                    "nativeSrc": "1640:5:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "1640:5:1",
                                                     "type": ""
@@ -953,6 +1098,7 @@
                                             [
                                                 {
                                                     "name": "cleaned",
+                                                    "nativeSrc": "1650:7:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "1650:7:1",
                                                     "type": ""
@@ -963,6 +1109,7 @@
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "1739:79:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "1739:79:1",
                                                 "statements":
@@ -970,6 +1117,7 @@
                                                     {
                                                         "body":
                                                         {
+                                                            "nativeSrc": "1796:16:1",
                                                             "nodeType": "YulBlock",
                                                             "src": "1796:16:1",
                                                             "statements":
@@ -981,6 +1129,7 @@
                                                                         [
                                                                             {
                                                                                 "kind": "number",
+                                                                                "nativeSrc": "1805:1:1",
                                                                                 "nodeType": "YulLiteral",
                                                                                 "src": "1805:1:1",
                                                                                 "type": "",
@@ -988,6 +1137,7 @@
                                                                             },
                                                                             {
                                                                                 "kind": "number",
+                                                                                "nativeSrc": "1808:1:1",
                                                                                 "nodeType": "YulLiteral",
                                                                                 "src": "1808:1:1",
                                                                                 "type": "",
@@ -997,12 +1147,15 @@
                                                                         "functionName":
                                                                         {
                                                                             "name": "revert",
+                                                                            "nativeSrc": "1798:6:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "1798:6:1"
                                                                         },
+                                                                        "nativeSrc": "1798:12:1",
                                                                         "nodeType": "YulFunctionCall",
                                                                         "src": "1798:12:1"
                                                                     },
+                                                                    "nativeSrc": "1798:12:1",
                                                                     "nodeType": "YulExpressionStatement",
                                                                     "src": "1798:12:1"
                                                                 }
@@ -1017,6 +1170,7 @@
                                                                     [
                                                                         {
                                                                             "name": "value",
+                                                                            "nativeSrc": "1762:5:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "1762:5:1"
                                                                         },
@@ -1025,6 +1179,7 @@
                                                                             [
                                                                                 {
                                                                                     "name": "value",
+                                                                                    "nativeSrc": "1787:5:1",
                                                                                     "nodeType": "YulIdentifier",
                                                                                     "src": "1787:5:1"
                                                                                 }
@@ -1032,9 +1187,11 @@
                                                                             "functionName":
                                                                             {
                                                                                 "name": "cleanup_t_uint256",
+                                                                                "nativeSrc": "1769:17:1",
                                                                                 "nodeType": "YulIdentifier",
                                                                                 "src": "1769:17:1"
                                                                             },
+                                                                            "nativeSrc": "1769:24:1",
                                                                             "nodeType": "YulFunctionCall",
                                                                             "src": "1769:24:1"
                                                                         }
@@ -1042,9 +1199,11 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "eq",
+                                                                        "nativeSrc": "1759:2:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "1759:2:1"
                                                                     },
+                                                                    "nativeSrc": "1759:35:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "1759:35:1"
                                                                 }
@@ -1052,23 +1211,28 @@
                                                             "functionName":
                                                             {
                                                                 "name": "iszero",
+                                                                "nativeSrc": "1752:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1752:6:1"
                                                             },
+                                                            "nativeSrc": "1752:43:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "1752:43:1"
                                                         },
+                                                        "nativeSrc": "1749:63:1",
                                                         "nodeType": "YulIf",
                                                         "src": "1749:63:1"
                                                     }
                                                 ]
                                             },
                                             "name": "validator_revert_t_uint256",
+                                            "nativeSrc": "1696:122:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "value",
+                                                    "nativeSrc": "1732:5:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "1732:5:1",
                                                     "type": ""
@@ -1079,11 +1243,13 @@
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "1876:87:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "1876:87:1",
                                                 "statements":
                                                 [
                                                     {
+                                                        "nativeSrc": "1886:29:1",
                                                         "nodeType": "YulAssignment",
                                                         "src": "1886:29:1",
                                                         "value":
@@ -1092,6 +1258,7 @@
                                                             [
                                                                 {
                                                                     "name": "offset",
+                                                                    "nativeSrc": "1908:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "1908:6:1"
                                                                 }
@@ -1099,9 +1266,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "calldataload",
+                                                                "nativeSrc": "1895:12:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1895:12:1"
                                                             },
+                                                            "nativeSrc": "1895:20:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "1895:20:1"
                                                         },
@@ -1109,6 +1278,7 @@
                                                         [
                                                             {
                                                                 "name": "value",
+                                                                "nativeSrc": "1886:5:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1886:5:1"
                                                             }
@@ -1121,6 +1291,7 @@
                                                             [
                                                                 {
                                                                     "name": "value",
+                                                                    "nativeSrc": "1951:5:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "1951:5:1"
                                                                 }
@@ -1128,29 +1299,35 @@
                                                             "functionName":
                                                             {
                                                                 "name": "validator_revert_t_uint256",
+                                                                "nativeSrc": "1924:26:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1924:26:1"
                                                             },
+                                                            "nativeSrc": "1924:33:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "1924:33:1"
                                                         },
+                                                        "nativeSrc": "1924:33:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "1924:33:1"
                                                     }
                                                 ]
                                             },
                                             "name": "abi_decode_t_uint256",
+                                            "nativeSrc": "1824:139:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "offset",
+                                                    "nativeSrc": "1854:6:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "1854:6:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "end",
+                                                    "nativeSrc": "1862:3:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "1862:3:1",
                                                     "type": ""
@@ -1160,6 +1337,7 @@
                                             [
                                                 {
                                                     "name": "value",
+                                                    "nativeSrc": "1870:5:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "1870:5:1",
                                                     "type": ""
@@ -1170,11 +1348,13 @@
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "2088:608:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "2088:608:1",
                                                 "statements":
                                                 [
                                                     {
+                                                        "nativeSrc": "2098:90:1",
                                                         "nodeType": "YulAssignment",
                                                         "src": "2098:90:1",
                                                         "value":
@@ -1186,6 +1366,7 @@
                                                                     [
                                                                         {
                                                                             "name": "length",
+                                                                            "nativeSrc": "2180:6:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "2180:6:1"
                                                                         }
@@ -1193,9 +1374,11 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "array_allocation_size_t_array$_t_uint256_$dyn_memory_ptr",
+                                                                        "nativeSrc": "2123:56:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "2123:56:1"
                                                                     },
+                                                                    "nativeSrc": "2123:64:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "2123:64:1"
                                                                 }
@@ -1203,9 +1386,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "allocate_memory",
+                                                                "nativeSrc": "2107:15:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "2107:15:1"
                                                             },
+                                                            "nativeSrc": "2107:81:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "2107:81:1"
                                                         },
@@ -1213,17 +1398,20 @@
                                                         [
                                                             {
                                                                 "name": "array",
+                                                                "nativeSrc": "2098:5:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "2098:5:1"
                                                             }
                                                         ]
                                                     },
                                                     {
+                                                        "nativeSrc": "2197:16:1",
                                                         "nodeType": "YulVariableDeclaration",
                                                         "src": "2197:16:1",
                                                         "value":
                                                         {
                                                             "name": "array",
+                                                            "nativeSrc": "2208:5:1",
                                                             "nodeType": "YulIdentifier",
                                                             "src": "2208:5:1"
                                                         },
@@ -1231,6 +1419,7 @@
                                                         [
                                                             {
                                                                 "name": "dst",
+                                                                "nativeSrc": "2201:3:1",
                                                                 "nodeType": "YulTypedName",
                                                                 "src": "2201:3:1",
                                                                 "type": ""
@@ -1244,11 +1433,13 @@
                                                             [
                                                                 {
                                                                     "name": "array",
+                                                                    "nativeSrc": "2230:5:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "2230:5:1"
                                                                 },
                                                                 {
                                                                     "name": "length",
+                                                                    "nativeSrc": "2237:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "2237:6:1"
                                                                 }
@@ -1256,16 +1447,20 @@
                                                             "functionName":
                                                             {
                                                                 "name": "mstore",
+                                                                "nativeSrc": "2223:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "2223:6:1"
                                                             },
+                                                            "nativeSrc": "2223:21:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "2223:21:1"
                                                         },
+                                                        "nativeSrc": "2223:21:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "2223:21:1"
                                                     },
                                                     {
+                                                        "nativeSrc": "2253:23:1",
                                                         "nodeType": "YulAssignment",
                                                         "src": "2253:23:1",
                                                         "value":
@@ -1274,11 +1469,13 @@
                                                             [
                                                                 {
                                                                     "name": "array",
+                                                                    "nativeSrc": "2264:5:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "2264:5:1"
                                                                 },
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "2271:4:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "2271:4:1",
                                                                     "type": "",
@@ -1288,9 +1485,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "add",
+                                                                "nativeSrc": "2260:3:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "2260:3:1"
                                                             },
+                                                            "nativeSrc": "2260:16:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "2260:16:1"
                                                         },
@@ -1298,12 +1497,14 @@
                                                         [
                                                             {
                                                                 "name": "dst",
+                                                                "nativeSrc": "2253:3:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "2253:3:1"
                                                             }
                                                         ]
                                                     },
                                                     {
+                                                        "nativeSrc": "2286:44:1",
                                                         "nodeType": "YulVariableDeclaration",
                                                         "src": "2286:44:1",
                                                         "value":
@@ -1312,6 +1513,7 @@
                                                             [
                                                                 {
                                                                     "name": "offset",
+                                                                    "nativeSrc": "2304:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "2304:6:1"
                                                                 },
@@ -1320,11 +1522,13 @@
                                                                     [
                                                                         {
                                                                             "name": "length",
+                                                                            "nativeSrc": "2316:6:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "2316:6:1"
                                                                         },
                                                                         {
                                                                             "kind": "number",
+                                                                            "nativeSrc": "2324:4:1",
                                                                             "nodeType": "YulLiteral",
                                                                             "src": "2324:4:1",
                                                                             "type": "",
@@ -1334,9 +1538,11 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "mul",
+                                                                        "nativeSrc": "2312:3:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "2312:3:1"
                                                                     },
+                                                                    "nativeSrc": "2312:17:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "2312:17:1"
                                                                 }
@@ -1344,9 +1550,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "add",
+                                                                "nativeSrc": "2300:3:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "2300:3:1"
                                                             },
+                                                            "nativeSrc": "2300:30:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "2300:30:1"
                                                         },
@@ -1354,6 +1562,7 @@
                                                         [
                                                             {
                                                                 "name": "srcEnd",
+                                                                "nativeSrc": "2290:6:1",
                                                                 "nodeType": "YulTypedName",
                                                                 "src": "2290:6:1",
                                                                 "type": ""
@@ -1363,6 +1572,7 @@
                                                     {
                                                         "body":
                                                         {
+                                                            "nativeSrc": "2358:103:1",
                                                             "nodeType": "YulBlock",
                                                             "src": "2358:103:1",
                                                             "statements":
@@ -1374,12 +1584,15 @@
                                                                         "functionName":
                                                                         {
                                                                             "name": "revert_error_81385d8c0b31fffe14be1da910c8bd3a80be4cfa248e04f42ec0faea3132a8ef",
+                                                                            "nativeSrc": "2372:77:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "2372:77:1"
                                                                         },
+                                                                        "nativeSrc": "2372:79:1",
                                                                         "nodeType": "YulFunctionCall",
                                                                         "src": "2372:79:1"
                                                                     },
+                                                                    "nativeSrc": "2372:79:1",
                                                                     "nodeType": "YulExpressionStatement",
                                                                     "src": "2372:79:1"
                                                                 }
@@ -1391,11 +1604,13 @@
                                                             [
                                                                 {
                                                                     "name": "srcEnd",
+                                                                    "nativeSrc": "2345:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "2345:6:1"
                                                                 },
                                                                 {
                                                                     "name": "end",
+                                                                    "nativeSrc": "2353:3:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "2353:3:1"
                                                                 }
@@ -1403,28 +1618,34 @@
                                                             "functionName":
                                                             {
                                                                 "name": "gt",
+                                                                "nativeSrc": "2342:2:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "2342:2:1"
                                                             },
+                                                            "nativeSrc": "2342:15:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "2342:15:1"
                                                         },
+                                                        "nativeSrc": "2339:122:1",
                                                         "nodeType": "YulIf",
                                                         "src": "2339:122:1"
                                                     },
                                                     {
                                                         "body":
                                                         {
+                                                            "nativeSrc": "2546:144:1",
                                                             "nodeType": "YulBlock",
                                                             "src": "2546:144:1",
                                                             "statements":
                                                             [
                                                                 {
+                                                                    "nativeSrc": "2561:21:1",
                                                                     "nodeType": "YulVariableDeclaration",
                                                                     "src": "2561:21:1",
                                                                     "value":
                                                                     {
                                                                         "name": "src",
+                                                                        "nativeSrc": "2579:3:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "2579:3:1"
                                                                     },
@@ -1432,6 +1653,7 @@
                                                                     [
                                                                         {
                                                                             "name": "elementPos",
+                                                                            "nativeSrc": "2565:10:1",
                                                                             "nodeType": "YulTypedName",
                                                                             "src": "2565:10:1",
                                                                             "type": ""
@@ -1445,6 +1667,7 @@
                                                                         [
                                                                             {
                                                                                 "name": "dst",
+                                                                                "nativeSrc": "2603:3:1",
                                                                                 "nodeType": "YulIdentifier",
                                                                                 "src": "2603:3:1"
                                                                             },
@@ -1453,11 +1676,13 @@
                                                                                 [
                                                                                     {
                                                                                         "name": "elementPos",
+                                                                                        "nativeSrc": "2629:10:1",
                                                                                         "nodeType": "YulIdentifier",
                                                                                         "src": "2629:10:1"
                                                                                     },
                                                                                     {
                                                                                         "name": "end",
+                                                                                        "nativeSrc": "2641:3:1",
                                                                                         "nodeType": "YulIdentifier",
                                                                                         "src": "2641:3:1"
                                                                                     }
@@ -1465,9 +1690,11 @@
                                                                                 "functionName":
                                                                                 {
                                                                                     "name": "abi_decode_t_uint256",
+                                                                                    "nativeSrc": "2608:20:1",
                                                                                     "nodeType": "YulIdentifier",
                                                                                     "src": "2608:20:1"
                                                                                 },
+                                                                                "nativeSrc": "2608:37:1",
                                                                                 "nodeType": "YulFunctionCall",
                                                                                 "src": "2608:37:1"
                                                                             }
@@ -1475,16 +1702,20 @@
                                                                         "functionName":
                                                                         {
                                                                             "name": "mstore",
+                                                                            "nativeSrc": "2596:6:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "2596:6:1"
                                                                         },
+                                                                        "nativeSrc": "2596:50:1",
                                                                         "nodeType": "YulFunctionCall",
                                                                         "src": "2596:50:1"
                                                                     },
+                                                                    "nativeSrc": "2596:50:1",
                                                                     "nodeType": "YulExpressionStatement",
                                                                     "src": "2596:50:1"
                                                                 },
                                                                 {
+                                                                    "nativeSrc": "2659:21:1",
                                                                     "nodeType": "YulAssignment",
                                                                     "src": "2659:21:1",
                                                                     "value":
@@ -1493,11 +1724,13 @@
                                                                         [
                                                                             {
                                                                                 "name": "dst",
+                                                                                "nativeSrc": "2670:3:1",
                                                                                 "nodeType": "YulIdentifier",
                                                                                 "src": "2670:3:1"
                                                                             },
                                                                             {
                                                                                 "kind": "number",
+                                                                                "nativeSrc": "2675:4:1",
                                                                                 "nodeType": "YulLiteral",
                                                                                 "src": "2675:4:1",
                                                                                 "type": "",
@@ -1507,9 +1740,11 @@
                                                                         "functionName":
                                                                         {
                                                                             "name": "add",
+                                                                            "nativeSrc": "2666:3:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "2666:3:1"
                                                                         },
+                                                                        "nativeSrc": "2666:14:1",
                                                                         "nodeType": "YulFunctionCall",
                                                                         "src": "2666:14:1"
                                                                     },
@@ -1517,6 +1752,7 @@
                                                                     [
                                                                         {
                                                                             "name": "dst",
+                                                                            "nativeSrc": "2659:3:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "2659:3:1"
                                                                         }
@@ -1530,11 +1766,13 @@
                                                             [
                                                                 {
                                                                     "name": "src",
+                                                                    "nativeSrc": "2499:3:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "2499:3:1"
                                                                 },
                                                                 {
                                                                     "name": "srcEnd",
+                                                                    "nativeSrc": "2504:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "2504:6:1"
                                                                 }
@@ -1542,20 +1780,25 @@
                                                             "functionName":
                                                             {
                                                                 "name": "lt",
+                                                                "nativeSrc": "2496:2:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "2496:2:1"
                                                             },
+                                                            "nativeSrc": "2496:15:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "2496:15:1"
                                                         },
+                                                        "nativeSrc": "2470:220:1",
                                                         "nodeType": "YulForLoop",
                                                         "post":
                                                         {
+                                                            "nativeSrc": "2512:25:1",
                                                             "nodeType": "YulBlock",
                                                             "src": "2512:25:1",
                                                             "statements":
                                                             [
                                                                 {
+                                                                    "nativeSrc": "2514:21:1",
                                                                     "nodeType": "YulAssignment",
                                                                     "src": "2514:21:1",
                                                                     "value":
@@ -1564,11 +1807,13 @@
                                                                         [
                                                                             {
                                                                                 "name": "src",
+                                                                                "nativeSrc": "2525:3:1",
                                                                                 "nodeType": "YulIdentifier",
                                                                                 "src": "2525:3:1"
                                                                             },
                                                                             {
                                                                                 "kind": "number",
+                                                                                "nativeSrc": "2530:4:1",
                                                                                 "nodeType": "YulLiteral",
                                                                                 "src": "2530:4:1",
                                                                                 "type": "",
@@ -1578,9 +1823,11 @@
                                                                         "functionName":
                                                                         {
                                                                             "name": "add",
+                                                                            "nativeSrc": "2521:3:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "2521:3:1"
                                                                         },
+                                                                        "nativeSrc": "2521:14:1",
                                                                         "nodeType": "YulFunctionCall",
                                                                         "src": "2521:14:1"
                                                                     },
@@ -1588,6 +1835,7 @@
                                                                     [
                                                                         {
                                                                             "name": "src",
+                                                                            "nativeSrc": "2514:3:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "2514:3:1"
                                                                         }
@@ -1597,16 +1845,19 @@
                                                         },
                                                         "pre":
                                                         {
+                                                            "nativeSrc": "2474:21:1",
                                                             "nodeType": "YulBlock",
                                                             "src": "2474:21:1",
                                                             "statements":
                                                             [
                                                                 {
+                                                                    "nativeSrc": "2476:17:1",
                                                                     "nodeType": "YulVariableDeclaration",
                                                                     "src": "2476:17:1",
                                                                     "value":
                                                                     {
                                                                         "name": "offset",
+                                                                        "nativeSrc": "2487:6:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "2487:6:1"
                                                                     },
@@ -1614,6 +1865,7 @@
                                                                     [
                                                                         {
                                                                             "name": "src",
+                                                                            "nativeSrc": "2480:3:1",
                                                                             "nodeType": "YulTypedName",
                                                                             "src": "2480:3:1",
                                                                             "type": ""
@@ -1627,23 +1879,27 @@
                                                 ]
                                             },
                                             "name": "abi_decode_available_length_t_array$_t_uint256_$dyn_memory_ptr",
+                                            "nativeSrc": "1986:710:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "offset",
+                                                    "nativeSrc": "2058:6:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "2058:6:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "length",
+                                                    "nativeSrc": "2066:6:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "2066:6:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "end",
+                                                    "nativeSrc": "2074:3:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "2074:3:1",
                                                     "type": ""
@@ -1653,6 +1909,7 @@
                                             [
                                                 {
                                                     "name": "array",
+                                                    "nativeSrc": "2082:5:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "2082:5:1",
                                                     "type": ""
@@ -1663,6 +1920,7 @@
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "2796:293:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "2796:293:1",
                                                 "statements":
@@ -1670,6 +1928,7 @@
                                                     {
                                                         "body":
                                                         {
+                                                            "nativeSrc": "2845:83:1",
                                                             "nodeType": "YulBlock",
                                                             "src": "2845:83:1",
                                                             "statements":
@@ -1681,12 +1940,15 @@
                                                                         "functionName":
                                                                         {
                                                                             "name": "revert_error_1b9f4a0a5773e33b91aa01db23bf8c55fce1411167c872835e7fa00a4f17d46d",
+                                                                            "nativeSrc": "2847:77:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "2847:77:1"
                                                                         },
+                                                                        "nativeSrc": "2847:79:1",
                                                                         "nodeType": "YulFunctionCall",
                                                                         "src": "2847:79:1"
                                                                     },
+                                                                    "nativeSrc": "2847:79:1",
                                                                     "nodeType": "YulExpressionStatement",
                                                                     "src": "2847:79:1"
                                                                 }
@@ -1704,11 +1966,13 @@
                                                                             [
                                                                                 {
                                                                                     "name": "offset",
+                                                                                    "nativeSrc": "2824:6:1",
                                                                                     "nodeType": "YulIdentifier",
                                                                                     "src": "2824:6:1"
                                                                                 },
                                                                                 {
                                                                                     "kind": "number",
+                                                                                    "nativeSrc": "2832:4:1",
                                                                                     "nodeType": "YulLiteral",
                                                                                     "src": "2832:4:1",
                                                                                     "type": "",
@@ -1718,14 +1982,17 @@
                                                                             "functionName":
                                                                             {
                                                                                 "name": "add",
+                                                                                "nativeSrc": "2820:3:1",
                                                                                 "nodeType": "YulIdentifier",
                                                                                 "src": "2820:3:1"
                                                                             },
+                                                                            "nativeSrc": "2820:17:1",
                                                                             "nodeType": "YulFunctionCall",
                                                                             "src": "2820:17:1"
                                                                         },
                                                                         {
                                                                             "name": "end",
+                                                                            "nativeSrc": "2839:3:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "2839:3:1"
                                                                         }
@@ -1733,9 +2000,11 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "slt",
+                                                                        "nativeSrc": "2816:3:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "2816:3:1"
                                                                     },
+                                                                    "nativeSrc": "2816:27:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "2816:27:1"
                                                                 }
@@ -1743,16 +2012,20 @@
                                                             "functionName":
                                                             {
                                                                 "name": "iszero",
+                                                                "nativeSrc": "2809:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "2809:6:1"
                                                             },
+                                                            "nativeSrc": "2809:35:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "2809:35:1"
                                                         },
+                                                        "nativeSrc": "2806:122:1",
                                                         "nodeType": "YulIf",
                                                         "src": "2806:122:1"
                                                     },
                                                     {
+                                                        "nativeSrc": "2937:34:1",
                                                         "nodeType": "YulVariableDeclaration",
                                                         "src": "2937:34:1",
                                                         "value":
@@ -1761,6 +2034,7 @@
                                                             [
                                                                 {
                                                                     "name": "offset",
+                                                                    "nativeSrc": "2964:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "2964:6:1"
                                                                 }
@@ -1768,9 +2042,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "calldataload",
+                                                                "nativeSrc": "2951:12:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "2951:12:1"
                                                             },
+                                                            "nativeSrc": "2951:20:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "2951:20:1"
                                                         },
@@ -1778,6 +2054,7 @@
                                                         [
                                                             {
                                                                 "name": "length",
+                                                                "nativeSrc": "2941:6:1",
                                                                 "nodeType": "YulTypedName",
                                                                 "src": "2941:6:1",
                                                                 "type": ""
@@ -1785,6 +2062,7 @@
                                                         ]
                                                     },
                                                     {
+                                                        "nativeSrc": "2980:103:1",
                                                         "nodeType": "YulAssignment",
                                                         "src": "2980:103:1",
                                                         "value":
@@ -1796,11 +2074,13 @@
                                                                     [
                                                                         {
                                                                             "name": "offset",
+                                                                            "nativeSrc": "3056:6:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "3056:6:1"
                                                                         },
                                                                         {
                                                                             "kind": "number",
+                                                                            "nativeSrc": "3064:4:1",
                                                                             "nodeType": "YulLiteral",
                                                                             "src": "3064:4:1",
                                                                             "type": "",
@@ -1810,19 +2090,23 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "add",
+                                                                        "nativeSrc": "3052:3:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "3052:3:1"
                                                                     },
+                                                                    "nativeSrc": "3052:17:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "3052:17:1"
                                                                 },
                                                                 {
                                                                     "name": "length",
+                                                                    "nativeSrc": "3071:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "3071:6:1"
                                                                 },
                                                                 {
                                                                     "name": "end",
+                                                                    "nativeSrc": "3079:3:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "3079:3:1"
                                                                 }
@@ -1830,9 +2114,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "abi_decode_available_length_t_array$_t_uint256_$dyn_memory_ptr",
+                                                                "nativeSrc": "2989:62:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "2989:62:1"
                                                             },
+                                                            "nativeSrc": "2989:94:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "2989:94:1"
                                                         },
@@ -1840,6 +2126,7 @@
                                                         [
                                                             {
                                                                 "name": "array",
+                                                                "nativeSrc": "2980:5:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "2980:5:1"
                                                             }
@@ -1848,17 +2135,20 @@
                                                 ]
                                             },
                                             "name": "abi_decode_t_array$_t_uint256_$dyn_memory_ptr",
+                                            "nativeSrc": "2719:370:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "offset",
+                                                    "nativeSrc": "2774:6:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "2774:6:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "end",
+                                                    "nativeSrc": "2782:3:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "2782:3:1",
                                                     "type": ""
@@ -1868,6 +2158,7 @@
                                             [
                                                 {
                                                     "name": "array",
+                                                    "nativeSrc": "2790:5:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "2790:5:1",
                                                     "type": ""
@@ -1878,6 +2169,7 @@
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "3186:448:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "3186:448:1",
                                                 "statements":
@@ -1885,6 +2177,7 @@
                                                     {
                                                         "body":
                                                         {
+                                                            "nativeSrc": "3232:83:1",
                                                             "nodeType": "YulBlock",
                                                             "src": "3232:83:1",
                                                             "statements":
@@ -1896,12 +2189,15 @@
                                                                         "functionName":
                                                                         {
                                                                             "name": "revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b",
+                                                                            "nativeSrc": "3234:77:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "3234:77:1"
                                                                         },
+                                                                        "nativeSrc": "3234:79:1",
                                                                         "nodeType": "YulFunctionCall",
                                                                         "src": "3234:79:1"
                                                                     },
+                                                                    "nativeSrc": "3234:79:1",
                                                                     "nodeType": "YulExpressionStatement",
                                                                     "src": "3234:79:1"
                                                                 }
@@ -1916,11 +2212,13 @@
                                                                     [
                                                                         {
                                                                             "name": "dataEnd",
+                                                                            "nativeSrc": "3207:7:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "3207:7:1"
                                                                         },
                                                                         {
                                                                             "name": "headStart",
+                                                                            "nativeSrc": "3216:9:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "3216:9:1"
                                                                         }
@@ -1928,14 +2226,17 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "sub",
+                                                                        "nativeSrc": "3203:3:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "3203:3:1"
                                                                     },
+                                                                    "nativeSrc": "3203:23:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "3203:23:1"
                                                                 },
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "3228:2:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "3228:2:1",
                                                                     "type": "",
@@ -1945,21 +2246,26 @@
                                                             "functionName":
                                                             {
                                                                 "name": "slt",
+                                                                "nativeSrc": "3199:3:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "3199:3:1"
                                                             },
+                                                            "nativeSrc": "3199:32:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "3199:32:1"
                                                         },
+                                                        "nativeSrc": "3196:119:1",
                                                         "nodeType": "YulIf",
                                                         "src": "3196:119:1"
                                                     },
                                                     {
+                                                        "nativeSrc": "3325:302:1",
                                                         "nodeType": "YulBlock",
                                                         "src": "3325:302:1",
                                                         "statements":
                                                         [
                                                             {
+                                                                "nativeSrc": "3340:45:1",
                                                                 "nodeType": "YulVariableDeclaration",
                                                                 "src": "3340:45:1",
                                                                 "value":
@@ -1971,11 +2277,13 @@
                                                                             [
                                                                                 {
                                                                                     "name": "headStart",
+                                                                                    "nativeSrc": "3371:9:1",
                                                                                     "nodeType": "YulIdentifier",
                                                                                     "src": "3371:9:1"
                                                                                 },
                                                                                 {
                                                                                     "kind": "number",
+                                                                                    "nativeSrc": "3382:1:1",
                                                                                     "nodeType": "YulLiteral",
                                                                                     "src": "3382:1:1",
                                                                                     "type": "",
@@ -1985,9 +2293,11 @@
                                                                             "functionName":
                                                                             {
                                                                                 "name": "add",
+                                                                                "nativeSrc": "3367:3:1",
                                                                                 "nodeType": "YulIdentifier",
                                                                                 "src": "3367:3:1"
                                                                             },
+                                                                            "nativeSrc": "3367:17:1",
                                                                             "nodeType": "YulFunctionCall",
                                                                             "src": "3367:17:1"
                                                                         }
@@ -1995,9 +2305,11 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "calldataload",
+                                                                        "nativeSrc": "3354:12:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "3354:12:1"
                                                                     },
+                                                                    "nativeSrc": "3354:31:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "3354:31:1"
                                                                 },
@@ -2005,6 +2317,7 @@
                                                                 [
                                                                     {
                                                                         "name": "offset",
+                                                                        "nativeSrc": "3344:6:1",
                                                                         "nodeType": "YulTypedName",
                                                                         "src": "3344:6:1",
                                                                         "type": ""
@@ -2014,6 +2327,7 @@
                                                             {
                                                                 "body":
                                                                 {
+                                                                    "nativeSrc": "3432:83:1",
                                                                     "nodeType": "YulBlock",
                                                                     "src": "3432:83:1",
                                                                     "statements":
@@ -2025,12 +2339,15 @@
                                                                                 "functionName":
                                                                                 {
                                                                                     "name": "revert_error_c1322bf8034eace5e0b5c7295db60986aa89aae5e0ea0873e4689e076861a5db",
+                                                                                    "nativeSrc": "3434:77:1",
                                                                                     "nodeType": "YulIdentifier",
                                                                                     "src": "3434:77:1"
                                                                                 },
+                                                                                "nativeSrc": "3434:79:1",
                                                                                 "nodeType": "YulFunctionCall",
                                                                                 "src": "3434:79:1"
                                                                             },
+                                                                            "nativeSrc": "3434:79:1",
                                                                             "nodeType": "YulExpressionStatement",
                                                                             "src": "3434:79:1"
                                                                         }
@@ -2042,11 +2359,13 @@
                                                                     [
                                                                         {
                                                                             "name": "offset",
+                                                                            "nativeSrc": "3404:6:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "3404:6:1"
                                                                         },
                                                                         {
                                                                             "kind": "number",
+                                                                            "nativeSrc": "3412:18:1",
                                                                             "nodeType": "YulLiteral",
                                                                             "src": "3412:18:1",
                                                                             "type": "",
@@ -2056,16 +2375,20 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "gt",
+                                                                        "nativeSrc": "3401:2:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "3401:2:1"
                                                                     },
+                                                                    "nativeSrc": "3401:30:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "3401:30:1"
                                                                 },
+                                                                "nativeSrc": "3398:117:1",
                                                                 "nodeType": "YulIf",
                                                                 "src": "3398:117:1"
                                                             },
                                                             {
+                                                                "nativeSrc": "3529:88:1",
                                                                 "nodeType": "YulAssignment",
                                                                 "src": "3529:88:1",
                                                                 "value":
@@ -2077,11 +2400,13 @@
                                                                             [
                                                                                 {
                                                                                     "name": "headStart",
+                                                                                    "nativeSrc": "3589:9:1",
                                                                                     "nodeType": "YulIdentifier",
                                                                                     "src": "3589:9:1"
                                                                                 },
                                                                                 {
                                                                                     "name": "offset",
+                                                                                    "nativeSrc": "3600:6:1",
                                                                                     "nodeType": "YulIdentifier",
                                                                                     "src": "3600:6:1"
                                                                                 }
@@ -2089,14 +2414,17 @@
                                                                             "functionName":
                                                                             {
                                                                                 "name": "add",
+                                                                                "nativeSrc": "3585:3:1",
                                                                                 "nodeType": "YulIdentifier",
                                                                                 "src": "3585:3:1"
                                                                             },
+                                                                            "nativeSrc": "3585:22:1",
                                                                             "nodeType": "YulFunctionCall",
                                                                             "src": "3585:22:1"
                                                                         },
                                                                         {
                                                                             "name": "dataEnd",
+                                                                            "nativeSrc": "3609:7:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "3609:7:1"
                                                                         }
@@ -2104,9 +2432,11 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "abi_decode_t_array$_t_uint256_$dyn_memory_ptr",
+                                                                        "nativeSrc": "3539:45:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "3539:45:1"
                                                                     },
+                                                                    "nativeSrc": "3539:78:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "3539:78:1"
                                                                 },
@@ -2114,6 +2444,7 @@
                                                                 [
                                                                     {
                                                                         "name": "value0",
+                                                                        "nativeSrc": "3529:6:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "3529:6:1"
                                                                     }
@@ -2124,17 +2455,20 @@
                                                 ]
                                             },
                                             "name": "abi_decode_tuple_t_array$_t_uint256_$dyn_memory_ptr",
+                                            "nativeSrc": "3095:539:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "headStart",
+                                                    "nativeSrc": "3156:9:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "3156:9:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "dataEnd",
+                                                    "nativeSrc": "3167:7:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "3167:7:1",
                                                     "type": ""
@@ -2144,6 +2478,7 @@
                                             [
                                                 {
                                                     "name": "value0",
+                                                    "nativeSrc": "3179:6:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "3179:6:1",
                                                     "type": ""
@@ -2154,6 +2489,7 @@
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "3705:53:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "3705:53:1",
                                                 "statements":
@@ -2165,6 +2501,7 @@
                                                             [
                                                                 {
                                                                     "name": "pos",
+                                                                    "nativeSrc": "3722:3:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "3722:3:1"
                                                                 },
@@ -2173,6 +2510,7 @@
                                                                     [
                                                                         {
                                                                             "name": "value",
+                                                                            "nativeSrc": "3745:5:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "3745:5:1"
                                                                         }
@@ -2180,9 +2518,11 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "cleanup_t_uint256",
+                                                                        "nativeSrc": "3727:17:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "3727:17:1"
                                                                     },
+                                                                    "nativeSrc": "3727:24:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "3727:24:1"
                                                                 }
@@ -2190,29 +2530,35 @@
                                                             "functionName":
                                                             {
                                                                 "name": "mstore",
+                                                                "nativeSrc": "3715:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "3715:6:1"
                                                             },
+                                                            "nativeSrc": "3715:37:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "3715:37:1"
                                                         },
+                                                        "nativeSrc": "3715:37:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "3715:37:1"
                                                     }
                                                 ]
                                             },
                                             "name": "abi_encode_t_uint256_to_t_uint256_fromStack",
+                                            "nativeSrc": "3640:118:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "value",
+                                                    "nativeSrc": "3693:5:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "3693:5:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "pos",
+                                                    "nativeSrc": "3700:3:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "3700:3:1",
                                                     "type": ""
@@ -2223,11 +2569,13 @@
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "3862:124:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "3862:124:1",
                                                 "statements":
                                                 [
                                                     {
+                                                        "nativeSrc": "3872:26:1",
                                                         "nodeType": "YulAssignment",
                                                         "src": "3872:26:1",
                                                         "value":
@@ -2236,11 +2584,13 @@
                                                             [
                                                                 {
                                                                     "name": "headStart",
+                                                                    "nativeSrc": "3884:9:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "3884:9:1"
                                                                 },
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "3895:2:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "3895:2:1",
                                                                     "type": "",
@@ -2250,9 +2600,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "add",
+                                                                "nativeSrc": "3880:3:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "3880:3:1"
                                                             },
+                                                            "nativeSrc": "3880:18:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "3880:18:1"
                                                         },
@@ -2260,6 +2612,7 @@
                                                         [
                                                             {
                                                                 "name": "tail",
+                                                                "nativeSrc": "3872:4:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "3872:4:1"
                                                             }
@@ -2272,6 +2625,7 @@
                                                             [
                                                                 {
                                                                     "name": "value0",
+                                                                    "nativeSrc": "3952:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "3952:6:1"
                                                                 },
@@ -2280,11 +2634,13 @@
                                                                     [
                                                                         {
                                                                             "name": "headStart",
+                                                                            "nativeSrc": "3965:9:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "3965:9:1"
                                                                         },
                                                                         {
                                                                             "kind": "number",
+                                                                            "nativeSrc": "3976:1:1",
                                                                             "nodeType": "YulLiteral",
                                                                             "src": "3976:1:1",
                                                                             "type": "",
@@ -2294,9 +2650,11 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "add",
+                                                                        "nativeSrc": "3961:3:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "3961:3:1"
                                                                     },
+                                                                    "nativeSrc": "3961:17:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "3961:17:1"
                                                                 }
@@ -2304,29 +2662,35 @@
                                                             "functionName":
                                                             {
                                                                 "name": "abi_encode_t_uint256_to_t_uint256_fromStack",
+                                                                "nativeSrc": "3908:43:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "3908:43:1"
                                                             },
+                                                            "nativeSrc": "3908:71:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "3908:71:1"
                                                         },
+                                                        "nativeSrc": "3908:71:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "3908:71:1"
                                                     }
                                                 ]
                                             },
                                             "name": "abi_encode_tuple_t_uint256__to_t_uint256__fromStack_reversed",
+                                            "nativeSrc": "3764:222:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "headStart",
+                                                    "nativeSrc": "3834:9:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "3834:9:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "value0",
+                                                    "nativeSrc": "3846:6:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "3846:6:1",
                                                     "type": ""
@@ -2336,6 +2700,7 @@
                                             [
                                                 {
                                                     "name": "tail",
+                                                    "nativeSrc": "3857:4:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "3857:4:1",
                                                     "type": ""

--- a/test/cmdlineTests/standard_irOptimized_ast_requested/in.sol
+++ b/test/cmdlineTests/standard_irOptimized_ast_requested/in.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity *;
+
+contract C {}

--- a/test/cmdlineTests/standard_irOptimized_ast_requested/input.json
+++ b/test/cmdlineTests/standard_irOptimized_ast_requested/input.json
@@ -1,0 +1,9 @@
+{
+	"language": "Solidity",
+	"sources": {
+		"C": {"urls": ["standard_irOptimized_ast_requested/in.sol"]}
+	},
+	"settings": {
+		"outputSelection": {"*": {"*": ["irOptimizedAst"]}}
+	}
+}

--- a/test/cmdlineTests/standard_irOptimized_ast_requested/output.json
+++ b/test/cmdlineTests/standard_irOptimized_ast_requested/output.json
@@ -1,0 +1,729 @@
+{
+    "contracts":
+    {
+        "C":
+        {
+            "C":
+            {
+                "irOptimizedAst":
+                {
+                    "code":
+                    {
+                        "block":
+                        {
+                            "nativeSrc": "44:790:0",
+                            "nodeType": "YulBlock",
+                            "src": "-1:-1:0",
+                            "statements":
+                            [
+                                {
+                                    "expression":
+                                    {
+                                        "arguments":
+                                        [
+                                            {
+                                                "kind": "number",
+                                                "nativeSrc": "103:2:0",
+                                                "nodeType": "YulLiteral",
+                                                "src": "56:13:0",
+                                                "type": "",
+                                                "value": "64"
+                                            },
+                                            {
+                                                "arguments":
+                                                [
+                                                    {
+                                                        "kind": "number",
+                                                        "nativeSrc": "119:3:0",
+                                                        "nodeType": "YulLiteral",
+                                                        "src": "56:13:0",
+                                                        "type": "",
+                                                        "value": "128"
+                                                    }
+                                                ],
+                                                "functionName":
+                                                {
+                                                    "name": "memoryguard",
+                                                    "nativeSrc": "107:11:0",
+                                                    "nodeType": "YulIdentifier",
+                                                    "src": "56:13:0"
+                                                },
+                                                "nativeSrc": "107:16:0",
+                                                "nodeType": "YulFunctionCall",
+                                                "src": "56:13:0"
+                                            }
+                                        ],
+                                        "functionName":
+                                        {
+                                            "name": "mstore",
+                                            "nativeSrc": "96:6:0",
+                                            "nodeType": "YulIdentifier",
+                                            "src": "56:13:0"
+                                        },
+                                        "nativeSrc": "96:28:0",
+                                        "nodeType": "YulFunctionCall",
+                                        "src": "56:13:0"
+                                    },
+                                    "nativeSrc": "96:28:0",
+                                    "nodeType": "YulExpressionStatement",
+                                    "src": "56:13:0"
+                                },
+                                {
+                                    "body":
+                                    {
+                                        "nativeSrc": "148:83:0",
+                                        "nodeType": "YulBlock",
+                                        "src": "56:13:0",
+                                        "statements":
+                                        [
+                                            {
+                                                "expression":
+                                                {
+                                                    "arguments": [],
+                                                    "functionName":
+                                                    {
+                                                        "name": "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb",
+                                                        "nativeSrc": "150:77:0",
+                                                        "nodeType": "YulIdentifier",
+                                                        "src": "56:13:0"
+                                                    },
+                                                    "nativeSrc": "150:79:0",
+                                                    "nodeType": "YulFunctionCall",
+                                                    "src": "56:13:0"
+                                                },
+                                                "nativeSrc": "150:79:0",
+                                                "nodeType": "YulExpressionStatement",
+                                                "src": "56:13:0"
+                                            }
+                                        ]
+                                    },
+                                    "condition":
+                                    {
+                                        "arguments": [],
+                                        "functionName":
+                                        {
+                                            "name": "callvalue",
+                                            "nativeSrc": "136:9:0",
+                                            "nodeType": "YulIdentifier",
+                                            "src": "56:13:0"
+                                        },
+                                        "nativeSrc": "136:11:0",
+                                        "nodeType": "YulFunctionCall",
+                                        "src": "56:13:0"
+                                    },
+                                    "nativeSrc": "133:98:0",
+                                    "nodeType": "YulIf",
+                                    "src": "56:13:0"
+                                },
+                                {
+                                    "expression":
+                                    {
+                                        "arguments": [],
+                                        "functionName":
+                                        {
+                                            "name": "constructor_C_2",
+                                            "nativeSrc": "241:15:0",
+                                            "nodeType": "YulIdentifier",
+                                            "src": "56:13:0"
+                                        },
+                                        "nativeSrc": "241:17:0",
+                                        "nodeType": "YulFunctionCall",
+                                        "src": "56:13:0"
+                                    },
+                                    "nativeSrc": "241:17:0",
+                                    "nodeType": "YulExpressionStatement",
+                                    "src": "56:13:0"
+                                },
+                                {
+                                    "nativeSrc": "268:30:0",
+                                    "nodeType": "YulVariableDeclaration",
+                                    "src": "56:13:0",
+                                    "value":
+                                    {
+                                        "arguments": [],
+                                        "functionName":
+                                        {
+                                            "name": "allocate_unbounded",
+                                            "nativeSrc": "278:18:0",
+                                            "nodeType": "YulIdentifier",
+                                            "src": "56:13:0"
+                                        },
+                                        "nativeSrc": "278:20:0",
+                                        "nodeType": "YulFunctionCall",
+                                        "src": "56:13:0"
+                                    },
+                                    "variables":
+                                    [
+                                        {
+                                            "name": "_1",
+                                            "nativeSrc": "272:2:0",
+                                            "nodeType": "YulTypedName",
+                                            "src": "56:13:0",
+                                            "type": ""
+                                        }
+                                    ]
+                                },
+                                {
+                                    "expression":
+                                    {
+                                        "arguments":
+                                        [
+                                            {
+                                                "name": "_1",
+                                                "nativeSrc": "316:2:0",
+                                                "nodeType": "YulIdentifier",
+                                                "src": "56:13:0"
+                                            },
+                                            {
+                                                "arguments":
+                                                [
+                                                    {
+                                                        "hexValue": "435f325f6465706c6f796564",
+                                                        "kind": "string",
+                                                        "nativeSrc": "331:14:0",
+                                                        "nodeType": "YulLiteral",
+                                                        "src": "56:13:0",
+                                                        "type": "",
+                                                        "value": "C_2_deployed"
+                                                    }
+                                                ],
+                                                "functionName":
+                                                {
+                                                    "name": "dataoffset",
+                                                    "nativeSrc": "320:10:0",
+                                                    "nodeType": "YulIdentifier",
+                                                    "src": "56:13:0"
+                                                },
+                                                "nativeSrc": "320:26:0",
+                                                "nodeType": "YulFunctionCall",
+                                                "src": "56:13:0"
+                                            },
+                                            {
+                                                "arguments":
+                                                [
+                                                    {
+                                                        "hexValue": "435f325f6465706c6f796564",
+                                                        "kind": "string",
+                                                        "nativeSrc": "357:14:0",
+                                                        "nodeType": "YulLiteral",
+                                                        "src": "56:13:0",
+                                                        "type": "",
+                                                        "value": "C_2_deployed"
+                                                    }
+                                                ],
+                                                "functionName":
+                                                {
+                                                    "name": "datasize",
+                                                    "nativeSrc": "348:8:0",
+                                                    "nodeType": "YulIdentifier",
+                                                    "src": "56:13:0"
+                                                },
+                                                "nativeSrc": "348:24:0",
+                                                "nodeType": "YulFunctionCall",
+                                                "src": "56:13:0"
+                                            }
+                                        ],
+                                        "functionName":
+                                        {
+                                            "name": "codecopy",
+                                            "nativeSrc": "307:8:0",
+                                            "nodeType": "YulIdentifier",
+                                            "src": "56:13:0"
+                                        },
+                                        "nativeSrc": "307:66:0",
+                                        "nodeType": "YulFunctionCall",
+                                        "src": "56:13:0"
+                                    },
+                                    "nativeSrc": "307:66:0",
+                                    "nodeType": "YulExpressionStatement",
+                                    "src": "56:13:0"
+                                },
+                                {
+                                    "expression":
+                                    {
+                                        "arguments":
+                                        [
+                                            {
+                                                "name": "_1",
+                                                "nativeSrc": "390:2:0",
+                                                "nodeType": "YulIdentifier",
+                                                "src": "56:13:0"
+                                            },
+                                            {
+                                                "arguments":
+                                                [
+                                                    {
+                                                        "hexValue": "435f325f6465706c6f796564",
+                                                        "kind": "string",
+                                                        "nativeSrc": "403:14:0",
+                                                        "nodeType": "YulLiteral",
+                                                        "src": "56:13:0",
+                                                        "type": "",
+                                                        "value": "C_2_deployed"
+                                                    }
+                                                ],
+                                                "functionName":
+                                                {
+                                                    "name": "datasize",
+                                                    "nativeSrc": "394:8:0",
+                                                    "nodeType": "YulIdentifier",
+                                                    "src": "56:13:0"
+                                                },
+                                                "nativeSrc": "394:24:0",
+                                                "nodeType": "YulFunctionCall",
+                                                "src": "56:13:0"
+                                            }
+                                        ],
+                                        "functionName":
+                                        {
+                                            "name": "return",
+                                            "nativeSrc": "383:6:0",
+                                            "nodeType": "YulIdentifier",
+                                            "src": "56:13:0"
+                                        },
+                                        "nativeSrc": "383:36:0",
+                                        "nodeType": "YulFunctionCall",
+                                        "src": "56:13:0"
+                                    },
+                                    "nativeSrc": "383:36:0",
+                                    "nodeType": "YulExpressionStatement",
+                                    "src": "56:13:0"
+                                },
+                                {
+                                    "body":
+                                    {
+                                        "nativeSrc": "469:43:0",
+                                        "nodeType": "YulBlock",
+                                        "src": "56:13:0",
+                                        "statements":
+                                        [
+                                            {
+                                                "nativeSrc": "483:19:0",
+                                                "nodeType": "YulAssignment",
+                                                "src": "56:13:0",
+                                                "value":
+                                                {
+                                                    "arguments":
+                                                    [
+                                                        {
+                                                            "kind": "number",
+                                                            "nativeSrc": "499:2:0",
+                                                            "nodeType": "YulLiteral",
+                                                            "src": "56:13:0",
+                                                            "type": "",
+                                                            "value": "64"
+                                                        }
+                                                    ],
+                                                    "functionName":
+                                                    {
+                                                        "name": "mload",
+                                                        "nativeSrc": "493:5:0",
+                                                        "nodeType": "YulIdentifier",
+                                                        "src": "56:13:0"
+                                                    },
+                                                    "nativeSrc": "493:9:0",
+                                                    "nodeType": "YulFunctionCall",
+                                                    "src": "56:13:0"
+                                                },
+                                                "variableNames":
+                                                [
+                                                    {
+                                                        "name": "memPtr",
+                                                        "nativeSrc": "483:6:0",
+                                                        "nodeType": "YulIdentifier",
+                                                        "src": "56:13:0"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "name": "allocate_unbounded",
+                                    "nativeSrc": "429:83:0",
+                                    "nodeType": "YulFunctionDefinition",
+                                    "returnVariables":
+                                    [
+                                        {
+                                            "name": "memPtr",
+                                            "nativeSrc": "462:6:0",
+                                            "nodeType": "YulTypedName",
+                                            "src": "56:13:0",
+                                            "type": ""
+                                        }
+                                    ],
+                                    "src": "56:13:0"
+                                },
+                                {
+                                    "body":
+                                    {
+                                        "nativeSrc": "611:36:0",
+                                        "nodeType": "YulBlock",
+                                        "src": "56:13:0",
+                                        "statements":
+                                        [
+                                            {
+                                                "expression":
+                                                {
+                                                    "arguments":
+                                                    [
+                                                        {
+                                                            "kind": "number",
+                                                            "nativeSrc": "632:1:0",
+                                                            "nodeType": "YulLiteral",
+                                                            "src": "56:13:0",
+                                                            "type": "",
+                                                            "value": "0"
+                                                        },
+                                                        {
+                                                            "kind": "number",
+                                                            "nativeSrc": "635:1:0",
+                                                            "nodeType": "YulLiteral",
+                                                            "src": "56:13:0",
+                                                            "type": "",
+                                                            "value": "0"
+                                                        }
+                                                    ],
+                                                    "functionName":
+                                                    {
+                                                        "name": "revert",
+                                                        "nativeSrc": "625:6:0",
+                                                        "nodeType": "YulIdentifier",
+                                                        "src": "56:13:0"
+                                                    },
+                                                    "nativeSrc": "625:12:0",
+                                                    "nodeType": "YulFunctionCall",
+                                                    "src": "56:13:0"
+                                                },
+                                                "nativeSrc": "625:12:0",
+                                                "nodeType": "YulExpressionStatement",
+                                                "src": "56:13:0"
+                                            }
+                                        ]
+                                    },
+                                    "name": "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb",
+                                    "nativeSrc": "522:125:0",
+                                    "nodeType": "YulFunctionDefinition",
+                                    "src": "56:13:0"
+                                },
+                                {
+                                    "body":
+                                    {
+                                        "nativeSrc": "726:59:0",
+                                        "nodeType": "YulBlock",
+                                        "src": "56:13:0",
+                                        "statements": []
+                                    },
+                                    "name": "constructor_C_2",
+                                    "nativeSrc": "699:86:0",
+                                    "nodeType": "YulFunctionDefinition",
+                                    "src": "56:13:0"
+                                }
+                            ]
+                        },
+                        "nodeType": "YulCode"
+                    },
+                    "name": "C_2",
+                    "nodeType": "YulObject",
+                    "subObjects":
+                    [
+                        {
+                            "code":
+                            {
+                                "block":
+                                {
+                                    "nativeSrc": "899:588:0",
+                                    "nodeType": "YulBlock",
+                                    "src": "-1:-1:0",
+                                    "statements":
+                                    [
+                                        {
+                                            "expression":
+                                            {
+                                                "arguments":
+                                                [
+                                                    {
+                                                        "kind": "number",
+                                                        "nativeSrc": "966:2:0",
+                                                        "nodeType": "YulLiteral",
+                                                        "src": "56:13:0",
+                                                        "type": "",
+                                                        "value": "64"
+                                                    },
+                                                    {
+                                                        "arguments":
+                                                        [
+                                                            {
+                                                                "kind": "number",
+                                                                "nativeSrc": "982:3:0",
+                                                                "nodeType": "YulLiteral",
+                                                                "src": "56:13:0",
+                                                                "type": "",
+                                                                "value": "128"
+                                                            }
+                                                        ],
+                                                        "functionName":
+                                                        {
+                                                            "name": "memoryguard",
+                                                            "nativeSrc": "970:11:0",
+                                                            "nodeType": "YulIdentifier",
+                                                            "src": "56:13:0"
+                                                        },
+                                                        "nativeSrc": "970:16:0",
+                                                        "nodeType": "YulFunctionCall",
+                                                        "src": "56:13:0"
+                                                    }
+                                                ],
+                                                "functionName":
+                                                {
+                                                    "name": "mstore",
+                                                    "nativeSrc": "959:6:0",
+                                                    "nodeType": "YulIdentifier",
+                                                    "src": "56:13:0"
+                                                },
+                                                "nativeSrc": "959:28:0",
+                                                "nodeType": "YulFunctionCall",
+                                                "src": "56:13:0"
+                                            },
+                                            "nativeSrc": "959:28:0",
+                                            "nodeType": "YulExpressionStatement",
+                                            "src": "56:13:0"
+                                        },
+                                        {
+                                            "expression":
+                                            {
+                                                "arguments": [],
+                                                "functionName":
+                                                {
+                                                    "name": "revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74",
+                                                    "nativeSrc": "1001:77:0",
+                                                    "nodeType": "YulIdentifier",
+                                                    "src": "56:13:0"
+                                                },
+                                                "nativeSrc": "1001:79:0",
+                                                "nodeType": "YulFunctionCall",
+                                                "src": "56:13:0"
+                                            },
+                                            "nativeSrc": "1001:79:0",
+                                            "nodeType": "YulExpressionStatement",
+                                            "src": "56:13:0"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nativeSrc": "1147:77:0",
+                                                "nodeType": "YulBlock",
+                                                "src": "56:13:0",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "nativeSrc": "1165:44:0",
+                                                        "nodeType": "YulAssignment",
+                                                        "src": "56:13:0",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nativeSrc": "1198:3:0",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "56:13:0",
+                                                                    "type": "",
+                                                                    "value": "224"
+                                                                },
+                                                                {
+                                                                    "name": "value",
+                                                                    "nativeSrc": "1203:5:0",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "56:13:0"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "shr",
+                                                                "nativeSrc": "1194:3:0",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "56:13:0"
+                                                            },
+                                                            "nativeSrc": "1194:15:0",
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "56:13:0"
+                                                        },
+                                                        "variableNames":
+                                                        [
+                                                            {
+                                                                "name": "newValue",
+                                                                "nativeSrc": "1165:8:0",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "56:13:0"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "name": "shift_right_224_unsigned",
+                                            "nativeSrc": "1094:130:0",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "parameters":
+                                            [
+                                                {
+                                                    "name": "value",
+                                                    "nativeSrc": "1128:5:0",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "56:13:0",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "returnVariables":
+                                            [
+                                                {
+                                                    "name": "newValue",
+                                                    "nativeSrc": "1138:8:0",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "56:13:0",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "56:13:0"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nativeSrc": "1278:51:0",
+                                                "nodeType": "YulBlock",
+                                                "src": "56:13:0",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "nativeSrc": "1296:19:0",
+                                                        "nodeType": "YulAssignment",
+                                                        "src": "56:13:0",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nativeSrc": "1312:2:0",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "56:13:0",
+                                                                    "type": "",
+                                                                    "value": "64"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "mload",
+                                                                "nativeSrc": "1306:5:0",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "56:13:0"
+                                                            },
+                                                            "nativeSrc": "1306:9:0",
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "56:13:0"
+                                                        },
+                                                        "variableNames":
+                                                        [
+                                                            {
+                                                                "name": "memPtr",
+                                                                "nativeSrc": "1296:6:0",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "56:13:0"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "name": "allocate_unbounded",
+                                            "nativeSrc": "1238:91:0",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "returnVariables":
+                                            [
+                                                {
+                                                    "name": "memPtr",
+                                                    "nativeSrc": "1271:6:0",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "56:13:0",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "56:13:0"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nativeSrc": "1432:44:0",
+                                                "nodeType": "YulBlock",
+                                                "src": "56:13:0",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nativeSrc": "1457:1:0",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "56:13:0",
+                                                                    "type": "",
+                                                                    "value": "0"
+                                                                },
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nativeSrc": "1460:1:0",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "56:13:0",
+                                                                    "type": "",
+                                                                    "value": "0"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "revert",
+                                                                "nativeSrc": "1450:6:0",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "56:13:0"
+                                                            },
+                                                            "nativeSrc": "1450:12:0",
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "56:13:0"
+                                                        },
+                                                        "nativeSrc": "1450:12:0",
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "56:13:0"
+                                                    }
+                                                ]
+                                            },
+                                            "name": "revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74",
+                                            "nativeSrc": "1343:133:0",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "src": "56:13:0"
+                                        }
+                                    ]
+                                },
+                                "nodeType": "YulCode"
+                            },
+                            "name": "C_2_deployed",
+                            "nodeType": "YulObject",
+                            "subObjects":
+                            [
+                                {
+                                    "nodeType": "YulData",
+                                    "value": "<BYTECODE REMOVED>"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "sources":
+    {
+        "C":
+        {
+            "id": 0
+        }
+    }
+}

--- a/test/cmdlineTests/standard_ir_ast_requested/in.sol
+++ b/test/cmdlineTests/standard_ir_ast_requested/in.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity *;
+
+contract C {}

--- a/test/cmdlineTests/standard_ir_ast_requested/input.json
+++ b/test/cmdlineTests/standard_ir_ast_requested/input.json
@@ -1,0 +1,9 @@
+{
+	"language": "Solidity",
+	"sources": {
+		"C": {"urls": ["standard_ir_ast_requested/in.sol"]}
+	},
+	"settings": {
+		"outputSelection": {"*": {"*": ["irAst"]}}
+	}
+}

--- a/test/cmdlineTests/standard_ir_ast_requested/output.json
+++ b/test/cmdlineTests/standard_ir_ast_requested/output.json
@@ -1,0 +1,729 @@
+{
+    "contracts":
+    {
+        "C":
+        {
+            "C":
+            {
+                "irAst":
+                {
+                    "code":
+                    {
+                        "block":
+                        {
+                            "nativeSrc": "44:790:0",
+                            "nodeType": "YulBlock",
+                            "src": "-1:-1:0",
+                            "statements":
+                            [
+                                {
+                                    "expression":
+                                    {
+                                        "arguments":
+                                        [
+                                            {
+                                                "kind": "number",
+                                                "nativeSrc": "103:2:0",
+                                                "nodeType": "YulLiteral",
+                                                "src": "56:13:0",
+                                                "type": "",
+                                                "value": "64"
+                                            },
+                                            {
+                                                "arguments":
+                                                [
+                                                    {
+                                                        "kind": "number",
+                                                        "nativeSrc": "119:3:0",
+                                                        "nodeType": "YulLiteral",
+                                                        "src": "56:13:0",
+                                                        "type": "",
+                                                        "value": "128"
+                                                    }
+                                                ],
+                                                "functionName":
+                                                {
+                                                    "name": "memoryguard",
+                                                    "nativeSrc": "107:11:0",
+                                                    "nodeType": "YulIdentifier",
+                                                    "src": "56:13:0"
+                                                },
+                                                "nativeSrc": "107:16:0",
+                                                "nodeType": "YulFunctionCall",
+                                                "src": "56:13:0"
+                                            }
+                                        ],
+                                        "functionName":
+                                        {
+                                            "name": "mstore",
+                                            "nativeSrc": "96:6:0",
+                                            "nodeType": "YulIdentifier",
+                                            "src": "56:13:0"
+                                        },
+                                        "nativeSrc": "96:28:0",
+                                        "nodeType": "YulFunctionCall",
+                                        "src": "56:13:0"
+                                    },
+                                    "nativeSrc": "96:28:0",
+                                    "nodeType": "YulExpressionStatement",
+                                    "src": "56:13:0"
+                                },
+                                {
+                                    "body":
+                                    {
+                                        "nativeSrc": "148:83:0",
+                                        "nodeType": "YulBlock",
+                                        "src": "56:13:0",
+                                        "statements":
+                                        [
+                                            {
+                                                "expression":
+                                                {
+                                                    "arguments": [],
+                                                    "functionName":
+                                                    {
+                                                        "name": "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb",
+                                                        "nativeSrc": "150:77:0",
+                                                        "nodeType": "YulIdentifier",
+                                                        "src": "56:13:0"
+                                                    },
+                                                    "nativeSrc": "150:79:0",
+                                                    "nodeType": "YulFunctionCall",
+                                                    "src": "56:13:0"
+                                                },
+                                                "nativeSrc": "150:79:0",
+                                                "nodeType": "YulExpressionStatement",
+                                                "src": "56:13:0"
+                                            }
+                                        ]
+                                    },
+                                    "condition":
+                                    {
+                                        "arguments": [],
+                                        "functionName":
+                                        {
+                                            "name": "callvalue",
+                                            "nativeSrc": "136:9:0",
+                                            "nodeType": "YulIdentifier",
+                                            "src": "56:13:0"
+                                        },
+                                        "nativeSrc": "136:11:0",
+                                        "nodeType": "YulFunctionCall",
+                                        "src": "56:13:0"
+                                    },
+                                    "nativeSrc": "133:98:0",
+                                    "nodeType": "YulIf",
+                                    "src": "56:13:0"
+                                },
+                                {
+                                    "expression":
+                                    {
+                                        "arguments": [],
+                                        "functionName":
+                                        {
+                                            "name": "constructor_C_2",
+                                            "nativeSrc": "241:15:0",
+                                            "nodeType": "YulIdentifier",
+                                            "src": "56:13:0"
+                                        },
+                                        "nativeSrc": "241:17:0",
+                                        "nodeType": "YulFunctionCall",
+                                        "src": "56:13:0"
+                                    },
+                                    "nativeSrc": "241:17:0",
+                                    "nodeType": "YulExpressionStatement",
+                                    "src": "56:13:0"
+                                },
+                                {
+                                    "nativeSrc": "268:30:0",
+                                    "nodeType": "YulVariableDeclaration",
+                                    "src": "56:13:0",
+                                    "value":
+                                    {
+                                        "arguments": [],
+                                        "functionName":
+                                        {
+                                            "name": "allocate_unbounded",
+                                            "nativeSrc": "278:18:0",
+                                            "nodeType": "YulIdentifier",
+                                            "src": "56:13:0"
+                                        },
+                                        "nativeSrc": "278:20:0",
+                                        "nodeType": "YulFunctionCall",
+                                        "src": "56:13:0"
+                                    },
+                                    "variables":
+                                    [
+                                        {
+                                            "name": "_1",
+                                            "nativeSrc": "272:2:0",
+                                            "nodeType": "YulTypedName",
+                                            "src": "56:13:0",
+                                            "type": ""
+                                        }
+                                    ]
+                                },
+                                {
+                                    "expression":
+                                    {
+                                        "arguments":
+                                        [
+                                            {
+                                                "name": "_1",
+                                                "nativeSrc": "316:2:0",
+                                                "nodeType": "YulIdentifier",
+                                                "src": "56:13:0"
+                                            },
+                                            {
+                                                "arguments":
+                                                [
+                                                    {
+                                                        "hexValue": "435f325f6465706c6f796564",
+                                                        "kind": "string",
+                                                        "nativeSrc": "331:14:0",
+                                                        "nodeType": "YulLiteral",
+                                                        "src": "56:13:0",
+                                                        "type": "",
+                                                        "value": "C_2_deployed"
+                                                    }
+                                                ],
+                                                "functionName":
+                                                {
+                                                    "name": "dataoffset",
+                                                    "nativeSrc": "320:10:0",
+                                                    "nodeType": "YulIdentifier",
+                                                    "src": "56:13:0"
+                                                },
+                                                "nativeSrc": "320:26:0",
+                                                "nodeType": "YulFunctionCall",
+                                                "src": "56:13:0"
+                                            },
+                                            {
+                                                "arguments":
+                                                [
+                                                    {
+                                                        "hexValue": "435f325f6465706c6f796564",
+                                                        "kind": "string",
+                                                        "nativeSrc": "357:14:0",
+                                                        "nodeType": "YulLiteral",
+                                                        "src": "56:13:0",
+                                                        "type": "",
+                                                        "value": "C_2_deployed"
+                                                    }
+                                                ],
+                                                "functionName":
+                                                {
+                                                    "name": "datasize",
+                                                    "nativeSrc": "348:8:0",
+                                                    "nodeType": "YulIdentifier",
+                                                    "src": "56:13:0"
+                                                },
+                                                "nativeSrc": "348:24:0",
+                                                "nodeType": "YulFunctionCall",
+                                                "src": "56:13:0"
+                                            }
+                                        ],
+                                        "functionName":
+                                        {
+                                            "name": "codecopy",
+                                            "nativeSrc": "307:8:0",
+                                            "nodeType": "YulIdentifier",
+                                            "src": "56:13:0"
+                                        },
+                                        "nativeSrc": "307:66:0",
+                                        "nodeType": "YulFunctionCall",
+                                        "src": "56:13:0"
+                                    },
+                                    "nativeSrc": "307:66:0",
+                                    "nodeType": "YulExpressionStatement",
+                                    "src": "56:13:0"
+                                },
+                                {
+                                    "expression":
+                                    {
+                                        "arguments":
+                                        [
+                                            {
+                                                "name": "_1",
+                                                "nativeSrc": "390:2:0",
+                                                "nodeType": "YulIdentifier",
+                                                "src": "56:13:0"
+                                            },
+                                            {
+                                                "arguments":
+                                                [
+                                                    {
+                                                        "hexValue": "435f325f6465706c6f796564",
+                                                        "kind": "string",
+                                                        "nativeSrc": "403:14:0",
+                                                        "nodeType": "YulLiteral",
+                                                        "src": "56:13:0",
+                                                        "type": "",
+                                                        "value": "C_2_deployed"
+                                                    }
+                                                ],
+                                                "functionName":
+                                                {
+                                                    "name": "datasize",
+                                                    "nativeSrc": "394:8:0",
+                                                    "nodeType": "YulIdentifier",
+                                                    "src": "56:13:0"
+                                                },
+                                                "nativeSrc": "394:24:0",
+                                                "nodeType": "YulFunctionCall",
+                                                "src": "56:13:0"
+                                            }
+                                        ],
+                                        "functionName":
+                                        {
+                                            "name": "return",
+                                            "nativeSrc": "383:6:0",
+                                            "nodeType": "YulIdentifier",
+                                            "src": "56:13:0"
+                                        },
+                                        "nativeSrc": "383:36:0",
+                                        "nodeType": "YulFunctionCall",
+                                        "src": "56:13:0"
+                                    },
+                                    "nativeSrc": "383:36:0",
+                                    "nodeType": "YulExpressionStatement",
+                                    "src": "56:13:0"
+                                },
+                                {
+                                    "body":
+                                    {
+                                        "nativeSrc": "469:43:0",
+                                        "nodeType": "YulBlock",
+                                        "src": "56:13:0",
+                                        "statements":
+                                        [
+                                            {
+                                                "nativeSrc": "483:19:0",
+                                                "nodeType": "YulAssignment",
+                                                "src": "56:13:0",
+                                                "value":
+                                                {
+                                                    "arguments":
+                                                    [
+                                                        {
+                                                            "kind": "number",
+                                                            "nativeSrc": "499:2:0",
+                                                            "nodeType": "YulLiteral",
+                                                            "src": "56:13:0",
+                                                            "type": "",
+                                                            "value": "64"
+                                                        }
+                                                    ],
+                                                    "functionName":
+                                                    {
+                                                        "name": "mload",
+                                                        "nativeSrc": "493:5:0",
+                                                        "nodeType": "YulIdentifier",
+                                                        "src": "56:13:0"
+                                                    },
+                                                    "nativeSrc": "493:9:0",
+                                                    "nodeType": "YulFunctionCall",
+                                                    "src": "56:13:0"
+                                                },
+                                                "variableNames":
+                                                [
+                                                    {
+                                                        "name": "memPtr",
+                                                        "nativeSrc": "483:6:0",
+                                                        "nodeType": "YulIdentifier",
+                                                        "src": "56:13:0"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "name": "allocate_unbounded",
+                                    "nativeSrc": "429:83:0",
+                                    "nodeType": "YulFunctionDefinition",
+                                    "returnVariables":
+                                    [
+                                        {
+                                            "name": "memPtr",
+                                            "nativeSrc": "462:6:0",
+                                            "nodeType": "YulTypedName",
+                                            "src": "56:13:0",
+                                            "type": ""
+                                        }
+                                    ],
+                                    "src": "56:13:0"
+                                },
+                                {
+                                    "body":
+                                    {
+                                        "nativeSrc": "611:36:0",
+                                        "nodeType": "YulBlock",
+                                        "src": "56:13:0",
+                                        "statements":
+                                        [
+                                            {
+                                                "expression":
+                                                {
+                                                    "arguments":
+                                                    [
+                                                        {
+                                                            "kind": "number",
+                                                            "nativeSrc": "632:1:0",
+                                                            "nodeType": "YulLiteral",
+                                                            "src": "56:13:0",
+                                                            "type": "",
+                                                            "value": "0"
+                                                        },
+                                                        {
+                                                            "kind": "number",
+                                                            "nativeSrc": "635:1:0",
+                                                            "nodeType": "YulLiteral",
+                                                            "src": "56:13:0",
+                                                            "type": "",
+                                                            "value": "0"
+                                                        }
+                                                    ],
+                                                    "functionName":
+                                                    {
+                                                        "name": "revert",
+                                                        "nativeSrc": "625:6:0",
+                                                        "nodeType": "YulIdentifier",
+                                                        "src": "56:13:0"
+                                                    },
+                                                    "nativeSrc": "625:12:0",
+                                                    "nodeType": "YulFunctionCall",
+                                                    "src": "56:13:0"
+                                                },
+                                                "nativeSrc": "625:12:0",
+                                                "nodeType": "YulExpressionStatement",
+                                                "src": "56:13:0"
+                                            }
+                                        ]
+                                    },
+                                    "name": "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb",
+                                    "nativeSrc": "522:125:0",
+                                    "nodeType": "YulFunctionDefinition",
+                                    "src": "56:13:0"
+                                },
+                                {
+                                    "body":
+                                    {
+                                        "nativeSrc": "726:59:0",
+                                        "nodeType": "YulBlock",
+                                        "src": "56:13:0",
+                                        "statements": []
+                                    },
+                                    "name": "constructor_C_2",
+                                    "nativeSrc": "699:86:0",
+                                    "nodeType": "YulFunctionDefinition",
+                                    "src": "56:13:0"
+                                }
+                            ]
+                        },
+                        "nodeType": "YulCode"
+                    },
+                    "name": "C_2",
+                    "nodeType": "YulObject",
+                    "subObjects":
+                    [
+                        {
+                            "code":
+                            {
+                                "block":
+                                {
+                                    "nativeSrc": "899:588:0",
+                                    "nodeType": "YulBlock",
+                                    "src": "-1:-1:0",
+                                    "statements":
+                                    [
+                                        {
+                                            "expression":
+                                            {
+                                                "arguments":
+                                                [
+                                                    {
+                                                        "kind": "number",
+                                                        "nativeSrc": "966:2:0",
+                                                        "nodeType": "YulLiteral",
+                                                        "src": "56:13:0",
+                                                        "type": "",
+                                                        "value": "64"
+                                                    },
+                                                    {
+                                                        "arguments":
+                                                        [
+                                                            {
+                                                                "kind": "number",
+                                                                "nativeSrc": "982:3:0",
+                                                                "nodeType": "YulLiteral",
+                                                                "src": "56:13:0",
+                                                                "type": "",
+                                                                "value": "128"
+                                                            }
+                                                        ],
+                                                        "functionName":
+                                                        {
+                                                            "name": "memoryguard",
+                                                            "nativeSrc": "970:11:0",
+                                                            "nodeType": "YulIdentifier",
+                                                            "src": "56:13:0"
+                                                        },
+                                                        "nativeSrc": "970:16:0",
+                                                        "nodeType": "YulFunctionCall",
+                                                        "src": "56:13:0"
+                                                    }
+                                                ],
+                                                "functionName":
+                                                {
+                                                    "name": "mstore",
+                                                    "nativeSrc": "959:6:0",
+                                                    "nodeType": "YulIdentifier",
+                                                    "src": "56:13:0"
+                                                },
+                                                "nativeSrc": "959:28:0",
+                                                "nodeType": "YulFunctionCall",
+                                                "src": "56:13:0"
+                                            },
+                                            "nativeSrc": "959:28:0",
+                                            "nodeType": "YulExpressionStatement",
+                                            "src": "56:13:0"
+                                        },
+                                        {
+                                            "expression":
+                                            {
+                                                "arguments": [],
+                                                "functionName":
+                                                {
+                                                    "name": "revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74",
+                                                    "nativeSrc": "1001:77:0",
+                                                    "nodeType": "YulIdentifier",
+                                                    "src": "56:13:0"
+                                                },
+                                                "nativeSrc": "1001:79:0",
+                                                "nodeType": "YulFunctionCall",
+                                                "src": "56:13:0"
+                                            },
+                                            "nativeSrc": "1001:79:0",
+                                            "nodeType": "YulExpressionStatement",
+                                            "src": "56:13:0"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nativeSrc": "1147:77:0",
+                                                "nodeType": "YulBlock",
+                                                "src": "56:13:0",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "nativeSrc": "1165:44:0",
+                                                        "nodeType": "YulAssignment",
+                                                        "src": "56:13:0",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nativeSrc": "1198:3:0",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "56:13:0",
+                                                                    "type": "",
+                                                                    "value": "224"
+                                                                },
+                                                                {
+                                                                    "name": "value",
+                                                                    "nativeSrc": "1203:5:0",
+                                                                    "nodeType": "YulIdentifier",
+                                                                    "src": "56:13:0"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "shr",
+                                                                "nativeSrc": "1194:3:0",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "56:13:0"
+                                                            },
+                                                            "nativeSrc": "1194:15:0",
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "56:13:0"
+                                                        },
+                                                        "variableNames":
+                                                        [
+                                                            {
+                                                                "name": "newValue",
+                                                                "nativeSrc": "1165:8:0",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "56:13:0"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "name": "shift_right_224_unsigned",
+                                            "nativeSrc": "1094:130:0",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "parameters":
+                                            [
+                                                {
+                                                    "name": "value",
+                                                    "nativeSrc": "1128:5:0",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "56:13:0",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "returnVariables":
+                                            [
+                                                {
+                                                    "name": "newValue",
+                                                    "nativeSrc": "1138:8:0",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "56:13:0",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "56:13:0"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nativeSrc": "1278:51:0",
+                                                "nodeType": "YulBlock",
+                                                "src": "56:13:0",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "nativeSrc": "1296:19:0",
+                                                        "nodeType": "YulAssignment",
+                                                        "src": "56:13:0",
+                                                        "value":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nativeSrc": "1312:2:0",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "56:13:0",
+                                                                    "type": "",
+                                                                    "value": "64"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "mload",
+                                                                "nativeSrc": "1306:5:0",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "56:13:0"
+                                                            },
+                                                            "nativeSrc": "1306:9:0",
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "56:13:0"
+                                                        },
+                                                        "variableNames":
+                                                        [
+                                                            {
+                                                                "name": "memPtr",
+                                                                "nativeSrc": "1296:6:0",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "56:13:0"
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            "name": "allocate_unbounded",
+                                            "nativeSrc": "1238:91:0",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "returnVariables":
+                                            [
+                                                {
+                                                    "name": "memPtr",
+                                                    "nativeSrc": "1271:6:0",
+                                                    "nodeType": "YulTypedName",
+                                                    "src": "56:13:0",
+                                                    "type": ""
+                                                }
+                                            ],
+                                            "src": "56:13:0"
+                                        },
+                                        {
+                                            "body":
+                                            {
+                                                "nativeSrc": "1432:44:0",
+                                                "nodeType": "YulBlock",
+                                                "src": "56:13:0",
+                                                "statements":
+                                                [
+                                                    {
+                                                        "expression":
+                                                        {
+                                                            "arguments":
+                                                            [
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nativeSrc": "1457:1:0",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "56:13:0",
+                                                                    "type": "",
+                                                                    "value": "0"
+                                                                },
+                                                                {
+                                                                    "kind": "number",
+                                                                    "nativeSrc": "1460:1:0",
+                                                                    "nodeType": "YulLiteral",
+                                                                    "src": "56:13:0",
+                                                                    "type": "",
+                                                                    "value": "0"
+                                                                }
+                                                            ],
+                                                            "functionName":
+                                                            {
+                                                                "name": "revert",
+                                                                "nativeSrc": "1450:6:0",
+                                                                "nodeType": "YulIdentifier",
+                                                                "src": "56:13:0"
+                                                            },
+                                                            "nativeSrc": "1450:12:0",
+                                                            "nodeType": "YulFunctionCall",
+                                                            "src": "56:13:0"
+                                                        },
+                                                        "nativeSrc": "1450:12:0",
+                                                        "nodeType": "YulExpressionStatement",
+                                                        "src": "56:13:0"
+                                                    }
+                                                ]
+                                            },
+                                            "name": "revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74",
+                                            "nativeSrc": "1343:133:0",
+                                            "nodeType": "YulFunctionDefinition",
+                                            "src": "56:13:0"
+                                        }
+                                    ]
+                                },
+                                "nodeType": "YulCode"
+                            },
+                            "name": "C_2_deployed",
+                            "nodeType": "YulObject",
+                            "subObjects":
+                            [
+                                {
+                                    "nodeType": "YulData",
+                                    "value": "<BYTECODE REMOVED>"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "sources":
+    {
+        "C":
+        {
+            "id": 0
+        }
+    }
+}

--- a/test/cmdlineTests/standard_optimizer_generatedSources/output.json
+++ b/test/cmdlineTests/standard_optimizer_generatedSources/output.json
@@ -19,11 +19,13 @@
                             {
                                 "ast":
                                 {
+                                    "nativeSrc": "0:1445:1",
                                     "nodeType": "YulBlock",
                                     "src": "0:1445:1",
                                     "statements":
                                     [
                                         {
+                                            "nativeSrc": "6:3:1",
                                             "nodeType": "YulBlock",
                                             "src": "6:3:1",
                                             "statements": []
@@ -31,6 +33,7 @@
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "46:95:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "46:95:1",
                                                 "statements":
@@ -42,6 +45,7 @@
                                                             [
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "63:1:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "63:1:1",
                                                                     "type": "",
@@ -52,6 +56,7 @@
                                                                     [
                                                                         {
                                                                             "kind": "number",
+                                                                            "nativeSrc": "70:3:1",
                                                                             "nodeType": "YulLiteral",
                                                                             "src": "70:3:1",
                                                                             "type": "",
@@ -59,6 +64,7 @@
                                                                         },
                                                                         {
                                                                             "kind": "number",
+                                                                            "nativeSrc": "75:10:1",
                                                                             "nodeType": "YulLiteral",
                                                                             "src": "75:10:1",
                                                                             "type": "",
@@ -68,9 +74,11 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "shl",
+                                                                        "nativeSrc": "66:3:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "66:3:1"
                                                                     },
+                                                                    "nativeSrc": "66:20:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "66:20:1"
                                                                 }
@@ -78,12 +86,15 @@
                                                             "functionName":
                                                             {
                                                                 "name": "mstore",
+                                                                "nativeSrc": "56:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "56:6:1"
                                                             },
+                                                            "nativeSrc": "56:31:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "56:31:1"
                                                         },
+                                                        "nativeSrc": "56:31:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "56:31:1"
                                                     },
@@ -94,6 +105,7 @@
                                                             [
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "103:1:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "103:1:1",
                                                                     "type": "",
@@ -101,6 +113,7 @@
                                                                 },
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "106:4:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "106:4:1",
                                                                     "type": "",
@@ -110,12 +123,15 @@
                                                             "functionName":
                                                             {
                                                                 "name": "mstore",
+                                                                "nativeSrc": "96:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "96:6:1"
                                                             },
+                                                            "nativeSrc": "96:15:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "96:15:1"
                                                         },
+                                                        "nativeSrc": "96:15:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "96:15:1"
                                                     },
@@ -126,6 +142,7 @@
                                                             [
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "127:1:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "127:1:1",
                                                                     "type": "",
@@ -133,6 +150,7 @@
                                                                 },
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "130:4:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "130:4:1",
                                                                     "type": "",
@@ -142,34 +160,41 @@
                                                             "functionName":
                                                             {
                                                                 "name": "revert",
+                                                                "nativeSrc": "120:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "120:6:1"
                                                             },
+                                                            "nativeSrc": "120:15:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "120:15:1"
                                                         },
+                                                        "nativeSrc": "120:15:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "120:15:1"
                                                     }
                                                 ]
                                             },
                                             "name": "panic_error_0x41",
+                                            "nativeSrc": "14:127:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "src": "14:127:1"
                                         },
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "241:1020:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "241:1020:1",
                                                 "statements":
                                                 [
                                                     {
+                                                        "nativeSrc": "251:12:1",
                                                         "nodeType": "YulVariableDeclaration",
                                                         "src": "251:12:1",
                                                         "value":
                                                         {
                                                             "kind": "number",
+                                                            "nativeSrc": "261:2:1",
                                                             "nodeType": "YulLiteral",
                                                             "src": "261:2:1",
                                                             "type": "",
@@ -179,6 +204,7 @@
                                                         [
                                                             {
                                                                 "name": "_1",
+                                                                "nativeSrc": "255:2:1",
                                                                 "nodeType": "YulTypedName",
                                                                 "src": "255:2:1",
                                                                 "type": ""
@@ -188,6 +214,7 @@
                                                     {
                                                         "body":
                                                         {
+                                                            "nativeSrc": "308:16:1",
                                                             "nodeType": "YulBlock",
                                                             "src": "308:16:1",
                                                             "statements":
@@ -199,6 +226,7 @@
                                                                         [
                                                                             {
                                                                                 "kind": "number",
+                                                                                "nativeSrc": "317:1:1",
                                                                                 "nodeType": "YulLiteral",
                                                                                 "src": "317:1:1",
                                                                                 "type": "",
@@ -206,6 +234,7 @@
                                                                             },
                                                                             {
                                                                                 "kind": "number",
+                                                                                "nativeSrc": "320:1:1",
                                                                                 "nodeType": "YulLiteral",
                                                                                 "src": "320:1:1",
                                                                                 "type": "",
@@ -215,12 +244,15 @@
                                                                         "functionName":
                                                                         {
                                                                             "name": "revert",
+                                                                            "nativeSrc": "310:6:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "310:6:1"
                                                                         },
+                                                                        "nativeSrc": "310:12:1",
                                                                         "nodeType": "YulFunctionCall",
                                                                         "src": "310:12:1"
                                                                     },
+                                                                    "nativeSrc": "310:12:1",
                                                                     "nodeType": "YulExpressionStatement",
                                                                     "src": "310:12:1"
                                                                 }
@@ -235,11 +267,13 @@
                                                                     [
                                                                         {
                                                                             "name": "dataEnd",
+                                                                            "nativeSrc": "283:7:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "283:7:1"
                                                                         },
                                                                         {
                                                                             "name": "headStart",
+                                                                            "nativeSrc": "292:9:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "292:9:1"
                                                                         }
@@ -247,14 +281,17 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "sub",
+                                                                        "nativeSrc": "279:3:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "279:3:1"
                                                                     },
+                                                                    "nativeSrc": "279:23:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "279:23:1"
                                                                 },
                                                                 {
                                                                     "name": "_1",
+                                                                    "nativeSrc": "304:2:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "304:2:1"
                                                                 }
@@ -262,16 +299,20 @@
                                                             "functionName":
                                                             {
                                                                 "name": "slt",
+                                                                "nativeSrc": "275:3:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "275:3:1"
                                                             },
+                                                            "nativeSrc": "275:32:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "275:32:1"
                                                         },
+                                                        "nativeSrc": "272:52:1",
                                                         "nodeType": "YulIf",
                                                         "src": "272:52:1"
                                                     },
                                                     {
+                                                        "nativeSrc": "333:37:1",
                                                         "nodeType": "YulVariableDeclaration",
                                                         "src": "333:37:1",
                                                         "value":
@@ -280,6 +321,7 @@
                                                             [
                                                                 {
                                                                     "name": "headStart",
+                                                                    "nativeSrc": "360:9:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "360:9:1"
                                                                 }
@@ -287,9 +329,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "calldataload",
+                                                                "nativeSrc": "347:12:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "347:12:1"
                                                             },
+                                                            "nativeSrc": "347:23:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "347:23:1"
                                                         },
@@ -297,6 +341,7 @@
                                                         [
                                                             {
                                                                 "name": "offset",
+                                                                "nativeSrc": "337:6:1",
                                                                 "nodeType": "YulTypedName",
                                                                 "src": "337:6:1",
                                                                 "type": ""
@@ -304,11 +349,13 @@
                                                         ]
                                                     },
                                                     {
+                                                        "nativeSrc": "379:28:1",
                                                         "nodeType": "YulVariableDeclaration",
                                                         "src": "379:28:1",
                                                         "value":
                                                         {
                                                             "kind": "number",
+                                                            "nativeSrc": "389:18:1",
                                                             "nodeType": "YulLiteral",
                                                             "src": "389:18:1",
                                                             "type": "",
@@ -318,6 +365,7 @@
                                                         [
                                                             {
                                                                 "name": "_2",
+                                                                "nativeSrc": "383:2:1",
                                                                 "nodeType": "YulTypedName",
                                                                 "src": "383:2:1",
                                                                 "type": ""
@@ -327,6 +375,7 @@
                                                     {
                                                         "body":
                                                         {
+                                                            "nativeSrc": "434:16:1",
                                                             "nodeType": "YulBlock",
                                                             "src": "434:16:1",
                                                             "statements":
@@ -338,6 +387,7 @@
                                                                         [
                                                                             {
                                                                                 "kind": "number",
+                                                                                "nativeSrc": "443:1:1",
                                                                                 "nodeType": "YulLiteral",
                                                                                 "src": "443:1:1",
                                                                                 "type": "",
@@ -345,6 +395,7 @@
                                                                             },
                                                                             {
                                                                                 "kind": "number",
+                                                                                "nativeSrc": "446:1:1",
                                                                                 "nodeType": "YulLiteral",
                                                                                 "src": "446:1:1",
                                                                                 "type": "",
@@ -354,12 +405,15 @@
                                                                         "functionName":
                                                                         {
                                                                             "name": "revert",
+                                                                            "nativeSrc": "436:6:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "436:6:1"
                                                                         },
+                                                                        "nativeSrc": "436:12:1",
                                                                         "nodeType": "YulFunctionCall",
                                                                         "src": "436:12:1"
                                                                     },
+                                                                    "nativeSrc": "436:12:1",
                                                                     "nodeType": "YulExpressionStatement",
                                                                     "src": "436:12:1"
                                                                 }
@@ -371,11 +425,13 @@
                                                             [
                                                                 {
                                                                     "name": "offset",
+                                                                    "nativeSrc": "422:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "422:6:1"
                                                                 },
                                                                 {
                                                                     "name": "_2",
+                                                                    "nativeSrc": "430:2:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "430:2:1"
                                                                 }
@@ -383,16 +439,20 @@
                                                             "functionName":
                                                             {
                                                                 "name": "gt",
+                                                                "nativeSrc": "419:2:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "419:2:1"
                                                             },
+                                                            "nativeSrc": "419:14:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "419:14:1"
                                                         },
+                                                        "nativeSrc": "416:34:1",
                                                         "nodeType": "YulIf",
                                                         "src": "416:34:1"
                                                     },
                                                     {
+                                                        "nativeSrc": "459:32:1",
                                                         "nodeType": "YulVariableDeclaration",
                                                         "src": "459:32:1",
                                                         "value":
@@ -401,11 +461,13 @@
                                                             [
                                                                 {
                                                                     "name": "headStart",
+                                                                    "nativeSrc": "473:9:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "473:9:1"
                                                                 },
                                                                 {
                                                                     "name": "offset",
+                                                                    "nativeSrc": "484:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "484:6:1"
                                                                 }
@@ -413,9 +475,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "add",
+                                                                "nativeSrc": "469:3:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "469:3:1"
                                                             },
+                                                            "nativeSrc": "469:22:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "469:22:1"
                                                         },
@@ -423,6 +487,7 @@
                                                         [
                                                             {
                                                                 "name": "_3",
+                                                                "nativeSrc": "463:2:1",
                                                                 "nodeType": "YulTypedName",
                                                                 "src": "463:2:1",
                                                                 "type": ""
@@ -432,6 +497,7 @@
                                                     {
                                                         "body":
                                                         {
+                                                            "nativeSrc": "539:16:1",
                                                             "nodeType": "YulBlock",
                                                             "src": "539:16:1",
                                                             "statements":
@@ -443,6 +509,7 @@
                                                                         [
                                                                             {
                                                                                 "kind": "number",
+                                                                                "nativeSrc": "548:1:1",
                                                                                 "nodeType": "YulLiteral",
                                                                                 "src": "548:1:1",
                                                                                 "type": "",
@@ -450,6 +517,7 @@
                                                                             },
                                                                             {
                                                                                 "kind": "number",
+                                                                                "nativeSrc": "551:1:1",
                                                                                 "nodeType": "YulLiteral",
                                                                                 "src": "551:1:1",
                                                                                 "type": "",
@@ -459,12 +527,15 @@
                                                                         "functionName":
                                                                         {
                                                                             "name": "revert",
+                                                                            "nativeSrc": "541:6:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "541:6:1"
                                                                         },
+                                                                        "nativeSrc": "541:12:1",
                                                                         "nodeType": "YulFunctionCall",
                                                                         "src": "541:12:1"
                                                                     },
+                                                                    "nativeSrc": "541:12:1",
                                                                     "nodeType": "YulExpressionStatement",
                                                                     "src": "541:12:1"
                                                                 }
@@ -482,11 +553,13 @@
                                                                             [
                                                                                 {
                                                                                     "name": "_3",
+                                                                                    "nativeSrc": "518:2:1",
                                                                                     "nodeType": "YulIdentifier",
                                                                                     "src": "518:2:1"
                                                                                 },
                                                                                 {
                                                                                     "kind": "number",
+                                                                                    "nativeSrc": "522:4:1",
                                                                                     "nodeType": "YulLiteral",
                                                                                     "src": "522:4:1",
                                                                                     "type": "",
@@ -496,14 +569,17 @@
                                                                             "functionName":
                                                                             {
                                                                                 "name": "add",
+                                                                                "nativeSrc": "514:3:1",
                                                                                 "nodeType": "YulIdentifier",
                                                                                 "src": "514:3:1"
                                                                             },
+                                                                            "nativeSrc": "514:13:1",
                                                                             "nodeType": "YulFunctionCall",
                                                                             "src": "514:13:1"
                                                                         },
                                                                         {
                                                                             "name": "dataEnd",
+                                                                            "nativeSrc": "529:7:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "529:7:1"
                                                                         }
@@ -511,9 +587,11 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "slt",
+                                                                        "nativeSrc": "510:3:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "510:3:1"
                                                                     },
+                                                                    "nativeSrc": "510:27:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "510:27:1"
                                                                 }
@@ -521,16 +599,20 @@
                                                             "functionName":
                                                             {
                                                                 "name": "iszero",
+                                                                "nativeSrc": "503:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "503:6:1"
                                                             },
+                                                            "nativeSrc": "503:35:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "503:35:1"
                                                         },
+                                                        "nativeSrc": "500:55:1",
                                                         "nodeType": "YulIf",
                                                         "src": "500:55:1"
                                                     },
                                                     {
+                                                        "nativeSrc": "564:26:1",
                                                         "nodeType": "YulVariableDeclaration",
                                                         "src": "564:26:1",
                                                         "value":
@@ -539,6 +621,7 @@
                                                             [
                                                                 {
                                                                     "name": "_3",
+                                                                    "nativeSrc": "587:2:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "587:2:1"
                                                                 }
@@ -546,9 +629,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "calldataload",
+                                                                "nativeSrc": "574:12:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "574:12:1"
                                                             },
+                                                            "nativeSrc": "574:16:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "574:16:1"
                                                         },
@@ -556,6 +641,7 @@
                                                         [
                                                             {
                                                                 "name": "_4",
+                                                                "nativeSrc": "568:2:1",
                                                                 "nodeType": "YulTypedName",
                                                                 "src": "568:2:1",
                                                                 "type": ""
@@ -565,6 +651,7 @@
                                                     {
                                                         "body":
                                                         {
+                                                            "nativeSrc": "613:22:1",
                                                             "nodeType": "YulBlock",
                                                             "src": "613:22:1",
                                                             "statements":
@@ -576,12 +663,15 @@
                                                                         "functionName":
                                                                         {
                                                                             "name": "panic_error_0x41",
+                                                                            "nativeSrc": "615:16:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "615:16:1"
                                                                         },
+                                                                        "nativeSrc": "615:18:1",
                                                                         "nodeType": "YulFunctionCall",
                                                                         "src": "615:18:1"
                                                                     },
+                                                                    "nativeSrc": "615:18:1",
                                                                     "nodeType": "YulExpressionStatement",
                                                                     "src": "615:18:1"
                                                                 }
@@ -593,11 +683,13 @@
                                                             [
                                                                 {
                                                                     "name": "_4",
+                                                                    "nativeSrc": "605:2:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "605:2:1"
                                                                 },
                                                                 {
                                                                     "name": "_2",
+                                                                    "nativeSrc": "609:2:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "609:2:1"
                                                                 }
@@ -605,16 +697,20 @@
                                                             "functionName":
                                                             {
                                                                 "name": "gt",
+                                                                "nativeSrc": "602:2:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "602:2:1"
                                                             },
+                                                            "nativeSrc": "602:10:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "602:10:1"
                                                         },
+                                                        "nativeSrc": "599:36:1",
                                                         "nodeType": "YulIf",
                                                         "src": "599:36:1"
                                                     },
                                                     {
+                                                        "nativeSrc": "644:20:1",
                                                         "nodeType": "YulVariableDeclaration",
                                                         "src": "644:20:1",
                                                         "value":
@@ -623,6 +719,7 @@
                                                             [
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "658:1:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "658:1:1",
                                                                     "type": "",
@@ -630,6 +727,7 @@
                                                                 },
                                                                 {
                                                                     "name": "_4",
+                                                                    "nativeSrc": "661:2:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "661:2:1"
                                                                 }
@@ -637,9 +735,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "shl",
+                                                                "nativeSrc": "654:3:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "654:3:1"
                                                             },
+                                                            "nativeSrc": "654:10:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "654:10:1"
                                                         },
@@ -647,6 +747,7 @@
                                                         [
                                                             {
                                                                 "name": "_5",
+                                                                "nativeSrc": "648:2:1",
                                                                 "nodeType": "YulTypedName",
                                                                 "src": "648:2:1",
                                                                 "type": ""
@@ -654,6 +755,7 @@
                                                         ]
                                                     },
                                                     {
+                                                        "nativeSrc": "673:23:1",
                                                         "nodeType": "YulVariableDeclaration",
                                                         "src": "673:23:1",
                                                         "value":
@@ -662,6 +764,7 @@
                                                             [
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "693:2:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "693:2:1",
                                                                     "type": "",
@@ -671,9 +774,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "mload",
+                                                                "nativeSrc": "687:5:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "687:5:1"
                                                             },
+                                                            "nativeSrc": "687:9:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "687:9:1"
                                                         },
@@ -681,6 +786,7 @@
                                                         [
                                                             {
                                                                 "name": "memPtr",
+                                                                "nativeSrc": "677:6:1",
                                                                 "nodeType": "YulTypedName",
                                                                 "src": "677:6:1",
                                                                 "type": ""
@@ -688,6 +794,7 @@
                                                         ]
                                                     },
                                                     {
+                                                        "nativeSrc": "705:56:1",
                                                         "nodeType": "YulVariableDeclaration",
                                                         "src": "705:56:1",
                                                         "value":
@@ -696,6 +803,7 @@
                                                             [
                                                                 {
                                                                     "name": "memPtr",
+                                                                    "nativeSrc": "727:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "727:6:1"
                                                                 },
@@ -707,11 +815,13 @@
                                                                             [
                                                                                 {
                                                                                     "name": "_5",
+                                                                                    "nativeSrc": "743:2:1",
                                                                                     "nodeType": "YulIdentifier",
                                                                                     "src": "743:2:1"
                                                                                 },
                                                                                 {
                                                                                     "kind": "number",
+                                                                                    "nativeSrc": "747:2:1",
                                                                                     "nodeType": "YulLiteral",
                                                                                     "src": "747:2:1",
                                                                                     "type": "",
@@ -721,9 +831,11 @@
                                                                             "functionName":
                                                                             {
                                                                                 "name": "add",
+                                                                                "nativeSrc": "739:3:1",
                                                                                 "nodeType": "YulIdentifier",
                                                                                 "src": "739:3:1"
                                                                             },
+                                                                            "nativeSrc": "739:11:1",
                                                                             "nodeType": "YulFunctionCall",
                                                                             "src": "739:11:1"
                                                                         },
@@ -732,6 +844,7 @@
                                                                             [
                                                                                 {
                                                                                     "kind": "number",
+                                                                                    "nativeSrc": "756:2:1",
                                                                                     "nodeType": "YulLiteral",
                                                                                     "src": "756:2:1",
                                                                                     "type": "",
@@ -741,9 +854,11 @@
                                                                             "functionName":
                                                                             {
                                                                                 "name": "not",
+                                                                                "nativeSrc": "752:3:1",
                                                                                 "nodeType": "YulIdentifier",
                                                                                 "src": "752:3:1"
                                                                             },
+                                                                            "nativeSrc": "752:7:1",
                                                                             "nodeType": "YulFunctionCall",
                                                                             "src": "752:7:1"
                                                                         }
@@ -751,9 +866,11 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "and",
+                                                                        "nativeSrc": "735:3:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "735:3:1"
                                                                     },
+                                                                    "nativeSrc": "735:25:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "735:25:1"
                                                                 }
@@ -761,9 +878,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "add",
+                                                                "nativeSrc": "723:3:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "723:3:1"
                                                             },
+                                                            "nativeSrc": "723:38:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "723:38:1"
                                                         },
@@ -771,6 +890,7 @@
                                                         [
                                                             {
                                                                 "name": "newFreePtr",
+                                                                "nativeSrc": "709:10:1",
                                                                 "nodeType": "YulTypedName",
                                                                 "src": "709:10:1",
                                                                 "type": ""
@@ -780,6 +900,7 @@
                                                     {
                                                         "body":
                                                         {
+                                                            "nativeSrc": "820:22:1",
                                                             "nodeType": "YulBlock",
                                                             "src": "820:22:1",
                                                             "statements":
@@ -791,12 +912,15 @@
                                                                         "functionName":
                                                                         {
                                                                             "name": "panic_error_0x41",
+                                                                            "nativeSrc": "822:16:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "822:16:1"
                                                                         },
+                                                                        "nativeSrc": "822:18:1",
                                                                         "nodeType": "YulFunctionCall",
                                                                         "src": "822:18:1"
                                                                     },
+                                                                    "nativeSrc": "822:18:1",
                                                                     "nodeType": "YulExpressionStatement",
                                                                     "src": "822:18:1"
                                                                 }
@@ -811,11 +935,13 @@
                                                                     [
                                                                         {
                                                                             "name": "newFreePtr",
+                                                                            "nativeSrc": "779:10:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "779:10:1"
                                                                         },
                                                                         {
                                                                             "name": "_2",
+                                                                            "nativeSrc": "791:2:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "791:2:1"
                                                                         }
@@ -823,9 +949,11 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "gt",
+                                                                        "nativeSrc": "776:2:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "776:2:1"
                                                                     },
+                                                                    "nativeSrc": "776:18:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "776:18:1"
                                                                 },
@@ -834,11 +962,13 @@
                                                                     [
                                                                         {
                                                                             "name": "newFreePtr",
+                                                                            "nativeSrc": "799:10:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "799:10:1"
                                                                         },
                                                                         {
                                                                             "name": "memPtr",
+                                                                            "nativeSrc": "811:6:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "811:6:1"
                                                                         }
@@ -846,9 +976,11 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "lt",
+                                                                        "nativeSrc": "796:2:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "796:2:1"
                                                                     },
+                                                                    "nativeSrc": "796:22:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "796:22:1"
                                                                 }
@@ -856,12 +988,15 @@
                                                             "functionName":
                                                             {
                                                                 "name": "or",
+                                                                "nativeSrc": "773:2:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "773:2:1"
                                                             },
+                                                            "nativeSrc": "773:46:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "773:46:1"
                                                         },
+                                                        "nativeSrc": "770:72:1",
                                                         "nodeType": "YulIf",
                                                         "src": "770:72:1"
                                                     },
@@ -872,6 +1007,7 @@
                                                             [
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "858:2:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "858:2:1",
                                                                     "type": "",
@@ -879,6 +1015,7 @@
                                                                 },
                                                                 {
                                                                     "name": "newFreePtr",
+                                                                    "nativeSrc": "862:10:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "862:10:1"
                                                                 }
@@ -886,21 +1023,26 @@
                                                             "functionName":
                                                             {
                                                                 "name": "mstore",
+                                                                "nativeSrc": "851:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "851:6:1"
                                                             },
+                                                            "nativeSrc": "851:22:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "851:22:1"
                                                         },
+                                                        "nativeSrc": "851:22:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "851:22:1"
                                                     },
                                                     {
+                                                        "nativeSrc": "882:17:1",
                                                         "nodeType": "YulVariableDeclaration",
                                                         "src": "882:17:1",
                                                         "value":
                                                         {
                                                             "name": "memPtr",
+                                                            "nativeSrc": "893:6:1",
                                                             "nodeType": "YulIdentifier",
                                                             "src": "893:6:1"
                                                         },
@@ -908,6 +1050,7 @@
                                                         [
                                                             {
                                                                 "name": "dst",
+                                                                "nativeSrc": "886:3:1",
                                                                 "nodeType": "YulTypedName",
                                                                 "src": "886:3:1",
                                                                 "type": ""
@@ -921,11 +1064,13 @@
                                                             [
                                                                 {
                                                                     "name": "memPtr",
+                                                                    "nativeSrc": "915:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "915:6:1"
                                                                 },
                                                                 {
                                                                     "name": "_4",
+                                                                    "nativeSrc": "923:2:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "923:2:1"
                                                                 }
@@ -933,16 +1078,20 @@
                                                             "functionName":
                                                             {
                                                                 "name": "mstore",
+                                                                "nativeSrc": "908:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "908:6:1"
                                                             },
+                                                            "nativeSrc": "908:18:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "908:18:1"
                                                         },
+                                                        "nativeSrc": "908:18:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "908:18:1"
                                                     },
                                                     {
+                                                        "nativeSrc": "935:22:1",
                                                         "nodeType": "YulAssignment",
                                                         "src": "935:22:1",
                                                         "value":
@@ -951,11 +1100,13 @@
                                                             [
                                                                 {
                                                                     "name": "memPtr",
+                                                                    "nativeSrc": "946:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "946:6:1"
                                                                 },
                                                                 {
                                                                     "name": "_1",
+                                                                    "nativeSrc": "954:2:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "954:2:1"
                                                                 }
@@ -963,9 +1114,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "add",
+                                                                "nativeSrc": "942:3:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "942:3:1"
                                                             },
+                                                            "nativeSrc": "942:15:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "942:15:1"
                                                         },
@@ -973,12 +1126,14 @@
                                                         [
                                                             {
                                                                 "name": "dst",
+                                                                "nativeSrc": "935:3:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "935:3:1"
                                                             }
                                                         ]
                                                     },
                                                     {
+                                                        "nativeSrc": "966:34:1",
                                                         "nodeType": "YulVariableDeclaration",
                                                         "src": "966:34:1",
                                                         "value":
@@ -990,11 +1145,13 @@
                                                                     [
                                                                         {
                                                                             "name": "_3",
+                                                                            "nativeSrc": "988:2:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "988:2:1"
                                                                         },
                                                                         {
                                                                             "name": "_5",
+                                                                            "nativeSrc": "992:2:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "992:2:1"
                                                                         }
@@ -1002,14 +1159,17 @@
                                                                     "functionName":
                                                                     {
                                                                         "name": "add",
+                                                                        "nativeSrc": "984:3:1",
                                                                         "nodeType": "YulIdentifier",
                                                                         "src": "984:3:1"
                                                                     },
+                                                                    "nativeSrc": "984:11:1",
                                                                     "nodeType": "YulFunctionCall",
                                                                     "src": "984:11:1"
                                                                 },
                                                                 {
                                                                     "name": "_1",
+                                                                    "nativeSrc": "997:2:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "997:2:1"
                                                                 }
@@ -1017,9 +1177,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "add",
+                                                                "nativeSrc": "980:3:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "980:3:1"
                                                             },
+                                                            "nativeSrc": "980:20:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "980:20:1"
                                                         },
@@ -1027,6 +1189,7 @@
                                                         [
                                                             {
                                                                 "name": "srcEnd",
+                                                                "nativeSrc": "970:6:1",
                                                                 "nodeType": "YulTypedName",
                                                                 "src": "970:6:1",
                                                                 "type": ""
@@ -1036,6 +1199,7 @@
                                                     {
                                                         "body":
                                                         {
+                                                            "nativeSrc": "1032:16:1",
                                                             "nodeType": "YulBlock",
                                                             "src": "1032:16:1",
                                                             "statements":
@@ -1047,6 +1211,7 @@
                                                                         [
                                                                             {
                                                                                 "kind": "number",
+                                                                                "nativeSrc": "1041:1:1",
                                                                                 "nodeType": "YulLiteral",
                                                                                 "src": "1041:1:1",
                                                                                 "type": "",
@@ -1054,6 +1219,7 @@
                                                                             },
                                                                             {
                                                                                 "kind": "number",
+                                                                                "nativeSrc": "1044:1:1",
                                                                                 "nodeType": "YulLiteral",
                                                                                 "src": "1044:1:1",
                                                                                 "type": "",
@@ -1063,12 +1229,15 @@
                                                                         "functionName":
                                                                         {
                                                                             "name": "revert",
+                                                                            "nativeSrc": "1034:6:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "1034:6:1"
                                                                         },
+                                                                        "nativeSrc": "1034:12:1",
                                                                         "nodeType": "YulFunctionCall",
                                                                         "src": "1034:12:1"
                                                                     },
+                                                                    "nativeSrc": "1034:12:1",
                                                                     "nodeType": "YulExpressionStatement",
                                                                     "src": "1034:12:1"
                                                                 }
@@ -1080,11 +1249,13 @@
                                                             [
                                                                 {
                                                                     "name": "srcEnd",
+                                                                    "nativeSrc": "1015:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "1015:6:1"
                                                                 },
                                                                 {
                                                                     "name": "dataEnd",
+                                                                    "nativeSrc": "1023:7:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "1023:7:1"
                                                                 }
@@ -1092,16 +1263,20 @@
                                                             "functionName":
                                                             {
                                                                 "name": "gt",
+                                                                "nativeSrc": "1012:2:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1012:2:1"
                                                             },
+                                                            "nativeSrc": "1012:19:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "1012:19:1"
                                                         },
+                                                        "nativeSrc": "1009:39:1",
                                                         "nodeType": "YulIf",
                                                         "src": "1009:39:1"
                                                     },
                                                     {
+                                                        "nativeSrc": "1057:22:1",
                                                         "nodeType": "YulVariableDeclaration",
                                                         "src": "1057:22:1",
                                                         "value":
@@ -1110,11 +1285,13 @@
                                                             [
                                                                 {
                                                                     "name": "_3",
+                                                                    "nativeSrc": "1072:2:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "1072:2:1"
                                                                 },
                                                                 {
                                                                     "name": "_1",
+                                                                    "nativeSrc": "1076:2:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "1076:2:1"
                                                                 }
@@ -1122,9 +1299,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "add",
+                                                                "nativeSrc": "1068:3:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1068:3:1"
                                                             },
+                                                            "nativeSrc": "1068:11:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "1068:11:1"
                                                         },
@@ -1132,6 +1311,7 @@
                                                         [
                                                             {
                                                                 "name": "src",
+                                                                "nativeSrc": "1061:3:1",
                                                                 "nodeType": "YulTypedName",
                                                                 "src": "1061:3:1",
                                                                 "type": ""
@@ -1141,6 +1321,7 @@
                                                     {
                                                         "body":
                                                         {
+                                                            "nativeSrc": "1144:86:1",
                                                             "nodeType": "YulBlock",
                                                             "src": "1144:86:1",
                                                             "statements":
@@ -1152,6 +1333,7 @@
                                                                         [
                                                                             {
                                                                                 "name": "dst",
+                                                                                "nativeSrc": "1165:3:1",
                                                                                 "nodeType": "YulIdentifier",
                                                                                 "src": "1165:3:1"
                                                                             },
@@ -1160,6 +1342,7 @@
                                                                                 [
                                                                                     {
                                                                                         "name": "src",
+                                                                                        "nativeSrc": "1183:3:1",
                                                                                         "nodeType": "YulIdentifier",
                                                                                         "src": "1183:3:1"
                                                                                     }
@@ -1167,9 +1350,11 @@
                                                                                 "functionName":
                                                                                 {
                                                                                     "name": "calldataload",
+                                                                                    "nativeSrc": "1170:12:1",
                                                                                     "nodeType": "YulIdentifier",
                                                                                     "src": "1170:12:1"
                                                                                 },
+                                                                                "nativeSrc": "1170:17:1",
                                                                                 "nodeType": "YulFunctionCall",
                                                                                 "src": "1170:17:1"
                                                                             }
@@ -1177,16 +1362,20 @@
                                                                         "functionName":
                                                                         {
                                                                             "name": "mstore",
+                                                                            "nativeSrc": "1158:6:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "1158:6:1"
                                                                         },
+                                                                        "nativeSrc": "1158:30:1",
                                                                         "nodeType": "YulFunctionCall",
                                                                         "src": "1158:30:1"
                                                                     },
+                                                                    "nativeSrc": "1158:30:1",
                                                                     "nodeType": "YulExpressionStatement",
                                                                     "src": "1158:30:1"
                                                                 },
                                                                 {
+                                                                    "nativeSrc": "1201:19:1",
                                                                     "nodeType": "YulAssignment",
                                                                     "src": "1201:19:1",
                                                                     "value":
@@ -1195,11 +1384,13 @@
                                                                         [
                                                                             {
                                                                                 "name": "dst",
+                                                                                "nativeSrc": "1212:3:1",
                                                                                 "nodeType": "YulIdentifier",
                                                                                 "src": "1212:3:1"
                                                                             },
                                                                             {
                                                                                 "name": "_1",
+                                                                                "nativeSrc": "1217:2:1",
                                                                                 "nodeType": "YulIdentifier",
                                                                                 "src": "1217:2:1"
                                                                             }
@@ -1207,9 +1398,11 @@
                                                                         "functionName":
                                                                         {
                                                                             "name": "add",
+                                                                            "nativeSrc": "1208:3:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "1208:3:1"
                                                                         },
+                                                                        "nativeSrc": "1208:12:1",
                                                                         "nodeType": "YulFunctionCall",
                                                                         "src": "1208:12:1"
                                                                     },
@@ -1217,6 +1410,7 @@
                                                                     [
                                                                         {
                                                                             "name": "dst",
+                                                                            "nativeSrc": "1201:3:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "1201:3:1"
                                                                         }
@@ -1230,11 +1424,13 @@
                                                             [
                                                                 {
                                                                     "name": "src",
+                                                                    "nativeSrc": "1099:3:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "1099:3:1"
                                                                 },
                                                                 {
                                                                     "name": "srcEnd",
+                                                                    "nativeSrc": "1104:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "1104:6:1"
                                                                 }
@@ -1242,20 +1438,25 @@
                                                             "functionName":
                                                             {
                                                                 "name": "lt",
+                                                                "nativeSrc": "1096:2:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1096:2:1"
                                                             },
+                                                            "nativeSrc": "1096:15:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "1096:15:1"
                                                         },
+                                                        "nativeSrc": "1088:142:1",
                                                         "nodeType": "YulForLoop",
                                                         "post":
                                                         {
+                                                            "nativeSrc": "1112:23:1",
                                                             "nodeType": "YulBlock",
                                                             "src": "1112:23:1",
                                                             "statements":
                                                             [
                                                                 {
+                                                                    "nativeSrc": "1114:19:1",
                                                                     "nodeType": "YulAssignment",
                                                                     "src": "1114:19:1",
                                                                     "value":
@@ -1264,11 +1465,13 @@
                                                                         [
                                                                             {
                                                                                 "name": "src",
+                                                                                "nativeSrc": "1125:3:1",
                                                                                 "nodeType": "YulIdentifier",
                                                                                 "src": "1125:3:1"
                                                                             },
                                                                             {
                                                                                 "name": "_1",
+                                                                                "nativeSrc": "1130:2:1",
                                                                                 "nodeType": "YulIdentifier",
                                                                                 "src": "1130:2:1"
                                                                             }
@@ -1276,9 +1479,11 @@
                                                                         "functionName":
                                                                         {
                                                                             "name": "add",
+                                                                            "nativeSrc": "1121:3:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "1121:3:1"
                                                                         },
+                                                                        "nativeSrc": "1121:12:1",
                                                                         "nodeType": "YulFunctionCall",
                                                                         "src": "1121:12:1"
                                                                     },
@@ -1286,6 +1491,7 @@
                                                                     [
                                                                         {
                                                                             "name": "src",
+                                                                            "nativeSrc": "1114:3:1",
                                                                             "nodeType": "YulIdentifier",
                                                                             "src": "1114:3:1"
                                                                         }
@@ -1295,6 +1501,7 @@
                                                         },
                                                         "pre":
                                                         {
+                                                            "nativeSrc": "1092:3:1",
                                                             "nodeType": "YulBlock",
                                                             "src": "1092:3:1",
                                                             "statements": []
@@ -1302,11 +1509,13 @@
                                                         "src": "1088:142:1"
                                                     },
                                                     {
+                                                        "nativeSrc": "1239:16:1",
                                                         "nodeType": "YulAssignment",
                                                         "src": "1239:16:1",
                                                         "value":
                                                         {
                                                             "name": "memPtr",
+                                                            "nativeSrc": "1249:6:1",
                                                             "nodeType": "YulIdentifier",
                                                             "src": "1249:6:1"
                                                         },
@@ -1314,6 +1523,7 @@
                                                         [
                                                             {
                                                                 "name": "value0",
+                                                                "nativeSrc": "1239:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1239:6:1"
                                                             }
@@ -1322,17 +1532,20 @@
                                                 ]
                                             },
                                             "name": "abi_decode_tuple_t_array$_t_uint256_$dyn_memory_ptr",
+                                            "nativeSrc": "146:1115:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "headStart",
+                                                    "nativeSrc": "207:9:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "207:9:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "dataEnd",
+                                                    "nativeSrc": "218:7:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "218:7:1",
                                                     "type": ""
@@ -1342,6 +1555,7 @@
                                             [
                                                 {
                                                     "name": "value0",
+                                                    "nativeSrc": "230:6:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "230:6:1",
                                                     "type": ""
@@ -1352,11 +1566,13 @@
                                         {
                                             "body":
                                             {
+                                                "nativeSrc": "1367:76:1",
                                                 "nodeType": "YulBlock",
                                                 "src": "1367:76:1",
                                                 "statements":
                                                 [
                                                     {
+                                                        "nativeSrc": "1377:26:1",
                                                         "nodeType": "YulAssignment",
                                                         "src": "1377:26:1",
                                                         "value":
@@ -1365,11 +1581,13 @@
                                                             [
                                                                 {
                                                                     "name": "headStart",
+                                                                    "nativeSrc": "1389:9:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "1389:9:1"
                                                                 },
                                                                 {
                                                                     "kind": "number",
+                                                                    "nativeSrc": "1400:2:1",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "1400:2:1",
                                                                     "type": "",
@@ -1379,9 +1597,11 @@
                                                             "functionName":
                                                             {
                                                                 "name": "add",
+                                                                "nativeSrc": "1385:3:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1385:3:1"
                                                             },
+                                                            "nativeSrc": "1385:18:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "1385:18:1"
                                                         },
@@ -1389,6 +1609,7 @@
                                                         [
                                                             {
                                                                 "name": "tail",
+                                                                "nativeSrc": "1377:4:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1377:4:1"
                                                             }
@@ -1401,11 +1622,13 @@
                                                             [
                                                                 {
                                                                     "name": "headStart",
+                                                                    "nativeSrc": "1419:9:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "1419:9:1"
                                                                 },
                                                                 {
                                                                     "name": "value0",
+                                                                    "nativeSrc": "1430:6:1",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "1430:6:1"
                                                                 }
@@ -1413,29 +1636,35 @@
                                                             "functionName":
                                                             {
                                                                 "name": "mstore",
+                                                                "nativeSrc": "1412:6:1",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "1412:6:1"
                                                             },
+                                                            "nativeSrc": "1412:25:1",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "1412:25:1"
                                                         },
+                                                        "nativeSrc": "1412:25:1",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "1412:25:1"
                                                     }
                                                 ]
                                             },
                                             "name": "abi_encode_tuple_t_uint256__to_t_uint256__fromStack_reversed",
+                                            "nativeSrc": "1266:177:1",
                                             "nodeType": "YulFunctionDefinition",
                                             "parameters":
                                             [
                                                 {
                                                     "name": "headStart",
+                                                    "nativeSrc": "1336:9:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "1336:9:1",
                                                     "type": ""
                                                 },
                                                 {
                                                     "name": "value0",
+                                                    "nativeSrc": "1347:6:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "1347:6:1",
                                                     "type": ""
@@ -1445,6 +1674,7 @@
                                             [
                                                 {
                                                     "name": "tail",
+                                                    "nativeSrc": "1358:4:1",
                                                     "nodeType": "YulTypedName",
                                                     "src": "1358:4:1",
                                                     "type": ""

--- a/test/cmdlineTests/standard_yul/output.json
+++ b/test/cmdlineTests/standard_yul/output.json
@@ -50,5 +50,128 @@
 "
             }
         }
+    },
+    "sources":
+    {
+        "A":
+        {
+            "ast":
+            {
+                "code":
+                {
+                    "block":
+                    {
+                        "nativeSrc": "0:42:0",
+                        "nodeType": "YulBlock",
+                        "src": "0:42:0",
+                        "statements":
+                        [
+                            {
+                                "nativeSrc": "2:17:0",
+                                "nodeType": "YulVariableDeclaration",
+                                "src": "2:17:0",
+                                "value":
+                                {
+                                    "arguments":
+                                    [
+                                        {
+                                            "kind": "number",
+                                            "nativeSrc": "17:1:0",
+                                            "nodeType": "YulLiteral",
+                                            "src": "17:1:0",
+                                            "type": "",
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "functionName":
+                                    {
+                                        "name": "mload",
+                                        "nativeSrc": "11:5:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "11:5:0"
+                                    },
+                                    "nativeSrc": "11:8:0",
+                                    "nodeType": "YulFunctionCall",
+                                    "src": "11:8:0"
+                                },
+                                "variables":
+                                [
+                                    {
+                                        "name": "x",
+                                        "nativeSrc": "6:1:0",
+                                        "nodeType": "YulTypedName",
+                                        "src": "6:1:0",
+                                        "type": ""
+                                    }
+                                ]
+                            },
+                            {
+                                "expression":
+                                {
+                                    "arguments":
+                                    [
+                                        {
+                                            "arguments":
+                                            [
+                                                {
+                                                    "name": "x",
+                                                    "nativeSrc": "31:1:0",
+                                                    "nodeType": "YulIdentifier",
+                                                    "src": "31:1:0"
+                                                },
+                                                {
+                                                    "kind": "number",
+                                                    "nativeSrc": "34:1:0",
+                                                    "nodeType": "YulLiteral",
+                                                    "src": "34:1:0",
+                                                    "type": "",
+                                                    "value": "0"
+                                                }
+                                            ],
+                                            "functionName":
+                                            {
+                                                "name": "add",
+                                                "nativeSrc": "27:3:0",
+                                                "nodeType": "YulIdentifier",
+                                                "src": "27:3:0"
+                                            },
+                                            "nativeSrc": "27:9:0",
+                                            "nodeType": "YulFunctionCall",
+                                            "src": "27:9:0"
+                                        },
+                                        {
+                                            "kind": "number",
+                                            "nativeSrc": "38:1:0",
+                                            "nodeType": "YulLiteral",
+                                            "src": "38:1:0",
+                                            "type": "",
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "functionName":
+                                    {
+                                        "name": "sstore",
+                                        "nativeSrc": "20:6:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "20:6:0"
+                                    },
+                                    "nativeSrc": "20:20:0",
+                                    "nodeType": "YulFunctionCall",
+                                    "src": "20:20:0"
+                                },
+                                "nativeSrc": "20:20:0",
+                                "nodeType": "YulExpressionStatement",
+                                "src": "20:20:0"
+                            }
+                        ]
+                    },
+                    "nodeType": "YulCode"
+                },
+                "name": "object",
+                "nodeType": "YulObject",
+                "subObjects": []
+            },
+            "id": 1
+        }
     }
 }

--- a/test/cmdlineTests/standard_yul_object/output.json
+++ b/test/cmdlineTests/standard_yul_object/output.json
@@ -52,5 +52,135 @@ data_4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45 616263
 "
             }
         }
+    },
+    "sources":
+    {
+        "A":
+        {
+            "ast":
+            {
+                "code":
+                {
+                    "block":
+                    {
+                        "nativeSrc": "28:56:0",
+                        "nodeType": "YulBlock",
+                        "src": "28:56:0",
+                        "statements":
+                        [
+                            {
+                                "nativeSrc": "30:31:0",
+                                "nodeType": "YulVariableDeclaration",
+                                "src": "30:31:0",
+                                "value":
+                                {
+                                    "arguments":
+                                    [
+                                        {
+                                            "hexValue": "446174614e616d65",
+                                            "kind": "string",
+                                            "nativeSrc": "50:10:0",
+                                            "nodeType": "YulLiteral",
+                                            "src": "50:10:0",
+                                            "type": "",
+                                            "value": "DataName"
+                                        }
+                                    ],
+                                    "functionName":
+                                    {
+                                        "name": "dataoffset",
+                                        "nativeSrc": "39:10:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "39:10:0"
+                                    },
+                                    "nativeSrc": "39:22:0",
+                                    "nodeType": "YulFunctionCall",
+                                    "src": "39:22:0"
+                                },
+                                "variables":
+                                [
+                                    {
+                                        "name": "x",
+                                        "nativeSrc": "34:1:0",
+                                        "nodeType": "YulTypedName",
+                                        "src": "34:1:0",
+                                        "type": ""
+                                    }
+                                ]
+                            },
+                            {
+                                "expression":
+                                {
+                                    "arguments":
+                                    [
+                                        {
+                                            "arguments":
+                                            [
+                                                {
+                                                    "name": "x",
+                                                    "nativeSrc": "73:1:0",
+                                                    "nodeType": "YulIdentifier",
+                                                    "src": "73:1:0"
+                                                },
+                                                {
+                                                    "kind": "number",
+                                                    "nativeSrc": "76:1:0",
+                                                    "nodeType": "YulLiteral",
+                                                    "src": "76:1:0",
+                                                    "type": "",
+                                                    "value": "0"
+                                                }
+                                            ],
+                                            "functionName":
+                                            {
+                                                "name": "add",
+                                                "nativeSrc": "69:3:0",
+                                                "nodeType": "YulIdentifier",
+                                                "src": "69:3:0"
+                                            },
+                                            "nativeSrc": "69:9:0",
+                                            "nodeType": "YulFunctionCall",
+                                            "src": "69:9:0"
+                                        },
+                                        {
+                                            "kind": "number",
+                                            "nativeSrc": "80:1:0",
+                                            "nodeType": "YulLiteral",
+                                            "src": "80:1:0",
+                                            "type": "",
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "functionName":
+                                    {
+                                        "name": "sstore",
+                                        "nativeSrc": "62:6:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "62:6:0"
+                                    },
+                                    "nativeSrc": "62:20:0",
+                                    "nodeType": "YulFunctionCall",
+                                    "src": "62:20:0"
+                                },
+                                "nativeSrc": "62:20:0",
+                                "nodeType": "YulExpressionStatement",
+                                "src": "62:20:0"
+                            }
+                        ]
+                    },
+                    "nodeType": "YulCode"
+                },
+                "name": "NamedObject",
+                "nodeType": "YulObject",
+                "subObjects":
+                [
+                    {
+                        "nodeType": "YulData",
+                        "value": "616263"
+                    }
+                ]
+            },
+            "id": 1
+        }
     }
 }

--- a/test/cmdlineTests/standard_yul_object_name/output.json
+++ b/test/cmdlineTests/standard_yul_object_name/output.json
@@ -77,5 +77,190 @@ sub_0: assembly {
 "
             }
         }
+    },
+    "sources":
+    {
+        "A":
+        {
+            "ast":
+            {
+                "code":
+                {
+                    "block":
+                    {
+                        "nativeSrc": "28:56:0",
+                        "nodeType": "YulBlock",
+                        "src": "28:56:0",
+                        "statements":
+                        [
+                            {
+                                "nativeSrc": "30:31:0",
+                                "nodeType": "YulVariableDeclaration",
+                                "src": "30:31:0",
+                                "value":
+                                {
+                                    "arguments":
+                                    [
+                                        {
+                                            "hexValue": "446174614e616d65",
+                                            "kind": "string",
+                                            "nativeSrc": "50:10:0",
+                                            "nodeType": "YulLiteral",
+                                            "src": "50:10:0",
+                                            "type": "",
+                                            "value": "DataName"
+                                        }
+                                    ],
+                                    "functionName":
+                                    {
+                                        "name": "dataoffset",
+                                        "nativeSrc": "39:10:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "39:10:0"
+                                    },
+                                    "nativeSrc": "39:22:0",
+                                    "nodeType": "YulFunctionCall",
+                                    "src": "39:22:0"
+                                },
+                                "variables":
+                                [
+                                    {
+                                        "name": "x",
+                                        "nativeSrc": "34:1:0",
+                                        "nodeType": "YulTypedName",
+                                        "src": "34:1:0",
+                                        "type": ""
+                                    }
+                                ]
+                            },
+                            {
+                                "expression":
+                                {
+                                    "arguments":
+                                    [
+                                        {
+                                            "arguments":
+                                            [
+                                                {
+                                                    "name": "x",
+                                                    "nativeSrc": "73:1:0",
+                                                    "nodeType": "YulIdentifier",
+                                                    "src": "73:1:0"
+                                                },
+                                                {
+                                                    "kind": "number",
+                                                    "nativeSrc": "76:1:0",
+                                                    "nodeType": "YulLiteral",
+                                                    "src": "76:1:0",
+                                                    "type": "",
+                                                    "value": "0"
+                                                }
+                                            ],
+                                            "functionName":
+                                            {
+                                                "name": "add",
+                                                "nativeSrc": "69:3:0",
+                                                "nodeType": "YulIdentifier",
+                                                "src": "69:3:0"
+                                            },
+                                            "nativeSrc": "69:9:0",
+                                            "nodeType": "YulFunctionCall",
+                                            "src": "69:9:0"
+                                        },
+                                        {
+                                            "kind": "number",
+                                            "nativeSrc": "80:1:0",
+                                            "nodeType": "YulLiteral",
+                                            "src": "80:1:0",
+                                            "type": "",
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "functionName":
+                                    {
+                                        "name": "sstore",
+                                        "nativeSrc": "62:6:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "62:6:0"
+                                    },
+                                    "nativeSrc": "62:20:0",
+                                    "nodeType": "YulFunctionCall",
+                                    "src": "62:20:0"
+                                },
+                                "nativeSrc": "62:20:0",
+                                "nodeType": "YulExpressionStatement",
+                                "src": "62:20:0"
+                            }
+                        ]
+                    },
+                    "nodeType": "YulCode"
+                },
+                "name": "NamedObject",
+                "nodeType": "YulObject",
+                "subObjects":
+                [
+                    {
+                        "nodeType": "YulData",
+                        "value": "616263"
+                    },
+                    {
+                        "code":
+                        {
+                            "block":
+                            {
+                                "nativeSrc": "135:16:0",
+                                "nodeType": "YulBlock",
+                                "src": "135:16:0",
+                                "statements":
+                                [
+                                    {
+                                        "expression":
+                                        {
+                                            "arguments":
+                                            [
+                                                {
+                                                    "kind": "number",
+                                                    "nativeSrc": "144:1:0",
+                                                    "nodeType": "YulLiteral",
+                                                    "src": "144:1:0",
+                                                    "type": "",
+                                                    "value": "0"
+                                                },
+                                                {
+                                                    "kind": "number",
+                                                    "nativeSrc": "147:1:0",
+                                                    "nodeType": "YulLiteral",
+                                                    "src": "147:1:0",
+                                                    "type": "",
+                                                    "value": "0"
+                                                }
+                                            ],
+                                            "functionName":
+                                            {
+                                                "name": "revert",
+                                                "nativeSrc": "137:6:0",
+                                                "nodeType": "YulIdentifier",
+                                                "src": "137:6:0"
+                                            },
+                                            "nativeSrc": "137:12:0",
+                                            "nodeType": "YulFunctionCall",
+                                            "src": "137:12:0"
+                                        },
+                                        "nativeSrc": "137:12:0",
+                                        "nodeType": "YulExpressionStatement",
+                                        "src": "137:12:0"
+                                    }
+                                ]
+                            },
+                            "nodeType": "YulCode"
+                        },
+                        "name": "OtherObject",
+                        "nodeType": "YulObject",
+                        "subObjects": []
+                    }
+                ]
+            },
+            "id": 1
+        }
     }
 }

--- a/test/cmdlineTests/standard_yul_optimiserSteps/output.json
+++ b/test/cmdlineTests/standard_yul_optimiserSteps/output.json
@@ -45,5 +45,128 @@
 "
             }
         }
+    },
+    "sources":
+    {
+        "A":
+        {
+            "ast":
+            {
+                "code":
+                {
+                    "block":
+                    {
+                        "nativeSrc": "0:42:0",
+                        "nodeType": "YulBlock",
+                        "src": "0:42:0",
+                        "statements":
+                        [
+                            {
+                                "nativeSrc": "2:17:0",
+                                "nodeType": "YulVariableDeclaration",
+                                "src": "2:17:0",
+                                "value":
+                                {
+                                    "arguments":
+                                    [
+                                        {
+                                            "kind": "number",
+                                            "nativeSrc": "17:1:0",
+                                            "nodeType": "YulLiteral",
+                                            "src": "17:1:0",
+                                            "type": "",
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "functionName":
+                                    {
+                                        "name": "mload",
+                                        "nativeSrc": "11:5:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "11:5:0"
+                                    },
+                                    "nativeSrc": "11:8:0",
+                                    "nodeType": "YulFunctionCall",
+                                    "src": "11:8:0"
+                                },
+                                "variables":
+                                [
+                                    {
+                                        "name": "x",
+                                        "nativeSrc": "6:1:0",
+                                        "nodeType": "YulTypedName",
+                                        "src": "6:1:0",
+                                        "type": ""
+                                    }
+                                ]
+                            },
+                            {
+                                "expression":
+                                {
+                                    "arguments":
+                                    [
+                                        {
+                                            "arguments":
+                                            [
+                                                {
+                                                    "name": "x",
+                                                    "nativeSrc": "31:1:0",
+                                                    "nodeType": "YulIdentifier",
+                                                    "src": "31:1:0"
+                                                },
+                                                {
+                                                    "kind": "number",
+                                                    "nativeSrc": "34:1:0",
+                                                    "nodeType": "YulLiteral",
+                                                    "src": "34:1:0",
+                                                    "type": "",
+                                                    "value": "0"
+                                                }
+                                            ],
+                                            "functionName":
+                                            {
+                                                "name": "add",
+                                                "nativeSrc": "27:3:0",
+                                                "nodeType": "YulIdentifier",
+                                                "src": "27:3:0"
+                                            },
+                                            "nativeSrc": "27:9:0",
+                                            "nodeType": "YulFunctionCall",
+                                            "src": "27:9:0"
+                                        },
+                                        {
+                                            "kind": "number",
+                                            "nativeSrc": "38:1:0",
+                                            "nodeType": "YulLiteral",
+                                            "src": "38:1:0",
+                                            "type": "",
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "functionName":
+                                    {
+                                        "name": "sstore",
+                                        "nativeSrc": "20:6:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "20:6:0"
+                                    },
+                                    "nativeSrc": "20:20:0",
+                                    "nodeType": "YulFunctionCall",
+                                    "src": "20:20:0"
+                                },
+                                "nativeSrc": "20:20:0",
+                                "nodeType": "YulExpressionStatement",
+                                "src": "20:20:0"
+                            }
+                        ]
+                    },
+                    "nodeType": "YulCode"
+                },
+                "name": "object",
+                "nodeType": "YulObject",
+                "subObjects": []
+            },
+            "id": 1
+        }
     }
 }

--- a/test/cmdlineTests/standard_yul_optimized/output.json
+++ b/test/cmdlineTests/standard_yul_optimized/output.json
@@ -40,5 +40,128 @@
 "
             }
         }
+    },
+    "sources":
+    {
+        "A":
+        {
+            "ast":
+            {
+                "code":
+                {
+                    "block":
+                    {
+                        "nativeSrc": "0:42:0",
+                        "nodeType": "YulBlock",
+                        "src": "0:42:0",
+                        "statements":
+                        [
+                            {
+                                "nativeSrc": "2:17:0",
+                                "nodeType": "YulVariableDeclaration",
+                                "src": "2:17:0",
+                                "value":
+                                {
+                                    "arguments":
+                                    [
+                                        {
+                                            "kind": "number",
+                                            "nativeSrc": "17:1:0",
+                                            "nodeType": "YulLiteral",
+                                            "src": "17:1:0",
+                                            "type": "",
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "functionName":
+                                    {
+                                        "name": "mload",
+                                        "nativeSrc": "11:5:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "11:5:0"
+                                    },
+                                    "nativeSrc": "11:8:0",
+                                    "nodeType": "YulFunctionCall",
+                                    "src": "11:8:0"
+                                },
+                                "variables":
+                                [
+                                    {
+                                        "name": "x",
+                                        "nativeSrc": "6:1:0",
+                                        "nodeType": "YulTypedName",
+                                        "src": "6:1:0",
+                                        "type": ""
+                                    }
+                                ]
+                            },
+                            {
+                                "expression":
+                                {
+                                    "arguments":
+                                    [
+                                        {
+                                            "arguments":
+                                            [
+                                                {
+                                                    "name": "x",
+                                                    "nativeSrc": "31:1:0",
+                                                    "nodeType": "YulIdentifier",
+                                                    "src": "31:1:0"
+                                                },
+                                                {
+                                                    "kind": "number",
+                                                    "nativeSrc": "34:1:0",
+                                                    "nodeType": "YulLiteral",
+                                                    "src": "34:1:0",
+                                                    "type": "",
+                                                    "value": "0"
+                                                }
+                                            ],
+                                            "functionName":
+                                            {
+                                                "name": "add",
+                                                "nativeSrc": "27:3:0",
+                                                "nodeType": "YulIdentifier",
+                                                "src": "27:3:0"
+                                            },
+                                            "nativeSrc": "27:9:0",
+                                            "nodeType": "YulFunctionCall",
+                                            "src": "27:9:0"
+                                        },
+                                        {
+                                            "kind": "number",
+                                            "nativeSrc": "38:1:0",
+                                            "nodeType": "YulLiteral",
+                                            "src": "38:1:0",
+                                            "type": "",
+                                            "value": "0"
+                                        }
+                                    ],
+                                    "functionName":
+                                    {
+                                        "name": "sstore",
+                                        "nativeSrc": "20:6:0",
+                                        "nodeType": "YulIdentifier",
+                                        "src": "20:6:0"
+                                    },
+                                    "nativeSrc": "20:20:0",
+                                    "nodeType": "YulFunctionCall",
+                                    "src": "20:20:0"
+                                },
+                                "nativeSrc": "20:20:0",
+                                "nodeType": "YulExpressionStatement",
+                                "src": "20:20:0"
+                            }
+                        ]
+                    },
+                    "nodeType": "YulCode"
+                },
+                "name": "object",
+                "nodeType": "YulObject",
+                "subObjects": []
+            },
+            "id": 1
+        }
     }
 }

--- a/test/cmdlineTests/strict_asm_ast_compact_json/args
+++ b/test/cmdlineTests/strict_asm_ast_compact_json/args
@@ -1,0 +1,1 @@
+--strict-assembly --ast-compact-json --pretty-json --json-indent 4

--- a/test/cmdlineTests/strict_asm_ast_compact_json/input.yul
+++ b/test/cmdlineTests/strict_asm_ast_compact_json/input.yul
@@ -1,0 +1,15 @@
+/// @use-src 0:"input.sol"
+object "C_6_deployed" {
+    code {
+        /// @src 0:60:101  "contract C {..."
+        mstore(64, 128)
+
+        // f()
+        fun_f_5()
+
+        /// @src 0:77:99  "function f() public {}"
+        function fun_f_5() {
+        }
+        /// @src 0:60:101  "contract C {..."
+    }
+}

--- a/test/cmdlineTests/strict_asm_ast_compact_json/output
+++ b/test/cmdlineTests/strict_asm_ast_compact_json/output
@@ -1,0 +1,91 @@
+
+======= strict_asm_ast_compact_json/input.yul (EVM) =======
+AST:
+
+{
+    "code":
+    {
+        "block":
+        {
+            "nativeSrc": "60:246:0",
+            "nodeType": "YulBlock",
+            "src": "-1:-1:0",
+            "statements":
+            [
+                {
+                    "expression":
+                    {
+                        "arguments":
+                        [
+                            {
+                                "kind": "number",
+                                "nativeSrc": "122:2:0",
+                                "nodeType": "YulLiteral",
+                                "src": "60:41:0",
+                                "type": "",
+                                "value": "64"
+                            },
+                            {
+                                "kind": "number",
+                                "nativeSrc": "126:3:0",
+                                "nodeType": "YulLiteral",
+                                "src": "60:41:0",
+                                "type": "",
+                                "value": "128"
+                            }
+                        ],
+                        "functionName":
+                        {
+                            "name": "mstore",
+                            "nativeSrc": "115:6:0",
+                            "nodeType": "YulIdentifier",
+                            "src": "60:41:0"
+                        },
+                        "nativeSrc": "115:15:0",
+                        "nodeType": "YulFunctionCall",
+                        "src": "60:41:0"
+                    },
+                    "nativeSrc": "115:15:0",
+                    "nodeType": "YulExpressionStatement",
+                    "src": "60:41:0"
+                },
+                {
+                    "expression":
+                    {
+                        "arguments": [],
+                        "functionName":
+                        {
+                            "name": "fun_f_5",
+                            "nativeSrc": "155:7:0",
+                            "nodeType": "YulIdentifier",
+                            "src": "60:41:0"
+                        },
+                        "nativeSrc": "155:9:0",
+                        "nodeType": "YulFunctionCall",
+                        "src": "60:41:0"
+                    },
+                    "nativeSrc": "155:9:0",
+                    "nodeType": "YulExpressionStatement",
+                    "src": "60:41:0"
+                },
+                {
+                    "body":
+                    {
+                        "nativeSrc": "244:11:0",
+                        "nodeType": "YulBlock",
+                        "src": "77:22:0",
+                        "statements": []
+                    },
+                    "name": "fun_f_5",
+                    "nativeSrc": "225:30:0",
+                    "nodeType": "YulFunctionDefinition",
+                    "src": "77:22:0"
+                }
+            ]
+        },
+        "nodeType": "YulCode"
+    },
+    "name": "C_6_deployed",
+    "nodeType": "YulObject",
+    "subObjects": []
+}

--- a/test/libsolidity/ASTJSON/assembly/call.json
+++ b/test/libsolidity/ASTJSON/assembly/call.json
@@ -39,6 +39,7 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "56:34:1",
                   "nodeType": "YulBlock",
                   "src": "56:34:1",
                   "statements":
@@ -53,6 +54,7 @@
                             [
                               {
                                 "kind": "number",
+                                "nativeSrc": "67:1:1",
                                 "nodeType": "YulLiteral",
                                 "src": "67:1:1",
                                 "type": "",
@@ -60,6 +62,7 @@
                               },
                               {
                                 "kind": "number",
+                                "nativeSrc": "70:1:1",
                                 "nodeType": "YulLiteral",
                                 "src": "70:1:1",
                                 "type": "",
@@ -67,6 +70,7 @@
                               },
                               {
                                 "kind": "number",
+                                "nativeSrc": "73:1:1",
                                 "nodeType": "YulLiteral",
                                 "src": "73:1:1",
                                 "type": "",
@@ -74,6 +78,7 @@
                               },
                               {
                                 "kind": "number",
+                                "nativeSrc": "76:1:1",
                                 "nodeType": "YulLiteral",
                                 "src": "76:1:1",
                                 "type": "",
@@ -81,6 +86,7 @@
                               },
                               {
                                 "kind": "number",
+                                "nativeSrc": "79:1:1",
                                 "nodeType": "YulLiteral",
                                 "src": "79:1:1",
                                 "type": "",
@@ -88,6 +94,7 @@
                               },
                               {
                                 "kind": "number",
+                                "nativeSrc": "82:1:1",
                                 "nodeType": "YulLiteral",
                                 "src": "82:1:1",
                                 "type": "",
@@ -95,6 +102,7 @@
                               },
                               {
                                 "kind": "number",
+                                "nativeSrc": "85:1:1",
                                 "nodeType": "YulLiteral",
                                 "src": "85:1:1",
                                 "type": "",
@@ -104,9 +112,11 @@
                             "functionName":
                             {
                               "name": "call",
+                              "nativeSrc": "62:4:1",
                               "nodeType": "YulIdentifier",
                               "src": "62:4:1"
                             },
+                            "nativeSrc": "62:25:1",
                             "nodeType": "YulFunctionCall",
                             "src": "62:25:1"
                           }
@@ -114,12 +124,15 @@
                         "functionName":
                         {
                           "name": "pop",
+                          "nativeSrc": "58:3:1",
                           "nodeType": "YulIdentifier",
                           "src": "58:3:1"
                         },
+                        "nativeSrc": "58:30:1",
                         "nodeType": "YulFunctionCall",
                         "src": "58:30:1"
                       },
+                      "nativeSrc": "58:30:1",
                       "nodeType": "YulExpressionStatement",
                       "src": "58:30:1"
                     }

--- a/test/libsolidity/ASTJSON/assembly/call_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/call_parseOnly.json
@@ -26,6 +26,7 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "56:34:1",
                   "nodeType": "YulBlock",
                   "src": "56:34:1",
                   "statements":
@@ -40,6 +41,7 @@
                             [
                               {
                                 "kind": "number",
+                                "nativeSrc": "67:1:1",
                                 "nodeType": "YulLiteral",
                                 "src": "67:1:1",
                                 "type": "",
@@ -47,6 +49,7 @@
                               },
                               {
                                 "kind": "number",
+                                "nativeSrc": "70:1:1",
                                 "nodeType": "YulLiteral",
                                 "src": "70:1:1",
                                 "type": "",
@@ -54,6 +57,7 @@
                               },
                               {
                                 "kind": "number",
+                                "nativeSrc": "73:1:1",
                                 "nodeType": "YulLiteral",
                                 "src": "73:1:1",
                                 "type": "",
@@ -61,6 +65,7 @@
                               },
                               {
                                 "kind": "number",
+                                "nativeSrc": "76:1:1",
                                 "nodeType": "YulLiteral",
                                 "src": "76:1:1",
                                 "type": "",
@@ -68,6 +73,7 @@
                               },
                               {
                                 "kind": "number",
+                                "nativeSrc": "79:1:1",
                                 "nodeType": "YulLiteral",
                                 "src": "79:1:1",
                                 "type": "",
@@ -75,6 +81,7 @@
                               },
                               {
                                 "kind": "number",
+                                "nativeSrc": "82:1:1",
                                 "nodeType": "YulLiteral",
                                 "src": "82:1:1",
                                 "type": "",
@@ -82,6 +89,7 @@
                               },
                               {
                                 "kind": "number",
+                                "nativeSrc": "85:1:1",
                                 "nodeType": "YulLiteral",
                                 "src": "85:1:1",
                                 "type": "",
@@ -91,9 +99,11 @@
                             "functionName":
                             {
                               "name": "call",
+                              "nativeSrc": "62:4:1",
                               "nodeType": "YulIdentifier",
                               "src": "62:4:1"
                             },
+                            "nativeSrc": "62:25:1",
                             "nodeType": "YulFunctionCall",
                             "src": "62:25:1"
                           }
@@ -101,12 +111,15 @@
                         "functionName":
                         {
                           "name": "pop",
+                          "nativeSrc": "58:3:1",
                           "nodeType": "YulIdentifier",
                           "src": "58:3:1"
                         },
+                        "nativeSrc": "58:30:1",
                         "nodeType": "YulFunctionCall",
                         "src": "58:30:1"
                       },
+                      "nativeSrc": "58:30:1",
                       "nodeType": "YulExpressionStatement",
                       "src": "58:30:1"
                     }

--- a/test/libsolidity/ASTJSON/assembly/empty_block.json
+++ b/test/libsolidity/ASTJSON/assembly/empty_block.json
@@ -39,11 +39,13 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "61:6:1",
                   "nodeType": "YulBlock",
                   "src": "61:6:1",
                   "statements":
                   [
                     {
+                      "nativeSrc": "63:2:1",
                       "nodeType": "YulBlock",
                       "src": "63:2:1",
                       "statements": []

--- a/test/libsolidity/ASTJSON/assembly/empty_block_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/empty_block_parseOnly.json
@@ -26,11 +26,13 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "61:6:1",
                   "nodeType": "YulBlock",
                   "src": "61:6:1",
                   "statements":
                   [
                     {
+                      "nativeSrc": "63:2:1",
                       "nodeType": "YulBlock",
                       "src": "63:2:1",
                       "statements": []

--- a/test/libsolidity/ASTJSON/assembly/function.json
+++ b/test/libsolidity/ASTJSON/assembly/function.json
@@ -39,6 +39,7 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "61:43:1",
                   "nodeType": "YulBlock",
                   "src": "61:43:1",
                   "statements":
@@ -46,6 +47,7 @@
                     {
                       "body":
                       {
+                        "nativeSrc": "76:22:1",
                         "nodeType": "YulBlock",
                         "src": "76:22:1",
                         "statements":
@@ -60,6 +62,7 @@
                                   [
                                     {
                                       "kind": "number",
+                                      "nativeSrc": "92:2:1",
                                       "nodeType": "YulLiteral",
                                       "src": "92:2:1",
                                       "type": "",
@@ -69,9 +72,11 @@
                                   "functionName":
                                   {
                                     "name": "blockhash",
+                                    "nativeSrc": "82:9:1",
                                     "nodeType": "YulIdentifier",
                                     "src": "82:9:1"
                                   },
+                                  "nativeSrc": "82:13:1",
                                   "nodeType": "YulFunctionCall",
                                   "src": "82:13:1"
                                 }
@@ -79,18 +84,22 @@
                               "functionName":
                               {
                                 "name": "pop",
+                                "nativeSrc": "78:3:1",
                                 "nodeType": "YulIdentifier",
                                 "src": "78:3:1"
                               },
+                              "nativeSrc": "78:18:1",
                               "nodeType": "YulFunctionCall",
                               "src": "78:18:1"
                             },
+                            "nativeSrc": "78:18:1",
                             "nodeType": "YulExpressionStatement",
                             "src": "78:18:1"
                           }
                         ]
                       },
                       "name": "g",
+                      "nativeSrc": "63:35:1",
                       "nodeType": "YulFunctionDefinition",
                       "src": "63:35:1"
                     },
@@ -101,12 +110,15 @@
                         "functionName":
                         {
                           "name": "g",
+                          "nativeSrc": "99:1:1",
                           "nodeType": "YulIdentifier",
                           "src": "99:1:1"
                         },
+                        "nativeSrc": "99:3:1",
                         "nodeType": "YulFunctionCall",
                         "src": "99:3:1"
                       },
+                      "nativeSrc": "99:3:1",
                       "nodeType": "YulExpressionStatement",
                       "src": "99:3:1"
                     }

--- a/test/libsolidity/ASTJSON/assembly/function_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/function_parseOnly.json
@@ -26,6 +26,7 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "61:43:1",
                   "nodeType": "YulBlock",
                   "src": "61:43:1",
                   "statements":
@@ -33,6 +34,7 @@
                     {
                       "body":
                       {
+                        "nativeSrc": "76:22:1",
                         "nodeType": "YulBlock",
                         "src": "76:22:1",
                         "statements":
@@ -47,6 +49,7 @@
                                   [
                                     {
                                       "kind": "number",
+                                      "nativeSrc": "92:2:1",
                                       "nodeType": "YulLiteral",
                                       "src": "92:2:1",
                                       "type": "",
@@ -56,9 +59,11 @@
                                   "functionName":
                                   {
                                     "name": "blockhash",
+                                    "nativeSrc": "82:9:1",
                                     "nodeType": "YulIdentifier",
                                     "src": "82:9:1"
                                   },
+                                  "nativeSrc": "82:13:1",
                                   "nodeType": "YulFunctionCall",
                                   "src": "82:13:1"
                                 }
@@ -66,18 +71,22 @@
                               "functionName":
                               {
                                 "name": "pop",
+                                "nativeSrc": "78:3:1",
                                 "nodeType": "YulIdentifier",
                                 "src": "78:3:1"
                               },
+                              "nativeSrc": "78:18:1",
                               "nodeType": "YulFunctionCall",
                               "src": "78:18:1"
                             },
+                            "nativeSrc": "78:18:1",
                             "nodeType": "YulExpressionStatement",
                             "src": "78:18:1"
                           }
                         ]
                       },
                       "name": "g",
+                      "nativeSrc": "63:35:1",
                       "nodeType": "YulFunctionDefinition",
                       "src": "63:35:1"
                     },
@@ -88,12 +97,15 @@
                         "functionName":
                         {
                           "name": "g",
+                          "nativeSrc": "99:1:1",
                           "nodeType": "YulIdentifier",
                           "src": "99:1:1"
                         },
+                        "nativeSrc": "99:3:1",
                         "nodeType": "YulFunctionCall",
                         "src": "99:3:1"
                       },
+                      "nativeSrc": "99:3:1",
                       "nodeType": "YulExpressionStatement",
                       "src": "99:3:1"
                     }

--- a/test/libsolidity/ASTJSON/assembly/leave.json
+++ b/test/libsolidity/ASTJSON/assembly/leave.json
@@ -39,6 +39,7 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "56:26:1",
                   "nodeType": "YulBlock",
                   "src": "56:26:1",
                   "statements":
@@ -46,17 +47,20 @@
                     {
                       "body":
                       {
+                        "nativeSrc": "71:9:1",
                         "nodeType": "YulBlock",
                         "src": "71:9:1",
                         "statements":
                         [
                           {
+                            "nativeSrc": "73:5:1",
                             "nodeType": "YulLeave",
                             "src": "73:5:1"
                           }
                         ]
                       },
                       "name": "f",
+                      "nativeSrc": "58:22:1",
                       "nodeType": "YulFunctionDefinition",
                       "src": "58:22:1"
                     }

--- a/test/libsolidity/ASTJSON/assembly/leave_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/leave_parseOnly.json
@@ -26,6 +26,7 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "56:26:1",
                   "nodeType": "YulBlock",
                   "src": "56:26:1",
                   "statements":
@@ -33,17 +34,20 @@
                     {
                       "body":
                       {
+                        "nativeSrc": "71:9:1",
                         "nodeType": "YulBlock",
                         "src": "71:9:1",
                         "statements":
                         [
                           {
+                            "nativeSrc": "73:5:1",
                             "nodeType": "YulLeave",
                             "src": "73:5:1"
                           }
                         ]
                       },
                       "name": "f",
+                      "nativeSrc": "58:22:1",
                       "nodeType": "YulFunctionDefinition",
                       "src": "58:22:1"
                     }

--- a/test/libsolidity/ASTJSON/assembly/loop.json
+++ b/test/libsolidity/ASTJSON/assembly/loop.json
@@ -39,6 +39,7 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "61:49:1",
                   "nodeType": "YulBlock",
                   "src": "61:49:1",
                   "statements":
@@ -46,15 +47,18 @@
                     {
                       "body":
                       {
+                        "nativeSrc": "90:18:1",
                         "nodeType": "YulBlock",
                         "src": "90:18:1",
                         "statements":
                         [
                           {
+                            "nativeSrc": "92:5:1",
                             "nodeType": "YulBreak",
                             "src": "92:5:1"
                           },
                           {
+                            "nativeSrc": "98:8:1",
                             "nodeType": "YulContinue",
                             "src": "98:8:1"
                           }
@@ -63,14 +67,17 @@
                       "condition":
                       {
                         "kind": "number",
+                        "nativeSrc": "70:1:1",
                         "nodeType": "YulLiteral",
                         "src": "70:1:1",
                         "type": "",
                         "value": "1"
                       },
+                      "nativeSrc": "63:45:1",
                       "nodeType": "YulForLoop",
                       "post":
                       {
+                        "nativeSrc": "72:17:1",
                         "nodeType": "YulBlock",
                         "src": "72:17:1",
                         "statements":
@@ -85,6 +92,7 @@
                                   [
                                     {
                                       "kind": "number",
+                                      "nativeSrc": "84:1:1",
                                       "nodeType": "YulLiteral",
                                       "src": "84:1:1",
                                       "type": "",
@@ -94,9 +102,11 @@
                                   "functionName":
                                   {
                                     "name": "sload",
+                                    "nativeSrc": "78:5:1",
                                     "nodeType": "YulIdentifier",
                                     "src": "78:5:1"
                                   },
+                                  "nativeSrc": "78:8:1",
                                   "nodeType": "YulFunctionCall",
                                   "src": "78:8:1"
                                 }
@@ -104,12 +114,15 @@
                               "functionName":
                               {
                                 "name": "pop",
+                                "nativeSrc": "74:3:1",
                                 "nodeType": "YulIdentifier",
                                 "src": "74:3:1"
                               },
+                              "nativeSrc": "74:13:1",
                               "nodeType": "YulFunctionCall",
                               "src": "74:13:1"
                             },
+                            "nativeSrc": "74:13:1",
                             "nodeType": "YulExpressionStatement",
                             "src": "74:13:1"
                           }
@@ -117,6 +130,7 @@
                       },
                       "pre":
                       {
+                        "nativeSrc": "67:2:1",
                         "nodeType": "YulBlock",
                         "src": "67:2:1",
                         "statements": []

--- a/test/libsolidity/ASTJSON/assembly/loop_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/loop_parseOnly.json
@@ -26,6 +26,7 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "61:49:1",
                   "nodeType": "YulBlock",
                   "src": "61:49:1",
                   "statements":
@@ -33,15 +34,18 @@
                     {
                       "body":
                       {
+                        "nativeSrc": "90:18:1",
                         "nodeType": "YulBlock",
                         "src": "90:18:1",
                         "statements":
                         [
                           {
+                            "nativeSrc": "92:5:1",
                             "nodeType": "YulBreak",
                             "src": "92:5:1"
                           },
                           {
+                            "nativeSrc": "98:8:1",
                             "nodeType": "YulContinue",
                             "src": "98:8:1"
                           }
@@ -50,14 +54,17 @@
                       "condition":
                       {
                         "kind": "number",
+                        "nativeSrc": "70:1:1",
                         "nodeType": "YulLiteral",
                         "src": "70:1:1",
                         "type": "",
                         "value": "1"
                       },
+                      "nativeSrc": "63:45:1",
                       "nodeType": "YulForLoop",
                       "post":
                       {
+                        "nativeSrc": "72:17:1",
                         "nodeType": "YulBlock",
                         "src": "72:17:1",
                         "statements":
@@ -72,6 +79,7 @@
                                   [
                                     {
                                       "kind": "number",
+                                      "nativeSrc": "84:1:1",
                                       "nodeType": "YulLiteral",
                                       "src": "84:1:1",
                                       "type": "",
@@ -81,9 +89,11 @@
                                   "functionName":
                                   {
                                     "name": "sload",
+                                    "nativeSrc": "78:5:1",
                                     "nodeType": "YulIdentifier",
                                     "src": "78:5:1"
                                   },
+                                  "nativeSrc": "78:8:1",
                                   "nodeType": "YulFunctionCall",
                                   "src": "78:8:1"
                                 }
@@ -91,12 +101,15 @@
                               "functionName":
                               {
                                 "name": "pop",
+                                "nativeSrc": "74:3:1",
                                 "nodeType": "YulIdentifier",
                                 "src": "74:3:1"
                               },
+                              "nativeSrc": "74:13:1",
                               "nodeType": "YulFunctionCall",
                               "src": "74:13:1"
                             },
+                            "nativeSrc": "74:13:1",
                             "nodeType": "YulExpressionStatement",
                             "src": "74:13:1"
                           }
@@ -104,6 +117,7 @@
                       },
                       "pre":
                       {
+                        "nativeSrc": "67:2:1",
                         "nodeType": "YulBlock",
                         "src": "67:2:1",
                         "statements": []

--- a/test/libsolidity/ASTJSON/assembly/nested_functions.json
+++ b/test/libsolidity/ASTJSON/assembly/nested_functions.json
@@ -39,6 +39,7 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "72:76:1",
                   "nodeType": "YulBlock",
                   "src": "72:76:1",
                   "statements":
@@ -46,6 +47,7 @@
                     {
                       "body":
                       {
+                        "nativeSrc": "94:35:1",
                         "nodeType": "YulBlock",
                         "src": "94:35:1",
                         "statements":
@@ -53,26 +55,31 @@
                           {
                             "body":
                             {
+                              "nativeSrc": "118:3:1",
                               "nodeType": "YulBlock",
                               "src": "118:3:1",
                               "statements": []
                             },
                             "name": "f2",
+                            "nativeSrc": "104:17:1",
                             "nodeType": "YulFunctionDefinition",
                             "src": "104:17:1"
                           }
                         ]
                       },
                       "name": "f1",
+                      "nativeSrc": "80:49:1",
                       "nodeType": "YulFunctionDefinition",
                       "src": "80:49:1"
                     },
                     {
+                      "nativeSrc": "136:6:1",
                       "nodeType": "YulAssignment",
                       "src": "136:6:1",
                       "value":
                       {
                         "kind": "number",
+                        "nativeSrc": "141:1:1",
                         "nodeType": "YulLiteral",
                         "src": "141:1:1",
                         "type": "",
@@ -82,6 +89,7 @@
                       [
                         {
                           "name": "x",
+                          "nativeSrc": "136:1:1",
                           "nodeType": "YulIdentifier",
                           "src": "136:1:1"
                         }

--- a/test/libsolidity/ASTJSON/assembly/nested_functions_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/nested_functions_parseOnly.json
@@ -26,6 +26,7 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "72:76:1",
                   "nodeType": "YulBlock",
                   "src": "72:76:1",
                   "statements":
@@ -33,6 +34,7 @@
                     {
                       "body":
                       {
+                        "nativeSrc": "94:35:1",
                         "nodeType": "YulBlock",
                         "src": "94:35:1",
                         "statements":
@@ -40,26 +42,31 @@
                           {
                             "body":
                             {
+                              "nativeSrc": "118:3:1",
                               "nodeType": "YulBlock",
                               "src": "118:3:1",
                               "statements": []
                             },
                             "name": "f2",
+                            "nativeSrc": "104:17:1",
                             "nodeType": "YulFunctionDefinition",
                             "src": "104:17:1"
                           }
                         ]
                       },
                       "name": "f1",
+                      "nativeSrc": "80:49:1",
                       "nodeType": "YulFunctionDefinition",
                       "src": "80:49:1"
                     },
                     {
+                      "nativeSrc": "136:6:1",
                       "nodeType": "YulAssignment",
                       "src": "136:6:1",
                       "value":
                       {
                         "kind": "number",
+                        "nativeSrc": "141:1:1",
                         "nodeType": "YulLiteral",
                         "src": "141:1:1",
                         "type": "",
@@ -69,6 +76,7 @@
                       [
                         {
                           "name": "x",
+                          "nativeSrc": "136:1:1",
                           "nodeType": "YulIdentifier",
                           "src": "136:1:1"
                         }

--- a/test/libsolidity/ASTJSON/assembly/slot_offset.json
+++ b/test/libsolidity/ASTJSON/assembly/slot_offset.json
@@ -124,16 +124,19 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "95:45:1",
                   "nodeType": "YulBlock",
                   "src": "95:45:1",
                   "statements":
                   [
                     {
+                      "nativeSrc": "97:17:1",
                       "nodeType": "YulVariableDeclaration",
                       "src": "97:17:1",
                       "value":
                       {
                         "name": "s.offset",
+                        "nativeSrc": "106:8:1",
                         "nodeType": "YulIdentifier",
                         "src": "106:8:1"
                       },
@@ -141,6 +144,7 @@
                       [
                         {
                           "name": "x",
+                          "nativeSrc": "101:1:1",
                           "nodeType": "YulTypedName",
                           "src": "101:1:1",
                           "type": ""
@@ -148,6 +152,7 @@
                       ]
                     },
                     {
+                      "nativeSrc": "115:23:1",
                       "nodeType": "YulVariableDeclaration",
                       "src": "115:23:1",
                       "value":
@@ -156,11 +161,13 @@
                         [
                           {
                             "name": "s.slot",
+                            "nativeSrc": "128:6:1",
                             "nodeType": "YulIdentifier",
                             "src": "128:6:1"
                           },
                           {
                             "kind": "number",
+                            "nativeSrc": "136:1:1",
                             "nodeType": "YulLiteral",
                             "src": "136:1:1",
                             "type": "",
@@ -170,9 +177,11 @@
                         "functionName":
                         {
                           "name": "mul",
+                          "nativeSrc": "124:3:1",
                           "nodeType": "YulIdentifier",
                           "src": "124:3:1"
                         },
+                        "nativeSrc": "124:14:1",
                         "nodeType": "YulFunctionCall",
                         "src": "124:14:1"
                       },
@@ -180,6 +189,7 @@
                       [
                         {
                           "name": "y",
+                          "nativeSrc": "119:1:1",
                           "nodeType": "YulTypedName",
                           "src": "119:1:1",
                           "type": ""

--- a/test/libsolidity/ASTJSON/assembly/slot_offset_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/slot_offset_parseOnly.json
@@ -89,16 +89,19 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "95:45:1",
                   "nodeType": "YulBlock",
                   "src": "95:45:1",
                   "statements":
                   [
                     {
+                      "nativeSrc": "97:17:1",
                       "nodeType": "YulVariableDeclaration",
                       "src": "97:17:1",
                       "value":
                       {
                         "name": "s.offset",
+                        "nativeSrc": "106:8:1",
                         "nodeType": "YulIdentifier",
                         "src": "106:8:1"
                       },
@@ -106,6 +109,7 @@
                       [
                         {
                           "name": "x",
+                          "nativeSrc": "101:1:1",
                           "nodeType": "YulTypedName",
                           "src": "101:1:1",
                           "type": ""
@@ -113,6 +117,7 @@
                       ]
                     },
                     {
+                      "nativeSrc": "115:23:1",
                       "nodeType": "YulVariableDeclaration",
                       "src": "115:23:1",
                       "value":
@@ -121,11 +126,13 @@
                         [
                           {
                             "name": "s.slot",
+                            "nativeSrc": "128:6:1",
                             "nodeType": "YulIdentifier",
                             "src": "128:6:1"
                           },
                           {
                             "kind": "number",
+                            "nativeSrc": "136:1:1",
                             "nodeType": "YulLiteral",
                             "src": "136:1:1",
                             "type": "",
@@ -135,9 +142,11 @@
                         "functionName":
                         {
                           "name": "mul",
+                          "nativeSrc": "124:3:1",
                           "nodeType": "YulIdentifier",
                           "src": "124:3:1"
                         },
+                        "nativeSrc": "124:14:1",
                         "nodeType": "YulFunctionCall",
                         "src": "124:14:1"
                       },
@@ -145,6 +154,7 @@
                       [
                         {
                           "name": "y",
+                          "nativeSrc": "119:1:1",
                           "nodeType": "YulTypedName",
                           "src": "119:1:1",
                           "type": ""

--- a/test/libsolidity/ASTJSON/assembly/stringlit.json
+++ b/test/libsolidity/ASTJSON/assembly/stringlit.json
@@ -39,17 +39,20 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "56:18:1",
                   "nodeType": "YulBlock",
                   "src": "56:18:1",
                   "statements":
                   [
                     {
+                      "nativeSrc": "58:14:1",
                       "nodeType": "YulVariableDeclaration",
                       "src": "58:14:1",
                       "value":
                       {
                         "hexValue": "616263",
                         "kind": "string",
+                        "nativeSrc": "67:5:1",
                         "nodeType": "YulLiteral",
                         "src": "67:5:1",
                         "type": "",
@@ -59,6 +62,7 @@
                       [
                         {
                           "name": "x",
+                          "nativeSrc": "62:1:1",
                           "nodeType": "YulTypedName",
                           "src": "62:1:1",
                           "type": ""

--- a/test/libsolidity/ASTJSON/assembly/stringlit_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/stringlit_parseOnly.json
@@ -26,17 +26,20 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "56:18:1",
                   "nodeType": "YulBlock",
                   "src": "56:18:1",
                   "statements":
                   [
                     {
+                      "nativeSrc": "58:14:1",
                       "nodeType": "YulVariableDeclaration",
                       "src": "58:14:1",
                       "value":
                       {
                         "hexValue": "616263",
                         "kind": "string",
+                        "nativeSrc": "67:5:1",
                         "nodeType": "YulLiteral",
                         "src": "67:5:1",
                         "type": "",
@@ -46,6 +49,7 @@
                       [
                         {
                           "name": "x",
+                          "nativeSrc": "62:1:1",
                           "nodeType": "YulTypedName",
                           "src": "62:1:1",
                           "type": ""

--- a/test/libsolidity/ASTJSON/assembly/switch.json
+++ b/test/libsolidity/ASTJSON/assembly/switch.json
@@ -39,16 +39,19 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "61:129:1",
                   "nodeType": "YulBlock",
                   "src": "61:129:1",
                   "statements":
                   [
                     {
+                      "nativeSrc": "75:10:1",
                       "nodeType": "YulVariableDeclaration",
                       "src": "75:10:1",
                       "value":
                       {
                         "kind": "number",
+                        "nativeSrc": "84:1:1",
                         "nodeType": "YulLiteral",
                         "src": "84:1:1",
                         "type": "",
@@ -58,6 +61,7 @@
                       [
                         {
                           "name": "v",
+                          "nativeSrc": "79:1:1",
                           "nodeType": "YulTypedName",
                           "src": "79:1:1",
                           "type": ""
@@ -70,16 +74,19 @@
                         {
                           "body":
                           {
+                            "nativeSrc": "139:10:1",
                             "nodeType": "YulBlock",
                             "src": "139:10:1",
                             "statements":
                             [
                               {
+                                "nativeSrc": "141:6:1",
                                 "nodeType": "YulAssignment",
                                 "src": "141:6:1",
                                 "value":
                                 {
                                   "kind": "number",
+                                  "nativeSrc": "146:1:1",
                                   "nodeType": "YulLiteral",
                                   "src": "146:1:1",
                                   "type": "",
@@ -89,6 +96,7 @@
                                 [
                                   {
                                     "name": "v",
+                                    "nativeSrc": "141:1:1",
                                     "nodeType": "YulIdentifier",
                                     "src": "141:1:1"
                                   }
@@ -96,11 +104,13 @@
                               }
                             ]
                           },
+                          "nativeSrc": "132:17:1",
                           "nodeType": "YulCase",
                           "src": "132:17:1",
                           "value":
                           {
                             "kind": "number",
+                            "nativeSrc": "137:1:1",
                             "nodeType": "YulLiteral",
                             "src": "137:1:1",
                             "type": "",
@@ -110,16 +120,19 @@
                         {
                           "body":
                           {
+                            "nativeSrc": "170:10:1",
                             "nodeType": "YulBlock",
                             "src": "170:10:1",
                             "statements":
                             [
                               {
+                                "nativeSrc": "172:6:1",
                                 "nodeType": "YulAssignment",
                                 "src": "172:6:1",
                                 "value":
                                 {
                                   "kind": "number",
+                                  "nativeSrc": "177:1:1",
                                   "nodeType": "YulLiteral",
                                   "src": "177:1:1",
                                   "type": "",
@@ -129,6 +142,7 @@
                                 [
                                   {
                                     "name": "v",
+                                    "nativeSrc": "172:1:1",
                                     "nodeType": "YulIdentifier",
                                     "src": "172:1:1"
                                   }
@@ -136,6 +150,7 @@
                               }
                             ]
                           },
+                          "nativeSrc": "162:18:1",
                           "nodeType": "YulCase",
                           "src": "162:18:1",
                           "value": "default"
@@ -147,12 +162,15 @@
                         "functionName":
                         {
                           "name": "calldatasize",
+                          "nativeSrc": "105:12:1",
                           "nodeType": "YulIdentifier",
                           "src": "105:12:1"
                         },
+                        "nativeSrc": "105:14:1",
                         "nodeType": "YulFunctionCall",
                         "src": "105:14:1"
                       },
+                      "nativeSrc": "98:82:1",
                       "nodeType": "YulSwitch",
                       "src": "98:82:1"
                     }

--- a/test/libsolidity/ASTJSON/assembly/switch_default.json
+++ b/test/libsolidity/ASTJSON/assembly/switch_default.json
@@ -39,6 +39,7 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "61:33:1",
                   "nodeType": "YulBlock",
                   "src": "61:33:1",
                   "statements":
@@ -49,15 +50,18 @@
                         {
                           "body":
                           {
+                            "nativeSrc": "79:2:1",
                             "nodeType": "YulBlock",
                             "src": "79:2:1",
                             "statements": []
                           },
+                          "nativeSrc": "72:9:1",
                           "nodeType": "YulCase",
                           "src": "72:9:1",
                           "value":
                           {
                             "kind": "number",
+                            "nativeSrc": "77:1:1",
                             "nodeType": "YulLiteral",
                             "src": "77:1:1",
                             "type": "",
@@ -67,10 +71,12 @@
                         {
                           "body":
                           {
+                            "nativeSrc": "90:2:1",
                             "nodeType": "YulBlock",
                             "src": "90:2:1",
                             "statements": []
                           },
+                          "nativeSrc": "82:10:1",
                           "nodeType": "YulCase",
                           "src": "82:10:1",
                           "value": "default"
@@ -79,11 +85,13 @@
                       "expression":
                       {
                         "kind": "number",
+                        "nativeSrc": "70:1:1",
                         "nodeType": "YulLiteral",
                         "src": "70:1:1",
                         "type": "",
                         "value": "0"
                       },
+                      "nativeSrc": "63:29:1",
                       "nodeType": "YulSwitch",
                       "src": "63:29:1"
                     }

--- a/test/libsolidity/ASTJSON/assembly/switch_default_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/switch_default_parseOnly.json
@@ -26,6 +26,7 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "61:33:1",
                   "nodeType": "YulBlock",
                   "src": "61:33:1",
                   "statements":
@@ -36,15 +37,18 @@
                         {
                           "body":
                           {
+                            "nativeSrc": "79:2:1",
                             "nodeType": "YulBlock",
                             "src": "79:2:1",
                             "statements": []
                           },
+                          "nativeSrc": "72:9:1",
                           "nodeType": "YulCase",
                           "src": "72:9:1",
                           "value":
                           {
                             "kind": "number",
+                            "nativeSrc": "77:1:1",
                             "nodeType": "YulLiteral",
                             "src": "77:1:1",
                             "type": "",
@@ -54,10 +58,12 @@
                         {
                           "body":
                           {
+                            "nativeSrc": "90:2:1",
                             "nodeType": "YulBlock",
                             "src": "90:2:1",
                             "statements": []
                           },
+                          "nativeSrc": "82:10:1",
                           "nodeType": "YulCase",
                           "src": "82:10:1",
                           "value": "default"
@@ -66,11 +72,13 @@
                       "expression":
                       {
                         "kind": "number",
+                        "nativeSrc": "70:1:1",
                         "nodeType": "YulLiteral",
                         "src": "70:1:1",
                         "type": "",
                         "value": "0"
                       },
+                      "nativeSrc": "63:29:1",
                       "nodeType": "YulSwitch",
                       "src": "63:29:1"
                     }

--- a/test/libsolidity/ASTJSON/assembly/switch_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/switch_parseOnly.json
@@ -26,16 +26,19 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "61:129:1",
                   "nodeType": "YulBlock",
                   "src": "61:129:1",
                   "statements":
                   [
                     {
+                      "nativeSrc": "75:10:1",
                       "nodeType": "YulVariableDeclaration",
                       "src": "75:10:1",
                       "value":
                       {
                         "kind": "number",
+                        "nativeSrc": "84:1:1",
                         "nodeType": "YulLiteral",
                         "src": "84:1:1",
                         "type": "",
@@ -45,6 +48,7 @@
                       [
                         {
                           "name": "v",
+                          "nativeSrc": "79:1:1",
                           "nodeType": "YulTypedName",
                           "src": "79:1:1",
                           "type": ""
@@ -57,16 +61,19 @@
                         {
                           "body":
                           {
+                            "nativeSrc": "139:10:1",
                             "nodeType": "YulBlock",
                             "src": "139:10:1",
                             "statements":
                             [
                               {
+                                "nativeSrc": "141:6:1",
                                 "nodeType": "YulAssignment",
                                 "src": "141:6:1",
                                 "value":
                                 {
                                   "kind": "number",
+                                  "nativeSrc": "146:1:1",
                                   "nodeType": "YulLiteral",
                                   "src": "146:1:1",
                                   "type": "",
@@ -76,6 +83,7 @@
                                 [
                                   {
                                     "name": "v",
+                                    "nativeSrc": "141:1:1",
                                     "nodeType": "YulIdentifier",
                                     "src": "141:1:1"
                                   }
@@ -83,11 +91,13 @@
                               }
                             ]
                           },
+                          "nativeSrc": "132:17:1",
                           "nodeType": "YulCase",
                           "src": "132:17:1",
                           "value":
                           {
                             "kind": "number",
+                            "nativeSrc": "137:1:1",
                             "nodeType": "YulLiteral",
                             "src": "137:1:1",
                             "type": "",
@@ -97,16 +107,19 @@
                         {
                           "body":
                           {
+                            "nativeSrc": "170:10:1",
                             "nodeType": "YulBlock",
                             "src": "170:10:1",
                             "statements":
                             [
                               {
+                                "nativeSrc": "172:6:1",
                                 "nodeType": "YulAssignment",
                                 "src": "172:6:1",
                                 "value":
                                 {
                                   "kind": "number",
+                                  "nativeSrc": "177:1:1",
                                   "nodeType": "YulLiteral",
                                   "src": "177:1:1",
                                   "type": "",
@@ -116,6 +129,7 @@
                                 [
                                   {
                                     "name": "v",
+                                    "nativeSrc": "172:1:1",
                                     "nodeType": "YulIdentifier",
                                     "src": "172:1:1"
                                   }
@@ -123,6 +137,7 @@
                               }
                             ]
                           },
+                          "nativeSrc": "162:18:1",
                           "nodeType": "YulCase",
                           "src": "162:18:1",
                           "value": "default"
@@ -134,12 +149,15 @@
                         "functionName":
                         {
                           "name": "calldatasize",
+                          "nativeSrc": "105:12:1",
                           "nodeType": "YulIdentifier",
                           "src": "105:12:1"
                         },
+                        "nativeSrc": "105:14:1",
                         "nodeType": "YulFunctionCall",
                         "src": "105:14:1"
                       },
+                      "nativeSrc": "98:82:1",
                       "nodeType": "YulSwitch",
                       "src": "98:82:1"
                     }

--- a/test/libsolidity/ASTJSON/assembly/var_access.json
+++ b/test/libsolidity/ASTJSON/assembly/var_access.json
@@ -81,16 +81,19 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "77:10:1",
                   "nodeType": "YulBlock",
                   "src": "77:10:1",
                   "statements":
                   [
                     {
+                      "nativeSrc": "79:6:1",
                       "nodeType": "YulAssignment",
                       "src": "79:6:1",
                       "value":
                       {
                         "kind": "number",
+                        "nativeSrc": "84:1:1",
                         "nodeType": "YulLiteral",
                         "src": "84:1:1",
                         "type": "",
@@ -100,6 +103,7 @@
                       [
                         {
                           "name": "x",
+                          "nativeSrc": "79:1:1",
                           "nodeType": "YulIdentifier",
                           "src": "79:1:1"
                         }

--- a/test/libsolidity/ASTJSON/assembly/var_access_parseOnly.json
+++ b/test/libsolidity/ASTJSON/assembly/var_access_parseOnly.json
@@ -59,16 +59,19 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "77:10:1",
                   "nodeType": "YulBlock",
                   "src": "77:10:1",
                   "statements":
                   [
                     {
+                      "nativeSrc": "79:6:1",
                       "nodeType": "YulAssignment",
                       "src": "79:6:1",
                       "value":
                       {
                         "kind": "number",
+                        "nativeSrc": "84:1:1",
                         "nodeType": "YulLiteral",
                         "src": "84:1:1",
                         "type": "",
@@ -78,6 +81,7 @@
                       [
                         {
                           "name": "x",
+                          "nativeSrc": "79:1:1",
                           "nodeType": "YulIdentifier",
                           "src": "79:1:1"
                         }

--- a/test/libsolidity/ASTJSON/yul_hex_literal.json
+++ b/test/libsolidity/ASTJSON/yul_hex_literal.json
@@ -39,17 +39,20 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "66:142:1",
                   "nodeType": "YulBlock",
                   "src": "66:142:1",
                   "statements":
                   [
                     {
+                      "nativeSrc": "80:15:1",
                       "nodeType": "YulVariableDeclaration",
                       "src": "80:15:1",
                       "value":
                       {
                         "hexValue": "74657374",
                         "kind": "string",
+                        "nativeSrc": "89:6:1",
                         "nodeType": "YulLiteral",
                         "src": "89:6:1",
                         "type": "",
@@ -59,6 +62,7 @@
                       [
                         {
                           "name": "a",
+                          "nativeSrc": "84:1:1",
                           "nodeType": "YulTypedName",
                           "src": "84:1:1",
                           "type": ""
@@ -66,12 +70,14 @@
                       ]
                     },
                     {
+                      "nativeSrc": "108:54:1",
                       "nodeType": "YulVariableDeclaration",
                       "src": "108:54:1",
                       "value":
                       {
                         "hexValue": "112233445566778899aabbccddeeff6677889900",
                         "kind": "string",
+                        "nativeSrc": "117:45:1",
                         "nodeType": "YulLiteral",
                         "src": "117:45:1",
                         "type": ""
@@ -80,6 +86,7 @@
                       [
                         {
                           "name": "b",
+                          "nativeSrc": "112:1:1",
                           "nodeType": "YulTypedName",
                           "src": "112:1:1",
                           "type": ""
@@ -87,12 +94,14 @@
                       ]
                     },
                     {
+                      "nativeSrc": "175:23:1",
                       "nodeType": "YulVariableDeclaration",
                       "src": "175:23:1",
                       "value":
                       {
                         "hexValue": "1234abcd",
                         "kind": "string",
+                        "nativeSrc": "184:14:1",
                         "nodeType": "YulLiteral",
                         "src": "184:14:1",
                         "type": ""
@@ -101,6 +110,7 @@
                       [
                         {
                           "name": "c",
+                          "nativeSrc": "179:1:1",
                           "nodeType": "YulTypedName",
                           "src": "179:1:1",
                           "type": ""

--- a/test/libsolidity/ASTJSON/yul_hex_literal_parseOnly.json
+++ b/test/libsolidity/ASTJSON/yul_hex_literal_parseOnly.json
@@ -26,17 +26,20 @@
               {
                 "AST":
                 {
+                  "nativeSrc": "66:142:1",
                   "nodeType": "YulBlock",
                   "src": "66:142:1",
                   "statements":
                   [
                     {
+                      "nativeSrc": "80:15:1",
                       "nodeType": "YulVariableDeclaration",
                       "src": "80:15:1",
                       "value":
                       {
                         "hexValue": "74657374",
                         "kind": "string",
+                        "nativeSrc": "89:6:1",
                         "nodeType": "YulLiteral",
                         "src": "89:6:1",
                         "type": "",
@@ -46,6 +49,7 @@
                       [
                         {
                           "name": "a",
+                          "nativeSrc": "84:1:1",
                           "nodeType": "YulTypedName",
                           "src": "84:1:1",
                           "type": ""
@@ -53,12 +57,14 @@
                       ]
                     },
                     {
+                      "nativeSrc": "108:54:1",
                       "nodeType": "YulVariableDeclaration",
                       "src": "108:54:1",
                       "value":
                       {
                         "hexValue": "112233445566778899aabbccddeeff6677889900",
                         "kind": "string",
+                        "nativeSrc": "117:45:1",
                         "nodeType": "YulLiteral",
                         "src": "117:45:1",
                         "type": ""
@@ -67,6 +73,7 @@
                       [
                         {
                           "name": "b",
+                          "nativeSrc": "112:1:1",
                           "nodeType": "YulTypedName",
                           "src": "112:1:1",
                           "type": ""
@@ -74,12 +81,14 @@
                       ]
                     },
                     {
+                      "nativeSrc": "175:23:1",
                       "nodeType": "YulVariableDeclaration",
                       "src": "175:23:1",
                       "value":
                       {
                         "hexValue": "1234abcd",
                         "kind": "string",
+                        "nativeSrc": "184:14:1",
                         "nodeType": "YulLiteral",
                         "src": "184:14:1",
                         "type": ""
@@ -88,6 +97,7 @@
                       [
                         {
                           "name": "c",
+                          "nativeSrc": "179:1:1",
                           "nodeType": "YulTypedName",
                           "src": "179:1:1",
                           "type": ""

--- a/test/solc/CommandLineParser.cpp
+++ b/test/solc/CommandLineParser.cpp
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(cli_mode_options)
 				"dir1/file1.sol:L=0x1234567890123456789012345678901234567890,"
 				"dir2/file2.sol:L=0x1111122222333334444455555666667777788888",
 			"--ast-compact-json", "--asm", "--asm-json", "--opcodes", "--bin", "--bin-runtime", "--abi",
-			"--ir", "--ir-optimized", "--hashes", "--userdoc", "--devdoc", "--metadata", "--storage-layout",
+			"--ir", "--ir-ast-json", "--ir-optimized", "--ir-optimized-ast-json", "--hashes", "--userdoc", "--devdoc", "--metadata", "--storage-layout",
 			"--gas",
 			"--combined-json="
 				"abi,metadata,bin,bin-runtime,opcodes,asm,storage-layout,generated-sources,generated-sources-runtime,"
@@ -192,7 +192,8 @@ BOOST_AUTO_TEST_CASE(cli_mode_options)
 		expectedOptions.compiler.outputs = {
 			true, true, true, true, true,
 			true, true, true, true, true,
-			true, true, true, true,
+			true, true, true, true, true,
+			true,
 		};
 		expectedOptions.compiler.estimateGas = true;
 		expectedOptions.compiler.combinedJsonRequests = {
@@ -290,6 +291,7 @@ BOOST_AUTO_TEST_CASE(assembly_mode_options)
 			"--asm",
 			"--bin",
 			"--ir-optimized",
+			"--ast-compact-json",
 		};
 		commandLine += assemblyOptions;
 		if (expectedLanguage == YulStack::Language::StrictAssembly)
@@ -329,6 +331,7 @@ BOOST_AUTO_TEST_CASE(assembly_mode_options)
 		expectedOptions.compiler.outputs.asm_ = true;
 		expectedOptions.compiler.outputs.binary = true;
 		expectedOptions.compiler.outputs.irOptimized = true;
+		expectedOptions.compiler.outputs.astCompactJson = true;
 		if (expectedLanguage == YulStack::Language::StrictAssembly)
 		{
 			expectedOptions.optimizer.enabled = true;


### PR DESCRIPTION
Adds:

- Command line output option`--ast-compact-json` with Yul input. This outputs the Yul AST in JSON compact format.
- Command line output options `--ir-ast-json` and `--ir-optimized-ast-json` with Solidity input. Those options will produce the AST of the Yul-IR and the optimized Yul-IR, respectively, in JSON compact format. 

Resolves #9590. Although #9590 was grouped with #13720 which appears to have other dependencies, #9590 itself is pretty straightforward and can be implemented similarly to the Solidity ASTs that are already present. 