### PR TITLE
SMTChecker: Fix generation of smtlib scripts

### DIFF
--- a/libsolidity/formal/BMC.cpp
+++ b/libsolidity/formal/BMC.cpp
@@ -81,13 +81,13 @@ void BMC::analyze(SourceUnit const& _source, map<ASTNode const*, set<Verificatio
 
 	SMTEncoder::resetSourceAnalysis();
 
+	state().prepareForSourceUnit(_source, false);
 	m_solvedTargets = std::move(_solvedTargets);
 	m_context.setSolver(m_interface.get());
 	m_context.reset();
 	m_context.setAssertionAccumulation(true);
 	m_variableUsage.setFunctionInlining(shouldInlineFunctionCall);
 	createFreeConstants(sourceDependencies(_source));
-	state().prepareForSourceUnit(_source, false);
 	m_unprovedAmt = 0;
 
 	_source.accept(*this);


### PR DESCRIPTION
When both CHC and BMC engines are used, the type of state variable changes when trusted mode for external calls is used. This is because in CHC engine, trusted mode means we pack more information into the symbolic state. In BMC this type is always simple.

However, if BMC is run after CHC, in the current code state variables are reset (and their declaration dumped into SMT-LIB script) before BMC resets the type of the state variable.

The proposed solution is to simply reset the variable type (in `state().prepareForSourceUnit`) before the first variable of this type is created (in `m_context.reset()`).

Fixes #14375.