### PR TITLE
Deduplicate environment variables in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,11 +363,10 @@ defaults:
         MAKEFLAGS: -j 3
 
   - base_archlinux_large: &base_archlinux_large
-      docker:
-        - image: archlinux:base
+      <<: *base_archlinux
       resource_class: large
       environment: &base_archlinux_large_env
-        TERM: xterm
+        <<: *base_archlinux_env
         MAKEFLAGS: -j 5
 
   - base_cimg_small: &base_cimg_small
@@ -403,11 +402,10 @@ defaults:
         MAKEFLAGS: -j5
 
   - base_osx_large: &base_osx_large
-      macos:
-        xcode: "14.2.0"
+      <<: *base_osx
       resource_class: large
       environment: &base_osx_large_env
-        TERM: xterm
+        <<: *base_osx_env
         MAKEFLAGS: -j10
 
   - base_python_small: &base_python_small
@@ -429,29 +427,29 @@ defaults:
       <<: *base_ubuntu_clang
       resource_class: small
       environment: &base_ubuntu_clang_small_env
-        TERM: xterm
+        <<: *base_ubuntu_clang_env
         MAKEFLAGS: -j 2
 
   - base_ubuntu2004: &base_ubuntu2004
       docker:
-          - image: << pipeline.parameters.ubuntu-2004-docker-image >>
+        - image: << pipeline.parameters.ubuntu-2004-docker-image >>
       environment: &base_ubuntu2004_env
-          TERM: xterm
-          MAKEFLAGS: -j 3
+        TERM: xterm
+        MAKEFLAGS: -j 3
 
   - base_ubuntu2004_small: &base_ubuntu2004_small
       <<: *base_ubuntu2004
       resource_class: small
       environment: &base_ubuntu2004_small_env
-          TERM: xterm
-          MAKEFLAGS: -j 2
+        <<: *base_ubuntu2004_env
+        MAKEFLAGS: -j 2
 
   - base_ubuntu2004_xlarge: &base_ubuntu2004_xlarge
       <<: *base_ubuntu2004
       resource_class: xlarge
       environment: &base_ubuntu2004_xlarge_env
-          TERM: xterm
-          MAKEFLAGS: -j 10
+        <<: *base_ubuntu2004_env
+        MAKEFLAGS: -j 10
 
   - base_ubuntu2204: &base_ubuntu2204
       docker:
@@ -473,30 +471,28 @@ defaults:
       <<: *base_ubuntu2204_clang
       resource_class: large
       environment: &base_ubuntu2204_clang_large_env
-        TERM: xterm
-        CC: clang
-        CXX: clang++
+        <<: *base_ubuntu2204_clang_env
         MAKEFLAGS: -j 5
 
   - base_ubuntu2204_small: &base_ubuntu2204_small
       <<: *base_ubuntu2204
       resource_class: small
       environment: &base_ubuntu2204_small_env
-        TERM: xterm
+        <<: *base_ubuntu2204_env
         MAKEFLAGS: -j 2
 
   - base_ubuntu2204_large: &base_ubuntu2204_large
       <<: *base_ubuntu2204
       resource_class: large
       environment: &base_ubuntu2204_large_env
-        TERM: xterm
+        <<: *base_ubuntu2204_env
         MAKEFLAGS: -j 5
 
   - base_ubuntu2204_xlarge: &base_ubuntu2204_xlarge
       <<: *base_ubuntu2204
       resource_class: xlarge
       environment: &base_ubuntu2204_xlarge_env
-        TERM: xterm
+        <<: *base_ubuntu2204_env
         MAKEFLAGS: -j 10
 
   - base_win: &base_win

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -884,17 +884,15 @@ jobs:
     # Runs slightly faster on large and xlarge but we only run it nightly so efficiency matters more.
     <<: *base_ubuntu2204
     environment:
+      <<: *base_ubuntu2204_env
       CMAKE_OPTIONS: -DSANITIZE=address
-      MAKEFLAGS: -j 3
       CMAKE_BUILD_TYPE: Release
     <<: *steps_build
 
   b_ubu_clang: &b_ubu_clang
     <<: *base_ubuntu2204_clang_large
     environment:
-      TERM: xterm
-      CC: clang
-      CXX: clang++
+      <<: *base_ubuntu2204_clang_large_env
       MAKEFLAGS: -j 10
     <<: *steps_build
 
