### PR TITLE
Sanitize metadata in Standard JSON output in command-line tests

### DIFF
--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -221,6 +221,7 @@ EOF
         # shellcheck disable=SC1003
         sed -i.bak -E -e 's/\\n/\'$'\n/g' "$stdout_path"
         sed -i.bak -e 's/\(^[ ]*auxdata:[[:space:]]\)0x[0-9a-f]*$/\1<AUXDATA REMOVED>/' "$stdout_path"
+        sed -i.bak -e 's/\(\\"version\\":[ ]*\\"\)[^"\\]*\(\\"\)/\1<VERSION REMOVED>\2/' "$stdout_path"
         rm "$stdout_path.bak"
     else
         sed -i.bak -e '/^Warning: This is a pre-release compiler version, please do not use it in production./d' "$stderr_path"

--- a/test/cmdlineTests/metadata/args
+++ b/test/cmdlineTests/metadata/args
@@ -1,0 +1,1 @@
+--metadata

--- a/test/cmdlineTests/metadata/input.sol
+++ b/test/cmdlineTests/metadata/input.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity *;
+
+contract C {}

--- a/test/cmdlineTests/metadata/output
+++ b/test/cmdlineTests/metadata/output
@@ -1,0 +1,4 @@
+
+======= metadata/input.sol:C =======
+Metadata:
+{"compiler":{"version": "<VERSION REMOVED>"},"language":"Solidity","output":{"abi":[],"devdoc":{"kind":"dev","methods":{},"version":1},"userdoc":{"kind":"user","methods":{},"version":1}},"settings":{"compilationTarget":{"metadata/input.sol":"C"},"evmVersion":"shanghai","libraries":{},"metadata":{"bytecodeHash":"ipfs"},"optimizer":{"enabled":false,"runs":200},"remappings":[]},"sources":{"metadata/input.sol":{"keccak256":"0x5cf617b1707a484e3c4bd59643013dec76ab7d75900b46855214729ae3e0ceb0","license":"GPL-3.0","urls":["bzz-raw://ac418a02dfadf87234150d3568f33269e3f49460345cb39300e017a6d755eff2","dweb:/ipfs/QmQq3owBu25x2WV46HB1WyKzJpxiAPecU7eMKqtXCF7eeS"]}},"version":1}

--- a/test/cmdlineTests/standard_metadata/args
+++ b/test/cmdlineTests/standard_metadata/args
@@ -1,0 +1,1 @@
+--allow-paths .

--- a/test/cmdlineTests/standard_metadata/in.sol
+++ b/test/cmdlineTests/standard_metadata/in.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity *;
+
+contract C {}

--- a/test/cmdlineTests/standard_metadata/input.json
+++ b/test/cmdlineTests/standard_metadata/input.json
@@ -1,0 +1,11 @@
+{
+	"language": "Solidity",
+	"sources": {
+		"C": {"urls": ["standard_metadata/in.sol"]}
+	},
+	"settings": {
+		"outputSelection": {
+			"*": {"*": ["metadata"]}
+		}
+	}
+}

--- a/test/cmdlineTests/standard_metadata/output.json
+++ b/test/cmdlineTests/standard_metadata/output.json
@@ -1,0 +1,19 @@
+{
+    "contracts":
+    {
+        "C":
+        {
+            "C":
+            {
+                "metadata": "{\"compiler\":{\"version\":\"<VERSION REMOVED>\"},\"language\":\"Solidity\",\"output\":{\"abi\":[],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"C\":\"C\"},\"evmVersion\":\"shanghai\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"C\":{\"keccak256\":\"0x5cf617b1707a484e3c4bd59643013dec76ab7d75900b46855214729ae3e0ceb0\",\"license\":\"GPL-3.0\",\"urls\":[\"bzz-raw://ac418a02dfadf87234150d3568f33269e3f49460345cb39300e017a6d755eff2\",\"dweb:/ipfs/QmQq3owBu25x2WV46HB1WyKzJpxiAPecU7eMKqtXCF7eeS\"]}},\"version\":1}"
+            }
+        }
+    },
+    "sources":
+    {
+        "C":
+        {
+            "id": 0
+        }
+    }
+}


### PR DESCRIPTION
Currently `cmdlineTests.sh` replaces compiler version in metadata in ordinary CLI tests but not in ones producing Standard JSON output. I need such a test in my upcoming PRs so I decided to fix this.