### PR TITLE
Improved build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,7 +10,7 @@ else
     BUILD_TYPE="$1"
 fi
 
-if [[ "$(git tag --points-at HEAD 2>/dev/null)" == v* ]]; then
+if [[ "$(git tag --points-at HEAD 2>/dev/null | head -n 1)" == v* ]]; then
 	touch "${ROOTDIR}/prerelease.txt"
 fi
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
+# Check if git is installed
+if ! command -v git &> /dev/null; then
+    echo "Error: git is not installed. Please install git and try again."
+    exit 1
+fi
+
 ROOTDIR="$(dirname "$0")/.."
 BUILDDIR="${ROOTDIR}/build"
 
@@ -10,6 +16,7 @@ else
     BUILD_TYPE="$1"
 fi
 
+# Check the first git tag that points to the current commit and starts with "v"
 if [[ "$(git tag --points-at HEAD 2>/dev/null | head -n 1)" == v* ]]; then
 	touch "${ROOTDIR}/prerelease.txt"
 fi


### PR DESCRIPTION
Makes 2 improvements:

1. Checks if `git` is installed before executing the command. If not, it will inform the user to do so.
2. Git Tag Check: The command `git tag --points-at HEAD` might produce multiple tags. To handle this scenario, it will use the first one if it happens.