### PR TITLE
Do not allocate memory on reverts with errors of small static encoding size.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,9 @@ Language Features:
 
 
 Compiler Features:
-* SMTChecker: Create balance check verification target for CHC engine.
+ * SMTChecker: Create balance check verification target for CHC engine.
+ * Yul IR Code Generation: Cheaper code for reverting with errors of a small static encoding size.
+
 
 Bugfixes:
  * Commandline Interface: Fix ICE when the optimizer is disabled and an empty/blank string is used for ``--yul-optimizations`` sequence.

--- a/test/cmdlineTests/require_with_error_ir/output
+++ b/test/cmdlineTests/require_with_error_ir/output
@@ -186,7 +186,9 @@ object "C_36" {
             function require_helper_t_error_7_CustomError_t_rational_1_by_1_t_stringliteral_332c39dcd398ea34a48b871898d589f55fc4c7bce00562fb670c972e7e1b0720(condition , expr_15) {
                 if iszero(condition)
                 {
+
                     let memPtr := allocate_unbounded()
+
                     mstore(memPtr, 0x97ea5a2f00000000000000000000000000000000000000000000000000000000)
                     let end := abi_encode_tuple_t_rational_1_by_1_t_stringliteral_332c39dcd398ea34a48b871898d589f55fc4c7bce00562fb670c972e7e1b0720__to_t_uint256_t_string_memory_ptr__fromStack(add(memPtr, 4) , expr_15)
                     revert(memPtr, sub(end, memPtr))
@@ -241,7 +243,9 @@ object "C_36" {
             function require_helper_t_error_7_CustomError_t_rational_2_by_1_t_stringliteral_89027a4db8d1d3a0787296eb1553fba0dc506f981f9697f1a66994c458d392b5(condition , expr_29) {
                 if iszero(condition)
                 {
+
                     let memPtr := allocate_unbounded()
+
                     mstore(memPtr, 0x97ea5a2f00000000000000000000000000000000000000000000000000000000)
                     let end := abi_encode_tuple_t_rational_2_by_1_t_stringliteral_89027a4db8d1d3a0787296eb1553fba0dc506f981f9697f1a66994c458d392b5__to_t_uint256_t_string_memory_ptr__fromStack(add(memPtr, 4) , expr_29)
                     revert(memPtr, sub(end, memPtr))

--- a/test/cmdlineTests/require_with_string_ir/output
+++ b/test/cmdlineTests/require_with_string_ir/output
@@ -228,7 +228,9 @@ object "C_28" {
             function require_helper_t_string_memory_ptr(condition , expr_12_mpos) {
                 if iszero(condition)
                 {
+
                     let memPtr := allocate_unbounded()
+
                     mstore(memPtr, 0x08c379a000000000000000000000000000000000000000000000000000000000)
                     let end := abi_encode_tuple_t_string_memory_ptr__to_t_string_memory_ptr__fromStack(add(memPtr, 4) , expr_12_mpos)
                     revert(memPtr, sub(end, memPtr))
@@ -266,7 +268,9 @@ object "C_28" {
             function require_helper_t_stringliteral_b25d43cff48de8365ad132c5f45b74f4593f9e69e5b749d86685f77282c88e46(condition ) {
                 if iszero(condition)
                 {
+
                     let memPtr := allocate_unbounded()
+
                     mstore(memPtr, 0x08c379a000000000000000000000000000000000000000000000000000000000)
                     let end := abi_encode_tuple_t_stringliteral_b25d43cff48de8365ad132c5f45b74f4593f9e69e5b749d86685f77282c88e46__to_t_string_memory_ptr__fromStack(add(memPtr, 4) )
                     revert(memPtr, sub(end, memPtr))

--- a/test/libsolidity/semanticTests/errors/errors_by_parameter_type.sol
+++ b/test/libsolidity/semanticTests/errors/errors_by_parameter_type.sol
@@ -1,0 +1,45 @@
+pragma abicoder v2;
+
+struct S {
+    uint256 a;
+    bool b;
+    string s;
+}
+
+error E();
+error E1(uint256);
+error E2(string);
+error E3(S);
+error E4(address);
+error E5(function() external pure);
+
+contract C {
+    function a() external pure {
+        require(false, E());
+    }
+    function b() external pure {
+        require(false, E1(1));
+    }
+    function c() external pure {
+        require(false, E2("string literal"));
+    }
+    function d() external pure {
+        require(false, E3(S(1, true, "string literal")));
+    }
+    function e() external view {
+        require(false, E4(address(this)));
+    }
+    function f() external view {
+        require(false, E5(this.a));
+    }
+}
+
+// ====
+// compileViaYul: true
+// ----
+// a() -> FAILURE, hex"92bbf6e8"
+// b() -> FAILURE, hex"47e26897", hex"0000000000000000000000000000000000000000000000000000000000000001"
+// c() -> FAILURE, hex"8f372c34", hex"0000000000000000000000000000000000000000000000000000000000000020", hex"000000000000000000000000000000000000000000000000000000000000000e", hex"737472696e67206c69746572616c000000000000000000000000000000000000"
+// d() -> FAILURE, hex"5717173e", hex"0000000000000000000000000000000000000000000000000000000000000020", hex"0000000000000000000000000000000000000000000000000000000000000001", hex"0000000000000000000000000000000000000000000000000000000000000001", hex"0000000000000000000000000000000000000000000000000000000000000060", hex"000000000000000000000000000000000000000000000000000000000000000e", hex"737472696e67206c69746572616c000000000000000000000000000000000000"
+// e() -> FAILURE, hex"7efef9ea", hex"000000000000000000000000c06afe3a8444fc0004668591e8306bfb9968e79e"
+// f() -> FAILURE, hex"0c3f12eb", hex"c06afe3a8444fc0004668591e8306bfb9968e79e0dbe671f0000000000000000"

--- a/test/libsolidity/semanticTests/errors/small_error_optimization.sol
+++ b/test/libsolidity/semanticTests/errors/small_error_optimization.sol
@@ -1,0 +1,22 @@
+error E();
+contract A {
+	uint8[] x;
+	function f() public {
+		for (uint i = 0; i < 100; ++i)
+			x.push(uint8(i));
+		revert E();
+	}
+}
+contract B {
+	function f() public {
+		(new A()).f();
+	}
+}
+// ----
+// f() -> FAILURE, hex"92bbf6e8"
+// gas irOptimized: 221918
+// gas irOptimized code: 42800
+// gas legacy: 233746
+// gas legacy code: 37400
+// gas legacyOptimized: 224864
+// gas legacyOptimized code: 34200


### PR DESCRIPTION
I guess lack of micro-optimization like this is what drives people to aggressively resort to inline assembly like in this case seen in https://github.com/ethereum/solidity/issues/13149