### PR TITLE
SMTChecker: Fix inconsistency on constant condition check after a loop is unrolled

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ Bugfixes:
  * AST: Fix wrong initial ID for Yul nodes in the AST.
  * NatSpec: Fix internal error when requesting userdoc or devdoc for a contract that emits an event defined in a foreign contract or interface.
  * SMTChecker: Fix encoding error that causes loops to unroll after completion.
+ * SMTChecker: Fix inconsistency on constant condition checks when ``while`` or ``for`` loops are unrolled before the condition check.
 
 
 ### 0.8.21 (2023-07-19)

--- a/libsolidity/formal/BMC.h
+++ b/libsolidity/formal/BMC.h
@@ -190,7 +190,7 @@ private:
 	smtutil::CheckResult checkSatisfiable();
 	//@}
 
-	std::tuple<smtutil::Expression, smtutil::Expression> mergeVariablesFromLoopCheckpoints();
+	smtutil::Expression mergeVariablesFromLoopCheckpoints();
 	bool isInsideLoop() const;
 
 	std::unique_ptr<smtutil::SolverInterface> m_interface;

--- a/test/libsolidity/smtCheckerTests/loops/do_while_bmc_iterations_7.sol
+++ b/test/libsolidity/smtCheckerTests/loops/do_while_bmc_iterations_7.sol
@@ -1,0 +1,19 @@
+contract C
+{
+	uint256[] y;
+
+	function f() public view {
+		uint256 x = 0;
+		do {
+			++x;
+		} while (x < y.length);
+		require(x != 0);
+	}
+}
+// ====
+// SMTEngine: bmc
+// SMTSolvers: z3
+// BMCLoopIterations: 1
+// ----
+// Warning 6838: (124-130): BMC: Condition is always true.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/loops/do_while_bmc_iterations_semantics_1.sol
+++ b/test/libsolidity/smtCheckerTests/loops/do_while_bmc_iterations_semantics_1.sol
@@ -7,7 +7,7 @@ contract C {
 				y = 1;
 			++x;
 		} while (x < 3 || y == 1);
-        // BMC loop iteration setting is not enough to leave the loop
+		// BMC loop iteration setting is not enough to leave the loop
 		assert(x == 0); // should hold - no assumptions on value if didn't complete loop
 		assert(y == 0); // should hold - no assumptions on value if didn't complete loop
 	}

--- a/test/libsolidity/smtCheckerTests/loops/do_while_bmc_iterations_semantics_2.sol
+++ b/test/libsolidity/smtCheckerTests/loops/do_while_bmc_iterations_semantics_2.sol
@@ -7,9 +7,10 @@ contract C {
 				y = 1;
 			++x;
 		} while (x < 3 || y == 1);
-        // BMC loop iteration setting is just enough to leave the loop
-		assert(x == 3); // should hold
+		// BMC loop iteration setting is just enough to leave the loop
+		assert(x == 3);
 		assert(y == 1); // should fail, when x == 3 loop is completed
+		assert(y == 0);
 	}
 }
 // ====
@@ -17,5 +18,5 @@ contract C {
 // SMTSolvers: z3
 // BMCLoopIterations: 4
 // ----
-// Warning 4661: (244-258): BMC: Assertion violation happens here.
-// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 4661: (223-237): BMC: Assertion violation happens here.
+// Info 6002: BMC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/loops/do_while_bmc_iterations_semantics_3.sol
+++ b/test/libsolidity/smtCheckerTests/loops/do_while_bmc_iterations_semantics_3.sol
@@ -7,9 +7,10 @@ contract C {
 				y = 1;
 			++x;
 		} while (x < 3 || y == 1);
-        // BMC loop iteration setting is more than enough to leave the loop
-		assert(x == 3); // should hold
-		assert(y == 0); // should hold
+		// BMC loop iteration setting is more than enough to leave the loop
+		assert(x == 3);
+		assert(y == 1); // should fail
+		assert(y == 0);
 	}
 }
 // ====
@@ -17,4 +18,5 @@ contract C {
 // SMTSolvers: z3
 // BMCLoopIterations: 5
 // ----
+// Warning 4661: (228-242): BMC: Assertion violation happens here.
 // Info 6002: BMC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/loops/do_while_bmc_iterations_semantics_4.sol
+++ b/test/libsolidity/smtCheckerTests/loops/do_while_bmc_iterations_semantics_4.sol
@@ -3,11 +3,11 @@ contract C {
 		uint x = 0;
 		int y = 0;
 		do {
-            ++x;
+			++x;
 			if (x >= 3)
 				y = 1;
 		} while (x < 3 || y == 1);
-        // BMC loop iteration setting is more than enough to leave the loop
+		// BMC loop iteration setting is more than enough to leave the loop
 		assert(x == 3); // should hold
 		assert(y == 1); // should hold
 	}

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_bmc_iterations_10.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_bmc_iterations_10.sol
@@ -1,0 +1,19 @@
+contract C
+{
+	uint256[] y;
+
+	function f() public view {
+		uint256 x = 0;
+		for (uint i = 0; i < y.length; i++) {
+			x = 1;
+		}
+		// tests that constant condition warning is not reported
+		require(x != 0);
+	}
+}
+// ====
+// SMTEngine: bmc
+// SMTSolvers: z3
+// BMCLoopIterations: 1
+// ----
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_bmc_iterations_semantics_1.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_bmc_iterations_semantics_1.sol
@@ -7,13 +7,13 @@ contract C {
 				y = 1;
 		}
         // BMC loop iteration setting is not enough to leave the loop
-		assert(x == 0); // should hold - no assumptions on value if didn't complete loop
-		assert(y == 0); // should hold - no assumptions on value if didn't complete loop
+		assert(x == 0); // should hold - no assumptions on value if didn't complete the loop
+		assert(y == 0); // should hold - no assumptions on value if didn't complete the loop
 	}
 }
 // ====
 // SMTEngine: bmc
 // SMTSolvers: z3
