### PR TITLE
Refactor CircleCI config to define proper commands for reused fragments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,6 +239,65 @@ commands:
          name: docs pragma version check
          command: ./scripts/docs_version_pragma_check.sh
 
+  # --------------------------------------------------------------------------
+  # Artifact Commands
+
+  store_artifacts_solc:
+    description: Store compiled solc executable as artifact
+    steps:
+      - store_artifacts:
+          path: build/solc/solc
+          destination: solc
+
+  store_artifacts_solc_windows:
+    description: Store compiled Windows solc executable as artifact
+    steps:
+      - store_artifacts:
+          path: upload/
+
+  store_artifacts_yul_phaser:
+    steps:
+      - store_artifacts:
+          path: build/tools/yul-phaser
+          destination: yul-phaser
+
+  persist_executables_to_workspace:
+    description: Persist compiled target executables to workspace
+    steps:
+      - persist_to_workspace:
+          root: build
+          paths:
+            - solc/solc
+            - test/soltest
+            - test/tools/solfuzzer
+
+  persist_ossfuzz_executables_to_workspace:
+    description: Persist compiled OSSFUZZ executables to workspace
+    steps:
+      - persist_to_workspace:
+          root: build
+          paths:
+            - test/tools/ossfuzz/abiv2_proto_ossfuzz
+            - test/tools/ossfuzz/abiv2_isabelle_ossfuzz
+            - test/tools/ossfuzz/const_opt_ossfuzz
+            - test/tools/ossfuzz/solc_mutator_ossfuzz
+            - test/tools/ossfuzz/solc_ossfuzz
+            - test/tools/ossfuzz/stack_reuse_codegen_ossfuzz
+            - test/tools/ossfuzz/strictasm_assembly_ossfuzz
+            - test/tools/ossfuzz/strictasm_diff_ossfuzz
+            - test/tools/ossfuzz/strictasm_opt_ossfuzz
+            - test/tools/ossfuzz/yul_proto_diff_ossfuzz
+            - test/tools/ossfuzz/yul_proto_diff_custom_mutate_ossfuzz
+            - test/tools/ossfuzz/yul_proto_ossfuzz
+            - test/tools/ossfuzz/sol_proto_ossfuzz
+
+  store_artifacts_test_results:
+    description: Store test output dir as artifact
+    steps:
+      - store_artifacts:
+          path: test_results/
+          destination: test_results/
+
 defaults:
 
   # --------------------------------------------------------------------------
@@ -261,53 +320,6 @@ defaults:
           - via-ir-no-optimize
 
   # --------------------------------------------------------------------------
-  # Artifacts Templates
-
-  # compiled solc executable target
-  - artifacts_solc: &artifacts_solc
-      path: build/solc/solc
-      destination: solc
-
-  # windows artifacts
-  - artifact_solc_windows: &artifact_solc_windows
-      path: upload/
-
-  - artifact_yul_phaser: &artifact_yul_phaser
-      path: build/tools/yul-phaser
-      destination: yul-phaser
-
-  # compiled executable targets
-  - artifacts_executables: &artifacts_executables
-      root: build
-      paths:
-        - solc/solc
-        - test/soltest
-        - test/tools/solfuzzer
-
-  # compiled OSSFUZZ targets
-  - artifacts_executables_ossfuzz: &artifacts_executables_ossfuzz
-      root: build
-      paths:
-        - test/tools/ossfuzz/abiv2_proto_ossfuzz
-        - test/tools/ossfuzz/abiv2_isabelle_ossfuzz
-        - test/tools/ossfuzz/const_opt_ossfuzz
-        - test/tools/ossfuzz/solc_mutator_ossfuzz
-        - test/tools/ossfuzz/solc_ossfuzz
-        - test/tools/ossfuzz/stack_reuse_codegen_ossfuzz
-        - test/tools/ossfuzz/strictasm_assembly_ossfuzz
-        - test/tools/ossfuzz/strictasm_diff_ossfuzz
-        - test/tools/ossfuzz/strictasm_opt_ossfuzz
-        - test/tools/ossfuzz/yul_proto_diff_ossfuzz
-        - test/tools/ossfuzz/yul_proto_diff_custom_mutate_ossfuzz
-        - test/tools/ossfuzz/yul_proto_ossfuzz
-        - test/tools/ossfuzz/sol_proto_ossfuzz
-
-  # test result output directory
-  - artifacts_test_results: &artifacts_test_results
-      path: test_results/
-      destination: test_results/
-
-  # --------------------------------------------------------------------------
   # Step Templates
 
   - steps_soltest: &steps_soltest
@@ -321,7 +333,7 @@ defaults:
         - run_soltest
         - store_test_results:
             path: test_results/
