### PR TITLE
Update natspec-format.rst : Added structs and enums to Tags

### DIFF
--- a/docs/natspec-format.rst
+++ b/docs/natspec-format.rst
@@ -115,10 +115,10 @@ in the same way as if it were tagged with ``@notice``.
 =============== ====================================================================================== =============================
 Tag                                                                                                    Context
 =============== ====================================================================================== =============================
-``@title``      A title that should describe the contract/interface                                    contract, library, interface
-``@author``     The name of the author                                                                 contract, library, interface
-``@notice``     Explain to an end user what this does                                                  contract, library, interface, function, public state variable, event
-``@dev``        Explain to a developer any extra details                                               contract, library, interface, function, state variable, event
+``@title``      A title that should describe the contract/interface                                    contract, library, interface, structs, enums
+``@author``     The name of the author                                                                 contract, library, interface, structs, enums
+``@notice``     Explain to an end user what this does                                                  contract, library, interface, function, public state variable, event, structs, enums
+``@dev``        Explain to a developer any extra details                                               contract, library, interface, function, state variable, event, structs, enums
 ``@param``      Documents a parameter just like in Doxygen (must be followed by parameter name)        function, event
 ``@return``     Documents the return variables of a contract's function                                function, public state variable
 ``@inheritdoc`` Copies all missing tags from the base function (must be followed by the contract name) function, public state variable

--- a/docs/natspec-format.rst
+++ b/docs/natspec-format.rst
@@ -115,10 +115,10 @@ in the same way as if it were tagged with ``@notice``.
 =============== ====================================================================================== =============================
 Tag                                                                                                    Context
 =============== ====================================================================================== =============================
-``@title``      A title that should describe the contract/interface                                    contract, library, interface, structs, enums
-``@author``     The name of the author                                                                 contract, library, interface, structs, enums
-``@notice``     Explain to an end user what this does                                                  contract, library, interface, function, public state variable, event, structs, enums
-``@dev``        Explain to a developer any extra details                                               contract, library, interface, function, state variable, event, structs, enums
+``@title``      A title that should describe the contract/interface                                    contract, library, interface, struct, enum
+``@author``     The name of the author                                                                 contract, library, interface, struct, enum
+``@notice``     Explain to an end user what this does                                                  contract, library, interface, function, public state variable, event, struct, enum
+``@dev``        Explain to a developer any extra details                                               contract, library, interface, function, state variable, event, struct, enum
 ``@param``      Documents a parameter just like in Doxygen (must be followed by parameter name)        function, event
 ``@return``     Documents the return variables of a contract's function                                function, public state variable
 ``@inheritdoc`` Copies all missing tags from the base function (must be followed by the contract name) function, public state variable


### PR DESCRIPTION
Added structs and enums to `@title`, `@author`, `@notice`, and `@dev` in [Tags](https://docs.soliditylang.org/en/v0.8.20/natspec-format.html#tags) table in  [NatSpec Format](https://docs.soliditylang.org/en/v0.8.20/natspec-format.html#tags), 
as per [v0.8.20 release notes](https://github.com/ethereum/solidity/releases/tag/v0.8.20).

Fixes #14217