### PR TITLE
deprecate using namespace std

### DIFF
--- a/scripts/check_style.sh
+++ b/scripts/check_style.sh
@@ -38,6 +38,13 @@ NAMESPACE_STD_FREE_FILES=(
     libyul/backends/evm/*
     libyul/optimiser/*
     solc/*
+    test/contracts/*
+    test/libevmasm/*
+    test/liblangutil/*
+    test/libsolutil/*
+    test/libsolidity/*
+    test/libsolidity/analysis/*
+    test/libsolidity/interface/*
 )
 
 (

--- a/test/contracts/AuctionRegistrar.cpp
+++ b/test/contracts/AuctionRegistrar.cpp
@@ -32,7 +32,6 @@
 #include <string>
 #include <optional>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::util;
 using namespace solidity::test;
@@ -235,47 +234,47 @@ protected:
 	{
 	public:
 		RegistrarInterface(SolidityExecutionFramework& _framework): ContractInterface(_framework) {}
-		void reserve(string const& _name)
+		void reserve(std::string const& _name)
 		{
 			callString("reserve", _name);
 		}
-		h160 owner(string const& _name)
+		h160 owner(std::string const& _name)
 		{
 			return callStringReturnsAddress("owner", _name);
 		}
-		void setAddress(string const& _name, h160 const& _address, bool _primary)
+		void setAddress(std::string const& _name, h160 const& _address, bool _primary)
 		{
 			callStringAddressBool("setAddress", _name, _address, _primary);
 		}
-		h160 addr(string const& _name)
+		h160 addr(std::string const& _name)
 		{
 			return callStringReturnsAddress("addr", _name);
 		}
-		string name(h160 const& _addr)
+		std::string name(h160 const& _addr)
 		{
 			return callAddressReturnsString("name", _addr);
 		}
-		void setSubRegistrar(string const& _name, h160 const& _address)
+		void setSubRegistrar(std::string const& _name, h160 const& _address)
 		{
 			callStringAddress("setSubRegistrar", _name, _address);
 		}
-		h160 subRegistrar(string const& _name)
+		h160 subRegistrar(std::string const& _name)
 		{
 			return callStringReturnsAddress("subRegistrar", _name);
 		}
-		void setContent(string const& _name, h256 const& _content)
+		void setContent(std::string const& _name, h256 const& _content)
 		{
 			callStringBytes32("setContent", _name, _content);
 		}
-		h256 content(string const& _name)
+		h256 content(std::string const& _name)
 		{
 			return callStringReturnsBytes32("content", _name);
 		}
-		void transfer(string const& _name, h160 const& _target)
+		void transfer(std::string const& _name, h160 const& _target)
 		{
 			return callStringAddress("transfer", _name, _target);
 		}
-		void disown(string const& _name)
+		void disown(std::string const& _name)
 		{
 			return callString("disown", _name);
 		}
@@ -298,7 +297,7 @@ BOOST_AUTO_TEST_CASE(reserve)
 {
 	// Test that reserving works for long strings
 	deployRegistrar();
-	vector<string> names{"abcabcabcabcabc", "defdefdefdefdef", "ghighighighighighighighighighighighighighighi"};
+	std::vector<std::string> names{"abcabcabcabcabc", "defdefdefdefdef", "ghighighighighighighighighighighighighighighi"};
 
 	RegistrarInterface registrar(*this);
 
@@ -317,7 +316,7 @@ BOOST_AUTO_TEST_CASE(double_reserve_long)
 {
 	// Test that it is not possible to re-reserve from a different address.
 	deployRegistrar();
-	string name = "abcabcabcabcabcabcabcabcabcabca";
+	std::string name = "abcabcabcabcabcabcabcabcabcabca";
 	RegistrarInterface registrar(*this);
 	registrar.reserve(name);
 	BOOST_CHECK_EQUAL(registrar.owner(name), m_sender);
@@ -333,10 +332,10 @@ BOOST_AUTO_TEST_CASE(properties)
 	// Test setting and retrieving  the various properties works.
 	deployRegistrar();
 	RegistrarInterface registrar(*this);
-	string names[] = {"abcaeouoeuaoeuaoeu", "defncboagufra,fui", "ghagpyajfbcuajouhaeoi"};
+	std::string names[] = {"abcaeouoeuaoeuaoeu", "defncboagufra,fui", "ghagpyajfbcuajouhaeoi"};
 	size_t addr = 0x9872543;
 	size_t count = 1;
-	for (string const& name: names)
+	for (std::string const& name: names)
 	{
 		m_sender = account(0);
 		sendEther(account(count), u256(20) * ether);
@@ -369,7 +368,7 @@ BOOST_AUTO_TEST_CASE(properties)
 BOOST_AUTO_TEST_CASE(transfer)
 {
 	deployRegistrar();
-	string name = "abcaoeguaoucaeoduceo";
+	std::string name = "abcaoeguaoucaeoduceo";
 	RegistrarInterface registrar(*this);
 	registrar.reserve(name);
 	registrar.setContent(name, h256(u256(123)));
@@ -381,7 +380,7 @@ BOOST_AUTO_TEST_CASE(transfer)
 BOOST_AUTO_TEST_CASE(disown)
 {
 	deployRegistrar();
-	string name = "abcaoeguaoucaeoduceo";
+	std::string name = "abcaoeguaoucaeoduceo";
 
 	RegistrarInterface registrar(*this);
 	registrar.reserve(name);
@@ -408,7 +407,7 @@ BOOST_AUTO_TEST_CASE(disown)
 BOOST_AUTO_TEST_CASE(auction_simple)
 {
 	deployRegistrar();
-	string name = "x";
+	std::string name = "x";
 
 	RegistrarInterface registrar(*this);
 	// initiate auction
@@ -426,7 +425,7 @@ BOOST_AUTO_TEST_CASE(auction_simple)
 BOOST_AUTO_TEST_CASE(auction_bidding)
 {
 	deployRegistrar();
-	string name = "x";
+	std::string name = "x";
 
 	unsigned startTime = 0x776347e2;
 	m_evmcHost->tx_context.block_timestamp = startTime;

--- a/test/contracts/Wallet.cpp
+++ b/test/contracts/Wallet.cpp
@@ -38,7 +38,6 @@
 
 #include <test/libsolidity/SolidityExecutionFramework.h>
 
-using namespace std;
 using namespace solidity::test;
 using namespace solidity::util;
 
@@ -445,7 +444,7 @@ class WalletTestFramework: public SolidityExecutionFramework
 protected:
 	void deployWallet(
 		u256 const& _value = 0,
-		vector<h160> const& _owners = vector<h160>{},
+		std::vector<h160> const& _owners = std::vector<h160>{},
 		u256 _required = 1,
 		u256 _dailyLimit = 0
 	)
@@ -535,7 +534,7 @@ BOOST_AUTO_TEST_CASE(remove_owner)
 
 BOOST_AUTO_TEST_CASE(initial_owners)
 {
-	vector<h160> owners{
+	std::vector<h160> owners{
 		h160("0x42c56279432962a17176998a4747d1b4d6ed4367"),
 		h160("0xd4d4669f5ba9f4c27d38ef02a358c339b5560c47"),
 		h160("0xe6716f9544a56c530d868e4bfbacb172315bdead"),

--- a/test/libevmasm/Assembler.cpp
+++ b/test/libevmasm/Assembler.cpp
@@ -34,9 +34,9 @@
 #include <string>
 #include <tuple>
 
-using namespace std;
 using namespace solidity::langutil;
 using namespace solidity::evmasm;
+using namespace std::string_literals;
 
 namespace solidity::frontend::test
 {
@@ -55,34 +55,34 @@ BOOST_AUTO_TEST_SUITE(Assembler)
 
 BOOST_AUTO_TEST_CASE(all_assembly_items)
 {
-	map<string, unsigned> indices = {
+	std::map<std::string, unsigned> indices = {
 		{ "root.asm", 0 },
 		{ "sub.asm", 1 },
 		{ "verbatim.asm", 2 }
 	};
 	EVMVersion evmVersion = solidity::test::CommonOptions::get().evmVersion();
 	Assembly _assembly{evmVersion, false, {}};
-	auto root_asm = make_shared<string>("root.asm");
+	auto root_asm = std::make_shared<std::string>("root.asm");
 	_assembly.setSourceLocation({1, 3, root_asm});
 
 	Assembly _subAsm{evmVersion, false, {}};
-	auto sub_asm = make_shared<string>("sub.asm");
+	auto sub_asm = std::make_shared<std::string>("sub.asm");
 	_subAsm.setSourceLocation({6, 8, sub_asm});
 
 	Assembly _verbatimAsm(evmVersion, true, "");
-	auto verbatim_asm = make_shared<string>("verbatim.asm");
+	auto verbatim_asm = std::make_shared<std::string>("verbatim.asm");
 	_verbatimAsm.setSourceLocation({8, 18, verbatim_asm});
 
 	// PushImmutable
 	_subAsm.appendImmutable("someImmutable");
 	_subAsm.append(AssemblyItem(PushTag, 0));
 	_subAsm.append(Instruction::INVALID);
-	shared_ptr<Assembly> _subAsmPtr = make_shared<Assembly>(_subAsm);
+	std::shared_ptr<Assembly> _subAsmPtr = std::make_shared<Assembly>(_subAsm);
 
 	_verbatimAsm.appendVerbatim({0xff,0xff}, 0, 0);
 	_verbatimAsm.appendVerbatim({0x74, 0x65, 0x73, 0x74}, 0, 1);
 	_verbatimAsm.append(Instruction::MSTORE);
-	shared_ptr<Assembly> _verbatimAsmPtr = make_shared<Assembly>(_verbatimAsm);
+	std::shared_ptr<Assembly> _verbatimAsmPtr = std::make_shared<Assembly>(_verbatimAsm);
 
 	// Tag
 	auto tag = _assembly.newTag();
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(all_assembly_items)
 		"\n"
 		"auxdata: 0x4266eeaa\n"
 	);
-	string json{
+	std::string json{
 		"{\".auxdata\":\"4266eeaa\",\".code\":["
 		"{\"begin\":1,\"end\":3,\"name\":\"tag\",\"source\":0,\"value\":\"1\"},"
 		"{\"begin\":1,\"end\":3,\"name\":\"JUMPDEST\",\"source\":0},"
@@ -221,11 +221,11 @@ BOOST_AUTO_TEST_CASE(immutables_and_its_source_maps)
 	// Tests for 1, 2, 3 number of immutables.
 	for (int numImmutables = 1; numImmutables <= 3; ++numImmutables)
 	{
-		BOOST_TEST_MESSAGE("NumImmutables: "s + to_string(numImmutables));
+		BOOST_TEST_MESSAGE("NumImmutables: "s + std::to_string(numImmutables));
 		// Tests for the cases 1, 2, 3 occurrences of an immutable reference.
 		for (int numActualRefs = 1; numActualRefs <= 3; ++numActualRefs)
 		{
-			BOOST_TEST_MESSAGE("NumActualRefs: "s + to_string(numActualRefs));
+			BOOST_TEST_MESSAGE("NumActualRefs: "s + std::to_string(numActualRefs));
 			auto const NumExpectedMappings =
 				(
 					2 +                        // PUSH <a> PUSH <b>
@@ -238,21 +238,21 @@ BOOST_AUTO_TEST_CASE(immutables_and_its_source_maps)
 				NumSubs +                  // PUSH <addr> for every sub assembly
 				1;                         // INVALID
 
-			auto assemblyName = make_shared<string>("root.asm");
-			auto subName = make_shared<string>("sub.asm");
+			auto assemblyName = std::make_shared<std::string>("root.asm");
+			auto subName = std::make_shared<std::string>("sub.asm");
 
-			map<string, unsigned> indices = {
+			std::map<std::string, unsigned> indices = {
 				{ *assemblyName, 0 },
 				{ *subName, 1 }
 			};
 
-			auto subAsm = make_shared<Assembly>(evmVersion, false, string{});
+			auto subAsm = std::make_shared<Assembly>(evmVersion, false, std::string{});
 			for (char i = 0; i < numImmutables; ++i)
 			{
 				for (int r = 0; r < numActualRefs; ++r)
 				{
 					subAsm->setSourceLocation(SourceLocation{10*i, 10*i + 6 + r, subName});
-					subAsm->appendImmutable(string(1, char('a' + i))); // "a", "b", ...
+					subAsm->appendImmutable(std::string(1, char('a' + i))); // "a", "b", ...
 				}
 			}
 
@@ -262,34 +262,34 @@ BOOST_AUTO_TEST_CASE(immutables_and_its_source_maps)
 				assembly.setSourceLocation({10*i, 10*i + 3+i, assemblyName});
 				assembly.append(u256(0x71));              // immutble value
 				assembly.append(u256(0));                 // target... modules?
-				assembly.appendImmutableAssignment(string(1, char('a' + i - 1)));
+				assembly.appendImmutableAssignment(std::string(1, char('a' + i - 1)));
 			}
 
 			assembly.appendSubroutine(subAsm);
 
 			checkCompilation(assembly);
 
-			string const sourceMappings = AssemblyItem::computeSourceMapping(assembly.items(), indices);
+			std::string const sourceMappings = AssemblyItem::computeSourceMapping(assembly.items(), indices);
 			auto const numberOfMappings = std::count(sourceMappings.begin(), sourceMappings.end(), ';');
 
 			LinkerObject const& obj = assembly.assemble();
-			string const disassembly = disassemble(obj.bytecode, evmVersion, "\n");
+			std::string const disassembly = disassemble(obj.bytecode, evmVersion, "\n");
 			auto const numberOfOpcodes = std::count(disassembly.begin(), disassembly.end(), '\n');
 
 			#if 0 // {{{ debug prints
 			{
 				LinkerObject const& subObj = assembly.sub(0).assemble();
-				string const subDisassembly = disassemble(subObj.bytecode, "\n");
-				cout << '\n';
-				cout << "### immutables: " << numImmutables << ", refs: " << numActualRefs << '\n';
-				cout << " - srcmap: \"" << sourceMappings << "\"\n";
-				cout << " - src mappings: " << numberOfMappings << '\n';
-				cout << " - opcodes: " << numberOfOpcodes << '\n';
-				cout << " - subs: " << assembly.numSubs() << '\n';
-				cout << " - sub opcodes " << std::count(subDisassembly.begin(), subDisassembly.end(), '\n') << '\n';
-				cout << " - sub srcmaps " << AssemblyItem::computeSourceMapping(subAsm->items(), indices) << '\n';
-				cout << " - main bytecode:\n\t" << disassemble(obj.bytecode, "\n\t");
-				cout << "\r - sub bytecode:\n\t" << disassemble(subObj.bytecode, "\n\t");
+				std::string const subDisassembly = disassemble(subObj.bytecode, "\n");
+				std::cout << '\n';
+				std::cout << "### immutables: " << numImmutables << ", refs: " << numActualRefs << '\n';
+				std::cout << " - srcmap: \"" << sourceMappings << "\"\n";
+				std::cout << " - src mappings: " << numberOfMappings << '\n';
+				std::cout << " - opcodes: " << numberOfOpcodes << '\n';
+				std::cout << " - subs: " << assembly.numSubs() << '\n';
+				std::cout << " - sub opcodes " << std::count(subDisassembly.begin(), subDisassembly.end(), '\n') << '\n';
+				std::cout << " - sub srcmaps " << AssemblyItem::computeSourceMapping(subAsm->items(), indices) << '\n';
+				std::cout << " - main bytecode:\n\t" << disassemble(obj.bytecode, "\n\t");
+				std::cout << "\r - sub bytecode:\n\t" << disassemble(subObj.bytecode, "\n\t");
 			}
 			#endif // }}}
 
@@ -301,22 +301,22 @@ BOOST_AUTO_TEST_CASE(immutables_and_its_source_maps)
 
 BOOST_AUTO_TEST_CASE(immutable)
 {
-	map<string, unsigned> indices = {
+	std::map<std::string, unsigned> indices = {
 		{ "root.asm", 0 },
 		{ "sub.asm", 1 }
 	};
 	EVMVersion evmVersion = solidity::test::CommonOptions::get().evmVersion();
 	Assembly _assembly{evmVersion, true, {}};
-	auto root_asm = make_shared<string>("root.asm");
+	auto root_asm = std::make_shared<std::string>("root.asm");
 	_assembly.setSourceLocation({1, 3, root_asm});
 
 	Assembly _subAsm{evmVersion, false, {}};
-	auto sub_asm = make_shared<string>("sub.asm");
+	auto sub_asm = std::make_shared<std::string>("sub.asm");
 	_subAsm.setSourceLocation({6, 8, sub_asm});
 	_subAsm.appendImmutable("someImmutable");
 	_subAsm.appendImmutable("someOtherImmutable");
 	_subAsm.appendImmutable("someImmutable");
-	shared_ptr<Assembly> _subAsmPtr = make_shared<Assembly>(_subAsm);
+	std::shared_ptr<Assembly> _subAsmPtr = std::make_shared<Assembly>(_subAsm);
 
 	_assembly.append(u256(42));
 	_assembly.append(u256(0));
@@ -330,9 +330,9 @@ BOOST_AUTO_TEST_CASE(immutable)
 
 	checkCompilation(_assembly);
 
-	string genericPush0 = evmVersion.hasPush0() ? "5f" : "6000";
+	std::string genericPush0 = evmVersion.hasPush0() ? "5f" : "6000";
 	// PUSH1 0x1b v/s PUSH1 0x19
-	string dataOffset = evmVersion.hasPush0() ? "6019" : "601b" ;
+	std::string dataOffset = evmVersion.hasPush0() ? "6019" : "601b" ;
 
 	BOOST_CHECK_EQUAL(
 		_assembly.assemble().toHex(),
@@ -406,8 +406,8 @@ BOOST_AUTO_TEST_CASE(subobject_encode_decode)
 	EVMVersion evmVersion = solidity::test::CommonOptions::get().evmVersion();
 	Assembly assembly{evmVersion, true, {}};
 
-	shared_ptr<Assembly> subAsmPtr = make_shared<Assembly>(evmVersion, false, string{});
-	shared_ptr<Assembly> subSubAsmPtr = make_shared<Assembly>(evmVersion, false, string{});
+	std::shared_ptr<Assembly> subAsmPtr = std::make_shared<Assembly>(evmVersion, false, std::string{});
+	std::shared_ptr<Assembly> subSubAsmPtr = std::make_shared<Assembly>(evmVersion, false, std::string{});
 
 	assembly.appendSubroutine(subAsmPtr);
 	subAsmPtr->appendSubroutine(subSubAsmPtr);
@@ -416,7 +416,7 @@ BOOST_AUTO_TEST_CASE(subobject_encode_decode)
 	BOOST_REQUIRE_THROW(assembly.encodeSubPath({1}), solidity::evmasm::AssemblyException);
 	BOOST_REQUIRE_THROW(assembly.decodeSubPath(1), solidity::evmasm::AssemblyException);
 
-	vector<size_t> subPath{0, 0};
+	std::vector<size_t> subPath{0, 0};
 	BOOST_CHECK(assembly.decodeSubPath(assembly.encodeSubPath(subPath)) == subPath);
 }
 

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -39,7 +39,6 @@
 #include <tuple>
 #include <memory>
 
-using namespace std;
 using namespace solidity::langutil;
 using namespace solidity::evmasm;
 
@@ -874,7 +873,7 @@ BOOST_AUTO_TEST_CASE(block_deduplicator)
 	BlockDeduplicator deduplicator(input);
 	deduplicator.deduplicate();
 
-	set<u256> pushTags;
+	std::set<u256> pushTags;
 	for (AssemblyItem const& item: input)
 		if (item.type() == PushTag)
 			pushTags.insert(item.data());
@@ -968,7 +967,7 @@ BOOST_AUTO_TEST_CASE(block_deduplicator_loops)
 	BlockDeduplicator deduplicator(input);
 	deduplicator.deduplicate();
 
-	set<u256> pushTags;
+	std::set<u256> pushTags;
 	for (AssemblyItem const& item: input)
 		if (item.type() == PushTag)
 			pushTags.insert(item.data());
@@ -1051,7 +1050,7 @@ BOOST_AUTO_TEST_CASE(peephole_pop_calldatasize)
 
 BOOST_AUTO_TEST_CASE(peephole_commutative_swap1)
 {
-	vector<Instruction> ops{
+	std::vector<Instruction> ops{
 		Instruction::ADD,
 		Instruction::MUL,
 		Instruction::EQ,
@@ -1088,7 +1087,7 @@ BOOST_AUTO_TEST_CASE(peephole_commutative_swap1)
 BOOST_AUTO_TEST_CASE(peephole_noncommutative_swap1)
 {
 	// NOTE: not comprehensive
-	vector<Instruction> ops{
+	std::vector<Instruction> ops{
 		Instruction::SUB,
 		Instruction::DIV,
 		Instruction::SDIV,
@@ -1125,7 +1124,7 @@ BOOST_AUTO_TEST_CASE(peephole_noncommutative_swap1)
 
 BOOST_AUTO_TEST_CASE(peephole_swap_comparison)
 {
-	map<Instruction, Instruction> swappableOps{
+	std::map<Instruction, Instruction> swappableOps{
 		{ Instruction::LT, Instruction::GT },
 		{ Instruction::GT, Instruction::LT },
 		{ Instruction::SLT, Instruction::SGT },
@@ -1261,7 +1260,7 @@ BOOST_AUTO_TEST_CASE(jumpdest_removal_subassemblies)
 	settings.expectedExecutionsPerDeployment = OptimiserSettings{}.expectedExecutionsPerDeployment;
 
 	Assembly main{settings.evmVersion, false, {}};
-	AssemblyPointer sub = make_shared<Assembly>(settings.evmVersion, true, string{});
+	AssemblyPointer sub = std::make_shared<Assembly>(settings.evmVersion, true, std::string{});
 
 	sub->append(u256(1));
 	auto t1 = sub->newTag();
@@ -1428,7 +1427,7 @@ BOOST_AUTO_TEST_CASE(verbatim_knownstate)
 			Instruction::DUP3,
 			Instruction::DUP4
 		});
-	map<int, unsigned> const& stackElements = state.stackElements();
+	std::map<int, unsigned> const& stackElements = state.stackElements();
 
 	BOOST_CHECK(state.stackHeight() == 4);
 	// One more than stack height because of the initial unknown element.
@@ -1540,7 +1539,7 @@ BOOST_AUTO_TEST_CASE(cse_remove_redundant_shift_masking)
 
 BOOST_AUTO_TEST_CASE(cse_remove_unwanted_masking_of_address)
 {
-	vector<Instruction> ops{
+	std::vector<Instruction> ops{
 		Instruction::ADDRESS,
 		Instruction::CALLER,
 		Instruction::ORIGIN,

--- a/test/liblangutil/CharStream.cpp
+++ b/test/liblangutil/CharStream.cpp
@@ -28,7 +28,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 using namespace solidity::test;
 
 namespace boost::test_tools::tt_detail
@@ -39,16 +38,16 @@ struct print_log_value<std::optional<int>>
 {
 	void operator()(std::ostream& _out, std::optional<int> const& _value) const
 	{
-		_out << (_value ? to_string(*_value) : "[nullopt]");
+		_out << (_value ? to_string(*_value) : "[std::nullopt]");
 	}
 };
 
 template<>
-struct print_log_value<nullopt_t>
+struct print_log_value<std::nullopt_t>
 {
-	void operator()(std::ostream& _out, nullopt_t const&) const
+	void operator()(std::ostream& _out, std::nullopt_t const&) const
 	{
-		_out << "[nullopt]";
+		_out << "[std::nullopt]";
 	}
 };
 
@@ -77,7 +76,7 @@ BOOST_AUTO_TEST_CASE(test_fail)
 
 namespace
 {
-std::optional<int> toPosition(int _line, int _column, string const& _text)
+std::optional<int> toPosition(int _line, int _column, std::string const& _text)
 {
 	return CharStream{_text, "source"}.translateLineColumnToPosition(
 		LineColumn{_line, _column}
@@ -88,30 +87,30 @@ std::optional<int> toPosition(int _line, int _column, string const& _text)
 
 BOOST_AUTO_TEST_CASE(translateLineColumnToPosition)
 {
-	BOOST_CHECK_EQUAL(toPosition(-1, 0, "ABC"), nullopt);
-	BOOST_CHECK_EQUAL(toPosition(0, -1, "ABC"), nullopt);
+	BOOST_CHECK_EQUAL(toPosition(-1, 0, "ABC"), std::nullopt);
+	BOOST_CHECK_EQUAL(toPosition(0, -1, "ABC"), std::nullopt);
 
 	BOOST_CHECK_EQUAL(toPosition(0, 0, ""), 0);
-	BOOST_CHECK_EQUAL(toPosition(1, 0, ""), nullopt);
-	BOOST_CHECK_EQUAL(toPosition(0, 1, ""), nullopt);
+	BOOST_CHECK_EQUAL(toPosition(1, 0, ""), std::nullopt);
+	BOOST_CHECK_EQUAL(toPosition(0, 1, ""), std::nullopt);
 
 	// With last line containing no LF
 	BOOST_CHECK_EQUAL(toPosition(0, 0, "ABC"), 0);
 	BOOST_CHECK_EQUAL(toPosition(0, 1, "ABC"), 1);
 	BOOST_CHECK_EQUAL(toPosition(0, 2, "ABC"), 2);
 	BOOST_CHECK_EQUAL(toPosition(0, 3, "ABC"), 3);
-	BOOST_CHECK_EQUAL(toPosition(0, 4, "ABC"), nullopt);
-	BOOST_CHECK_EQUAL(toPosition(1, 0, "ABC"), nullopt);
+	BOOST_CHECK_EQUAL(toPosition(0, 4, "ABC"), std::nullopt);
+	BOOST_CHECK_EQUAL(toPosition(1, 0, "ABC"), std::nullopt);
 
 	BOOST_CHECK_EQUAL(toPosition(0, 3, "ABC\nDEF"), 3);
-	BOOST_CHECK_EQUAL(toPosition(0, 4, "ABC\nDEF"), nullopt);
+	BOOST_CHECK_EQUAL(toPosition(0, 4, "ABC\nDEF"), std::nullopt);
 	BOOST_CHECK_EQUAL(toPosition(1, 0, "ABC\nDEF"), 4);
 	BOOST_CHECK_EQUAL(toPosition(1, 1, "ABC\nDEF"), 5);
 	BOOST_CHECK_EQUAL(toPosition(1, 2, "ABC\nDEF"), 6);
 	BOOST_CHECK_EQUAL(toPosition(1, 3, "ABC\nDEF"), 7);
-	BOOST_CHECK_EQUAL(toPosition(1, 4, "ABC\nDEF"), nullopt);
-	BOOST_CHECK_EQUAL(toPosition(2, 0, "ABC\nDEF"), nullopt);
-	BOOST_CHECK_EQUAL(toPosition(2, 1, "ABC\nDEF"), nullopt);
+	BOOST_CHECK_EQUAL(toPosition(1, 4, "ABC\nDEF"), std::nullopt);
+	BOOST_CHECK_EQUAL(toPosition(2, 0, "ABC\nDEF"), std::nullopt);
+	BOOST_CHECK_EQUAL(toPosition(2, 1, "ABC\nDEF"), std::nullopt);
 
 	// With last line containing LF
 	BOOST_CHECK_EQUAL(toPosition(0, 0, "ABC\nDEF\n"), 0);
@@ -122,9 +121,9 @@ BOOST_AUTO_TEST_CASE(translateLineColumnToPosition)
 	BOOST_CHECK_EQUAL(toPosition(1, 1, "ABC\nDEF\n"), 5);
 	BOOST_CHECK_EQUAL(toPosition(1, 2, "ABC\nDEF\n"), 6);
 	BOOST_CHECK_EQUAL(toPosition(1, 3, "ABC\nDEF\n"), 7);
-	BOOST_CHECK_EQUAL(toPosition(1, 4, "ABC\nDEF\n"), nullopt);
+	BOOST_CHECK_EQUAL(toPosition(1, 4, "ABC\nDEF\n"), std::nullopt);
 	BOOST_CHECK_EQUAL(toPosition(2, 0, "ABC\nDEF\n"), 8);
-	BOOST_CHECK_EQUAL(toPosition(2, 1, "ABC\nDEF\n"), nullopt);
+	BOOST_CHECK_EQUAL(toPosition(2, 1, "ABC\nDEF\n"), std::nullopt);
 
 	BOOST_CHECK_EQUAL(toPosition(2, 0, "ABC\nDEF\nGHI\n"), 8);
 	BOOST_CHECK_EQUAL(toPosition(2, 1, "ABC\nDEF\nGHI\n"), 9);

--- a/test/liblangutil/Scanner.cpp
+++ b/test/liblangutil/Scanner.cpp
@@ -24,8 +24,8 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 using namespace solidity::langutil;
+using namespace std::string_literals;
 
 namespace solidity::langutil::test
 {
@@ -89,15 +89,15 @@ BOOST_AUTO_TEST_CASE(assembly_multiple_assign)
 BOOST_AUTO_TEST_CASE(string_printable)
 {
 	for (unsigned v = 0x20; v < 0x7e; v++) {
-		string lit{static_cast<char>(v)};
+		std::string lit{static_cast<char>(v)};
 		// Escape \ and " (since we are quoting with ")
 		if (v == '\\' || v == '"')
-			lit = string{'\\'} + lit;
+			lit = std::string{'\\'} + lit;
 		CharStream stream("  { \"" + lit + "\"", "");
 		Scanner scanner(stream);
 		BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
 		BOOST_CHECK_EQUAL(scanner.next(), Token::StringLiteral);
-		BOOST_CHECK_EQUAL(scanner.currentLiteral(), string{static_cast<char>(v)});
+		BOOST_CHECK_EQUAL(scanner.currentLiteral(), std::string{static_cast<char>(v)});
 		BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 	}
 	// Special case of unescaped " for strings quoted with '
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(string_nonprintable)
 		// Skip the valid ones
 		if (v >= 0x20 && v <= 0x7e)
 			continue;
-		string lit{static_cast<char>(v)};
+		std::string lit{static_cast<char>(v)};
 		CharStream stream("  { \"" + lit + "\"", "");
 		Scanner scanner(stream);
 		BOOST_CHECK_EQUAL(scanner.currentToken(), Token::LBrace);
@@ -148,14 +148,14 @@ BOOST_AUTO_TEST_CASE(string_escapes_all)
 
 struct TestScanner
 {
-	unique_ptr<CharStream> stream;
-	unique_ptr<Scanner> scanner;
-	explicit TestScanner(string _text) { reset(std::move(_text)); }
+	std::unique_ptr<CharStream> stream;
+	std::unique_ptr<Scanner> scanner;
+	explicit TestScanner(std::string _text) { reset(std::move(_text)); }
 
 	void reset(std::string _text)
 	{
-		stream = make_unique<CharStream>(std::move(_text), "");
-		scanner = make_unique<Scanner>(*stream);
+		stream = std::make_unique<CharStream>(std::move(_text), "");
+		scanner = std::make_unique<Scanner>(*stream);
 	}
 
 	decltype(auto) currentToken() { return scanner->currentToken(); }
@@ -801,7 +801,7 @@ BOOST_AUTO_TEST_CASE(regular_line_break_in_single_line_comment)
 {
 	for (auto const& nl: {"\r", "\n", "\r\n"})
 	{
-		TestScanner scanner("// abc " + string(nl) + " def ");
+		TestScanner scanner("// abc " + std::string(nl) + " def ");
 		BOOST_CHECK_EQUAL(scanner.currentCommentLiteral(), "");
 		BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Identifier);
 		BOOST_CHECK_EQUAL(scanner.currentLiteral(), "def");
@@ -813,10 +813,10 @@ BOOST_AUTO_TEST_CASE(irregular_line_breaks_in_single_line_comment)
 {
 	for (auto const& nl: {"\v", "\f", "\xE2\x80\xA8", "\xE2\x80\xA9"})
 	{
-		TestScanner scanner("// abc " + string(nl) + " def ");
+		TestScanner scanner("// abc " + std::string(nl) + " def ");
 		BOOST_CHECK_EQUAL(scanner.currentCommentLiteral(), "");
 		BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
-		for (size_t i = 0; i < string(nl).size() - 1; i++)
+		for (size_t i = 0; i < std::string(nl).size() - 1; i++)
 			BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
 		BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
 		BOOST_CHECK_EQUAL(scanner.currentLiteral(), "def");
@@ -828,7 +828,7 @@ BOOST_AUTO_TEST_CASE(regular_line_breaks_in_single_line_doc_comment)
 {
 	for (auto const& nl: {"\r", "\n", "\r\n"})
 	{
-		TestScanner scanner("/// abc " + string(nl) + " def ");
+		TestScanner scanner("/// abc " + std::string(nl) + " def ");
 		BOOST_CHECK_EQUAL(scanner.currentCommentLiteral(), "abc ");
 		BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Identifier);
 		BOOST_CHECK_EQUAL(scanner.currentLiteral(), "def");
@@ -856,10 +856,10 @@ BOOST_AUTO_TEST_CASE(irregular_line_breaks_in_single_line_doc_comment)
 {
 	for (auto const& nl: {"\v", "\f", "\xE2\x80\xA8", "\xE2\x80\xA9"})
 	{
-		TestScanner scanner("/// abc " + string(nl) + " def ");
+		TestScanner scanner("/// abc " + std::string(nl) + " def ");
 		BOOST_CHECK_EQUAL(scanner.currentCommentLiteral(), "abc ");
 		BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
-		for (size_t i = 0; i < string(nl).size() - 1; i++)
+		for (size_t i = 0; i < std::string(nl).size() - 1; i++)
 			BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
 		BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
 		BOOST_CHECK_EQUAL(scanner.currentLiteral(), "def");
@@ -884,9 +884,9 @@ BOOST_AUTO_TEST_CASE(irregular_line_breaks_in_strings)
 {
 	for (auto const& nl: {"\v", "\f", "\xE2\x80\xA8", "\xE2\x80\xA9"})
 	{
-		TestScanner scanner("\"abc " + string(nl) + " def\"");
+		TestScanner scanner("\"abc " + std::string(nl) + " def\"");
 		BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
-		for (size_t i = 0; i < string(nl).size(); i++)
+		for (size_t i = 0; i < std::string(nl).size(); i++)
 			BOOST_CHECK_EQUAL(scanner.next(), Token::Illegal);
 		BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
 		BOOST_CHECK_EQUAL(scanner.currentLiteral(), "def");
@@ -898,7 +898,7 @@ BOOST_AUTO_TEST_CASE(irregular_line_breaks_in_strings)
 BOOST_AUTO_TEST_CASE(solidity_keywords)
 {
 	// These are tokens which have a different meaning in Yul.
-	string keywords = "return byte bool address var in true false leave switch case default";
+	std::string keywords = "return byte bool address var in true false leave switch case default";
 	TestScanner scanner(keywords);
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Return);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Byte);
@@ -962,7 +962,7 @@ BOOST_AUTO_TEST_CASE(yul_identifier_with_dots)
 
 BOOST_AUTO_TEST_CASE(yul_function)
 {
-	string sig = "function f(a, b) -> x, y";
+	std::string sig = "function f(a, b) -> x, y";
 	TestScanner scanner(sig);
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Function);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);
@@ -994,7 +994,7 @@ BOOST_AUTO_TEST_CASE(yul_function)
 
 BOOST_AUTO_TEST_CASE(yul_function_with_whitespace)
 {
-	string sig = "function f (a, b) - > x, y";
+	std::string sig = "function f (a, b) - > x, y";
 	TestScanner scanner(sig);
 	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Function);
 	BOOST_CHECK_EQUAL(scanner.next(), Token::Identifier);

--- a/test/libsolidity/ABIDecoderTests.cpp
+++ b/test/libsolidity/ABIDecoderTests.cpp
@@ -28,7 +28,6 @@
 
 #include <test/libsolidity/ABITestsCommon.h>
 
-using namespace std;
 using namespace std::placeholders;
 using namespace solidity::test;
 
@@ -39,7 +38,7 @@ BOOST_FIXTURE_TEST_SUITE(ABIDecoderTest, SolidityExecutionFramework)
 
 BOOST_AUTO_TEST_CASE(value_types)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			function f(uint a, uint16 b, uint24 c, int24 d, bytes3 x, bool e, C g) public returns (uint) {
 				if (a != 1) return 1;
@@ -57,14 +56,14 @@ BOOST_AUTO_TEST_CASE(value_types)
 		compileAndRun(sourceCode);
 		ABI_CHECK(callContractFunction(
 			"f(uint256,uint16,uint24,int24,bytes3,bool,address)",
-			1, 2, 3, 4, string("abc"), true, m_contractAddress
+			1, 2, 3, 4, std::string("abc"), true, m_contractAddress
 		), encodeArgs(u256(20)));
 	)
 }
 
 BOOST_AUTO_TEST_CASE(decode_from_memory_simple)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			uint public _a;
 			uint[] public _b;
@@ -90,7 +89,7 @@ BOOST_AUTO_TEST_CASE(decode_from_memory_simple)
 
 BOOST_AUTO_TEST_CASE(decode_function_type)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract D {
 			function () external returns (uint) public _a;
 			constructor(function () external returns (uint) a) {
@@ -124,7 +123,7 @@ BOOST_AUTO_TEST_CASE(decode_function_type)
 
 BOOST_AUTO_TEST_CASE(decode_function_type_array)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract D {
 			function () external returns (uint)[] public _a;
 			constructor(function () external returns (uint)[] memory a) {
@@ -190,7 +189,7 @@ BOOST_AUTO_TEST_CASE(decode_function_type_array)
 
 BOOST_AUTO_TEST_CASE(decode_from_memory_complex)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			uint public _a;
 			uint[] public _b;
@@ -209,23 +208,23 @@ BOOST_AUTO_TEST_CASE(decode_from_memory_complex)
 			3, 0x21, 0x22, 0x23,
 			// c
 			0x40, 0x80,
-			8, string("abcdefgh"),
-			52, string("ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ")
+			8, std::string("abcdefgh"),
+			52, std::string("ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ")
 		));
 		ABI_CHECK(callContractFunction("_a()"), encodeArgs(7));
 		ABI_CHECK(callContractFunction("_b(uint256)", 0), encodeArgs(0x21));
 		ABI_CHECK(callContractFunction("_b(uint256)", 1), encodeArgs(0x22));
 		ABI_CHECK(callContractFunction("_b(uint256)", 2), encodeArgs(0x23));
 		ABI_CHECK(callContractFunction("_b(uint256)", 3), encodeArgs());
-		ABI_CHECK(callContractFunction("_c(uint256)", 0), encodeArgs(0x20, 8, string("abcdefgh")));
-		ABI_CHECK(callContractFunction("_c(uint256)", 1), encodeArgs(0x20, 52, string("ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ")));
+		ABI_CHECK(callContractFunction("_c(uint256)", 0), encodeArgs(0x20, 8, std::string("abcdefgh")));
+		ABI_CHECK(callContractFunction("_c(uint256)", 1), encodeArgs(0x20, 52, std::string("ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ")));
 		ABI_CHECK(callContractFunction("_c(uint256)", 2), encodeArgs());
 	)
 }
 
 BOOST_AUTO_TEST_CASE(short_input_value_type)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			function f(uint a, uint b) public pure returns (uint) { return a; }
 		}
@@ -240,7 +239,7 @@ BOOST_AUTO_TEST_CASE(short_input_value_type)
 
 BOOST_AUTO_TEST_CASE(short_input_array)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			function f(uint[] memory a) public pure returns (uint) { return 7; }
 		}
@@ -257,7 +256,7 @@ BOOST_AUTO_TEST_CASE(short_input_array)
 
 BOOST_AUTO_TEST_CASE(short_dynamic_input_array)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			function f(bytes[1] memory a) public pure returns (uint) { return 7; }
 		}
@@ -270,7 +269,7 @@ BOOST_AUTO_TEST_CASE(short_dynamic_input_array)
 
 BOOST_AUTO_TEST_CASE(short_input_bytes)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			function e(bytes memory a) public pure returns (uint) { return 7; }
 			function f(bytes[] memory a) public pure returns (uint) { return 7; }
@@ -291,7 +290,7 @@ BOOST_AUTO_TEST_CASE(short_input_bytes)
 
 BOOST_AUTO_TEST_CASE(validation_int_inside_arrays)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			enum E { A, B }
 			function f(uint16[] memory a) public pure returns (uint r) { assembly { r := mload(add(a, 0x20)) } }
@@ -315,7 +314,7 @@ BOOST_AUTO_TEST_CASE(validation_int_inside_arrays)
 
 BOOST_AUTO_TEST_CASE(validation_function_type)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			function f(function () external) public pure returns (uint r) { r = 1; }
 			function g(function () external[] memory) public pure returns (uint r) { r = 2; }
@@ -324,8 +323,8 @@ BOOST_AUTO_TEST_CASE(validation_function_type)
 		}
 	)";
 	bool newDecoder = false;
-	string validFun{"01234567890123456789abcd"};
-	string invalidFun{"01234567890123456789abcdX"};
+	std::string validFun{"01234567890123456789abcd"};
+	std::string invalidFun{"01234567890123456789abcdX"};
 	BOTH_ENCODERS(
 		compileAndRun(sourceCode);
 		ABI_CHECK(callContractFunction("f(function)", validFun), encodeArgs(1));
@@ -343,7 +342,7 @@ BOOST_AUTO_TEST_CASE(validation_function_type)
 
 BOOST_AUTO_TEST_CASE(struct_short)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			struct S { int a; uint b; bytes16 c; }
 			function f(S memory s) public pure returns (S memory q) {
@@ -370,7 +369,7 @@ BOOST_AUTO_TEST_CASE(struct_short)
 
 BOOST_AUTO_TEST_CASE(complex_struct)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			enum E {A, B, C}
 			struct T { uint x; E e; uint8 y; }
@@ -390,7 +389,7 @@ BOOST_AUTO_TEST_CASE(complex_struct)
 	)";
 	NEW_ENCODER(
 		compileAndRun(sourceCode, 0, "C");
-		string sig = "f(uint256,(address,(uint256,uint8,uint8)[])[2],(address,(uint256,uint8,uint8)[])[],uint256)";
+		std::string sig = "f(uint256,(address,(uint256,uint8,uint8)[])[2],(address,(uint256,uint8,uint8)[])[],uint256)";
 		bytes args = encodeArgs(
 			7, 0x80, 0x1e0, 8,
 			// S[2] s1

--- a/test/libsolidity/ABIEncoderTests.cpp
+++ b/test/libsolidity/ABIEncoderTests.cpp
@@ -32,7 +32,6 @@
 #include <string>
 #include <tuple>
 
-using namespace std;
 using namespace std::placeholders;
 using namespace solidity::util;
 using namespace solidity::test;
@@ -50,7 +49,7 @@ BOOST_FIXTURE_TEST_SUITE(ABIEncoderTest, SolidityExecutionFramework)
 
 BOOST_AUTO_TEST_CASE(value_types)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			event E(uint a, uint16 b, uint24 c, int24 d, bytes3 x, bool, C);
 			function f() public {
@@ -67,14 +66,14 @@ BOOST_AUTO_TEST_CASE(value_types)
 		compileAndRun(sourceCode);
 		callContractFunction("f()");
 		REQUIRE_LOG_DATA(encodeArgs(
-			10, u256(65534), u256(0x121212), u256(-1), string("\x1b\xab\xab"), true, h160("fffffffffffffffffffffffffffffffffffffffb")
+			10, u256(65534), u256(0x121212), u256(-1), std::string("\x1b\xab\xab"), true, h160("fffffffffffffffffffffffffffffffffffffffb")
 		));
 	)
 }
 
 BOOST_AUTO_TEST_CASE(string_literal)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			event E(string, bytes20, string);
 			function f() public {
@@ -86,9 +85,9 @@ BOOST_AUTO_TEST_CASE(string_literal)
 		compileAndRun(sourceCode);
 		callContractFunction("f()");
 		REQUIRE_LOG_DATA(encodeArgs(
-			0x60, string("abcde"), 0xa0,
-			6, string("abcdef"),
-			0x8b, string("abcdefabcdefgehabcabcasdfjklabcdefabcedefghabcabcasdfjklabcdefabcdefghabcabcasdfjklabcdeefabcdefghabcabcasdefjklabcdefabcdefghabcabcasdfjkl")
+			0x60, std::string("abcde"), 0xa0,
+			6, std::string("abcdef"),
+			0x8b, std::string("abcdefabcdefgehabcabcasdfjklabcdefabcedefghabcabcasdfjklabcdefabcdefghabcabcasdfjklabcdeefabcdefghabcabcasdefjklabcdefabcdefghabcabcasdfjkl")
 		));
 	)
 }
@@ -96,7 +95,7 @@ BOOST_AUTO_TEST_CASE(string_literal)
 
 BOOST_AUTO_TEST_CASE(enum_type_cleanup)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			enum E { A, B }
 			function f(uint x) public returns (E en) {
@@ -114,7 +113,7 @@ BOOST_AUTO_TEST_CASE(enum_type_cleanup)
 
 BOOST_AUTO_TEST_CASE(conversion)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			event E(bytes4, bytes4, uint16, uint8, int16, int8);
 			function f() public {
@@ -132,7 +131,7 @@ BOOST_AUTO_TEST_CASE(conversion)
 		compileAndRun(sourceCode);
 		callContractFunction("f()");
 		REQUIRE_LOG_DATA(encodeArgs(
-			string(3, 0) + string("\x0a"), string("\xf1\xf2"),
+			std::string(3, 0) + std::string("\x0a"), std::string("\xf1\xf2"),
 			0xff, 0xff, u256(-1), u256(1)
 		));
 	)
@@ -140,7 +139,7 @@ BOOST_AUTO_TEST_CASE(conversion)
 
 BOOST_AUTO_TEST_CASE(memory_array_one_dim)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			event E(uint a, int16[] b, uint c);
 			function f() public {
@@ -172,7 +171,7 @@ BOOST_AUTO_TEST_CASE(memory_array_one_dim)
 
 BOOST_AUTO_TEST_CASE(memory_array_two_dim)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			event E(uint a, int16[][2] b, uint c);
 			function f() public {
@@ -197,7 +196,7 @@ BOOST_AUTO_TEST_CASE(memory_array_two_dim)
 
 BOOST_AUTO_TEST_CASE(memory_byte_array)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			event E(uint a, bytes[] b, uint c);
 			function f() public {
@@ -214,15 +213,15 @@ BOOST_AUTO_TEST_CASE(memory_byte_array)
 		REQUIRE_LOG_DATA(encodeArgs(
 			10, 0x60, 11,
 			2, 0x40, 0xc0,
-			66, string("abcabcdefghjklmnopqrsuvwabcdefgijklmnopqrstuwabcdefgijklmnoprstuvw"),
-			63, string("abcdefghijklmnopqrtuvwabcfghijklmnopqstuvwabcdeghijklmopqrstuvw")
+			66, std::string("abcabcdefghjklmnopqrsuvwabcdefgijklmnopqrstuwabcdefgijklmnoprstuvw"),
+			63, std::string("abcdefghijklmnopqrtuvwabcfghijklmnopqstuvwabcdeghijklmopqrstuvw")
 		));
 	)
 }
 
 BOOST_AUTO_TEST_CASE(storage_byte_array)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			bytes short;
 			bytes long;
@@ -239,15 +238,15 @@ BOOST_AUTO_TEST_CASE(storage_byte_array)
 		callContractFunction("f()");
 		REQUIRE_LOG_DATA(encodeArgs(
 			0x40, 0x80,
-			31, string("123456789012345678901234567890a"),
-			75, string("ffff123456789012345678901234567890afffffffff123456789012345678901234567890a")
+			31, std::string("123456789012345678901234567890a"),
+			75, std::string("ffff123456789012345678901234567890afffffffff123456789012345678901234567890a")
 		));
 	)
 }
 
 BOOST_AUTO_TEST_CASE(storage_array)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			address[3] addr;
 			event E(address[3] a);
@@ -274,7 +273,7 @@ BOOST_AUTO_TEST_CASE(storage_array)
 
 BOOST_AUTO_TEST_CASE(storage_array_dyn)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			address[] addr;
 			event E(address[] a);
@@ -301,7 +300,7 @@ BOOST_AUTO_TEST_CASE(storage_array_dyn)
 
 BOOST_AUTO_TEST_CASE(storage_array_compact)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			int72[] x;
 			event E(int72[]);
@@ -329,7 +328,7 @@ BOOST_AUTO_TEST_CASE(storage_array_compact)
 
 BOOST_AUTO_TEST_CASE(external_function)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			event E(function(uint) external returns (uint), function(uint) external returns (uint));
 			function(uint) external returns (uint) g;
@@ -342,14 +341,14 @@ BOOST_AUTO_TEST_CASE(external_function)
 	BOTH_ENCODERS(
 		compileAndRun(sourceCode);
 		callContractFunction("f(uint256)", u256(0));
-		string functionIdF = asString(m_contractAddress.ref()) + asString(util::selectorFromSignatureH32("f(uint256)").ref());
+		std::string functionIdF = asString(m_contractAddress.ref()) + asString(util::selectorFromSignatureH32("f(uint256)").ref());
 		REQUIRE_LOG_DATA(encodeArgs(functionIdF, functionIdF));
 	)
 }
 
 BOOST_AUTO_TEST_CASE(external_function_cleanup)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			event E(function(uint) external returns (uint), function(uint) external returns (uint));
 			// This test relies on the fact that g is stored in slot zero.
@@ -364,13 +363,13 @@ BOOST_AUTO_TEST_CASE(external_function_cleanup)
 	BOTH_ENCODERS(
 		compileAndRun(sourceCode);
 		callContractFunction("f(uint256)", u256(0));
-		REQUIRE_LOG_DATA(encodeArgs(string(24, char(-1)), string(24, char(-1))));
+		REQUIRE_LOG_DATA(encodeArgs(std::string(24, char(-1)), std::string(24, char(-1))));
 	)
 }
 
 BOOST_AUTO_TEST_CASE(calldata)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			event E(bytes);
 			function f(bytes calldata a) external {
@@ -378,8 +377,8 @@ BOOST_AUTO_TEST_CASE(calldata)
 			}
 		}
 	)";
-	string s("abcdef");
-	string t("abcdefgggggggggggggggggggggggggggggggggggggggghhheeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeggg");
+	std::string s("abcdef");
+	std::string t("abcdefgggggggggggggggggggggggggggggggggggggggghhheeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeggg");
 	BOTH_ENCODERS(
 		compileAndRun(sourceCode);
 		callContractFunction("f(bytes)", 0x20, s.size(), s);
@@ -393,7 +392,7 @@ BOOST_AUTO_TEST_CASE(function_name_collision)
 {
 	// This tests a collision between a function name used by inline assembly
 	// and by the ABI encoder
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			function f(uint x) public returns (uint) {
 				assembly {
@@ -417,7 +416,7 @@ BOOST_AUTO_TEST_CASE(function_name_collision)
 
 BOOST_AUTO_TEST_CASE(structs)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			struct S { uint16 a; uint16 b; T[] sub; uint16 c; }
 			struct T { uint64[2] x; }
@@ -452,13 +451,13 @@ BOOST_AUTO_TEST_CASE(structs)
 		);
 		BOOST_CHECK(callContractFunction("f()") == encoded);
 		REQUIRE_LOG_DATA(encoded);
-		BOOST_CHECK_EQUAL(logTopic(0, 0), keccak256(string("e(uint16,(uint16,uint16,(uint64[2])[],uint16))")));
+		BOOST_CHECK_EQUAL(logTopic(0, 0), keccak256(std::string("e(uint16,(uint16,uint16,(uint64[2])[],uint16))")));
 	)
 }
 
 BOOST_AUTO_TEST_CASE(structs2)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			enum E {A, B, C}
 			struct T { uint x; E e; uint8 y; }
@@ -517,7 +516,7 @@ BOOST_AUTO_TEST_CASE(structs2)
 
 BOOST_AUTO_TEST_CASE(bool_arrays)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			bool[] x;
 			bool[4] y;
@@ -550,7 +549,7 @@ BOOST_AUTO_TEST_CASE(bool_arrays)
 
 BOOST_AUTO_TEST_CASE(bool_arrays_split)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			bool[] x;
 			bool[4] y;
@@ -587,7 +586,7 @@ BOOST_AUTO_TEST_CASE(bool_arrays_split)
 BOOST_AUTO_TEST_CASE(bytesNN_arrays)
 {
 	// This tests that encoding packed arrays from storage work correctly.
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			bytes8[] x;
 			bytesWIDTH[SIZE] y;
@@ -610,12 +609,12 @@ BOOST_AUTO_TEST_CASE(bytesNN_arrays)
 		{
 			for (size_t width: {1u, 2u, 4u, 5u, 7u, 15u, 16u, 17u, 31u, 32u})
 			{
-				string source = boost::algorithm::replace_all_copy(sourceCode, "SIZE", to_string(size));
-				source = boost::algorithm::replace_all_copy(source, "UINTWIDTH", to_string(width * 8));
-				source = boost::algorithm::replace_all_copy(source, "WIDTH", to_string(width));
+				std::string source = boost::algorithm::replace_all_copy(sourceCode, "SIZE", std::to_string(size));
+				source = boost::algorithm::replace_all_copy(source, "UINTWIDTH", std::to_string(width * 8));
+				source = boost::algorithm::replace_all_copy(source, "WIDTH", std::to_string(width));
 				compileAndRun(source, 0, "C");
 				ABI_CHECK(callContractFunction("store()"), bytes{});
-				vector<u256> arr;
+				std::vector<u256> arr;
 				for (size_t i = 0; i < size; i ++)
 					arr.emplace_back(u256(i + 1) << (8 * (32 - width)));
 				bytes encoded = encodeArgs(
@@ -632,7 +631,7 @@ BOOST_AUTO_TEST_CASE(bytesNN_arrays)
 BOOST_AUTO_TEST_CASE(bytesNN_arrays_dyn)
 {
 	// This tests that encoding packed arrays from storage work correctly.
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			bytes8[] x;
 			bytesWIDTH[] y;
@@ -655,12 +654,12 @@ BOOST_AUTO_TEST_CASE(bytesNN_arrays_dyn)
 		{
 			for (size_t width: {1u, 2u, 4u, 5u, 7u, 15u, 16u, 17u, 31u, 32u})
 			{
-				string source = boost::algorithm::replace_all_copy(sourceCode, "SIZE", to_string(size));
-				source = boost::algorithm::replace_all_copy(source, "UINTWIDTH", to_string(width * 8));
-				source = boost::algorithm::replace_all_copy(source, "WIDTH", to_string(width));
+				std::string source = boost::algorithm::replace_all_copy(sourceCode, "SIZE", std::to_string(size));
+				source = boost::algorithm::replace_all_copy(source, "UINTWIDTH", std::to_string(width * 8));
+				source = boost::algorithm::replace_all_copy(source, "WIDTH", std::to_string(width));
 				compileAndRun(source, 0, "C");
 				ABI_CHECK(callContractFunction("store()"), bytes{});
-				vector<u256> arr;
+				std::vector<u256> arr;
 				for (size_t i = 0; i < size; i ++)
 					arr.emplace_back(u256(i + 1) << (8 * (32 - width)));
 				bytes encoded = encodeArgs(
@@ -677,7 +676,7 @@ BOOST_AUTO_TEST_CASE(bytesNN_arrays_dyn)
 
 BOOST_AUTO_TEST_CASE(packed_structs)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			struct S { bool a; int8 b; function() external g; bytes3 d; int8 e; }
 			S s;
@@ -712,7 +711,7 @@ BOOST_AUTO_TEST_CASE(packed_structs)
 
 BOOST_AUTO_TEST_CASE(struct_in_constructor)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			struct S {
 				string a;
@@ -732,7 +731,7 @@ BOOST_AUTO_TEST_CASE(struct_in_constructor)
 
 BOOST_AUTO_TEST_CASE(struct_in_constructor_indirect)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			struct S {
 				string a;
@@ -765,7 +764,7 @@ BOOST_AUTO_TEST_CASE(struct_in_constructor_indirect)
 
 BOOST_AUTO_TEST_CASE(struct_in_constructor_data_short)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		contract C {
 			struct S {
 				string a;

--- a/test/libsolidity/ABIJsonTest.cpp
+++ b/test/libsolidity/ABIJsonTest.cpp
@@ -28,20 +28,19 @@
 
 #include <fstream>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::util;
 using namespace solidity::frontend;
 using namespace solidity::frontend::test;
 
-ABIJsonTest::ABIJsonTest(string const& _filename):
+ABIJsonTest::ABIJsonTest(std::string const& _filename):
 	TestCase(_filename)
 {
 	m_source = m_reader.source();
 	m_expectation = m_reader.simpleExpectations();
 }
 
-TestCase::TestResult ABIJsonTest::run(ostream& _stream, string const& _linePrefix, bool _formatted)
+TestCase::TestResult ABIJsonTest::run(std::ostream& _stream, std::string const& _linePrefix, bool _formatted)
 {
 	CompilerStack compiler;
 
@@ -52,11 +51,11 @@ TestCase::TestResult ABIJsonTest::run(ostream& _stream, string const& _linePrefi
 	compiler.setEVMVersion(solidity::test::CommonOptions::get().evmVersion());
 	compiler.setOptimiserSettings(solidity::test::CommonOptions::get().optimize);
 	if (!compiler.parseAndAnalyze())
-		BOOST_THROW_EXCEPTION(runtime_error("Parsing contract failed"));
+		BOOST_THROW_EXCEPTION(std::runtime_error("Parsing contract failed"));
 
 	m_obtainedResult.clear();
 	bool first = true;
-	for (string const& contractName: compiler.contractNames())
+	for (std::string const& contractName: compiler.contractNames())
 	{
 		if (!first)
 			m_obtainedResult += "\n\n";

--- a/test/libsolidity/ABITestsCommon.h
+++ b/test/libsolidity/ABITestsCommon.h
@@ -23,7 +23,7 @@ namespace solidity::frontend::test
 
 #define NEW_ENCODER(CODE) \
 { \
-	string sourceCodeTmp = sourceCode; \
+	std::string sourceCodeTmp = sourceCode; \
 	sourceCode = "pragma abicoder v2;\n" + sourceCode; \
 	{ CODE } \
 	sourceCode = sourceCodeTmp; \
@@ -31,7 +31,7 @@ namespace solidity::frontend::test
 
 #define OLD_ENCODER(CODE) \
 { \
-	string sourceCodeTmp = sourceCode; \
+	std::string sourceCodeTmp = sourceCode; \
 	sourceCode = "pragma abicoder v1;\n" + sourceCode; \
 	{ CODE } \
 	sourceCode = sourceCodeTmp; \

--- a/test/libsolidity/ASTJSONTest.cpp
+++ b/test/libsolidity/ASTJSONTest.cpp
@@ -36,22 +36,22 @@
 #include <memory>
 #include <stdexcept>
 
+using namespace solidity;
 using namespace solidity::langutil;
 using namespace solidity::frontend;
 using namespace solidity::frontend::test;
 using namespace solidity::util::formatting;
 using namespace solidity::util;
-using namespace solidity;
-using namespace std;
 namespace fs = boost::filesystem;
 using namespace boost::unit_test;
+using namespace std::string_literals;
 
 namespace
 {
 
-string const sourceDelimiter("==== Source: ");
+std::string const sourceDelimiter("==== Source: ");
 
-string compilerStateToString(CompilerStack::State _state)
+std::string compilerStateToString(CompilerStack::State _state)
 {
 	switch (_state)
 	{
@@ -65,17 +65,17 @@ string compilerStateToString(CompilerStack::State _state)
 	soltestAssert(false, "Unexpected value of state parameter");
 }
 
-CompilerStack::State stringToCompilerState(const string& _state)
+CompilerStack::State stringToCompilerState(const std::string& _state)
 {
 	for (unsigned int i = CompilerStack::State::Empty; i <= CompilerStack::State::CompilationSuccessful; ++i)
 	{
 		if (_state == compilerStateToString(CompilerStack::State(i)))
 			return CompilerStack::State(i);
 	}
-	BOOST_THROW_EXCEPTION(runtime_error("Unsupported compiler state (" + _state + ") in test contract file"));
+	BOOST_THROW_EXCEPTION(std::runtime_error("Unsupported compiler state (" + _state + ") in test contract file"));
 }
 
-void replaceVersionWithTag(string& _input)
+void replaceVersionWithTag(std::string& _input)
 {
 	boost::algorithm::replace_all(
 		_input,
@@ -84,7 +84,7 @@ void replaceVersionWithTag(string& _input)
 	);
 }
 
-void replaceTagWithVersion(string& _input)
+void replaceTagWithVersion(std::string& _input)
 {
 	boost::algorithm::replace_all(
 		_input,
@@ -95,9 +95,9 @@ void replaceTagWithVersion(string& _input)
 
 }
 
-void ASTJSONTest::generateTestVariants(string const& _filename)
+void ASTJSONTest::generateTestVariants(std::string const& _filename)
 {
-	string_view baseName = _filename;
+	std::string_view baseName = _filename;
 	baseName.remove_suffix(4);
 
 	const std::vector<CompilerStack::State> variantCompileStates = {
@@ -117,18 +117,18 @@ void ASTJSONTest::generateTestVariants(string const& _filename)
 	}
 }
 
-void ASTJSONTest::fillSources(string const& _filename)
+void ASTJSONTest::fillSources(std::string const& _filename)
 {
-	ifstream file(_filename);
+	std::ifstream file(_filename);
 	if (!file)
-		BOOST_THROW_EXCEPTION(runtime_error("Cannot open test contract: \"" + _filename + "\"."));
-	file.exceptions(ios::badbit);
+		BOOST_THROW_EXCEPTION(std::runtime_error("Cannot open test contract: \"" + _filename + "\"."));
+	file.exceptions(std::ios::badbit);
 
-	string sourceName;
-	string source;
-	string line;
-	string const delimiter("// ----");
-	string const failMarker("// failAfter:");
+	std::string sourceName;
+	std::string source;
+	std::string line;
+	std::string const delimiter("// ----");
+	std::string const failMarker("// failAfter:");
 	while (getline(file, line))
 	{
 		if (boost::algorithm::starts_with(line, sourceDelimiter))
@@ -140,14 +140,14 @@ void ASTJSONTest::fillSources(string const& _filename)
 				sourceDelimiter.size(),
 				line.size() - " ===="s.size() - sourceDelimiter.size()
 			);
-			source = string();
+			source = std::string();
 		}
 		else if (boost::algorithm::starts_with(line, failMarker))
 		{
-			string state = line.substr(failMarker.size());
+			std::string state = line.substr(failMarker.size());
 			boost::algorithm::trim(state);
 			if (m_expectedFailAfter.has_value())
-				BOOST_THROW_EXCEPTION(runtime_error("Duplicated \"failAfter\" directive"));
+				BOOST_THROW_EXCEPTION(std::runtime_error("Duplicated \"failAfter\" directive"));
 			m_expectedFailAfter = stringToCompilerState(state);
 
 		}
@@ -161,7 +161,7 @@ void ASTJSONTest::fillSources(string const& _filename)
 void ASTJSONTest::validateTestConfiguration() const
 {
 	if (m_variants.empty())
-		BOOST_THROW_EXCEPTION(runtime_error("No file with expected result found."));
+		BOOST_THROW_EXCEPTION(std::runtime_error("No file with expected result found."));
 
 	if (m_expectedFailAfter.has_value())
 	{
@@ -172,8 +172,8 @@ void ASTJSONTest::validateTestConfiguration() const
 
 		if (unexpectedTestVariant != m_variants.end())
 			BOOST_THROW_EXCEPTION(
-				runtime_error(
-					string("Unexpected JSON file: ") + unexpectedTestVariant->astFilename() +
+				std::runtime_error(
+					std::string("Unexpected JSON file: ") + unexpectedTestVariant->astFilename() +
 					" in \"failAfter: " +
 					compilerStateToString(m_expectedFailAfter.value()) + "\" scenario."
 				)
@@ -181,23 +181,23 @@ void ASTJSONTest::validateTestConfiguration() const
 	}
 }
 
-ASTJSONTest::ASTJSONTest(string const& _filename):
+ASTJSONTest::ASTJSONTest(std::string const& _filename):
 	EVMVersionRestrictedTestCase(_filename)
 {
 	if (!boost::algorithm::ends_with(_filename, ".sol"))
-		BOOST_THROW_EXCEPTION(runtime_error("Invalid test contract file name: \"" + _filename + "\"."));
+		BOOST_THROW_EXCEPTION(std::runtime_error("Invalid test contract file name: \"" + _filename + "\"."));
 
 	generateTestVariants(_filename);
 	fillSources(_filename);
 	validateTestConfiguration();
 }
 
-TestCase::TestResult ASTJSONTest::run(ostream& _stream, string const& _linePrefix, bool const _formatted)
+TestCase::TestResult ASTJSONTest::run(std::ostream& _stream, std::string const& _linePrefix, bool const _formatted)
 {
 	CompilerStack c;
 
 	StringMap sources;
-	map<string, unsigned> sourceIndices;
+	std::map<std::string, unsigned> sourceIndices;
 	for (size_t i = 0; i < m_sources.size(); i++)
 	{
 		sources[m_sources[i].first] = m_sources[i].second;
@@ -237,10 +237,10 @@ TestCase::TestResult ASTJSONTest::run(ostream& _stream, string const& _linePrefi
 
 bool ASTJSONTest::runTest(
 	TestVariant& _variant,
-	map<string, unsigned> const& _sourceIndices,
+	std::map<std::string, unsigned> const& _sourceIndices,
 	CompilerStack& _compiler,
-	ostream& _stream,
-	string const& _linePrefix,
+	std::ostream& _stream,
+	std::string const& _linePrefix,
 	bool const _formatted
 )
 {
@@ -249,7 +249,7 @@ bool ASTJSONTest::runTest(
 
 	for (size_t i = 0; i < m_sources.size(); i++)
 	{
-		ostringstream result;
+		std::ostringstream result;
 		ASTJsonExporter(_compiler.state(), _sourceIndices).print(result, _compiler.ast(m_sources[i].first), JsonFormat{ JsonFormat::Pretty });
 		_variant.result += result.str();
 		if (i != m_sources.size() - 1)
@@ -264,49 +264,49 @@ bool ASTJSONTest::runTest(
 
 	if (_variant.expectation != _variant.result)
 	{
-		string nextIndentLevel = _linePrefix + "  ";
+		std::string nextIndentLevel = _linePrefix + "  ";
 		AnsiColorized(_stream, _formatted, {BOLD, CYAN}) <<
 			_linePrefix <<
 			"Expected result" <<
 			(!_variant.name().empty() ? " (" + _variant.name() + "):" : ":") <<
-			endl;
+			std::endl;
 		{
-			istringstream stream(_variant.expectation);
-			string line;
+			std::istringstream stream(_variant.expectation);
+			std::string line;
 			while (getline(stream, line))
-				_stream << nextIndentLevel << line << endl;
+				_stream << nextIndentLevel << line << std::endl;
 		}
-		_stream << endl;
+		_stream << std::endl;
 
 		AnsiColorized(_stream, _formatted, {BOLD, CYAN}) <<
 			_linePrefix <<
 			"Obtained result" <<
 			(!_variant.name().empty() ? " (" + _variant.name() + "):" : ":") <<
-			endl;
+			std::endl;
 		{
-			istringstream stream(_variant.result);
-			string line;
+			std::istringstream stream(_variant.result);
+			std::string line;
 			while (getline(stream, line))
-				_stream << nextIndentLevel << line << endl;
+				_stream << nextIndentLevel << line << std::endl;
 		}
-		_stream << endl;
+		_stream << std::endl;
 		return false;
 	}
 
 	return true;
 }
 
-void ASTJSONTest::printSource(ostream& _stream, string const& _linePrefix, bool const) const
+void ASTJSONTest::printSource(std::ostream& _stream, std::string const& _linePrefix, bool const) const
 {
 	for (auto const& source: m_sources)
 	{
 		if (m_sources.size() > 1 || source.first != "a")
-			_stream << _linePrefix << sourceDelimiter << source.first << " ====" << endl << endl;
-		stringstream stream(source.second);
-		string line;
+			_stream << _linePrefix << sourceDelimiter << source.first << " ====" << std::endl << std::endl;
+		std::stringstream stream(source.second);
+		std::string line;
 		while (getline(stream, line))
-			_stream << _linePrefix << line << endl;
-		_stream << endl;
+			_stream << _linePrefix << line << std::endl;
+		_stream << std::endl;
 	}
 }
 
@@ -320,13 +320,13 @@ void ASTJSONTest::printUpdatedExpectations(std::ostream&, std::string const&) co
 		);
 }
 
-void ASTJSONTest::updateExpectation(string const& _filename, string const& _expectation, string const& _variant) const
+void ASTJSONTest::updateExpectation(std::string const& _filename, std::string const& _expectation, std::string const& _variant) const
 {
-	ofstream file(_filename.c_str());
-	if (!file) BOOST_THROW_EXCEPTION(runtime_error("Cannot write " + _variant + "AST expectation to \"" + _filename + "\"."));
-	file.exceptions(ios::badbit);
+	std::ofstream file(_filename.c_str());
+	if (!file) BOOST_THROW_EXCEPTION(std::runtime_error("Cannot write " + _variant + "AST expectation to \"" + _filename + "\"."));
+	file.exceptions(std::ios::badbit);
 
-	string replacedResult = _expectation;
+	std::string replacedResult = _expectation;
 	replaceVersionWithTag(replacedResult);
 
 	file << replacedResult;

--- a/test/libsolidity/ASTPropertyTest.cpp
+++ b/test/libsolidity/ASTPropertyTest.cpp
@@ -40,23 +40,23 @@ using namespace solidity::langutil;
 using namespace solidity::frontend;
 using namespace solidity::frontend::test;
 using namespace solidity;
-using namespace std;
+using namespace std::string_literals;
 
-ASTPropertyTest::ASTPropertyTest(string const& _filename):
+ASTPropertyTest::ASTPropertyTest(std::string const& _filename):
 	TestCase(_filename)
 {
 	if (!boost::algorithm::ends_with(_filename, ".sol"))
-		BOOST_THROW_EXCEPTION(runtime_error("Not a Solidity file: \"" + _filename + "\"."));
+		BOOST_THROW_EXCEPTION(std::runtime_error("Not a Solidity file: \"" + _filename + "\"."));
 
 	m_source = m_reader.source();
 	readExpectations();
 	soltestAssert(m_tests.size() > 0, "No tests specified in " + _filename);
 }
 
-string ASTPropertyTest::formatExpectations(bool _obtainedResult)
+std::string ASTPropertyTest::formatExpectations(bool _obtainedResult)
 {
-	string expectations;
-	for (string const& testId: m_testOrder)
+	std::string expectations;
+	for (std::string const& testId: m_testOrder)
 	{
 		soltestAssert(m_tests.count(testId) > 0);
 		expectations +=
@@ -68,10 +68,10 @@ string ASTPropertyTest::formatExpectations(bool _obtainedResult)
 	return expectations;
 }
 
-vector<StringPair> ASTPropertyTest::readKeyValuePairs(string const& _input)
+std::vector<StringPair> ASTPropertyTest::readKeyValuePairs(std::string const& _input)
 {
-	vector<StringPair> result;
-	for (string line: _input | ranges::views::split('\n') | ranges::to<vector<string>>)
+	std::vector<StringPair> result;
+	for (std::string line: _input | ranges::views::split('\n') | ranges::to<std::vector<std::string>>)
 	{
 		boost::trim(line);
 		if (line.empty())
@@ -83,14 +83,14 @@ vector<StringPair> ASTPropertyTest::readKeyValuePairs(string const& _input)
 		);
 
 		auto colonPosition = line.find_first_of(':');
-		soltestAssert(colonPosition != string::npos, "Property test is missing a colon: " + line);
+		soltestAssert(colonPosition != std::string::npos, "Property test is missing a colon: " + line);
 
 		StringPair pair{
 			boost::trim_copy(line.substr(0, colonPosition)),
 			boost::trim_copy(line.substr(colonPosition + 1))
 		};
-		soltestAssert(!get<0>(pair).empty() != false, "Empty key in property test: " + line);
-		soltestAssert(!get<1>(pair).empty() != false, "Empty value in property test: " + line);
+		soltestAssert(!std::get<0>(pair).empty() != false, "Empty key in property test: " + line);
+		soltestAssert(!std::get<1>(pair).empty() != false, "Empty value in property test: " + line);
 
 		result.push_back(pair);
 	}
@@ -110,7 +110,7 @@ void ASTPropertyTest::readExpectations()
 
 void ASTPropertyTest::extractTestsFromAST(Json::Value const& _astJson)
 {
-	queue<Json::Value> nodesToVisit;
+	std::queue<Json::Value> nodesToVisit;
 	nodesToVisit.push(_astJson);
 
 	while (!nodesToVisit.empty())
@@ -121,7 +121,7 @@ void ASTPropertyTest::extractTestsFromAST(Json::Value const& _astJson)
 			for (auto&& member: node)
 				nodesToVisit.push(member);
 		else if (node.isObject())
-			for (string const& memberName: node.getMemberNames())
+			for (std::string const& memberName: node.getMemberNames())
 			{
 				if (memberName != "documentation")
 				{
@@ -129,12 +129,12 @@ void ASTPropertyTest::extractTestsFromAST(Json::Value const& _astJson)
 					continue;
 				}
 
-				string nodeDocstring = node["documentation"].isObject() ?
+				std::string nodeDocstring = node["documentation"].isObject() ?
 					node["documentation"]["text"].asString() :
 					node["documentation"].asString();
 				soltestAssert(!nodeDocstring.empty());
 
-				vector<StringPair> pairs = readKeyValuePairs(nodeDocstring);
+				std::vector<StringPair> pairs = readKeyValuePairs(nodeDocstring);
 				if (pairs.empty())
 					continue;
 
@@ -151,7 +151,7 @@ void ASTPropertyTest::extractTestsFromAST(Json::Value const& _astJson)
 					m_tests[testId].property = testedProperty;
 
 					soltestAssert(node.isMember("nodeType"));
-					optional<Json::Value> propertyNode = jsonValueByPath(node, testedProperty);
+					std::optional<Json::Value> propertyNode = jsonValueByPath(node, testedProperty);
 					soltestAssert(
 						propertyNode.has_value(),
 						node["nodeType"].asString() + " node does not have a property named \""s + testedProperty + "\""
@@ -179,7 +179,7 @@ void ASTPropertyTest::extractTestsFromAST(Json::Value const& _astJson)
 	m_obtainedResult = formatExpectations(true /* _obtainedResult */);
 }
 
