### PR TITLE
`AnalysisFramework` refactor

### DIFF
--- a/test/libsolidity/AnalysisFramework.cpp
+++ b/test/libsolidity/AnalysisFramework.cpp
@@ -173,22 +173,6 @@ bool AnalysisFramework::stageSuccessful(PipelineStage _stage) const
 	unreachable();
 }
 
-SourceUnit const* AnalysisFramework::parseAndAnalyse(std::string const& _source)
-{
-	auto sourceAndError = parseAnalyseAndReturnError(_source);
-	BOOST_REQUIRE(!!sourceAndError.first);
-	std::string message;
-	if (!sourceAndError.second.empty())
-		message = "Unexpected error: " + formatErrors(compiler().errors());
-	BOOST_REQUIRE_MESSAGE(sourceAndError.second.empty(), message);
-	return sourceAndError.first;
-}
-
-bool AnalysisFramework::success(std::string const& _source)
-{
-	return parseAnalyseAndReturnError(_source).second.empty();
-}
-
 ErrorList AnalysisFramework::expectError(std::string const& _source, bool _warning, bool _allowMultiple)
 {
 	auto sourceAndErrors = parseAnalyseAndReturnError(_source, _warning, true, _allowMultiple);

--- a/test/libsolidity/AnalysisFramework.cpp
+++ b/test/libsolidity/AnalysisFramework.cpp
@@ -86,7 +86,12 @@ std::unique_ptr<CompilerStack> AnalysisFramework::createStack() const
 
 void AnalysisFramework::setupCompiler(CompilerStack& _compiler)
 {
+	// These are just defaults based on the (global) CLI options.
+	// Technically, every TestCase should override these with values passed to it in TestCase::Config.
+	// In practice TestCase::Config always matches global config so most test cases don't care.
 	_compiler.setEVMVersion(solidity::test::CommonOptions::get().evmVersion());
+	_compiler.setEOFVersion(solidity::test::CommonOptions::get().eofVersion());
+	_compiler.setOptimiserSettings(solidity::test::CommonOptions::get().optimize);
 }
 
 void AnalysisFramework::executeCompilationPipeline()

--- a/test/libsolidity/AnalysisFramework.h
+++ b/test/libsolidity/AnalysisFramework.h
@@ -58,8 +58,6 @@ protected:
 	);
 	virtual ~AnalysisFramework() = default;
 
-	SourceUnit const* parseAndAnalyse(std::string const& _source);
-	bool success(std::string const& _source);
 	langutil::ErrorList expectError(std::string const& _source, bool _warning = false, bool _allowMultiple = false);
 
 public:
@@ -189,16 +187,19 @@ CHECK_ERROR_OR_WARNING(text, Warning, std::vector<std::string>{(substring)}, tru
 CHECK_ERROR_OR_WARNING(text, Warning, substrings, true, true)
 
 // [checkSuccess(text)] asserts that the compilation down to typechecking succeeds.
-#define CHECK_SUCCESS(text) do { BOOST_CHECK(success((text))); } while(0)
+#define CHECK_SUCCESS(text) do { \
+	auto [ast, errors] = parseAnalyseAndReturnError((text)); \
+	BOOST_CHECK(errors.empty()); \
+} while(0)
 
 #define CHECK_SUCCESS_NO_WARNINGS(text) \
 do \
 { \
-	auto sourceAndError = parseAnalyseAndReturnError((text), true); \
+	auto [ast, errors] = parseAnalyseAndReturnError((text), true); \
 	std::string message; \
-	if (!sourceAndError.second.empty()) \
-		message = formatErrors(compiler().errors());\
-	BOOST_CHECK_MESSAGE(sourceAndError.second.empty(), message); \
+	if (!errors.empty()) \
+		message = formatErrors(errors);\
+	BOOST_CHECK_MESSAGE(errors.empty(), message); \
 } \
 while(0)
 

