### PR TITLE
Ensure gettext/envsubst is installed on the docker buildpack-deps images

### DIFF
--- a/scripts/docker/buildpack-deps/Dockerfile.emscripten
+++ b/scripts/docker/buildpack-deps/Dockerfile.emscripten
@@ -33,13 +33,13 @@
 # Using $(em-config CACHE)/sysroot/usr seems to work, though, and still has cmake find the
 # dependencies automatically.
 FROM emscripten/emsdk:3.1.19 AS base
-LABEL version="15"
+LABEL version="16"
 
 ADD emscripten.jam /usr/src
 RUN set -ex && \
 	\
 	apt-get update && \
-	apt-get install lz4 --no-install-recommends && \
+	apt-get install lz4 gettext-base --no-install-recommends && \
 	\
 	cd /usr/src && \
 	git clone https://github.com/Z3Prover/z3.git -b z3-4.12.1 --depth 1 && \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu.clang.ossfuzz
@@ -22,13 +22,13 @@
 # (c) 2016-2021 solidity contributors.
 #------------------------------------------------------------------------------
 FROM gcr.io/oss-fuzz-base/base-clang:latest as base
-LABEL version="1"
+LABEL version="2"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update; \
 	apt-get -qqy install --no-install-recommends \
-		build-essential \
+		build-essential gettext-base \
 		software-properties-common \
 		ninja-build git wget \
 		libbz2-dev zlib1g-dev git curl uuid-dev \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:focal AS base
-LABEL version="19"
+LABEL version="20"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -32,7 +32,7 @@ RUN set -ex; \
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1c52189c923f6ca9 ; \
 	apt-get update; \
 	apt-get install -qqy --no-install-recommends \
-		build-essential \
+		build-essential gettext-base \
 		software-properties-common \
 		cmake ninja-build \
 		libboost-filesystem-dev libboost-test-dev libboost-system-dev \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:jammy AS base
-LABEL version="4"
+LABEL version="5"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -32,7 +32,7 @@ RUN set -ex; \
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1c52189c923f6ca9 ; \
 	apt-get update; \
 	apt-get install -qqy --no-install-recommends \
-		build-essential \
+		build-essential gettext-base \
 		software-properties-common \
 		cmake ninja-build \
 		libboost-filesystem-dev libboost-test-dev libboost-system-dev \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204.clang
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204.clang
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:jammy AS base
-LABEL version="3"
+LABEL version="4"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -32,7 +32,7 @@ RUN set -ex; \
 	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1c52189c923f6ca9 ; \
 	apt-get update; \
 	apt-get install -qqy --no-install-recommends \
-		build-essential \
+		build-essential gettext-base \
 		software-properties-common \
 		cmake ninja-build \
 		libboost-filesystem-dev libboost-test-dev libboost-system-dev \


### PR DESCRIPTION
The `envsubst` command used by the `matrix_notification` script is not always present in all docker images (see: https://app.circleci.com/pipelines/github/ethereum/solidity/29747/workflows/f794b73b-c603-4bf5-8c2d-5397521b4580/jobs/1321683/parallel-runs/1/steps/1-112)

This PR adds it to all Ubuntu images not only the `b_ems` that was the one missing it. Luckily, `envsubst` is already present in the MacOS images and Windows images that has `bash` as default shell.