### PR TITLE
Parallelize optimized and unoptimized bytecode reports in CI

### DIFF
--- a/.circleci/compare_bytecode_reports.sh
+++ b/.circleci/compare_bytecode_reports.sh
@@ -37,21 +37,23 @@ interfaces=(
     standard-json
 )
 
-report_files=()
-for platform in "${no_cli_platforms[@]}"; do
-    report_files+=("bytecode-report-${platform}.txt")
-done
-for platform in "${native_platforms[@]}"; do
-    for interface in "${interfaces[@]}"; do
-        report_files+=("bytecode-report-${platform}-${interface}.txt")
+for preset in "$@"; do
+    report_files=()
+    for platform in "${no_cli_platforms[@]}"; do
+        report_files+=("bytecode-report-${platform}-${preset}.txt")
     done
+    for platform in "${native_platforms[@]}"; do
+        for interface in "${interfaces[@]}"; do
+            report_files+=("bytecode-report-${platform}-${interface}-${preset}.txt")
+        done
+    done
+
+    echo "Reports to compare:"
+    printf -- "- %s\n" "${report_files[@]}"
+
+    if ! diff --brief --report-identical-files --from-file "${report_files[@]}"; then
+        diff --unified=0 --report-identical-files --from-file "${report_files[@]}" | head --lines 50
+        zip "bytecode-reports-${preset}.zip" "${report_files[@]}"
+        exit 1
+    fi
 done
-
-echo "Reports to compare:"
-printf -- "- %s\n" "${report_files[@]}"
-
-if ! diff --brief --report-identical-files --from-file "${report_files[@]}"; then
-    diff --unified=0 --report-identical-files --from-file "${report_files[@]}" | head --lines 50
-    zip "all-bytecode-reports.zip" "${report_files[@]}"
-    exit 1
-fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,8 @@ commands:
           - native
       binary_path:
         type: string
+      preset:
+        type: string
     steps:
       - run:
           name: Generate bytecode reports for the selected preset
@@ -90,13 +92,14 @@ commands:
             .circleci/parallel_bytecode_report.sh \
                 "<< parameters.label >>" \
                 "<< parameters.binary_type >>" \
-                "${PWD}/<< parameters.binary_path >>"
+                "${PWD}/<< parameters.binary_path >>" \
+                "<< parameters.preset >>"
       - store_artifacts:
-          path: bytecode-report-<< parameters.label >>-standard-json.txt
+          path: bytecode-report-<< parameters.label >>-standard-json-<< parameters.preset >>.txt
       - store_artifacts:
-          path: bytecode-report-<< parameters.label >>-cli.txt
+          path: bytecode-report-<< parameters.label >>-cli-<< parameters.preset >>.txt
       - store_artifacts:
-          path: bytecode-report-<< parameters.label >>.txt
+          path: bytecode-report-<< parameters.label >>-<< parameters.preset >>.txt
       - persist_to_workspace:
           root: .
           paths:
@@ -216,6 +219,21 @@ defaults:
   - run_docs_pragma_min_version: &run_docs_pragma_min_version
       name: docs pragma version check
       command: ./scripts/docs_version_pragma_check.sh
+
+  # --------------------------------------------------------------------------
+  # Matrix templates
+
+  - bytecode_compare_env_presets: &bytecode_compare_env_presets
+      PRESETS:
+        legacy-optimize
+        legacy-no-optimize
+
+  - bytecode_compare_preset_matrix: &bytecode_compare_preset_matrix
+      parameters:
+        preset:
+          # NOTE: Keep in sync with preset list in bytecode_compare_env_presets
+          - legacy-optimize
+          - legacy-no-optimize
 
   # --------------------------------------------------------------------------
   # Artifacts Templates
@@ -1481,6 +1499,9 @@ jobs:
   # are currently built on different Ubuntu base images.
   # It can be safely removed once we move both to the same Ubuntu version.
   b_bytecode_ubu_static:
+    parameters:
+      preset:
+        type: string
     <<: *base_ubuntu2004_small
     parallelism: 2 # For prepare_bytecode_report
     steps:
@@ -1491,8 +1512,12 @@ jobs:
           label: "ubuntu2004-static"
           binary_type: native
           binary_path: "build/solc/solc-static-linux"
+          preset: "<< parameters.preset >>"
 
   b_bytecode_ubu:
+    parameters:
+      preset:
+        type: string
     <<: *base_ubuntu2204_small
     parallelism: 2 # For prepare_bytecode_report
     steps:
@@ -1503,8 +1528,12 @@ jobs:
           label: "ubuntu"
           binary_type: native
           binary_path: "build/solc/solc"
