### PR TITLE
Check style coverage for using namespace std

### DIFF
--- a/scripts/check_style.sh
+++ b/scripts/check_style.sh
@@ -20,6 +20,10 @@ EXCLUDE_FILES=(
 EXCLUDE_FILES_JOINED=$(printf "%s\|" "${EXCLUDE_FILES[@]}")
 EXCLUDE_FILES_JOINED=${EXCLUDE_FILES_JOINED%??}
 
+NAMESPACE_STD_FREE_FILES=(
+    libevmasm/*
+)
+
 (
 REPO_ROOT="$(dirname "$0")"/..
 cd "$REPO_ROOT" || exit 1
@@ -58,6 +62,9 @@ FORMATERROR=$(
     # unqualified move()/forward() checks, i.e. make sure that std::move() and std::forward() are used instead of move() and forward()
     preparedGrep "move\(.+\)" | grep -v "std::move" | grep -E "[^a-z]move"
     preparedGrep "forward\(.+\)" | grep -v "std::forward" | grep -E "[^a-z]forward"
+    # make sure `using namespace std` is not used in INCLUDE_DIRECTORIES
+    # shellcheck disable=SC2068,SC2068
+    grep -nIE -d skip "using namespace std;" ${NAMESPACE_STD_FREE_FILES[@]}
 ) | grep -E -v -e "^[a-zA-Z\./]*:[0-9]*:\s*\/(\/|\*)" -e "^test/" || true
 )
 


### PR DESCRIPTION
Partially fixes: https://github.com/ethereum/solidity/issues/14403

Works by providing an inclusion list of directories which will be checked for the presence of using namespace std;. Finding it in one of these directories will yield errors. The goal is to add to these inclusion directories once each has been altered to use explicit namespaces.