### PR TITLE
Fix mistake about default value for inliner setting in docs

### DIFF
--- a/docs/internals/optimizer.rst
+++ b/docs/internals/optimizer.rst
@@ -27,7 +27,7 @@ optimized Yul IR for a Solidity source. Similarly, one can use ``solc --strict-a
 for a stand-alone Yul mode.
 
 .. note::
-    The `peephole optimizer <https://en.wikipedia.org/wiki/Peephole_optimization>`_ and the inliner are always
+    The `peephole optimizer <https://en.wikipedia.org/wiki/Peephole_optimization>`_ is always
     enabled by default and can only be turned off via the :ref:`Standard JSON <compiler-api>`.
 
 You can find more details on both optimizer modules and their optimization steps below.

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -153,8 +153,8 @@ explanatory purposes.
             "constantOptimizer": false,
             "cse": false,
             "deduplicate": false,
-            // inliner defaults to "true"
-            "inliner": true,
+            // inliner defaults to "false"
+            "inliner": false,
             // jumpdestRemover defaults to "true"
             "jumpdestRemover": true,
             "orderLiterals": false,

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -272,9 +272,9 @@ Input Description
             // The peephole optimizer is always on if no details are given,
             // use details to switch it off.
             "peephole": true,
-            // The inliner is always on if no details are given,
-            // use details to switch it off.
-            "inliner": true,
+            // The inliner is always off if no details are given,
+            // use details to switch it on.
+            "inliner": false,
             // The unused jumpdest remover is always on if no details are given,
             // use details to switch it off.
             "jumpdestRemover": true,


### PR DESCRIPTION
FIx a problem identified by @cameel in our docs. The `inliner` is always **off** by default, not the opposite.