-        - store_artifacts: *artifacts_test_results
+        - store_artifacts_test_results
         - matrix_notify_failure_unless_pr
 
   - steps_test_lsp: &steps_test_lsp
@@ -341,9 +353,9 @@ defaults:
       steps:
         - checkout
         - run_build
-        - store_artifacts: *artifacts_solc
-        - store_artifacts: *artifact_yul_phaser
-        - persist_to_workspace: *artifacts_executables
+        - store_artifacts_solc
+        - store_artifacts_yul_phaser
+        - persist_executables_to_workspace
         - matrix_notify_failure_unless_pr
 
   - steps_soltest_all: &steps_soltest_all
@@ -354,7 +366,7 @@ defaults:
         - run_soltest_all
         - store_test_results:
             path: test_results/
-        - store_artifacts: *artifacts_test_results
+        - store_artifacts_test_results:
         - matrix_notify_failure_unless_pr
 
   - steps_cmdline_tests: &steps_cmdline_tests
@@ -365,7 +377,7 @@ defaults:
         - run_cmdline_tests
         - store_test_results:
             path: test_results/
-        - store_artifacts: *artifacts_test_results
+        - store_artifacts_test_results:
         - matrix_notify_failure_unless_pr
 
   - steps_install_dependencies_osx: &steps_install_dependencies_osx
@@ -991,7 +1003,7 @@ jobs:
     steps:
       - checkout
       - run_build
-      - persist_to_workspace: *artifacts_executables
+      - persist_executables_to_workspace
       - matrix_notify_failure_unless_pr
 
   t_ubu_codecov:
@@ -1014,7 +1026,7 @@ jobs:
       - run:
           name: "Coverage: All"
           command: codecov --flags all --gcov-root build
-      - store_artifacts: *artifacts_test_results
+      - store_artifacts_test_results
       - matrix_notify_failure_unless_pr
 
   # Builds in C++20 mode and uses debug build in order to speed up.
@@ -1037,7 +1049,7 @@ jobs:
       - checkout
       - setup_prerelease_commit_hash
       - run_build_ossfuzz
-      - persist_to_workspace: *artifacts_executables_ossfuzz
+      - persist_ossfuzz_executables_to_workspace
       - matrix_notify_failure_unless_pr
 
   t_ubu_ossfuzz: &t_ubu_ossfuzz
@@ -1054,7 +1066,7 @@ jobs:
             scripts/regressions.py -o test_results
       - store_test_results:
           path: test_results/
-      - store_artifacts: *artifacts_test_results
+      - store_artifacts_test_results
 
   b_archlinux:
     <<: *base_archlinux_large
@@ -1069,8 +1081,8 @@ jobs:
             pacman --noconfirm -Syu --noprogressbar --needed base-devel boost cmake cvc4 git openssh tar
       - checkout
       - run_build
-      - store_artifacts: *artifacts_solc
-      - persist_to_workspace: *artifacts_executables
+      - store_artifacts_solc
+      - persist_executables_to_workspace
       - matrix_notify_failure_unless_pr
 
   b_osx:
@@ -1084,8 +1096,8 @@ jobs:
           condition: true
           <<: *steps_install_dependencies_osx
       - run_build
-      - store_artifacts: *artifacts_solc
-      - store_artifacts: *artifact_yul_phaser
+      - store_artifacts_solc
+      - store_artifacts_yul_phaser
       - persist_to_workspace:
           root: .
           paths:
@@ -1110,7 +1122,7 @@ jobs:
       - run_soltest
       - store_test_results:
           path: test_results/
-      - store_artifacts: *artifacts_test_results
+      - store_artifacts_test_results
       - matrix_notify_failure_unless_pr
 
   t_osx_cli:
@@ -1124,7 +1136,7 @@ jobs:
       - attach_workspace:
           at: .
       - run_cmdline_tests
-      - store_artifacts: *artifacts_test_results
+      - store_artifacts_test_results
       - matrix_notify_failure_unless_pr
 
   b_ems:
@@ -1499,7 +1511,7 @@ jobs:
           name: "Run solc.exe to make sure build was successful."
           command: .\build\solc\Release\solc.exe --version
           shell: powershell.exe
-      - store_artifacts: *artifact_solc_windows
+      - store_artifacts_solc_windows
       - persist_to_workspace:
           root: build
           paths:
@@ -1532,7 +1544,7 @@ jobs:
           shell: powershell.exe
       - store_test_results:
           path: test_results/
-      - store_artifacts: *artifacts_test_results
+      - store_artifacts_test_results
       - matrix_notify_failure_unless_pr
 
   # Note: b_bytecode_ubu_static is required because b_ubu_static and b_ubu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,12 +249,6 @@ commands:
           path: build/solc/solc
           destination: solc
 