--- a/test/libsolidity/GasTest.cpp
+++ b/test/libsolidity/GasTest.cpp
@@ -99,6 +99,7 @@ void GasTest::printUpdatedExpectations(std::ostream& _stream, std::string const&
 
 void GasTest::setupCompiler(CompilerStack& _compiler)
 {
+	AnalysisFramework::setupCompiler(_compiler);
 
 	// Prerelease CBOR metadata varies in size due to changing version numbers and build dates.
 	// This leads to volatile creation cost estimates. Therefore we force the compiler to
@@ -112,6 +113,10 @@ void GasTest::setupCompiler(CompilerStack& _compiler)
 	}
 	settings.expectedExecutionsPerDeployment = m_optimiseRuns;
 	_compiler.setOptimiserSettings(settings);
+
+	// Intentionally ignoring EVM version specified on the command line.
+	// Gas expectations are only valid for the default version.
+	_compiler.setEVMVersion(EVMVersion{});
 }
 
 TestCase::TestResult GasTest::run(std::ostream& _stream, std::string const& _linePrefix, bool _formatted)

--- a/test/libsolidity/GasTest.h
+++ b/test/libsolidity/GasTest.h
@@ -44,6 +44,9 @@ public:
 	void printSource(std::ostream &_stream, std::string const &_linePrefix = "", bool _formatted = false) const override;
 	void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix) const override;
 
+protected:
+	void setupCompiler(CompilerStack& _compiler) override;
+
 private:
 	void parseExpectations(std::istream& _stream);
 

--- a/test/libsolidity/MemoryGuardTest.cpp
+++ b/test/libsolidity/MemoryGuardTest.cpp
@@ -36,13 +36,15 @@ using namespace solidity::frontend;
 using namespace solidity::frontend::test;
 using namespace yul;
 
+void MemoryGuardTest::setupCompiler(CompilerStack& _compiler)
+{
+	_compiler.setViaIR(true);
+	_compiler.setOptimiserSettings(OptimiserSettings::none());
+}
+
 TestCase::TestResult MemoryGuardTest::run(std::ostream& _stream, std::string const& _linePrefix, bool _formatted)
 {
-	compiler().reset();
-	compiler().setSources(StringMap{{"", m_source}});
-	compiler().setViaIR(true);
-	compiler().setOptimiserSettings(OptimiserSettings::none());
-	if (!compiler().compile())
+	if (!runFramework(m_source, PipelineStage::Compilation))
 	{
 		_stream << formatErrors(filteredErrors(), _formatted);
 		return TestResult::FatalError;

--- a/test/libsolidity/MemoryGuardTest.cpp
+++ b/test/libsolidity/MemoryGuardTest.cpp
@@ -38,6 +38,8 @@ using namespace yul;
 
 void MemoryGuardTest::setupCompiler(CompilerStack& _compiler)
 {
+	AnalysisFramework::setupCompiler(_compiler);
+
 	_compiler.setViaIR(true);
 	_compiler.setOptimiserSettings(OptimiserSettings::none());
 }

--- a/test/libsolidity/MemoryGuardTest.h
+++ b/test/libsolidity/MemoryGuardTest.h
@@ -48,6 +48,9 @@ public:
 	}
 
 	TestResult run(std::ostream& _stream, std::string const& _linePrefix = "", bool _formatted = false) override;
+
+protected:
+	void setupCompiler(CompilerStack& _compiler) override;
 };
 
 }

--- a/test/libsolidity/SMTCheckerTest.cpp
+++ b/test/libsolidity/SMTCheckerTest.cpp
@@ -126,11 +126,11 @@ SMTCheckerTest::SMTCheckerTest(std::string const& _filename): SyntaxTest(_filena
 	m_modelCheckerSettings.bmcLoopIterations = std::optional<unsigned>{bmcLoopIterations};
 }
 
