### PR TITLE
Make `--no-optimize-yul` disable `optimizeStackAllocation`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * Commandline Interface: ``--no-optimize-yul`` would not disable optimized stack allocation (unlike setting ``settings.optimizer.details.yul`` to ``false`` in Standard JSON).
  * Commandline Interface: It is no longer possible to specify both ``--optimize-yul`` and ``--no-optimize-yul`` at the same time.
  * SMTChecker: Fix encoding of side-effects inside ``if`` and ``ternary conditional``statements in the BMC engine.
 

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -265,6 +265,7 @@ OptimiserSettings CommandLineOptions::optimiserSettings() const
 
 	if (optimizer.noOptimizeYul)
 		settings.runYulOptimiser = false;
+	settings.optimizeStackAllocation = settings.runYulOptimiser;
 
 	if (optimizer.expectedExecutionsPerDeployment.has_value())
 		settings.expectedExecutionsPerDeployment = optimizer.expectedExecutionsPerDeployment.value();


### PR DESCRIPTION
A fix for a small bug I noticed while restoring `--no-optimize-yul` option for #14243.

On the CLI `--no-optimize-yul` does not disable `OptimiserSettings::optimizeStackAllocation` while `settings.optimizer.details.yul: false` in Standard JSON does: https://github.com/ethereum/solidity/blob/4a1dbdaedb652ea649a4238038354f26486693bc/libsolidity/interface/StandardCompiler.cpp#L598

This is technically a breaking change but I think we should treat it as a bugfix - these two options clearly should be equivalent.