### PR TITLE
CLI and Standard JSON equivalence tests

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -121,7 +121,7 @@ function assertFail
 
 function msg_on_error
 {
-    local error_message
+    local error_message=""
     local no_stdout=false
     local no_stderr=false
 

--- a/scripts/common_cmdline.sh
+++ b/scripts/common_cmdline.sh
@@ -103,3 +103,30 @@ function compileFull
         false
     fi
 }
+
+function stripCLIDecorations
+{
+    sed -e '/^=======.*=======$/d' \
+        -e '/^Binary:$/d' \
+        -e '/^Binary of the runtime part:$/d' \
+        -e '/^Opcodes:$/d' \
+        -e '/^IR:$/d' \
+        -e '/^Optimized IR:$/d' \
+        -e '/^EVM assembly:$/d' \
+        -e '/^JSON AST (compact format):$/d' \
+        -e '/^Function signatures:$/d' \
+        -e '/^Contract Storage Layout:$/d' \
+        -e '/^Developer Documentation$/d' \
+        -e '/^User Documentation$/d' \
+        -e '/^Contract JSON ABI$/d' \
+        -e '/^Metadata:$/d' \
+        -e '/^EVM$/d' \
+        -e '/^Pretty printed source:$/d' \
+        -e '/^Text representation:$/d' \
+        -e '/^Binary representation:$/d'
+}
+
+function stripEmptyLines
+{
+    sed -e '/^\s*$/d'
+}

--- a/test/cmdlineTests/~cli_and_standard_json_equivalence/test.sh
+++ b/test/cmdlineTests/~cli_and_standard_json_equivalence/test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=scripts/common.sh
+source "${REPO_ROOT}/scripts/common.sh"
+# shellcheck source=scripts/common_cmdline.sh
+source "${REPO_ROOT}/scripts/common_cmdline.sh"
+
+function test_cli_and_standard_json_equivalence
+{
+    (( $# == 5 )) || assertFail
+    local cli_options="$1"
+    local selected_cli_output="$2"
+    local standard_json_settings="$3"
+    local selected_standard_json_output="$4"
+    local input_file_relative_path="$5"
+
+    # CLI normalizes paths, Standard JSON uses them as is. Using paths that would change under this
+    # normalization will make the comparison fail. To avoid this use already normalized paths.
+    # The sanity check below should reject most of these by disallowing absolute paths, relative
+    # paths with ./ or ../ segments and paths with redundant slashes, but keep in mind it's not foolproof.
+    [[ $input_file_relative_path =~ ^/|^\.$|\./|^\.\.$|\.\./|// ]] && assertfail
+
+    local cli_output standard_json_output
+    cli_output=$(
+        # shellcheck disable=SC2086 # Intentionally unquoted. May contain multiple options.
+        msg_on_error --no-stderr \
+            "$SOLC" $cli_options "$selected_cli_output" "$input_file_relative_path"
+    )
+    standard_json_output=$(
+        singleContractOutputViaStandardJSON \
+            Solidity \
+            "$selected_standard_json_output" \
+            "$standard_json_settings" \
+            "$input_file_relative_path"
+    )
+
+    diff_values \
+        "$(echo "$cli_output" | stripCLIDecorations | stripEmptyLines)" \
+        "$(echo "$standard_json_output" | stripEmptyLines)" \
+        --ignore-space-change \
+        --ignore-blank-lines
+}
+
+cd "$REPO_ROOT"
+
+printTask "    - --optimize vs optimizer.enabled: true (--asm output)"
+test_cli_and_standard_json_equivalence \
+    '--optimize' \
+    '--asm' \
+    '"optimizer": {"enabled": true}' \
+    'evm.assembly' \
+    "test/libsolidity/semanticTests/various/erc20.sol"
+
+printTask "    - --optimize-yul vs optimizer.details.yul: true (--asm output)"
+test_cli_and_standard_json_equivalence \
+    '--optimize-yul' \
+    '--asm' \
+    '"optimizer": {"enabled": false, "details": {"yul": true}}' \
+    'evm.assembly' \
+    "test/libsolidity/semanticTests/various/erc20.sol"


### PR DESCRIPTION
Mentioned in https://github.com/ethereum/solidity/pull/14268#issuecomment-1571037857.
~Depends on #14268.~ Merged.

We don't really have any tests checking whether CLI options properly map to Standard JSON settings. Even in a PR like #14268 I basically assumed that they match, but did not really check because it's quite tedious. In this particular case turned out to be not exactly true (it was off due to the difference in `stackAllocation` handling), as pointed out by @aarlt.

I actually already modified `cmdlineTests.sh` for #14243 to be able to compile via Standard JSON, and that's the main thing needed to have such a test. In the end I did not include that in the PR because it turned out to be easier to do viaIR comparison via the CLI, but we could still use it for a CLI vs Standard JSON comparison.