-void SMTCheckerTest::setupCompiler()
+void SMTCheckerTest::setupCompiler(CompilerStack& _compiler)
 {
-	SyntaxTest::setupCompiler();
+	SyntaxTest::setupCompiler(_compiler);
 
-	compiler().setModelCheckerSettings(m_modelCheckerSettings);
+	_compiler.setModelCheckerSettings(m_modelCheckerSettings);
 }
 
 void SMTCheckerTest::filterObtainedErrors()

--- a/test/libsolidity/SMTCheckerTest.h
+++ b/test/libsolidity/SMTCheckerTest.h
@@ -38,7 +38,7 @@ public:
 	}
 	SMTCheckerTest(std::string const& _filename);
 
-	void setupCompiler() override;
+	void setupCompiler(CompilerStack& _compiler) override;
 	void filterObtainedErrors() override;
 
 	void printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix) const override;

--- a/test/libsolidity/SolidityCompiler.cpp
+++ b/test/libsolidity/SolidityCompiler.cpp
@@ -32,6 +32,8 @@ class SolidityCompilerFixture: protected AnalysisFramework
 {
 	void setupCompiler(CompilerStack& _compiler) override
 	{
+		AnalysisFramework::setupCompiler(_compiler);
+
 		// FIXME: This test was probably supposed to respect CommonOptions::get().optimize but
 		// due to a bug it was always running with optimizer disabled and it does not pass with it.
 		_compiler.setOptimiserSettings(false);

--- a/test/libsolidity/SolidityCompiler.cpp
+++ b/test/libsolidity/SolidityCompiler.cpp
@@ -28,7 +28,17 @@
 namespace solidity::frontend::test
 {
 
-BOOST_FIXTURE_TEST_SUITE(SolidityCompiler, AnalysisFramework)
+class SolidityCompilerFixture: protected AnalysisFramework
+{
+	void setupCompiler(CompilerStack& _compiler) override
+	{
+		// FIXME: This test was probably supposed to respect CommonOptions::get().optimize but
+		// due to a bug it was always running with optimizer disabled and it does not pass with it.
+		_compiler.setOptimiserSettings(false);
+	}
+};
+
+BOOST_FIXTURE_TEST_SUITE(SolidityCompiler, SolidityCompilerFixture)
 
 BOOST_AUTO_TEST_CASE(does_not_include_creation_time_only_internal_functions)
 {
@@ -39,12 +49,13 @@ BOOST_AUTO_TEST_CASE(does_not_include_creation_time_only_internal_functions)
 			function f() internal { unchecked { for (uint i = 0; i < 10; ++i) x += 3 + i; } }
 		}
 	)";
-	compiler().setOptimiserSettings(solidity::test::CommonOptions::get().optimize);
-	BOOST_REQUIRE(success(sourceCode));
+
+	runFramework(sourceCode, PipelineStage::Compilation);
 	BOOST_REQUIRE_MESSAGE(
-		compiler().compile(),
+		pipelineSuccessful(),
 		"Contract compilation failed:\n" + formatErrors(filteredErrors(), true /* _colored */)
 	);
+
 	bytes const& creationBytecode = solidity::test::bytecodeSansMetadata(compiler().object("C").bytecode);
 	bytes const& runtimeBytecode = solidity::test::bytecodeSansMetadata(compiler().runtimeObject("C").bytecode);
 	BOOST_CHECK(creationBytecode.size() >= 90);

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(function_no_implementation)
 			function functionName(bytes32 input) public virtual returns (bytes32 out);
 		}
 	)";
-	auto [sourceUnit, errors] = parseAnalyseAndReturnError(text);
+	auto [sourceUnit, errors] = runAnalysisAndExpectNoParsingErrors(text);
 	soltestAssert(sourceUnit);
 	soltestAssert(errors.empty(), "Unexpected error: " + formatErrors(errors));
 
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(abstract_contract)
 		abstract contract base { function foo() public virtual; }
 		contract derived is base { function foo() public override {} }
 	)";