@@ -905,18 +903,15 @@ jobs:
         type: string
     <<: *base_ubuntu2204_clang
     environment:
-      TERM: xterm
-      CC: clang
-      CXX: clang++
-      MAKEFLAGS: -j 3
+      <<: *base_ubuntu2204_clang_env
       CMAKE_OPTIONS: << parameters.cmake_options >>
     <<: *steps_build
 
   b_ubu_force_release: &b_ubu_force_release
     <<: *b_ubu
     environment:
+      <<: *base_ubuntu2204_xlarge_env
       FORCE_RELEASE: ON
-      MAKEFLAGS: -j 10
 
   b_ubu_static:
     # We temporarily keep building static release binaries on ubuntu 20.04
@@ -925,8 +920,7 @@ jobs:
     # On large runs 2x faster than on medium. 3x on xlarge.
     <<: *base_ubuntu2004_xlarge
     environment:
-      TERM: xterm
-      MAKEFLAGS: -j 10
+      <<: *base_ubuntu2204_xlarge_env
       CMAKE_OPTIONS: -DCMAKE_BUILD_TYPE=Release -DUSE_Z3_DLOPEN=ON -DUSE_CVC4=OFF -DSOLC_STATIC_STDLIBS=ON
     steps:
       - checkout
@@ -948,9 +942,9 @@ jobs:
     # Runs ~30% faster on large but we only run it nightly so efficiency matters more.
     <<: *base_ubuntu2204
     environment:
+      <<: *base_ubuntu2204_env
       COVERAGE: ON
       CMAKE_BUILD_TYPE: Debug
-      MAKEFLAGS: -j 3
     steps:
       - checkout
       - run: *run_build
@@ -960,6 +954,7 @@ jobs:
   t_ubu_codecov:
     <<: *base_ubuntu2204_large
     environment:
+      <<: *base_ubuntu2204_large_env
       EVM: << pipeline.parameters.evm-version >>
       OPTIMIZE: 1
     steps:
@@ -984,6 +979,7 @@ jobs:
   b_ubu_cxx20:
     <<: *base_ubuntu2204_large
     environment:
+      <<: *base_ubuntu2204_large_env
       CMAKE_BUILD_TYPE: Debug
       CMAKE_OPTIONS: -DCMAKE_CXX_STANDARD=20 -DUSE_CVC4=OFF
       MAKEFLAGS: -j 10
@@ -1019,8 +1015,7 @@ jobs:
   b_archlinux:
     <<: *base_archlinux_large
     environment:
-      TERM: xterm
-      MAKEFLAGS: -j 5
+      <<: *base_archlinux_large_env
       # This can be switched off if we run out of sync with Arch.
       USE_Z3: ON
     steps:
@@ -1037,9 +1032,8 @@ jobs:
   b_osx:
     <<: *base_osx_large
     environment:
-      TERM: xterm
+      <<: *base_osx_large_env
       CMAKE_BUILD_TYPE: Release
-      MAKEFLAGS: -j10
     steps:
       - checkout
       - when:
@@ -1059,9 +1053,9 @@ jobs:
   t_osx_soltest: &t_osx_soltest
     <<: *base_osx
     environment:
+      <<: *base_osx_env
       EVM: << pipeline.parameters.evm-version >>
       OPTIMIZE: 0
-      TERM: xterm
     steps:
       - checkout
       - when:
@@ -1091,7 +1085,7 @@ jobs:
   b_ems:
     <<: *base_ems_large
     environment:
-      TERM: xterm
+      <<: *base_ems_large_env
       MAKEFLAGS: -j 10
     steps:
       - checkout
@@ -1138,9 +1132,9 @@ jobs:
     <<: *base_archlinux
     parallelism: 20
     environment:
+      <<: *base_archlinux_env
       EVM: << pipeline.parameters.evm-version >>
       OPTIMIZE: 0
-      TERM: xterm
       # For Archlinux we do not have prebuilt docker images and we would need to build evmone from source,
       # thus we forgo semantics tests to speed things up.
       SOLTEST_FLAGS: --no-semantic-tests --no-smt
@@ -1157,6 +1151,7 @@ jobs:
     <<: *base_ubuntu2204_clang
     parallelism: 20
     environment:
+      <<: *base_ubuntu2204_clang_env
       EVM: << pipeline.parameters.evm-version >>
       OPTIMIZE: 0
       # The high parallelism in this job is causing the SMT tests to run out of memory,
