### PR TITLE
Add readthedocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,18 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+
+formats:
+  - pdf
+  - epub
+
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
The docs builds started to fail https://readthedocs.org/projects/solidity/builds/20585241/ due to the drop of support for `OpenSSL<1.1.1` in urllib3 (see: https://github.com/urllib3/urllib3/issues/2168) and the fact that readthedocs uses python `3.7`  by default.

This PR adds the readthedocs settings to the repo and update the python version to `3.11` so the docs can be built again.