-	auto [sourceUnit, errors] = parseAnalyseAndReturnError(text);
+	auto [sourceUnit, errors] = runAnalysisAndExpectNoParsingErrors(text);
 	soltestAssert(sourceUnit);
 	soltestAssert(errors.empty(), "Unexpected error: " + formatErrors(errors));
 
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(abstract_contract_with_overload)
 		abstract contract base { function foo(bool) public virtual; }
 		abstract contract derived is base { function foo(uint) public {} }
 	)";
-	auto [sourceUnit, errors] = parseAnalyseAndReturnError(text);
+	auto [sourceUnit, errors] = runAnalysisAndExpectNoParsingErrors(text);
 	soltestAssert(sourceUnit);
 	soltestAssert(errors.empty(), "Unexpected error: " + formatErrors(errors));
 
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(implement_abstract_via_constructor)
 		abstract contract base { function foo() public virtual; }
 		abstract contract foo is base { constructor() {} }
 	)";
-	auto [sourceUnit, errors] = parseAnalyseAndReturnError(text);
+	auto [sourceUnit, errors] = runAnalysisAndExpectNoParsingErrors(text);
 	soltestAssert(sourceUnit);
 	soltestAssert(errors.empty(), "Unexpected error: " + formatErrors(errors));
 
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(function_canonical_signature)
 			}
 		}
 	)";
-	auto [sourceUnit, errors] = parseAnalyseAndReturnError(text);
+	auto [sourceUnit, errors] = runAnalysisAndExpectNoParsingErrors(text);
 	soltestAssert(sourceUnit);
 	soltestAssert(errors.empty(), "Unexpected error: " + formatErrors(errors));
 
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(function_canonical_signature_type_aliases)
 			}
 		}
 	)";
-	auto [sourceUnit, errors] = parseAnalyseAndReturnError(text);
+	auto [sourceUnit, errors] = runAnalysisAndExpectNoParsingErrors(text);
 	soltestAssert(sourceUnit);
 	soltestAssert(errors.empty(), "Unexpected error: " + formatErrors(errors));
 
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(function_external_types)
 			}
 		}
 	)";
-	auto [sourceUnit, errors] = parseAnalyseAndReturnError(text);
+	auto [sourceUnit, errors] = runAnalysisAndExpectNoParsingErrors(text);
 	soltestAssert(sourceUnit);
 	soltestAssert(errors.empty(), "Unexpected error: " + formatErrors(errors));
 
@@ -196,7 +196,7 @@ BOOST_AUTO_TEST_CASE(enum_external_type)
 			}
 		}
 	)";
-	auto [sourceUnit, errors] = parseAnalyseAndReturnError(text);
+	auto [sourceUnit, errors] = runAnalysisAndExpectNoParsingErrors(text);
 	soltestAssert(sourceUnit);
 	soltestAssert(errors.empty(), "Unexpected error: " + formatErrors(errors));
 
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE(external_struct_signatures)
 	// Ignore analysis errors. This test only checks that correct signatures
 	// are generated for external structs, but they are not yet supported
 	// in code generation and therefore cause an error in the TypeChecker.
-	SourceUnit const* sourceUnit = parseAnalyseAndReturnError(text, false, true, true).first;
+	SourceUnit const* sourceUnit = runAnalysisAndExpectNoParsingErrors(text, false, true, true).first;
 	for (ASTPointer<ASTNode> const& node: sourceUnit->nodes())
 		if (ContractDefinition* contract = dynamic_cast<ContractDefinition*>(node.get()))
 		{
@@ -259,7 +259,7 @@ BOOST_AUTO_TEST_CASE(external_struct_signatures_in_libraries)
 	// Ignore analysis errors. This test only checks that correct signatures
 	// are generated for external structs, but calldata structs are not yet supported
 	// in code generation and therefore cause an error in the TypeChecker.
-	SourceUnit const* sourceUnit = parseAnalyseAndReturnError(text, false, true, true).first;
+	SourceUnit const* sourceUnit = runAnalysisAndExpectNoParsingErrors(text, false, true, true).first;
 	for (ASTPointer<ASTNode> const& node: sourceUnit->nodes())
 		if (ContractDefinition* contract = dynamic_cast<ContractDefinition*>(node.get()))
 		{
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE(struct_with_mapping_in_library)
 			function f(X storage x) external {}
 		}
 	)";