@@ -1191,7 +1186,7 @@ jobs:
     <<: *base_ubuntu2204
     parallelism: 7 # Should match number of tests in .circleci/cli.sh
     environment:
-      TERM: xterm
+      <<: *base_ubuntu2204_env
       ASAN_OPTIONS: check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2
       # Suppress CLN memory leak.
       # See: https://github.com/ethereum/solidity/issues/13891 for details.
@@ -1202,6 +1197,7 @@ jobs:
     <<: *base_ubuntu2204
     parallelism: 20
     environment:
+      <<: *base_ubuntu2204_env
       EVM: << pipeline.parameters.evm-version >>
       OPTIMIZE: 0
       SOLTEST_FLAGS: --no-smt
@@ -1215,6 +1211,7 @@ jobs:
     <<: *base_ubuntu2204_clang
     parallelism: 20
     environment:
+      <<: *base_ubuntu2204_clang_env
       EVM: << pipeline.parameters.evm-version >>
       OPTIMIZE: 0
       SOLTEST_FLAGS: --no-smt
@@ -1225,6 +1222,7 @@ jobs:
     <<: *base_ubuntu2204_clang
     parallelism: 20
     environment:
+      <<: *base_ubuntu2204_clang_env
       EVM: << pipeline.parameters.evm-version >>
       SOLTEST_FLAGS: --no-smt
     <<: *steps_soltest
@@ -1260,7 +1258,7 @@ jobs:
     docker:
       - image: cimg/node:18.16
     environment:
-      TERM: xterm
+      <<: *base_node_small_env
       HARDHAT_TESTS_SOLC_PATH: /tmp/workspace/soljson.js
     steps:
       - checkout
@@ -1581,9 +1579,8 @@ jobs:
   t_bytecode_compare:
     <<: *base_ubuntu2204_small
     environment:
+      <<: *base_ubuntu2204_small_env
       <<: *bytecode_compare_env_presets
-      TERM: xterm
-      MAKEFLAGS: -j 2
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,7 +358,7 @@ defaults:
   - base_archlinux: &base_archlinux
       docker:
         - image: archlinux:base
-      environment:
+      environment: &base_archlinux_env
         TERM: xterm
         MAKEFLAGS: -j 3
 
@@ -366,7 +366,7 @@ defaults:
       docker:
         - image: archlinux:base
       resource_class: large
-      environment:
+      environment: &base_archlinux_large_env
         TERM: xterm
         MAKEFLAGS: -j 5
 
@@ -374,7 +374,7 @@ defaults:
       docker:
         - image: cimg/base:current
       resource_class: small
-      environment:
+      environment: &base_cimg_small_env
         TERM: xterm
         MAKEFLAGS: -j 2
 
@@ -382,7 +382,7 @@ defaults:
       docker:
         - image: << pipeline.parameters.emscripten-docker-image >>
       resource_class: large
-      environment:
+      environment: &base_ems_large_env
         TERM: xterm
         MAKEFLAGS: -j 5
 
@@ -390,7 +390,7 @@ defaults:
       docker:
         - image: cimg/node:current
       resource_class: small
-      environment:
+      environment: &base_node_small_env
         TERM: xterm
         MAKEFLAGS: -j 2
 
@@ -398,7 +398,7 @@ defaults:
       macos:
         xcode: "14.2.0"
       resource_class: macos.x86.medium.gen2
-      environment:
+      environment: &base_osx_env
         TERM: xterm
         MAKEFLAGS: -j5
 
@@ -406,7 +406,7 @@ defaults:
       macos:
         xcode: "14.2.0"
       resource_class: large
-      environment:
+      environment: &base_osx_large_env
         TERM: xterm
         MAKEFLAGS: -j10
 
@@ -414,56 +414,56 @@ defaults:
       docker:
         - image: cimg/python:3.6
       resource_class: small
-      environment:
+      environment: &base_python_small_env
         TERM: xterm
         MAKEFLAGS: -j 2
 
   - base_ubuntu_clang: &base_ubuntu_clang
       docker:
         - image: << pipeline.parameters.ubuntu-clang-ossfuzz-docker-image >>
-      environment:
+      environment: &base_ubuntu_clang_env
         TERM: xterm
         MAKEFLAGS: -j 3
 
   - base_ubuntu_clang_small: &base_ubuntu_clang_small
       <<: *base_ubuntu_clang
       resource_class: small
