### PR TITLE
Add sudo to buildpack-deps images

### DIFF
--- a/scripts/docker/buildpack-deps/Dockerfile.emscripten
+++ b/scripts/docker/buildpack-deps/Dockerfile.emscripten
@@ -33,13 +33,13 @@
 # Using $(em-config CACHE)/sysroot/usr seems to work, though, and still has cmake find the
 # dependencies automatically.
 FROM emscripten/emsdk:3.1.19 AS base
-LABEL version="15"
+LABEL version="16"
 
 ADD emscripten.jam /usr/src
 RUN set -ex && \
 	\
 	apt-get update && \
-	apt-get install lz4 --no-install-recommends && \
+	apt-get install lz4 sudo --no-install-recommends && \
 	\
 	cd /usr/src && \
 	git clone https://github.com/Z3Prover/z3.git -b z3-4.12.1 --depth 1 && \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu.clang.ossfuzz
@@ -22,13 +22,13 @@
 # (c) 2016-2021 solidity contributors.
 #------------------------------------------------------------------------------
 FROM gcr.io/oss-fuzz-base/base-clang:latest as base
-LABEL version="1"
+LABEL version="2"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update; \
 	apt-get -qqy install --no-install-recommends \
-		build-essential \
+		build-essential sudo \
 		software-properties-common \
 		ninja-build git wget \
 		libbz2-dev zlib1g-dev git curl uuid-dev \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:focal AS base
-LABEL version="19"
+LABEL version="20"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -32,7 +32,7 @@ RUN set -ex; \
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1c52189c923f6ca9 ; \
 	apt-get update; \
 	apt-get install -qqy --no-install-recommends \
-		build-essential \
+		build-essential sudo \
 		software-properties-common \
 		cmake ninja-build \
 		libboost-filesystem-dev libboost-test-dev libboost-system-dev \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:jammy AS base
-LABEL version="4"
+LABEL version="5"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -32,7 +32,7 @@ RUN set -ex; \
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1c52189c923f6ca9 ; \
 	apt-get update; \
 	apt-get install -qqy --no-install-recommends \
-		build-essential \
+		build-essential sudo \
 		software-properties-common \
 		cmake ninja-build \
 		libboost-filesystem-dev libboost-test-dev libboost-system-dev \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204.clang
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204.clang
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:jammy AS base
-LABEL version="3"
+LABEL version="4"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -32,7 +32,7 @@ RUN set -ex; \
 	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1c52189c923f6ca9 ; \
 	apt-get update; \
 	apt-get install -qqy --no-install-recommends \
-		build-essential \
+		build-essential sudo \
 		software-properties-common \
 		cmake ninja-build \
 		libboost-filesystem-dev libboost-test-dev libboost-system-dev \


### PR DESCRIPTION
Some images lack the `sudo` command. This PR adds it to all builder images so they are compatible with the `cimg` images provided by CircleCI: https://circleci.com/docs/circleci-images/#pre-installed-tools

`sudo` is required to fix the installation of `envsubst` in the `matrix_notification` command mentioned in https://github.com/ethereum/solidity/pull/14219#issue-1707892328, since this command is used by many different jobs with different base images (i.e. the builder images and the CircleCI `cimg`) which may or may not have `sudo`. Thus, installing without `sudo` works for the builder images but not for the `cimg`, failing with `permission denied`, while the opposite fails with `command not found` for the builder images but works for the `cimg` (which is the scenario that this PR fixes).

I will open another PR switching the docker images in the CI and fixing this issue https://app.circleci.com/pipelines/github/ethereum/solidity/29747/workflows/f794b73b-c603-4bf5-8c2d-5397521b4580/jobs/1321683/parallel-runs/1/steps/1-112