-  store_artifacts_solc_windows:
-    description: Store compiled Windows solc executable as artifact
-    steps:
-      - store_artifacts:
-          path: upload/
-
   store_artifacts_yul_phaser:
     steps:
       - store_artifacts:
@@ -1517,7 +1511,8 @@ jobs:
           name: "Run solc.exe to make sure build was successful."
           command: .\build\solc\Release\solc.exe --version
           shell: powershell.exe
-      - store_artifacts_solc_windows
+      - store_artifacts:
+          path: upload/
       - persist_to_workspace:
           root: build
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,6 +298,75 @@ commands:
           path: test_results/
           destination: test_results/
 
+  # --------------------------------------------------------------------------
+  # Complex Build Commands
+
+  soltest:
+    steps:
+      - checkout
+      - attach_workspace:
+          at: build
+      # NOTE: Different build jobs produce different soltest executables (release/debug,
+      # clang/gcc, windows/linux/macos, etc.). The executable used by these steps comes from the
+      # attached workspace and we only see the items added to the workspace by jobs we depend on.
+      - run_soltest
+      - store_test_results:
+          path: test_results/
+      - store_artifacts_test_results
+      - matrix_notify_failure_unless_pr
+
+  test_lsp:
+    steps:
+      - checkout
+      - attach_workspace:
+          at: build
+      - run:
+          name: Install dependencies
+          command: pip install --user deepdiff colorama
+      - run:
+          name: Executing solc LSP test suite
+          command: ./test/lsp.py ./build/solc/solc --non-interactive
+      - matrix_notify_failure_unless_pr
+
+  build:
+    steps:
+      - checkout
+      - run_build
+      - store_artifacts_solc
+      - store_artifacts_yul_phaser
+      - persist_executables_to_workspace
+      - matrix_notify_failure_unless_pr
+
+  soltest_all:
+    steps:
+      - checkout
+      - attach_workspace:
+          at: build
+      - run_soltest_all
+      - store_test_results:
+          path: test_results/
+      - store_artifacts_test_results
+      - matrix_notify_failure_unless_pr
+
+  cmdline_tests:
+    steps:
+      - checkout
+      - attach_workspace:
+          at: build
+      - run_cmdline_tests
+      - store_test_results:
+          path: test_results/
+      - store_artifacts_test_results
+      - matrix_notify_failure_unless_pr
+
+  install_dependencies_osx:
+    steps:
+      # FIXME: We used to cache dependencies on macOS but now it takes longer than just installing
+      # them each time. See https://github.com/ethereum/solidity/issues/12925.
+      - run:
+          name: Install build dependencies
+          command: ./.circleci/osx_install_dependencies.sh
+
 defaults:
 
   # --------------------------------------------------------------------------
@@ -320,74 +389,6 @@ defaults:
           - via-ir-no-optimize
 
   # --------------------------------------------------------------------------
-  # Step Templates
-
-  - steps_soltest: &steps_soltest
-      steps:
-        - checkout
-        - attach_workspace:
-            at: build
-        # NOTE: Different build jobs produce different soltest executables (release/debug,
-        # clang/gcc, windows/linux/macos, etc.). The executable used by these steps comes from the
-        # attached workspace and we only see the items added to the workspace by jobs we depend on.
-        - run_soltest
-        - store_test_results:
-            path: test_results/
-        - store_artifacts_test_results
-        - matrix_notify_failure_unless_pr
-
-  - steps_test_lsp: &steps_test_lsp
-      steps:
-        - checkout
-        - attach_workspace:
-            at: build
-        - run:
-            name: Install dependencies
-            command: pip install --user deepdiff colorama
-        - run:
-            name: Executing solc LSP test suite
-            command: ./test/lsp.py ./build/solc/solc --non-interactive
-        - matrix_notify_failure_unless_pr
-
-  - steps_build: &steps_build
-      steps:
-        - checkout
-        - run_build
-        - store_artifacts_solc
-        - store_artifacts_yul_phaser
-        - persist_executables_to_workspace
-        - matrix_notify_failure_unless_pr
-
-  - steps_soltest_all: &steps_soltest_all
-      steps:
-        - checkout
-        - attach_workspace:
-            at: build
-        - run_soltest_all
-        - store_test_results:
-            path: test_results/
-        - store_artifacts_test_results:
-        - matrix_notify_failure_unless_pr
-
-  - steps_cmdline_tests: &steps_cmdline_tests
-      steps:
-        - checkout
-        - attach_workspace:
-            at: build
-        - run_cmdline_tests
-        - store_test_results:
-            path: test_results/
-        - store_artifacts_test_results:
-        - matrix_notify_failure_unless_pr
-
-  - steps_install_dependencies_osx: &steps_install_dependencies_osx
-      steps:
-        # FIXME: We used to cache dependencies on macOS but now it takes longer than just installing
-        # them each time. See https://github.com/ethereum/solidity/issues/12925.
-        - run:
-            name: Install build dependencies
-            command: ./.circleci/osx_install_dependencies.sh
-
   # --------------------------------------------------------------------------
   # Base Image Templates
 
