### PR TITLE
Account for unassigned return variables in stack layout generation.

### DIFF
--- a/libyul/backends/evm/StackLayoutGenerator.h
+++ b/libyul/backends/evm/StackLayoutGenerator.h
@@ -66,7 +66,7 @@ public:
 	static std::vector<StackTooDeep> reportStackTooDeep(CFG const& _cfg, YulString _functionName);
 
 private:
-	StackLayoutGenerator(StackLayout& _context);
+	StackLayoutGenerator(StackLayout& _context, CFG::FunctionInfo const* _functionInfo);
 
 	/// @returns the optimal entry stack layout, s.t. @a _operation can be applied to it and
 	/// the result can be transformed to @a _exitStack with minimal stack shuffling.
@@ -115,6 +115,7 @@ private:
 	void fillInJunk(CFG::BasicBlock const& _block, CFG::FunctionInfo const* _functionInfo = nullptr);
 
 	StackLayout& m_layout;
+	CFG::FunctionInfo const* m_currentFunctionInfo = nullptr;
 };
 
 }

--- a/test/libyul/evmCodeTransform/unassigned_return_variable.yul
+++ b/test/libyul/evmCodeTransform/unassigned_return_variable.yul
@@ -1,0 +1,19 @@
+{
+  // This used to throw during stack layout generation.
+  function g(b,s) -> y {
+    y := g(b, g(y, s))
+  }
+}
+// ====
+// stackOptimization: true
+// ----
+//     /* "":0:111   */
+//   stop
+//     /* "":60:109   */
+// tag_1:
+//   pop
+//     /* "":99:100   */
+//   0x00
+//     /* "":97:104   */
+//   tag_1
+//   jump	// in


### PR DESCRIPTION
Should fix https://github.com/ethereum/solidity/issues/14037

I'd like to have better validation here, verifying that this is really only the first use of a previously unassigned return variable - but adding infrastructure for that would be quite involved. And we currently also don't validate this properly in ``OptimizedCodeTransform.cpp:L338``, so this doesn't make things worse at least.

I'd say this can go without changelog entry - previously these cases didn't occur (short of custom yul optimizer sequences which are very uncommon), so I'd subsume this under "minimal yul optimizations per default" as far as the changelog is concerned.