### PR TITLE
Do not let low-level semantic test calls depend on a well-defined contract ABI.

### DIFF
--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -410,7 +410,8 @@ TestCase::TestResult SemanticTest::runTest(
 
 			test.setFailure(!m_transactionSuccessful);
 			test.setRawBytes(std::move(output));
-			test.setContractABI(m_compiler.contractABI(m_compiler.lastContractName(m_sources.mainSourceFile)));
+			if (test.call().kind != FunctionCall::Kind::LowLevel)
+				test.setContractABI(m_compiler.contractABI(m_compiler.lastContractName(m_sources.mainSourceFile)));
 		}
 
 		vector<string> effects;


### PR DESCRIPTION
This will only affect "low-level" calls of semantic tests like
```
// (): <raw calldata> -> <raw returndata>
```

In these cases, we don't need a contract ABI, since there is no concrete function signature to use for formatting arguments and return values anyways.

However, this will help in bootstrapping minimal code generation for experimental solidity (for which we won't have ABI types in the beginning - but we can still start adding semantic tests quickly via such "low-level calls")