### PR TITLE
Make mixedCase the recommended naming style for constants

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Important Bugfixes:
 Language Features:
  * Allow qualified access to events from other contracts.
  * Relax restrictions on initialization of immutable variables. Reads and writes may now happen at any point at construction time outside of functions and modifiers. Explicit initialization is no longer mandatory.
+ * Make mixedCase the recommended naming style for constants.
 
 
 Compiler Features:

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -1260,8 +1260,11 @@ Use mixedCase. Examples: ``totalSupply``, ``remainingSupply``, ``balancesOf``, `
 Constants
 =========
 
-Constants should be named with all capital letters with underscores separating
-words. Examples: ``MAX_BLOCKS``, ``TOKEN_NAME``, ``TOKEN_TICKER``, ``CONTRACT_VERSION``.
+Constants should use mixedCase. Examples: ``maxBlocks``, ``tokenName``, ``tokenTicker``, ``contractVersion``.
+
+Names with all capital letters with underscores separating words are acceptable
+only in legacy code and for implementing existing interfaces requiring this convention.
+Examples: ``MAX_BLOCKS``, ``TOKEN_NAME``, ``TOKEN_TICKER``, ``CONTRACT_VERSION``.
 
 
 Modifier Names


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/14270.