### PR TITLE
Remove redundant Yul optimization from `IRGenerator`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@ Bugfixes:
  * Commandline Interface: It is no longer possible to specify both ``--optimize-yul`` and ``--no-optimize-yul`` at the same time.
  * SMTChecker: Fix encoding of side-effects inside ``if`` and ``ternary conditional``statements in the BMC engine.
  * SMTChecker: Fix false negative when a verification target can be violated only by trusted external call from another public function.
+ * Yul Optimizer: Fix optimized IR being unnecessarily passed through the Yul optimizer again before bytecode generation.
 
 AST Changes:
  * AST: Add the ``experimentalSolidity`` field to the ``SourceUnit`` nodes, which indicate whether the experimental parsing mode has been enabled via ``pragma experimental solidity``.

--- a/libsolidity/codegen/ir/IRGenerationContext.h
+++ b/libsolidity/codegen/ir/IRGenerationContext.h
@@ -23,7 +23,6 @@
 
 #include <libsolidity/ast/AST.h>
 #include <libsolidity/codegen/ir/IRVariable.h>
-#include <libsolidity/interface/OptimiserSettings.h>
 #include <libsolidity/interface/DebugSettings.h>
 
 #include <libsolidity/codegen/MultiUseYulFunctionCollector.h>
@@ -73,7 +72,6 @@ public:
 		langutil::EVMVersion _evmVersion,
 		ExecutionContext _executionContext,
 		RevertStrings _revertStrings,
-		OptimiserSettings _optimiserSettings,
 		std::map<std::string, unsigned> _sourceIndices,
 		langutil::DebugInfoSelection const& _debugInfoSelection,
 		langutil::CharStreamProvider const* _soliditySourceProvider
@@ -81,7 +79,6 @@ public:
 		m_evmVersion(_evmVersion),
 		m_executionContext(_executionContext),
 		m_revertStrings(_revertStrings),
-		m_optimiserSettings(std::move(_optimiserSettings)),
 		m_sourceIndices(std::move(_sourceIndices)),
 		m_debugInfoSelection(_debugInfoSelection),
 		m_soliditySourceProvider(_soliditySourceProvider)
@@ -176,7 +173,6 @@ private:
 	langutil::EVMVersion m_evmVersion;
 	ExecutionContext m_executionContext;
 	RevertStrings m_revertStrings;
-	OptimiserSettings m_optimiserSettings;
 	std::map<std::string, unsigned> m_sourceIndices;
 	std::set<std::string> m_usedSourceNames;
 	ContractDefinition const* m_mostDerivedContract = nullptr;

--- a/libsolidity/codegen/ir/IRGenerator.h
+++ b/libsolidity/codegen/ir/IRGenerator.h
@@ -23,7 +23,6 @@
 
 #pragma once
 
-#include <libsolidity/interface/OptimiserSettings.h>
 #include <libsolidity/ast/ASTForward.h>
 #include <libsolidity/ast/CallGraph.h>
 #include <libsolidity/codegen/ir/IRGenerationContext.h>
@@ -50,19 +49,16 @@ public:
 		langutil::EVMVersion _evmVersion,
 		std::optional<uint8_t> _eofVersion,
 		RevertStrings _revertStrings,
-		OptimiserSettings _optimiserSettings,
 		std::map<std::string, unsigned> _sourceIndices,
 		langutil::DebugInfoSelection const& _debugInfoSelection,
 		langutil::CharStreamProvider const* _soliditySourceProvider
 	):
 		m_evmVersion(_evmVersion),
 		m_eofVersion(_eofVersion),
-		m_optimiserSettings(_optimiserSettings),
 		m_context(
 			_evmVersion,
 			ExecutionContext::Creation,
 			_revertStrings,
-			std::move(_optimiserSettings),
 			std::move(_sourceIndices),
 			_debugInfoSelection,
 			_soliditySourceProvider
@@ -70,9 +66,8 @@ public:
 		m_utils(_evmVersion, m_context.revertStrings(), m_context.functionCollector())
 	{}
 
-	/// Generates and returns the IR code, in unoptimized and optimized form
-	/// (or just pretty-printed, depending on the optimizer settings).
-	std::tuple<std::string, Json::Value, std::string, Json::Value> run(
+	/// Generates and returns (unoptimized) IR code.
+	std::string run(
 		ContractDefinition const& _contract,
 		bytes const& _cborMetadata,
 		std::map<ContractDefinition const*, std::string_view const> const& _otherYulSources
@@ -143,7 +138,6 @@ private:
 
 	langutil::EVMVersion const m_evmVersion;
 	std::optional<uint8_t> const m_eofVersion;
-	OptimiserSettings const m_optimiserSettings;
 
 	IRGenerationContext m_context;
 	YulUtilFunctions m_utils;

--- a/test/cmdlineTests/~via_ir_equivalence/test.sh
+++ b/test/cmdlineTests/~via_ir_equivalence/test.sh
@@ -33,7 +33,8 @@ function test_via_ir_equivalence()
     for yul_file in $(find . -name "${output_file_prefix}*.yul" | sort -V); do
         asm_output_two_stage+=$(
             msg_on_error --no-stderr \
-                "$SOLC" --strict-assembly --asm "${optimizer_flags[@]}" "$yul_file" | stripCLIDecorations
+                "$SOLC" --strict-assembly --asm "${optimizer_flags[@]}" --no-optimize-yul "$yul_file" |
+                    stripCLIDecorations
         )
     done
 
@@ -50,7 +51,8 @@ function test_via_ir_equivalence()
     for yul_file in $(find . -name "${output_file_prefix}*.yul" | sort -V); do
         bin_output_two_stage+=$(
             msg_on_error --no-stderr \
-                "$SOLC" --strict-assembly --bin "${optimizer_flags[@]}" "$yul_file" | stripCLIDecorations
+                "$SOLC" --strict-assembly --bin "${optimizer_flags[@]}" "$yul_file" --no-optimize-yul |
+                    stripCLIDecorations
         )
     done
 


### PR DESCRIPTION
~Depends on #14149.~ Merged.
Together with #14268 fixes #14241.

~Temporarily includes commits from #14268 (until that PR is merged).~ Merged.