### PR TITLE
[Docs website] Add site_url root path to images [Fixes #14435]

### DIFF
--- a/docs/_static/js/constants.js
+++ b/docs/_static/js/constants.js
@@ -1,11 +1,18 @@
+// Site URL
+const SITE_URL = "https://docs.soliditylang.org"
+const { origin, pathname } = location;
+const pathSplit = pathname.split("/");
+const rootPath = origin.includes(SITE_URL) && pathSplit.length > 3 ? pathSplit.splice(1, 2).join("/") : ''
+const ROOT_URL = `${origin}/${rootPath}`;
+
 // Color mode constants
 const [DARK, LIGHT] = ["dark", "light"];
-const LIGHT_LOGO_PATH = "_static/img/logo.svg";
-const DARK_LOGO_PATH = "_static/img/logo-dark.svg";
-const SUN_ICON_PATH = "_static/img/sun.svg";
-const MOON_ICON_PATH = "_static/img/moon.svg";
-const LIGHT_HAMBURGER_PATH = "_static/img/hamburger-light.svg";
-const DARK_HAMBURGER_PATH = "_static/img/hamburger-dark.svg";
+const LIGHT_LOGO_PATH = `${ROOT_URL}/_static/img/logo.svg`;
+const DARK_LOGO_PATH = `${ROOT_URL}/_static/img/logo-dark.svg`;
+const SUN_ICON_PATH = `${ROOT_URL}/_static/img/sun.svg`;
+const MOON_ICON_PATH = `${ROOT_URL}/_static/img/moon.svg`;
+const LIGHT_HAMBURGER_PATH = `${ROOT_URL}/_static/img/hamburger-light.svg`;
+const DARK_HAMBURGER_PATH = `${ROOT_URL}/_static/img/hamburger-dark.svg`;
 const COLOR_TOGGLE_ICON_CLASS = "color-toggle-icon";
 const SOLIDITY_LOGO_CLASS = "solidity-logo";
 const LS_COLOR_SCHEME = "color-scheme";


### PR DESCRIPTION
## Description

Adds a base path to all image references to avoid relative path issue noted in #14435. This allows us to keep using the "version" indicated in the path (as opposed to hard-coding `/en/latest/`). Nested paths such as `https://docs.soliditylang.org/en/latest/internals/layout_in_storage.html` should no longer cause a bug with the images in the header.