@@ -932,7 +933,8 @@ jobs:
     # this runs 2x faster on xlarge but takes 4x more resources (compared to medium).
     # Enough other jobs depend on it that it's worth it though.
     <<: *base_ubuntu2204_xlarge
-    <<: *steps_build
+    steps:
+      - build
 
   # x64 ASAN build, for testing for memory related bugs
   b_ubu_asan: &b_ubu_asan
@@ -942,14 +944,16 @@ jobs:
       <<: *base_ubuntu2204_env
       CMAKE_OPTIONS: -DSANITIZE=address
       CMAKE_BUILD_TYPE: Release
-    <<: *steps_build
+    steps:
+      - build
 
   b_ubu_clang: &b_ubu_clang
     <<: *base_ubuntu2204_clang_large
     environment:
       <<: *base_ubuntu2204_clang_large_env
       MAKEFLAGS: -j 10
-    <<: *steps_build
+    steps:
+      - build
 
   b_ubu_san_clang:
     # This runs a bit faster on large and xlarge but on nightly efficiency matters more.
@@ -960,7 +964,8 @@ jobs:
     environment:
       <<: *base_ubuntu2204_clang_env
       CMAKE_OPTIONS: << parameters.cmake_options >>
-    <<: *steps_build
+    steps:
+      - build
 
   b_ubu_force_release: &b_ubu_force_release
     <<: *b_ubu
@@ -1092,9 +1097,7 @@ jobs:
       CMAKE_BUILD_TYPE: Release
     steps:
       - checkout
-      - when:
-          condition: true
-          <<: *steps_install_dependencies_osx
+      - install_dependencies_osx
       - run_build
       - store_artifacts_solc
       - store_artifacts_yul_phaser
@@ -1114,9 +1117,7 @@ jobs:
       OPTIMIZE: 0
     steps:
       - checkout
-      - when:
-          condition: true
-          <<: *steps_install_dependencies_osx
+      - install_dependencies_osx
       - attach_workspace:
           at: .
       - run_soltest
@@ -1130,9 +1131,7 @@ jobs:
     parallelism: 7 # Should match number of tests in .circleci/cli.sh
     steps:
       - checkout
-      - when:
-          condition: true
-          <<: *steps_install_dependencies_osx
+      - install_dependencies_osx
       - attach_workspace:
           at: .
       - run_cmdline_tests
@@ -1179,11 +1178,13 @@ jobs:
   t_ubu_soltest_all: &t_ubu_soltest_all
     <<: *base_ubuntu2204_large
     parallelism: 50
-    <<: *steps_soltest_all
+    steps:
+      - soltest_all
 
   t_ubu_lsp: &t_ubu_lsp
     <<: *base_ubuntu2204_small
-    <<: *steps_test_lsp
+    steps:
+      - test_lsp
 
   t_archlinux_soltest: &t_archlinux_soltest
     <<: *base_archlinux
@@ -1200,9 +1201,7 @@ jobs:
           name: Install runtime dependencies
           command: |
             pacman --noconfirm -Syu --noprogressbar --needed base-devel boost cmake z3 cvc4 git openssh tar
-      - when:
-          condition: true
-          <<: *steps_soltest
+      - soltest
 
   t_ubu_clang_soltest: &t_ubu_clang_soltest
     <<: *base_ubuntu2204_clang
@@ -1214,7 +1213,8 @@ jobs:
       # The high parallelism in this job is causing the SMT tests to run out of memory,
       # so disabling for now.
       SOLTEST_FLAGS: --no-smt
-    <<: *steps_soltest
+    steps:
+      - soltest
 
   t_ubu_force_release_soltest_all: &t_ubu_force_release_soltest_all
     # NOTE: This definition is identical to t_ubu_soltest_all but in the workflow we make it depend on
@@ -1224,7 +1224,8 @@ jobs:
   t_ubu_cli: &t_ubu_cli
     <<: *base_ubuntu2204_small
     parallelism: 7 # Should match number of tests in .circleci/cli.sh
-    <<: *steps_cmdline_tests
+    steps:
+      - cmdline_tests
 
   t_ubu_force_release_cli: &t_ubu_force_release_cli
     <<: *t_ubu_cli
@@ -1248,7 +1249,8 @@ jobs:
       # Suppress CLN memory leak.
       # See: https://github.com/ethereum/solidity/issues/13891 for details.
       LSAN_OPTIONS: suppressions=/root/project/.circleci/cln-asan.supp:print_suppressions=0
