### PR TITLE
Remove warning about Free fucntion shadowing Interface function

### DIFF
--- a/libsolidity/analysis/DeclarationContainer.cpp
+++ b/libsolidity/analysis/DeclarationContainer.cpp
@@ -122,7 +122,11 @@ bool DeclarationContainer::registerDeclaration(
 		if (conflictingDeclaration(_declaration, _name))
 			return false;
 
-		if (m_enclosingContainer && _declaration.isVisibleAsUnqualifiedName())
+		if (
+			m_enclosingContainer &&
+			_declaration.isVisibleAsUnqualifiedName() &&
+			!_declaration.isParentInterface()
+		)
 			m_homonymCandidates.emplace_back(*_name, _location ? _location : &_declaration.location());
 	}
 

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -118,6 +118,9 @@ public:
 	///@todo make this const-safe by providing a different way to access the annotation
 	virtual ASTAnnotation& annotation() const;
 
+	/// Whether this node is a child of Interface contract.
+	virtual bool isParentInterface() const { return false; }
+
 	///@{
 	///@name equality operators
 	/// Equality relies on the fact that nodes cannot be copied.
@@ -963,6 +966,7 @@ public:
 		std::vector<ASTPointer<ModifierInvocation>> _modifiers,
 		ASTPointer<ParameterList> const& _returnParameters,
 		ASTPointer<Block> const& _body,
+		bool _isParentInterface,
 		ASTPointer<Expression> const& _experimentalReturnExpression = {}
 	):
 		CallableDeclaration(_id, _location, _name, _nameLocation, _visibility, _parameters, _isVirtual, _overrides, _returnParameters),
@@ -973,6 +977,7 @@ public:
 		m_kind(_kind),
 		m_functionModifiers(std::move(_modifiers)),
 		m_body(_body),
+		m_isParentInterface(_isParentInterface),
 		m_experimentalReturnExpression(_experimentalReturnExpression)
 	{
 		solAssert(_kind == Token::Constructor || _kind == Token::Function || _kind == Token::Fallback || _kind == Token::Receive, "");
@@ -1036,6 +1041,8 @@ public:
 	) const override;
 
 	Expression const* experimentalReturnExpression() const { return m_experimentalReturnExpression.get(); }
+	/// Whether this node is a child of Interface contract.
+	bool isParentInterface() const override { return m_isParentInterface; }
 
 private:
 	StateMutability m_stateMutability;
@@ -1043,6 +1050,7 @@ private:
 	Token const m_kind;
 	std::vector<ASTPointer<ModifierInvocation>> m_functionModifiers;
 	ASTPointer<Block> m_body;
+	bool m_isParentInterface;
 	ASTPointer<Expression> m_experimentalReturnExpression;
 };
 

--- a/libsolidity/ast/ASTJsonImporter.h
+++ b/libsolidity/ast/ASTJsonImporter.h
@@ -62,11 +62,11 @@ private:
 	std::optional<std::vector<langutil::SourceLocation>> createSourceLocations(Json::Value const& _node) const;
 	/// Creates an ASTNode for a given JSON-ast of unknown type
 	/// @returns Pointer to a new created ASTNode
-	ASTPointer<ASTNode> convertJsonToASTNode(Json::Value const& _ast);
+	ASTPointer<ASTNode> convertJsonToASTNode(Json::Value const& _ast, bool _isParentInterface = false);
 	/// @returns a pointer to the more specific subclass of ASTNode
 	/// as indicated by the nodeType field of the json
 	template<class T>
-	ASTPointer<T> convertJsonToASTNode(Json::Value const& _node);
+	ASTPointer<T> convertJsonToASTNode(Json::Value const& _node, bool _isParentInterface = false);
 
 	langutil::SourceLocation createNameSourceLocation(Json::Value const& _node);
 	/// @returns source location of a mapping key name
