### PR TITLE
Fix intermittent error in `install_foundry` command 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,7 @@ commands:
               --silent \
               --fail \
               --show-error \
+              --header "Authorization: Bearer ${GITHUB_ACCESS_TOKEN}" \
               "https://api.github.com/repos/${FOUNDRY_REPO}/git/refs/tags/${FOUNDRY_VERSION}" \
               | jq --raw-output .object.sha \
             )

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -571,6 +571,8 @@ defaults:
   # Parameterized Job Templates
 
   # Separate compile-only runs of those external tests where a full run takes much longer.
+  # Also see https://github.com/ethereum/solidity/pull/14234 for why we excluded those
+  # external tests from the nightly jobs.
   - job_ems_compile_ext_colony: &job_ems_compile_ext_colony
       <<: *requires_b_ems
       name: t_ems_compile_ext_colony


### PR DESCRIPTION
The `install_foundry` command fails from time to time with the following error: https://app.circleci.com/pipelines/github/ethereum/solidity/29819/workflows/8bf56b71-d3c4-48ca-ab74-4264020b4886/jobs/1324702?invite=true#step-103-17

```
curl: (22) The requested URL returned error: 403
```

I suspect that this is due to the fact that we are not doing authenticated request to github in this specific CI job, and consequently hitting the limit of request per hour that Github imposes on unauthenticated requests (see: https://docs.github.com/en/rest/overview/authenticating-to-the-rest-api?apiVersion=2022-11-28).

This PR fixes that by adding the `Authorization` header to the request to the Github API. It also adds a missing comment to the `job_ems_compile_ext_colony` as mentioned here https://github.com/ethereum/solidity/pull/14234#discussion_r1196315143, which is unrelated but it is simple enough to be changed together I think.