### PR TITLE
docs: add clarification about post-execution modifier behavior

### DIFF
--- a/docs/contracts/function-modifiers.rst
+++ b/docs/contracts/function-modifiers.rst
@@ -132,7 +132,7 @@ variables are set to their :ref:`default values<default-value>` just as if the f
 body.
 
 The ``_`` symbol can appear in the modifier multiple times. Each occurrence is replaced with
-the function body.
+the function body, and the function returns the return value of the final occurrence.
 
 Arbitrary expressions are allowed for modifier arguments and in this context,
 all symbols visible from the function are visible in the modifier. Symbols


### PR DESCRIPTION
Based on a conversation with @hrkrshnn, this PR adds clarification to the `function modifiers` section of the docs regarding the behavior of modifiers with post-execution actions.

Specifically, it clarifies two facts:
- If a function returns directly from an assembly block, all post-call execution in the modifier will be skipped.
- If the `_;` symbol is included in a modifier multiple times, the function will return the value from the final occurrence.