### PR TITLE
Unify preamble injection in `AnalysisFramework`

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -112,6 +112,8 @@ set(libsolidity_util_sources
     libsolidity/util/BytesUtils.cpp
     libsolidity/util/BytesUtilsTests.cpp
     libsolidity/util/BytesUtils.h
+    libsolidity/util/Common.cpp
+    libsolidity/util/Common.h
     libsolidity/util/ContractABIUtils.cpp
     libsolidity/util/ContractABIUtils.h
     libsolidity/util/SoltestErrors.h

--- a/test/libsolidity/AnalysisFramework.cpp
+++ b/test/libsolidity/AnalysisFramework.cpp
@@ -21,6 +21,7 @@
 
 #include <test/libsolidity/AnalysisFramework.h>
 
+#include <test/libsolidity/util/Common.h>
 #include <test/Common.h>
 
 #include <libsolidity/interface/CompilerStack.h>
@@ -51,13 +52,7 @@ AnalysisFramework::parseAnalyseAndReturnError(
 )
 {
 	compiler().reset();
-	// Do not insert license if it is already present.
-	bool insertLicense = _insertLicenseAndVersionPragma && _source.find("SPDX-License-Identifier:") == string::npos;
-	compiler().setSources({{"",
-		string{_insertLicenseAndVersionPragma ? "pragma solidity >=0.0;\n" : ""} +
-		string{insertLicense ? "// SPDX-License-Identifier: GPL-3.0\n" : ""} +
-		_source
-	}});
+	compiler().setSources({{"", _insertLicenseAndVersionPragma ? withPreamble(_source) : _source}});
 	compiler().setEVMVersion(solidity::test::CommonOptions::get().evmVersion());
 	compiler().setParserErrorRecovery(_allowRecoveryErrors);
 	_allowMultipleErrors = _allowMultipleErrors || _allowRecoveryErrors;

--- a/test/libsolidity/AnalysisFramework.cpp
+++ b/test/libsolidity/AnalysisFramework.cpp
@@ -52,7 +52,7 @@ AnalysisFramework::parseAnalyseAndReturnError(
 {
 	compiler().reset();
 	// Do not insert license if it is already present.
-	bool insertLicense = _insertLicenseAndVersionPragma && _source.find("// SPDX-License-Identifier:") == string::npos;
+	bool insertLicense = _insertLicenseAndVersionPragma && _source.find("SPDX-License-Identifier:") == string::npos;
 	compiler().setSources({{"",
 		string{_insertLicenseAndVersionPragma ? "pragma solidity >=0.0;\n" : ""} +
 		string{insertLicense ? "// SPDX-License-Identifier: GPL-3.0\n" : ""} +

--- a/test/libsolidity/GasTest.cpp
+++ b/test/libsolidity/GasTest.cpp
@@ -17,6 +17,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 #include <test/libsolidity/GasTest.h>
+#include <test/libsolidity/util/Common.h>
 #include <test/Common.h>
 #include <libsolutil/CommonIO.h>
 #include <libsolutil/JSON.h>
@@ -99,7 +100,6 @@ void GasTest::printUpdatedExpectations(ostream& _stream, string const& _linePref
 
 TestCase::TestResult GasTest::run(ostream& _stream, string const& _linePrefix, bool _formatted)
 {
-	string const preamble = "pragma solidity >=0.0;\n// SPDX-License-Identifier: GPL-3.0\n";
 	compiler().reset();
 	// Prerelease CBOR metadata varies in size due to changing version numbers and build dates.
 	// This leads to volatile creation cost estimates. Therefore we force the compiler to
@@ -113,7 +113,7 @@ TestCase::TestResult GasTest::run(ostream& _stream, string const& _linePrefix, b
 	}
 	settings.expectedExecutionsPerDeployment = m_optimiseRuns;
 	compiler().setOptimiserSettings(settings);
-	compiler().setSources({{"", preamble + m_source}});
+	compiler().setSources({{"", withPreamble(m_source)}});
 
 	if (!compiler().parseAndAnalyze() || !compiler().compile())
 	{

--- a/test/libsolidity/SolidityExecutionFramework.cpp
+++ b/test/libsolidity/SolidityExecutionFramework.cpp
@@ -146,7 +146,7 @@ string SolidityExecutionFramework::addPreamble(string const& _sourceCode)
 {
 	// Silence compiler version warning
 	string preamble = "pragma solidity >=0.0;\n";
-	if (_sourceCode.find("// SPDX-License-Identifier:") == string::npos)
+	if (_sourceCode.find("SPDX-License-Identifier:") == string::npos)
 		preamble += "// SPDX-License-Identifier: unlicensed\n";
 	if (
 		solidity::test::CommonOptions::get().useABIEncoderV1 &&

--- a/test/libsolidity/SolidityExecutionFramework.cpp
+++ b/test/libsolidity/SolidityExecutionFramework.cpp
@@ -22,6 +22,7 @@
  */
 
 #include <test/libsolidity/SolidityExecutionFramework.h>
+#include <test/libsolidity/util/Common.h>
 
 #include <liblangutil/DebugInfoSelection.h>
 #include <liblangutil/Exceptions.h>
@@ -48,12 +49,12 @@ bytes SolidityExecutionFramework::multiSourceCompileContract(
 {
 	if (_mainSourceName.has_value())
 		solAssert(_sourceCode.find(_mainSourceName.value()) != _sourceCode.end(), "");
-	map<string, string> sourcesWithPreamble = _sourceCode;
-	for (auto& entry: sourcesWithPreamble)
-		entry.second = addPreamble(entry.second);
 
 	m_compiler.reset();
-	m_compiler.setSources(sourcesWithPreamble);
+	m_compiler.setSources(withPreamble(
+		_sourceCode,
+		solidity::test::CommonOptions::get().useABIEncoderV1 // _addAbicoderV1Pragma
+	));
 	m_compiler.setLibraries(_libraryAddresses);
 	m_compiler.setRevertStringBehaviour(m_revertStrings);
 	m_compiler.setEVMVersion(m_evmVersion);
@@ -140,19 +141,4 @@ bytes SolidityExecutionFramework::compileContract(
 		_contractName,
 		_libraryAddresses
 	);
-}
-
-string SolidityExecutionFramework::addPreamble(string const& _sourceCode)
-{
-	// Silence compiler version warning
-	string preamble = "pragma solidity >=0.0;\n";
-	if (_sourceCode.find("SPDX-License-Identifier:") == string::npos)
-		preamble += "// SPDX-License-Identifier: unlicensed\n";
-	if (
-		solidity::test::CommonOptions::get().useABIEncoderV1 &&
-		_sourceCode.find("pragma experimental ABIEncoderV2;") == string::npos &&
-		_sourceCode.find("pragma abicoder") == string::npos
-	)
-		preamble += "pragma abicoder v1;\n";
-	return preamble + _sourceCode;
 }

--- a/test/libsolidity/SolidityExecutionFramework.h
+++ b/test/libsolidity/SolidityExecutionFramework.h
@@ -79,9 +79,6 @@ public:
 		std::map<std::string, solidity::test::Address> const& _libraryAddresses = {}
 	);
 
-	/// Returns @param _sourceCode prefixed with the version pragma and the abi coder v1 pragma,
-	/// the latter only if it is forced.
-	static std::string addPreamble(std::string const& _sourceCode);
 protected:
 	using CompilerStack = solidity::frontend::CompilerStack;
 	std::optional<uint8_t> m_eofVersion;

--- a/test/libsolidity/SyntaxTest.cpp
+++ b/test/libsolidity/SyntaxTest.cpp
@@ -18,6 +18,7 @@
 
 #include <test/libsolidity/SyntaxTest.h>
 
+#include <test/libsolidity/util/Common.h>
 #include <test/Common.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -43,24 +44,10 @@ SyntaxTest::SyntaxTest(string const& _filename, langutil::EVMVersion _evmVersion
 	m_parserErrorRecovery = _parserErrorRecovery;
 }
 
-string SyntaxTest::addPreamble(string const& _sourceCode)
-{
-	// Silence compiler version warning
-	string preamble = "pragma solidity >=0.0;\n";
-	// NOTE: this check is intentionally loose to match weird cases.
-	// We can manually adjust a test case where this causes problem.
-	if (_sourceCode.find("SPDX-License-Identifier:") == string::npos)
-		preamble += "// SPDX-License-Identifier: GPL-3.0\n";
-	return preamble + _sourceCode;
-}
-
 void SyntaxTest::setupCompiler()
 {
 	compiler().reset();
-	auto sourcesWithPragma = m_sources.sources;
-	for (auto& source: sourcesWithPragma)
-		source.second = addPreamble(source.second);
-	compiler().setSources(sourcesWithPragma);
+	compiler().setSources(withPreamble(m_sources.sources));
 	compiler().setEVMVersion(m_evmVersion);
 	compiler().setParserErrorRecovery(m_parserErrorRecovery);
 	compiler().setOptimiserSettings(

--- a/test/libsolidity/SyntaxTest.h
+++ b/test/libsolidity/SyntaxTest.h
@@ -48,9 +48,6 @@ public:
 	SyntaxTest(std::string const& _filename, langutil::EVMVersion _evmVersion, bool _parserErrorRecovery = false);
 
 protected:
-	/// Returns @param _sourceCode prefixed with the version pragma and the SPDX license identifier.
-	static std::string addPreamble(std::string const& _sourceCode);
-
 	virtual void setupCompiler();
 	void parseAndAnalyze() override;
 	virtual void filterObtainedErrors();

--- a/test/libsolidity/util/Common.cpp
+++ b/test/libsolidity/util/Common.cpp
@@ -1,0 +1,46 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <test/libsolidity/util/Common.h>
+
+using namespace std;
+using namespace solidity;
+using namespace solidity::frontend;
+
+string test::withPreamble(string const& _sourceCode)
+{
+	static string const versionPragma = "pragma solidity >=0.0;\n";
+	static string const licenseComment = "// SPDX-License-Identifier: GPL-3.0\n";
+
+	// NOTE: this check is intentionally loose to match weird cases.
+	// We can manually adjust a test case where this causes problem.
+	bool licenseMissing = _sourceCode.find("SPDX-License-Identifier:") == string::npos;
+
+	return
+		versionPragma +
+		(licenseMissing ? licenseComment : "") +
+		_sourceCode;
+}
+
+StringMap test::withPreamble(StringMap _sources)
+{
+	for (auto&& [sourceName, source]: _sources)
+		source = withPreamble(source);
+
+	return _sources;
+}

--- a/test/libsolidity/util/Common.cpp
+++ b/test/libsolidity/util/Common.cpp
@@ -18,6 +18,8 @@
 
 #include <test/libsolidity/util/Common.h>
 
+#include <regex>
+
 using namespace std;
 using namespace solidity;
 using namespace solidity::frontend;
@@ -48,4 +50,18 @@ StringMap test::withPreamble(StringMap _sources, bool _addAbicoderV1Pragma)
 		source = withPreamble(source, _addAbicoderV1Pragma);
 
 	return _sources;
+}
+
+string test::stripPreReleaseWarning(string const& _stderrContent)
+{
+	static regex const preReleaseWarningRegex{
+		R"(Warning( \(3805\))?: This is a pre-release compiler version, please do not use it in production\.\n)"
+		R"((\n)?)"
+	};
+	static regex const noOutputRegex{
+		R"(Compiler run successful, no output requested\.\n)"
+	};
+
+	string output = regex_replace(_stderrContent, preReleaseWarningRegex, "");
+	return regex_replace(std::move(output), noOutputRegex, "");
 }

--- a/test/libsolidity/util/Common.cpp
+++ b/test/libsolidity/util/Common.cpp
@@ -22,25 +22,30 @@ using namespace std;
 using namespace solidity;
 using namespace solidity::frontend;
 
-string test::withPreamble(string const& _sourceCode)
+string test::withPreamble(string const& _sourceCode, bool _addAbicoderV1Pragma)
 {
 	static string const versionPragma = "pragma solidity >=0.0;\n";
 	static string const licenseComment = "// SPDX-License-Identifier: GPL-3.0\n";
+	static string const abicoderPragma = "pragma abicoder v1;\n";
 
-	// NOTE: this check is intentionally loose to match weird cases.
+	// NOTE: These checks are intentionally loose to match weird cases.
 	// We can manually adjust a test case where this causes problem.
 	bool licenseMissing = _sourceCode.find("SPDX-License-Identifier:") == string::npos;
+	bool abicoderMissing =
+		_sourceCode.find("pragma experimental ABIEncoderV2;") == string::npos &&
+		_sourceCode.find("pragma abicoder") == string::npos;
 
 	return
 		versionPragma +
 		(licenseMissing ? licenseComment : "") +
+		(abicoderMissing && _addAbicoderV1Pragma ? abicoderPragma : "") +
 		_sourceCode;
 }
 
-StringMap test::withPreamble(StringMap _sources)
+StringMap test::withPreamble(StringMap _sources, bool _addAbicoderV1Pragma)
 {
 	for (auto&& [sourceName, source]: _sources)
-		source = withPreamble(source);
+		source = withPreamble(source, _addAbicoderV1Pragma);
 
 	return _sources;
 }

--- a/test/libsolidity/util/Common.h
+++ b/test/libsolidity/util/Common.h
@@ -32,4 +32,6 @@ std::string withPreamble(std::string const& _sourceCode, bool _addAbicoderV1Prag
 /// @returns a copy of @p _sources with preamble prepended to all sources.
 StringMap withPreamble(StringMap _sources, bool _addAbicoderV1Pragma = false);
 
+std::string stripPreReleaseWarning(std::string const& _stderrContent);
+
 } // namespace solidity::frontend::test

--- a/test/libsolidity/util/Common.h
+++ b/test/libsolidity/util/Common.h
@@ -26,9 +26,10 @@ namespace solidity::frontend::test
 {
 
 /// @returns @p _sourceCode prefixed with the version pragma and the SPDX license identifier.
-std::string withPreamble(std::string const& _sourceCode);
+/// Can optionally also insert an abicoder pragma when missing.
+std::string withPreamble(std::string const& _sourceCode, bool _addAbicoderV1Pragma = false);
 
 /// @returns a copy of @p _sources with preamble prepended to all sources.
-StringMap withPreamble(StringMap _sources);
+StringMap withPreamble(StringMap _sources, bool _addAbicoderV1Pragma = false);
 
 } // namespace solidity::frontend::test

--- a/test/libsolidity/util/Common.h
+++ b/test/libsolidity/util/Common.h
@@ -1,0 +1,34 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+/// Utilities shared by multiple libsolidity tests.
+
+#include <libsolidity/interface/CompilerStack.h>
+
+#include <string>
+
+namespace solidity::frontend::test
+{
+
+/// @returns @p _sourceCode prefixed with the version pragma and the SPDX license identifier.
+std::string withPreamble(std::string const& _sourceCode);
+
+/// @returns a copy of @p _sources with preamble prepended to all sources.
+StringMap withPreamble(StringMap _sources);
+
+} // namespace solidity::frontend::test

--- a/test/solc/Common.cpp
+++ b/test/solc/Common.cpp
@@ -17,6 +17,7 @@
 // SPDX-License-Identifier: GPL-3.0
 
 #include <test/solc/Common.h>
+#include <test/libsolidity/util/Common.h>
 
 #include <solc/CommandLineInterface.h>
 
@@ -78,18 +79,4 @@ test::OptionsReaderAndMessages test::runCLI(
 		sout.str(),
 		stripPreReleaseWarning(serr.str()),
 	};
-}
-
-string test::stripPreReleaseWarning(string const& _stderrContent)
-{
-	static regex const preReleaseWarningRegex{
-		R"(Warning( \(3805\))?: This is a pre-release compiler version, please do not use it in production\.\n)"
-		R"((\n)?)"
-	};
-	static regex const noOutputRegex{
-		R"(Compiler run successful, no output requested\.\n)"
-	};
-
-	string output = regex_replace(_stderrContent, preReleaseWarningRegex, "");
-	return regex_replace(std::move(output), noOutputRegex, "");
 }

--- a/test/solc/Common.h
+++ b/test/solc/Common.h
@@ -67,6 +67,4 @@ OptionsReaderAndMessages runCLI(
 	std::string const& _standardInputContent = ""
 );
 
-std::string stripPreReleaseWarning(std::string const& _stderrContent);
-
 } // namespace solidity::frontend::test

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(isoltest
 	../TestCase.cpp
 	../TestCaseReader.cpp
 	../libsolidity/util/BytesUtils.cpp
+	../libsolidity/util/Common.cpp
 	../libsolidity/util/ContractABIUtils.cpp
 	../libsolidity/util/TestFileParser.cpp
 	../libsolidity/util/TestFunctionCall.cpp


### PR DESCRIPTION
Another refactor before #14433.

Even though `AnalysisFramework` can insert preamble automatically, this code is baked into `parseAnalyseAndReturnError()`, which is not universally used by all test cases. The result is that some test cases reinvent the wheel and implement that bit on their own, always slightly differently. Some of them do not insert license if it's already there, some don't care. Some can handle multi-line comments, some can't.

This is quite frustrating because when you're writing a new test case you have to waste time  to figure out why there are so many versions of it, which one you need and how to use it. Then you realize you can't easily reuse it and end up adding yet another copy. This PR unifies all that duplicated code into a reusable `withPreamble()` method available to all test cases inheriting from `AnalysisFramework`.

It would be nice to also have the error filtering automatically adjust error locations to account for the preamble (`SyntaxTest` already has code for doing that), but I'll leave that for another day.