### PR TITLE
docs: mention that `push0` also decreases the runtime costs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@ Language Features:
 
 
 Compiler Features:
- * Assembler: Use ``push0`` for placing ``0`` in the stack for EVM versions starting from "Shanghai". This decreases the deployment costs.
+ * Assembler: Use ``push0`` for placing ``0`` in the stack for EVM versions starting from "Shanghai". This decreases the deployment and runtime costs.
  * EVM: Set default EVM version to "Shanghai".
  * EVM: Support for the EVM Version "Shanghai".
  * NatSpec: Add support for NatSpec documentation in ``enum`` definitions.


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/pull/14107#discussion_r1163830306