+          preset: "<< parameters.preset >>"
 
   b_bytecode_osx:
+    parameters:
+      preset:
+        type: string
     <<: *base_osx
     parallelism: 2 # For prepare_bytecode_report
     steps:
@@ -1515,8 +1544,12 @@ jobs:
           label: "osx"
           binary_type: native
           binary_path: "build/solc/solc"
+          preset: "<< parameters.preset >>"
 
   b_bytecode_win:
+    parameters:
+      preset:
+        type: string
     <<: *base_win
     parallelism: 2 # For prepare_bytecode_report
     steps:
@@ -1532,8 +1565,12 @@ jobs:
           label: "windows"
           binary_type: native
           binary_path: "build/solc/Release/solc.exe"
+          preset: "<< parameters.preset >>"
 
   b_bytecode_ems:
+    parameters:
+      preset:
+        type: string
     <<: *base_node_small
     steps:
       - checkout
@@ -1543,18 +1580,23 @@ jobs:
           label: "emscripten"
           binary_type: solcjs
           binary_path: "emscripten_build/libsolc/soljson.js"
+          preset: "<< parameters.preset >>"
 
   t_bytecode_compare:
     <<: *base_ubuntu2204_small
+    environment:
+      <<: *bytecode_compare_env_presets
+      TERM: xterm
+      MAKEFLAGS: -j 2
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - run: .circleci/compare_bytecode_reports.sh
+      - run: .circleci/compare_bytecode_reports.sh $PRESETS
       - store_artifacts:
           # NOTE: store_artifacts does not support the 'when' attribute.
           # Fortunately when the artifact does not exist it just says "No artifact files found" and ignores it.
-          path: all-bytecode-reports.zip
+          path: bytecode-reports-*.zip
       - matrix_notify_failure_unless_pr
 
   c_release_binaries:
@@ -1704,22 +1746,27 @@ workflows:
       # Bytecode comparison:
       - b_bytecode_ubu_static:
           <<: *on_all_tags_and_branches
+          matrix: *bytecode_compare_preset_matrix
           requires:
             - b_ubu_static
       - b_bytecode_ubu:
           <<: *on_all_tags_and_branches
+          matrix: *bytecode_compare_preset_matrix
           requires:
             - b_ubu
       - b_bytecode_win:
           <<: *on_all_tags_and_branches
+          matrix: *bytecode_compare_preset_matrix
           requires:
             - b_win
       - b_bytecode_osx:
           <<: *on_all_tags_and_branches
+          matrix: *bytecode_compare_preset_matrix
           requires:
             - b_osx
       - b_bytecode_ems:
           <<: *on_all_tags_and_branches
+          matrix: *bytecode_compare_preset_matrix
           requires:
             - b_ems
       - t_bytecode_compare:

--- a/.circleci/parallel_bytecode_report.sh
+++ b/.circleci/parallel_bytecode_report.sh
@@ -27,10 +27,11 @@ set -euo pipefail
 # (c) 2023 solidity contributors.
 #------------------------------------------------------------------------------
 
-(( $# == 3 )) || { >&2 echo "Wrong number of arguments."; exit 1; }
+(( $# == 4 )) || { >&2 echo "Wrong number of arguments."; exit 1; }
 label="$1"
 binary_type="$2"
 binary_path="$3" # This path must be absolute
+preset="$4"
 
 [[ $binary_type == native || $binary_type == solcjs ]] || { >&2 echo "Invalid binary type: ${binary_type}"; exit 1; }
 
@@ -51,7 +52,8 @@ if [[ $binary_type == native ]]; then
     python3 ../scripts/bytecodecompare/prepare_report.py \
         "$binary_path" \
         --interface "$interface" \
-        --report-file "../bytecode-report-${label}-${interface}.txt"
+        --preset "$preset" \
+        --report-file "../bytecode-report-${label}-${interface}-${preset}.txt"
 else
     echo "Installing solc-js"
     git clone --depth 1 https://github.com/ethereum/solc-js.git solc-js
@@ -69,5 +71,6 @@ else
     echo "Generating bytecode reports"
     # shellcheck disable=SC2035
     ./prepare_report.js \
-        *.sol > "../bytecode-report-${label}.txt"
+        --preset "$preset" \
+        *.sol > "../bytecode-report-${label}-${preset}.txt"
 fi


### PR DESCRIPTION
~Depends on #14353.~ Merged.
Closes #13056.

This is the second step in parallelizing the bytecode report generation, after #14330. Now that I can generate optimized and unoptimized report separately via presets (#14350), I'm doing just that, in parallel.

This time using CircleCI's job matrix rather than `circleci tests split` utility. The downside is that it doubles the number of jobs. The upside is that it's simpler.