### PR TITLE
Disable gp2 tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1681,7 +1681,8 @@ workflows:
       - t_ext: *job_native_test_ext_prb_math
       - t_ext: *job_native_test_ext_elementfi
       - t_ext: *job_native_test_ext_brink
-      - t_ext: *job_native_test_ext_gp2
+      # NOTE: We are disabling gp2 tests due to constant failures.
+      # - t_ext: *job_native_test_ext_gp2
       # NOTE: The external tests below were commented because they
       # depend on a specific version of hardhat which does not support shanghai EVM.
       #- t_ext: *job_native_test_ext_trident
@@ -1703,7 +1704,8 @@ workflows:
             - t_native_test_ext_prb_math
             - t_native_test_ext_elementfi
             - t_native_test_ext_brink
-            - t_native_test_ext_gp2
+            # NOTE: We are disabling gp2 tests due to constant failures.
+            #- t_native_test_ext_gp2
             # NOTE: The external tests below were commented because they
             # depend on a specific version of hardhat which does not support shanghai EVM.
             #- t_native_test_ext_trident


### PR DESCRIPTION
As decided in our last meeting we will disable external tests that keep failing constantly since the main purpose of the external tests is for benchmarking changes in the optimizer and we don't need to maintain that many external tests for that right now.

For reference, the last gp2 failure was: https://app.circleci.com/pipelines/github/ethereum/solidity/30014/workflows/0a005789-c64f-47f4-8752-13805ed9e757/jobs/1333492?invite=true#step-109-158. Giving that, now we will disable it temporarily ;)