-    <<: *steps_cmdline_tests
+    steps:
+      - cmdline_tests
 
   t_ubu_asan_soltest:
     <<: *base_ubuntu2204
@@ -1262,7 +1264,8 @@ jobs:
       # Suppress CLN memory leak.
       # See: https://github.com/ethereum/solidity/issues/13891 for details.
       LSAN_OPTIONS: suppressions=/root/project/.circleci/cln-asan.supp
-    <<: *steps_soltest
+    steps:
+      - soltest
 
   t_ubu_asan_clang_soltest:
     <<: *base_ubuntu2204_clang
@@ -1273,7 +1276,8 @@ jobs:
       OPTIMIZE: 0
       SOLTEST_FLAGS: --no-smt
       ASAN_OPTIONS: check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2
-    <<: *steps_soltest
+    steps:
+      - soltest
 
   t_ubu_ubsan_clang_soltest:
     <<: *base_ubuntu2204_clang
@@ -1282,12 +1286,14 @@ jobs:
       <<: *base_ubuntu2204_clang_env
       EVM: << pipeline.parameters.evm-version >>
       SOLTEST_FLAGS: --no-smt
-    <<: *steps_soltest
+    steps:
+      - soltest
 
   t_ubu_ubsan_clang_cli:
     <<: *base_ubuntu2204_clang
     parallelism: 7 # Should match number of tests in .circleci/cli.sh
-    <<: *steps_cmdline_tests
+    steps:
+      - cmdline_tests
 
   t_ems_solcjs:
     # Unlike other t_ems jobs this one actually runs 2x faster on medium (compared to small).

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,47 +179,67 @@ commands:
           paths:
             - << parameters.install_path >>
 
-defaults:
-
   # --------------------------------------------------------------------------
-  # Build Templates
+  # Build Commands
 
-  - setup_prerelease_commit_hash: &setup_prerelease_commit_hash
-      name: Store commit hash and prerelease
-      command: |
-        if [ "$CIRCLE_BRANCH" = release -o -n "$CIRCLE_TAG" ]; then echo -n > prerelease.txt; else date -u +"nightly.%Y.%-m.%-d" > prerelease.txt; fi
-        echo -n "$CIRCLE_SHA1" > commit_hash.txt
+  setup_prerelease_commit_hash:
+    steps:
+      - run:
+          name: Store commit hash and prerelease
+          command: |
+            if [[ $CIRCLE_BRANCH == release || -n $CIRCLE_TAG ]]; then
+              echo -n > prerelease.txt;
+            else
+              date -u +"nightly.%Y.%-m.%-d" > prerelease.txt;
+            fi
+            echo -n "$CIRCLE_SHA1" > commit_hash.txt
 
-  - run_build: &run_build
-      name: Build
-      command: scripts/ci/build.sh
+  run_build:
+    steps:
+      - run:
+          name: Build
+          command: scripts/ci/build.sh
 
-  - run_build_ossfuzz: &run_build_ossfuzz
-      name: Build_ossfuzz
-      command: scripts/ci/build_ossfuzz.sh
+  run_build_ossfuzz:
+    steps:
+      - run:
+          name: Build_ossfuzz
+          command: scripts/ci/build_ossfuzz.sh
 
-  - run_proofs: &run_proofs
-      name: Correctness proofs for optimization rules
-      command: scripts/run_proofs.sh
+  run_proofs:
+    steps:
+      - run:
+          name: Correctness proofs for optimization rules
+          command: scripts/run_proofs.sh
 
-  - run_soltest: &run_soltest
-      name: soltest
-      no_output_timeout: 30m
-      command: ./.circleci/soltest.sh
+  run_soltest:
+    steps:
+      - run:
+          name: soltest
+          no_output_timeout: 30m
+          command: ./.circleci/soltest.sh
 
-  - run_soltest_all: &run_soltest_all
-      name: soltest_all
-      no_output_timeout: 30m
-      command: ./.circleci/soltest_all.sh
+  run_soltest_all:
+    steps:
+      - run:
+          name: soltest_all
+          no_output_timeout: 30m
+          command: ./.circleci/soltest_all.sh
 
-  - run_cmdline_tests: &run_cmdline_tests
-      name: command line tests
-      no_output_timeout: 30m
-      command: .circleci/parallel_cli_tests.py
+  run_cmdline_tests:
+    steps:
+      - run:
+          name: command line tests
+          no_output_timeout: 30m
+          command: .circleci/parallel_cli_tests.py
 
-  - run_docs_pragma_min_version: &run_docs_pragma_min_version
-      name: docs pragma version check
-      command: ./scripts/docs_version_pragma_check.sh
+  run_docs_pragma_min_version:
+    steps:
+      - run:
+         name: docs pragma version check
+         command: ./scripts/docs_version_pragma_check.sh
+
+defaults:
 
   # --------------------------------------------------------------------------
   # Matrix templates
