### PR TITLE
Clean up via-IR equivalence command-line test

### DIFF
--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -321,6 +321,7 @@ function test_via_ir_equivalence()
     local optimize_flag="$2"
     [[ $optimize_flag == --optimize || $optimize_flag == "" ]] || assertFail "The second argument must be --optimize if present."
 
+    local output_file_prefix
     output_file_prefix=$(basename "$1" .sol)
 
     local optimizer_flags=()
@@ -329,7 +330,7 @@ function test_via_ir_equivalence()
 
     msg_on_error --no-stderr "$SOLC" --ir-optimized --debug-info location "${optimizer_flags[@]}" "$solidity_file" |
         sed '/^Optimized IR:$/d' |
-        split_on_empty_lines_into_numbered_files $output_file_prefix ".yul"
+        split_on_empty_lines_into_numbered_files "$output_file_prefix" ".yul"
 
     for yul_file in $(find . -name "${output_file_prefix}*.yul" | sort -V); do
         msg_on_error --no-stderr "$SOLC" --strict-assembly --asm "${optimizer_flags[@]}" "$yul_file" |

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -339,7 +339,7 @@ function test_via_ir_equivalence()
 
     local asm_output_two_stage asm_output_via_ir
     for asm_file in $(find . -name "${output_file_prefix}*.asm" | sort -V); do
-        asm_output_two_stage+=$(sed '/^asm_output_two_stage:$/d' "$asm_file" | sed '/^=======/d')
+        asm_output_two_stage+=$(sed '/^=======/d')
     done
 
     asm_output_via_ir=$(

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -317,14 +317,9 @@ function test_via_ir_equivalence()
     pushd "$SOLTMPDIR" > /dev/null
 
     (( $# <= 2 )) || fail "This function accepts at most two arguments."
-
-    if [[ $2 != --optimize ]] && [[ $2 != "" ]]
-    then
-        fail "The second argument must be --optimize if present."
-    fi
-
     local solidity_file="$1"
     local optimize_flag="$2"
+    [[ $optimize_flag == --optimize || $optimize_flag == "" ]] || assertFail "The second argument must be --optimize if present."
 
     output_file_prefix=$(basename "$1" .sol)
 


### PR DESCRIPTION
A bunch of refactors extracted from #14243. No changes in functionality.

It can be reviewed and merged separately, so I want to get it out of the way.