-	auto [sourceUnit, errors] = parseAnalyseAndReturnError(text);
+	auto [sourceUnit, errors] = runAnalysisAndExpectNoParsingErrors(text);
 	soltestAssert(sourceUnit);
 	soltestAssert(errors.empty(), "Unexpected error: " + formatErrors(errors));
 
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(state_variable_accessors)
 		}
 	)";
 
-	auto [sourceUnit, errors] = parseAnalyseAndReturnError(text);
+	auto [sourceUnit, errors] = runAnalysisAndExpectNoParsingErrors(text);
 	soltestAssert(sourceUnit);
 	soltestAssert(errors.empty(), "Unexpected error: " + formatErrors(errors));
 
@@ -349,7 +349,7 @@ BOOST_AUTO_TEST_CASE(private_state_variable)
 		}
 	)";
 
-	auto [sourceUnit, errors] = parseAnalyseAndReturnError(text);
+	auto [sourceUnit, errors] = runAnalysisAndExpectNoParsingErrors(text);
 	soltestAssert(sourceUnit);
 	soltestAssert(errors.empty(), "Unexpected error: " + formatErrors(errors));
 
@@ -397,7 +397,7 @@ BOOST_AUTO_TEST_CASE(warn_nonpresent_pragma)
 		// SPDX-License-Identifier: GPL-3.0
 		contract C {}
 	)";
-	auto sourceAndError = parseAnalyseAndReturnError(text, true, false);
+	auto sourceAndError = runAnalysisAndExpectNoParsingErrors(text, true, false);
 	BOOST_REQUIRE(!sourceAndError.second.empty());
 	BOOST_REQUIRE(!!sourceAndError.first);
 	BOOST_CHECK(searchErrorMessage(*sourceAndError.second.front(), "Source file does not specify required compiler version!"));

--- a/test/libsolidity/SyntaxTest.h
+++ b/test/libsolidity/SyntaxTest.h
@@ -48,7 +48,7 @@ public:
 	);
 
 protected:
-	virtual void setupCompiler();
+	void setupCompiler(CompilerStack& _compiler) override;
 	void parseAndAnalyze() override;
 	virtual void filterObtainedErrors();
 


### PR DESCRIPTION
This is the main part of the refactors I did for #14506, before I switched to `SyntaxTest` as a base class (which is why that PR does not depend on this refactor now).

This factors out common compiler stack setup and operation into several virtual functions in `AnalysisFramework`. These functions are generally usable as is but can also be customized in test cases that do some non-standard things. This makes the design closer to the one already used by `SyntaxTest`.

The rest of the PR is the adjustment of existing test cases to use that mechanism. Until now most of them were actually ignoring what `AnalysisFramework` provides, using it only as a holder for `CompilerStack`. Only the Boost-based tests were using it for more via `parseAnalyseAndReturnError()` and `parseAndAnalyse()`. The problem with these functions though was that while the names imply something pretty generic, they were coded for one particular way to run `CompilerStack` - which seems to be the reason why the rest of the test cases ignored them. This PR rewrites them on the new system and gives them names that better reflect what they're doing.

The refactor does not really save us that much code, but makes things less confusing and error-prone. It consolidates the disparate bits that run compiler stack on test code with a single consistent one that respects the CLI options (like `--optimize` or `--evm-version`) by default.