### PR TITLE
Disallow the use of `TypeType` in complex expressions 

### DIFF
--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1598,6 +1598,7 @@ public:
 	bool hasSimpleZeroValueInMemory() const override { solAssert(false, ""); }
 	std::string toString(bool _withoutDataLocation) const override { return "type(" + m_actualType->toString(_withoutDataLocation) + ")"; }
 	MemberList::MemberMap nativeMembers(ASTNode const* _currentScope) const override;
+	Type const* mobileType() const override { return nullptr; }
 
 	BoolResult isExplicitlyConvertibleTo(Type const& _convertTo) const override;
 protected:

--- a/test/libsolidity/syntaxTests/conversion/implicit_conversion_of_super_in_operators.sol
+++ b/test/libsolidity/syntaxTests/conversion/implicit_conversion_of_super_in_operators.sol
@@ -53,4 +53,4 @@ contract C {
 // TypeError 7366: (480-493): Operator -= not compatible with types type(contract super C) and contract C.
 // TypeError 4247: (503-508): Expression has to be an lvalue.
 // TypeError 7366: (503-516): Operator += not compatible with types type(contract super C) and contract C.
-// TypeError 1080: (527-546): True expression's type type(contract super C) does not match false expression's type contract C.
+// TypeError 9717: (534-539): Invalid mobile type in true expression.

--- a/test/libsolidity/syntaxTests/inline_arrays/unnamed_types_in_inline_array_3.sol
+++ b/test/libsolidity/syntaxTests/inline_arrays/unnamed_types_in_inline_array_3.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        [uint];
+    }
+}
+// ----
+// TypeError 9563: (53-57): Invalid mobile type.

--- a/test/libsolidity/syntaxTests/metaTypes/array_type_from_ternary.sol
+++ b/test/libsolidity/syntaxTests/metaTypes/array_type_from_ternary.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f(bool c) public {
+        (c ? uint[2] : uint[2])[3];
+    }
+}
+// ----
+// TypeError 9717: (58-65): Invalid mobile type in true expression.
+// TypeError 3703: (68-75): Invalid mobile type in false expression.

--- a/test/libsolidity/syntaxTests/metaTypes/contract_from_ternary.sol
+++ b/test/libsolidity/syntaxTests/metaTypes/contract_from_ternary.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() public pure { }
+    function g(bool c) public {
+        (c ? C : C).f();
+    }
+}
+// ----
+// TypeError 9717: (91-92): Invalid mobile type in true expression.
+// TypeError 3703: (95-96): Invalid mobile type in false expression.

--- a/test/libsolidity/syntaxTests/metaTypes/explicit_type_conversion.sol
+++ b/test/libsolidity/syntaxTests/metaTypes/explicit_type_conversion.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f(bool c) pure public returns (int) {
+        return (c ? int : int)(0);
+    }
+}
+// ----
+// TypeError 9717: (84-87): Invalid mobile type in true expression.
+// TypeError 3703: (90-93): Invalid mobile type in false expression.

--- a/test/libsolidity/syntaxTests/metaTypes/library_from_ternary.sol
+++ b/test/libsolidity/syntaxTests/metaTypes/library_from_ternary.sol
@@ -1,0 +1,12 @@
+library L {
+    function f() public pure { }
+}
+
+contract C {
+    function g(bool c) public {
+        (c ? L : L).f();
+    }
+}
+// ----
+// TypeError 9717: (106-107): Invalid mobile type in true expression.
+// TypeError 3703: (110-111): Invalid mobile type in false expression.

--- a/test/libsolidity/syntaxTests/metaTypes/struct_from_ternary.sol
+++ b/test/libsolidity/syntaxTests/metaTypes/struct_from_ternary.sol
@@ -1,0 +1,14 @@
+struct S {
+    uint x;
+    uint y;
+    uint z;
+}
+
+contract C {
+    function f(bool c) public pure {
+        S memory s = (c ? S : S)(0, 1, 2);
+    }
+}
+// ----
+// TypeError 9717: (126-127): Invalid mobile type in true expression.
+// TypeError 3703: (130-131): Invalid mobile type in false expression.

--- a/test/libsolidity/syntaxTests/metaTypes/type_expression_nested_ternary_max_keyword.sol
+++ b/test/libsolidity/syntaxTests/metaTypes/type_expression_nested_ternary_max_keyword.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f(bool b) public pure returns (uint) {
+        return type(b ? uint : uint).max;
+    }
+}
+// ----
+// TypeError 9717: (89-93): Invalid mobile type in true expression.
+// TypeError 3703: (96-100): Invalid mobile type in false expression.

