### PR TITLE
[Docs website] Update "Edit on GitHub" path to `develop` branch

### DIFF
--- a/docs/_static/js/initialize.js
+++ b/docs/_static/js/initialize.js
@@ -143,6 +143,19 @@ const updateActiveNavLink = () => {
 
 document.addEventListener("locationchange", updateActiveNavLink);
 
+function updateGitHubEditPath() {
+  // Replaces the version number in the GitHub edit path with "develop"
+  const gitHubEditAnchor = document.querySelector(".wy-breadcrumbs-aside > a");
+  const url = new URL(gitHubEditAnchor.href);
+  const split = url.pathname.split("/");
+  const versionIndex = split.indexOf("blob") + 1;
+  split[versionIndex] = "develop";
+  url.pathname = split.join("/");
+  gitHubEditAnchor.setAttribute("href", url.toString());
+  gitHubEditAnchor.setAttribute("target", "_blank");
+  gitHubEditAnchor.setAttribute("rel", "noopener noreferrer");
+}
+
 function initialize() {
   // Preload fonts
   const fonts = [
@@ -214,6 +227,9 @@ function initialize() {
 
   // Update active nav link
   updateActiveNavLink();
+
+  // Update GitHub edit path to direct to `develop` branch
+  updateGitHubEditPath();
 }
 
 document.addEventListener("DOMContentLoaded", initialize);


### PR DESCRIPTION
## Description

Currently the "Edit on GitHub" button shown at the top of each docs page links to the specific version being viewed in the docs. These files are frozen/snapshotted for that version and cannot be edited.

This adds logic to alter the "Edit on GitHub" button to direct users to the `develop` branch instead of the version-specific branch. Also adds `target="_blank"` to open link in new tab.

## Preview deploy
https://solidity-docs-dev--3.org.readthedocs.build/en/3/
(Build from personal fork)

## Related issue
None filed