### PR TITLE
Bump docker images and evmone version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,20 +9,20 @@ version: 2.1
 parameters:
   ubuntu-2004-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2004-18
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:db35d88a16f19adfac6dfd88bda4b32a85a82430f28830aad97bcd10fa4f846c"
+    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2004-19
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:9c7d3be930936a70f0340d5e9fa9a0b8bf69e11192e7e2d37807afe1b7f55534"
   ubuntu-2204-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2204-3
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:73e4e80128a0596c3ddb36e36e8039514a9f33ca8799bec82060a49b0cdae461"
+    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2204-4
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:7555c26c82fd0dcbc02cbd422b74468f8de1b7f2972b84fadcfa90f7371d6de5"
   ubuntu-2204-clang-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2204.clang-2
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:0d4fa1da806f9b3daabd2d1dc0842899af794a838e475c14045c3fb289cc8103"
+    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2204.clang-3
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:3d5efffd1e4c381041d1dff6331add86976373bde1c9dfca97ebd3d735e09dab"
   ubuntu-clang-ossfuzz-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu.clang.ossfuzz-23
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:7a84f67829ec2fdcfc8a61ebf22f9dc27b04a9edeb1531565ab3e0ebb1cbc4a0"
+    # solbuildpackpusher/solidity-buildpack-deps:ubuntu.clang.ossfuzz-1
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:d1bba750ab3f9ad9d28d45e332c2ec2126d248c1d619af369a3ef0c29f5936c3"
   emscripten-docker-image:
     type: string
     # solbuildpackpusher/solidity-buildpack-deps:emscripten-15

--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -73,10 +73,10 @@ then
   rm -r "$z3_dir"
 
   # evmone
-  evmone_version="0.9.1"
+  evmone_version="0.10.0"
   evmone_package="evmone-${evmone_version}-darwin-x86_64.tar.gz"
   wget "https://github.com/ethereum/evmone/releases/download/v${evmone_version}/${evmone_package}"
-  validate_checksum "$evmone_package" 70420a893a9b1036fcb63526b806d97658db8c373bcab1c3e8382594dc8593e4
+  validate_checksum "$evmone_package" 1b7773779287d7908baca6b8d556a98800cbd7d6e5c910b55fa507642bc0a15c
   tar xzpf "$evmone_package" -C /usr/local
   rm "$evmone_package"
 

--- a/scripts/install_evmone.ps1
+++ b/scripts/install_evmone.ps1
@@ -3,7 +3,7 @@ $ErrorActionPreference = "Stop"
 # Needed for Invoke-WebRequest to work via CI.
 $progressPreference = "silentlyContinue"
 
-Invoke-WebRequest -URI "https://github.com/ethereum/evmone/releases/download/v0.9.1/evmone-0.9.1-windows-amd64.zip" -OutFile "evmone.zip"
+Invoke-WebRequest -URI "https://github.com/ethereum/evmone/releases/download/v0.10.0/evmone-0.10.0-windows-amd64.zip" -OutFile "evmone.zip"
 tar -xf evmone.zip "bin/evmone.dll"
 mkdir deps
 mv bin/evmone.dll deps

--- a/test/Common.h
+++ b/test/Common.h
@@ -33,17 +33,17 @@ namespace solidity::test
 
 #ifdef _WIN32
 static constexpr auto evmoneFilename = "evmone.dll";
-static constexpr auto evmoneDownloadLink = "https://github.com/ethereum/evmone/releases/download/v0.9.1/evmone-0.9.1-windows-amd64.zip";
+static constexpr auto evmoneDownloadLink = "https://github.com/ethereum/evmone/releases/download/v0.10.0/evmone-0.10.0-windows-amd64.zip";
 static constexpr auto heraFilename = "hera.dll";
 static constexpr auto heraDownloadLink = "https://github.com/ewasm/hera/archive/v0.6.0.tar.gz";
 #elif defined(__APPLE__)
 static constexpr auto evmoneFilename = "libevmone.dylib";
-static constexpr auto evmoneDownloadLink = "https://github.com/ethereum/evmone/releases/download/v0.9.1/evmone-0.9.1-darwin-x86_64.tar.gz";
+static constexpr auto evmoneDownloadLink = "https://github.com/ethereum/evmone/releases/download/v0.10.0/evmone-0.10.0-darwin-x86_64.tar.gz";
 static constexpr auto heraFilename = "libhera.dylib";
 static constexpr auto heraDownloadLink = "https://github.com/ewasm/hera/releases/download/v0.6.0/hera-0.6.0-darwin-x86_64.tar.gz";
 #else
 static constexpr auto evmoneFilename = "libevmone.so";