@@ -298,7 +318,7 @@ defaults:
         # NOTE: Different build jobs produce different soltest executables (release/debug,
         # clang/gcc, windows/linux/macos, etc.). The executable used by these steps comes from the
         # attached workspace and we only see the items added to the workspace by jobs we depend on.
-        - run: *run_soltest
+        - run_soltest
         - store_test_results:
             path: test_results/
         - store_artifacts: *artifacts_test_results
@@ -320,7 +340,7 @@ defaults:
   - steps_build: &steps_build
       steps:
         - checkout
-        - run: *run_build
+        - run_build
         - store_artifacts: *artifacts_solc
         - store_artifacts: *artifact_yul_phaser
         - persist_to_workspace: *artifacts_executables
@@ -331,7 +351,7 @@ defaults:
         - checkout
         - attach_workspace:
             at: build
-        - run: *run_soltest_all
+        - run_soltest_all
         - store_test_results:
             path: test_results/
         - store_artifacts: *artifacts_test_results
@@ -342,7 +362,7 @@ defaults:
         - checkout
         - attach_workspace:
             at: build
-        - run: *run_cmdline_tests
+        - run_cmdline_tests
         - store_test_results:
             path: test_results/
         - store_artifacts: *artifacts_test_results
@@ -867,14 +887,14 @@ jobs:
       - checkout
       - install_python3:
           packages: z3-solver
-      - run: *run_proofs
+      - run_proofs
       - matrix_notify_failure_unless_pr
 
   chk_docs_pragma_min_version:
     <<: *base_ubuntu2204_small
     steps:
       - checkout
-      - run: *run_docs_pragma_min_version
+      - run_docs_pragma_min_version
       - matrix_notify_failure_unless_pr
 
   t_ubu_pyscripts:
@@ -947,7 +967,7 @@ jobs:
       CMAKE_OPTIONS: -DCMAKE_BUILD_TYPE=Release -DUSE_Z3_DLOPEN=ON -DUSE_CVC4=OFF -DSOLC_STATIC_STDLIBS=ON
     steps:
       - checkout
-      - run: *run_build
+      - run_build
       - run:
           name: strip binary
           command: strip build/solc/solc
@@ -970,7 +990,7 @@ jobs:
       CMAKE_BUILD_TYPE: Debug
     steps:
       - checkout
-      - run: *run_build
+      - run_build
       - persist_to_workspace: *artifacts_executables
       - matrix_notify_failure_unless_pr
 
@@ -990,7 +1010,7 @@ jobs:
       - run:
           name: "Code Coverage: Syntax Tests"
           command: codecov --flags syntax --gcov-root build
-      - run: *run_soltest
+      - run_soltest
       - run:
           name: "Coverage: All"
           command: codecov --flags all --gcov-root build
@@ -1008,15 +1028,15 @@ jobs:
       MAKEFLAGS: -j 10
     steps:
       - checkout
-      - run: *run_build
+      - run_build
       - matrix_notify_failure_unless_pr
 
   b_ubu_ossfuzz: &b_ubu_ossfuzz
     <<: *base_ubuntu_clang
     steps:
       - checkout
-      - run: *setup_prerelease_commit_hash
-      - run: *run_build_ossfuzz
+      - setup_prerelease_commit_hash
+      - run_build_ossfuzz
       - persist_to_workspace: *artifacts_executables_ossfuzz
       - matrix_notify_failure_unless_pr
 
@@ -1048,7 +1068,7 @@ jobs:
           command: |
             pacman --noconfirm -Syu --noprogressbar --needed base-devel boost cmake cvc4 git openssh tar
       - checkout
-      - run: *run_build
+      - run_build
       - store_artifacts: *artifacts_solc
       - persist_to_workspace: *artifacts_executables
       - matrix_notify_failure_unless_pr
@@ -1063,7 +1083,7 @@ jobs:
       - when:
           condition: true
           <<: *steps_install_dependencies_osx
-      - run: *run_build
+      - run_build
       - store_artifacts: *artifacts_solc
       - store_artifacts: *artifact_yul_phaser
       - persist_to_workspace:
@@ -1087,7 +1107,7 @@ jobs:
           <<: *steps_install_dependencies_osx
       - attach_workspace:
           at: .
-      - run: *run_soltest
+      - run_soltest
       - store_test_results:
           path: test_results/
       - store_artifacts: *artifacts_test_results
@@ -1103,7 +1123,7 @@ jobs:
           <<: *steps_install_dependencies_osx
       - attach_workspace:
           at: .
-      - run: *run_cmdline_tests
+      - run_cmdline_tests
       - store_artifacts: *artifacts_test_results
       - matrix_notify_failure_unless_pr
 
