### PR TITLE
Prefer authenticated request to github api when the token is available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,11 +128,15 @@ commands:
           command: |
             FOUNDRY_REPO="foundry-rs/foundry"
             FOUNDRY_VERSION="<< parameters.version >>"
+            # Make authenticated requests when the Github token is available
+            if [[ -n "$GITHUB_ACCESS_TOKEN" ]]; then
+              EXTRA_HEADERS=(--header 'Authorization: Bearer '"${GITHUB_ACCESS_TOKEN}")
+            fi
             FOUNDRY_RELEASE_SHA=$(curl \
               --silent \
               --fail \
               --show-error \
-              --header "Authorization: Bearer ${GITHUB_ACCESS_TOKEN}" \
+              "${EXTRA_HEADERS[@]}" \
               "https://api.github.com/repos/${FOUNDRY_REPO}/git/refs/tags/${FOUNDRY_VERSION}" \
               | jq --raw-output .object.sha \
             )


### PR DESCRIPTION
The PR https://github.com/ethereum/solidity/pull/14242 changed the `install_foundry` command to perform authenticated requests to the Github API when querying the foundry release SHA hash, since unauthenticated requests have a lower limit of requests per hour, which was causing intermittent failures.

However, external contributors do not have access to the GITHUB_ACCESS_TOKEN environment variable set in the CircleCI project settings, and thus fail to perform the authenticated request to the Github API:
https://app.circleci.com/pipelines/github/ethereum/solidity/29901/workflows/d2d574cb-6624-486f-904b-598b20118606/jobs/1328298

This PR changes the previous behavior to only add the `Authorization` header when the GITHUB_ACCESS_TOKEN is available.