### PR TITLE
Ensure gettext/envsubst installed in GNU/Linux images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,24 +9,24 @@ version: 2.1
 parameters:
   ubuntu-2004-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2004-19
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:9c7d3be930936a70f0340d5e9fa9a0b8bf69e11192e7e2d37807afe1b7f55534"
+    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2004-20
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:7a1e1b01eda0d1e20704279672bcfd53dbbc481898ff960958a225dea76345bd"
   ubuntu-2204-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2204-4
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:7555c26c82fd0dcbc02cbd422b74468f8de1b7f2972b84fadcfa90f7371d6de5"
+    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2204-5
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:4df420b7ccd96f540a4300a4fae0fcac2f4d3f23ffff9e3777c1f2d7c37ef901"
   ubuntu-2204-clang-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2204.clang-3
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:3d5efffd1e4c381041d1dff6331add86976373bde1c9dfca97ebd3d735e09dab"
+    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2204.clang-4
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:538596bf55961197f8b5670d8a6742d9bcd502b6a1045ae9d372cdf35ce69d93"
   ubuntu-clang-ossfuzz-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu.clang.ossfuzz-1
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:d1bba750ab3f9ad9d28d45e332c2ec2126d248c1d619af369a3ef0c29f5936c3"
+    # solbuildpackpusher/solidity-buildpack-deps:ubuntu.clang.ossfuzz-2
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:a4fc3a41240c3bc58882d3f504e446c6931b547119012f5c45f79b0df91dbdd1"
   emscripten-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:emscripten-15
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:e2729bd6c0734bb49d04e2688fec3dcf880394f351f69358dd2bd92c0f6fd309"
+    # solbuildpackpusher/solidity-buildpack-deps:emscripten-16
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:19fcb5ac029bbc27ec36e10f7d14ea224d8010145f9690562ef084fd16146b0c"
   evm-version:
     type: string
     default: london

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,23 @@ commands:
         type: string
     steps:
       - run:
+          name: Ensure envsubst is installed
+          command: |
+            os_family="$(uname -s | tr '[:upper:]' '[:lower:]')"
+            if [[ "$os_family" == "linux" ]]
+            then
+              os="$(grep --regexp '^ID=' /etc/os-release | cut --characters=4-)"
+              case "$os" in
+                ubuntu)
+                  sudo apt-get update
+                  sudo apt-get install --quiet --yes gettext-base
+                  ;;
+                arch)
+                  sudo pacman --quiet --sync --noconfirm gettext
+                  ;;
+              esac
+            fi
+      - run:
           name: "Matrix notification"
           when: << parameters.condition >>
           command: scripts/ci/notification/matrix_notification.sh << parameters.event >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ commands:
     steps:
       - run:
           name: Ensure envsubst is installed
+          when: << parameters.condition >>
           command: |
             os_family="$(uname -s | tr '[:upper:]' '[:lower:]')"
             if [[ "$os_family" == "linux" ]]

--- a/scripts/ci/notification/matrix_notification.sh
+++ b/scripts/ci/notification/matrix_notification.sh
@@ -27,6 +27,7 @@ function notify() {
     curl "https://${MATRIX_SERVER}/_matrix/client/v3/rooms/${MATRIX_NOTIFY_ROOM_ID}/send/m.room.message" \
         --request POST \
         --include \
+        --fail \
         --header "Content-Type: application/json" \
         --header "Accept: application/json" \
         --header "Authorization: Bearer ${MATRIX_ACCESS_TOKEN}" \

--- a/scripts/ci/notification/matrix_notification.sh
+++ b/scripts/ci/notification/matrix_notification.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -euo pipefail
-shopt -s inherit_errexit
 
 SCRIPT_DIR="$(dirname "$0")"
 


### PR DESCRIPTION
Depends on #14228 

Install missing dependence used by the `matrix_notification` script. The script started to fail in some Linux-based images that didn't have `envsubst` installed.

This PR also removes `inherit_errexit` which is not required anymore and does not seem to be supported by default in MacOS bash installation.

Note that `uname` will be available in both `macos` and `windows` (when using bash as default shell).

~TODO: I will update the `config.yml` with the new docker images as soon GH finishes to build them.~