### PR TITLE
Change installation documentation for Arch Linux

### DIFF
--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -132,11 +132,13 @@ The nightly version can be installed using these commands:
 Furthermore, some Linux distributions provide their own packages. These packages are not directly
 maintained by us but usually kept up-to-date by the respective package maintainers.
 
-For example, Arch Linux has packages for the latest development version:
+For example, Arch Linux has packages for the latest development version as AUR packages: `solidity <https://aur.archlinux.org/packages/solidity>`_
+and `solidity-bin <https://aur.archlinux.org/packages/solidity-bin>`_.
 
-.. code-block:: bash
+.. note::
 
-    pacman -S solidity
+    Please be aware that `AUR <https://wiki.archlinux.org/title/Arch_User_Repository>`_ packages
+    are user-produced content and unofficial packages. Exercise caution when using them.
 
 There is also a `snap package <https://snapcraft.io/solc>`_, however, it is **currently unmaintained**.
 It is installable in all the `supported Linux distros <https://snapcraft.io/docs/core/install>`_. To


### PR DESCRIPTION
## Page

https://docs.soliditylang.org/en/latest/installing-solidity.html#linux-packages

## Description

According to [2d5142adfcc33148b9208083c09e21547a044abd](https://github.com/archlinux/svntogit-community/commit/2d5142adfcc33148b9208083c09e21547a044abd), `solidity` official package was removed. This changes Solidity's documentation to reference the two packages added in Arch User Repository (AUR), [solidity](https://aur.archlinux.org/packages/solidity) and [solidity-bin](https://aur.archlinux.org/packages/solidity-bin).