### PR TITLE
Set CPUs for `soltest.sh` based on the number of available cores

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,6 +366,7 @@ defaults:
       environment: &base_archlinux_env
         TERM: xterm
         MAKEFLAGS: -j 3
+        CPUs: 3
 
   - base_archlinux_large: &base_archlinux_large
       <<: *base_archlinux
@@ -373,6 +374,7 @@ defaults:
       environment: &base_archlinux_large_env
         <<: *base_archlinux_env
         MAKEFLAGS: -j 5
+        CPUs: 5
 
   - base_cimg_small: &base_cimg_small
       docker:
@@ -381,6 +383,7 @@ defaults:
       environment: &base_cimg_small_env
         TERM: xterm
         MAKEFLAGS: -j 2
+        CPUs: 2
 
   - base_ems_large: &base_ems_large
       docker:
@@ -389,6 +392,7 @@ defaults:
       environment: &base_ems_large_env
         TERM: xterm
         MAKEFLAGS: -j 5
+        CPUs: 5
 
   - base_node_small: &base_node_small
       docker:
@@ -397,6 +401,7 @@ defaults:
       environment: &base_node_small_env
         TERM: xterm
         MAKEFLAGS: -j 2
+        CPUs: 2
 
   - base_osx: &base_osx
       macos:
@@ -405,6 +410,7 @@ defaults:
       environment: &base_osx_env
         TERM: xterm
         MAKEFLAGS: -j5
+        CPUs: 5
 
   - base_osx_large: &base_osx_large
       <<: *base_osx
@@ -412,6 +418,7 @@ defaults:
       environment: &base_osx_large_env
         <<: *base_osx_env
         MAKEFLAGS: -j10
+        CPUs: 10
 
   - base_python_small: &base_python_small
       docker:
@@ -420,6 +427,7 @@ defaults:
       environment: &base_python_small_env
         TERM: xterm
         MAKEFLAGS: -j 2
+        CPUs: 2
 
   - base_ubuntu_clang: &base_ubuntu_clang
       docker:
@@ -427,6 +435,7 @@ defaults:
       environment: &base_ubuntu_clang_env
         TERM: xterm
         MAKEFLAGS: -j 3
+        CPUs: 3
 
   - base_ubuntu_clang_small: &base_ubuntu_clang_small
       <<: *base_ubuntu_clang
@@ -434,6 +443,7 @@ defaults:
       environment: &base_ubuntu_clang_small_env
         <<: *base_ubuntu_clang_env
         MAKEFLAGS: -j 2
+        CPUs: 2
 
   - base_ubuntu2004: &base_ubuntu2004
       docker:
@@ -441,6 +451,7 @@ defaults:
       environment: &base_ubuntu2004_env
         TERM: xterm
         MAKEFLAGS: -j 3
+        CPUs: 3
 
   - base_ubuntu2004_small: &base_ubuntu2004_small
       <<: *base_ubuntu2004
@@ -448,6 +459,7 @@ defaults:
       environment: &base_ubuntu2004_small_env
         <<: *base_ubuntu2004_env
         MAKEFLAGS: -j 2
+        CPUs: 2
 
   - base_ubuntu2004_xlarge: &base_ubuntu2004_xlarge
       <<: *base_ubuntu2004
@@ -455,6 +467,7 @@ defaults:
       environment: &base_ubuntu2004_xlarge_env
         <<: *base_ubuntu2004_env
         MAKEFLAGS: -j 10
+        CPUs: 10
 
   - base_ubuntu2204: &base_ubuntu2204
       docker:
@@ -462,6 +475,7 @@ defaults:
       environment: &base_ubuntu2204_env
         TERM: xterm
         MAKEFLAGS: -j 3
+        CPUs: 3
 
   - base_ubuntu2204_clang: &base_ubuntu2204_clang
       docker:
@@ -471,6 +485,7 @@ defaults:
         CC: clang
         CXX: clang++
         MAKEFLAGS: -j 3
+        CPUs: 3
 
   - base_ubuntu2204_clang_large: &base_ubuntu2204_clang_large
       <<: *base_ubuntu2204_clang
@@ -478,6 +493,7 @@ defaults:
       environment: &base_ubuntu2204_clang_large_env
         <<: *base_ubuntu2204_clang_env
         MAKEFLAGS: -j 5
+        CPUs: 5
 
   - base_ubuntu2204_small: &base_ubuntu2204_small
       <<: *base_ubuntu2204
