### PR TITLE
Make `SyntaxTest` easier to extend with custom expectations

### DIFF
--- a/liblangutil/Exceptions.h
+++ b/liblangutil/Exceptions.h
@@ -206,6 +206,7 @@ public:
 
 	ErrorId errorId() const { return m_errorId; }
 	Type type() const { return m_type; }
+	Severity severity() const { return errorSeverity(m_type); }
 
 	SourceLocation const* sourceLocation() const noexcept;
 	SecondarySourceLocation const* secondarySourceLocation() const noexcept;

--- a/liblangutil/Exceptions.h
+++ b/liblangutil/Exceptions.h
@@ -170,6 +170,8 @@ class Error: virtual public util::Exception
 public:
 	enum class Type
 	{
+		Info,
+		Warning,
 		CodeGenerationError,
 		DeclarationError,
 		DocstringParsingError,
@@ -185,15 +187,14 @@ public:
 		UnimplementedFeatureError,
 		YulException,
 		SMTLogicException,
-		Warning,
-		Info
 	};
 
 	enum class Severity
 	{
-		Error,
+		// NOTE: We rely on these being ordered from least to most severe.
+		Info,
 		Warning,
-		Info
+		Error,
 	};
 
 	Error(

--- a/test/CommonSyntaxTest.h
+++ b/test/CommonSyntaxTest.h
@@ -62,13 +62,26 @@ public:
 	void printSource(std::ostream& _stream, std::string const &_linePrefix = "", bool _formatted = false) const override;
 	void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix) const override
 	{
-		if (!m_errorList.empty())
-			printErrorList(_stream, m_errorList, _linePrefix, false);
+		printObtainedResult(_stream, _linePrefix, false);
 	}
 
 	static std::string errorMessage(util::Exception const& _e);
 protected:
+	/// Should be implemented by those derived test cases that want to allow extra expectations
+	/// after the error/warning expectations. The default implementation does not allow them and
+	/// fails instead.
+	/// @param _stream Input stream positioned at the beginning of the extra expectations.
+	virtual void parseCustomExpectations(std::istream& _stream);
+
 	virtual void parseAndAnalyze() = 0;
+
+	/// Should return true if obtained values match expectations.
+	/// The default implementation only compares the error list. Derived classes that support
+	/// custom expectations should override this to include them in the comparison.
+	virtual bool expectationsMatch();
+
+	virtual void printExpectedResult(std::ostream& _stream, std::string const& _linePrefix, bool _formatted) const;
+	virtual void printObtainedResult(std::ostream& _stream, std::string const& _linePrefix, bool _formatted) const;
 
 	static void printErrorList(
 		std::ostream& _stream,

--- a/test/TestCaseReader.cpp
+++ b/test/TestCaseReader.cpp
@@ -114,15 +114,17 @@ pair<SourceMap, size_t> TestCaseReader::parseSourcesAndSettingsWithLineNumber(is
 	static string const sourceDelimiterEnd("====");
 	static string const comment("// ");
 	static string const settingsDelimiter("// ====");
-	static string const delimiter("// ----");
+	static string const expectationsDelimiter("// ----");
 	bool sourcePart = true;
 	while (getline(_stream, line))
 	{
 		lineNumber++;
 
-		if (boost::algorithm::starts_with(line, delimiter))
+		// Anything below the delimiter is left up to the test case to process in a custom way.
+		if (boost::algorithm::starts_with(line, expectationsDelimiter))
 			break;
-		else if (boost::algorithm::starts_with(line, settingsDelimiter))
+
+		if (boost::algorithm::starts_with(line, settingsDelimiter))
 			sourcePart = false;
 		else if (sourcePart)
 		{

--- a/test/libsolidity/SyntaxTest.cpp
+++ b/test/libsolidity/SyntaxTest.cpp
@@ -38,7 +38,13 @@ using namespace solidity::frontend::test;
 using namespace boost::unit_test;
 namespace fs = boost::filesystem;
 
-SyntaxTest::SyntaxTest(string const& _filename, langutil::EVMVersion _evmVersion): CommonSyntaxTest(_filename, _evmVersion)
+SyntaxTest::SyntaxTest(
+	string const& _filename,
+	langutil::EVMVersion _evmVersion,
+	Error::Severity _minSeverity
+):
+	CommonSyntaxTest(_filename, _evmVersion),
+	m_minSeverity(_minSeverity)
 {
 	m_optimiseYul = m_reader.boolSetting("optimize-yul", true);
 }
@@ -98,6 +104,9 @@ void SyntaxTest::filterObtainedErrors()
 {
 	for (auto const& currentError: filteredErrors())
 	{
+		if (currentError->severity() < m_minSeverity)
+			continue;
+
 		int locationStart = -1;
 		int locationEnd = -1;
 		string sourceName;

--- a/test/libsolidity/SyntaxTest.h
+++ b/test/libsolidity/SyntaxTest.h
@@ -48,7 +48,7 @@ protected:
 	void parseAndAnalyze() override;
 	virtual void filterObtainedErrors();
 
-	bool m_optimiseYul = true;
+	bool m_optimiseYul{};
 };
 
 }

--- a/test/libsolidity/SyntaxTest.h
+++ b/test/libsolidity/SyntaxTest.h
@@ -41,7 +41,11 @@ public:
 	{
 		return std::make_unique<SyntaxTest>(_config.filename, _config.evmVersion);
 	}
-	SyntaxTest(std::string const& _filename, langutil::EVMVersion _evmVersion);
+	SyntaxTest(
+		std::string const& _filename,
+		langutil::EVMVersion _evmVersion,
+		langutil::Error::Severity _minSeverity = langutil::Error::Severity::Info
+	);
 
 protected:
 	virtual void setupCompiler();
@@ -49,6 +53,7 @@ protected:
 	virtual void filterObtainedErrors();
 
 	bool m_optimiseYul{};
+	langutil::Error::Severity m_minSeverity{};
 };
 
 }


### PR DESCRIPTION
Prerequisite for #14433.

I originally planned to derive my new Natspec test case from `TestCase` with `AnalysisFramework` as a mixin. This allowed me to go 90% of the way, but then it turned out that some useful behaviors of our syntax tests are not a reusable part of the base test case, but available only in `SyntaxTest`:
- Formatting errors the same way as in syntax tests (and parsing that format back).
- Highlighting locations of syntax errors in he source.
- Multi-file tests.

Some of them are in `CommonSyntaxTest`, but that in turn does not use `AnalysisFramework` and I'd have to reimplement some of the functionality that `SyntaxTest` already has.

This PR modifies `CommonSyntaxTest` and `SyntaxTest` to make it easier to use them as a base for test cases that want to include errors and warnings in their expectations, but also have extra output when analysis succeeds. The Natspec test case will use this mechanism to expect either errors (if Natspec is invalid) or JSON content.