### PR TITLE
Bump circleci cimg/node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -592,13 +592,14 @@ defaults:
       name: t_native_test_ext_gnosis
       project: gnosis
       binary_type: native
-      image: cimg/node:16.18
+      image: cimg/node:18.16
 
   - job_native_test_ext_zeppelin: &job_native_test_ext_zeppelin
       <<: *requires_b_ubu_static
       name: t_native_test_ext_zeppelin
       project: zeppelin
       binary_type: native
+      image: cimg/node:18.16
       resource_class: large
 
   - job_native_test_ext_ens: &job_native_test_ext_ens
@@ -606,14 +607,14 @@ defaults:
       name: t_native_test_ext_ens
       project: ens
       binary_type: native
-      image: cimg/node:18.11
+      image: cimg/node:18.16
 
   - job_native_test_ext_trident: &job_native_test_ext_trident
       <<: *requires_b_ubu_static
       name: t_native_test_ext_trident
       project: trident
       binary_type: native
-      image: cimg/node:16.18
+      image: cimg/node:18.16
 
   - job_native_test_ext_euler: &job_native_test_ext_euler
       <<: *requires_b_ubu_static
@@ -627,6 +628,7 @@ defaults:
       name: t_native_test_ext_yield_liquidator
       project: yield-liquidator
       binary_type: native
+      image: cimg/node:18.16
 
   - job_native_test_ext_bleeps: &job_native_test_ext_bleeps
       <<: *requires_b_ubu_static
@@ -640,34 +642,35 @@ defaults:
       name: t_native_test_ext_pool_together
       project: pool-together
       binary_type: native
-      image: cimg/node:16.18
+      image: cimg/node:18.16
 
   - job_native_test_ext_perpetual_pools: &job_native_test_ext_perpetual_pools
       <<: *requires_b_ubu_static
       name: t_native_test_ext_perpetual_pools
       project: perpetual-pools
       binary_type: native
-      image: cimg/node:18.11
+      image: cimg/node:18.16
 
   - job_native_test_ext_uniswap: &job_native_test_ext_uniswap
       <<: *requires_b_ubu_static
       name: t_native_test_ext_uniswap
       project: uniswap
       binary_type: native
-      image: cimg/node:16.18
+      image: cimg/node:18.16
 
   - job_native_test_ext_prb_math: &job_native_test_ext_prb_math
       <<: *requires_b_ubu_static
       name: t_native_test_ext_prb_math
       project: prb-math
       binary_type: native
-      image: cimg/node:18.11
+      image: cimg/node:18.16
 
   - job_native_test_ext_elementfi: &job_native_test_ext_elementfi
       <<: *requires_b_ubu_static
       name: t_native_test_ext_elementfi
       project: elementfi
       binary_type: native
+      image: cimg/node:18.16
       resource_class: medium
 
   - job_native_test_ext_brink: &job_native_test_ext_brink
@@ -675,14 +678,14 @@ defaults:
       name: t_native_test_ext_brink
       project: brink
       binary_type: native
-      image: cimg/node:18.11
+      image: cimg/node:18.16
 
   - job_native_test_ext_chainlink: &job_native_test_ext_chainlink
       <<: *requires_b_ubu_static
       name: t_native_test_ext_chainlink
       project: chainlink
       binary_type: native
-      image: cimg/node:16.18
+      image: cimg/node:18.16
       resource_class: large # Tests run out of memory on a smaller machine
 
   - job_native_test_ext_gp2: &job_native_test_ext_gp2
@@ -690,7 +693,7 @@ defaults:
       name: t_native_test_ext_gp2
       project: gp2
       binary_type: native
-      image: cimg/node:18.11
+      image: cimg/node:18.16
 
   - job_b_ubu_asan_clang: &job_b_ubu_asan_clang
       <<: *on_all_tags_and_branches
@@ -1228,7 +1231,7 @@ jobs:
   t_ems_ext_hardhat:
     <<: *base_node_small
     docker:
-      - image: cimg/node:18.11
+      - image: cimg/node:18.16
     environment:
       TERM: xterm
       HARDHAT_TESTS_SOLC_PATH: /tmp/workspace/soljson.js


### PR DESCRIPTION
Fixes external tests that started to [fail](https://app.circleci.com/pipelines/github/ethereum/solidity/30139/workflows/1667d6d8-fdb7-4a50-9a7c-0c6bfea0f8f2/jobs/1338355 ) because they were using the `cimg/node:current` but CircleCI updated the node to version `20.3` on June 9 and this broke npm builds for `open zeppelin`, `element-fi` and `yield-liquidator`.

The PR also update the node version of other external tests to node version `18.16`.

