### PR TITLE
gas optimisation in Yul based ERC20 Example

### DIFF
--- a/docs/yul.rst
+++ b/docs/yul.rst
@@ -1343,7 +1343,7 @@ Complete ERC20 Example
 
                 /* ---------- calldata decoding functions ----------- */
                 function selector() -> s {
-                    s := div(calldataload(0), 0x100000000000000000000000000000000000000000000000000000000)
+                    s := shr(224, calldataload(0))
                 }
 
                 function decodeAsAddress(offset) -> v {


### PR DESCRIPTION
using **shr** opcode (costs 3 gas) instead of **div** (cost 5 gas)