### PR TITLE
Fix gp2 external test script

### DIFF
--- a/test/externalTests/gp2.sh
+++ b/test/externalTests/gp2.sh
@@ -69,16 +69,6 @@ function gp2_test
     force_hardhat_unlimited_contract_size "$config_file" "$config_var"
     yarn
 
-    # New hardhat release breaks GP2 tests, and since GP2 repository has been archived, we are pinning hardhat
-    # to the previous stable version. See https://github.com/ethereum/solidity/pull/13485
-    yarn add hardhat@2.10.2
-    # hardhat-tenderly@1.2.0 and upwards break the build, hence we are pinning the version to the last stable one.
-    # See https://github.com/cowprotocol/contracts/issues/32
-    yarn add @tenderly/hardhat-tenderly@1.1.6
-
-    # Add missing sinon type definitions
-    yarn add @types/sinon
-
     # Some dependencies come with pre-built artifacts. We want to build from scratch.
     rm -r node_modules/@gnosis.pm/safe-contracts/build/
 


### PR DESCRIPTION
As https://github.com/cowprotocol/contracts/pull/49 was merged upstream and it fixed the version of `hardhat-tenderly` to `1.1.6`, updated `hardhat` to `2.13.1` and added `sinon` type definitions as explicit dependency, we don't need to keep these workarounds anymore.