@@ -1135,7 +1155,7 @@ jobs:
     <<: *base_ubuntu2204_small
     steps:
       - checkout
-      - run: *setup_prerelease_commit_hash
+      - setup_prerelease_commit_hash
       - run:
           name: Build documentation
           command: ./docs/docs.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,14 +217,14 @@ commands:
       - run:
           name: soltest
           no_output_timeout: 30m
-          command: ./.circleci/soltest.sh
+          command: .circleci/soltest.sh
 
   run_soltest_all:
     steps:
       - run:
           name: soltest_all
           no_output_timeout: 30m
-          command: ./.circleci/soltest_all.sh
+          command: .circleci/soltest_all.sh
 
   run_cmdline_tests:
     steps:
@@ -237,7 +237,7 @@ commands:
     steps:
       - run:
          name: docs pragma version check
-         command: ./scripts/docs_version_pragma_check.sh
+         command: scripts/docs_version_pragma_check.sh
 
   # --------------------------------------------------------------------------
   # Artifact Commands
@@ -329,7 +329,7 @@ commands:
           command: pip install --user deepdiff colorama
       - run:
           name: Executing solc LSP test suite
-          command: ./test/lsp.py ./build/solc/solc --non-interactive
+          command: test/lsp.py build/solc/solc --non-interactive
       - matrix_notify_failure_unless_pr
 
   build:
@@ -369,7 +369,7 @@ commands:
       # them each time. See https://github.com/ethereum/solidity/issues/12925.
       - run:
           name: Install build dependencies
-          command: ./.circleci/osx_install_dependencies.sh
+          command: .circleci/osx_install_dependencies.sh
 
 defaults:
 
@@ -803,7 +803,11 @@ jobs:
             pip install --user codespell
       - run:
           name: Check spelling
-          command: ~/.local/bin/codespell --skip "*.enc,.git,Dockerfile*,LICENSE,codespell_whitelist.txt,codespell_ignored_lines.txt" --ignore-words ./scripts/codespell_whitelist.txt --exclude-file ./scripts/codespell_ignored_lines.txt
+          command: |
+            ~/.local/bin/codespell \
+              --skip "*.enc,.git,Dockerfile*,LICENSE,codespell_whitelist.txt,codespell_ignored_lines.txt" \
+              --ignore-words scripts/codespell_whitelist.txt \
+              --exclude-file scripts/codespell_ignored_lines.txt
       - matrix_notify_failure_unless_pr
 
   chk_docs_examples:
@@ -817,7 +821,7 @@ jobs:
           command: sudo npm install -g solhint
       - run:
           name: Test Docs examples
-          command: ./test/docsCodeStyle.sh
+          command: test/docsCodeStyle.sh
       - matrix_notify_failure_unless_pr
 
   chk_coding_style:
@@ -831,13 +835,13 @@ jobs:
             sudo apt install -y shellcheck
       - run:
           name: Check for C++ coding style
-          command: ./scripts/check_style.sh
+          command: scripts/check_style.sh
       - run:
           name: checking shell scripts
-          command: ./scripts/chk_shellscripts/chk_shellscripts.sh
+          command: scripts/chk_shellscripts/chk_shellscripts.sh
       - run:
           name: Check for broken symlinks
-          command: ./scripts/check_symlinks.sh
+          command: scripts/check_symlinks.sh
       - matrix_notify_failure_unless_pr
 
   chk_errorcodes:
@@ -846,7 +850,7 @@ jobs:
       - checkout
       - run:
           name: Check for error codes
-          command: ./scripts/error_codes.py --check
+          command: scripts/error_codes.py --check
       - matrix_notify_failure_unless_pr
 
   chk_pylint:
@@ -866,7 +870,7 @@ jobs:
       - run: pylint --version
       - run:
           name: Linting Python Scripts
-          command: ./scripts/pylint_all.py
+          command: scripts/pylint_all.py
       - matrix_notify_failure_unless_pr
 
   chk_antlr_grammar:
@@ -880,7 +884,7 @@ jobs:
             sudo apt install -y openjdk-17-jdk
       - run:
           name: Run tests
-          command: ./scripts/test_antlr_grammar.sh
+          command: scripts/test_antlr_grammar.sh
       - matrix_notify_failure_unless_pr
 
   chk_buglist:
@@ -895,7 +899,7 @@ jobs:
             npm install mktemp
       - run:
           name: Test buglist
-          command: ./test/buglistTests.js
+          command: test/buglistTests.js
       - matrix_notify_failure_unless_pr
 
   chk_proofs:
@@ -1168,7 +1172,7 @@ jobs:
       - setup_prerelease_commit_hash
       - run:
           name: Build documentation
