### PR TITLE
Fix infinite isoltest expectation update loop on values not taking full slots

### DIFF
--- a/test/libsolidity/util/BytesUtils.cpp
+++ b/test/libsolidity/util/BytesUtils.cpp
@@ -263,7 +263,20 @@ string BytesUtils::formatRawBytes(
 	auto it = _bytes.begin();
 
 	if (_bytes.size() != ContractABIUtils::encodingSize(_parameters))
-		parameters = ContractABIUtils::defaultParameters((_bytes.size() + 31) / 32);
+	{
+		// Interpret all full 32-byte values as integers.
+		parameters = ContractABIUtils::defaultParameters(_bytes.size() / 32);
+
+		// We'd introduce trailing zero bytes if we interpreted the final bit as an integer.
+		// We want a right-aligned sequence of bytes instead.
+		if (_bytes.size() % 32 != 0)
+			parameters.push_back({
+				bytes(),
+				"",
+				ABIType{ABIType::HexString, ABIType::AlignRight, _bytes.size() % 32},
+				FormatInfo{},
+			});
+	}
 	else
 		parameters = _parameters;
 	soltestAssert(ContractABIUtils::encodingSize(parameters) >= _bytes.size());
@@ -371,7 +384,20 @@ string BytesUtils::formatBytesRange(
 	auto it = _bytes.begin();
 
 	if (_bytes.size() != ContractABIUtils::encodingSize(_parameters))
-		parameters = ContractABIUtils::defaultParameters((_bytes.size() + 31) / 32);
+	{
+		// Interpret all full 32-byte values as integers.
+		parameters = ContractABIUtils::defaultParameters(_bytes.size() / 32);
+
+		// We'd introduce trailing zero bytes if we interpreted the final bit as an integer.
+		// We want a right-aligned sequence of bytes instead.
+		if (_bytes.size() % 32 != 0)
+			parameters.push_back({
+				bytes(),
+				"",
+				ABIType{ABIType::HexString, ABIType::AlignRight, _bytes.size() % 32},
+				FormatInfo{},
+			});
+	}
 	else
 		parameters = _parameters;
 	soltestAssert(ContractABIUtils::encodingSize(parameters) >= _bytes.size());

--- a/test/libsolidity/util/BytesUtils.cpp
+++ b/test/libsolidity/util/BytesUtils.cpp
@@ -283,7 +283,10 @@ string BytesUtils::formatRawBytes(
 
 	for (auto const& parameter: parameters)
 	{
-		long actualSize = min(distance(it, _bytes.end()), static_cast<long>(parameter.abiType.size));
+		long actualSize = min(
+			distance(it, _bytes.end()),
+			static_cast<ParameterList::difference_type>(parameter.abiType.size)
+		);
 		bytes byteRange(parameter.abiType.size, 0);
 		copy(it, it + actualSize, byteRange.begin());
 
@@ -404,7 +407,10 @@ string BytesUtils::formatBytesRange(
 
 	for (auto const& parameter: parameters)
 	{
-		long actualSize = min(distance(it, _bytes.end()), static_cast<long>(parameter.abiType.size));
+		long actualSize = min(
+			distance(it, _bytes.end()),
+			static_cast<ParameterList::difference_type>(parameter.abiType.size)
+		);
 		bytes byteRange(parameter.abiType.size, 0);
 		copy(it, it + actualSize, byteRange.begin());
 


### PR DESCRIPTION
I ran into this while working on #12668. Isoltest falls into an infinite expectation update loop on some tests, e.g. [`malformed_panic_2.sol`](https://github.com/ethereum/solidity/blob/develop/test/libsolidity/semanticTests/tryCatch/malformed_panic_2.sol). This happens when the test fails for whatever reason and you accept the expectation update. The updated value does not really match what is returned from the EVM and it asks you to update again, ad infinitum.

### Example of the problem
Let's take a look at [`malformed_panic_2.sol`](https://github.com/ethereum/solidity/blob/develop/test/libsolidity/semanticTests/tryCatch/malformed_panic_2.sol). The expectation that triggers the problem is this:
```solidity
// b() -> FAILURE, hex"4e487b710000"
```
Isoltest will reformat it as something like this:
```solidity
Obtained result:
// b() -> FAILURE, 35408467139433450592217433187231851964680881867096292958875400487594354540544
Warning: The call to "b()" returned
[4e,48,7b,71,0,0,0,0,0,0,0,0,0,0,0,0,39,3,0,0,3f,3,0,0,21,0,0,0,0,0,0,0]
```
the specific number is different each time and is the original expectation followed by some random garbage. Note also that the integer does not match the bytes shown below it. Its hex value is instead:
```
0x4e487b71000000000000000000000000703c5d549f5500004100000000000000
```

### The cause
There are two separate bugs here.

The first one is that when formatting the expectation, `BytesUtils` assumes a specific format for the output (described by the [`ParameterList`](https://github.com/ethereum/solidity/blob/v0.8.21/test/libsolidity/util/SoltestTypes.h#L152-L185) type). If the output happens to be shorter than the format, it increments an iterator past the end of the vector containing it, grabbing some random garbage from memory. That's what we see in the expectations.

Identical bug exists in both `BytesUtils::formatBytesRange()` and `BytesUtils::formatRawBytes()`. The first one we use to format the expectation comment, the second to display the array of individual bytes. That's why they don't match in the example I have shown above.

The second bug is that by default the expectation is always formatted as a sequence of 32-byte integers. When isoltest rereads such an expectation, it sees each integer as 32 bytes (because integers are right-aligned). That will never match output whose length is not a multiple of 32 bytes.

The only reason it does not happen more often is that we have some predefined "templates" for what expectations should look like and we only use default ones when the output length does not match those expected ones. For example if the function returns a proper `Panic` or `Error`, it will match the parameter format returned by `ContractABIUtils::failureParameters()` and we'll use that. To trigger it you need a weird example like the above, where something that looks like a `Panic` is returned (same selector), but the length of revert data is different than it would be in an actual `Panic`. Still, it happens often enough to be noticeable. I ran into this quite a few times in the past, never knowing why it's happening.