### PR TITLE
Fix: do not require functions to be external in model checker

### DIFF
--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -1358,7 +1358,7 @@ bool SMTEncoder::visit(MemberAccess const& _memberAccess)
 	{
 		auto const* functionType = dynamic_cast<FunctionType const*>(_memberAccess.annotation().type);
 		if (functionType && functionType->hasDeclaration())
-			defineExpr(_memberAccess, functionType->externalIdentifier());
+			defineExpr(_memberAccess, u256(_memberAccess.id()));
 
 		return true;
 	}

--- a/test/libsolidity/smtCheckerTests/functions/functions_library_internal.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_library_internal.sol
@@ -1,0 +1,14 @@
+library L {
+	function value(function()internal a, uint256 b) internal {}
+}
+contract C {
+	using L for function()internal;
+
+	function f() public {
+		function()internal x;
+		x.value(42);
+ 	}
+}
+// ====
+// SMTEngine: all
+// ----


### PR DESCRIPTION
Closes https://github.com/ethereum/solidity/issues/14181

Bug was caused by trying to get external id for internal functions (they do not have one).

edit: fix is not correct. Closed without merge.