### PR TITLE
Bump  buildpack-deps images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ parameters:
     default: "solbuildpackpusher/solidity-buildpack-deps@sha256:a4fc3a41240c3bc58882d3f504e446c6931b547119012f5c45f79b0df91dbdd1"
   emscripten-docker-image:
     type: string
+    # NOTE: Please remember to update the `build_emscripten.sh` whenever the hash of this image changes.
     # solbuildpackpusher/solidity-buildpack-deps:emscripten-16
     default: "solbuildpackpusher/solidity-buildpack-deps@sha256:19fcb5ac029bbc27ec36e10f7d14ea224d8010145f9690562ef084fd16146b0c"
   evm-version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,24 +9,24 @@ version: 2.1
 parameters:
   ubuntu-2004-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2004-19
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:9c7d3be930936a70f0340d5e9fa9a0b8bf69e11192e7e2d37807afe1b7f55534"
+    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2004-20
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:7a1e1b01eda0d1e20704279672bcfd53dbbc481898ff960958a225dea76345bd"
   ubuntu-2204-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2204-4
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:7555c26c82fd0dcbc02cbd422b74468f8de1b7f2972b84fadcfa90f7371d6de5"
+    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2204-5
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:4df420b7ccd96f540a4300a4fae0fcac2f4d3f23ffff9e3777c1f2d7c37ef901"
   ubuntu-2204-clang-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2204.clang-3
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:3d5efffd1e4c381041d1dff6331add86976373bde1c9dfca97ebd3d735e09dab"
+    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2204.clang-4
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:538596bf55961197f8b5670d8a6742d9bcd502b6a1045ae9d372cdf35ce69d93"
   ubuntu-clang-ossfuzz-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu.clang.ossfuzz-1
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:d1bba750ab3f9ad9d28d45e332c2ec2126d248c1d619af369a3ef0c29f5936c3"
+    # solbuildpackpusher/solidity-buildpack-deps:ubuntu.clang.ossfuzz-2
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:a4fc3a41240c3bc58882d3f504e446c6931b547119012f5c45f79b0df91dbdd1"
   emscripten-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:emscripten-15
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:e2729bd6c0734bb49d04e2688fec3dcf880394f351f69358dd2bd92c0f6fd309"
+    # solbuildpackpusher/solidity-buildpack-deps:emscripten-16
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:19fcb5ac029bbc27ec36e10f7d14ea224d8010145f9690562ef084fd16146b0c"
   evm-version:
     type: string
     default: london

--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -33,9 +33,9 @@ if (( $# != 0 )); then
     params="$(printf "%q " "${@}")"
 fi
 
-# solbuildpackpusher/solidity-buildpack-deps:emscripten-15
+# solbuildpackpusher/solidity-buildpack-deps:emscripten-16
 # NOTE: Without `safe.directory` git would assume it's not safe to operate on /root/project since it's owned by a different user.
 # See https://github.blog/2022-04-12-git-security-vulnerability-announced/
 docker run -v "$(pwd):/root/project" -w /root/project \
-    solbuildpackpusher/solidity-buildpack-deps@sha256:f86cb1fb4631b1fbb927149f60caea7b095be5b85d379456eee09cb105e7f225 \
+    solbuildpackpusher/solidity-buildpack-deps@sha256:19fcb5ac029bbc27ec36e10f7d14ea224d8010145f9690562ef084fd16146b0c \
     /bin/bash -c "git config --global --add safe.directory /root/project && ./scripts/ci/build_emscripten.sh ${params}"


### PR DESCRIPTION
Depends on https://github.com/ethereum/solidity/pull/14228.

Not really necessary, but it would be nice to keep some consistence of the tools installed by default in our images with the CircleCI `cimg` that we also use.