### PR TITLE
Check style coverage for using namespace std

### DIFF
--- a/.github/workflows/welcome-external-pr.yml
+++ b/.github/workflows/welcome-external-pr.yml
@@ -6,42 +6,16 @@ on:
       - opened
 
 env:
-  ORGANIZATION: Ethereum
   DRY_RUN: false
 
 jobs:
   comment-external-pr:
     runs-on: ubuntu-latest
     steps:
-      - name: Get organization members
-        id: get_members
-        env:
-          GH_TOKEN: ${{ secrets.READ_ORG }}
-          CONTRIBUTOR: ${{ github.event.pull_request.user.login }}
-        run: |
-          gh api graphql \
-            --raw-field organization="$ORGANIZATION" \
-            --raw-field query='
-              query($organization: String!) {
-                organization(login: $organization) {
-                  team(slug: "Solidity") {
-                    members(first: 100) {
-                      nodes {
-                        login
-                      }
-                    }
-                  }
-                }
-              }' > org_members.json
-          echo "CONTRIBUTOR_IS_ORG_MEMBER=$(
-            jq \
-              --arg contributor $CONTRIBUTOR \
-              '.data.organization.team.members | any(.nodes[].login; . == $contributor)' \
-              org_members.json
-          )" >> $GITHUB_OUTPUT
-
+      # Note: this step requires that the INTERNAL_CONTRIBUTORS environment variable
+      # is already defined in the repository with the current json list of internal contributors.
       - name: Comment on external contribution PR
-        if: ${{ steps.get_members.outputs.CONTRIBUTOR_IS_ORG_MEMBER == 'false' }}
+        if: "!contains(fromJSON(vars.INTERNAL_CONTRIBUTORS), github.event.pull_request.user.login)"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.html_url }}

--- a/scripts/check_style.sh
+++ b/scripts/check_style.sh
@@ -20,6 +20,10 @@ EXCLUDE_FILES=(
 EXCLUDE_FILES_JOINED=$(printf "%s\|" "${EXCLUDE_FILES[@]}")
 EXCLUDE_FILES_JOINED=${EXCLUDE_FILES_JOINED%??}
 
+NAMESPACE_STD_FREE_FILES=(
+    libevmasm/*
+)
+
 (
 REPO_ROOT="$(dirname "$0")"/..
 cd "$REPO_ROOT" || exit 1
@@ -58,6 +62,9 @@ FORMATERROR=$(
     # unqualified move()/forward() checks, i.e. make sure that std::move() and std::forward() are used instead of move() and forward()
     preparedGrep "move\(.+\)" | grep -v "std::move" | grep -E "[^a-z]move"
     preparedGrep "forward\(.+\)" | grep -v "std::forward" | grep -E "[^a-z]forward"
+    # make sure `using namespace std` is not used in INCLUDE_DIRECTORIES
+    # shellcheck disable=SC2068,SC2068
+    grep -nIE -d skip "using namespace std;" ${NAMESPACE_STD_FREE_FILES[@]}
 ) | grep -E -v -e "^[a-zA-Z\./]*:[0-9]*:\s*\/(\/|\*)" -e "^test/" || true
 )
 

--- a/test/tools/ossfuzz/protoToAbiV2.h
+++ b/test/tools/ossfuzz/protoToAbiV2.h
@@ -390,7 +390,7 @@ private:
 		return m_isLastDynParamRightPadded;
 	}
 
-	/// Convert delimter to a comma or null string.
+	/// Convert delimiter to a comma or null string.
 	static std::string delimiterToString(Delimiter _delimiter, bool _space = true);
 	/// Generates number in the range [1, @param _n] uniformly at random.
 	unsigned randomNumberOneToN(unsigned _n)


### PR DESCRIPTION
Partially fixes: https://github.com/ethereum/solidity/issues/14403

Works by providing an inclusion list of directories which will be checked for the presence of `using namespace std;`. Finding it in one of these directories will yield errors. The goal is to add to these inclusion directories once each has been altered to use explicit namespaces.