### PR TITLE
Error instead of assert for struct copy to storage

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -3240,6 +3240,20 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 					return { 9862_error, "\"send\" and \"transfer\" are only available for objects of type \"address payable\", not \"" + exprType->humanReadableName() + "\"." };
 				}
 			}
+			else if (auto const* arrayType = dynamic_cast<ArrayType const*>(exprType))
+			{
+				if (
+					memberName == "push" &&
+					exprType->category() == Type::Category::Array &&
+					arrayType->baseType()->category() == Type::Category::Struct
+				) {
+					return { 1598_error,
+						"Source struct cannot be pushed to target struct array " +
+						exprType->humanReadableName() +
+						". E.g. beuase push memory struct array to storage struct array not yet implemented."
+					};
+				}
+			}
 
 			return { 9582_error, errorMsg };
 		}();

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -148,6 +148,7 @@ struct StructDeclarationAnnotation: TypeDeclarationAnnotation
 	/// Whether the struct contains a mapping type, either directly or, indirectly inside another
 	/// struct or an array.
 	std::optional<bool> containsNestedMapping;
+	std::optional<bool> containsStructArray;
 };
 
 struct ContractDefinitionAnnotation: TypeDeclarationAnnotation, StructurallyDocumentedAnnotation

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1035,6 +1035,7 @@ public:
 	bigint storageSizeUpperBound() const override;
 	u256 storageSize() const override;
 	bool containsNestedMapping() const override;
+	bool containsStructArray() const;
 	bool nameable() const override { return true; }
 	std::string toString(bool _withoutDataLocation) const override;
 

--- a/test/libsolidity/syntaxTests/array/struct_array_to_storage/memory_struct_array_to_storage_assign.sol
+++ b/test/libsolidity/syntaxTests/array/struct_array_to_storage/memory_struct_array_to_storage_assign.sol
@@ -1,0 +1,46 @@
+contract C {
+	struct Child { uint32 i; }
+	struct Parent { Child[] children; }
+
+	Child sChild;
+	Child[] sChildren;
+	Child[] sChildren1;
+	Parent sParent;
+	Parent[] sParents;
+
+	function test() public {
+		Child memory child;
+		Child memory child1;
+		Child[] memory children;
+		Child[] memory children1;
+		Parent memory parent;
+		Parent[] memory parents;
+
+		child1 = child; // OK
+		sChild = child; // OK
+
+		children1 = children; // OK
+		children = sChildren; // OK
+		sChildren = children; // Not yet supported
+		sChildren1 = sChildren; // OK
+
+		sParent.children = children; // Not yet supported
+		sParent.children = sChildren; // OK
+
+
+		parent = Parent(children); // OK
+		parents[0] = Parent(children); // OK
+
+		sParent = Parent(sChildren); // Not yet supported
+		sParent = Parent(children); // Not yet supported
+		sParent = Parent(sChildren); // Not yet supported
+		sParents[0] = Parent(sChildren); // Not yet supported
+	}
+}
+// ----
+// TypeError 7407: (474-482): Type struct C.Child[] memory is not implicitly convertible to expected type struct C.Child[] storage ref. Copy of non-storage struct array to storage array is not yet supported.
+// TypeError 7407: (559-567): Type struct C.Child[] memory is not implicitly convertible to expected type struct C.Child[] storage ref. Copy of non-storage struct array to storage array is not yet supported.
+// TypeError 7407: (717-734): Type struct C.Parent memory is not implicitly convertible to expected type struct C.Parent storage ref. Copy to storage struct array from non-storage array is not yet supported.
+// TypeError 7407: (769-785): Type struct C.Parent memory is not implicitly convertible to expected type struct C.Parent storage ref. Copy to storage struct array from non-storage array is not yet supported.
+// TypeError 7407: (820-837): Type struct C.Parent memory is not implicitly convertible to expected type struct C.Parent storage ref. Copy to storage struct array from non-storage array is not yet supported.
+// TypeError 7407: (876-893): Type struct C.Parent memory is not implicitly convertible to expected type struct C.Parent storage ref. Copy to storage struct array from non-storage array is not yet supported.

--- a/test/libsolidity/syntaxTests/array/struct_array_to_storage/memory_struct_array_to_storage_push_err1.sol
+++ b/test/libsolidity/syntaxTests/array/struct_array_to_storage/memory_struct_array_to_storage_push_err1.sol
@@ -1,0 +1,14 @@
+contract C {
+	struct Child { uint32 i; }
+	struct Parent { Child[] children; }
+
+	Child[] sChildren;
+
+	function test() public {
+		Child[] memory children;
+
+		sChildren.push(children); // Not yet supported
+	}
+}
+// ----
+// TypeError 1598: (156-170): Source struct cannot be pushed to target struct array struct C.Child[] storage ref. E.g. beuase push memory struct array to storage struct array not yet implemented.

--- a/test/libsolidity/syntaxTests/array/struct_array_to_storage/memory_struct_array_to_storage_push_err2.sol
+++ b/test/libsolidity/syntaxTests/array/struct_array_to_storage/memory_struct_array_to_storage_push_err2.sol
@@ -1,0 +1,14 @@
+contract C {
+	struct Child { uint32 i; }
+	struct Parent { Child[] children; }
+
+	Parent[] sParents;
+
+	function test() public {
+		Child[] memory children;
+
+		sParents.push(Parent(children)); // Not yet supported
+	}
+}
+// ----
+// TypeError 1598: (156-169): Source struct cannot be pushed to target struct array struct C.Parent[] storage ref. E.g. beuase push memory struct array to storage struct array not yet implemented.

--- a/test/libsolidity/syntaxTests/array/struct_array_to_storage/memory_struct_array_to_storage_push_err3.sol
+++ b/test/libsolidity/syntaxTests/array/struct_array_to_storage/memory_struct_array_to_storage_push_err3.sol
@@ -1,0 +1,14 @@
+contract C {
+	struct Child { uint32 i; }
+	struct Parent { Child[] children; }
+
+	Child[] sChildren;
+	Parent[] sParents;
+
+	function test() public {
+
+		sParents.push(Parent(sChildren)); // Not yet supported
+	}
+}
+// ----
+// TypeError 1598: (149-162): Source struct cannot be pushed to target struct array struct C.Parent[] storage ref. E.g. beuase push memory struct array to storage struct array not yet implemented.

--- a/test/libsolidity/syntaxTests/array/struct_array_to_storage/memory_struct_array_to_storage_push_ok.sol
+++ b/test/libsolidity/syntaxTests/array/struct_array_to_storage/memory_struct_array_to_storage_push_ok.sol
@@ -1,0 +1,15 @@
+contract C {
+	struct Child { uint32 i; }
+	struct Parent { Child[] children; }
+
+	Child sChild;
+	Child[] sChildren;
+
+	function test() public {
+		Child memory child;
+
+		sChildren.push(child); // OK
+		sChildren.push(sChild); // OK
+	}
+}
+// ----


### PR DESCRIPTION
Fixes #12783 
Fixes  #3446

Suggested fix for issuing an an error message instead of assert when trying to copy non-storage struct array to storage.

The added tests for the push cases are split into several files, since if there are more then one such errors in a file, only the first error is shown.

There are some `semanticTests/array/copying/` **existing tests that fail** because of the change from the assert to the compilation error. Should these failed tests be moved from `sematicTests` to `syntaxTests`?