### PR TITLE
Stylecheck script fails on MacOS #13492

### DIFF
--- a/libsolidity/analysis/ControlFlowBuilder.cpp
+++ b/libsolidity/analysis/ControlFlowBuilder.cpp
@@ -582,7 +582,7 @@ void ControlFlowBuilder::operator()(yul::FunctionCall const& _functionCall)
 	solAssert(m_currentNode && m_inlineAssembly, "");
 	yul::ASTWalker::operator()(_functionCall);
 
-	if (auto const *builtinFunction = m_inlineAssembly->dialect().builtin(_functionCall.functionName.name))
+	if (auto const* builtinFunction = m_inlineAssembly->dialect().builtin(_functionCall.functionName.name))
 	{
 		if (builtinFunction->controlFlowSideEffects.canTerminate)
 			connect(m_currentNode, m_transactionReturnNode);

--- a/libsolidity/analysis/ControlFlowBuilder.h
+++ b/libsolidity/analysis/ControlFlowBuilder.h
@@ -152,7 +152,7 @@ private:
 
 	CFGNode* newLabel();
 	CFGNode* createLabelHere();
-	void placeAndConnectLabel(CFGNode *_node);
+	void placeAndConnectLabel(CFGNode* _node);
 
 	CFG::NodeContainer& m_nodeContainer;
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1552,7 +1552,7 @@ void TypeChecker::checkExpressionAssignment(Type const& _type, Expression const&
 	{
 		bool isLocalOrReturn = false;
 		if (auto const* identifier = dynamic_cast<Identifier const*>(&_expression))
-			if (auto const *variableDeclaration = dynamic_cast<VariableDeclaration const*>(identifier->annotation().referencedDeclaration))
+			if (auto const* variableDeclaration = dynamic_cast<VariableDeclaration const*>(identifier->annotation().referencedDeclaration))
 				if (variableDeclaration->isLocalOrReturn())
 					isLocalOrReturn = true;
 		if (!isLocalOrReturn)

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3425,7 +3425,7 @@ MemberList::MemberMap FunctionType::nativeMembers(ASTNode const* _scope) const
 		if (auto const* functionDefinition = dynamic_cast<FunctionDefinition const*>(m_declaration))
 		{
 			solAssert(functionDefinition->visibility() > Visibility::Internal, "");
-			auto const *contract = dynamic_cast<ContractDefinition const*>(m_declaration->scope());
+			auto const* contract = dynamic_cast<ContractDefinition const*>(m_declaration->scope());
 			solAssert(contract, "");
 			solAssert(contract->isLibrary(), "");
 			return {{"selector", TypeProvider::fixedBytes(4)}};

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -373,7 +373,7 @@ private:
 	/// Stack of current visited AST nodes, used for location attachment
 	std::stack<ASTNode const*> m_visitedNodes;
 	/// The runtime context if in Creation mode, this is used for generating tags that would be stored into the storage and then used at runtime.
-	CompilerContext *m_runtimeContext;
+	CompilerContext* m_runtimeContext;
 	/// The index of the runtime subroutine.
 	size_t m_runtimeSub = std::numeric_limits<size_t>::max();
 	/// An index of low-level function labels by name.

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -2231,7 +2231,7 @@ bool ExpressionCompiler::visit(IndexRangeAccess const& _indexAccess)
 
 	Type const& baseType = *_indexAccess.baseExpression().annotation().type;
 
-	ArrayType const *arrayType = dynamic_cast<ArrayType const*>(&baseType);
+	ArrayType const* arrayType = dynamic_cast<ArrayType const*>(&baseType);
 	if (!arrayType)
 		if (ArraySliceType const* sliceType = dynamic_cast<ArraySliceType const*>(&baseType))
 			arrayType = &sliceType->arrayType();

--- a/libyul/backends/evm/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/StackLayoutGenerator.cpp
@@ -346,7 +346,7 @@ void StackLayoutGenerator::processEntryPoint(CFG::BasicBlock const& _entry, CFG:
 		// entry layout of the backwards jump target as the initial exit layout of the backwards-jumping block.
 		while (!toVisit.empty())
 		{
-			CFG::BasicBlock const *block = *toVisit.begin();
+			CFG::BasicBlock const* block = *toVisit.begin();
 			toVisit.pop_front();
 
 			if (visited.count(block))


### PR DESCRIPTION
- Install GNU grep on macOS with `brew install grep`
- Use GNU grep with -E option
- The following errors fixed.
```
$scripts/check_style.sh
ggrep: warning: stray \ before /
ggrep: warning: stray \ before /
ggrep: warning: * at start of expression
ggrep: warning: * at start of expression
```

The change was tested on macOS and Linux

Fixes https://github.com/ethereum/solidity/issues/13492