@@ -485,6 +501,7 @@ defaults:
       environment: &base_ubuntu2204_small_env
         <<: *base_ubuntu2204_env
         MAKEFLAGS: -j 2
+        CPUs: 2
 
   - base_ubuntu2204_large: &base_ubuntu2204_large
       <<: *base_ubuntu2204
@@ -492,6 +509,7 @@ defaults:
       environment: &base_ubuntu2204_large_env
         <<: *base_ubuntu2204_env
         MAKEFLAGS: -j 5
+        CPUs: 5
 
   - base_ubuntu2204_xlarge: &base_ubuntu2204_xlarge
       <<: *base_ubuntu2204
@@ -499,6 +517,7 @@ defaults:
       environment: &base_ubuntu2204_xlarge_env
         <<: *base_ubuntu2204_env
         MAKEFLAGS: -j 10
+        CPUs: 10
 
   - base_win: &base_win
       executor:

--- a/.circleci/soltest.sh
+++ b/.circleci/soltest.sh
@@ -36,6 +36,7 @@ set -e
 
 OPTIMIZE=${OPTIMIZE:-"0"}
 EVM=${EVM:-"invalid"}
+CPUs=${CPUs:-3}
 REPODIR="$(realpath "$(dirname "$0")/..")"
 
 IFS=" " read -r -a BOOST_TEST_ARGS <<< "$BOOST_TEST_ARGS"
@@ -67,7 +68,6 @@ get_logfile_basename() {
 # long-running test cases are next to each other.
 CIRCLE_NODE_INDEX=$(((CIRCLE_NODE_INDEX + 23 * INDEX_SHIFT) % CIRCLE_NODE_TOTAL))
 
-CPUs=3
 PIDs=()
 for run in $(seq 0 $((CPUs - 1)))
 do


### PR DESCRIPTION
Recently, while discussing our soltest parallelisation with @blishko I realized that we always run 3 processes inside each image, regardless of how many cores are available. As a result the available cores are underutilized and soltest jobs do not finish as fast as they potentially could. This PR makes an attempt to fix that.

### Results
#### Memory
One of our concerns was that this might have been set to 3 to avoid exceeding available memory. In my test runs this does not seem to be the case though. Even with this change applied, for most of soltest jobs memory usage peaks at 25%. In some cases it reaches 50%. It's nowhere near 100%. 

#### Timing
Here's the timing comparison between a [run on my experimental `circleci-config-commands`](https://app.circleci.com/pipelines/github/ethereum/solidity/30774/workflows/cd274a5a-08b0-42b1-9433-25849394c89f) branch (should have the same timing as `develop`) and an [earlier run from this PR](https://app.circleci.com/pipelines/github/ethereum/solidity/30775/workflows/42d44440-4b3d-4672-9d9f-23740d49ccc0):

| job                                | before  | after   | parallelism | machine |
|------------------------------------|---------|---------|-------------|---------|
| `t_ubu_clang_soltest`              | 35s     | 41s     | 20          | 2 CPU / 4 GB (medium)
| `t_archlinux_soltest`              | 1m 0s   | 50s     | 20          | 2 CPU / 4 GB (medium)
| `t_ubu_soltest_all`                | 8m 11s  | 8m 26s  | 50          | 4 CPU / 8 GB (large)
| `t_ubu_force_release_soltest_all`  | 9m 40s  | 7m 42s  | 50          | 4 CPU / 8 GB (large)
| `t_osx_soltest`                    | 15m 21s | 10m 22s | 1           | 4 CPU / 8 GB (MacOS medium Gen2)
| `t_win_soltest`                    | 25m 46s | 24m 24s | 1           | 4 CPU / 8 GB (Windows medium)

Note that on Windows we use a PowerShell script that is not parallelized, so we have just one process in the container. On macOS the job is not parallelized (`parallelism = 1`), but the script is.

Oddly, the change did not significantly affect `t_ubu_soltest_all`. I checked and it did spawn 3 processes with 75% CPU use before and does spawn 5 now with 100% utilization. I did not do a precise comparison, but just by eyeballing the resource graph on CircleCI it looks like there's no change in performance. The total running time is influenced by a few slower runs among the 50 while most finish after 3-4 min, and after the change the stragglers are still there and the majority still finishes around the same time (or maybe even a bit later).  At least it does not seem to make things worse. In any case, it's hard to tell just from the graph, but hopefully the total running time is actually shorter and saves us some credits.

On macOS there's a big improvement and for that alone this seems worth it.