### PR TITLE
Refactor syntax test setup

### DIFF
--- a/test/libsolidity/AnalysisFramework.cpp
+++ b/test/libsolidity/AnalysisFramework.cpp
@@ -75,6 +75,11 @@ AnalysisFramework::parseAnalyseAndReturnError(
 	return make_pair(&compiler().ast(""), std::move(errors));
 }
 
+std::unique_ptr<CompilerStack> AnalysisFramework::createStack() const
+{
+	return std::make_unique<CompilerStack>();
+}
+
 ErrorList AnalysisFramework::filterErrors(ErrorList const& _errorList, bool _includeWarningsAndInfos) const
 {
 	ErrorList errors;

--- a/test/libsolidity/AnalysisFramework.h
+++ b/test/libsolidity/AnalysisFramework.h
@@ -76,7 +76,7 @@ protected:
 	solidity::frontend::CompilerStack& compiler()
 	{
 		if (!m_compiler)
-			m_compiler = std::make_unique<solidity::frontend::CompilerStack>();
+			m_compiler = createStack();
 		return *m_compiler;
 	}
 
@@ -84,9 +84,13 @@ protected:
 	solidity::frontend::CompilerStack const& compiler() const
 	{
 		if (!m_compiler)
-			m_compiler = std::make_unique<solidity::frontend::CompilerStack>();
+			m_compiler = createStack();
 		return *m_compiler;
 	}
+
+	/// Creates a new instance of @p CompilerStack. Override if your test case needs to pass in
+	/// custom constructor arguments.
+	virtual std::unique_ptr<CompilerStack> createStack() const;
 
 private:
 	mutable std::unique_ptr<solidity::frontend::CompilerStack> m_compiler;

--- a/test/libsolidity/SMTCheckerTest.cpp
+++ b/test/libsolidity/SMTCheckerTest.cpp
@@ -127,14 +127,11 @@ SMTCheckerTest::SMTCheckerTest(string const& _filename): SyntaxTest(_filename, E
 	m_modelCheckerSettings.bmcLoopIterations = std::optional<unsigned>{bmcLoopIterations};
 }
 
-TestCase::TestResult SMTCheckerTest::run(ostream& _stream, string const& _linePrefix, bool _formatted)
+void SMTCheckerTest::setupCompiler()
 {
-	setupCompiler();
-	compiler().setModelCheckerSettings(m_modelCheckerSettings);
-	parseAndAnalyze();
-	filterObtainedErrors();
+	SyntaxTest::setupCompiler();
 
-	return conclude(_stream, _linePrefix, _formatted);
+	compiler().setModelCheckerSettings(m_modelCheckerSettings);
 }
 
 void SMTCheckerTest::filterObtainedErrors()

--- a/test/libsolidity/SMTCheckerTest.h
+++ b/test/libsolidity/SMTCheckerTest.h
@@ -38,8 +38,7 @@ public:
 	}
 	SMTCheckerTest(std::string const& _filename);
 
-	TestResult run(std::ostream& _stream, std::string const& _linePrefix = "", bool _formatted = false) override;
-
+	void setupCompiler() override;
 	void filterObtainedErrors() override;
 
 	void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix) const override;

--- a/test/libsolidity/SyntaxTest.cpp
+++ b/test/libsolidity/SyntaxTest.cpp
@@ -43,15 +43,6 @@ SyntaxTest::SyntaxTest(string const& _filename, langutil::EVMVersion _evmVersion
 	m_parserErrorRecovery = _parserErrorRecovery;
 }
 
-TestCase::TestResult SyntaxTest::run(ostream& _stream, string const& _linePrefix, bool _formatted)
-{
-	setupCompiler();
-	parseAndAnalyze();
-	filterObtainedErrors();
-
-	return conclude(_stream, _linePrefix, _formatted);
-}
-
 string SyntaxTest::addPreamble(string const& _sourceCode)
 {
 	// Silence compiler version warning
@@ -83,6 +74,8 @@ void SyntaxTest::setupCompiler()
 
 void SyntaxTest::parseAndAnalyze()
 {
+	setupCompiler();
+
 	if (compiler().parse() && compiler().analyze())
 		try
 		{
@@ -112,6 +105,8 @@ void SyntaxTest::parseAndAnalyze()
 				-1
 			});
 		}
+
+	filterObtainedErrors();
 }
 
 void SyntaxTest::filterObtainedErrors()

--- a/test/libsolidity/SyntaxTest.h
+++ b/test/libsolidity/SyntaxTest.h
@@ -47,13 +47,11 @@ public:
 	}
 	SyntaxTest(std::string const& _filename, langutil::EVMVersion _evmVersion, bool _parserErrorRecovery = false);
 
-	TestResult run(std::ostream& _stream, std::string const& _linePrefix = "", bool _formatted = false) override;
-
 protected:
 	/// Returns @param _sourceCode prefixed with the version pragma and the SPDX license identifier.
 	static std::string addPreamble(std::string const& _sourceCode);
 
-	void setupCompiler();
+	virtual void setupCompiler();
 	void parseAndAnalyze() override;
 	virtual void filterObtainedErrors();
 


### PR DESCRIPTION
Closes #14465.

The main goal here is to make it possible to initialize the `CompilerStack` with a custom callback. Unlike #14465 this is done in `AnalysisFramework` only, without touching `CompilerStack` API.

While at it, I also noticed that both `SyntaxTest` and `SMTCheckerTest` don't seem to use the virtual methods provided by base classes the way it was intended. They override `TestCase::run()` instead of `setupCompiler()` and `parseAndAnalyze()` which seem like they were meant to serve as extension points. The PR fixes that as well.