### PR TITLE
Disallow initialization of immutables in for loops and conditionals

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * Immutables: Disallow initialization of immutables in for loops and ternary expressions.
  * SMTChecker: Fix encoding of side-effects inside ``if`` and ``ternary conditional``statements in the BMC engine.
 
 

--- a/libsolidity/analysis/ImmutableValidator.h
+++ b/libsolidity/analysis/ImmutableValidator.h
@@ -50,11 +50,13 @@ public:
 
 private:
 	bool visit(Assignment const& _assignment);
+	bool visit(Conditional const& _conditional);
 	bool visit(FunctionDefinition const& _functionDefinition);
 	bool visit(ModifierDefinition const& _modifierDefinition);
 	bool visit(MemberAccess const& _memberAccess);
 	bool visit(IfStatement const& _ifStatement);
 	bool visit(WhileStatement const& _whileStatement);
+	bool visit(ForStatement const& _forStatement);
 	bool visit(TryStatement const& _tryStatement);
 	void endVisit(IdentifierPath const& _identifierPath);
 	void endVisit(Identifier const& _identifier);

--- a/test/libsolidity/syntaxTests/immutable/conditionally_initialized.sol
+++ b/test/libsolidity/syntaxTests/immutable/conditionally_initialized.sol
@@ -6,4 +6,4 @@ contract C {
     }
 }
 // ----
-// TypeError 4599: (86-87): Cannot write to immutable here: Immutable variables cannot be initialized inside an if statement.
+// TypeError 4599: (86-87): Cannot write to immutable here: Immutable variables cannot be initialized inside a conditional (if/ternary) statement.

--- a/test/libsolidity/syntaxTests/immutable/for_loop_initialized.sol
+++ b/test/libsolidity/syntaxTests/immutable/for_loop_initialized.sol
@@ -1,0 +1,12 @@
+contract C {
+    uint immutable x;
+    constructor() {
+        for (x = 1; x < 10; ++x)
+            x = 5;
+    }
+}
+
+// ----
+// TypeError 6672: (68-69): Cannot write to immutable here: Immutable variables cannot be initialized inside a loop.
+// TypeError 6672: (85-86): Cannot write to immutable here: Immutable variables cannot be initialized inside a loop.
+// TypeError 6672: (100-101): Cannot write to immutable here: Immutable variables cannot be initialized inside a loop.

--- a/test/libsolidity/syntaxTests/immutable/ternary_initialized.sol
+++ b/test/libsolidity/syntaxTests/immutable/ternary_initialized.sol
@@ -1,0 +1,15 @@
+contract A
+{
+    uint256 immutable x;
+    uint256 y = 0;
+
+    constructor(bool _branch)
+    {
+        _branch ? x = 1 : y = 2;
+        _branch ? y = 3 : x = 4;
+    }
+}
+
+// ----
+// TypeError 4599: (112-113): Cannot write to immutable here: Immutable variables cannot be initialized inside a conditional (if/ternary) statement.
+// TypeError 4599: (153-154): Cannot write to immutable here: Immutable variables cannot be initialized inside a conditional (if/ternary) statement.


### PR DESCRIPTION
Pending decision of whether we fix this and then relax the immutable initialization restrictions, or just relax the restrictions right away (in which case this will be closed).