### PR TITLE
Generate CLI and Standard JSON bytecode reports in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,9 +80,22 @@ commands:
         type: string
     steps:
       - run: mkdir test-cases/
-      - run: cd test-cases && python3 ../scripts/isolate_tests.py ../test/
-      - run: cd test-cases && python3 ../scripts/bytecodecompare/prepare_report.py << parameters.binary_path >> --interface standard-json --report-file "../bytecode-report-<< parameters.label >>-standard-json.txt"
-      - run: cd test-cases && python3 ../scripts/bytecodecompare/prepare_report.py << parameters.binary_path >> --interface cli --report-file "../bytecode-report-<< parameters.label >>-cli.txt"
+      - run:
+          name: Prepare input files
+          command: |
+            cd test-cases/
+            python3 ../scripts/isolate_tests.py ../test/
+      - run:
+          name: Generate bytecode report
+          command: |
+            cd test-cases/
+            interface=$(echo -e "standard-json\ncli" | circleci tests split)
+            echo "Selected interface: ${interface}"
+
+            python3 ../scripts/bytecodecompare/prepare_report.py \
+              << parameters.binary_path >> \
+              --interface "$interface" \
+              --report-file "../bytecode-report-<< parameters.label >>-${interface}.txt"
       - store_artifacts:
           path: bytecode-report-<< parameters.label >>-standard-json.txt
       - store_artifacts:
@@ -1476,6 +1489,7 @@ jobs:
       TERM: xterm
       MAKEFLAGS: -j 2
       LC_ALL: C
+    parallelism: 2 # For prepare_bytecode_report
     steps:
       - checkout
       - attach_workspace:
@@ -1490,6 +1504,7 @@ jobs:
       TERM: xterm
       MAKEFLAGS: -j 2
       LC_ALL: C
+    parallelism: 2 # For prepare_bytecode_report
     steps:
       - checkout
       - attach_workspace:
@@ -1504,6 +1519,7 @@ jobs:
       TERM: xterm
       MAKEFLAGS: -j 5
       LC_ALL: C
+    parallelism: 2 # For prepare_bytecode_report
     steps:
       - checkout
       - attach_workspace:
@@ -1516,6 +1532,7 @@ jobs:
     <<: *base_win
     environment:
       LC_ALL: C
+    parallelism: 2 # For prepare_bytecode_report
     steps:
       # NOTE: For bytecode generation we need the input files to be byte-for-byte identical on all
       # platforms so line ending conversions must absolutely be disabled.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,17 +81,16 @@ commands:
     steps:
       - run: mkdir test-cases/
       - run: cd test-cases && python3 ../scripts/isolate_tests.py ../test/
-      - run: cd test-cases && python3 ../scripts/bytecodecompare/prepare_report.py << parameters.binary_path >> --interface standard-json --report-file "../bytecode-report-<< parameters.label >>-json.txt"
+      - run: cd test-cases && python3 ../scripts/bytecodecompare/prepare_report.py << parameters.binary_path >> --interface standard-json --report-file "../bytecode-report-<< parameters.label >>-standard-json.txt"
       - run: cd test-cases && python3 ../scripts/bytecodecompare/prepare_report.py << parameters.binary_path >> --interface cli --report-file "../bytecode-report-<< parameters.label >>-cli.txt"
       - store_artifacts:
-          path: bytecode-report-<< parameters.label >>-json.txt
+          path: bytecode-report-<< parameters.label >>-standard-json.txt
       - store_artifacts:
           path: bytecode-report-<< parameters.label >>-cli.txt
       - persist_to_workspace:
           root: .
           paths:
-            - bytecode-report-<< parameters.label >>-json.txt
-            - bytecode-report-<< parameters.label >>-cli.txt
+            - bytecode-report-<< parameters.label >>-*.txt
       - matrix_notify_failure_unless_pr
 
   install_python3:
@@ -1553,13 +1552,13 @@ jobs:
     environment:
       REPORT_FILES: |
         bytecode-report-emscripten.txt
-        bytecode-report-ubuntu2004-static-json.txt
+        bytecode-report-ubuntu2004-static-standard-json.txt
         bytecode-report-ubuntu2004-static-cli.txt
-        bytecode-report-ubuntu-json.txt
+        bytecode-report-ubuntu-standard-json.txt
         bytecode-report-ubuntu-cli.txt
-        bytecode-report-osx-json.txt
+        bytecode-report-osx-standard-json.txt
         bytecode-report-osx-cli.txt
-        bytecode-report-windows-json.txt
+        bytecode-report-windows-standard-json.txt
         bytecode-report-windows-cli.txt
     steps:
       - attach_workspace:


### PR DESCRIPTION
In #13583 I'll be adding additional bytecode report runs, which will double the amount of work. Those jobs are already slow enough, and the Windows one actually got almost 2.5 times slower since last year (WTF, why?).

This PR makes CI generate Standard JSON and CLI reports in parallel. This halves the running time of all or them except `b_bytecode_ems` (which does not have CLI).

This addresses #13056 in a minimal way. Not sure if going all the way to split these tests into fine-grained batches is even worth it. This minimal version is already a big improvement with very little effort. In my upcoming PR I'm going to split it once more, into optimized and non-optimized report, which should halve the times again.d I think this will be enough for now.

### Time comparison
| Job | [`develop` in May 2022](https://app.circleci.com/pipelines/github/ethereum/solidity/23305/workflows/ea43cc31-b20f-4a9f-aafa-f639ef7688aa) | [`develop` now](https://app.circleci.com/pipelines/github/ethereum/solidity/30186/workflows/3097f127-697e-4f6d-a513-50005ea3f7ff) | [this PR](https://app.circleci.com/pipelines/github/ethereum/solidity/30197/workflows/e56053b4-7fdd-4a37-a4d5-90118a1c88f9) |
|-------------------------|---------|---------|---------|
| `b_bytecode_win`        | 11m 01s | 25m 16s | 11m 53s |
| `b_bytecode_ubu_static` |         | 6m 8s   | 3m 53s  |
| `b_bytecode_ubu`        | 8m 47s  | 12m 6s  | 6m 29s  |
| `b_bytecode_osx`        | 13m 14s | 11m 19s | 6m 5s   |
| `b_bytecode_ems`        | 6m 11s  | 7m 21s  | 6m 47s  |
| `t_bytecode_compare`    | 46s     | 28s     | 26s     |