-TestCase::TestResult ASTPropertyTest::run(ostream& _stream, string const& _linePrefix, bool const _formatted)
+TestCase::TestResult ASTPropertyTest::run(std::ostream& _stream, std::string const& _linePrefix, bool const _formatted)
 {
 	CompilerStack compiler;
 
@@ -190,7 +190,7 @@ TestCase::TestResult ASTPropertyTest::run(ostream& _stream, string const& _lineP
 	compiler.setEVMVersion(solidity::test::CommonOptions::get().evmVersion());
 	compiler.setOptimiserSettings(solidity::test::CommonOptions::get().optimize);
 	if (!compiler.parseAndAnalyze())
-		BOOST_THROW_EXCEPTION(runtime_error(
+		BOOST_THROW_EXCEPTION(std::runtime_error(
 			"Parsing contract failed" +
 			SourceReferenceFormatter::formatErrorInformation(compiler.errors(), compiler, _formatted)
 		));

--- a/test/libsolidity/AnalysisFramework.cpp
+++ b/test/libsolidity/AnalysisFramework.cpp
@@ -35,16 +35,15 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::util;
 using namespace solidity::langutil;
 using namespace solidity::frontend;
 using namespace solidity::frontend::test;
 
-pair<SourceUnit const*, ErrorList>
+std::pair<SourceUnit const*, ErrorList>
 AnalysisFramework::parseAnalyseAndReturnError(
-	string const& _source,
+	std::string const& _source,
 	bool _reportWarnings,
 	bool _insertLicenseAndVersionPragma,
 	bool _allowMultipleErrors
@@ -99,7 +98,7 @@ ErrorList AnalysisFramework::filterErrors(ErrorList const& _errorList, bool _inc
 			{
 				SourceLocation const* location = currentError->sourceLocation();
 				// sufficient for now, but in future we might clone the error completely, including the secondary location
-				newError = make_shared<Error>(
+				newError = std::make_shared<Error>(
 					currentError->errorId(),
 					currentError->type(),
 					messagePrefix + " ....",
@@ -114,18 +113,18 @@ ErrorList AnalysisFramework::filterErrors(ErrorList const& _errorList, bool _inc
 	return errors;
 }
 
-SourceUnit const* AnalysisFramework::parseAndAnalyse(string const& _source)
+SourceUnit const* AnalysisFramework::parseAndAnalyse(std::string const& _source)
 {
 	auto sourceAndError = parseAnalyseAndReturnError(_source);
 	BOOST_REQUIRE(!!sourceAndError.first);
-	string message;
+	std::string message;
 	if (!sourceAndError.second.empty())
 		message = "Unexpected error: " + formatErrors(compiler().errors());
 	BOOST_REQUIRE_MESSAGE(sourceAndError.second.empty(), message);
 	return sourceAndError.first;
 }
 
-bool AnalysisFramework::success(string const& _source)
+bool AnalysisFramework::success(std::string const& _source)
 {
 	return parseAnalyseAndReturnError(_source).second.empty();
 }
@@ -138,7 +137,7 @@ ErrorList AnalysisFramework::expectError(std::string const& _source, bool _warni
 	return sourceAndErrors.second;
 }
 
-string AnalysisFramework::formatErrors(
+std::string AnalysisFramework::formatErrors(
 	langutil::ErrorList const& _errors,
 	bool _colored,
 	bool _withErrorIds
@@ -152,7 +151,7 @@ string AnalysisFramework::formatErrors(
 	);
 }
 
-string AnalysisFramework::formatError(
+std::string AnalysisFramework::formatError(
 	Error const& _error,
 	bool _colored,
 	bool _withErrorIds
@@ -166,11 +165,11 @@ string AnalysisFramework::formatError(
 	);
 }
 
-ContractDefinition const* AnalysisFramework::retrieveContractByName(SourceUnit const& _source, string const& _name)
+ContractDefinition const* AnalysisFramework::retrieveContractByName(SourceUnit const& _source, std::string const& _name)
 {
 	ContractDefinition* contract = nullptr;
 
-	for (shared_ptr<ASTNode> const& node: _source.nodes())
+	for (std::shared_ptr<ASTNode> const& node: _source.nodes())
 		if ((contract = dynamic_cast<ContractDefinition*>(node.get())) && contract->name() == _name)
 			return contract;
 

--- a/test/libsolidity/Assembly.cpp
+++ b/test/libsolidity/Assembly.cpp
@@ -43,7 +43,6 @@
 #include <string>
 #include <iostream>
 
-using namespace std;
 using namespace solidity::langutil;
 using namespace solidity::evmasm;
 
@@ -90,7 +89,7 @@ evmasm::AssemblyItems compileContract(std::shared_ptr<CharStream> _sourceCode)
 				RevertStrings::Default,
 				solidity::test::CommonOptions::get().optimize ? OptimiserSettings::standard() : OptimiserSettings::minimal()
 			);
-			compiler.compileContract(*contract, map<ContractDefinition const*, shared_ptr<Compiler const>>{}, bytes());
+			compiler.compileContract(*contract, std::map<ContractDefinition const*, std::shared_ptr<Compiler const>>{}, bytes());
 
 			return compiler.runtimeAssembly().items();
 		}
@@ -102,7 +101,7 @@ void printAssemblyLocations(AssemblyItems const& _items)
 {
 	auto printRepeated = [](SourceLocation const& _loc, size_t _repetitions)
 	{
-		cout <<
+		std::cout <<
 			"\t\tvector<SourceLocation>(" <<
 			_repetitions <<
 			", SourceLocation{" <<
@@ -111,10 +110,10 @@ void printAssemblyLocations(AssemblyItems const& _items)
 			_loc.end <<
 			", make_shared<string>(\"" <<
 			*_loc.sourceName <<
-			"\")}) +" << endl;
+			"\")}) +" << std::endl;
 	};
 
-	vector<SourceLocation> locations;
+	std::vector<SourceLocation> locations;
 	for (auto const& item: _items)
 		locations.push_back(item.location());
 	size_t repetitions = 0;
@@ -136,15 +135,15 @@ void printAssemblyLocations(AssemblyItems const& _items)
 		printRepeated(*previousLoc, repetitions);
 }
 
-void checkAssemblyLocations(AssemblyItems const& _items, vector<SourceLocation> const& _locations)
+void checkAssemblyLocations(AssemblyItems const& _items, std::vector<SourceLocation> const& _locations)
 {
 	BOOST_CHECK_EQUAL(_items.size(), _locations.size());
-	for (size_t i = 0; i < min(_items.size(), _locations.size()); ++i)
+	for (size_t i = 0; i < std::min(_items.size(), _locations.size()); ++i)
 	{
 		if (_items[i].location().start != _locations[i].start ||
 			_items[i].location().end != _locations[i].end)
 		{
-			BOOST_CHECK_MESSAGE(false, "Location mismatch for item " + to_string(i) + ". Found the following locations:");
+			BOOST_CHECK_MESSAGE(false, "Location mismatch for item " + std::to_string(i) + ". Found the following locations:");
 			printAssemblyLocations(_items);
 			return;
 		}
@@ -158,7 +157,7 @@ BOOST_AUTO_TEST_SUITE(Assembly)
 
 BOOST_AUTO_TEST_CASE(location_test)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 	pragma abicoder v1;
 	contract test {
 		function f() public returns (uint256 a) {
@@ -166,34 +165,34 @@ BOOST_AUTO_TEST_CASE(location_test)
 		}
 	}
 	)";
-	AssemblyItems items = compileContract(make_shared<CharStream>(sourceCode, ""));
-	shared_ptr<string> sourceName = make_shared<string>();
+	AssemblyItems items = compileContract(std::make_shared<CharStream>(sourceCode, ""));
+	std::shared_ptr<std::string> sourceName = std::make_shared<std::string>();
 	bool hasShifts = solidity::test::CommonOptions::get().evmVersion().hasBitwiseShifting();
 
-	auto codegenCharStream = make_shared<CharStream>("", "--CODEGEN--");
+	auto codegenCharStream = std::make_shared<CharStream>("", "--CODEGEN--");
 
-	vector<SourceLocation> locations;
+	std::vector<SourceLocation> locations;
 	if (solidity::test::CommonOptions::get().optimize)
 		locations =
-			vector<SourceLocation>(31, SourceLocation{23, 103, sourceName}) +
-			vector<SourceLocation>(1, SourceLocation{41, 100, sourceName}) +
-			vector<SourceLocation>(1, SourceLocation{93, 95, sourceName}) +
-			vector<SourceLocation>(15, SourceLocation{41, 100, sourceName});
+			std::vector<SourceLocation>(31, SourceLocation{23, 103, sourceName}) +
+			std::vector<SourceLocation>(1, SourceLocation{41, 100, sourceName}) +
+			std::vector<SourceLocation>(1, SourceLocation{93, 95, sourceName}) +
+			std::vector<SourceLocation>(15, SourceLocation{41, 100, sourceName});
 	else
 		locations =
-			vector<SourceLocation>(hasShifts ? 31 : 32, SourceLocation{23, 103, sourceName}) +
-			vector<SourceLocation>(24, SourceLocation{41, 100, sourceName}) +
-			vector<SourceLocation>(1, SourceLocation{70, 79, sourceName}) +
-			vector<SourceLocation>(1, SourceLocation{93, 95, sourceName}) +
-			vector<SourceLocation>(2, SourceLocation{86, 95, sourceName}) +
-			vector<SourceLocation>(2, SourceLocation{41, 100, sourceName});
+			std::vector<SourceLocation>(hasShifts ? 31 : 32, SourceLocation{23, 103, sourceName}) +
+			std::vector<SourceLocation>(24, SourceLocation{41, 100, sourceName}) +
+			std::vector<SourceLocation>(1, SourceLocation{70, 79, sourceName}) +
+			std::vector<SourceLocation>(1, SourceLocation{93, 95, sourceName}) +
+			std::vector<SourceLocation>(2, SourceLocation{86, 95, sourceName}) +
+			std::vector<SourceLocation>(2, SourceLocation{41, 100, sourceName});
 	checkAssemblyLocations(items, locations);
 }
 
 
 BOOST_AUTO_TEST_CASE(jump_type)
 {
-	auto sourceCode = make_shared<CharStream>(R"(
+	auto sourceCode = std::make_shared<CharStream>(R"(
 	pragma abicoder v1;
 	contract C {
 		function f(uint a) public pure returns (uint t) {
@@ -206,7 +205,7 @@ BOOST_AUTO_TEST_CASE(jump_type)
 	)", "");
 	AssemblyItems items = compileContract(sourceCode);
 
-	string jumpTypes;
+	std::string jumpTypes;
 	for (AssemblyItem const& item: items)
 		if (item.getJumpType() != AssemblyItem::JumpType::Ordinary)
 			jumpTypes += item.getJumpTypeAsString() + "\n";

--- a/test/libsolidity/ErrorCheck.cpp
+++ b/test/libsolidity/ErrorCheck.cpp
@@ -27,7 +27,6 @@
 #include <set>
 #include <iostream>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::langutil;
 using namespace solidity::frontend;
@@ -42,29 +41,29 @@ std::string errorMessage(Error const& _e)
 
 bool solidity::frontend::test::searchErrorMessage(Error const& _err, std::string const& _substr)
 {
-	if (string const* errorMessage = _err.comment())
+	if (std::string const* errorMessage = _err.comment())
 	{
 		if (errorMessage->find(_substr) == std::string::npos)
 		{
-			cout << "Expected message \"" << _substr << "\" but found \"" << *errorMessage << "\".\n";
+			std::cout << "Expected message \"" << _substr << "\" but found \"" << *errorMessage << "\".\n";
 			return false;
 		}
 		return true;
 	}
 	else
-		cout << "Expected error message but found none." << endl;
+		std::cout << "Expected error message but found none." << std::endl;
 	return _substr.empty();
 }
 
-string solidity::frontend::test::searchErrors(ErrorList const& _errors, vector<pair<Error::Type, string>> const& _expectations)
+std::string solidity::frontend::test::searchErrors(ErrorList const& _errors, std::vector<std::pair<Error::Type, std::string>> const& _expectations)
 {
 	auto expectations = _expectations;
 	for (auto const& error: _errors)
 	{
-		string msg = errorMessage(*error);
+		std::string msg = errorMessage(*error);
 		bool found = false;
 		for (auto it = expectations.begin(); it != expectations.end(); ++it)
-			if (msg.find(it->second) != string::npos && error->type() == it->first)
+			if (msg.find(it->second) != std::string::npos && error->type() == it->first)
 			{
 				found = true;
 				expectations.erase(it);
@@ -75,7 +74,7 @@ string solidity::frontend::test::searchErrors(ErrorList const& _errors, vector<p
 	}
 	if (!expectations.empty())
 	{
-		string msg = "Expected error(s) not present:\n";
+		std::string msg = "Expected error(s) not present:\n";
 		for (auto const& expectation: expectations)
 			msg += expectation.second + "\n";
 		return msg;

--- a/test/libsolidity/GasCosts.cpp
+++ b/test/libsolidity/GasCosts.cpp
@@ -26,7 +26,6 @@
 
 #include <cmath>
 
-using namespace std;
 using namespace solidity::langutil;
 using namespace solidity::langutil;
 using namespace solidity::evmasm;
@@ -168,7 +167,7 @@ BOOST_AUTO_TEST_CASE(string_storage)
 
 BOOST_AUTO_TEST_CASE(single_callvaluecheck)
 {
-	string sourceCode = R"(
+	std::string sourceCode = R"(
 		// All functions nonpayable, we can check callvalue at the beginning
 		contract Nonpayable {
 			address a;

--- a/test/libsolidity/GasMeter.cpp
+++ b/test/libsolidity/GasMeter.cpp
@@ -28,7 +28,6 @@
 #include <libsolidity/ast/AST.h>
 #include <libsolidity/interface/GasEstimator.h>
 
-using namespace std;
 using namespace solidity::langutil;
 using namespace solidity::evmasm;
 using namespace solidity::frontend;
@@ -40,7 +39,7 @@ namespace solidity::frontend::test
 class GasMeterTestFramework: public SolidityExecutionFramework
 {
 public:
-	void compile(string const& _sourceCode)
+	void compile(std::string const& _sourceCode)
 	{
 		m_compiler.reset();
 		m_compiler.setSources({{"", "pragma solidity >=0.0;\n"
@@ -50,10 +49,10 @@ public:
 		BOOST_REQUIRE_MESSAGE(m_compiler.compile(), "Compiling contract failed");
 	}
 
-	void testCreationTimeGas(string const& _sourceCode, u256 const& _tolerance = u256(0))
+	void testCreationTimeGas(std::string const& _sourceCode, u256 const& _tolerance = u256(0))
 	{
 		compileAndRun(_sourceCode);
-		auto state = make_shared<KnownState>();
+		auto state = std::make_shared<KnownState>();
 		PathGasMeter meter(*m_compiler.assemblyItems(m_compiler.lastContractName()), solidity::test::CommonOptions::get().evmVersion());
 		GasMeter::GasConsumption gas = meter.estimateMax(0, state);
 		u256 bytecodeSize(m_compiler.runtimeObject(m_compiler.lastContractName()).bytecode.size());
@@ -74,7 +73,7 @@ public:
 
 	/// Compares the gas computed by PathGasMeter for the given signature (but unknown arguments)
 	/// against the actual gas usage computed by the VM on the given set of argument variants.
-	void testRunTimeGas(string const& _sig, vector<bytes> _argumentVariants, u256 const& _tolerance = u256(0))
+	void testRunTimeGas(std::string const& _sig, std::vector<bytes> _argumentVariants, u256 const& _tolerance = u256(0))
 	{
 		u256 gasUsed = 0;
 		GasMeter::GasConsumption gas;
@@ -83,8 +82,8 @@ public:
 		{
 			sendMessage(hash.asBytes() + arguments, false, 0);
 			BOOST_CHECK(m_transactionSuccessful);
-			gasUsed = max(gasUsed, m_gasUsed);
-			gas = max(gas, gasForTransaction(hash.asBytes() + arguments, false));
+			gasUsed = std::max(gasUsed, m_gasUsed);
+			gas = std::max(gas, gasForTransaction(hash.asBytes() + arguments, false));
 		}
 
 		gas += GasEstimator(solidity::test::CommonOptions::get().evmVersion()).functionalEstimation(
@@ -171,7 +170,7 @@ BOOST_AUTO_TEST_CASE(branches)
 		}
 	)";
 	testCreationTimeGas(sourceCode, 1);
-	testRunTimeGas("f(uint256)", vector<bytes>{encodeArgs(2), encodeArgs(8)}, 1);
+	testRunTimeGas("f(uint256)", std::vector<bytes>{encodeArgs(2), encodeArgs(8)}, 1);
 }
 
 BOOST_AUTO_TEST_CASE(function_calls)
@@ -196,7 +195,7 @@ BOOST_AUTO_TEST_CASE(function_calls)
 	// However, GasMeter always assumes cold costs.
 	testRunTimeGas(
 		"f(uint256)",
-		vector<bytes>{encodeArgs(2), encodeArgs(8)},
+		std::vector<bytes>{encodeArgs(2), encodeArgs(8)},
 		m_evmVersion < EVMVersion::berlin() ?
 		u256(0) :
 		u256(2100)
@@ -225,13 +224,13 @@ BOOST_AUTO_TEST_CASE(multiple_external_functions)
 	// However, GasMeter always assumes cold costs.
 	testRunTimeGas(
 		"f(uint256)",
-		vector<bytes>{encodeArgs(2), encodeArgs(8)},
+		std::vector<bytes>{encodeArgs(2), encodeArgs(8)},
 		m_evmVersion < EVMVersion::berlin() ?
 		u256(0) :
 		u256(2100)
 	);
 
-	testRunTimeGas("g(uint256)", vector<bytes>{encodeArgs(2)});
+	testRunTimeGas("g(uint256)", std::vector<bytes>{encodeArgs(2)});
 }
 
 BOOST_AUTO_TEST_CASE(exponent_size)
@@ -250,9 +249,9 @@ BOOST_AUTO_TEST_CASE(exponent_size)
 		}
 	)";
 	testCreationTimeGas(sourceCode);
-	testRunTimeGas("f(uint256)", vector<bytes>{encodeArgs(2)});
-	testRunTimeGas("g(uint256)", vector<bytes>{encodeArgs(2)});
-	testRunTimeGas("h(uint256)", vector<bytes>{encodeArgs(2)});
+	testRunTimeGas("f(uint256)", std::vector<bytes>{encodeArgs(2)});
+	testRunTimeGas("g(uint256)", std::vector<bytes>{encodeArgs(2)});
+	testRunTimeGas("h(uint256)", std::vector<bytes>{encodeArgs(2)});
 }
 
 BOOST_AUTO_TEST_CASE(balance_gas)
@@ -265,7 +264,7 @@ BOOST_AUTO_TEST_CASE(balance_gas)
 		}
 	)";
 	testCreationTimeGas(sourceCode);
-	testRunTimeGas("lookup_balance(address)", vector<bytes>{encodeArgs(2), encodeArgs(100)});
+	testRunTimeGas("lookup_balance(address)", std::vector<bytes>{encodeArgs(2), encodeArgs(100)});
 }
 
 BOOST_AUTO_TEST_CASE(extcodesize_gas)
@@ -280,7 +279,7 @@ BOOST_AUTO_TEST_CASE(extcodesize_gas)
 		}
 	)";
 	testCreationTimeGas(sourceCode);
-	testRunTimeGas("f()", vector<bytes>{encodeArgs()});
+	testRunTimeGas("f()", std::vector<bytes>{encodeArgs()});
 }
 
 BOOST_AUTO_TEST_CASE(regular_functions_exclude_fallback)
@@ -294,7 +293,7 @@ BOOST_AUTO_TEST_CASE(regular_functions_exclude_fallback)
 		}
 	)";
 	testCreationTimeGas(sourceCode);
-	testRunTimeGas("x()", vector<bytes>{encodeArgs()});
+	testRunTimeGas("x()", std::vector<bytes>{encodeArgs()});
 }
 
 BOOST_AUTO_TEST_CASE(complex_control_flow)
@@ -335,7 +334,7 @@ BOOST_AUTO_TEST_CASE(complex_control_flow)
 	)";
 	testCreationTimeGas(sourceCode);
 	// max gas is used for small x
-	testRunTimeGas("ln(int128)", vector<bytes>{encodeArgs(0), encodeArgs(10), encodeArgs(105), encodeArgs(30000)});
+	testRunTimeGas("ln(int128)", std::vector<bytes>{encodeArgs(0), encodeArgs(10), encodeArgs(105), encodeArgs(30000)});
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/libsolidity/GasTest.cpp
+++ b/test/libsolidity/GasTest.cpp
@@ -33,10 +33,9 @@ using namespace solidity::langutil;
 using namespace solidity::frontend;
 using namespace solidity::frontend::test;
 using namespace solidity;
-using namespace std;
 using namespace boost::unit_test;
 
-GasTest::GasTest(string const& _filename):
+GasTest::GasTest(std::string const& _filename):
 	TestCase(_filename)
 {
 	m_source = m_reader.source();
@@ -48,20 +47,20 @@ GasTest::GasTest(string const& _filename):
 
 void GasTest::parseExpectations(std::istream& _stream)
 {
-	map<std::string, std::string>* currentKind = nullptr;
-	string line;
+	std::map<std::string, std::string>* currentKind = nullptr;
+	std::string line;
 
 	while (getline(_stream, line))
 		if (!boost::starts_with(line, "// "))
-			BOOST_THROW_EXCEPTION(runtime_error("Invalid expectation: expected \"// \"."));
+			BOOST_THROW_EXCEPTION(std::runtime_error("Invalid expectation: expected \"// \"."));
 		else if (boost::ends_with(line, ":"))
 		{
-			string kind = line.substr(3, line.length() - 4);
+			std::string kind = line.substr(3, line.length() - 4);
 			boost::trim(kind);
 			currentKind = &m_expectations[std::move(kind)];
 		}
 		else if (!currentKind)
-			BOOST_THROW_EXCEPTION(runtime_error("No function kind specified. Expected \"creation:\", \"external:\" or \"internal:\"."));
+			BOOST_THROW_EXCEPTION(std::runtime_error("No function kind specified. Expected \"creation:\", \"external:\" or \"internal:\"."));
 		else
 		{
 			auto it = line.begin() + 3;
@@ -69,18 +68,18 @@ void GasTest::parseExpectations(std::istream& _stream)
 			auto functionNameBegin = it;
 			while (it != line.end() && *it != ':')
 				++it;
-			string functionName(functionNameBegin, it);
+			std::string functionName(functionNameBegin, it);
 			if (functionName == "fallback")
 				functionName.clear();
 			expect(it, line.end(), ':');
 			skipWhitespace(it, line.end());
 			if (it == line.end())
-				BOOST_THROW_EXCEPTION(runtime_error("Invalid expectation: expected gas cost."));
+				BOOST_THROW_EXCEPTION(std::runtime_error("Invalid expectation: expected gas cost."));
 			(*currentKind)[functionName] = std::string(it, line.end());
 		}
 }
 
-void GasTest::printUpdatedExpectations(ostream& _stream, string const& _linePrefix) const
+void GasTest::printUpdatedExpectations(std::ostream& _stream, std::string const& _linePrefix) const
 {
 	Json::Value estimates = compiler().gasEstimates(compiler().lastContractName());
 	for (auto groupIt = estimates.begin(); groupIt != estimates.end(); ++groupIt)
@@ -98,7 +97,7 @@ void GasTest::printUpdatedExpectations(ostream& _stream, string const& _linePref
 	}
 }
 
-TestCase::TestResult GasTest::run(ostream& _stream, string const& _linePrefix, bool _formatted)
+TestCase::TestResult GasTest::run(std::ostream& _stream, std::string const& _linePrefix, bool _formatted)
 {
 	compiler().reset();
 	// Prerelease CBOR metadata varies in size due to changing version numbers and build dates.
@@ -153,10 +152,10 @@ TestCase::TestResult GasTest::run(ostream& _stream, string const& _linePrefix, b
 	}
 }
 
-void GasTest::printSource(ostream& _stream, string const& _linePrefix, bool) const
+void GasTest::printSource(std::ostream& _stream, std::string const& _linePrefix, bool) const
 {
-	string line;
-	istringstream input(m_source);
+	std::string line;
+	std::istringstream input(m_source);
 	while (getline(input, line))
 		_stream << _linePrefix << line << std::endl;
 }

--- a/test/libsolidity/Imports.cpp
+++ b/test/libsolidity/Imports.cpp
@@ -32,7 +32,6 @@
 
 #include <string>
 
-using namespace std;
 
 namespace solidity::frontend::test
 {
@@ -42,7 +41,7 @@ BOOST_AUTO_TEST_SUITE(SolidityImports)
 BOOST_AUTO_TEST_CASE(remappings)
 {
 	CompilerStack c;
-	c.setRemappings(vector<ImportRemapper::Remapping>{{"", "s", "s_1.4.6"},{"", "t", "Tee"}});
+	c.setRemappings(std::vector<ImportRemapper::Remapping>{{"", "s", "s_1.4.6"},{"", "t", "Tee"}});
 	c.setSources({
 		{"a", "import \"s/s.sol\"; contract A is S {} pragma solidity >=0.0;"},
 		{"b", "import \"t/tee.sol\"; contract A is Tee {} pragma solidity >=0.0;"},
@@ -56,7 +55,7 @@ BOOST_AUTO_TEST_CASE(remappings)
 BOOST_AUTO_TEST_CASE(context_dependent_remappings)
 {
 	CompilerStack c;
-	c.setRemappings(vector<ImportRemapper::Remapping>{{"a", "s", "s_1.4.6"}, {"b", "s", "s_1.4.7"}});
+	c.setRemappings(std::vector<ImportRemapper::Remapping>{{"a", "s", "s_1.4.6"}, {"b", "s", "s_1.4.7"}});
 	c.setSources({
 		{"a/a.sol", "import \"s/s.sol\"; contract A is SSix {} pragma solidity >=0.0;"},
 		{"b/b.sol", "import \"s/s.sol\"; contract B is SSeven {} pragma solidity >=0.0;"},
@@ -70,7 +69,7 @@ BOOST_AUTO_TEST_CASE(context_dependent_remappings)
 BOOST_AUTO_TEST_CASE(context_dependent_remappings_ensure_default_and_module_preserved)
 {
 	CompilerStack c;
-	c.setRemappings(vector<ImportRemapper::Remapping>{
+	c.setRemappings(std::vector<ImportRemapper::Remapping>{
 		{"", "foo", "vendor/foo_2.0.0"},
 		{"vendor/bar", "foo", "vendor/foo_1.0.0"},
 		{"", "bar", "vendor/bar"}
@@ -88,7 +87,7 @@ BOOST_AUTO_TEST_CASE(context_dependent_remappings_ensure_default_and_module_pres
 BOOST_AUTO_TEST_CASE(context_dependent_remappings_order_independent_1)
 {
 	CompilerStack c;
-	c.setRemappings(vector<ImportRemapper::Remapping>{{"a", "x/y/z", "d"}, {"a/b", "x", "e"}});
+	c.setRemappings(std::vector<ImportRemapper::Remapping>{{"a", "x/y/z", "d"}, {"a/b", "x", "e"}});
 	c.setSources({
 		{"a/main.sol", "import \"x/y/z/z.sol\"; contract Main is D {} pragma solidity >=0.0;"},
 		{"a/b/main.sol", "import \"x/y/z/z.sol\"; contract Main is E {} pragma solidity >=0.0;"},
@@ -102,7 +101,7 @@ BOOST_AUTO_TEST_CASE(context_dependent_remappings_order_independent_1)
 BOOST_AUTO_TEST_CASE(context_dependent_remappings_order_independent_2)
 {
 	CompilerStack c;
-	c.setRemappings(vector<ImportRemapper::Remapping>{{"a/b", "x", "e"}, {"a", "x/y/z", "d"}});
+	c.setRemappings(std::vector<ImportRemapper::Remapping>{{"a/b", "x", "e"}, {"a", "x/y/z", "d"}});
 	c.setSources({
 		{"a/main.sol", "import \"x/y/z/z.sol\"; contract Main is D {} pragma solidity >=0.0;"},
 		{"a/b/main.sol", "import \"x/y/z/z.sol\"; contract Main is E {} pragma solidity >=0.0;"},

--- a/test/libsolidity/InlineAssembly.cpp
+++ b/test/libsolidity/InlineAssembly.cpp
@@ -42,7 +42,6 @@
 #include <optional>
 #include <string>
 
-using namespace std;
 using namespace solidity::langutil;
 using namespace solidity::yul;
 
@@ -53,7 +52,7 @@ namespace
 {
 
 std::optional<Error> parseAndReturnFirstError(
-	string const& _source,
+	std::string const& _source,
 	bool _assemble = false,
 	bool _allowWarnings = true,
 	YulStack::Language _language = YulStack::Language::Assembly,
@@ -79,7 +78,7 @@ std::optional<Error> parseAndReturnFirstError(
 		BOOST_FAIL("Fatal error leaked.");
 		success = false;
 	}
-	shared_ptr<Error const> error;
+	std::shared_ptr<Error const> error;
 	for (auto const& e: stack.errors())
 	{
 		if (_allowWarnings && e->type() == Error::Type::Warning)
@@ -99,7 +98,7 @@ std::optional<Error> parseAndReturnFirstError(
 }
 
 bool successParse(
-	string const& _source,
+	std::string const& _source,
 	bool _assemble = false,
 	bool _allowWarnings = true,
 	YulStack::Language _language = YulStack::Language::Assembly,
@@ -109,7 +108,7 @@ bool successParse(
 	return !parseAndReturnFirstError(_source, _assemble, _allowWarnings, _language, _machine);
 }
 
-bool successAssemble(string const& _source, bool _allowWarnings = true, YulStack::Language _language = YulStack::Language::Assembly)
+bool successAssemble(std::string const& _source, bool _allowWarnings = true, YulStack::Language _language = YulStack::Language::Assembly)
 {
 	return
 		successParse(_source, true, _allowWarnings, _language, YulStack::Machine::EVM);
@@ -128,7 +127,7 @@ Error expectError(
 	return *error;
 }
 
-void parsePrintCompare(string const& _source, bool _canWarn = false)
+void parsePrintCompare(std::string const& _source, bool _canWarn = false)
 {
 	YulStack stack(
 		solidity::test::CommonOptions::get().evmVersion(),
@@ -142,7 +141,7 @@ void parsePrintCompare(string const& _source, bool _canWarn = false)
 		BOOST_REQUIRE(!Error::containsErrors(stack.errors()));
 	else
 		BOOST_REQUIRE(stack.errors().empty());
-	string expectation = "object \"object\" {\n    code " + boost::replace_all_copy(_source, "\n", "\n    ") + "\n}\n";
+	std::string expectation = "object \"object\" {\n    code " + boost::replace_all_copy(_source, "\n", "\n    ") + "\n}\n";
 	BOOST_CHECK_EQUAL(stack.print(), expectation);
 }
 
@@ -219,8 +218,8 @@ BOOST_AUTO_TEST_CASE(print_string_literals)
 
 BOOST_AUTO_TEST_CASE(print_string_literal_unicode)
 {
-	string source = "{ let x := \"\\u1bac\" }";
-	string parsed = "object \"object\" {\n    code { let x := \"\\xe1\\xae\\xac\" }\n}\n";
+	std::string source = "{ let x := \"\\u1bac\" }";
+	std::string parsed = "object \"object\" {\n    code { let x := \"\\xe1\\xae\\xac\" }\n}\n";
 	YulStack stack(
 		solidity::test::CommonOptions::get().evmVersion(),
 		solidity::test::CommonOptions::get().eofVersion(),
@@ -232,7 +231,7 @@ BOOST_AUTO_TEST_CASE(print_string_literal_unicode)
 	BOOST_REQUIRE(stack.errors().empty());
 	BOOST_CHECK_EQUAL(stack.print(), parsed);
 
-	string parsedInner = "{ let x := \"\\xe1\\xae\\xac\" }";
+	std::string parsedInner = "{ let x := \"\\xe1\\xae\\xac\" }";
 	parsePrintCompare(parsedInner);
 }
 
@@ -258,7 +257,7 @@ BOOST_AUTO_TEST_CASE(function_definitions_multiple_args)
 
 BOOST_AUTO_TEST_CASE(function_calls)
 {
-	string source = R"({
+	std::string source = R"({
 	function y()
 	{ }
 	function f(a) -> b

--- a/test/libsolidity/LibSolc.cpp
+++ b/test/libsolidity/LibSolc.cpp
@@ -27,7 +27,6 @@
 #include <libsolidity/interface/Version.h>
 #include <libsolc/libsolc.h>
 
-using namespace std;
 
 namespace solidity::frontend::test
 {
@@ -37,7 +36,7 @@ namespace
 
 /// TODO: share this between StandardCompiler.cpp
 /// Helper to match a specific error type and message
-bool containsError(Json::Value const& _compilerResult, string const& _type, string const& _message)
+bool containsError(Json::Value const& _compilerResult, std::string const& _type, std::string const& _message)
 {
 	if (!_compilerResult.isMember("errors"))
 		return false;
@@ -54,10 +53,10 @@ bool containsError(Json::Value const& _compilerResult, string const& _type, stri
 	return false;
 }
 
-Json::Value compile(string const& _input, CStyleReadFileCallback _callback = nullptr)
+Json::Value compile(std::string const& _input, CStyleReadFileCallback _callback = nullptr)
 {
 	char* output_ptr = solidity_compile(_input.c_str(), _callback, nullptr);
-	string output(output_ptr);
+	std::string output(output_ptr);
 	solidity_free(output_ptr);
 	solidity_reset();
 	Json::Value ret;
@@ -65,7 +64,7 @@ Json::Value compile(string const& _input, CStyleReadFileCallback _callback = nul
 	return ret;
 }
 
-char* stringToSolidity(string const& _input)
+char* stringToSolidity(std::string const& _input)
 {
 	char* ptr = solidity_alloc(_input.length());
 	BOOST_REQUIRE(ptr != nullptr);
@@ -79,14 +78,14 @@ BOOST_AUTO_TEST_SUITE(LibSolc)
 
 BOOST_AUTO_TEST_CASE(read_version)
 {
-	string output(solidity_version());
+	std::string output(solidity_version());
 	BOOST_CHECK(output.find(VersionString) == 0);
 }
 
 BOOST_AUTO_TEST_CASE(read_license)
 {
-	string output(solidity_license());
-	BOOST_CHECK(output.find("GNU GENERAL PUBLIC LICENSE") != string::npos);
+	std::string output(solidity_license());
+	BOOST_CHECK(output.find("GNU GENERAL PUBLIC LICENSE") != std::string::npos);
 }
 
 BOOST_AUTO_TEST_CASE(standard_compilation)
@@ -148,16 +147,16 @@ BOOST_AUTO_TEST_CASE(with_callback)
 			// Passed in a nullptr in the compile() helper above.
 			BOOST_REQUIRE(_context == nullptr);
 			// Caller frees the pointers.
-			BOOST_REQUIRE(string(_kind) == ReadCallback::kindString(ReadCallback::Kind::ReadFile));
-			if (string(_path) == "found.sol")
+			BOOST_REQUIRE(std::string(_kind) == ReadCallback::kindString(ReadCallback::Kind::ReadFile));
+			if (std::string(_path) == "found.sol")
 			{
-				static string content{"import \"missing.sol\"; contract B {}"};
+				static std::string content{"import \"missing.sol\"; contract B {}"};
 				*o_contents = stringToSolidity(content);
 				*o_error = nullptr;
 			}
-			else if (string(_path) == "missing.sol")
+			else if (std::string(_path) == "missing.sol")
 			{
-				static string errorMsg{"Missing file."};
+				static std::string errorMsg{"Missing file."};
 				*o_error = stringToSolidity(errorMsg);
 				*o_contents = nullptr;
 			}

--- a/test/libsolidity/MemoryGuardTest.cpp
+++ b/test/libsolidity/MemoryGuardTest.cpp
@@ -28,7 +28,6 @@
 #include <memory>
 #include <stdexcept>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::util;
 using namespace solidity::util::formatting;
@@ -37,7 +36,7 @@ using namespace solidity::frontend;
 using namespace solidity::frontend::test;
 using namespace yul;
 
-TestCase::TestResult MemoryGuardTest::run(ostream& _stream, string const& _linePrefix, bool _formatted)
+TestCase::TestResult MemoryGuardTest::run(std::ostream& _stream, std::string const& _linePrefix, bool _formatted)
 {
 	compiler().reset();
 	compiler().setSources(StringMap{{"", m_source}});
@@ -50,7 +49,7 @@ TestCase::TestResult MemoryGuardTest::run(ostream& _stream, string const& _lineP
 	}
 
 	m_obtainedResult.clear();
-	for (string contractName: compiler().contractNames())
+	for (std::string contractName: compiler().contractNames())
 	{
 		ErrorList errors;
 		auto [object, analysisInfo] = yul::test::parse(
@@ -61,7 +60,7 @@ TestCase::TestResult MemoryGuardTest::run(ostream& _stream, string const& _lineP
 
 		if (!object || !analysisInfo || Error::containsErrors(errors))
 		{
-			AnsiColorized(_stream, _formatted, {formatting::BOLD, formatting::RED}) << _linePrefix << "Error parsing IR." << endl;
+			AnsiColorized(_stream, _formatted, {formatting::BOLD, formatting::RED}) << _linePrefix << "Error parsing IR." << std::endl;
 			return TestResult::FatalError;
 		}
 

--- a/test/libsolidity/Metadata.cpp
+++ b/test/libsolidity/Metadata.cpp
@@ -29,7 +29,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 
 namespace solidity::frontend::test
 {
@@ -37,13 +36,13 @@ namespace solidity::frontend::test
 namespace
 {
 
-map<string, string> requireParsedCBORMetadata(bytes const& _bytecode, CompilerStack::MetadataFormat _metadataFormat)
+std::map<std::string, std::string> requireParsedCBORMetadata(bytes const& _bytecode, CompilerStack::MetadataFormat _metadataFormat)
 {
 	bytes cborMetadata = solidity::test::onlyMetadata(_bytecode);
 	if (_metadataFormat != CompilerStack::MetadataFormat::NoMetadata)
 	{
 		BOOST_REQUIRE(!cborMetadata.empty());
-		std::optional<map<string, string>> tmp = solidity::test::parseCBORMetadata(cborMetadata);
+		std::optional<std::map<std::string, std::string>> tmp = solidity::test::parseCBORMetadata(cborMetadata);
 		BOOST_REQUIRE(tmp);
 		return *tmp;
 	}
@@ -51,13 +50,13 @@ map<string, string> requireParsedCBORMetadata(bytes const& _bytecode, CompilerSt
 	return {};
 }
 
-optional<string> compileAndCheckLicenseMetadata(string const& _contractName, char const* _sourceCode)
+std::optional<std::string> compileAndCheckLicenseMetadata(std::string const& _contractName, char const* _sourceCode)
 {
 	CompilerStack compilerStack;
 	compilerStack.setSources({{"A.sol", _sourceCode}});
 	BOOST_REQUIRE_MESSAGE(compilerStack.compile(), "Compiling contract failed");
 
-	string const& serialisedMetadata = compilerStack.metadata(_contractName);
+	std::string const& serialisedMetadata = compilerStack.metadata(_contractName);
 	Json::Value metadata;
 	BOOST_REQUIRE(util::jsonParseStrict(serialisedMetadata, metadata));
 	BOOST_CHECK(solidity::test::isValidMetadata(metadata));
@@ -71,7 +70,7 @@ optional<string> compileAndCheckLicenseMetadata(string const& _contractName, cha
 		return metadata["sources"]["A.sol"]["license"].asString();
 	}
 	else
-		return nullopt;
+		return std::nullopt;
 }
 
 }
@@ -93,7 +92,7 @@ BOOST_AUTO_TEST_CASE(metadata_stamp)
 		CompilerStack::MetadataFormat::WithReleaseVersionTag,
 		CompilerStack::MetadataFormat::WithPrereleaseVersionTag
 	})
-		for (auto metadataHash: set<CompilerStack::MetadataHash>{
+		for (auto metadataHash: std::set<CompilerStack::MetadataHash>{
 			CompilerStack::MetadataHash::IPFS,
 			CompilerStack::MetadataHash::Bzzr1,
 			CompilerStack::MetadataHash::None
@@ -107,7 +106,7 @@ BOOST_AUTO_TEST_CASE(metadata_stamp)
 			compilerStack.setMetadataHash(metadataHash);
 			BOOST_REQUIRE_MESSAGE(compilerStack.compile(), "Compiling contract failed");
 			bytes const& bytecode = compilerStack.runtimeObject("test").bytecode;
-			string const& metadata = compilerStack.metadata("test");
+			std::string const& metadata = compilerStack.metadata("test");
 			BOOST_CHECK(solidity::test::isValidMetadata(metadata));
 
 			auto const cborMetadata = requireParsedCBORMetadata(bytecode, metadataFormat);
@@ -116,7 +115,7 @@ BOOST_AUTO_TEST_CASE(metadata_stamp)
 			else
 			{
 				bytes hash;
-				string hashMethod;
+				std::string hashMethod;
 				if (metadataHash == CompilerStack::MetadataHash::IPFS)
 				{
 					hash = util::ipfsHash(metadata);
@@ -166,7 +165,7 @@ BOOST_AUTO_TEST_CASE(metadata_stamp_experimental)
 			CompilerStack::MetadataFormat::WithReleaseVersionTag,
 			CompilerStack::MetadataFormat::WithPrereleaseVersionTag
 	})
-		for (auto metadataHash: set<CompilerStack::MetadataHash>{
+		for (auto metadataHash: std::set<CompilerStack::MetadataHash>{
 			CompilerStack::MetadataHash::IPFS,
 			CompilerStack::MetadataHash::Bzzr1,
 			CompilerStack::MetadataHash::None
@@ -180,7 +179,7 @@ BOOST_AUTO_TEST_CASE(metadata_stamp_experimental)
 			compilerStack.setMetadataHash(metadataHash);
 			BOOST_REQUIRE_MESSAGE(compilerStack.compile(), "Compiling contract failed");
 			bytes const& bytecode = compilerStack.runtimeObject("test").bytecode;
-			string const& metadata = compilerStack.metadata("test");
+			std::string const& metadata = compilerStack.metadata("test");
 			BOOST_CHECK(solidity::test::isValidMetadata(metadata));
 
 			auto const cborMetadata = requireParsedCBORMetadata(bytecode, metadataFormat);
@@ -189,7 +188,7 @@ BOOST_AUTO_TEST_CASE(metadata_stamp_experimental)
 			else
 			{
 				bytes hash;
-				string hashMethod;
+				std::string hashMethod;
 				if (metadataHash == CompilerStack::MetadataHash::IPFS)
 				{
 					hash = util::ipfsHash(metadata);
@@ -250,7 +249,7 @@ BOOST_AUTO_TEST_CASE(metadata_eof_experimental)
 		compilerStack.setOptimiserSettings(true);
 		BOOST_REQUIRE_MESSAGE(compilerStack.compile(), "Compiling contract failed");
 		bytes const& bytecode = compilerStack.runtimeObject("test").bytecode;
-		string const& metadata = compilerStack.metadata("test");
+		std::string const& metadata = compilerStack.metadata("test");
 		BOOST_CHECK(solidity::test::isValidMetadata(metadata));
 
 		auto const cborMetadata = requireParsedCBORMetadata(bytecode, metadataFormat);
@@ -288,7 +287,7 @@ BOOST_AUTO_TEST_CASE(metadata_relevant_sources)
 	compilerStack.setOptimiserSettings(solidity::test::CommonOptions::get().optimize);
 	BOOST_REQUIRE_MESSAGE(compilerStack.compile(), "Compiling contract failed");
 
-	string const& serialisedMetadata = compilerStack.metadata("A");
+	std::string const& serialisedMetadata = compilerStack.metadata("A");
 	Json::Value metadata;
 	BOOST_REQUIRE(util::jsonParseStrict(serialisedMetadata, metadata));
 	BOOST_CHECK(solidity::test::isValidMetadata(metadata));
@@ -329,7 +328,7 @@ BOOST_AUTO_TEST_CASE(metadata_relevant_sources_imports)
 	compilerStack.setOptimiserSettings(solidity::test::CommonOptions::get().optimize);
 	BOOST_REQUIRE_MESSAGE(compilerStack.compile(), "Compiling contract failed");
 
-	string const& serialisedMetadata = compilerStack.metadata("C");
+	std::string const& serialisedMetadata = compilerStack.metadata("C");
 	Json::Value metadata;
 	BOOST_REQUIRE(util::jsonParseStrict(serialisedMetadata, metadata));
 	BOOST_CHECK(solidity::test::isValidMetadata(metadata));
@@ -357,7 +356,7 @@ BOOST_AUTO_TEST_CASE(metadata_useLiteralContent)
 		compilerStack.setOptimiserSettings(solidity::test::CommonOptions::get().optimize);
 		compilerStack.useMetadataLiteralSources(_literal);
 		BOOST_REQUIRE_MESSAGE(compilerStack.compile(), "Compiling contract failed");
-		string metadata_str = compilerStack.metadata("test");
+		std::string metadata_str = compilerStack.metadata("test");
 		Json::Value metadata;
 		BOOST_REQUIRE(util::jsonParseStrict(metadata_str, metadata));
 		BOOST_CHECK(solidity::test::isValidMetadata(metadata));
@@ -407,7 +406,7 @@ BOOST_AUTO_TEST_CASE(metadata_viair)
 		BOOST_CHECK(compilerStack.cborMetadata("test") == compilerStack.cborMetadata("test", _viaIR));
 		BOOST_CHECK(compilerStack.cborMetadata("test") != compilerStack.cborMetadata("test", !_viaIR));
 
-		map<string, string> const parsedCBORMetadata = requireParsedCBORMetadata(
+		std::map<std::string, std::string> const parsedCBORMetadata = requireParsedCBORMetadata(
 			compilerStack.runtimeObject("test").bytecode,
 			CompilerStack::MetadataFormat::WithReleaseVersionTag
 		);
@@ -431,7 +430,7 @@ BOOST_AUTO_TEST_CASE(metadata_revert_strings)
 	compilerStack.setRevertStringBehaviour(RevertStrings::Strip);
 	BOOST_REQUIRE_MESSAGE(compilerStack.compile(), "Compiling contract failed");
 
-	string const& serialisedMetadata = compilerStack.metadata("A");
+	std::string const& serialisedMetadata = compilerStack.metadata("A");
 	Json::Value metadata;
 	BOOST_REQUIRE(util::jsonParseStrict(serialisedMetadata, metadata));
 	BOOST_CHECK(solidity::test::isValidMetadata(metadata));
@@ -447,7 +446,7 @@ BOOST_AUTO_TEST_CASE(metadata_optimiser_sequence)
 		}
 	)";
 
-	vector<tuple<string, string>> sequences =
+	std::vector<std::tuple<std::string, std::string>> sequences =
 	{
 		// {"<optimizer sequence>", "<optimizer cleanup sequence>"}
 		{"", ""},
@@ -456,7 +455,7 @@ BOOST_AUTO_TEST_CASE(metadata_optimiser_sequence)
 		{"dhfoDgvulfnTUtnIf", "fDn"}
 	};
 
-	auto check = [sourceCode](string const& _optimizerSequence, string const& _optimizerCleanupSequence)
+	auto check = [sourceCode](std::string const& _optimizerSequence, std::string const& _optimizerCleanupSequence)
 	{
 		OptimiserSettings optimizerSettings = OptimiserSettings::minimal();
 		optimizerSettings.runYulOptimiser = true;
@@ -469,7 +468,7 @@ BOOST_AUTO_TEST_CASE(metadata_optimiser_sequence)
 
 		BOOST_REQUIRE_MESSAGE(compilerStack.compile(), "Compiling contract failed");
 
-		string const& serialisedMetadata = compilerStack.metadata("C");
+		std::string const& serialisedMetadata = compilerStack.metadata("C");
 		Json::Value metadata;
 		BOOST_REQUIRE(util::jsonParseStrict(serialisedMetadata, metadata));
 		BOOST_CHECK(solidity::test::isValidMetadata(metadata));
@@ -477,8 +476,8 @@ BOOST_AUTO_TEST_CASE(metadata_optimiser_sequence)
 		BOOST_CHECK(metadata["settings"]["optimizer"]["details"].isMember("yulDetails"));
 		BOOST_CHECK(metadata["settings"]["optimizer"]["details"]["yulDetails"].isMember("optimizerSteps"));
 
-		string const metadataOptimizerSteps = metadata["settings"]["optimizer"]["details"]["yulDetails"]["optimizerSteps"].asString();
-		string const expectedMetadataOptimiserSteps = _optimizerSequence + ":" + _optimizerCleanupSequence;
+		std::string const metadataOptimizerSteps = metadata["settings"]["optimizer"]["details"]["yulDetails"]["optimizerSteps"].asString();
+		std::string const expectedMetadataOptimiserSteps = _optimizerSequence + ":" + _optimizerCleanupSequence;
 		BOOST_CHECK_EQUAL(metadataOptimizerSteps, expectedMetadataOptimiserSteps);
 	};
 
@@ -493,7 +492,7 @@ BOOST_AUTO_TEST_CASE(metadata_license_missing)
 		contract C {
 		}
 	)";
-	BOOST_CHECK(compileAndCheckLicenseMetadata("C", sourceCode) == nullopt);
+	BOOST_CHECK(compileAndCheckLicenseMetadata("C", sourceCode) == std::nullopt);
 }
 
 BOOST_AUTO_TEST_CASE(metadata_license_gpl3)
@@ -544,7 +543,7 @@ BOOST_AUTO_TEST_CASE(metadata_license_bidi_marks)
 		"// NOTE: The text above is reversed using Unicode directional marks. In raw form it would look like this:\n"
 		"// <LRO>0.3-LPG :reifitnedI-esneciL-XDPS<PDF>\n"
 		"contract C {}\n";
-	BOOST_CHECK(compileAndCheckLicenseMetadata("C", sourceCode) == nullopt);
+	BOOST_CHECK(compileAndCheckLicenseMetadata("C", sourceCode) == std::nullopt);
 }
 
 BOOST_AUTO_TEST_CASE(metadata_license_bottom)
@@ -579,7 +578,7 @@ BOOST_AUTO_TEST_CASE(metadata_license_in_string)
 			bytes license = "// SPDX-License-Identifier: GPL-3.0";
 		}
 	)";
-	BOOST_CHECK(compileAndCheckLicenseMetadata("C", sourceCode) == nullopt);
+	BOOST_CHECK(compileAndCheckLicenseMetadata("C", sourceCode) == std::nullopt);
 }
 
 BOOST_AUTO_TEST_CASE(metadata_license_in_contract)
@@ -589,7 +588,7 @@ BOOST_AUTO_TEST_CASE(metadata_license_in_contract)
 		// SPDX-License-Identifier: GPL-3.0
 		}
 	)";
-	BOOST_CHECK(compileAndCheckLicenseMetadata("C", sourceCode) == nullopt);
+	BOOST_CHECK(compileAndCheckLicenseMetadata("C", sourceCode) == std::nullopt);
 }
 
 BOOST_AUTO_TEST_CASE(metadata_license_missing_colon)
@@ -598,7 +597,7 @@ BOOST_AUTO_TEST_CASE(metadata_license_missing_colon)
 		// SPDX-License-Identifier GPL-3.0
 		contract C {}
 	)";
-	BOOST_CHECK(compileAndCheckLicenseMetadata("C", sourceCode) == nullopt);
+	BOOST_CHECK(compileAndCheckLicenseMetadata("C", sourceCode) == std::nullopt);
 }
 
 BOOST_AUTO_TEST_CASE(metadata_license_multiline)

--- a/test/libsolidity/SMTCheckerTest.cpp
+++ b/test/libsolidity/SMTCheckerTest.cpp
@@ -21,13 +21,12 @@
 
 #include <range/v3/action/remove_if.hpp>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::langutil;
 using namespace solidity::frontend;
 using namespace solidity::frontend::test;
 
-SMTCheckerTest::SMTCheckerTest(string const& _filename): SyntaxTest(_filename, EVMVersion{})
+SMTCheckerTest::SMTCheckerTest(std::string const& _filename): SyntaxTest(_filename, EVMVersion{})
 {
 	auto contract = m_reader.stringSetting("SMTContract", "");
 	if (!contract.empty())
@@ -37,7 +36,7 @@ SMTCheckerTest::SMTCheckerTest(string const& _filename): SyntaxTest(_filename, E
 	if (extCallsMode)
 		m_modelCheckerSettings.externalCalls = *extCallsMode;
 	else
-		BOOST_THROW_EXCEPTION(runtime_error("Invalid SMT external calls mode."));
+		BOOST_THROW_EXCEPTION(std::runtime_error("Invalid SMT external calls mode."));
 
 	auto const& showUnproved = m_reader.stringSetting("SMTShowUnproved", "yes");
 	if (showUnproved == "no")
@@ -45,7 +44,7 @@ SMTCheckerTest::SMTCheckerTest(string const& _filename): SyntaxTest(_filename, E
 	else if (showUnproved == "yes")
 		m_modelCheckerSettings.showUnproved = true;
 	else
-		BOOST_THROW_EXCEPTION(runtime_error("Invalid SMT \"show unproved\" choice."));
+		BOOST_THROW_EXCEPTION(std::runtime_error("Invalid SMT \"show unproved\" choice."));
 
 	auto const& showUnsupported = m_reader.stringSetting("SMTShowUnsupported", "yes");
 	if (showUnsupported == "no")
@@ -53,14 +52,14 @@ SMTCheckerTest::SMTCheckerTest(string const& _filename): SyntaxTest(_filename, E
 	else if (showUnsupported == "yes")
 		m_modelCheckerSettings.showUnsupported = true;
 	else
-		BOOST_THROW_EXCEPTION(runtime_error("Invalid SMT \"show unsupported\" choice."));
+		BOOST_THROW_EXCEPTION(std::runtime_error("Invalid SMT \"show unsupported\" choice."));
 
 	m_modelCheckerSettings.solvers = smtutil::SMTSolverChoice::None();
 	auto const& choice = m_reader.stringSetting("SMTSolvers", "z3");
 	if (choice == "none")
 		m_modelCheckerSettings.solvers = smtutil::SMTSolverChoice::None();
 	else if (!m_modelCheckerSettings.solvers.setSolver(choice))
-		BOOST_THROW_EXCEPTION(runtime_error("Invalid SMT solver choice."));
+		BOOST_THROW_EXCEPTION(std::runtime_error("Invalid SMT solver choice."));
 
 	m_modelCheckerSettings.solvers &= ModelChecker::availableSolvers();
 
@@ -71,13 +70,13 @@ SMTCheckerTest::SMTCheckerTest(string const& _filename): SyntaxTest(_filename, E
 	if (targets)
 		m_modelCheckerSettings.targets = *targets;
 	else
-		BOOST_THROW_EXCEPTION(runtime_error("Invalid SMT targets."));
+		BOOST_THROW_EXCEPTION(std::runtime_error("Invalid SMT targets."));
 
 	auto engine = ModelCheckerEngine::fromString(m_reader.stringSetting("SMTEngine", "all"));
 	if (engine)
 		m_modelCheckerSettings.engine = *engine;
 	else
-		BOOST_THROW_EXCEPTION(runtime_error("Invalid SMT engine choice."));
+		BOOST_THROW_EXCEPTION(std::runtime_error("Invalid SMT engine choice."));
 
 	if (m_modelCheckerSettings.solvers.none() || m_modelCheckerSettings.engine.none())
 		m_shouldRun = false;
@@ -88,10 +87,10 @@ SMTCheckerTest::SMTCheckerTest(string const& _filename): SyntaxTest(_filename, E
 	else if (ignoreCex == "yes")
 		m_ignoreCex = true;
 	else
-		BOOST_THROW_EXCEPTION(runtime_error("Invalid SMT counterexample choice."));
+		BOOST_THROW_EXCEPTION(std::runtime_error("Invalid SMT counterexample choice."));
 
-	static auto removeInv = [](vector<SyntaxTestError>&& errors) {
-		vector<SyntaxTestError> filtered;
+	static auto removeInv = [](std::vector<SyntaxTestError>&& errors) {
+		std::vector<SyntaxTestError> filtered;
 		for (auto&& e: errors)
 			if (e.errorId != 1180_error)
 				filtered.emplace_back(e);
@@ -106,10 +105,10 @@ SMTCheckerTest::SMTCheckerTest(string const& _filename): SyntaxTest(_filename, E
 	else if (ignoreInv == "yes")
 		m_modelCheckerSettings.invariants = ModelCheckerInvariants::None();
 	else
-		BOOST_THROW_EXCEPTION(runtime_error("Invalid SMT invariant choice."));
+		BOOST_THROW_EXCEPTION(std::runtime_error("Invalid SMT invariant choice."));
 
 	auto const& ignoreOSSetting = m_reader.stringSetting("SMTIgnoreOS", "none");
-	for (string const& os: ignoreOSSetting | ranges::views::split(',') | ranges::to<vector<string>>())
+	for (std::string const& os: ignoreOSSetting | ranges::views::split(',') | ranges::to<std::vector<std::string>>())
 	{
 #ifdef __APPLE__
 		if (os == "macos")
@@ -139,11 +138,11 @@ void SMTCheckerTest::filterObtainedErrors()
 	SyntaxTest::filterObtainedErrors();
 	m_unfilteredErrorList = m_errorList;
 
-	static auto removeCex = [](vector<SyntaxTestError>& errors) {
+	static auto removeCex = [](std::vector<SyntaxTestError>& errors) {
 		for (auto& e: errors)
 			if (
 				auto cexPos = e.message.find("\\nCounterexample");
-				cexPos != string::npos
+				cexPos != std::string::npos
 			)
 				e.message = e.message.substr(0, cexPos);
 	};
@@ -155,7 +154,7 @@ void SMTCheckerTest::filterObtainedErrors()
 	}
 }
 
-void SMTCheckerTest::printUpdatedExpectations(ostream &_stream, const string &_linePrefix) const {
+void SMTCheckerTest::printUpdatedExpectations(std::ostream &_stream, const std::string &_linePrefix) const {
 	if (!m_unfilteredErrorList.empty())
 		printErrorList(_stream, m_unfilteredErrorList, _linePrefix, false);
 	else

--- a/test/libsolidity/SemVerMatcher.cpp
+++ b/test/libsolidity/SemVerMatcher.cpp
@@ -31,7 +31,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 using namespace solidity::langutil;
 
 namespace solidity::frontend::test
@@ -42,16 +41,16 @@ BOOST_AUTO_TEST_SUITE(SemVerMatcher)
 namespace
 {
 
-SemVerMatchExpression parseExpression(string const& _input)
+SemVerMatchExpression parseExpression(std::string const& _input)
 {
 	CharStream stream(_input, "");
 	Scanner scanner{stream};
-	vector<string> literals;
-	vector<Token> tokens;
+	std::vector<std::string> literals;
+	std::vector<Token> tokens;
 	while (scanner.currentToken() != Token::EOS)
 	{
 		auto token = scanner.currentToken();
-		string literal = scanner.currentLiteral();
+		std::string literal = scanner.currentLiteral();
 		if (literal.empty() && TokenTraits::toString(token))
 			literal = TokenTraits::toString(token);
 		literals.push_back(literal);
@@ -100,7 +99,7 @@ BOOST_AUTO_TEST_CASE(exception_on_invalid_version_in_semverversion_constructor)
 BOOST_AUTO_TEST_CASE(positive_range)
 {
 	// Positive range tests
-	vector<pair<string, string>> tests = {
+	std::vector<std::pair<std::string, std::string>> tests = {
 		{"*", "1.2.3-foo"},
 		{"1.0.0 - 2.0.0", "1.2.3"},
 		{"1.0.0", "1.0.0"},
@@ -198,7 +197,7 @@ BOOST_AUTO_TEST_CASE(positive_range)
 BOOST_AUTO_TEST_CASE(negative_range)
 {
 	// Negative range tests
-	vector<pair<string, string>> tests = {
+	std::vector<std::pair<std::string, std::string>> tests = {
 		{"^0^1", "0.0.0"},
 		{"^0^1", "1.0.0"},
 		{"1.0.0 - 2.0.0", "2.2.3"},

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -34,7 +34,6 @@
 #include <string>
 #include <utility>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::yul;
 using namespace solidity::langutil;
@@ -43,9 +42,10 @@ using namespace solidity::util::formatting;
 using namespace solidity::frontend::test;
 using namespace boost::algorithm;
 using namespace boost::unit_test;
+using namespace std::string_literals;
 namespace fs = boost::filesystem;
 
-ostream& solidity::frontend::test::operator<<(ostream& _output, RequiresYulOptimizer _requiresYulOptimizer)
+std::ostream& solidity::frontend::test::operator<<(std::ostream& _output, RequiresYulOptimizer _requiresYulOptimizer)
 {
 	switch (_requiresYulOptimizer)
 	{
@@ -57,10 +57,10 @@ ostream& solidity::frontend::test::operator<<(ostream& _output, RequiresYulOptim
 }
 
 SemanticTest::SemanticTest(
-	string const& _filename,
+	std::string const& _filename,
 	langutil::EVMVersion _evmVersion,
-	optional<uint8_t> _eofVersion,
-	vector<boost::filesystem::path> const& _vmPaths,
+	std::optional<uint8_t> _eofVersion,
+	std::vector<boost::filesystem::path> const& _vmPaths,
 	bool _enforceGasCost,
 	u256 _enforceGasCostMinValue
 ):
@@ -73,9 +73,9 @@ SemanticTest::SemanticTest(
 	m_enforceGasCost(_enforceGasCost),
 	m_enforceGasCostMinValue(std::move(_enforceGasCostMinValue))
 {
-	static set<string> const compileViaYulAllowedValues{"also", "true", "false"};
-	static set<string> const yulRunTriggers{"also", "true"};
-	static set<string> const legacyRunTriggers{"also", "false", "default"};
+	static std::set<std::string> const compileViaYulAllowedValues{"also", "true", "false"};
+	static std::set<std::string> const yulRunTriggers{"also", "true"};
+	static std::set<std::string> const legacyRunTriggers{"also", "false", "default"};
 
 	m_requiresYulOptimizer = m_reader.enumSetting<RequiresYulOptimizer>(
 		"requiresYulOptimizer",
@@ -91,14 +91,14 @@ SemanticTest::SemanticTest(
 	if (m_runWithABIEncoderV1Only && !solidity::test::CommonOptions::get().useABIEncoderV1)
 		m_shouldRun = false;
 
-	string compileViaYul = m_reader.stringSetting("compileViaYul", "also");
+	std::string compileViaYul = m_reader.stringSetting("compileViaYul", "also");
 	if (m_runWithABIEncoderV1Only && compileViaYul != "false")
-		BOOST_THROW_EXCEPTION(runtime_error(
+		BOOST_THROW_EXCEPTION(std::runtime_error(
 			"ABIEncoderV1Only tests cannot be run via yul, "
 			"so they need to also specify ``compileViaYul: false``"
 		));
 	if (!util::contains(compileViaYulAllowedValues, compileViaYul))
-		BOOST_THROW_EXCEPTION(runtime_error("Invalid compileViaYul value: " + compileViaYul + "."));
+		BOOST_THROW_EXCEPTION(std::runtime_error("Invalid compileViaYul value: " + compileViaYul + "."));
 	m_testCaseWantsYulRun = util::contains(yulRunTriggers, compileViaYul);
 	m_testCaseWantsLegacyRun = util::contains(legacyRunTriggers, compileViaYul);
 
@@ -118,19 +118,19 @@ SemanticTest::SemanticTest(
 	}
 }
 
-map<string, Builtin> SemanticTest::makeBuiltins()
+std::map<std::string, Builtin> SemanticTest::makeBuiltins()
 {
 	return {
 		{
 			"isoltest_builtin_test",
-			[](FunctionCall const&) -> optional<bytes>
+			[](FunctionCall const&) -> std::optional<bytes>
 			{
 				return toBigEndian(u256(0x1234));
 			}
 		},
 		{
 			"isoltest_side_effects_test",
-			[](FunctionCall const& _call) -> optional<bytes>
+			[](FunctionCall const& _call) -> std::optional<bytes>
 			{
 				if (_call.arguments.parameters.empty())
 					return toBigEndian(0);
@@ -140,7 +140,7 @@ map<string, Builtin> SemanticTest::makeBuiltins()
 		},
 		{
 			"balance",
-			[this](FunctionCall const& _call) -> optional<bytes>
+			[this](FunctionCall const& _call) -> std::optional<bytes>
 			{
 				soltestAssert(_call.arguments.parameters.size() <= 1, "Account address expected.");
 				h160 address;
@@ -153,7 +153,7 @@ map<string, Builtin> SemanticTest::makeBuiltins()
 		},
 		{
 			"storageEmpty",
-			[this](FunctionCall const& _call) -> optional<bytes>
+			[this](FunctionCall const& _call) -> std::optional<bytes>
 			{
 				soltestAssert(_call.arguments.parameters.empty(), "No arguments expected.");
 				return toBigEndian(u256(storageEmpty(m_contractAddress) ? 1 : 0));
@@ -161,7 +161,7 @@ map<string, Builtin> SemanticTest::makeBuiltins()
 		},
 		{
 			"account",
-			[this](FunctionCall const& _call) -> optional<bytes>
+			[this](FunctionCall const& _call) -> std::optional<bytes>
 			{
 				soltestAssert(_call.arguments.parameters.size() == 1, "Account number expected.");
 				size_t accountNumber = static_cast<size_t>(stoi(_call.arguments.parameters.at(0).rawString));
@@ -172,15 +172,15 @@ map<string, Builtin> SemanticTest::makeBuiltins()
 	};
 }
 
-vector<SideEffectHook> SemanticTest::makeSideEffectHooks() const
+std::vector<SideEffectHook> SemanticTest::makeSideEffectHooks() const
 {
 	using namespace std::placeholders;
 	return {
-		[](FunctionCall const& _call) -> vector<string>
+		[](FunctionCall const& _call) -> std::vector<std::string>
 		{
 			if (_call.signature == "isoltest_side_effects_test")
 			{
-				vector<string> result;
+				std::vector<std::string> result;
 				for (auto const& argument: _call.arguments.parameters)
 					result.emplace_back(util::toHex(argument.rawBytes));
 				return result;
@@ -191,7 +191,7 @@ vector<SideEffectHook> SemanticTest::makeSideEffectHooks() const
 	};
 }
 
-string SemanticTest::formatEventParameter(optional<AnnotatedEventSignature> _signature, bool _indexed, size_t _index, bytes const& _data)
+std::string SemanticTest::formatEventParameter(std::optional<AnnotatedEventSignature> _signature, bool _indexed, size_t _index, bytes const& _data)
 {
 	auto isPrintableASCII = [](bytes const& s)
 	{
@@ -214,7 +214,7 @@ string SemanticTest::formatEventParameter(optional<AnnotatedEventSignature> _sig
 		abiType = ABIType(ABIType::Type::String);
 	if (_signature.has_value())
 	{
-		vector<string> const& types = _indexed ? _signature->indexedTypes : _signature->nonIndexedTypes;
+		std::vector<std::string> const& types = _indexed ? _signature->indexedTypes : _signature->nonIndexedTypes;
 		if (_index < types.size())
 		{
 			if (types.at(_index) == "bool")
@@ -224,16 +224,16 @@ string SemanticTest::formatEventParameter(optional<AnnotatedEventSignature> _sig
 	return BytesUtils::formatBytes(_data, abiType);
 }
 
-vector<string> SemanticTest::eventSideEffectHook(FunctionCall const&) const
+std::vector<std::string> SemanticTest::eventSideEffectHook(FunctionCall const&) const
 {
-	vector<string> sideEffects;
-	vector<LogRecord> recordedLogs = ExecutionFramework::recordedLogs();
+	std::vector<std::string> sideEffects;
+	std::vector<LogRecord> recordedLogs = ExecutionFramework::recordedLogs();
 	for (LogRecord const& log: recordedLogs)
 	{
-		optional<AnnotatedEventSignature> eventSignature;
+		std::optional<AnnotatedEventSignature> eventSignature;
 		if (!log.topics.empty())
 			eventSignature = matchEvent(log.topics[0]);
-		stringstream sideEffect;
+		std::stringstream sideEffect;
 		sideEffect << "emit ";
 		if (eventSignature.has_value())
 			sideEffect << eventSignature.value().signature;
@@ -243,7 +243,7 @@ vector<string> SemanticTest::eventSideEffectHook(FunctionCall const&) const
 		if (m_contractAddress != log.creator)
 			sideEffect << " from 0x" << log.creator;
 
-		vector<string> eventStrings;
+		std::vector<std::string> eventStrings;
 		size_t index{0};
 		for (h256 const& topic: log.topics)
 		{
@@ -268,10 +268,10 @@ vector<string> SemanticTest::eventSideEffectHook(FunctionCall const&) const
 	return sideEffects;
 }
 
-optional<AnnotatedEventSignature> SemanticTest::matchEvent(util::h256 const& hash) const
+std::optional<AnnotatedEventSignature> SemanticTest::matchEvent(util::h256 const& hash) const
 {
-	optional<AnnotatedEventSignature> result;
-	for (string& contractName: m_compiler.contractNames())
+	std::optional<AnnotatedEventSignature> result;
+	for (std::string& contractName: m_compiler.contractNames())
 	{
 		ContractDefinition const& contract = m_compiler.contractDefinition(contractName);
 		for (EventDefinition const* event: contract.events())
@@ -312,7 +312,7 @@ frontend::OptimiserSettings SemanticTest::optimizerSettingsFor(RequiresYulOptimi
 	unreachable();
 }
 
-TestCase::TestResult SemanticTest::run(ostream& _stream, string const& _linePrefix, bool _formatted)
+TestCase::TestResult SemanticTest::run(std::ostream& _stream, std::string const& _linePrefix, bool _formatted)
 {
 	TestResult result = TestResult::Success;
 
@@ -338,8 +338,8 @@ TestCase::TestResult SemanticTest::run(ostream& _stream, string const& _linePref
 }
 
 TestCase::TestResult SemanticTest::runTest(
-	ostream& _stream,
-	string const& _linePrefix,
+	std::ostream& _stream,
+	std::string const& _linePrefix,
 	bool _formatted,
 	bool _isYulRun
 )
@@ -354,12 +354,12 @@ TestCase::TestResult SemanticTest::runTest(
 	m_compileViaYul = _isYulRun;
 
 	if (_isYulRun)
-		AnsiColorized(_stream, _formatted, {BOLD, CYAN}) << _linePrefix << "Running via Yul: " << endl;
+		AnsiColorized(_stream, _formatted, {BOLD, CYAN}) << _linePrefix << "Running via Yul: " << std::endl;
 
 	for (TestFunctionCall& test: m_tests)
 		test.reset();
 
-	map<string, solidity::test::Address> libraries;
+	std::map<std::string, solidity::test::Address> libraries;
 
 	bool constructed = false;
 
@@ -416,7 +416,7 @@ TestCase::TestResult SemanticTest::runTest(
 				output = callLowLevel(test.call().arguments.rawBytes(), test.call().value.value);
 			else if (test.call().kind == FunctionCall::Kind::Builtin)
 			{
-				optional<bytes> builtinOutput = m_builtins.at(test.call().signature)(test.call());
+				std::optional<bytes> builtinOutput = m_builtins.at(test.call().signature)(test.call());
 				if (builtinOutput.has_value())
 				{
 					m_transactionSuccessful = true;
@@ -460,7 +460,7 @@ TestCase::TestResult SemanticTest::runTest(
 				test.setContractABI(m_compiler.contractABI(m_compiler.lastContractName(m_sources.mainSourceFile)));
 		}
 
-		vector<string> effects;
+		std::vector<std::string> effects;
 		for (SideEffectHook const& hook: m_sideEffectHooks)
 			effects += hook(test.call());
 		test.setSideEffects(std::move(effects));
@@ -470,7 +470,7 @@ TestCase::TestResult SemanticTest::runTest(
 
 	if (!success)
 	{
-		AnsiColorized(_stream, _formatted, {BOLD, CYAN}) << _linePrefix << "Expected result:" << endl;
+		AnsiColorized(_stream, _formatted, {BOLD, CYAN}) << _linePrefix << "Expected result:" << std::endl;
 		for (TestFunctionCall const& test: m_tests)
 		{
 			ErrorReporter errorReporter;
@@ -480,11 +480,11 @@ TestCase::TestResult SemanticTest::runTest(
 				TestFunctionCall::RenderMode::ExpectedValuesExpectedGas,
 				_formatted,
 				/* _interactivePrint */ true
-			) << endl;
+			) << std::endl;
 			_stream << errorReporter.format(_linePrefix, _formatted);
 		}
-		_stream << endl;
-		AnsiColorized(_stream, _formatted, {BOLD, CYAN}) << _linePrefix << "Obtained result:" << endl;
+		_stream << std::endl;
+		AnsiColorized(_stream, _formatted, {BOLD, CYAN}) << _linePrefix << "Obtained result:" << std::endl;
 		for (TestFunctionCall const& test: m_tests)
 		{
 			ErrorReporter errorReporter;
@@ -494,22 +494,22 @@ TestCase::TestResult SemanticTest::runTest(
 				m_gasCostFailure ? TestFunctionCall::RenderMode::ExpectedValuesActualGas : TestFunctionCall::RenderMode::ActualValuesExpectedGas,
 				_formatted,
 				/* _interactivePrint */ true
-			) << endl;
+			) << std::endl;
 			_stream << errorReporter.format(_linePrefix, _formatted);
 		}
 		AnsiColorized(_stream, _formatted, {BOLD, RED})
-			<< _linePrefix << endl
-			<< _linePrefix << "Attention: Updates on the test will apply the detected format displayed." << endl;
+			<< _linePrefix << std::endl
+			<< _linePrefix << "Attention: Updates on the test will apply the detected format displayed." << std::endl;
 		if (_isYulRun && m_testCaseWantsLegacyRun)
 		{
-			_stream << _linePrefix << endl << _linePrefix;
+			_stream << _linePrefix << std::endl << _linePrefix;
 			AnsiColorized(_stream, _formatted, {RED_BACKGROUND}) << "Note that the test passed without Yul.";
-			_stream << endl;
+			_stream << std::endl;
 		}
 		else if (!_isYulRun && m_testCaseWantsYulRun)
 			AnsiColorized(_stream, _formatted, {BOLD, YELLOW})
-				<< _linePrefix << endl
-				<< _linePrefix << "Note that the test also has to pass via Yul." << endl;
+				<< _linePrefix << std::endl
+				<< _linePrefix << "Note that the test also has to pass via Yul." << std::endl;
 		return TestResult::Failure;
 	}
 
@@ -551,9 +551,9 @@ TestCase::TestResult SemanticTest::tryRunTestWithYulOptimizer(
 			soltestAssert(result == TestResult::Success || result == TestResult::Failure);
 
 			AnsiColorized(_stream, _formatted, {BOLD, YELLOW})
-				<< _linePrefix << endl
+				<< _linePrefix << std::endl
 				<< _linePrefix << "requiresYulOptimizer is set to " << m_requiresYulOptimizer
-				<< " but should be " << requiresYulOptimizer << endl;
+				<< " but should be " << requiresYulOptimizer << std::endl;
 			m_requiresYulOptimizer = requiresYulOptimizer;
 			return TestResult::Failure;
 		}
@@ -565,7 +565,7 @@ TestCase::TestResult SemanticTest::tryRunTestWithYulOptimizer(
 
 bool SemanticTest::checkGasCostExpectation(TestFunctionCall& io_test, bool _compileViaYul) const
 {
-	string setting =
+	std::string setting =
 		(_compileViaYul ? "ir"s : "legacy"s) +
 		(m_optimiserSettings == OptimiserSettings::full() ? "Optimized" : "");
 
@@ -592,27 +592,27 @@ bool SemanticTest::checkGasCostExpectation(TestFunctionCall& io_test, bool _comp
 		m_gasUsed == io_test.call().expectations.gasUsed.at(setting);
 }
 
-void SemanticTest::printSource(ostream& _stream, string const& _linePrefix, bool _formatted) const
+void SemanticTest::printSource(std::ostream& _stream, std::string const& _linePrefix, bool _formatted) const
 {
 	if (m_sources.sources.empty())
 		return;
 
 	bool outputNames = (m_sources.sources.size() - m_sources.externalSources.size() != 1 || !m_sources.sources.begin()->first.empty());
 
-	set<string> externals;
+	std::set<std::string> externals;
 	for (auto const& [name, path]: m_sources.externalSources)
 	{
 		externals.insert(name);
-		string externalSource;
+		std::string externalSource;
 		if (name == path)
 			externalSource = name;
 		else
 			externalSource = name + "=" + path.generic_string();
 
 		if (_formatted)
-			_stream << _linePrefix  << formatting::CYAN << "==== ExternalSource: " << externalSource << " ===="s << formatting::RESET << endl;
+			_stream << _linePrefix  << formatting::CYAN << "==== ExternalSource: " << externalSource << " ===="s << formatting::RESET << std::endl;
 		else
-			_stream << _linePrefix << "==== ExternalSource: " << externalSource << " ===="s << endl;
+			_stream << _linePrefix << "==== ExternalSource: " << externalSource << " ===="s << std::endl;
 	}
 
 	for (auto const& [name, source]: m_sources.sources)
@@ -625,9 +625,9 @@ void SemanticTest::printSource(ostream& _stream, string const& _linePrefix, bool
 
 				if (outputNames)
 					_stream << _linePrefix << formatting::CYAN << "==== Source: " << name
-							<< " ====" << formatting::RESET << endl;
+							<< " ====" << formatting::RESET << std::endl;
 
-				vector<char const*> sourceFormatting(source.length(), formatting::RESET);
+				std::vector<char const*> sourceFormatting(source.length(), formatting::RESET);
 				_stream << _linePrefix << sourceFormatting.front() << source.front();
 				for (size_t i = 1; i < source.length(); i++)
 				{
@@ -637,7 +637,7 @@ void SemanticTest::printSource(ostream& _stream, string const& _linePrefix, bool
 						_stream << source[i];
 					else
 					{
-						_stream << formatting::RESET << endl;
+						_stream << formatting::RESET << std::endl;
 						if (i + 1 < source.length())
 							_stream << _linePrefix << sourceFormatting[i];
 					}
@@ -647,50 +647,50 @@ void SemanticTest::printSource(ostream& _stream, string const& _linePrefix, bool
 			else
 			{
 				if (outputNames)
-					_stream << _linePrefix << "==== Source: " + name << " ====" << endl;
-				stringstream stream(source);
-				string line;
+					_stream << _linePrefix << "==== Source: " + name << " ====" << std::endl;
+				std::stringstream stream(source);
+				std::string line;
 				while (getline(stream, line))
-					_stream << _linePrefix << line << endl;
+					_stream << _linePrefix << line << std::endl;
 			}
 		}
 }
 
-void SemanticTest::printUpdatedExpectations(ostream& _stream, string const&) const
+void SemanticTest::printUpdatedExpectations(std::ostream& _stream, std::string const&) const
 {
 	for (TestFunctionCall const& test: m_tests)
 		_stream << test.format(
 			"",
 			m_gasCostFailure ? TestFunctionCall::RenderMode::ExpectedValuesActualGas : TestFunctionCall::RenderMode::ActualValuesExpectedGas,
 			/* _highlight = */ false
-		) << endl;
+		) << std::endl;
 }
 
-void SemanticTest::printUpdatedSettings(ostream& _stream, string const& _linePrefix)
+void SemanticTest::printUpdatedSettings(std::ostream& _stream, std::string const& _linePrefix)
 {
 	auto& settings = m_reader.settings();
 	if (settings.empty() && m_requiresYulOptimizer == RequiresYulOptimizer::False)
 		return;
 
-	_stream << _linePrefix << "// ====" << endl;
+	_stream << _linePrefix << "// ====" << std::endl;
 	if (m_requiresYulOptimizer != RequiresYulOptimizer::False)
-		_stream << _linePrefix << "// requiresYulOptimizer: " << m_requiresYulOptimizer << endl;
+		_stream << _linePrefix << "// requiresYulOptimizer: " << m_requiresYulOptimizer << std::endl;
 
 	for (auto const& [settingName, settingValue]: settings)
 		if (settingName != "requiresYulOptimizer")
-			_stream << _linePrefix << "// " << settingName << ": " << settingValue<< endl;
+			_stream << _linePrefix << "// " << settingName << ": " << settingValue<< std::endl;
 }
 
-void SemanticTest::parseExpectations(istream& _stream)
+void SemanticTest::parseExpectations(std::istream& _stream)
 {
 	m_tests += TestFileParser{_stream, m_builtins}.parseFunctionCalls(m_lineOffset);
 }
 
 bool SemanticTest::deploy(
-	string const& _contractName,
+	std::string const& _contractName,
 	u256 const& _value,
 	bytes const& _arguments,
-	map<string, solidity::test::Address> const& _libraries
+	std::map<std::string, solidity::test::Address> const& _libraries
 )
 {
 	auto output = compileAndRunWithoutCheck(m_sources.sources, _value, _contractName, _arguments, _libraries, m_sources.mainSourceFile);

--- a/test/libsolidity/SolidityCompiler.cpp
+++ b/test/libsolidity/SolidityCompiler.cpp
@@ -24,7 +24,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 
 namespace solidity::frontend::test
 {

--- a/test/libsolidity/SolidityEndToEndTest.cpp
+++ b/test/libsolidity/SolidityEndToEndTest.cpp
@@ -46,7 +46,6 @@
 #include <string>
 #include <tuple>
 
-using namespace std;
 using namespace std::placeholders;
 using namespace solidity;
 using namespace solidity::util;
@@ -90,7 +89,7 @@ BOOST_FIXTURE_TEST_SUITE(SolidityEndToEndTest, SolidityEndToEndTestExecutionFram
 
 BOOST_AUTO_TEST_CASE(creation_code_optimizer)
 {
-	string codeC = R"(
+	std::string codeC = R"(
 		contract C {
 			constructor(uint x) {
 			if (x == 0xFFFFFFFFFFFFFFFF42)
@@ -98,7 +97,7 @@ BOOST_AUTO_TEST_CASE(creation_code_optimizer)
 			}
 		}
 	)";
-	string codeD = R"(
+	std::string codeD = R"(
 		contract D {
 			function f() public pure returns (bytes memory) {
 				return type(C).creationCode;
@@ -170,7 +169,7 @@ BOOST_AUTO_TEST_CASE(recursive_calls)
 	)";
 	ALSO_VIA_YUL(
 		compileAndRun(sourceCode);
-		function<u256(u256)> recursive_calls_cpp = [&recursive_calls_cpp](u256 const& n) -> u256
+		std::function<u256(u256)> recursive_calls_cpp = [&recursive_calls_cpp](u256 const& n) -> u256
 		{
 			if (n <= 1)
 				return 1;
@@ -742,7 +741,7 @@ BOOST_AUTO_TEST_CASE(mapping_state_inc_dec)
 	)";
 
 	u256 value;
-	map<u256, u256> table;
+	std::map<u256, u256> table;
 	auto f = [&](u256 const& _x) -> u256
 	{
 		value = _x;
@@ -775,7 +774,7 @@ BOOST_AUTO_TEST_CASE(multi_level_mapping)
 			}
 		}
 	)";
-	map<u256, map<u256, u256>> table;
+	std::map<u256, std::map<u256, u256>> table;
 	auto f = [&](u256 const& _x, u256 const& _y, u256 const& _z) -> u256
 	{
 		if (_z == 0) return table[_x][_y];
@@ -810,7 +809,7 @@ BOOST_AUTO_TEST_CASE(constructor)
 		}
 	)";
 
-	map<u256, uint8_t> data;
+	std::map<u256, uint8_t> data;
 	data[7] = 8;
 	auto get = [&](u256 const& _x) -> u256
 	{
@@ -1069,7 +1068,7 @@ BOOST_AUTO_TEST_CASE(fixed_bytes_in_calls)
 	compileAndRun(sourceCode, 0, "Main");
 	BOOST_REQUIRE(callContractFunction("setHelper(address)", c_helperAddress) == bytes());
 	BOOST_REQUIRE(callContractFunction("getHelper()", c_helperAddress) == encodeArgs(c_helperAddress));
-	ABI_CHECK(callContractFunction("callHelper(bytes2,bool)", string("\0a", 2), true), encodeArgs(string("\0a\0\0\0", 5)));
+	ABI_CHECK(callContractFunction("callHelper(bytes2,bool)", std::string("\0a", 2), true), encodeArgs(std::string("\0a\0\0\0", 5)));
 }
 
 BOOST_AUTO_TEST_CASE(constructor_with_long_arguments)
@@ -1085,8 +1084,8 @@ BOOST_AUTO_TEST_CASE(constructor_with_long_arguments)
 			}
 		}
 	)";
-	string a = "01234567890123gabddunaouhdaoneudapcgadi4567890789012oneudapcgadi4567890789012oneudapcgadi4567890789012oneudapcgadi4567890789012oneudapcgadi4567890789012oneudapcgadi4567890789012oneudapcgadi4567890789012oneudapcgadi45678907890123456789abcd123456787890123456789abcd90123456789012345678901234567890123456789aboneudapcgadi4567890789012oneudapcgadi4567890789012oneudapcgadi45678907890123456789abcd123456787890123456789abcd90123456789012345678901234567890123456789aboneudapcgadi4567890789012oneudapcgadi4567890789012oneudapcgadi45678907890123456789abcd123456787890123456789abcd90123456789012345678901234567890123456789aboneudapcgadi4567890789012cdef";
-	string b = "AUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PY";
+	std::string a = "01234567890123gabddunaouhdaoneudapcgadi4567890789012oneudapcgadi4567890789012oneudapcgadi4567890789012oneudapcgadi4567890789012oneudapcgadi4567890789012oneudapcgadi4567890789012oneudapcgadi4567890789012oneudapcgadi45678907890123456789abcd123456787890123456789abcd90123456789012345678901234567890123456789aboneudapcgadi4567890789012oneudapcgadi4567890789012oneudapcgadi45678907890123456789abcd123456787890123456789abcd90123456789012345678901234567890123456789aboneudapcgadi4567890789012oneudapcgadi4567890789012oneudapcgadi45678907890123456789abcd123456787890123456789abcd90123456789012345678901234567890123456789aboneudapcgadi4567890789012cdef";
+	std::string b = "AUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PYAUTAHIACIANOTUHAOCUHAOEUNAOEHUNTHDYDHPYDRCPYDRSTITOEUBXHUDGO>PY";
 
 	compileAndRun(sourceCode, 0, "Main", encodeArgs(
 		u256(0x40),
@@ -1141,7 +1140,7 @@ BOOST_AUTO_TEST_CASE(blockhash)
 	while (blockNumber() < u256(255))
 		ABI_CHECK(callContractFunction("g()"), encodeArgs(true));
 
-	vector<u256> hashes;
+	std::vector<u256> hashes;
 	// ``blockhash()`` is only valid for the last 256 blocks, otherwise zero
 	hashes.emplace_back(0);
 	for (u256 i = blockNumber() - u256(255); i <= blockNumber(); i++)
@@ -1263,7 +1262,7 @@ BOOST_AUTO_TEST_CASE(generic_delegatecall)
 
 	for (auto v2: {false, true})
 	{
-		string source = "pragma abicoder " + string(v2 ? "v2" : "v1") + ";\n" + string(sourceCode);
+		std::string source = "pragma abicoder " + std::string(v2 ? "v2" : "v1") + ";\n" + std::string(sourceCode);
 
 		compileAndRun(source, 0, "Receiver");
 		h160 const c_receiverAddress = m_contractAddress;
@@ -1354,7 +1353,7 @@ BOOST_AUTO_TEST_CASE(library_call_protection)
 		ABI_CHECK(callContractFunction("np(Lib.S storage)", 0), encodeArgs());
 		ABI_CHECK(callContractFunction("v(Lib.S storage)", 0), encodeArgs(m_sender));
 		ABI_CHECK(callContractFunction("pu()"), encodeArgs(2));
-		compileAndRun(sourceCode, 0, "Test", bytes(), map<string, h160>{{":Lib", m_contractAddress}});
+		compileAndRun(sourceCode, 0, "Test", bytes(), std::map<std::string, h160>{{":Lib", m_contractAddress}});
 		ABI_CHECK(callContractFunction("s()"), encodeArgs(0));
 		ABI_CHECK(callContractFunction("np()"), encodeArgs(m_sender));
 		ABI_CHECK(callContractFunction("s()"), encodeArgs(3));
@@ -1420,7 +1419,7 @@ BOOST_AUTO_TEST_CASE(call_forward_bytes_length)
 		ABI_CHECK(callContractFunction("viaStorage()"), encodeArgs(4));
 
 		// Some additional unpadded data
-		bytes unpadded = asBytes(string("abc"));
+		bytes unpadded = asBytes(std::string("abc"));
 		ABI_CHECK(callContractFunctionNoEncoding("viaCalldata()", unpadded), encodeArgs(7));
 		ABI_CHECK(callContractFunctionNoEncoding("viaMemory()", unpadded), encodeArgs(7));
 		ABI_CHECK(callContractFunctionNoEncoding("viaStorage()", unpadded), encodeArgs(7));
@@ -1535,7 +1534,7 @@ BOOST_AUTO_TEST_CASE(struct_referencing)
 		compileAndRun(sourceCode, 0, "L");
 		ABI_CHECK(callContractFunction("f()"), encodeArgs(0, 3));
 		ABI_CHECK(callContractFunction("g()"), encodeArgs(4));
-		compileAndRun(sourceCode, 0, "C", bytes(), map<string, h160>{ {":L", m_contractAddress}});
+		compileAndRun(sourceCode, 0, "C", bytes(), std::map<std::string, h160>{ {":L", m_contractAddress}});
 		ABI_CHECK(callContractFunction("f()"), encodeArgs(1));
 		ABI_CHECK(callContractFunction("g()"), encodeArgs(2));
 		ABI_CHECK(callContractFunction("h()"), encodeArgs(0, 5));
@@ -1583,7 +1582,7 @@ BOOST_AUTO_TEST_CASE(enum_referencing)
 		compileAndRun(sourceCode, 0, "L");
 		ABI_CHECK(callContractFunction("f()"), encodeArgs(1));
 		ABI_CHECK(callContractFunction("g()"), encodeArgs(3));
-		compileAndRun(sourceCode, 0, "C", bytes(), map<string, h160>{{":L", m_contractAddress}});
+		compileAndRun(sourceCode, 0, "C", bytes(), std::map<std::string, h160>{{":L", m_contractAddress}});
 		ABI_CHECK(callContractFunction("f()"), encodeArgs(3));
 		ABI_CHECK(callContractFunction("g()"), encodeArgs(3));
 		ABI_CHECK(callContractFunction("h()"), encodeArgs(1));
@@ -1612,8 +1611,8 @@ BOOST_AUTO_TEST_CASE(bytes_in_arguments)
 	ALSO_VIA_YUL(
 		compileAndRun(sourceCode);
 
-		string innercalldata1 = asString(util::selectorFromSignatureH32("f(uint256,uint256)").asBytes() + encodeArgs(8, 9));
-		string innercalldata2 = asString(util::selectorFromSignatureH32("g(uint256)").asBytes() + encodeArgs(3));
+		std::string innercalldata1 = asString(util::selectorFromSignatureH32("f(uint256,uint256)").asBytes() + encodeArgs(8, 9));
+		std::string innercalldata2 = asString(util::selectorFromSignatureH32("g(uint256)").asBytes() + encodeArgs(3));
 		bytes calldata = encodeArgs(
 			12, 32 * 4, u256(32 * 4 + 32 + (innercalldata1.length() + 31) / 32 * 32), 13,
 			u256(innercalldata1.length()), innercalldata1,
@@ -1765,20 +1764,20 @@ BOOST_AUTO_TEST_CASE(return_multiple_strings_of_various_sizes)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Main");
-	string s1(
+	std::string s1(
 		"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
 		"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
 		"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
 		"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
 	);
-	string s2(
+	std::string s2(
 		"ABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZ"
 		"ABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZ"
 		"ABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZ"
 		"ABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZ"
 		"ABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZ"
 	);
-	vector<size_t> lengths{0, 30, 32, 63, 64, 65, 210, 300};
+	std::vector<size_t> lengths{0, 30, 32, 63, 64, 65, 210, 300};
 	for (auto l1: lengths)
 		for (auto l2: lengths)
 		{
@@ -1813,8 +1812,8 @@ BOOST_AUTO_TEST_CASE(accessor_involving_strings)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Main");
-	string s1("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz");
-	string s2("ABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZ");
+	std::string s1("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz");
+	std::string s2("ABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZ");
 	bytes s1Data = encodeArgs(u256(s1.length()), s1);
 	bytes s2Data = encodeArgs(u256(s2.length()), s2);
 	u256 b = 765;
@@ -1846,9 +1845,9 @@ BOOST_AUTO_TEST_CASE(bytes_in_function_calls)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Main");
-	string s1("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz");
-	string s2("ABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZ");
-	vector<size_t> lengths{0, 31, 64, 65};
+	std::string s1("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz");
+	std::string s2("ABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZABCDEFGHIJKLMNOPQRSTUVXYZ");
+	std::vector<size_t> lengths{0, 31, 64, 65};
 	for (auto l1: lengths)
 		for (auto l2: lengths)
 		{
@@ -1888,8 +1887,8 @@ BOOST_AUTO_TEST_CASE(return_bytes_internal)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Main");
-	string s1("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz");
-	vector<size_t> lengths{0, 31, 64, 65};
+	std::string s1("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz");
+	std::vector<size_t> lengths{0, 31, 64, 65};
 	for (auto l1: lengths)
 	{
 		bytes dyn1 = encodeArgs(u256(l1), s1.substr(0, l1));
@@ -1951,7 +1950,7 @@ BOOST_AUTO_TEST_CASE(calldata_struct_function_type)
 
 BOOST_AUTO_TEST_CASE(calldata_array_dynamic_three_dimensional)
 {
-	vector<vector<vector<u256>>> data {
+	std::vector<std::vector<std::vector<u256>>> data {
 		{
 			{ 0x010A01, 0x010A02, 0x010A03 },
 			{ 0x010B01, 0x010B02, 0x010B03 }
@@ -1970,12 +1969,12 @@ BOOST_AUTO_TEST_CASE(calldata_array_dynamic_three_dimensional)
 		if (!outerDynamicallySized && !middleDynamicallySized && !innerDynamicallySized)
 			continue;
 
-		string arrayType = "uint256";
+		std::string arrayType = "uint256";
 		arrayType += innerDynamicallySized ? "[]" : "[3]";
 		arrayType += middleDynamicallySized ? "[]" : "[2]";
 		arrayType += outerDynamicallySized ? "[]" : "[2]";
 
-		string sourceCode = R"(
+		std::string sourceCode = R"(
 			pragma abicoder v2;
 			contract C {
 				function test()" + arrayType + R"( calldata a) external returns (uint256) {
@@ -2049,16 +2048,16 @@ BOOST_AUTO_TEST_CASE(literal_strings)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Test");
-	string longStr = "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789001234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678900123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789001234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
-	string medium = "01234567890123456789012345678901234567890123456789012345678901234567890123456789";
-	string shortStr = "123";
-	string hello = "Hello, World!";
+	std::string longStr = "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789001234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678900123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789001234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
+	std::string medium = "01234567890123456789012345678901234567890123456789012345678901234567890123456789";
+	std::string shortStr = "123";
+	std::string hello = "Hello, World!";
 
 	ABI_CHECK(callContractFunction("f()"), encodeDyn(hello));
 	ABI_CHECK(callContractFunction("long()"), encodeDyn(longStr));
 	ABI_CHECK(callContractFunction("medium()"), encodeDyn(medium));
 	ABI_CHECK(callContractFunction("short()"), encodeDyn(shortStr));
-	ABI_CHECK(callContractFunction("empty()"), encodeDyn(string()));
+	ABI_CHECK(callContractFunction("empty()"), encodeDyn(std::string()));
 }
 
 BOOST_AUTO_TEST_CASE(initialise_string_constant)
@@ -2070,8 +2069,8 @@ BOOST_AUTO_TEST_CASE(initialise_string_constant)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Test");
-	string longStr = "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789001234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678900123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789001234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
-	string shortStr = "abcdef";
+	std::string longStr = "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789001234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678900123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789001234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
+	std::string shortStr = "abcdef";
 
 	ABI_CHECK(callContractFunction("long()"), encodeDyn(longStr));
 	ABI_CHECK(callContractFunction("short()"), encodeDyn(shortStr));
@@ -2087,7 +2086,7 @@ BOOST_AUTO_TEST_CASE(string_as_mapping_key)
 		}
 	)";
 
-	vector<string> strings{
+	std::vector<std::string> strings{
 		"Hello, World!",
 		"Hello,                            World!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1111",
 		"",
@@ -2123,7 +2122,7 @@ BOOST_AUTO_TEST_CASE(string_as_public_mapping_key)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Test");
-	vector<string> strings{
+	std::vector<std::string> strings{
 		"Hello, World!",
 		"Hello,                            World!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1111",
 		"",
@@ -2156,7 +2155,7 @@ BOOST_AUTO_TEST_CASE(nested_string_as_public_mapping_key)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "Test");
-	vector<string> strings{
+	std::vector<std::string> strings{
 		"Hello, World!",
 		"Hello,                            World!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1111",
 		"",
@@ -2211,13 +2210,13 @@ BOOST_AUTO_TEST_CASE(nested_mixed_string_as_public_mapping_key)
 
 	struct Index
 	{
-		string s1;
+		std::string s1;
 		int s2;
 		int s3;
-		string s4;
+		std::string s4;
 	};
 
-	vector<Index> data{
+	std::vector<Index> data{
 		{ "aabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcbc", 4, 23, "efg" },
 		{ "tiaron", 456, 63245, "908apzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapzapz" },
 		{ "", 2345, 12934, "665i65i65i65i65i65i65i65i65i65i65i65i65i65i65i65i65i65i5iart" },
@@ -2264,7 +2263,7 @@ BOOST_AUTO_TEST_CASE(library_call)
 	)";
 	ALSO_VIA_YUL(
 		compileAndRun(sourceCode, 0, "Lib");
-		compileAndRun(sourceCode, 0, "Test", bytes(), map<string, h160>{{":Lib", m_contractAddress}});
+		compileAndRun(sourceCode, 0, "Test", bytes(), std::map<std::string, h160>{{":Lib", m_contractAddress}});
 		ABI_CHECK(callContractFunction("f(uint256)", u256(33)), encodeArgs(u256(33) * 9));
 	)
 }
@@ -2281,7 +2280,7 @@ BOOST_AUTO_TEST_CASE(library_function_external)
 	)";
 	ALSO_VIA_YUL(
 		compileAndRun(sourceCode, 0, "Lib");
-		compileAndRun(sourceCode, 0, "Test", bytes(), map<string, h160>{{":Lib", m_contractAddress}});
+		compileAndRun(sourceCode, 0, "Test", bytes(), std::map<std::string, h160>{{":Lib", m_contractAddress}});
 		ABI_CHECK(callContractFunction("f(bytes)", u256(0x20), u256(5), "abcde"), encodeArgs("c"));
 	)
 }
@@ -2315,9 +2314,9 @@ BOOST_AUTO_TEST_CASE(using_library_mappings_external)
 		)";
 	for (auto v2: {false, true})
 	{
-		string prefix = "pragma abicoder " + string(v2 ? "v2" : "v1") + ";\n";
+		std::string prefix = "pragma abicoder " + std::string(v2 ? "v2" : "v1") + ";\n";
 		compileAndRun(prefix + libSourceCode, 0, "Lib");
-		compileAndRun(prefix + sourceCode, 0, "Test", bytes(), map<string, h160>{{":Lib", m_contractAddress}});
+		compileAndRun(prefix + sourceCode, 0, "Test", bytes(), std::map<std::string, h160>{{":Lib", m_contractAddress}});
 		ABI_CHECK(callContractFunction("f()"), encodeArgs(u256(2), u256(0), u256(84), u256(46), u256(0), u256(198)));
 	}
 }
@@ -2432,7 +2431,7 @@ BOOST_AUTO_TEST_CASE(short_strings)
 	)";
 	ALSO_VIA_YUL(
 		compileAndRun(sourceCode, 0, "A");
-		ABI_CHECK(callContractFunction("data1()"), encodeDyn(string("123")));
+		ABI_CHECK(callContractFunction("data1()"), encodeDyn(std::string("123")));
 		ABI_CHECK(callContractFunction("lengthChange()"), encodeArgs(u256(0)));
 		BOOST_CHECK(storageEmpty(m_contractAddress));
 		ABI_CHECK(callContractFunction("deleteElements()"), encodeArgs(u256(0)));
@@ -2458,7 +2457,7 @@ BOOST_AUTO_TEST_CASE(calldata_offset)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "CB", encodeArgs(u256(0x20), u256(0x00)));
-	ABI_CHECK(callContractFunction("last()", encodeArgs()), encodeDyn(string("nd")));
+	ABI_CHECK(callContractFunction("last()", encodeArgs()), encodeDyn(std::string("nd")));
 }
 
 BOOST_AUTO_TEST_CASE(reject_ether_sent_to_library)
@@ -2525,7 +2524,7 @@ BOOST_AUTO_TEST_CASE(inline_long_string_return)
 		}
 	)";
 
-	string strLong = "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789001234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678900123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789001234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
+	std::string strLong = "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789001234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678900123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789001234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890";
 	compileAndRun(sourceCode, 0, "C");
 	ABI_CHECK(callContractFunction("f()"), encodeDyn(strLong));
 }
@@ -2775,8 +2774,8 @@ BOOST_AUTO_TEST_CASE(shift_bytes)
 		}
 	)";
 	compileAndRun(sourceCode, 0, "C");
-	ABI_CHECK(callContractFunction("left(bytes20,uint8)", "12345678901234567890", 8 * 8), encodeArgs("901234567890" + string(8, 0)));
-	ABI_CHECK(callContractFunction("right(bytes20,uint8)", "12345678901234567890", 8 * 8), encodeArgs(string(8, 0) + "123456789012"));
+	ABI_CHECK(callContractFunction("left(bytes20,uint8)", "12345678901234567890", 8 * 8), encodeArgs("901234567890" + std::string(8, 0)));
+	ABI_CHECK(callContractFunction("right(bytes20,uint8)", "12345678901234567890", 8 * 8), encodeArgs(std::string(8, 0) + "123456789012"));
 }
 
 BOOST_AUTO_TEST_CASE(contracts_separated_with_comment)
@@ -3152,12 +3151,12 @@ BOOST_AUTO_TEST_CASE(bare_call_return_data)
 {
 	if (solidity::test::CommonOptions::get().evmVersion().supportsReturndata())
 	{
-		vector<string> calltypes = {"call", "delegatecall"};
+		std::vector<std::string> calltypes = {"call", "delegatecall"};
 		if (solidity::test::CommonOptions::get().evmVersion().hasStaticCall())
 			calltypes.emplace_back("staticcall");
-		for (string const& calltype: calltypes)
+		for (std::string const& calltype: calltypes)
 		{
-			string sourceCode = R"DELIMITER(
+			std::string sourceCode = R"DELIMITER(
 				contract A {
 					constructor() {
 					}
@@ -3256,14 +3255,14 @@ BOOST_AUTO_TEST_CASE(bare_call_return_data)
 			)DELIMITER";
 			ALSO_VIA_YUL(
 				compileAndRun(sourceCode, 0, "C");
-				ABI_CHECK(callContractFunction("f(string)", encodeDyn(string("return_bool()"))), encodeArgs(true, 0x40, 0x20, true));
-				ABI_CHECK(callContractFunction("f(string)", encodeDyn(string("return_int32()"))), encodeArgs(true, 0x40, 0x20, u256(-32)));
-				ABI_CHECK(callContractFunction("f(string)", encodeDyn(string("return_uint32()"))), encodeArgs(true, 0x40, 0x20, u256(0x3232)));
-				ABI_CHECK(callContractFunction("f(string)", encodeDyn(string("return_int256()"))), encodeArgs(true, 0x40, 0x20, u256(-256)));
-				ABI_CHECK(callContractFunction("f(string)", encodeDyn(string("return_uint256()"))), encodeArgs(true, 0x40, 0x20, u256(0x256256)));
-				ABI_CHECK(callContractFunction("f(string)", encodeDyn(string("return_bytes4()"))), encodeArgs(true, 0x40, 0x20, u256(0xabcd0012) << (28*8)));
-				ABI_CHECK(callContractFunction("f(string)", encodeDyn(string("return_multi()"))), encodeArgs(true, 0x40, 0x60, false, u256(0x3232), u256(0xabcd0012) << (28*8)));
-				ABI_CHECK(callContractFunction("f(string)", encodeDyn(string("return_bytes()"))), encodeArgs(true, 0x40, 0x60, 0x20, 0x02, encode(bytes{0x42,0x21}, false)));
+				ABI_CHECK(callContractFunction("f(string)", encodeDyn(std::string("return_bool()"))), encodeArgs(true, 0x40, 0x20, true));
+				ABI_CHECK(callContractFunction("f(string)", encodeDyn(std::string("return_int32()"))), encodeArgs(true, 0x40, 0x20, u256(-32)));
+				ABI_CHECK(callContractFunction("f(string)", encodeDyn(std::string("return_uint32()"))), encodeArgs(true, 0x40, 0x20, u256(0x3232)));
+				ABI_CHECK(callContractFunction("f(string)", encodeDyn(std::string("return_int256()"))), encodeArgs(true, 0x40, 0x20, u256(-256)));
+				ABI_CHECK(callContractFunction("f(string)", encodeDyn(std::string("return_uint256()"))), encodeArgs(true, 0x40, 0x20, u256(0x256256)));
+				ABI_CHECK(callContractFunction("f(string)", encodeDyn(std::string("return_bytes4()"))), encodeArgs(true, 0x40, 0x20, u256(0xabcd0012) << (28*8)));
+				ABI_CHECK(callContractFunction("f(string)", encodeDyn(std::string("return_multi()"))), encodeArgs(true, 0x40, 0x60, false, u256(0x3232), u256(0xabcd0012) << (28*8)));
+				ABI_CHECK(callContractFunction("f(string)", encodeDyn(std::string("return_bytes()"))), encodeArgs(true, 0x40, 0x60, 0x20, 0x02, encode(bytes{0x42,0x21}, false)));
 				ABI_CHECK(callContractFunction("check_bool()"), encodeArgs(true));
 				ABI_CHECK(callContractFunction("check_int32()"), encodeArgs(true));
 				ABI_CHECK(callContractFunction("check_uint32()"), encodeArgs(true));
@@ -3315,7 +3314,7 @@ BOOST_AUTO_TEST_CASE(abi_encodePacked)
 	for (auto v2: {false, true})
 	{
 		ALSO_VIA_YUL(
-			string prefix = "pragma abicoder " + string(v2 ? "v2" : "v1") + ";\n";
+			std::string prefix = "pragma abicoder " + std::string(v2 ? "v2" : "v1") + ";\n";
 			compileAndRun(prefix + sourceCode, 0, "C");
 			ABI_CHECK(callContractFunction("f0()"), encodeArgs(0x20, 0));
 			ABI_CHECK(callContractFunction("f1()"), encodeArgs(0x20, 2, "\x01\x02"));
@@ -3392,7 +3391,7 @@ BOOST_AUTO_TEST_CASE(abi_encodePacked_from_storage)
 	for (auto v2: {false, true})
 	{
 		ALSO_VIA_YUL(
-			string prefix = "pragma abicoder " + string(v2 ? "v2" : "v1") + ";\n";
+			std::string prefix = "pragma abicoder " + std::string(v2 ? "v2" : "v1") + ";\n";
 			compileAndRun(prefix + sourceCode, 0, "C");
 			bytes payload = encodeArgs(0xfffff1, 0, 0xfffff2, 0, 0, 0xfffff3, 0, 0, 0xfffff4);
 			bytes encoded = encodeArgs(0x20, 0x122, "\x01" + asString(payload) + "\x02");
@@ -3465,7 +3464,7 @@ BOOST_AUTO_TEST_CASE(abi_encodePacked_from_memory)
 	for (auto v2: {false, true})
 	{
 		ALSO_VIA_YUL(
-			string prefix = "pragma abicoder " + string(v2 ? "v2" : "v1") + ";\n";
+			std::string prefix = "pragma abicoder " + std::string(v2 ? "v2" : "v1") + ";\n";
 			compileAndRun(prefix + sourceCode, 0, "C");
 			bytes payload = encodeArgs(0xfffff1, 0, 0xfffff2, 0, 0, 0xfffff3, 0, 0, 0xfffff4);
 			bytes encoded = encodeArgs(0x20, 0x122, "\x01" + asString(payload) + "\x02");
@@ -3511,11 +3510,11 @@ BOOST_AUTO_TEST_CASE(abi_encodePacked_functionPtr)
 	for (auto v2: {false, true})
 	{
 		ALSO_VIA_YUL(
-			string prefix = "pragma abicoder " + string(v2 ? "v2" : "v1") + ";\n";
+			std::string prefix = "pragma abicoder " + std::string(v2 ? "v2" : "v1") + ";\n";
 			compileAndRun(prefix + sourceCode, 0, "C");
-			string directEncoding = asString(fromHex("08" "1112131400000000000011121314000000000087" "26121ff0" "02"));
+			std::string directEncoding = asString(fromHex("08" "1112131400000000000011121314000000000087" "26121ff0" "02"));
 			ABI_CHECK(callContractFunction("testDirect()"), encodeArgs(0x20, directEncoding.size(), directEncoding));
-			string arrayEncoding = asString(fromHex("08" "1112131400000000000011121314000000000087" "26121ff0" "0000000000000000" "02"));
+			std::string arrayEncoding = asString(fromHex("08" "1112131400000000000011121314000000000087" "26121ff0" "0000000000000000" "02"));
 			ABI_CHECK(callContractFunction("testFixedArray()"), encodeArgs(0x20, arrayEncoding.size(), arrayEncoding));
 			ABI_CHECK(callContractFunction("testDynamicArray()"), encodeArgs(0x20, arrayEncoding.size(), arrayEncoding));
 		)
@@ -3557,11 +3556,11 @@ BOOST_AUTO_TEST_CASE(abi_encodePackedV2_structs)
 		bytes structEnc = encodeArgs(int(0x12), u256(-7), int(2), int(3), u256(-7), u256(-8));
 		ABI_CHECK(callContractFunction("testStorage()"), encodeArgs());
 		BOOST_REQUIRE_EQUAL(numLogTopics(0), 2);
-		BOOST_CHECK_EQUAL(logTopic(0, 0), util::keccak256(string("E((uint8,int16,uint8[2],int16[]))")));
+		BOOST_CHECK_EQUAL(logTopic(0, 0), util::keccak256(std::string("E((uint8,int16,uint8[2],int16[]))")));
 		BOOST_CHECK_EQUAL(logTopic(0, 1), util::keccak256(asString(structEnc)));
 		ABI_CHECK(callContractFunction("testMemory()"), encodeArgs());
 		BOOST_REQUIRE_EQUAL(numLogTopics(0), 2);
-		BOOST_CHECK_EQUAL(logTopic(0, 0), util::keccak256(string("E((uint8,int16,uint8[2],int16[]))")));
+		BOOST_CHECK_EQUAL(logTopic(0, 0), util::keccak256(std::string("E((uint8,int16,uint8[2],int16[]))")));
 		BOOST_CHECK_EQUAL(logTopic(0, 1), util::keccak256(asString(structEnc)));
 	)
 }
@@ -3592,7 +3591,7 @@ BOOST_AUTO_TEST_CASE(abi_encodePackedV2_nestedArray)
 		bytes structEnc = encodeArgs(1, 2, 3, 0, 0, 0, 0, 4);
 		ABI_CHECK(callContractFunction("testNestedArrays()"), encodeArgs());
 		BOOST_REQUIRE_EQUAL(numLogTopics(0), 2);
-		BOOST_CHECK_EQUAL(logTopic(0, 0), util::keccak256(string("E((uint8,int16)[2][][3])")));
+		BOOST_CHECK_EQUAL(logTopic(0, 0), util::keccak256(std::string("E((uint8,int16)[2][][3])")));
 		BOOST_CHECK_EQUAL(logTopic(0, 1), util::keccak256(asString(structEnc)));
 	)
 }
@@ -3622,11 +3621,11 @@ BOOST_AUTO_TEST_CASE(abi_encodePackedV2_arrayOfStrings)
 		bytes arrayEncoding = encodeArgs("abc", "0123456789012345678901234567890123456789");
 		ABI_CHECK(callContractFunction("testStorage()"), encodeArgs());
 		BOOST_REQUIRE_EQUAL(numLogTopics(0), 2);
-		BOOST_CHECK_EQUAL(logTopic(0, 0), util::keccak256(string("E(string[])")));
+		BOOST_CHECK_EQUAL(logTopic(0, 0), util::keccak256(std::string("E(string[])")));
 		BOOST_CHECK_EQUAL(logTopic(0, 1), util::keccak256(asString(arrayEncoding)));
 		ABI_CHECK(callContractFunction("testMemory()"), encodeArgs());
 		BOOST_REQUIRE_EQUAL(numLogTopics(0), 2);
-		BOOST_CHECK_EQUAL(logTopic(0, 0), util::keccak256(string("E(string[])")));
+		BOOST_CHECK_EQUAL(logTopic(0, 0), util::keccak256(std::string("E(string[])")));
 		BOOST_CHECK_EQUAL(logTopic(0, 1), util::keccak256(asString(arrayEncoding)));
 	)
 }
@@ -3712,7 +3711,7 @@ BOOST_AUTO_TEST_CASE(contract_name)
 	ABI_CHECK(callContractFunction("name()"), argsD);
 	ABI_CHECK(callContractFunction("name2()"), argsC);
 
-	string longName = "ThisIsAVeryLongContractNameExceeding256bits";
+	std::string longName = "ThisIsAVeryLongContractNameExceeding256bits";
 	compileAndRun(sourceCode, 0, longName);
 	bytes argsLong = encodeArgs(u256(0x20), u256(longName.length()), longName);
 	ABI_CHECK(callContractFunction("name()"), argsLong);
@@ -3738,13 +3737,13 @@ BOOST_AUTO_TEST_CASE(event_wrong_abi_name)
 	)";
 	ALSO_VIA_YUL(
 		compileAndRun(sourceCode, 0, "ClientReceipt", bytes());
-		compileAndRun(sourceCode, 0, "Test", bytes(), map<string, h160>{{":ClientReceipt", m_contractAddress}});
+		compileAndRun(sourceCode, 0, "Test", bytes(), std::map<std::string, h160>{{":ClientReceipt", m_contractAddress}});
 
 		callContractFunction("f()");
 		BOOST_REQUIRE_EQUAL(numLogs(), 1);
 		BOOST_CHECK_EQUAL(logAddress(0), m_contractAddress);
 		BOOST_REQUIRE_EQUAL(numLogTopics(0), 3);
-		BOOST_CHECK_EQUAL(logTopic(0, 0), util::keccak256(string("Deposit(address,bytes32,uint256)")));
+		BOOST_CHECK_EQUAL(logTopic(0, 0), util::keccak256(std::string("Deposit(address,bytes32,uint256)")));
 	)
 }
 

--- a/test/libsolidity/SolidityExecutionFramework.cpp
+++ b/test/libsolidity/SolidityExecutionFramework.cpp
@@ -39,13 +39,12 @@ using namespace solidity::frontend;
 using namespace solidity::frontend::test;
 using namespace solidity::langutil;
 using namespace solidity::test;
-using namespace std;
 
 bytes SolidityExecutionFramework::multiSourceCompileContract(
-	map<string, string> const& _sourceCode,
-	optional<string> const& _mainSourceName,
-	string const& _contractName,
-	map<string, Address> const& _libraryAddresses
+	std::map<std::string, std::string> const& _sourceCode,
+	std::optional<std::string> const& _mainSourceName,
+	std::string const& _contractName,
+	std::map<std::string, Address> const& _libraryAddresses
 )
 {
 	if (_mainSourceName.has_value())
@@ -81,23 +80,23 @@ bytes SolidityExecutionFramework::multiSourceCompileContract(
 			.printErrorInformation(m_compiler.errors());
 		BOOST_ERROR("Compiling contract failed");
 	}
-	string contractName(_contractName.empty() ? m_compiler.lastContractName(_mainSourceName) : _contractName);
+	std::string contractName(_contractName.empty() ? m_compiler.lastContractName(_mainSourceName) : _contractName);
 	evmasm::LinkerObject obj = m_compiler.object(contractName);
 	BOOST_REQUIRE(obj.linkReferences.empty());
 	if (m_showMetadata)
-		cout << "metadata: " << m_compiler.metadata(contractName) << endl;
+		std::cout << "metadata: " << m_compiler.metadata(contractName) << std::endl;
 	return obj.bytecode;
 }
 
 bytes SolidityExecutionFramework::compileContract(
-	string const& _sourceCode,
-	string const& _contractName,
-	map<string, Address> const& _libraryAddresses
+	std::string const& _sourceCode,
+	std::string const& _contractName,
+	std::map<std::string, Address> const& _libraryAddresses
 )
 {
 	return multiSourceCompileContract(
 		{{"", _sourceCode}},
-		nullopt,
+		std::nullopt,
 		_contractName,
 		_libraryAddresses
 	);

--- a/test/libsolidity/SolidityExpressionCompiler.cpp
+++ b/test/libsolidity/SolidityExpressionCompiler.cpp
@@ -40,7 +40,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 using namespace solidity::evmasm;
 using namespace solidity::langutil;
 
@@ -78,13 +77,13 @@ private:
 
 Declaration const& resolveDeclaration(
 	SourceUnit const& _sourceUnit,
-	vector<string> const& _namespacedName,
+	std::vector<std::string> const& _namespacedName,
 	NameAndTypeResolver const& _resolver
 )
 {
 	ASTNode const* scope = &_sourceUnit;
 	// bracers are required, cause msvc couldn't handle this macro in for statement
-	for (string const& namePart: _namespacedName)
+	for (std::string const& namePart: _namespacedName)
 	{
 		auto declarations = _resolver.resolveName(namePart, scope);
 		BOOST_REQUIRE(!declarations.empty());
@@ -95,12 +94,12 @@ Declaration const& resolveDeclaration(
 }
 
 bytes compileFirstExpression(
-	string const& _sourceCode,
-	vector<vector<string>> _functions = {},
-	vector<vector<string>> _localVariables = {}
+	std::string const& _sourceCode,
+	std::vector<std::vector<std::string>> _functions = {},
+	std::vector<std::vector<std::string>> _localVariables = {}
 )
 {
-	string sourceCode = "pragma solidity >=0.0; // SPDX-License-Identifier: GPL-3\n" + _sourceCode;
+	std::string sourceCode = "pragma solidity >=0.0; // SPDX-License-Identifier: GPL-3\n" + _sourceCode;
 	CharStream stream(sourceCode, "");
 
 	ASTPointer<SourceUnit> sourceUnit;
@@ -114,12 +113,12 @@ bytes compileFirstExpression(
 	}
 	catch (boost::exception const& _e)
 	{
-		string msg = "Parsing source code failed with:\n" + boost::diagnostic_information(_e);
+		std::string msg = "Parsing source code failed with:\n" + boost::diagnostic_information(_e);
 		BOOST_FAIL(msg);
 	}
 	catch (...)
 	{
-		string msg = "Parsing source code failed with:\n" + boost::current_exception_diagnostic_information();
+		std::string msg = "Parsing source code failed with:\n" + boost::current_exception_diagnostic_information();
 		BOOST_FAIL(msg);
 	}
 
@@ -151,7 +150,7 @@ bytes compileFirstExpression(
 			context.setArithmetic(Arithmetic::Wrapping);
 			size_t parametersSize = _localVariables.size(); // assume they are all one slot on the stack
 			context.adjustStackOffset(static_cast<int>(parametersSize));
-			for (vector<string> const& variable: _localVariables)
+			for (std::vector<std::string> const& variable: _localVariables)
 				context.addVariable(
 					dynamic_cast<VariableDeclaration const&>(resolveDeclaration(*sourceUnit, variable, resolver)),
 					static_cast<unsigned>(parametersSize--)
@@ -162,7 +161,7 @@ bytes compileFirstExpression(
 				solidity::test::CommonOptions::get().optimize
 			).compile(*extractor.expression());
 
-			for (vector<string> const& function: _functions)
+			for (std::vector<std::string> const& function: _functions)
 				context << context.functionEntryLabel(dynamic_cast<FunctionDefinition const&>(
 					resolveDeclaration(*sourceUnit, function, resolver)
 				));

--- a/test/libsolidity/SolidityNameAndTypeResolution.cpp
+++ b/test/libsolidity/SolidityNameAndTypeResolution.cpp
@@ -32,7 +32,6 @@
 
 #include <string>
 
-using namespace std;
 using namespace solidity::langutil;
 
 namespace solidity::frontend::test

--- a/test/libsolidity/SolidityOptimizer.cpp
+++ b/test/libsolidity/SolidityOptimizer.cpp
@@ -35,7 +35,6 @@
 #include <memory>
 #include <limits>
 
-using namespace std;
 using namespace solidity::util;
 using namespace solidity::evmasm;
 using namespace solidity::test;
@@ -79,9 +78,9 @@ public:
 		size_t optimizedSize = numInstructions(m_optimizedBytecode);
 		BOOST_CHECK_MESSAGE(
 			_optimizeRuns < 50 || optimizedSize < nonOptimizedSize,
-			string("Optimizer did not reduce bytecode size. Non-optimized size: ") +
-			to_string(nonOptimizedSize) + " - optimized size: " +
-			to_string(optimizedSize)
+			std::string("Optimizer did not reduce bytecode size. Non-optimized size: ") +
+			std::to_string(nonOptimizedSize) + " - optimized size: " +
+			std::to_string(optimizedSize)
 		);
 		m_optimizedContract = m_contractAddress;
 	}

--- a/test/libsolidity/ViewPureChecker.cpp
+++ b/test/libsolidity/ViewPureChecker.cpp
@@ -27,7 +27,6 @@
 #include <string>
 #include <tuple>
 
-using namespace std;
 using namespace solidity::langutil;
 
 namespace solidity::frontend::test
@@ -37,7 +36,7 @@ BOOST_FIXTURE_TEST_SUITE(ViewPureChecker, AnalysisFramework)
 
 BOOST_AUTO_TEST_CASE(environment_access)
 {
-	vector<string> view{
+	std::vector<std::string> view{
 		"block.coinbase",
 		"block.timestamp",
 		"block.difficulty",
@@ -57,7 +56,7 @@ BOOST_AUTO_TEST_CASE(environment_access)
 
 	// ``block.blockhash`` and ``blockhash`` are tested separately below because their usage will
 	// produce warnings that can't be handled in a generic way.
-	vector<string> pure{
+	std::vector<std::string> pure{
 		"msg.data",
 		"msg.data[0]",
 		"msg.sig",
@@ -65,7 +64,7 @@ BOOST_AUTO_TEST_CASE(environment_access)
 		"block",
 		"tx"
 	};
-	for (string const& x: view)
+	for (std::string const& x: view)
 	{
 		CHECK_ERROR(
 			"contract C { function f() pure public { " + x + "; } }",
@@ -73,7 +72,7 @@ BOOST_AUTO_TEST_CASE(environment_access)
 			"Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires \"view\""
 		);
 	}
-	for (string const& x: pure)
+	for (std::string const& x: pure)
 	{
 		CHECK_WARNING(
 			"contract C { function f() view public { " + x + "; } }",
@@ -97,7 +96,7 @@ BOOST_AUTO_TEST_CASE(environment_access)
 
 BOOST_AUTO_TEST_CASE(address_staticcall)
 {
-	string text = R"(
+	std::string text = R"(
 		contract C {
 			function i() view public returns (bool) {
 				(bool success,) = address(0x4242).staticcall("");
@@ -114,7 +113,7 @@ BOOST_AUTO_TEST_CASE(address_staticcall)
 
 BOOST_AUTO_TEST_CASE(assembly_staticcall)
 {
-	string text = R"(
+	std::string text = R"(
 		contract C {
 			function i() view public {
 				assembly { pop(staticcall(gas(), 1, 2, 3, 4, 5)) }

--- a/test/libsolidity/analysis/FunctionCallGraph.cpp
+++ b/test/libsolidity/analysis/FunctionCallGraph.cpp
@@ -46,31 +46,31 @@
 #include <tuple>
 #include <vector>
 
-using namespace std;
 using namespace solidity::util;
 using namespace solidity::langutil;
 using namespace solidity::frontend;
+using namespace std::string_literals;
 
-using EdgeMap = map<
+using EdgeMap = std::map<
 	CallGraph::Node,
-	set<CallGraph::Node, CallGraph::CompareByID>,
+	std::set<CallGraph::Node, CallGraph::CompareByID>,
 	CallGraph::CompareByID
 >;
-using EdgeNames = set<tuple<string, string>>;
-using CallGraphMap = map<string, CallGraph const*>;
+using EdgeNames = std::set<std::tuple<std::string, std::string>>;
+using CallGraphMap = std::map<std::string, CallGraph const*>;
 
 namespace
 {
 
-unique_ptr<CompilerStack> parseAndAnalyzeContracts(string _sourceCode)
+std::unique_ptr<CompilerStack> parseAndAnalyzeContracts(std::string _sourceCode)
 {
-	ReadCallback::Callback fileReader = [](string const&, string const&)
+	ReadCallback::Callback fileReader = [](std::string const&, std::string const&)
 	{
 		soltestAssert(false, "For simplicity this test suite supports only files without imports.");
 		return ReadCallback::Result{true, ""};
 	};
 
-	auto compilerStack = make_unique<CompilerStack>(fileReader);
+	auto compilerStack = std::make_unique<CompilerStack>(fileReader);
 	compilerStack->setSources({{"", _sourceCode}});
 
 	// NOTE: The code in test cases is expected to be correct so we can keep error handling simple
@@ -100,23 +100,23 @@ EdgeNames edgeNames(EdgeMap const& _edgeMap)
 	return names;
 }
 
-tuple<CallGraphMap, CallGraphMap> collectGraphs(CompilerStack const& _compilerStack)
+std::tuple<CallGraphMap, CallGraphMap> collectGraphs(CompilerStack const& _compilerStack)
 {
 	soltestAssert(_compilerStack.state() >= CompilerStack::State::AnalysisSuccessful);
 
-	tuple<CallGraphMap, CallGraphMap> graphs;
+	std::tuple<CallGraphMap, CallGraphMap> graphs;
 
-	for (string const& fullyQualifiedContractName: _compilerStack.contractNames())
+	for (std::string const& fullyQualifiedContractName: _compilerStack.contractNames())
 	{
-		soltestAssert(get<0>(graphs).count(fullyQualifiedContractName) == 0 && get<1>(graphs).count(fullyQualifiedContractName) == 0, "");
+		soltestAssert(std::get<0>(graphs).count(fullyQualifiedContractName) == 0 && std::get<1>(graphs).count(fullyQualifiedContractName) == 0, "");
 
 		// This relies on two assumptions: (1) CompilerStack received an empty string as a path for
 		// the contract and (2) contracts used in test cases have no imports.
 		soltestAssert(fullyQualifiedContractName.size() > 0 && fullyQualifiedContractName[0] == ':', "");
-		string contractName = fullyQualifiedContractName.substr(1);
+		std::string contractName = fullyQualifiedContractName.substr(1);
 
-		get<0>(graphs).emplace(contractName, _compilerStack.contractDefinition(fullyQualifiedContractName).annotation().creationCallGraph->get());
-		get<1>(graphs).emplace(contractName, _compilerStack.contractDefinition(fullyQualifiedContractName).annotation().deployedCallGraph->get());
+		std::get<0>(graphs).emplace(contractName, _compilerStack.contractDefinition(fullyQualifiedContractName).annotation().creationCallGraph->get());
+		std::get<1>(graphs).emplace(contractName, _compilerStack.contractDefinition(fullyQualifiedContractName).annotation().deployedCallGraph->get());
 	}
 
 	return graphs;
@@ -124,25 +124,25 @@ tuple<CallGraphMap, CallGraphMap> collectGraphs(CompilerStack const& _compilerSt
 
 void checkCallGraphExpectations(
 	CallGraphMap const& _callGraphs,
-	map<string, EdgeNames> const& _expectedEdges,
-	map<string, set<string>> const& _expectedCreatedContractSets = {},
-	map<string, set<string>> const& _expectedEmittedEventSets = {}
+	std::map<std::string, EdgeNames> const& _expectedEdges,
+	std::map<std::string, std::set<std::string>> const& _expectedCreatedContractSets = {},
+	std::map<std::string, std::set<std::string>> const& _expectedEmittedEventSets = {}
 )
 {
 	auto getContractName = [](ContractDefinition const* _contract){ return _contract->name(); };
 	auto eventToString = [](EventDefinition const* _event){ return toString(CallGraph::Node(_event)); };
-	auto notEmpty = [](set<string> const& _set){ return !_set.empty(); };
+	auto notEmpty = [](std::set<std::string> const& _set){ return !_set.empty(); };
 
 	soltestAssert(
 		(_expectedCreatedContractSets | ranges::views::values | ranges::views::remove_if(notEmpty)).empty(),
 		"Contracts that are not expected to create other contracts should not be included in _expectedCreatedContractSets."
 	);
 	soltestAssert(
-		(_expectedEdges | ranges::views::keys | ranges::to<set>()) == (_callGraphs | ranges::views::keys | ranges::to<set>()) &&
+		(_expectedEdges | ranges::views::keys | ranges::to<std::set>()) == (_callGraphs | ranges::views::keys | ranges::to<std::set>()) &&
 		(ranges::views::set_difference(_expectedCreatedContractSets | ranges::views::keys, _expectedEdges | ranges::views::keys)).empty(),
 		"Contracts listed in expectations do not match contracts actually found in the source file or in other expectations."
 	);
-	for (string const& contractName: _expectedEdges | ranges::views::keys)
+	for (std::string const& contractName: _expectedEdges | ranges::views::keys)
 	{
 		soltestAssert(
 			(ranges::views::set_difference(valueOrDefault(_expectedCreatedContractSets, contractName, {}), _expectedEdges | ranges::views::keys)).empty(),
@@ -150,10 +150,10 @@ void checkCallGraphExpectations(
 		);
 	}
 
-	map<string, EdgeNames> edges;
-	map<string, set<string>> createdContractSets;
-	map<string, set<string>> emittedEventSets;
-	for (string const& contractName: _expectedEdges | ranges::views::keys)
+	std::map<std::string, EdgeNames> edges;
+	std::map<std::string, std::set<std::string>> createdContractSets;
+	std::map<std::string, std::set<std::string>> emittedEventSets;
+	for (std::string const& contractName: _expectedEdges | ranges::views::keys)
 	{
 		soltestAssert(_callGraphs.at(contractName) != nullptr, "");
 		CallGraph const& callGraph = *_callGraphs.at(contractName);
@@ -163,11 +163,11 @@ void checkCallGraphExpectations(
 			createdContractSets[contractName] = callGraph.bytecodeDependency |
 				ranges::views::keys |
 				ranges::views::transform(getContractName) |
-				ranges::to<set<string>>();
+				ranges::to<std::set<std::string>>();
 		if (!callGraph.emittedEvents.empty())
 			emittedEventSets[contractName] = callGraph.emittedEvents |
 				 ranges::views::transform(eventToString) |
-				 ranges::to<set<string>>();
+				 ranges::to<std::set<std::string>>();
 	}
 
 	BOOST_CHECK_EQUAL(edges, _expectedEdges);
@@ -175,39 +175,39 @@ void checkCallGraphExpectations(
 	BOOST_CHECK_EQUAL(emittedEventSets, _expectedEmittedEventSets);
 }
 
-ostream& operator<<(ostream& _out, EdgeNames const& _edgeNames)
+std::ostream& operator<<(std::ostream& _out, EdgeNames const& _edgeNames)
 {
 	for (auto const& [from, to]: _edgeNames)
-		_out << "    " << from << " -> " << to << endl;
+		_out << "    " << from << " -> " << to << std::endl;
 	return _out;
 }
 
-ostream& operator<<(ostream& _out, set<string> const& _set)
+std::ostream& operator<<(std::ostream& _out, std::set<std::string> const& _set)
 {
-	_out << "{" << (_set | ranges::views::join(", ") | ranges::to<string>()) << "}";
+	_out << "{" << (_set | ranges::views::join(", ") | ranges::to<std::string>()) << "}";
 	return _out;
 }
 
-ostream& operator<<(ostream& _out, map<string, EdgeNames> const& _edgeSets)
+std::ostream& operator<<(std::ostream& _out, std::map<std::string, EdgeNames> const& _edgeSets)
 {
 	// Extra newline for error report readability. Otherwise the first line does not start at the first column.
-	_out << endl;
+	_out << std::endl;
 
 	for (auto const &[contractName, edges]: _edgeSets)
 	{
-		_out << contractName << ":" << endl;
+		_out << contractName << ":" << std::endl;
 		_out << edges;
 	}
 	return _out;
 }
 
-ostream& operator<<(ostream& _out, map<string, set<string>> const& _map)
+std::ostream& operator<<(std::ostream& _out, std::map<std::string, std::set<std::string>> const& _map)
 {
 	// Extra newline for error report readability. Otherwise the first line does not start at the first column.
-	_out << endl;
+	_out << std::endl;
 
 	for (auto const &[key, value]: _map)
-		_out << key << ": " << value << endl;
+		_out << key << ": " << value << std::endl;
 	return _out;
 }
 
@@ -226,21 +226,21 @@ struct print_log_value<EdgeNames>
 };
 
 template<>
-struct print_log_value<set<string>>
+struct print_log_value<std::set<std::string>>
 {
-	void operator()(std::ostream& _output, set<string> const& _set) { ::operator<<(_output, _set); }
+	void operator()(std::ostream& _output, std::set<std::string> const& _set) { ::operator<<(_output, _set); }
 };
 
 template<>
-struct print_log_value<map<string, EdgeNames>>
+struct print_log_value<std::map<std::string, EdgeNames>>
 {
-	void operator()(std::ostream& _output, map<string, EdgeNames> const& _edgeSets) { ::operator<<(_output, _edgeSets); }
+	void operator()(std::ostream& _output, std::map<std::string, EdgeNames> const& _edgeSets) { ::operator<<(_output, _edgeSets); }
 };
 
 template<>
-struct print_log_value<map<string, set<string>>>
+struct print_log_value<std::map<std::string, std::set<std::string>>>
 {
-	void operator()(std::ostream& _output, map<string, set<string>> const& _map) { ::operator<<(_output, _map); }
+	void operator()(std::ostream& _output, std::map<std::string, std::set<std::string>> const& _map) { ::operator<<(_output, _map); }
 };
 
 } // namespace boost::test_tools::tt_detail
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_SUITE(FunctionCallGraphTest)
 
 BOOST_AUTO_TEST_CASE(only_definitions)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		function free() {}
 
 		library L {
@@ -269,14 +269,14 @@ BOOST_AUTO_TEST_CASE(only_definitions)
 			function prv() private {}
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {}},
 		{"L", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {
 			{"Entry", "function C.ext()"},
 			{"Entry", "function C.pub()"},
@@ -287,13 +287,13 @@ BOOST_AUTO_TEST_CASE(only_definitions)
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(ordinary_calls)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		function free() {}
 
 		library L {
@@ -310,14 +310,14 @@ BOOST_AUTO_TEST_CASE(ordinary_calls)
 			function prv() private { free(); free(); }
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {}},
 		{"L", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {
 			{"Entry", "function C.ext()"},
 			{"Entry", "function C.pub()"},
@@ -342,13 +342,13 @@ BOOST_AUTO_TEST_CASE(ordinary_calls)
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(call_chains_through_externals)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		library L {
 			function ext() external { C(address(0x0)).ext(); }
 			function pub() public {}
@@ -367,14 +367,14 @@ BOOST_AUTO_TEST_CASE(call_chains_through_externals)
 			function pub3() public { C(address(0x0)).ext(); }
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {}},
 		{"L", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {
 			{"Entry", "function C.ext()"},
 			{"Entry", "function C.ext2()"},
@@ -388,13 +388,13 @@ BOOST_AUTO_TEST_CASE(call_chains_through_externals)
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(calls_from_constructors)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		function free() returns (uint) {}
 
 		library L {
@@ -417,9 +417,9 @@ BOOST_AUTO_TEST_CASE(calls_from_constructors)
 			function inr() internal returns (uint) {}
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {
 			{"Entry", "constructor of C"},
 			{"constructor of C", "function C.inr()"},
@@ -432,7 +432,7 @@ BOOST_AUTO_TEST_CASE(calls_from_constructors)
 		{"L", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {
 			{"Entry", "function C.ext()"},
 		}},
@@ -444,13 +444,13 @@ BOOST_AUTO_TEST_CASE(calls_from_constructors)
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(calls_to_constructors)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		function free() { new D(); }
 
 		library L {
@@ -467,9 +467,9 @@ BOOST_AUTO_TEST_CASE(calls_to_constructors)
 
 		contract D {}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {
 			{"Entry", "constructor of C"},
 		}},
@@ -477,7 +477,7 @@ BOOST_AUTO_TEST_CASE(calls_to_constructors)
 		{"L", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {
 			{"Entry", "function C.ext()"},
 			{"function C.ext()", "function C.inr()"},
@@ -491,21 +491,21 @@ BOOST_AUTO_TEST_CASE(calls_to_constructors)
 		}},
 	};
 
-	map<string, set<string>> expectedCreatedContractsAtCreation = {
+	std::map<std::string, std::set<std::string>> expectedCreatedContractsAtCreation = {
 		{"C", {"D"}},
 	};
-	map<string, set<string>> expectedCreatedContractsAfterDeployment = {
+	std::map<std::string, std::set<std::string>> expectedCreatedContractsAfterDeployment = {
 		{"C", {"D"}},
 		{"L", {"C", "D"}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges, expectedCreatedContractsAtCreation);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges, expectedCreatedContractsAfterDeployment);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges, expectedCreatedContractsAtCreation);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges, expectedCreatedContractsAfterDeployment);
 }
 
 BOOST_AUTO_TEST_CASE(inherited_constructors)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		function free() {}
 
 		library L {
@@ -546,9 +546,9 @@ BOOST_AUTO_TEST_CASE(inherited_constructors)
 			function extG() external returns (uint) { new F(); }
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {
 			{"Entry", "constructor of C"},
 			{"constructor of C", "function C.inrC()"},
@@ -589,7 +589,7 @@ BOOST_AUTO_TEST_CASE(inherited_constructors)
 		{"L", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {
 			{"Entry", "function C.extC()"},
 			{"function C.extC()", "function C.inrC()"},
@@ -631,18 +631,18 @@ BOOST_AUTO_TEST_CASE(inherited_constructors)
 		}},
 	};
 
-	map<string, set<string>> expectedCreatedContractsAtCreation = {};
-	map<string, set<string>> expectedCreatedContractsAfterDeployment = {
+	std::map<std::string, std::set<std::string>> expectedCreatedContractsAtCreation = {};
+	std::map<std::string, std::set<std::string>> expectedCreatedContractsAfterDeployment = {
 		{"G", {"F"}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges, expectedCreatedContractsAtCreation);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges, expectedCreatedContractsAfterDeployment);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges, expectedCreatedContractsAtCreation);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges, expectedCreatedContractsAfterDeployment);
 }
 
 BOOST_AUTO_TEST_CASE(inheritance_specifiers)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		function fD() returns (uint) {}
 		function fE() returns (uint) {}
 		function fFD() returns (uint) {}
@@ -680,9 +680,9 @@ BOOST_AUTO_TEST_CASE(inheritance_specifiers)
 
 		contract G is D(fG()), E(fG()) {}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {
 			{"Entry", "constructor of C"},
 			{"Entry", "function fVarC()"},
@@ -726,7 +726,7 @@ BOOST_AUTO_TEST_CASE(inheritance_specifiers)
 		}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {}},
 		{"D", {}},
 		{"E", {}},
@@ -734,13 +734,13 @@ BOOST_AUTO_TEST_CASE(inheritance_specifiers)
 		{"G", {}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(inherited_functions_virtual_and_super)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		contract C {
 			function f() internal {}
 			function g() internal virtual {}
@@ -776,15 +776,15 @@ BOOST_AUTO_TEST_CASE(inherited_functions_virtual_and_super)
 			function callSuperH() external { super.h(); }
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {}},
 		{"D", {}},
 		{"E", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {
 			{"Entry", "function C.ext()"},
 		}},
@@ -820,13 +820,13 @@ BOOST_AUTO_TEST_CASE(inherited_functions_virtual_and_super)
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(overloaded_functions)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		enum E {E1, E2, E3}
 
 		function free() {}
@@ -850,14 +850,14 @@ BOOST_AUTO_TEST_CASE(overloaded_functions)
 			function f(bytes memory) internal {}
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {}},
 		{"D", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {
 			{"Entry", "function C.f(bool)"},
 		}},
@@ -878,13 +878,13 @@ BOOST_AUTO_TEST_CASE(overloaded_functions)
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(modifiers)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		library L {
 			modifier m() { g(); _; }
 
@@ -916,9 +916,9 @@ BOOST_AUTO_TEST_CASE(modifiers)
 			function q() internal override {}
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {}},
 		{"D", {}},
 		{"L", {}},
@@ -937,7 +937,7 @@ BOOST_AUTO_TEST_CASE(modifiers)
 		}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {}},
 		{"D", {}},
 		{"L", {}},
@@ -960,16 +960,16 @@ BOOST_AUTO_TEST_CASE(modifiers)
 		}},
 	};
 
-	map<string, set<string>> expectedCreatedContractsAtCreation = {{"E", {"C"}}};
-	map<string, set<string>> expectedCreatedContractsAfterDeployment = {{"E", {"C"}}};
+	std::map<std::string, std::set<std::string>> expectedCreatedContractsAtCreation = {{"E", {"C"}}};
+	std::map<std::string, std::set<std::string>> expectedCreatedContractsAfterDeployment = {{"E", {"C"}}};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges, expectedCreatedContractsAtCreation);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges, expectedCreatedContractsAfterDeployment);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges, expectedCreatedContractsAtCreation);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges, expectedCreatedContractsAfterDeployment);
 }
 
 BOOST_AUTO_TEST_CASE(events)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		function free() { emit L.Ev(); }
 
 		library L {
@@ -996,15 +996,15 @@ BOOST_AUTO_TEST_CASE(events)
 			function f() internal returns (uint) {}
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {}},
 		{"D", {}},
 		{"L", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {}},
 		{"D", {
 			{"Entry", "function D.ext()"},
@@ -1021,8 +1021,8 @@ BOOST_AUTO_TEST_CASE(events)
 		}},
 	};
 
-	map<string, set<string>> expectedCreationEvents = {};
-	map<string, set<string>> expectedDeployedEvents = {
+	std::map<std::string, std::set<std::string>> expectedCreationEvents = {};
+	std::map<std::string, std::set<std::string>> expectedDeployedEvents = {
 		{"D", {
 			"event D.EvD1(uint256)",
 			"event C.EvC(uint256)",
@@ -1034,13 +1034,13 @@ BOOST_AUTO_TEST_CASE(events)
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges, {}, expectedCreationEvents);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges, {}, expectedDeployedEvents);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges, {}, expectedCreationEvents);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges, {}, expectedDeployedEvents);
 }
 
 BOOST_AUTO_TEST_CASE(cycles)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		function free1() { free1(); }
 		function free2() { free3(); }
 		function free3() { free2(); }
@@ -1069,15 +1069,15 @@ BOOST_AUTO_TEST_CASE(cycles)
 			function virt() internal override { C.virt(); }
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"L", {}},
 		{"C", {}},
 		{"D", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"L", {}},
 		{"C", {}},
 		{"D", {
@@ -1106,13 +1106,13 @@ BOOST_AUTO_TEST_CASE(cycles)
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(interfaces_and_abstract_contracts)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		interface I {
 			event Ev(uint);
 
@@ -1143,16 +1143,16 @@ BOOST_AUTO_TEST_CASE(interfaces_and_abstract_contracts)
 			modifier m() override { _; }
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"I", {}},
 		{"J", {}},
 		{"C", {}},
 		{"D", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"I", {
 			{"Entry", "function I.ext1()"},
 			{"Entry", "function I.ext2()"},
@@ -1184,21 +1184,21 @@ BOOST_AUTO_TEST_CASE(interfaces_and_abstract_contracts)
 		}},
 	};
 
-	map<string, set<string>> expectedCreationEvents = {};
-	map<string, set<string>> expectedDeployedEvents = {
+	std::map<std::string, std::set<std::string>> expectedCreationEvents = {};
+	std::map<std::string, std::set<std::string>> expectedDeployedEvents = {
 		{"D", {
 			"event I.Ev(uint256)",
 		}},
 	};
 
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges, {}, expectedCreationEvents);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges, {}, expectedDeployedEvents);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges, {}, expectedCreationEvents);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges, {}, expectedDeployedEvents);
 }
 
 BOOST_AUTO_TEST_CASE(indirect_calls)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		function free1() {}
 		function free2() {}
 		function free3() {}
@@ -1253,9 +1253,9 @@ BOOST_AUTO_TEST_CASE(indirect_calls)
 			}
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"L", {}},
 		{"C", {}},
 		{"D", {
@@ -1273,7 +1273,7 @@ BOOST_AUTO_TEST_CASE(indirect_calls)
 		}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"L", {
 			{"InternalDispatch", "function L.inr1()"},
 			{"InternalDispatch", "function L.inr2()"},
@@ -1315,13 +1315,13 @@ BOOST_AUTO_TEST_CASE(indirect_calls)
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(calls_via_pointers)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		function free1() {}
 		function free2() {}
 		function free3() {}
@@ -1412,9 +1412,9 @@ BOOST_AUTO_TEST_CASE(calls_via_pointers)
 			}
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"L", {}},
 		{"C", {}},
 		{"D", {
@@ -1437,7 +1437,7 @@ BOOST_AUTO_TEST_CASE(calls_via_pointers)
 		}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"L", {}},
 		{"C", {
 			{"InternalDispatch", "function C.inr2()"},
@@ -1475,13 +1475,13 @@ BOOST_AUTO_TEST_CASE(calls_via_pointers)
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(pointer_to_overridden_function)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		contract C {
 			function f() internal virtual {}
 		}
@@ -1506,14 +1506,14 @@ BOOST_AUTO_TEST_CASE(pointer_to_overridden_function)
 			}
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {}},
 		{"D", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {}},
 		{"D", {
 			{"InternalDispatch", "function C.f()"},
@@ -1526,13 +1526,13 @@ BOOST_AUTO_TEST_CASE(pointer_to_overridden_function)
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(pointer_to_nonexistent_function)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		interface I {
 			function f() external;
 		}
@@ -1559,15 +1559,15 @@ BOOST_AUTO_TEST_CASE(pointer_to_nonexistent_function)
 			function g() internal override {}
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"I", {}},
 		{"C", {}},
 		{"D", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"I", {
 			{"Entry", "function I.f()"},
 			  }},
@@ -1593,39 +1593,39 @@ BOOST_AUTO_TEST_CASE(pointer_to_nonexistent_function)
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(function_self_reference)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		contract C {
 			function f() public returns (bool ret) {
 				return f == f;
 			}
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {
 			{"Entry", "function C.f()"},
 			{"InternalDispatch", "function C.f()"},
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(pointer_cycle)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		contract C {
 			function () ptr = f;
 
@@ -1637,14 +1637,14 @@ BOOST_AUTO_TEST_CASE(pointer_cycle)
 		}
 	)"s);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {
 			{"InternalDispatch", "function C.f()"},
 			{"function C.f()", "InternalDispatch"},
 		}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {
 			{"InternalDispatch", "function C.f()"},
 			{"Entry", "function C.test()"},
@@ -1652,15 +1652,15 @@ BOOST_AUTO_TEST_CASE(pointer_cycle)
 			{"function C.f()", "InternalDispatch"},
 		}},
 	};
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(using_for)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		struct S {
 			uint x;
 		}
@@ -1681,14 +1681,14 @@ BOOST_AUTO_TEST_CASE(using_for)
 			}
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"L", {}},
 		{"C", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"L", {
 			{"Entry", "function L.ext(struct S)"},
 		}},
@@ -1698,13 +1698,13 @@ BOOST_AUTO_TEST_CASE(using_for)
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(user_defined_binary_operator)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		type Int is int128;
 		using {add as +} for Int global;
 
@@ -1718,26 +1718,26 @@ BOOST_AUTO_TEST_CASE(user_defined_binary_operator)
 			}
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {
 			{"Entry", "function C.pub()"},
 			{"function C.pub()", "function add(Int,Int)"},
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(user_defined_unary_operator)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		type Int is int128;
 		using {sub as -} for Int global;
 
@@ -1751,26 +1751,26 @@ BOOST_AUTO_TEST_CASE(user_defined_unary_operator)
 			}
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {
 			{"Entry", "function C.pub()"},
 			{"function C.pub()", "function sub(Int)"},
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(getters)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		contract C {
 			uint public variable;
 			uint[][] public array;
@@ -1783,23 +1783,23 @@ BOOST_AUTO_TEST_CASE(getters)
 			}
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {{"Entry", "function C.test()"}}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(fallback_and_receive)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		contract C {
 			function ext() external {}
 			function inr() internal {}
@@ -1825,15 +1825,15 @@ BOOST_AUTO_TEST_CASE(fallback_and_receive)
 
 		contract E is C {}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {}},
 		{"D", {}},
 		{"E", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {
 			{"Entry", "function C.ext()"},
 			{"Entry", "receive of C"},
@@ -1854,13 +1854,13 @@ BOOST_AUTO_TEST_CASE(fallback_and_receive)
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(virtual_fallback_and_receive)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		contract C {
 			fallback() external virtual {}
 			receive() external payable virtual {}
@@ -1878,16 +1878,16 @@ BOOST_AUTO_TEST_CASE(virtual_fallback_and_receive)
 			receive() external payable override {}
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"C", {}},
 		{"D", {}},
 		{"E", {}},
 		{"F", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"C", {
 			{"Entry", "receive of C"},
 			{"Entry", "fallback of C"},
@@ -1906,13 +1906,13 @@ BOOST_AUTO_TEST_CASE(virtual_fallback_and_receive)
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(builtins)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		interface I {}
 
 		contract C {
@@ -1989,14 +1989,14 @@ BOOST_AUTO_TEST_CASE(builtins)
 			}
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"I", {}},
 		{"C", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"I", {}},
 		{"C", {
 			{"Entry", "function C.accessBuiltin()"},
@@ -2004,13 +2004,13 @@ BOOST_AUTO_TEST_CASE(builtins)
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(conversions_and_struct_array_constructors)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		interface I {}
 
 		enum E {A, B, C}
@@ -2053,14 +2053,14 @@ BOOST_AUTO_TEST_CASE(conversions_and_struct_array_constructors)
 			}
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"I", {}},
 		{"C", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"I", {}},
 		{"C", {
 			{"Entry", "function C.convert()"},
@@ -2069,13 +2069,13 @@ BOOST_AUTO_TEST_CASE(conversions_and_struct_array_constructors)
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(immutable_initialization)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		function free() pure returns (uint) { return 42; }
 
 		contract Base {
@@ -2098,9 +2098,9 @@ BOOST_AUTO_TEST_CASE(immutable_initialization)
 			}
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"Base", {}},
 		{"C", {
 			{"Entry", "function Base.inr()"},
@@ -2113,7 +2113,7 @@ BOOST_AUTO_TEST_CASE(immutable_initialization)
 		}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"Base", {
 			{"Entry", "function Base.ext()"},
 			{"function Base.ext()", "function free()"},
@@ -2128,13 +2128,13 @@ BOOST_AUTO_TEST_CASE(immutable_initialization)
 		}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_CASE(function_selector_access)
 {
-	unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
+	std::unique_ptr<CompilerStack> compilerStack = parseAndAnalyzeContracts(R"(
 		function free() pure {}
 
 		bytes4 constant extFreeConst = Base.ext.selector;
@@ -2171,9 +2171,9 @@ BOOST_AUTO_TEST_CASE(function_selector_access)
 			bytes4 constant pubConst = Base.pub.selector;
 		}
 	)"s);
-	tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
+	std::tuple<CallGraphMap, CallGraphMap> graphs = collectGraphs(*compilerStack);
 
-	map<string, EdgeNames> expectedCreationEdges = {
+	std::map<std::string, EdgeNames> expectedCreationEdges = {
 		{"Base", {}},
 		{"C", {}},
 		{"D", {
@@ -2188,7 +2188,7 @@ BOOST_AUTO_TEST_CASE(function_selector_access)
 		{"L", {}},
 	};
 
-	map<string, EdgeNames> expectedDeployedEdges = {
+	std::map<std::string, EdgeNames> expectedDeployedEdges = {
 		{"Base", {
 			{"Entry", "function Base.ext()"},
 			{"Entry", "function Base.pub()"},
@@ -2226,8 +2226,8 @@ BOOST_AUTO_TEST_CASE(function_selector_access)
 		{"L", {}},
 	};
 
-	checkCallGraphExpectations(get<0>(graphs), expectedCreationEdges);
-	checkCallGraphExpectations(get<1>(graphs), expectedDeployedEdges);
+	checkCallGraphExpectations(std::get<0>(graphs), expectedCreationEdges);
+	checkCallGraphExpectations(std::get<1>(graphs), expectedDeployedEdges);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/libsolidity/interface/FileReader.cpp
+++ b/test/libsolidity/interface/FileReader.cpp
@@ -30,7 +30,6 @@
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 using namespace solidity::util;
 using namespace solidity::test;
 
@@ -226,12 +225,12 @@ BOOST_AUTO_TEST_CASE(normalizeCLIPathForVFS_stripping_root_name)
 		BOOST_CHECK_EQUAL(normalizedPath.root_directory(), "/");
 
 #if defined(_WIN32)
-		string root = workDir.root_path().string();
+		std::string root = workDir.root_path().string();
 		soltestAssert(root.length() == 3 && root[1] == ':' && root[2] == '\\', "");
 
-		for (auto convert: {boost::to_lower_copy<string>, boost::to_upper_copy<string>})
+		for (auto convert: {boost::to_lower_copy<std::string>, boost::to_upper_copy<std::string>})
 		{
-			boost::filesystem::path workDirWin = convert(root, locale()) / workDir.relative_path();
+			boost::filesystem::path workDirWin = convert(root, std::locale()) / workDir.relative_path();
 			normalizedPath = FileReader::normalizeCLIPathForVFS(
 				workDirWin,
 				resolveSymlinks

--- a/test/libsolutil/Checksum.cpp
+++ b/test/libsolutil/Checksum.cpp
@@ -26,7 +26,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 
 namespace solidity::util::test
 {
@@ -47,7 +46,7 @@ BOOST_AUTO_TEST_CASE(calculate)
 	BOOST_CHECK_THROW(getChecksummedAddress("0x5aaeb6053f3e94c9b9a09f33669435e7ef1beaeK"), InvalidAddress);
 
 	// the official test suite from EIP-55
-	vector<string> cases {
+	std::vector<std::string> cases {
 		// all upper case
 		"0x52908400098527886E0F7030069857D2E4169EE7",
 		"0x8617E340B3D01FA5F11F306F4090FD50E238070D",
@@ -103,10 +102,10 @@ BOOST_AUTO_TEST_CASE(homocaps_valid)
 
 BOOST_AUTO_TEST_CASE(homocaps_invalid)
 {
-	string upper = "0x00AA0000000012400000000DDEEFF000000000BB";
+	std::string upper = "0x00AA0000000012400000000DDEEFF000000000BB";
 	BOOST_CHECK(passesAddressChecksum(upper, false));
 	BOOST_CHECK(!passesAddressChecksum(upper, true));
-	string lower = "0x11aa000000000000000d00cc00000000000000bb";
+	std::string lower = "0x11aa000000000000000d00cc00000000000000bb";
 	BOOST_CHECK(passesAddressChecksum(lower, false));
 	BOOST_CHECK(!passesAddressChecksum(lower, true));
 }

--- a/test/libsolutil/CommonData.cpp
+++ b/test/libsolutil/CommonData.cpp
@@ -28,7 +28,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 using namespace solidity::frontend;
 
 // TODO: Fix Boost...

--- a/test/libsolutil/CommonIO.cpp
+++ b/test/libsolutil/CommonIO.cpp
@@ -31,7 +31,6 @@
 #include <fstream>
 #include <string>
 
-using namespace std;
 using namespace solidity::test;
 
 #define TEST_CASE_NAME (boost::unit_test::framework::current_test_case().p_name)
@@ -68,31 +67,31 @@ BOOST_AUTO_TEST_CASE(readFileAsString_symlink)
 
 BOOST_AUTO_TEST_CASE(readUntilEnd_no_ending_newline)
 {
-	istringstream inputStream("ABC\ndef");
+	std::istringstream inputStream("ABC\ndef");
 	BOOST_TEST(readUntilEnd(inputStream) == "ABC\ndef");
 }
 
 BOOST_AUTO_TEST_CASE(readUntilEnd_with_ending_newline)
 {
-	istringstream inputStream("ABC\ndef\n");
+	std::istringstream inputStream("ABC\ndef\n");
 	BOOST_TEST(readUntilEnd(inputStream) == "ABC\ndef\n");
 }
 
 BOOST_AUTO_TEST_CASE(readUntilEnd_cr_lf_newline)
 {
-	istringstream inputStream("ABC\r\ndef");
+	std::istringstream inputStream("ABC\r\ndef");
 	BOOST_TEST(readUntilEnd(inputStream) == "ABC\r\ndef");
 }
 
 BOOST_AUTO_TEST_CASE(readUntilEnd_empty)
 {
-	istringstream inputStream("");
+	std::istringstream inputStream("");
 	BOOST_TEST(readUntilEnd(inputStream) == "");
 }
 
 BOOST_AUTO_TEST_CASE(readBytes_past_end)
 {
-	istringstream inputStream("abc");
+	std::istringstream inputStream("abc");
 	BOOST_CHECK_EQUAL(readBytes(inputStream, 0), "");
 	BOOST_CHECK_EQUAL(readBytes(inputStream, 1), "a");
 	BOOST_CHECK_EQUAL(readBytes(inputStream, 20), "bc");

--- a/test/libsolutil/FixedHash.cpp
+++ b/test/libsolutil/FixedHash.cpp
@@ -25,7 +25,6 @@
 #include <cstdint>
 #include <sstream>
 
-using namespace std;
 
 namespace solidity::util::test
 {

--- a/test/libsolutil/FunctionSelector.cpp
+++ b/test/libsolutil/FunctionSelector.cpp
@@ -25,7 +25,6 @@
 #include <cstdint>
 #include <sstream>
 
-using namespace std;
 
 namespace solidity::util::test
 {

--- a/test/libsolutil/IndentedWriter.cpp
+++ b/test/libsolutil/IndentedWriter.cpp
@@ -25,7 +25,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 
 namespace solidity::util::test
 {

--- a/test/libsolutil/IpfsHash.cpp
+++ b/test/libsolutil/IpfsHash.cpp
@@ -25,7 +25,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 
 namespace solidity::util::test
 {
@@ -37,16 +36,16 @@ BOOST_AUTO_TEST_CASE(test_small)
 	BOOST_CHECK_EQUAL(ipfsHashBase58({}), "QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH");
 	BOOST_CHECK_EQUAL(ipfsHashBase58("x"), "QmULKig5Fxrs2sC4qt9nNduucXfb92AFYQ6Hi3YRqDmrYC");
 	BOOST_CHECK_EQUAL(ipfsHashBase58("Solidity\n"), "QmSsm9M7PQRBnyiz1smizk8hZw3URfk8fSeHzeTo3oZidS");
-	BOOST_CHECK_EQUAL(ipfsHashBase58(string(200ul, char(0))), "QmSXR1N23uWzsANi8wpxMPw5dmmhqBVUAb4hUrHVLpNaMr");
-	BOOST_CHECK_EQUAL(ipfsHashBase58(string(10250ul, char(0))), "QmVJJBB3gKKBWYC9QTywpH8ZL1bDeTDJ17B63Af5kino9i");
-	BOOST_CHECK_EQUAL(ipfsHashBase58(string(100000ul, char(0))), "QmYgKa25YqEGpQmmZtPPFMNK3kpqqneHk6nMSEUYryEX1C");
-	BOOST_CHECK_EQUAL(ipfsHashBase58(string(121071ul, char(0))), "QmdMdRshQmqvyc92N82r7AKYdUF5FRh4DJo6GtrmEk3wgj");
+	BOOST_CHECK_EQUAL(ipfsHashBase58(std::string(200ul, char(0))), "QmSXR1N23uWzsANi8wpxMPw5dmmhqBVUAb4hUrHVLpNaMr");
+	BOOST_CHECK_EQUAL(ipfsHashBase58(std::string(10250ul, char(0))), "QmVJJBB3gKKBWYC9QTywpH8ZL1bDeTDJ17B63Af5kino9i");
+	BOOST_CHECK_EQUAL(ipfsHashBase58(std::string(100000ul, char(0))), "QmYgKa25YqEGpQmmZtPPFMNK3kpqqneHk6nMSEUYryEX1C");
+	BOOST_CHECK_EQUAL(ipfsHashBase58(std::string(121071ul, char(0))), "QmdMdRshQmqvyc92N82r7AKYdUF5FRh4DJo6GtrmEk3wgj");
 }
 
 BOOST_AUTO_TEST_CASE(test_medium)
 {
 	size_t length = 131071;
-	string data;
+	std::string data;
 	data.resize(length, 0);
 	BOOST_REQUIRE_EQUAL(data.size(), length);
 	BOOST_CHECK_EQUAL(ipfsHashBase58(data), "QmSxYSToKHsPqqRdRnsM9gmr3EYS6dakhVaHgbFdgYQWi6");
@@ -55,7 +54,7 @@ BOOST_AUTO_TEST_CASE(test_medium)
 BOOST_AUTO_TEST_CASE(test_largest_unchunked)
 {
 	size_t length = 1024 * 256 - 1;
-	string data;
+	std::string data;
 	data.resize(length, 0);
 	BOOST_REQUIRE_EQUAL(data.size(), length);
 	BOOST_CHECK_EQUAL(ipfsHashBase58(data), "QmbNDspMkzkMFKyS3eCJGedG7GWRQHSCzJCZLjxP7wyVAx");
@@ -64,7 +63,7 @@ BOOST_AUTO_TEST_CASE(test_largest_unchunked)
 BOOST_AUTO_TEST_CASE(test_smallest_chunked)
 {
 	size_t length = 1024 * 256 + 1;
-	string data;
+	std::string data;
 	data.resize(length, 0);
 	BOOST_REQUIRE_EQUAL(data.size(), length);
 	BOOST_CHECK_EQUAL(ipfsHashBase58(data), "QmbVuw4C4vcmVKqxoWtgDVobvcHrSn51qsmQmyxjk4sB2Q");
@@ -73,7 +72,7 @@ BOOST_AUTO_TEST_CASE(test_smallest_chunked)
 BOOST_AUTO_TEST_CASE(test_large)
 {
 	size_t length = 1310710;
-	string data;
+	std::string data;
 	data.resize(length, 0);
 	BOOST_REQUIRE_EQUAL(data.size(), length);
 	BOOST_CHECK_EQUAL(ipfsHashBase58(data), "QmNg7BJo8gEMDK8yGQbHEwPtycesnE6FUULX5iVd5TAL9f");
@@ -82,7 +81,7 @@ BOOST_AUTO_TEST_CASE(test_large)
 BOOST_AUTO_TEST_CASE(test_largest_one_level)
 {
 	size_t length = 45613056; // 1024 * 256 * 174;
-	string data;
+	std::string data;
 	data.resize(length, 0);
 	BOOST_REQUIRE_EQUAL(data.size(), length);
 	BOOST_CHECK_EQUAL(ipfsHashBase58(data), "QmY4HSz1oVGdUzb8poVYPLsoqBZjH6LZrtgnme9wWn2Qko");
@@ -91,7 +90,7 @@ BOOST_AUTO_TEST_CASE(test_largest_one_level)
 BOOST_AUTO_TEST_CASE(test_smallest_multi_level)
 {
 	size_t length = 45613057; // 1024 * 256 * 174 + 1;
-	string data;
+	std::string data;
 	data.resize(length, 0);
 	BOOST_REQUIRE_EQUAL(data.size(), length);
 	BOOST_CHECK_EQUAL(ipfsHashBase58(data), "QmehMASWcBsX7VcEQqs6rpR5AHoBfKyBVEgmkJHjpPg8jq");
@@ -100,7 +99,7 @@ BOOST_AUTO_TEST_CASE(test_smallest_multi_level)
 BOOST_AUTO_TEST_CASE(test_multi_level_tree)
 {
 	size_t length = 46661632;
-	string data;
+	std::string data;
 	data.resize(length, 0);
 	BOOST_REQUIRE_EQUAL(data.size(), length);
 	BOOST_CHECK_EQUAL(ipfsHashBase58(data), "QmaTb1sT9hrSXJLmf8bxJ9NuwndiHuMLsgNLgkS2eXu3Xj");

--- a/test/libsolutil/IterateReplacing.cpp
+++ b/test/libsolutil/IterateReplacing.cpp
@@ -25,7 +25,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 
 namespace solidity::util::test
 {
@@ -34,61 +33,61 @@ BOOST_AUTO_TEST_SUITE(IterateReplacing, *boost::unit_test::label("nooptions"))
 
 BOOST_AUTO_TEST_CASE(no_replacement)
 {
-	vector<string> v{"abc", "def", "ghi"};
-	function<std::optional<vector<string>>(string&)> f = [](string&) -> std::optional<vector<string>> { return {}; };
+	std::vector<std::string> v{"abc", "def", "ghi"};
+	std::function<std::optional<std::vector<std::string>>(std::string&)> f = [](std::string&) -> std::optional<std::vector<std::string>> { return {}; };
 	iterateReplacing(v, f);
-	vector<string> expectation{"abc", "def", "ghi"};
+	std::vector<std::string> expectation{"abc", "def", "ghi"};
 	BOOST_CHECK(v == expectation);
 }
 
 BOOST_AUTO_TEST_CASE(empty_input)
 {
-	vector<string> v;
-	function<std::optional<vector<string>>(string&)> f = [](string&) -> std::optional<vector<string>> { return {}; };
+	std::vector<std::string> v;
+	std::function<std::optional<std::vector<std::string>>(std::string&)> f = [](std::string&) -> std::optional<std::vector<std::string>> { return {}; };
 	iterateReplacing(v, f);
-	vector<string> expectation;
+	std::vector<std::string> expectation;
 	BOOST_CHECK(v == expectation);
 }
 
 BOOST_AUTO_TEST_CASE(delete_some)
 {
-	vector<string> v{"abc", "def", "ghi"};
-	function<std::optional<vector<string>>(string&)> f = [](string& _s) -> std::optional<vector<string>> {
+	std::vector<std::string> v{"abc", "def", "ghi"};
+	std::function<std::optional<std::vector<std::string>>(std::string&)> f = [](std::string& _s) -> std::optional<std::vector<std::string>> {
 		if (_s == "def")
-			return vector<string>();
+			return std::vector<std::string>();
 		else
 			return {};
 	};
 	iterateReplacing(v, f);
-	vector<string> expectation{"abc", "ghi"};
+	std::vector<std::string> expectation{"abc", "ghi"};
 	BOOST_CHECK(v == expectation);
 }
 
 BOOST_AUTO_TEST_CASE(inject_some_start)
 {
-	vector<string> v{"abc", "def", "ghi"};
-	function<std::optional<vector<string>>(string&)> f = [](string& _s) -> std::optional<vector<string>> {
+	std::vector<std::string> v{"abc", "def", "ghi"};
+	std::function<std::optional<std::vector<std::string>>(std::string&)> f = [](std::string& _s) -> std::optional<std::vector<std::string>> {
 		if (_s == "abc")
-			return vector<string>{"x", "y"};
+			return std::vector<std::string>{"x", "y"};
 		else
 			return {};
 	};
 	iterateReplacing(v, f);
-	vector<string> expectation{"x", "y", "def", "ghi"};
+	std::vector<std::string> expectation{"x", "y", "def", "ghi"};
 	BOOST_CHECK(v == expectation);
 }
 
 BOOST_AUTO_TEST_CASE(inject_some_end)
 {
-	vector<string> v{"abc", "def", "ghi"};
-	function<std::optional<vector<string>>(string&)> f = [](string& _s) -> std::optional<vector<string>> {
+	std::vector<std::string> v{"abc", "def", "ghi"};
+	std::function<std::optional<std::vector<std::string>>(std::string&)> f = [](std::string& _s) -> std::optional<std::vector<std::string>> {
 		if (_s == "ghi")
-			return vector<string>{"x", "y"};
+			return std::vector<std::string>{"x", "y"};
 		else
 			return {};
 	};
 	iterateReplacing(v, f);
-	vector<string> expectation{"abc", "def", "x", "y"};
+	std::vector<std::string> expectation{"abc", "def", "x", "y"};
 	BOOST_CHECK(v == expectation);
 }
 

--- a/test/libsolutil/JSON.cpp
+++ b/test/libsolutil/JSON.cpp
@@ -26,7 +26,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 
 namespace solidity::util::test
 {
@@ -35,7 +34,7 @@ BOOST_AUTO_TEST_SUITE(JsonTest, *boost::unit_test::label("nooptions"))
 
 BOOST_AUTO_TEST_CASE(json_types)
 {
-	auto check = [](Json::Value value, string const& expectation) {
+	auto check = [](Json::Value value, std::string const& expectation) {
 		BOOST_CHECK(jsonCompactPrint(value) == expectation);
 	};
 

--- a/test/libsolutil/Keccak256.cpp
+++ b/test/libsolutil/Keccak256.cpp
@@ -22,7 +22,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 
 namespace solidity::util::test
 {

--- a/test/libsolutil/LEB128.cpp
+++ b/test/libsolutil/LEB128.cpp
@@ -23,7 +23,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 
 namespace solidity::util::test
 {

--- a/test/libsolutil/StringUtils.cpp
+++ b/test/libsolutil/StringUtils.cpp
@@ -29,7 +29,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 
 namespace solidity::util::test
 {
@@ -75,7 +74,7 @@ BOOST_AUTO_TEST_CASE(test_dldistance)
 
 BOOST_AUTO_TEST_CASE(test_alternatives_list)
 {
-	vector<string> strings;
+	std::vector<std::string> strings;
 	BOOST_CHECK_EQUAL(quotedAlternativesList(strings), "");
 	strings.emplace_back("a");
 	BOOST_CHECK_EQUAL(quotedAlternativesList(strings), "\"a\"");
@@ -89,20 +88,20 @@ BOOST_AUTO_TEST_CASE(test_alternatives_list)
 
 BOOST_AUTO_TEST_CASE(test_human_readable_join)
 {
-	BOOST_CHECK_EQUAL(joinHumanReadable(vector<string>({})), "");
-	BOOST_CHECK_EQUAL(joinHumanReadable(vector<string>({"a"})), "a");
-	BOOST_CHECK_EQUAL(joinHumanReadable(vector<string>({"a", "b"})), "a, b");
-	BOOST_CHECK_EQUAL(joinHumanReadable(vector<string>({"a", "b", "c"})), "a, b, c");
+	BOOST_CHECK_EQUAL(joinHumanReadable(std::vector<std::string>({})), "");
+	BOOST_CHECK_EQUAL(joinHumanReadable(std::vector<std::string>({"a"})), "a");
+	BOOST_CHECK_EQUAL(joinHumanReadable(std::vector<std::string>({"a", "b"})), "a, b");
+	BOOST_CHECK_EQUAL(joinHumanReadable(std::vector<std::string>({"a", "b", "c"})), "a, b, c");
 
-	BOOST_CHECK_EQUAL(joinHumanReadable(vector<string>({}), "; "), "");
-	BOOST_CHECK_EQUAL(joinHumanReadable(vector<string>({"a"}), "; "), "a");
-	BOOST_CHECK_EQUAL(joinHumanReadable(vector<string>({"a", "b"}), "; "), "a; b");
-	BOOST_CHECK_EQUAL(joinHumanReadable(vector<string>({"a", "b", "c"}), "; "), "a; b; c");
+	BOOST_CHECK_EQUAL(joinHumanReadable(std::vector<std::string>({}), "; "), "");
+	BOOST_CHECK_EQUAL(joinHumanReadable(std::vector<std::string>({"a"}), "; "), "a");
+	BOOST_CHECK_EQUAL(joinHumanReadable(std::vector<std::string>({"a", "b"}), "; "), "a; b");
+	BOOST_CHECK_EQUAL(joinHumanReadable(std::vector<std::string>({"a", "b", "c"}), "; "), "a; b; c");
 
-	BOOST_CHECK_EQUAL(joinHumanReadable(vector<string>({}), "; ", " or "), "");
-	BOOST_CHECK_EQUAL(joinHumanReadable(vector<string>({"a"}), "; ", " or "), "a");
-	BOOST_CHECK_EQUAL(joinHumanReadable(vector<string>({"a", "b"}), "; ", " or "), "a or b");
-	BOOST_CHECK_EQUAL(joinHumanReadable(vector<string>({"a", "b", "c"}), "; ", " or "), "a; b or c");
+	BOOST_CHECK_EQUAL(joinHumanReadable(std::vector<std::string>({}), "; ", " or "), "");
+	BOOST_CHECK_EQUAL(joinHumanReadable(std::vector<std::string>({"a"}), "; ", " or "), "a");
+	BOOST_CHECK_EQUAL(joinHumanReadable(std::vector<std::string>({"a", "b"}), "; ", " or "), "a or b");
+	BOOST_CHECK_EQUAL(joinHumanReadable(std::vector<std::string>({"a", "b", "c"}), "; ", " or "), "a; b or c");
 }
 
 BOOST_AUTO_TEST_CASE(test_format_number_readable)

--- a/test/libsolutil/SwarmHash.cpp
+++ b/test/libsolutil/SwarmHash.cpp
@@ -27,7 +27,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 
 namespace solidity::util::test
 {
@@ -37,12 +36,12 @@ BOOST_AUTO_TEST_SUITE(SwarmHash, *boost::unit_test::label("nooptions"))
 namespace
 {
 
-string bzzr0HashHex(string const& _input)
+std::string bzzr0HashHex(std::string const& _input)
 {
 	return toHex(bzzr0Hash(_input).asBytes());
 }
 
-string bzzr1HashHex(bytes const& _input)
+std::string bzzr1HashHex(bytes const& _input)
 {
 	return toHex(bzzr1Hash(_input).asBytes());
 }
@@ -59,17 +58,17 @@ bytes sequence(size_t _length)
 
 BOOST_AUTO_TEST_CASE(test_zeros)
 {
-	BOOST_CHECK_EQUAL(bzzr0HashHex(string()), string("011b4d03dd8c01f1049143cf9c4c817e4b167f1d1b83e5c6f0f10d89ba1e7bce"));
-	BOOST_CHECK_EQUAL(bzzr0HashHex(string(0x1000 - 1, 0)), string("32f0faabc4265ac238cd945087133ce3d7e9bb2e536053a812b5373c54043adb"));
-	BOOST_CHECK_EQUAL(bzzr0HashHex(string(0x1000, 0)), string("411dd45de7246e94589ff5888362c41e85bd3e582a92d0fda8f0e90b76439bec"));
-	BOOST_CHECK_EQUAL(bzzr0HashHex(string(0x1000 + 1, 0)), string("69754a0098432bbc2e84fe1205276870748a61a065ab6ef44d6a2e7b13ce044d"));
-	BOOST_CHECK_EQUAL(bzzr0HashHex(string(0x2000 - 1, 0)), string("69ad3c581043404f775ffa8d6f1b25ad4a9ee812971190e90209c0966116a321"));
-	BOOST_CHECK_EQUAL(bzzr0HashHex(string(0x2000, 0)), string("f00222373ff82d0a178dc6271c78953e9c88f74130a52d401f5ec51475f63c43"));
-	BOOST_CHECK_EQUAL(bzzr0HashHex(string(0x2000 + 1, 0)), string("86d6773e79e02fd8145ee1aedba89ace0c15f2566db1249654000039a9a134bf"));
-	BOOST_CHECK_EQUAL(bzzr0HashHex(string(0x80000, 0)), string("cc0854fe2c6b98e920d5c14b1a88e6d4223e55b8f78883f60939aa2485e361bf"));
-	BOOST_CHECK_EQUAL(bzzr0HashHex(string(0x80020, 0)), string("ee9ffca246e70d3704740ba4df450fa6988d14a1c2439c7e734c7a77a4eb6fd3"));
-	BOOST_CHECK_EQUAL(bzzr0HashHex(string(0x800020, 0)), string("78b90b20c90559fb904535181a7c28929ea2f30a2329dbc25232de579709f12f"));
-	BOOST_CHECK_EQUAL(bzzr0HashHex(string(2095104, 0)), string("a9958184589fc11b4027a4c233e777ebe2e99c66f96b74aef2a0638a94dd5439"));
+	BOOST_CHECK_EQUAL(bzzr0HashHex(std::string()), std::string("011b4d03dd8c01f1049143cf9c4c817e4b167f1d1b83e5c6f0f10d89ba1e7bce"));
+	BOOST_CHECK_EQUAL(bzzr0HashHex(std::string(0x1000 - 1, 0)), std::string("32f0faabc4265ac238cd945087133ce3d7e9bb2e536053a812b5373c54043adb"));
+	BOOST_CHECK_EQUAL(bzzr0HashHex(std::string(0x1000, 0)), std::string("411dd45de7246e94589ff5888362c41e85bd3e582a92d0fda8f0e90b76439bec"));
+	BOOST_CHECK_EQUAL(bzzr0HashHex(std::string(0x1000 + 1, 0)), std::string("69754a0098432bbc2e84fe1205276870748a61a065ab6ef44d6a2e7b13ce044d"));
+	BOOST_CHECK_EQUAL(bzzr0HashHex(std::string(0x2000 - 1, 0)), std::string("69ad3c581043404f775ffa8d6f1b25ad4a9ee812971190e90209c0966116a321"));
+	BOOST_CHECK_EQUAL(bzzr0HashHex(std::string(0x2000, 0)), std::string("f00222373ff82d0a178dc6271c78953e9c88f74130a52d401f5ec51475f63c43"));
+	BOOST_CHECK_EQUAL(bzzr0HashHex(std::string(0x2000 + 1, 0)), std::string("86d6773e79e02fd8145ee1aedba89ace0c15f2566db1249654000039a9a134bf"));
+	BOOST_CHECK_EQUAL(bzzr0HashHex(std::string(0x80000, 0)), std::string("cc0854fe2c6b98e920d5c14b1a88e6d4223e55b8f78883f60939aa2485e361bf"));
+	BOOST_CHECK_EQUAL(bzzr0HashHex(std::string(0x80020, 0)), std::string("ee9ffca246e70d3704740ba4df450fa6988d14a1c2439c7e734c7a77a4eb6fd3"));
+	BOOST_CHECK_EQUAL(bzzr0HashHex(std::string(0x800020, 0)), std::string("78b90b20c90559fb904535181a7c28929ea2f30a2329dbc25232de579709f12f"));
+	BOOST_CHECK_EQUAL(bzzr0HashHex(std::string(2095104, 0)), std::string("a9958184589fc11b4027a4c233e777ebe2e99c66f96b74aef2a0638a94dd5439"));
 }
 
 BOOST_AUTO_TEST_CASE(bzz_hash_short)

--- a/test/libsolutil/TemporaryDirectoryTest.cpp
+++ b/test/libsolutil/TemporaryDirectoryTest.cpp
@@ -25,7 +25,6 @@
 
 #include <fstream>
 
-using namespace std;
 using namespace boost::test_tools;
 
 namespace solidity::util::test
@@ -58,8 +57,8 @@ BOOST_AUTO_TEST_CASE(TemporaryDirectory_should_delete_its_directory_even_if_not_
 		BOOST_TEST(boost::filesystem::is_directory(dirPath));
 
 		{
-			ofstream tmpFile((dirPath / "test-file.txt").string());
-			tmpFile << "Delete me!" << endl;
+			std::ofstream tmpFile((dirPath / "test-file.txt").string());
+			tmpFile << "Delete me!" << std::endl;
 		}
 		soltestAssert(boost::filesystem::is_regular_file(dirPath / "test-file.txt"), "");
 	}

--- a/test/libsolutil/UTF8.cpp
+++ b/test/libsolutil/UTF8.cpp
@@ -26,7 +26,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 
 namespace solidity::util::test
 {
@@ -35,13 +34,13 @@ BOOST_AUTO_TEST_SUITE(UTF8, *boost::unit_test::label("nooptions"))
 
 namespace {
 
-bool isValidUTF8(string const& _value)
+bool isValidUTF8(std::string const& _value)
 {
 	size_t pos;
 	return validateUTF8(asString(fromHex(_value)), pos);
 }
 
-bool isInvalidUTF8(string const& _value, size_t _expectedPos)
+bool isInvalidUTF8(std::string const& _value, size_t _expectedPos)
 {
 	size_t pos;
 	if (validateUTF8(asString(fromHex(_value)), pos))
@@ -94,7 +93,7 @@ BOOST_AUTO_TEST_CASE(invalid)
 
 BOOST_AUTO_TEST_CASE(corpus)
 {
-	string source = R"(
+	std::string source = R"(
 κόσμε
 
 hélló

--- a/test/libsolutil/Whiskers.cpp
+++ b/test/libsolutil/Whiskers.cpp
@@ -25,7 +25,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace std;
 
 namespace solidity::util::test
 {
@@ -34,14 +33,14 @@ BOOST_AUTO_TEST_SUITE(WhiskersTest, *boost::unit_test::label("nooptions"))
 
 BOOST_AUTO_TEST_CASE(no_templates)
 {
-	string templ = "this text does not contain templates";
+	std::string templ = "this text does not contain templates";
 	BOOST_CHECK_EQUAL(Whiskers(templ).render(), templ);
 }
 
 BOOST_AUTO_TEST_CASE(basic_replacement)
 {
-	string templ = "a <b> x <c> -> <d>.";
-	string result = Whiskers(templ)
+	std::string templ = "a <b> x <c> -> <d>.";
+	std::string result = Whiskers(templ)
 		("b", "BE")
 		("c", "CE")
 		("d", "DE")
@@ -51,43 +50,43 @@ BOOST_AUTO_TEST_CASE(basic_replacement)
 
 BOOST_AUTO_TEST_CASE(tag_unavailable)
 {
-	string templ = "<b>";
+	std::string templ = "<b>";
 	Whiskers m(templ);
 	BOOST_CHECK_THROW(m.render(), WhiskersError);
 }
 
 BOOST_AUTO_TEST_CASE(list_unavailable)
 {
-	string templ = "<#b></b>";
+	std::string templ = "<#b></b>";
 	Whiskers m(templ);
 	BOOST_CHECK_THROW(m.render(), WhiskersError);
 }
 
 BOOST_AUTO_TEST_CASE(name_type_collision)
 {
-	string templ = "<b><#b></b>";
+	std::string templ = "<b><#b></b>";
 	Whiskers m(templ);
 	m("b", "x");
-	BOOST_CHECK_THROW(m("b", vector<map<string, string>>{}), WhiskersError);
+	BOOST_CHECK_THROW(m("b", std::vector<std::map<std::string, std::string>>{}), WhiskersError);
 }
 
 BOOST_AUTO_TEST_CASE(conditional)
 {
-	string templ = "<?b>X</b>";
+	std::string templ = "<?b>X</b>";
 	BOOST_CHECK_EQUAL(Whiskers(templ)("b", true).render(), "X");
 	BOOST_CHECK_EQUAL(Whiskers(templ)("b", false).render(), "");
 }
 
 BOOST_AUTO_TEST_CASE(conditional_with_else)
 {
-	string templ = "<?b>X<!b>Y</b>";
+	std::string templ = "<?b>X<!b>Y</b>";
 	BOOST_CHECK_EQUAL(Whiskers(templ)("b", true).render(), "X");
 	BOOST_CHECK_EQUAL(Whiskers(templ)("b", false).render(), "Y");
 }
 
 BOOST_AUTO_TEST_CASE(broken_conditional_with_else)
 {
-	string templ = "<?b>X<!bY</b>";
+	std::string templ = "<?b>X<!bY</b>";
 	BOOST_CHECK_THROW(Whiskers{templ}, WhiskersError);
 
 	templ = "<?bX<!b>Y</b>";
@@ -99,7 +98,7 @@ BOOST_AUTO_TEST_CASE(broken_conditional_with_else)
 
 BOOST_AUTO_TEST_CASE(broken_conditional_value_with_else)
 {
-	string templ = "<?+b>X<!+bY</+b>";
+	std::string templ = "<?+b>X<!+bY</+b>";
 	BOOST_CHECK_THROW(Whiskers{templ}, WhiskersError);
 
 	templ = "<?+bX<!+b>Y</+b>";
@@ -111,7 +110,7 @@ BOOST_AUTO_TEST_CASE(broken_conditional_value_with_else)
 
 BOOST_AUTO_TEST_CASE(broken_list_parameter)
 {
-	string templ = "<#b><a></b";
+	std::string templ = "<#b><a></b";
 	BOOST_CHECK_THROW(Whiskers{templ}, WhiskersError);
 
 	templ = "<#b<a></b>";
@@ -120,7 +119,7 @@ BOOST_AUTO_TEST_CASE(broken_list_parameter)
 
 BOOST_AUTO_TEST_CASE(conditional_plus_params)
 {
-	string templ = " - <?b>_<r><!b>^<t></b> - ";
+	std::string templ = " - <?b>_<r><!b>^<t></b> - ";
 	Whiskers m1(templ);
 	m1("b", true);
 	m1("r", "R");
@@ -136,10 +135,10 @@ BOOST_AUTO_TEST_CASE(conditional_plus_params)
 
 BOOST_AUTO_TEST_CASE(conditional_plus_list)
 {
-	string templ = " - <?b>_<#l><x></l><!b><#l><y></l></b> - ";
+	std::string templ = " - <?b>_<#l><x></l><!b><#l><y></l></b> - ";
 	Whiskers m(templ);
 	m("b", false);
-	vector<map<string, string>> list(2);
+	std::vector<std::map<std::string, std::string>> list(2);
 	list[0]["x"] = "1";
 	list[0]["y"] = "a";
 	list[1]["x"] = "2";
@@ -150,21 +149,21 @@ BOOST_AUTO_TEST_CASE(conditional_plus_list)
 
 BOOST_AUTO_TEST_CASE(string_as_conditional)
 {
-	string templ = "<?+b>+<b><!+b>-</+b>";
+	std::string templ = "<?+b>+<b><!+b>-</+b>";
 	BOOST_CHECK_EQUAL(Whiskers(templ)("b", "abc").render(), "+abc");
 	BOOST_CHECK_EQUAL(Whiskers(templ)("b", "").render(), "-");
 }
 
 BOOST_AUTO_TEST_CASE(string_as_conditional_wrong)
 {
-	string templ = "<?+b>+<b></b>";
+	std::string templ = "<?+b>+<b></b>";
 	BOOST_CHECK_EQUAL(Whiskers(templ)("b", "abc").render(), "<?+b>+abc</b>");
 }
 
 BOOST_AUTO_TEST_CASE(complicated_replacement)
 {
-	string templ = "a <b> x <complicated> \n <nested>>.";
-	string result = Whiskers(templ)
+	std::string templ = "a <b> x <complicated> \n <nested>>.";
+	std::string result = Whiskers(templ)
 		("b", "BE")
 		("complicated", "CO<M>PL")
 		("nested", "NEST")
@@ -174,53 +173,53 @@ BOOST_AUTO_TEST_CASE(complicated_replacement)
 
 BOOST_AUTO_TEST_CASE(non_existing_list)
 {
-	string templ = "a <#b></b>";
+	std::string templ = "a <#b></b>";
 	Whiskers m(templ);
 	BOOST_CHECK_THROW(m.render(), WhiskersError);
 }
 
 BOOST_AUTO_TEST_CASE(empty_list)
 {
-	string templ = "a <#b></b>x";
-	string result = Whiskers(templ)("b", vector<Whiskers::StringMap>{}).render();
+	std::string templ = "a <#b></b>x";
+	std::string result = Whiskers(templ)("b", std::vector<Whiskers::StringMap>{}).render();
 	BOOST_CHECK_EQUAL(result, "a x");
 }
 
 BOOST_AUTO_TEST_CASE(list)
 {
-	string templ = "a<#b>( <g> - <h> )</b>x";
-	vector<map<string, string>> list(2);
+	std::string templ = "a<#b>( <g> - <h> )</b>x";
+	std::vector<std::map<std::string, std::string>> list(2);
 	list[0]["g"] = "GE";
 	list[0]["h"] = "H";
 	list[1]["g"] = "2GE";
 	list[1]["h"] = "2H";
-	string result = Whiskers(templ)("b", list).render();
+	std::string result = Whiskers(templ)("b", list).render();
 	BOOST_CHECK_EQUAL(result, "a( GE - H )( 2GE - 2H )x");
 }
 
 BOOST_AUTO_TEST_CASE(recursive_list)
 {
 	// Check that templates resulting from lists are not expanded again
-	string templ = "a<#b> 1<g>3 </b><x>";
-	vector<map<string, string>> list(1);
+	std::string templ = "a<#b> 1<g>3 </b><x>";
+	std::vector<std::map<std::string, std::string>> list(1);
 	list[0]["g"] = "<x>";
-	string result = Whiskers(templ)("x", "X")("b", list).render();
+	std::string result = Whiskers(templ)("x", "X")("b", list).render();
 	BOOST_CHECK_EQUAL(result, "a 1<x>3 X");
 }
 
 BOOST_AUTO_TEST_CASE(list_can_access_upper)
 {
-	string templ = "<#b>(<a>)</b>";
-	vector<map<string, string>> list(2);
+	std::string templ = "<#b>(<a>)</b>";
+	std::vector<std::map<std::string, std::string>> list(2);
 	Whiskers m(templ);
-	string result = m("a", "A")("b", list).render();
+	std::string result = m("a", "A")("b", list).render();
 	BOOST_CHECK_EQUAL(result, "(A)(A)");
 }
 
 BOOST_AUTO_TEST_CASE(parameter_collision)
 {
-	string templ = "a <#b></b>";
-	vector<map<string, string>> list(1);
+	std::string templ = "a <#b></b>";
+	std::vector<std::map<std::string, std::string>> list(1);
 	list[0]["a"] = "x";
 	Whiskers m(templ);
 	BOOST_CHECK_THROW(m("a", "X")("b", list), WhiskersError);
@@ -229,14 +228,14 @@ BOOST_AUTO_TEST_CASE(parameter_collision)
 
 BOOST_AUTO_TEST_CASE(invalid_param)
 {
-	string templ = "a <b >";
+	std::string templ = "a <b >";
 	Whiskers m(templ);
 	BOOST_CHECK_THROW(m("b ", "X"), WhiskersError);
 }
 
 BOOST_AUTO_TEST_CASE(invalid_param_rendered)
 {
-	string templ = "a <b >";
+	std::string templ = "a <b >";
 	Whiskers m(templ);
 	BOOST_CHECK_EQUAL(m.render(), templ);
 }


### PR DESCRIPTION
Related: https://github.com/ethereum/solidity/issues/14403

This PR deprecate `using namespace std` in some of the test folders
- [x]  test/contracts
- [x]  test/libevmasm
- [x]  test/liblangutil
- [x]  test/libsolutil
- [x] test/libsolidity 