-// BMCLoopIterations: 3
+// BMCLoopIterations: 2
 // ----
 // Info 6002: BMC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_bmc_iterations_semantics_2.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_bmc_iterations_semantics_2.sol
@@ -6,14 +6,16 @@ contract C {
 			if (x >= 3)
 				y = 1;
 		}
-        // BMC loop iteration setting is just enough to leave the loop
-		assert(x == 3); // should hold - no assumptions on value if didn't complete loop
-		assert(y == 0); // should hold - no assumptions on value if didn't complete loop
+		// BMC loop iteration setting is just enough to leave the loop
+		assert(x == 3);
+		assert(y == 1); // should fail
+		assert(y == 0);
 	}
 }
 // ====
 // SMTEngine: bmc
 // SMTSolvers: z3
-// BMCLoopIterations: 4
+// BMCLoopIterations: 3
 // ----
+// Warning 4661: (216-230): BMC: Assertion violation happens here.
 // Info 6002: BMC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/loops/for_loop_bmc_iterations_semantics_3.sol
+++ b/test/libsolidity/smtCheckerTests/loops/for_loop_bmc_iterations_semantics_3.sol
@@ -6,14 +6,16 @@ contract C {
 			if (x >= 3)
 				y = 1;
 		}
-        // BMC loop iteration setting is more than enough to leave the loop
-		assert(x == 3); // should hold - no assumptions on value if didn't complete loop
-		assert(y == 0); // should hold - no assumptions on value if didn't complete loop
+		// BMC loop iteration setting is more than enough to leave the loop
+		assert(x == 3);
+		assert(y == 1); // should fail
+		assert(y == 0);
 	}
 }
 // ====
 // SMTEngine: bmc
 // SMTSolvers: z3
-// BMCLoopIterations: 5
+// BMCLoopIterations: 4
 // ----
+// Warning 4661: (221-235): BMC: Assertion violation happens here.
 // Info 6002: BMC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/loops/while_bmc_iterations_8.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_bmc_iterations_8.sol
@@ -1,0 +1,18 @@
+contract C
+{
+	uint256[] y;
+
+	function f() public view {
+ 		uint256 x = 0;
+		while (x < y.length) {
+			x = 1;
+		}
+		// tests that constant condition warning is not reported
+		require(x != 0);
+	}
+}
+// ====
+// SMTEngine: bmc
+// SMTSolvers: z3
+// BMCLoopIterations: 1
+// ----

--- a/test/libsolidity/smtCheckerTests/loops/while_bmc_iterations_semantics_1.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_bmc_iterations_semantics_1.sol
@@ -7,14 +7,14 @@ contract C {
 				y = 1;
 			++x;
 		}
-        // BMC loop iteration setting is not enough to leave the loop
-		assert(x == 3);
-		assert(y == 1);
+		// BMC loop iteration setting is not enough to leave the loop
+		assert(x == 0); // should hold - no assumptions on value if didn't complete the loop
+		assert(y == 0); // should hold - no assumptions on value if didn't complete the loop
 	}
 }
 // ====
 // SMTEngine: bmc
 // SMTSolvers: z3
-// BMCLoopIterations: 3
+// BMCLoopIterations: 2
 // ----
 // Info 6002: BMC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/loops/while_bmc_iterations_semantics_2.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_bmc_iterations_semantics_2.sol
@@ -7,15 +7,16 @@ contract C {
 				y = 1;
 			++x;
 		}
-        // BMC loop iteration setting is just enough to leave the loop
-		assert(x == 3); // should hold
+ 		// BMC loop iteration setting is just enough to leave the loop
+		assert(x == 3);
 		assert(y == 1); // should fail
+		assert(y == 0);
 	}
 }
 // ====
 // SMTEngine: bmc
 // SMTSolvers: z3
-// BMCLoopIterations: 4
+// BMCLoopIterations: 3
 // ----
-// Warning 4661: (240-254): BMC: Assertion violation happens here.
-// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 4661: (220-234): BMC: Assertion violation happens here.
+// Info 6002: BMC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/loops/while_bmc_iterations_semantics_3.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_bmc_iterations_semantics_3.sol
@@ -7,14 +7,16 @@ contract C {
 				y = 1;
 			++x;
 		}
-        // BMC loop iteration setting is more than enough to leave the loop
-		assert(x == 3); // should hold
-		assert(y == 0); // should hold
+		// BMC loop iteration setting is more than enough to leave the loop
+		assert(x == 3);
+		assert(y == 1); // should fail
+		assert(y == 0);
 	}
 }
 // ====
 // SMTEngine: bmc
 // SMTSolvers: z3
-// BMCLoopIterations: 5
+// BMCLoopIterations: 4
 // ----
+// Warning 4661: (224-238): BMC: Assertion violation happens here.
 // Info 6002: BMC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/out_of_bounds/array_2d_4.sol
+++ b/test/libsolidity/smtCheckerTests/out_of_bounds/array_2d_4.sol
@@ -24,4 +24,4 @@ contract C {
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
 // Warning 2661: (184-197): BMC: Overflow (resulting value larger than 2**256 - 1) happens here.
 // Warning 2661: (228-244): BMC: Overflow (resulting value larger than 2**256 - 1) happens here.
-// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.


### PR DESCRIPTION
Closes https://github.com/ethereum/solidity/issues/14449.

It changes semantics a bit, which I think was wrong earlier:
- we now visit the condition again in case of `while` and `for` loops after the loop was unrolled `--model-checker-bmc-loop-iterations` number of times