### PR TITLE
Fix Bash syntax error that shows up in CLI test output when updating expectations

### DIFF
--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -115,7 +115,7 @@ function update_expectation {
     local newExpectation="${1}"
     local expectationFile="${2}"
 
-    if [[ $newExpectation == "" || $newExpectation -eq 0 && $expectationFile == */exit ]]
+    if [[ $newExpectation == '' || $newExpectation == '0' && $expectationFile == */exit ]]
     then
         if [[ -f $expectationFile ]]
         then


### PR DESCRIPTION
This fixes a small bug in `cmdlineTests.sh`, which was using `-eq` to check whether a variable contains `0`. This makes Bash try to interpret that variable as an integer and fail when it's not.

This happens in the code that handles updating expectations, so you'll only see it when running tests with `--update` or selecting `u` when the script asks you whether to update them.

Changing it to a string comparison fixes things.

### Output before
```
Running general commandline tests...
 - standard_default_success
Incorrect output on stdout received. Expected:
{
    {
        "A":
        {
            "id": 0
        }
    }
}
But got:
{
    "sources":
    {
        "A":
        {
            "id": 0
        }
    }
}
When running solc --standard-json --pretty-json --json-indent 4 <standard_default_success/input.json
test/cmdlineTests.sh: line 118: [[: {
    "sources":
    {
        "A":
        {
            "id": 0
        }
    }
}: syntax error: operand expected (error token is "{
    "sources":
    {
        "A":
        {
            "id": 0
        }
    }
}")
File standard_default_success/output.json updated to match the expectation.
Commandline tests successful.
```

### Output after
```
Running general commandline tests...
 - standard_default_success
Incorrect output on stdout received. Expected:
{
    {
        "A":
        {
            "id": 0
        }
    }
}
But got:
{
    "sources":
    {
        "A":
        {
            "id": 0
        }
    }
}
When running solc --standard-json --pretty-json --json-indent 4 <standard_default_success/input.json
File standard_default_success/output.json updated to match the expectation.
Commandline tests successful.
```