### PR TITLE
Add TMP and remove TODO and FIXME from pylint note tags list

### DIFF
--- a/scripts/pylintrc
+++ b/scripts/pylintrc
@@ -63,3 +63,7 @@ expected-line-ending-format=LF
 
 # Maximum number of characters on a single line.
 max-line-length=130
+
+[MISCELLANEOUS]
+
+notes=XXX,TMP


### PR DESCRIPTION
As suggested in https://github.com/ethereum/solidity/pull/13873#discussion_r1269430276 and https://github.com/ethereum/solidity/pull/13873#discussion_r1270697521

Note that TODO and FIXME are set by default: https://pylint.pycqa.org/en/latest/user_guide/configuration/all-options.html#miscellaneous-checker