### PR TITLE
Fix missing std qualifier for ASAN

### DIFF
--- a/test/libsolidity/SolidityOptimizer.cpp
+++ b/test/libsolidity/SolidityOptimizer.cpp
@@ -493,7 +493,7 @@ BOOST_AUTO_TEST_CASE(constant_optimization_early_exit)
 #endif
 #endif
 #if __SANITIZE_ADDRESS__
-	maxDuration = numeric_limits<size_t>::max();
+	maxDuration = std::numeric_limits<size_t>::max();
 	BOOST_TEST_MESSAGE("Disabled constant optimizer run time check for address sanitizer build.");
 #endif
 	BOOST_CHECK_MESSAGE(duration <= double(maxDuration), "Compilation of constants took longer than 20 seconds.");


### PR DESCRIPTION
Fixes an omitted `std::` namespace qualifier that was missed in https://github.com/ethereum/solidity/pull/14525, since it was under an unexpanded macro.