### PR TITLE
Bump fmtlib to 9.1.0

### DIFF
--- a/cmake/fmtlib.cmake
+++ b/cmake/fmtlib.cmake
@@ -4,9 +4,9 @@ FetchContent_Declare(
 	fmtlib
 	PREFIX "${PROJECT_BINARY_DIR}/deps"
 	DOWNLOAD_DIR "${PROJECT_SOURCE_DIR}/deps/downloads"
-	DOWNLOAD_NAME fmt-8.0.1.tar.gz
-	URL https://github.com/fmtlib/fmt/archive/8.0.1.tar.gz
-	URL_HASH SHA256=b06ca3130158c625848f3fb7418f235155a4d389b2abc3a6245fb01cb0eb1e01
+	DOWNLOAD_NAME fmt-9.1.0.tar.gz
+	URL https://github.com/fmtlib/fmt/archive/9.1.0.tar.gz
+	URL_HASH SHA256=5dea48d1fcddc3ec571ce2058e13910a0d4a6bab4cc09a809d8b1dd1c88ae6f2
 )
 
 if (CMAKE_VERSION VERSION_LESS "3.14.0")

--- a/libsolidity/lsp/SemanticTokensBuilder.cpp
+++ b/libsolidity/lsp/SemanticTokensBuilder.cpp
@@ -118,7 +118,7 @@ void SemanticTokensBuilder::encode(
 	auto const [line, startChar] = m_charStream->translatePositionToLineColumn(_sourceLocation.start);
 	auto const length = _sourceLocation.end - _sourceLocation.start;
 
-	lspDebug(fmt::format("encode [{}:{}..{}] {}", line, startChar, length, _tokenType));
+	lspDebug(fmt::format("encode [{}:{}..{}] {}", line, startChar, length, static_cast<int>(_tokenType)));
 
 	m_encodedTokens.append(line - m_lastLine);
 	if (line == m_lastLine)


### PR DESCRIPTION
In our downstream project, we have two dependencies: solidity and spdlog. Both of them depend on fmtlib. Unfortunately, the versions of fmtlib they use do not match, which leads to compilation failure.

The issue arises because spdlog attempts to use solidity's fmtlib, but the specific version (v8.0.1) has a bug. Ref: https://github.com/gabime/spdlog/issues/2142

While we could keep this change in our own fork, we believe it would be worthwhile to contribute it back to the upstream since spdlog is a very popular logging library.