-static constexpr auto evmoneDownloadLink = "https://github.com/ethereum/evmone/releases/download/v0.9.1/evmone-0.9.1-linux-x86_64.tar.gz";
+static constexpr auto evmoneDownloadLink = "https://github.com/ethereum/evmone/releases/download/v0.10.0/evmone-0.10.0-linux-x86_64.tar.gz";
 static constexpr auto heraFilename = "libhera.so";
 static constexpr auto heraDownloadLink = "https://github.com/ewasm/hera/releases/download/v0.6.0/hera-0.6.0-linux-x86_64.tar.gz";
 #endif

--- a/test/libsolidity/semanticTests/abiEncoderV2/abi_encode_v2_in_function_inherited_in_v1_contract.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/abi_encode_v2_in_function_inherited_in_v1_contract.sol
@@ -30,6 +30,6 @@ contract C is B {
 }
 // ----
 // test() -> 77
-// gas irOptimized: 119155
-// gas legacy: 151834
-// gas legacyOptimized: 110339
+// gas irOptimized: 119177
+// gas legacy: 151866
+// gas legacyOptimized: 110359

--- a/test/libsolidity/semanticTests/abiEncoderV2/abi_encode_v2_in_modifier_used_in_v1_contract.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/abi_encode_v2_in_modifier_used_in_v1_contract.sol
@@ -39,4 +39,4 @@ contract C is B {
 // ----
 // test() -> 5, 10
 // gas irOptimized: 87337
-// gas legacy: 102637
+// gas legacy: 102651

--- a/test/libsolidity/semanticTests/arithmetics/check_var_init.sol
+++ b/test/libsolidity/semanticTests/arithmetics/check_var_init.sol
@@ -16,4 +16,4 @@ contract D {
 // ----
 // f() -> FAILURE, hex"4e487b71", 0x11
 // g(), 100 wei -> 1
-// gas legacy: 100370
+// gas legacy: 100388

--- a/test/libsolidity/semanticTests/array/fixed_arrays_as_return_type.sol
+++ b/test/libsolidity/semanticTests/array/fixed_arrays_as_return_type.sol
@@ -19,6 +19,6 @@ contract B {
 
 // ----
 // f() -> 2, 3, 4, 5, 6, 1000, 1001, 1002, 1003, 1004
-// gas irOptimized: 115808
-// gas legacy: 229947
-// gas legacyOptimized: 130613
+// gas irOptimized: 115828
+// gas legacy: 230001
+// gas legacyOptimized: 130637

--- a/test/libsolidity/semanticTests/array/function_array_cross_calls.sol
+++ b/test/libsolidity/semanticTests/array/function_array_cross_calls.sol
@@ -43,6 +43,6 @@ contract C {
 
 // ----
 // test() -> 5, 6, 7
-// gas irOptimized: 260837
-// gas legacy: 441446
-// gas legacyOptimized: 279259
+// gas irOptimized: 260895
+// gas legacy: 441556
+// gas legacyOptimized: 279321

--- a/test/libsolidity/semanticTests/array/reusing_memory.sol
+++ b/test/libsolidity/semanticTests/array/reusing_memory.sol
@@ -24,6 +24,6 @@ contract Main {
 }
 // ----
 // f(uint256): 0x34 -> 0x46bddb1178e94d7f2892ff5f366840eb658911794f2c3a44c450aa2c505186c1
-// gas irOptimized: 112147
-// gas legacy: 125140
-// gas legacyOptimized: 113000
+// gas irOptimized: 112161
+// gas legacy: 125162
+// gas legacyOptimized: 113012

--- a/test/libsolidity/semanticTests/constructor/arrays_in_constructors.sol
+++ b/test/libsolidity/semanticTests/constructor/arrays_in_constructors.sol
@@ -24,6 +24,6 @@ contract Creator {
 }
 // ----
 // f(uint256,address[]): 7, 0x40, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 -> 7, 8
-// gas irOptimized: 429076
-// gas legacy: 581281
-// gas legacyOptimized: 444496
+// gas irOptimized: 429160
+// gas legacy: 581443
+// gas legacyOptimized: 444588

--- a/test/libsolidity/semanticTests/constructor/bytes_in_constructors_packer.sol
+++ b/test/libsolidity/semanticTests/constructor/bytes_in_constructors_packer.sol
@@ -24,6 +24,6 @@ contract Creator {
 }
 // ----
 // f(uint256,bytes): 7, 0x40, 78, "abcdefghijklmnopqrstuvwxyzabcdef", "ghijklmnopqrstuvwxyzabcdefghijkl", "mnopqrstuvwxyz" -> 7, "h"
-// gas irOptimized: 278448
-// gas legacy: 418282
-// gas legacyOptimized: 291665
+// gas irOptimized: 278528
+// gas legacy: 418462
+// gas legacyOptimized: 291755

--- a/test/libsolidity/semanticTests/constructor/constructor_function_complex.sol
+++ b/test/libsolidity/semanticTests/constructor/constructor_function_complex.sol
@@ -17,4 +17,4 @@ contract C {
 }
 // ----
 // f() -> 16
-// gas legacy: 102040
+// gas legacy: 102082

--- a/test/libsolidity/semanticTests/constructor/no_callvalue_check.sol
+++ b/test/libsolidity/semanticTests/constructor/no_callvalue_check.sol
@@ -17,6 +17,6 @@ contract C {
 }
 // ----
 // f(), 2000 ether -> true
-// gas irOptimized: 119451
-// gas legacy: 122615
-// gas legacyOptimized: 122484
+// gas irOptimized: 119457
+// gas legacy: 122621
+// gas legacyOptimized: 122490

--- a/test/libsolidity/semanticTests/events/event_emit_from_other_contract.sol
+++ b/test/libsolidity/semanticTests/events/event_emit_from_other_contract.sol
@@ -15,8 +15,8 @@ contract C {
 }
 // ----
 // constructor() ->
-// gas irOptimized: 165390
-// gas legacy: 244780
-// gas legacyOptimized: 171605
+// gas irOptimized: 165398
+// gas legacy: 244800
+// gas legacyOptimized: 171615
 // deposit(bytes32), 18 wei: 0x1234 ->
 // ~ emit Deposit(address,bytes32,uint256) from 0x137aa4dfc0911524504fcd4d98501f179bc13b4a: #0xc06afe3a8444fc0004668591e8306bfb9968e79e, #0x1234, 0x00

--- a/test/libsolidity/semanticTests/freeFunctions/new_operator.sol
+++ b/test/libsolidity/semanticTests/freeFunctions/new_operator.sol
@@ -13,4 +13,4 @@ contract D {
 }
 // ----
 // f() -> 2
-// gas legacy: 100201
+// gas legacy: 100211

--- a/test/libsolidity/semanticTests/functionCall/creation_function_call_no_args.sol
+++ b/test/libsolidity/semanticTests/functionCall/creation_function_call_no_args.sol
@@ -11,4 +11,4 @@ contract D {
 }
 // ----
 // f() -> 2
-// gas legacy: 100175
+// gas legacy: 100185

--- a/test/libsolidity/semanticTests/functionCall/creation_function_call_with_args.sol
+++ b/test/libsolidity/semanticTests/functionCall/creation_function_call_with_args.sol
@@ -15,7 +15,7 @@ contract D {
 }
 // ----
 // constructor(): 2 ->
-// gas irOptimized: 193985
-// gas legacy: 241212
-// gas legacyOptimized: 192949
+// gas irOptimized: 193999
+// gas legacy: 241234
+// gas legacyOptimized: 192961
 // f() -> 2

--- a/test/libsolidity/semanticTests/functionCall/creation_function_call_with_salt.sol
+++ b/test/libsolidity/semanticTests/functionCall/creation_function_call_with_salt.sol
@@ -17,7 +17,7 @@ contract D {
 // EVMVersion: >=constantinople
 // ----
 // constructor(): 2 ->
-// gas irOptimized: 194148
-// gas legacy: 241584
-// gas legacyOptimized: 193181
+// gas irOptimized: 194162
+// gas legacy: 241606
+// gas legacyOptimized: 193193
 // f() -> 2

--- a/test/libsolidity/semanticTests/functionCall/gas_and_value_basic.sol
+++ b/test/libsolidity/semanticTests/functionCall/gas_and_value_basic.sol
@@ -39,9 +39,9 @@ contract test {
 
 // ----
 // constructor(), 20 wei ->
-// gas irOptimized: 260040
-// gas legacy: 391566
-// gas legacyOptimized: 268079
+// gas irOptimized: 260052
+// gas legacy: 391588
+// gas legacyOptimized: 268089
 // sendAmount(uint256): 5 -> 5
 // outOfGas() -> FAILURE # call to helper should not succeed but amount should be transferred anyway #
 // checkState() -> false, 15

--- a/test/libsolidity/semanticTests/functionCall/gas_and_value_brace_syntax.sol
+++ b/test/libsolidity/semanticTests/functionCall/gas_and_value_brace_syntax.sol
@@ -38,9 +38,9 @@ contract test {
 
 // ----
 // constructor(), 20 wei ->
-// gas irOptimized: 260040
-// gas legacy: 391566
-// gas legacyOptimized: 268079
+// gas irOptimized: 260052
+// gas legacy: 391588
+// gas legacyOptimized: 268089
 // sendAmount(uint256): 5 -> 5
 // outOfGas() -> FAILURE # call to helper should not succeed but amount should be transferred anyway #
 // checkState() -> false, 15

--- a/test/libsolidity/semanticTests/functionTypes/store_function.sol
+++ b/test/libsolidity/semanticTests/functionTypes/store_function.sol
@@ -27,5 +27,5 @@ contract C {
 // ----
 // t() -> 9
 // gas irOptimized: 99064
-// gas legacy: 149071
-// gas legacyOptimized: 106176
+// gas legacy: 149095
+// gas legacyOptimized: 106188

--- a/test/libsolidity/semanticTests/immutable/multi_creation.sol
+++ b/test/libsolidity/semanticTests/immutable/multi_creation.sol
@@ -27,8 +27,8 @@ contract C {
 }
 // ----
 // f() -> 3, 7, 5
-// gas irOptimized: 124829
-// gas legacy: 148500
-// gas legacyOptimized: 123951
+// gas irOptimized: 124849
+// gas legacy: 148528
+// gas legacyOptimized: 123971
 // x() -> 7
 // y() -> 5

--- a/test/libsolidity/semanticTests/inheritance/address_overload_resolution.sol
+++ b/test/libsolidity/semanticTests/inheritance/address_overload_resolution.sol
@@ -22,7 +22,7 @@ contract D {
 // ----
 // f() -> 1
 // gas irOptimized: 77051
-// gas legacy: 112260
+// gas legacy: 112280
 // g() -> 5
 // gas irOptimized: 77106
-// gas legacy: 112796
+// gas legacy: 112816

--- a/test/libsolidity/semanticTests/inheritance/inherited_function_calldata_calldata_interface.sol
+++ b/test/libsolidity/semanticTests/inheritance/inherited_function_calldata_calldata_interface.sol
@@ -24,4 +24,4 @@ contract B {
 // ----
 // g() -> 42
 // gas irOptimized: 80813
-// gas legacy: 122447
+// gas legacy: 122471

--- a/test/libsolidity/semanticTests/inheritance/inherited_function_calldata_memory_interface.sol
+++ b/test/libsolidity/semanticTests/inheritance/inherited_function_calldata_memory_interface.sol
@@ -23,6 +23,6 @@ contract B {
 
 // ----
 // g() -> 42
-// gas irOptimized: 100266
-// gas legacy: 180398
-// gas legacyOptimized: 112576
+// gas irOptimized: 100282
+// gas legacy: 180440
+// gas legacyOptimized: 112596

--- a/test/libsolidity/semanticTests/inheritance/member_notation_ctor.sol
+++ b/test/libsolidity/semanticTests/inheritance/member_notation_ctor.sol
@@ -20,6 +20,6 @@ contract A {
 
 // ----
 // g(int256): -1 -> -1
-// gas legacy: 102064
+// gas legacy: 102086
 // g(int256): 10 -> 10
-// gas legacy: 101692
+// gas legacy: 101714

--- a/test/libsolidity/semanticTests/inheritance/value_for_constructor.sol
+++ b/test/libsolidity/semanticTests/inheritance/value_for_constructor.sol
@@ -40,9 +40,9 @@ contract Main {
 
 // ----
 // constructor(), 22 wei ->
-// gas irOptimized: 266864
-// gas legacy: 392744
-// gas legacyOptimized: 261611
+// gas irOptimized: 266886
+// gas legacy: 392786
+// gas legacyOptimized: 261633
 // getFlag() -> true
 // getName() -> "abc"
 // getBalances() -> 12, 10

--- a/test/libsolidity/semanticTests/isoltestTesting/balance_other_contract.sol
+++ b/test/libsolidity/semanticTests/isoltestTesting/balance_other_contract.sol
@@ -16,9 +16,9 @@ contract ClientReceipt {
 }
 // ----
 // constructor(), 2000 wei ->
-// gas irOptimized: 171859
-// gas legacy: 230026
-// gas legacyOptimized: 173877
+// gas irOptimized: 171865
+// gas legacy: 230038
+// gas legacyOptimized: 173883
 // balance -> 1500
 // gas irOptimized: 191881
 // gas legacy: 235167

--- a/test/libsolidity/semanticTests/operators/userDefined/operator_making_pure_external_call.sol
+++ b/test/libsolidity/semanticTests/operators/userDefined/operator_making_pure_external_call.sol
@@ -52,10 +52,10 @@ contract C {
 }
 // ----
 // testMul(int32,int32): 42, 10 -> 420
-// gas irOptimized: 102545
-// gas legacy: 183939
-// gas legacyOptimized: 123539
+// gas irOptimized: 102563
+// gas legacy: 183981
+// gas legacyOptimized: 123563
 // testInc(int32): 42 -> 43
-// gas irOptimized: 102368
-// gas legacy: 183197
-// gas legacyOptimized: 123227
+// gas irOptimized: 102386
+// gas legacy: 183239
+// gas legacyOptimized: 123251

--- a/test/libsolidity/semanticTests/operators/userDefined/operator_making_view_external_call.sol
+++ b/test/libsolidity/semanticTests/operators/userDefined/operator_making_view_external_call.sol
@@ -58,10 +58,10 @@ contract C {
 }
 // ----
 // testMul(int32,int32): 42, 10 -> 420
-// gas irOptimized: 102545
-// gas legacy: 183939
-// gas legacyOptimized: 123539
+// gas irOptimized: 102563
+// gas legacy: 183981
+// gas legacyOptimized: 123563
 // testInc(int32): 42 -> 43
-// gas irOptimized: 102368
-// gas legacy: 183197
-// gas legacyOptimized: 123227
+// gas irOptimized: 102386
+// gas legacy: 183239
+// gas legacyOptimized: 123251

--- a/test/libsolidity/semanticTests/salted_create/prediction_example.sol
+++ b/test/libsolidity/semanticTests/salted_create/prediction_example.sol
@@ -26,4 +26,4 @@ contract C {
 // compileViaYul: also
 // ----
 // createDSalted(bytes32,uint256): 42, 64 ->
-// gas legacy: 102921
+// gas legacy: 102943

--- a/test/libsolidity/semanticTests/salted_create/salted_create.sol
+++ b/test/libsolidity/semanticTests/salted_create/salted_create.sol
@@ -23,4 +23,4 @@ contract A {
 // same_salt() -> true
 // gas irOptimized: 98438897
 // gas legacy: 98439109
-// gas legacyOptimized: 98438966
+// gas legacyOptimized: 98438967

--- a/test/libsolidity/semanticTests/salted_create/salted_create_with_value.sol
+++ b/test/libsolidity/semanticTests/salted_create/salted_create_with_value.sol
@@ -21,6 +21,6 @@ contract A {
 // EVMVersion: >=constantinople
 // ----
 // f(), 10 ether -> 3007, 3008, 3009
-// gas irOptimized: 254190
-// gas legacy: 380967
-// gas legacyOptimized: 279640
+// gas irOptimized: 254238
+// gas legacy: 381063
+// gas legacyOptimized: 279694

--- a/test/libsolidity/semanticTests/smoke/alignment.sol
+++ b/test/libsolidity/semanticTests/smoke/alignment.sol
@@ -25,5 +25,5 @@ contract D {
 // stateDecimal() -> right(42)
 // stateBytes() -> left(0x4200ef)
 // internalStateDecimal() -> 0x20
-// gas legacy: 100255
+// gas legacy: 100265
 // update(bool,uint256,bytes32): false, -23, left(0x2300ef) -> false, -23, left(0x2300ef)

--- a/test/libsolidity/semanticTests/using/using_global_invisible.sol
+++ b/test/libsolidity/semanticTests/using/using_global_invisible.sol
@@ -40,4 +40,4 @@ contract D {
 // ----
 // library: "A":L
 // test() -> 3
-// gas legacy: 120859
+// gas legacy: 120881

--- a/test/libsolidity/semanticTests/various/code_access_content.sol
+++ b/test/libsolidity/semanticTests/various/code_access_content.sol
@@ -38,6 +38,6 @@ contract C {
 }
 // ----
 // testRuntime() -> true
-// gas legacy: 100165
+// gas legacy: 100177
 // testCreation() -> true
-// gas legacy: 100588
+// gas legacy: 100600

--- a/test/libsolidity/semanticTests/various/code_access_create.sol
+++ b/test/libsolidity/semanticTests/various/code_access_create.sol
@@ -24,4 +24,4 @@ contract C {
 
 // ----
 // test() -> 7
-// gas legacy: 100839
+// gas legacy: 100849

--- a/test/libsolidity/semanticTests/various/code_access_runtime.sol
+++ b/test/libsolidity/semanticTests/various/code_access_runtime.sol
@@ -24,4 +24,4 @@ contract C {
 // EVMVersion: >=constantinople
 // ----
 // test() -> 42
-// gas legacy: 100225
+// gas legacy: 100235

--- a/test/libsolidity/semanticTests/various/external_types_in_calls.sol
+++ b/test/libsolidity/semanticTests/various/external_types_in_calls.sol
@@ -25,5 +25,5 @@ contract C {
 
 // ----
 // test() -> 9, 7
-// gas legacy: 127478
+// gas legacy: 127514
 // t2() -> 9

--- a/test/libsolidity/semanticTests/various/selfdestruct.sol
+++ b/test/libsolidity/semanticTests/various/selfdestruct.sol
@@ -30,9 +30,9 @@ contract D {
 }
 // ----
 // constructor(), 1 ether ->
-// gas irOptimized: 186962
-// gas legacy: 255963
-// gas legacyOptimized: 178911
+// gas irOptimized: 186970
+// gas legacy: 255973
+// gas legacyOptimized: 178919
 // c() -> 0x137aa4dfc0911524504fcd4d98501f179bc13b4a
 // balance: 0x137aa4dfc0911524504fcd4d98501f179bc13b4a -> 1000000000000000000
 // balance -> 0

--- a/test/libsolidity/semanticTests/various/senders_balance.sol
+++ b/test/libsolidity/semanticTests/various/senders_balance.sol
@@ -17,7 +17,7 @@ contract D {
 
 // ----
 // constructor(), 27 wei ->
-// gas irOptimized: 169371
-// gas legacy: 218447
-// gas legacyOptimized: 167286
+// gas irOptimized: 169377
+// gas legacy: 218459
+// gas legacyOptimized: 167292
 // f() -> 27

--- a/test/libsolidity/semanticTests/various/staticcall_for_view_and_pure.sol
+++ b/test/libsolidity/semanticTests/various/staticcall_for_view_and_pure.sol
@@ -35,7 +35,7 @@ contract D {
 // EVMVersion: >=byzantium
 // ----
 // f() -> 0x1 # This should work, next should throw #
-// gas legacy: 102085
+// gas legacy: 102095
 // fview() -> FAILURE
 // gas irOptimized: 98438596
 // gas legacy: 98438774

--- a/test/libsolidity/semanticTests/various/value_complex.sol
+++ b/test/libsolidity/semanticTests/various/value_complex.sol
@@ -20,7 +20,7 @@ contract test {
 
 // ----
 // constructor(), 20 wei ->
-// gas irOptimized: 174345
-// gas legacy: 252286
-// gas legacyOptimized: 180346
+// gas irOptimized: 174351
+// gas legacy: 252296
+// gas legacyOptimized: 180352
 // sendAmount(uint256): 5 -> 8

--- a/test/libsolidity/semanticTests/various/value_insane.sol
+++ b/test/libsolidity/semanticTests/various/value_insane.sol
@@ -19,7 +19,7 @@ contract test {
 
 // ----
 // constructor(), 20 wei ->
-// gas irOptimized: 175209
-// gas legacy: 253810
-// gas legacyOptimized: 180778
+// gas irOptimized: 175215
+// gas legacy: 253820
+// gas legacyOptimized: 180784
 // sendAmount(uint256): 5 -> 8


### PR DESCRIPTION
Switches to the images built in https://github.com/ethereum/solidity/pull/14199 and bumps the evmone version whereever else it's left for bumping.