### PR TITLE
Enable setting compiler callback after construction

### DIFF
--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -247,6 +247,13 @@ void CompilerStack::setModelCheckerSettings(ModelCheckerSettings _settings)
 	m_modelCheckerSettings = _settings;
 }
 
+void CompilerStack::setCallback(ReadCallback::Callback _callback)
+{
+	if (m_stackState >= ParsedAndImported)
+		solThrow(CompilerError, "Must set callback before parsing.");
+	m_readFile = std::move(_callback);
+}
+
 void CompilerStack::setLibraries(map<string, util::h160> const& _libraries)
 {
 	if (m_stackState >= ParsedAndImported)

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -197,6 +197,10 @@ public:
 		m_requestedContractNames = _contractNames;
 	}
 
+	/// Sets callback for reading from files or interactinng with SMT solvers.
+	/// Must be set before parsing.
+	void setCallback(ReadCallback::Callback _callback);
+
 	/// Enable EVM Bytecode generation. This is enabled by default.
 	void enableEvmBytecodeGeneration(bool _enable = true) { m_generateEvmBytecode = _enable; }
 


### PR DESCRIPTION
This is a preparation for upcoming change in SMTChecker that will interact with the solvers solely using smtlib interface, i.e., using the callback for issuing queries to the solvers and reading back the answers.

That change will require using compiler with the SMT callback in SMTChecker tests. Since the class SMTCheckerTest currently cannot influece how the compiler object is constructed, it needs a way to set the callback after construction.