-          command: ./docs/docs.sh
+          command: docs/docs.sh
       - store_artifacts:
           path: docs/_build/html/
           destination: docs-html
@@ -1546,7 +1550,7 @@ jobs:
           command: python -m pip install --user deepdiff colorama
       - run:
           name: Executing solc LSP test suite
-          command: python ./test/lsp.py .\build\solc\Release\solc.exe --non-interactive
+          command: python test/lsp.py build\solc\Release\solc.exe --non-interactive
           shell: powershell.exe
       - store_test_results:
           path: test_results/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,10 +290,6 @@ defaults:
   # --------------------------------------------------------------------------
   # Step Templates
 
-  # store_test_results helper
-  - store_test_results: &store_test_results
-      path: test_results/
-
   - steps_soltest: &steps_soltest
       steps:
         - checkout
@@ -303,7 +299,8 @@ defaults:
         # clang/gcc, windows/linux/macos, etc.). The executable used by these steps comes from the
         # attached workspace and we only see the items added to the workspace by jobs we depend on.
         - run: *run_soltest
-        - store_test_results: *store_test_results
+        - store_test_results:
+            path: test_results/
         - store_artifacts: *artifacts_test_results
         - matrix_notify_failure_unless_pr
 
@@ -335,7 +332,8 @@ defaults:
         - attach_workspace:
             at: build
         - run: *run_soltest_all
-        - store_test_results: *store_test_results
+        - store_test_results:
+            path: test_results/
         - store_artifacts: *artifacts_test_results
         - matrix_notify_failure_unless_pr
 
@@ -345,7 +343,8 @@ defaults:
         - attach_workspace:
             at: build
         - run: *run_cmdline_tests
-        - store_test_results: *store_test_results
+        - store_test_results:
+            path: test_results/
         - store_artifacts: *artifacts_test_results
         - matrix_notify_failure_unless_pr
 
@@ -1033,7 +1032,8 @@ jobs:
             git clone https://github.com/ethereum/solidity-fuzzing-corpus /tmp/solidity-fuzzing-corpus
             mkdir -p test_results
             scripts/regressions.py -o test_results
-      - store_test_results: *store_test_results
+      - store_test_results:
+          path: test_results/
       - store_artifacts: *artifacts_test_results
 
   b_archlinux:
@@ -1088,7 +1088,8 @@ jobs:
       - attach_workspace:
           at: .
       - run: *run_soltest
-      - store_test_results: *store_test_results
+      - store_test_results:
+          path: test_results/
       - store_artifacts: *artifacts_test_results
       - matrix_notify_failure_unless_pr
 
@@ -1509,7 +1510,8 @@ jobs:
           name: Executing solc LSP test suite
           command: python ./test/lsp.py .\build\solc\Release\solc.exe --non-interactive
           shell: powershell.exe
-      - store_test_results: *store_test_results
+      - store_test_results:
+          path: test_results/
       - store_artifacts: *artifacts_test_results
       - matrix_notify_failure_unless_pr
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,6 +265,16 @@ commands:
             - test/soltest
             - test/tools/solfuzzer
 
+  persist_executables_to_workspace_osx:
+    description: Persist compiled target executables to workspace on macOS
+    steps:
+      - persist_to_workspace:
+          root: .
+          paths:
+            - build/solc/solc
+            - build/test/soltest
+            - build/test/tools/solfuzzer
+
   persist_ossfuzz_executables_to_workspace:
     description: Persist compiled OSSFUZZ executables to workspace
     steps:
@@ -1095,12 +1105,7 @@ jobs:
       - run_build
       - store_artifacts_solc
       - store_artifacts_yul_phaser
-      - persist_to_workspace:
-          root: .
-          paths:
-            - build/solc/solc
-            - build/test/soltest
-            - build/test/tools/solfuzzer
+      - persist_executables_to_workspace_osx
       - matrix_notify_failure_unless_pr
 
   t_osx_soltest: &t_osx_soltest


### PR DESCRIPTION
This is a quick refactor I did recently for #14478 when I wanted to parameterize our `run_build` step. This would allow me to parameterize it with the number of CPUs. In the end I chose a different approach and did not need it, but I think we should still merge it. It's something I wanted to clean up for quite a while but never had a good reason to actually do it.

Until now we've been YAML fragments under the `defaults` key to define sequences of steps or lists of artifacts. The downside of that mechanism is that it's pretty crude and requires workarounds to compose well in some situations (e.g. we need to wrap a list of steps in a condition if we're appending to another list rather than replacing it whole). Reusable commands are a way to do that with fewer quirks. They also have parameters, which will make them easier to extend in the future.

I recommend viewing the diff with whitespace ignored and preferably looking at individual commits. The changes are pretty straightforward, there's just quite a few of them, and this should make it more apparent.