@@ -89,7 +89,7 @@ private:
 	ASTPointer<UserDefinedValueTypeDefinition> createUserDefinedValueTypeDefinition(Json::Value const& _node);
 	ASTPointer<ParameterList> createParameterList(Json::Value const& _node);
 	ASTPointer<OverrideSpecifier> createOverrideSpecifier(Json::Value const& _node);
-	ASTPointer<FunctionDefinition> createFunctionDefinition(Json::Value const& _node);
+	ASTPointer<FunctionDefinition> createFunctionDefinition(Json::Value const& _node, bool _isParentInterface);
 	ASTPointer<VariableDeclaration> createVariableDeclaration(Json::Value const& _node);
 	ASTPointer<ModifierDefinition> createModifierDefinition(Json::Value const& _node);
 	ASTPointer<ModifierInvocation> createModifierInvocation(Json::Value const& _node);

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -380,6 +380,7 @@ ASTPointer<ContractDefinition> Parser::parseContractDefinition()
 	std::pair<ContractKind, bool> contractKind{};
 	documentation = parseStructuredDocumentation();
 	contractKind = parseContractKind();
+	bool isInterfaceContract = (contractKind.first == ContractKind::Interface);
 	std::tie(name, nameLocation) = expectIdentifierWithLocation();
 	if (m_scanner->currentToken() == Token::Is)
 		do
@@ -400,7 +401,7 @@ ASTPointer<ContractDefinition> Parser::parseContractDefinition()
 			currentTokenValue == Token::Receive ||
 			currentTokenValue == Token::Fallback
 		)
-			subNodes.push_back(parseFunctionDefinition());
+			subNodes.push_back(parseFunctionDefinition(false, true, isInterfaceContract));
 		else if (currentTokenValue == Token::Struct)
 			subNodes.push_back(parseStructDefinition());
 		else if (currentTokenValue == Token::Enum)
@@ -627,7 +628,7 @@ Parser::FunctionHeaderParserResult Parser::parseFunctionHeader(bool _isStateVari
 	return result;
 }
 
-ASTPointer<ASTNode> Parser::parseFunctionDefinition(bool _freeFunction, bool _allowBody)
+ASTPointer<ASTNode> Parser::parseFunctionDefinition(bool _freeFunction, bool _allowBody, bool _isParentInterface)
 {
 	RecursionGuard recursionGuard(*this);
 	ASTNodeFactory nodeFactory(*this);
@@ -705,6 +706,7 @@ ASTPointer<ASTNode> Parser::parseFunctionDefinition(bool _freeFunction, bool _al
 		header.modifiers,
 		header.returnParameters,
 		block,
+		_isParentInterface,
 		header.experimentalReturnExpression
 	);
 }

--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -102,7 +102,7 @@ private:
 	ASTPointer<OverrideSpecifier> parseOverrideSpecifier();
 	StateMutability parseStateMutability();
 	FunctionHeaderParserResult parseFunctionHeader(bool _isStateVariable);
-	ASTPointer<ASTNode> parseFunctionDefinition(bool _freeFunction = false, bool _allowBody = true);
+	ASTPointer<ASTNode> parseFunctionDefinition(bool _freeFunction = false, bool _allowBody = true, bool isParentInterface = false);
 	ASTPointer<StructDefinition> parseStructDefinition();
 	ASTPointer<EnumDefinition> parseEnumDefinition();
 	ASTPointer<UserDefinedValueTypeDefinition> parseUserDefinedValueTypeDefinition();


### PR DESCRIPTION
Fixes #10155

Suggested solution for remove warning messages that Free functions shadow Interface functions.
As I wrote in [this comment](https://github.com/ethereum/solidity/issues/10155#issuecomment-1565633372), it may be considered to extended the solution to other declaration types inside an Interface, such as struct and enum.

(Note: only after submitting the PR I noticed that the "good first issue" label was remove, so the PR may be redundant.  As I hope that the changes are useful I keep the PR open.)