-      environment:
+      environment: &base_ubuntu_clang_small_env
         TERM: xterm
         MAKEFLAGS: -j 2
 
   - base_ubuntu2004: &base_ubuntu2004
       docker:
           - image: << pipeline.parameters.ubuntu-2004-docker-image >>
-      environment:
+      environment: &base_ubuntu2004_env
           TERM: xterm
           MAKEFLAGS: -j 3
 
   - base_ubuntu2004_small: &base_ubuntu2004_small
       <<: *base_ubuntu2004
       resource_class: small
-      environment:
+      environment: &base_ubuntu2004_small_env
           TERM: xterm
           MAKEFLAGS: -j 2
 
   - base_ubuntu2004_xlarge: &base_ubuntu2004_xlarge
       <<: *base_ubuntu2004
       resource_class: xlarge
-      environment:
+      environment: &base_ubuntu2004_xlarge_env
           TERM: xterm
           MAKEFLAGS: -j 10
 
   - base_ubuntu2204: &base_ubuntu2204
       docker:
         - image: << pipeline.parameters.ubuntu-2204-docker-image >>
-      environment:
+      environment: &base_ubuntu2204_env
         TERM: xterm
         MAKEFLAGS: -j 3
 
   - base_ubuntu2204_clang: &base_ubuntu2204_clang
       docker:
         - image: << pipeline.parameters.ubuntu-2204-clang-docker-image >>
-      environment:
+      environment: &base_ubuntu2204_clang_env
         TERM: xterm
         CC: clang
         CXX: clang++
@@ -472,7 +472,7 @@ defaults:
   - base_ubuntu2204_clang_large: &base_ubuntu2204_clang_large
       <<: *base_ubuntu2204_clang
       resource_class: large
-      environment:
+      environment: &base_ubuntu2204_clang_large_env
         TERM: xterm
         CC: clang
         CXX: clang++
@@ -481,21 +481,21 @@ defaults:
   - base_ubuntu2204_small: &base_ubuntu2204_small
       <<: *base_ubuntu2204
       resource_class: small
-      environment:
+      environment: &base_ubuntu2204_small_env
         TERM: xterm
         MAKEFLAGS: -j 2
 
   - base_ubuntu2204_large: &base_ubuntu2204_large
       <<: *base_ubuntu2204
       resource_class: large
-      environment:
+      environment: &base_ubuntu2204_large_env
         TERM: xterm
         MAKEFLAGS: -j 5
 
   - base_ubuntu2204_xlarge: &base_ubuntu2204_xlarge
       <<: *base_ubuntu2204
       resource_class: xlarge
-      environment:
+      environment: &base_ubuntu2204_xlarge_env
         TERM: xterm
         MAKEFLAGS: -j 10
 


### PR DESCRIPTION
While working on #13583 I initially made some simple mistakes when defining environment variables for CI jobs, and realized that we can do it better to make such mistakes less likely.

This PR is a simple refactor to make jobs extend the set of environment variables defined in base image definitions instead of redefining them.

### Details
Currently, when we want an extra variable for a job, but still need the variables we defined for the base image, we repeat them like this:
```yaml
defaults:
  - base_ubuntu_clang: &base_ubuntu_clang
      docker:
        - image: << pipeline.parameters.ubuntu-clang-docker-image >>
      environment:
        TERM: xterm
        CC: clang
        CXX: clang++
        MAKEFLAGS: -j 3

jobs:
  b_ubu_clang:
    <<: *base_ubuntu_clang
    environment:
      TERM: xterm
      CC: clang
      CXX: clang++
      MAKEFLAGS: -j 3
      CMAKE_OPTIONS: << parameters.cmake_options >>
```

This is error-prone and verbose. In many cases we don't even repeat variables a job does not use, to make the job definition shorter.

The PR replaces this convention with reuse of environment dicts via YAML anchors like this:
```yaml
defaults:
  - base_ubuntu_clang: &base_ubuntu_clang
      docker:
        - image: << pipeline.parameters.ubuntu-clang-docker-image >>
      environment: &base_ubuntu_clang_env
        TERM: xterm
        CC: clang
        CXX: clang++
        MAKEFLAGS: -j 3

jobs:
  b_ubu_clang:
    <<: *base_ubuntu_clang
    environment:
      <<: *base_ubuntu_clang_env
      CMAKE_OPTIONS: << parameters.cmake_options >>
```