### PR TITLE
Work around differences in `lexically_normal()` on Boost 1.78+ and bump cmake and boost versions

### DIFF
--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -323,7 +323,7 @@ The following are dependencies for all builds of Solidity:
 | `CMake`_ (version 3.21.3+ on      | Cross-platform build file generator.                  |
 | Windows, 3.13+ otherwise)         |                                                       |
 +-----------------------------------+-------------------------------------------------------+
-| `Boost`_ (version 1.77 on         | C++ libraries.                                        |
+| `Boost`_ (version 1.77+ on        | C++ libraries.                                        |
 | Windows, 1.65+ otherwise)         |                                                       |
 +-----------------------------------+-------------------------------------------------------+
 | `Git`_                            | Command-line tool for retrieving source code.         |
@@ -410,7 +410,7 @@ You need to install the following dependencies for Windows builds of Solidity:
 +-----------------------------------+-------------------------------------------------------+
 | `Visual Studio 2019`_  (Optional) | C++ compiler and dev environment.                     |
 +-----------------------------------+-------------------------------------------------------+
-| `Boost`_ (version 1.77)           | C++ libraries.                                        |
+| `Boost`_ (version 1.77+)          | C++ libraries.                                        |
 +-----------------------------------+-------------------------------------------------------+
 
 If you already have one IDE and only need the compiler and libraries,

--- a/libsolidity/interface/FileReader.cpp
+++ b/libsolidity/interface/FileReader.cpp
@@ -325,7 +325,10 @@ bool FileReader::isPathPrefix(boost::filesystem::path const& _prefix, boost::fil
 	// NOTE: On Windows paths starting with a slash (rather than a drive letter) are considered relative by boost.
 	solAssert(_prefix.is_absolute() || isUNCPath(_prefix) || _prefix.root_path() == "/", "");
 	solAssert(_path.is_absolute() || isUNCPath(_path) || _path.root_path() == "/", "");
-	solAssert(_prefix == _prefix.lexically_normal() && _path == _path.lexically_normal(), "");
+	// NOTE: On Windows before Boost 1.78 lexically_normal() would not replace the `//` UNC prefix with `\\\\`.
+	// Later versions do. Use generic_path() to normalize all slashes to `/` and ignore that difference.
+	// This does not make the assert weaker because == ignores slash type anyway.
+	solAssert(_prefix == _prefix.lexically_normal().generic_string() && _path == _path.lexically_normal().generic_string(), "");
 	solAssert(!hasDotDotSegments(_prefix) && !hasDotDotSegments(_path), "");
 
 	boost::filesystem::path strippedPath = _path.lexically_relative(

--- a/scripts/install_deps.ps1
+++ b/scripts/install_deps.ps1
@@ -12,6 +12,7 @@ if ( -not (Test-Path "$PSScriptRoot\..\deps\boost") ) {
   }
   tar -xf cmake.zip
   mv cmake-3.27.4-windows-x86_64 "$PSScriptRoot\..\deps\cmake"
+  Remove-Item cmake.zip
 
   # FIXME: The default user agent results in Artifactory treating Invoke-WebRequest as a browser
   # and serving it a page that requires JavaScript.
@@ -20,9 +21,11 @@ if ( -not (Test-Path "$PSScriptRoot\..\deps\boost") ) {
     throw 'Downloaded Boost source package has wrong checksum.'
   }
   tar -xf boost.zip
+  Remove-Item boost.zip
   cd boost_1_83_0
   .\bootstrap.bat
   .\b2 -j4 -d0 link=static runtime-link=static variant=release threading=multi address-model=64 --with-filesystem --with-system --with-program_options --with-test --prefix="$PSScriptRoot\..\deps\boost" install
   if ( -not $? ) { throw "Error building boost." }
   cd ..
+  Remove-Item -LiteralPath .\boost_1_83_0 -Force -Recurse
 }

--- a/scripts/install_deps.ps1
+++ b/scripts/install_deps.ps1
@@ -6,21 +6,21 @@ $progressPreference = "silentlyContinue"
 if ( -not (Test-Path "$PSScriptRoot\..\deps\boost") ) {
   New-Item -ItemType Directory -Force -Path "$PSScriptRoot\..\deps"
 
-  Invoke-WebRequest -URI "https://github.com/Kitware/CMake/releases/download/v3.18.2/cmake-3.18.2-win64-x64.zip" -OutFile cmake.zip
-  if ((Get-FileHash cmake.zip).Hash -ne "5f4ec834fbd9b62fbf73bc48ed459fa2ea6a86c403106c90fedc2ac76d51612d") {
+  Invoke-WebRequest -URI "https://github.com/Kitware/CMake/releases/download/v3.27.4/cmake-3.27.4-windows-x86_64.zip" -OutFile cmake.zip
+  if ((Get-FileHash cmake.zip).Hash -ne "e5e060756444d0b2070328a8821c1ceb62bd6d267aae61bfff06f96c7ec943a6") {
     throw 'Downloaded CMake source package has wrong checksum.'
   }
   tar -xf cmake.zip
-  mv cmake-3.18.2-win64-x64 "$PSScriptRoot\..\deps\cmake"
+  mv cmake-3.27.4-windows-x86_64 "$PSScriptRoot\..\deps\cmake"
 
   # FIXME: The default user agent results in Artifactory treating Invoke-WebRequest as a browser
   # and serving it a page that requires JavaScript.
-  Invoke-WebRequest -URI "https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/boost_1_77_0.zip" -OutFile boost.zip -UserAgent ""
-  if ((Get-FileHash boost.zip).Hash -ne "d2886ceff60c35fc6dc9120e8faa960c1e9535f2d7ce447469eae9836110ea77") {
+  Invoke-WebRequest -URI "https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.zip" -OutFile boost.zip -UserAgent ""
+  if ((Get-FileHash boost.zip).Hash -ne "c86bd9d9eef795b4b0d3802279419fde5221922805b073b9bd822edecb1ca28e") {
     throw 'Downloaded Boost source package has wrong checksum.'
   }
   tar -xf boost.zip
-  cd boost_1_77_0
+  cd boost_1_83_0
   .\bootstrap.bat
   .\b2 -j4 -d0 link=static runtime-link=static variant=release threading=multi address-model=64 --with-filesystem --with-system --with-program_options --with-test --prefix="$PSScriptRoot\..\deps\boost" install
   if ( -not $? ) { throw "Error building boost." }


### PR DESCRIPTION
Fixes #14396.
Replaces #13434.

The problem is basically what I figured out in the original PR - the `//` part in UNC paths no longer remains unchanged after [`lexically_normal()`](https://www.boost.org/doc/libs/1_83_0/libs/filesystem/doc/reference.html#lexically_normal) so paths like `//a/b/c` are no longer considered normalized on Windows. The lexical normalization now changes `//` to `\\` (rather than `/` as I surmised). 

The good news is that all it affects is one of the sanity checks. Our portable normalization still works correctly because it always ignored the direction of slashes (`\\` gets normalized back to `//`). The fix is to relax the check to accept the unexpected backslashes.

This means that a Windows binary built with boost 1.78+ despite failing tests will not interpret paths in the wrong way. It may throw an ICE when it gets an UNC path, which is suboptimal, but such paths should be rare anyway. BTW I think we might even be better off disallowing them in the long term - they're not portable and just complicate the path logic for little practical gain.