--- a/test/libsolidity/syntaxTests/metaTypes/type_from_ternary_condition.sol
+++ b/test/libsolidity/syntaxTests/metaTypes/type_from_ternary_condition.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f(bool c) pure public {
+        type(c ? uint : uint);
+    }
+}
+// ----
+// TypeError 9717: (67-71): Invalid mobile type in true expression.
+// TypeError 3703: (74-78): Invalid mobile type in false expression.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_array_of_unitary_tuples.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_array_of_unitary_tuples.sol
@@ -1,0 +1,17 @@
+contract C {
+    function f() pure public {
+        abi.decode("", ((uint)[2]));
+        abi.decode("", ((uint)[]));
+        abi.decode("", ((uint)[][3]));
+        abi.decode("", ((uint)[4][]));
+        abi.decode("", ((uint)[5][6]));
+        abi.decode("", (((uint))[5][6]));
+    }
+}
+// ----
+// Warning 6133: (52-79): Statement has no effect.
+// Warning 6133: (89-115): Statement has no effect.
+// Warning 6133: (125-154): Statement has no effect.
+// Warning 6133: (164-193): Statement has no effect.
+// Warning 6133: (203-233): Statement has no effect.
+// Warning 6133: (243-275): Statement has no effect.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_enum.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_enum.sol
@@ -1,0 +1,8 @@
+contract C {
+    enum Color { red, green, blue }
+    function f() pure public {
+        abi.decode("", (Color));
+    }
+}
+// ----
+// Warning 6133: (88-111): Statement has no effect.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_argument_array_length_ternary_with_max_keyword.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_argument_array_length_ternary_with_max_keyword.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() pure public {
+        bool x;
+        abi.decode("", (uint[type(x = true ? uint8 : uint8).max]));
+    }
+}
+// ----
+// TypeError 9717: (105-110): Invalid mobile type in true expression.
+// TypeError 3703: (113-118): Invalid mobile type in false expression.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_argument_array_of_tuples.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_argument_array_of_tuples.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() pure public {
+        abi.decode("", ((uint, int)[5][6]));
+    }
+}
+// ----
+// TypeError 2614: (68-79): Indexed expression has to be a type, mapping or array (is tuple(type(uint256),type(int256)))

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_argument_indexed_array_literal.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_argument_indexed_array_literal.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() pure public {
+        abi.decode("", ([uint][2]));
+    }
+}
+// ----
+// TypeError 9563: (69-73): Invalid mobile type.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_argument_indexed_ternary_expression.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_argument_indexed_ternary_expression.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() pure public {
+        bool x;
+        abi.decode("", ((x = true ? uint : uint)[0]));
+    }
+}
+// ----
+// TypeError 9717: (96-100): Invalid mobile type in true expression.
+// TypeError 3703: (103-107): Invalid mobile type in false expression.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_argument_ternary_condition_expression.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_argument_ternary_condition_expression.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f() pure public {
+        abi.decode("", (true ? uint : uint));
+    }
+}
+// ----
+// TypeError 9717: (75-79): Invalid mobile type in true expression.
+// TypeError 3703: (82-86): Invalid mobile type in false expression.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_argument_ternary_expression_inside_parentheses.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_argument_ternary_expression_inside_parentheses.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f() pure public {
+        abi.decode("", ((true ? uint : uint)));
+    }
+}
+// ----
+// TypeError 9717: (76-80): Invalid mobile type in true expression.
+// TypeError 3703: (83-87): Invalid mobile type in false expression.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_argument_ternary_with_side_effect.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_argument_ternary_with_side_effect.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() pure public {
+        int x;
+        abi.decode("", ((x = 1) > 0 ? int : int));
+    }
+}
+// ----
+// TypeError 9717: (97-100): Invalid mobile type in true expression.
+// TypeError 3703: (103-106): Invalid mobile type in false expression.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_argument_tuple_type.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_argument_tuple_type.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() pure public {
+        abi.decode("", ((uint, int)));
+    }
+}
+// ----
+// TypeError 1039: (68-79): Argument has to be a type name.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_argument_type_expression.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_invalid_argument_type_expression.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() pure public {
+        abi.decode("", (type(uint)));
+    }
+}
+// ----
+// TypeError 1039: (68-78): Argument has to be a type name.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_member_acess.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_member_acess.sol
@@ -1,0 +1,19 @@
+library L {
+    struct S { int a; }
+    enum State { idle, running, blocked }
+}
+
+contract D {
+    struct X { uint b; }
+    enum Color { red, green, blue }
+}
+
+contract C {
+    function f() pure public {
+        abi.decode("", (L.S));
+        abi.decode("", (L.State));
+        abi.decode("", (D.X));
+        abi.decode("", (D.Color));
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_unitary_nested_tuple.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_unitary_nested_tuple.sol
@@ -1,0 +1,13 @@
+struct S { int a; }
+
+contract C {
+    function f() pure public {
+        abi.decode("", (((uint))));
+        abi.decode("", ((((uint)))));
+        abi.decode("", (((S))));
+    }
+}
+// ----
+// Warning 6133: (73-99): Statement has no effect.
+// Warning 6133: (109-137): Statement has no effect.
+// Warning 6133: (147-170): Statement has no effect.


### PR DESCRIPTION
Fix #14319.
~Depends on #14371.~ Merged.