### PR TITLE
Test coverage for `absolutePath()` and `sanitizePath()`

### DIFF
--- a/test/libsolutil/CommonIO.cpp
+++ b/test/libsolutil/CommonIO.cpp
@@ -25,18 +25,38 @@
 #include <test/FilesystemUtils.h>
 #include <test/libsolidity/util/SoltestErrors.h>
 
+#include <boost/test/data/test_case.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include <fstream>
 #include <string>
+#include <tuple>
 
+using namespace std::string_literals;
 using namespace solidity::test;
 
 #define TEST_CASE_NAME (boost::unit_test::framework::current_test_case().p_name)
 
 namespace solidity::util::test
 {
+
+namespace
+{
+
+/// Joins two paths in a way that matches the way used by util::absolutePath() to
+/// combine the import with the reference. Not generic - only does enough to handle example
+/// paths used in this test suite.
+std::string absolutePathJoin(std::string const& _parent, std::string const& _suffix)
+{
+	if (!_parent.empty() && _parent != "/" && !_suffix.empty())
+		return _parent + "/" + _suffix;
+
+	return _parent + _suffix;
+}
+
+}
 
 BOOST_AUTO_TEST_SUITE(CommonIOTest)
 
@@ -96,6 +116,426 @@ BOOST_AUTO_TEST_CASE(readBytes_past_end)
 	BOOST_CHECK_EQUAL(readBytes(inputStream, 1), "a");
 	BOOST_CHECK_EQUAL(readBytes(inputStream, 20), "bc");
 	BOOST_CHECK_EQUAL(readBytes(inputStream, 20), "");
+}
+
+BOOST_DATA_TEST_CASE(
+	absolutePath_direct_import,
+	boost::unit_test::data::make(std::vector<char const*>{
+		"",
+		"/",
+		"x",
+		"/x",
+		"x/",
+		"/x/",
+		"x/y",
+		"/x/y",
+		"x/y/",
+		"/x/y/",
+		".",
+		"..",
+		"./../.../../."
+	}),
+	reference
+)
+{
+	// absolutePath() should have no effect on a direct import, regardless of what the source
+	// unit name of the importing module is.
+
+	BOOST_TEST(absolutePath("", reference) == "");
+	BOOST_TEST(absolutePath("/", reference) == "/");
+	BOOST_TEST(absolutePath("//", reference) == "//");
+	BOOST_TEST(absolutePath("///", reference) == "///");
+
+	BOOST_TEST(absolutePath("\\", reference) == "\\");
+	BOOST_TEST(absolutePath("\\\\", reference) == "\\\\");
+	BOOST_TEST(absolutePath("\\\\\\", reference) == "\\\\\\");
+
+	BOOST_TEST(absolutePath(".\\", reference) == ".\\");
+	BOOST_TEST(absolutePath(".\\\\", reference) == ".\\\\");
+	BOOST_TEST(absolutePath(".\\\\\\", reference) == ".\\\\\\");
+
+	BOOST_TEST(absolutePath("..\\", reference) == "..\\");
+	BOOST_TEST(absolutePath("..\\\\", reference) == "..\\\\");
+	BOOST_TEST(absolutePath("..\\\\\\", reference) == "..\\\\\\");
+
+	BOOST_TEST(absolutePath("...", reference) == "...");
+	BOOST_TEST(absolutePath("....", reference) == "....");
+	BOOST_TEST(absolutePath("...a", reference) == "...a");
+
+	BOOST_TEST(absolutePath("/./", reference) == "/./");
+	BOOST_TEST(absolutePath("/././", reference) == "/././");
+	BOOST_TEST(absolutePath("/../", reference) == "/../");
+	BOOST_TEST(absolutePath("/../../", reference) == "/../../");
+	BOOST_TEST(absolutePath("//..//..//", reference) == "//..//..//");
+	BOOST_TEST(absolutePath("///..///..///", reference) == "///..///..///");
+
+	BOOST_TEST(absolutePath("@", reference) == "@");
+	BOOST_TEST(absolutePath(":", reference) == ":");
+	BOOST_TEST(absolutePath("|", reference) == "|");
+	BOOST_TEST(absolutePath("<>", reference) == "<>");
+	BOOST_TEST(absolutePath("123", reference) == "123");
+	BOOST_TEST(absolutePath("https://example.com", reference) == "https://example.com");
+
+	BOOST_TEST(absolutePath("a", reference) == "a");
+	BOOST_TEST(absolutePath("a/", reference) == "a/");
+	BOOST_TEST(absolutePath("/a", reference) == "/a");
+	BOOST_TEST(absolutePath("/a/", reference) == "/a/");
+
+	BOOST_TEST(absolutePath("a/b", reference) == "a/b");
+	BOOST_TEST(absolutePath("a/b/", reference) == "a/b/");
+	BOOST_TEST(absolutePath("/a/b", reference) == "/a/b");
+	BOOST_TEST(absolutePath("/a/b/", reference) == "/a/b/");
+
+	BOOST_TEST(absolutePath("/.", reference) == "/.");
+	BOOST_TEST(absolutePath("a.", reference) == "a.");
+	BOOST_TEST(absolutePath("a/.", reference) == "a/.");
+	BOOST_TEST(absolutePath("/a/.", reference) == "/a/.");
+	BOOST_TEST(absolutePath("a/./", reference) == "a/./");
+	BOOST_TEST(absolutePath("/a/./", reference) == "/a/./");
+
+	BOOST_TEST(absolutePath("/..", reference) == "/..");
+	BOOST_TEST(absolutePath("a..", reference) == "a..");
+	BOOST_TEST(absolutePath("a/..", reference) == "a/..");
+	BOOST_TEST(absolutePath("/a/..", reference) == "/a/..");
+	BOOST_TEST(absolutePath("a/../", reference) == "a/../");
+	BOOST_TEST(absolutePath("/a/../", reference) == "/a/../");
+
+	BOOST_TEST(absolutePath("a//", reference) == "a//");
+	BOOST_TEST(absolutePath("//a", reference) == "//a");
+	BOOST_TEST(absolutePath("//a//", reference) == "//a//");
+
+	BOOST_TEST(absolutePath("a//b", reference) == "a//b");
+	BOOST_TEST(absolutePath("a//b//", reference) == "a//b//");
+	BOOST_TEST(absolutePath("//a//b", reference) == "//a//b");
+	BOOST_TEST(absolutePath("//a//b//", reference) == "//a//b//");
+
+	BOOST_TEST(absolutePath("a\\b", reference) == "a\\b");
+	BOOST_TEST(absolutePath("a\\b\\", reference) == "a\\b\\");
+	BOOST_TEST(absolutePath("\\a\\b", reference) == "\\a\\b");
+	BOOST_TEST(absolutePath("\\a\\b\\", reference) == "\\a\\b\\");
+}
+
+BOOST_DATA_TEST_CASE(
+	absolutePath_relative_import_no_backtracking_into_reference,
+	boost::unit_test::data::make(std::vector<std::tuple<char const*, std::string>>{
+		{"", ""},
+		{"/", "/"},
+		{"x", ""},
+		{"/x", "/"},
+		{"x/", "x"},
+		{"/x/", "/x"},
+		{"x/y", "x"},
+		{"/x/y", "/x"},
+		{"x/y/", "x/y"},
+		{"/x/y/", "/x/y"},
+	}),
+	reference,
+	parent
+)
+{
+	BOOST_TEST(absolutePath(".", reference) == absolutePathJoin(parent, ""));
+	BOOST_TEST(absolutePath("./", reference) == absolutePathJoin(parent, ""));
+	BOOST_TEST(absolutePath(".//", reference) == absolutePathJoin(parent, ""));
+	BOOST_TEST(absolutePath(".///", reference) == absolutePathJoin(parent, ""));
+
+	BOOST_TEST(absolutePath("./.", reference) == absolutePathJoin(parent, ""));
+	BOOST_TEST(absolutePath("././", reference) == absolutePathJoin(parent, ""));
+	BOOST_TEST(absolutePath(".//./", reference) == absolutePathJoin(parent, ""));
+
+	BOOST_TEST(absolutePath("./a", reference) == absolutePathJoin(parent, "a"));
+	BOOST_TEST(absolutePath("./a/", reference) == absolutePathJoin(parent, "a"));
+	BOOST_TEST(absolutePath("./a/b", reference) == absolutePathJoin(parent, "a/b"));
+	BOOST_TEST(absolutePath("./a/b/", reference) == absolutePathJoin(parent, "a/b"));
+
+	BOOST_TEST(absolutePath("./@", reference) == absolutePathJoin(parent, "@"));
+	BOOST_TEST(absolutePath("./:", reference) == absolutePathJoin(parent, ":"));
+	BOOST_TEST(absolutePath("./|", reference) == absolutePathJoin(parent, "|"));
+	BOOST_TEST(absolutePath("./<>", reference) == absolutePathJoin(parent, "<>"));
+	BOOST_TEST(absolutePath("./123", reference) == absolutePathJoin(parent, "123"));
+	BOOST_TEST(absolutePath("./https://example.com", reference) == absolutePathJoin(parent, "https:/example.com"));
+
+	BOOST_TEST(absolutePath(".//a", reference) == absolutePathJoin(parent, "a"));
+	BOOST_TEST(absolutePath(".//a//", reference) == absolutePathJoin(parent, "a"));
+	BOOST_TEST(absolutePath(".//a//b", reference) == absolutePathJoin(parent, "a/b"));
+	BOOST_TEST(absolutePath(".//a//b//", reference) == absolutePathJoin(parent, "a/b"));
+
+	BOOST_TEST(absolutePath("./a\\", reference) == absolutePathJoin(parent, "a\\"));
+	BOOST_TEST(absolutePath("./a\\b", reference) == absolutePathJoin(parent, "a\\b"));
+	BOOST_TEST(absolutePath("./a\\b\\", reference) == absolutePathJoin(parent, "a\\b\\"));
+
+	BOOST_TEST(absolutePath("./a/.", reference) == absolutePathJoin(parent, "a"));
+	BOOST_TEST(absolutePath("./a/b/.", reference) == absolutePathJoin(parent, "a/b"));
+	BOOST_TEST(absolutePath("./a/./b/.", reference) == absolutePathJoin(parent, "a/b"));
+
+	BOOST_TEST(absolutePath("./a/..", reference) == absolutePathJoin(parent, ""));
+	BOOST_TEST(absolutePath("./a/../", reference) == absolutePathJoin(parent, ""));
+	BOOST_TEST(absolutePath("./a/b/..", reference) == absolutePathJoin(parent, "a"));
+	BOOST_TEST(absolutePath("./a/b/../", reference) == absolutePathJoin(parent, "a"));
+	BOOST_TEST(absolutePath("./a/../b", reference) == absolutePathJoin(parent, "b"));
+	BOOST_TEST(absolutePath("./a/../b/", reference) == absolutePathJoin(parent, "b"));
+	BOOST_TEST(absolutePath("./a/../b/..", reference) == absolutePathJoin(parent, ""));
+	BOOST_TEST(absolutePath("./a/../b/../", reference) == absolutePathJoin(parent, ""));
+
+	BOOST_TEST(absolutePath("./a\\..", reference) == absolutePathJoin(parent, "a\\.."));
+	BOOST_TEST(absolutePath("./a\\..\\", reference) == absolutePathJoin(parent, "a\\..\\"));
+	BOOST_TEST(absolutePath("./a\\b\\..", reference) == absolutePathJoin(parent, "a\\b\\.."));
+	BOOST_TEST(absolutePath("./a\\b\\..\\", reference) == absolutePathJoin(parent, "a\\b\\..\\"));
+	BOOST_TEST(absolutePath("./a\\..\\b", reference) == absolutePathJoin(parent, "a\\..\\b"));
+	BOOST_TEST(absolutePath("./a\\..\\b\\", reference) == absolutePathJoin(parent, "a\\..\\b\\"));
+	BOOST_TEST(absolutePath("./a\\..\\b\\..\\", reference) == absolutePathJoin(parent, "a\\..\\b\\..\\"));
+
+	BOOST_TEST(absolutePath("./a\\../..", reference) == absolutePathJoin(parent, ""));
+}
+
+BOOST_DATA_TEST_CASE(
+	absolutePath_relative_import_with_backtracking_1_level_into_reference,
+	boost::unit_test::data::make(std::vector<std::tuple<char const*, char const*>>{
+		{"", ""},
+		{"/", ""},
+		{"x", ""},
+		{"/x", ""},
+		{"x/", ""},
+		{"/x/", "/"},
+		{"x/y", ""},
+		{"/x/y", "/"},
+		{"x/y/", "x"},
+		{"/x/y/", "/x"},
+	}),
+	reference,
+	parent
+)
+{
+	BOOST_TEST(absolutePath("..", reference) == absolutePathJoin(parent, ""));
+	BOOST_TEST(absolutePath("../", reference) == absolutePathJoin(parent, ""));
+	BOOST_TEST(absolutePath("..//", reference) == absolutePathJoin(parent, ""));
+	BOOST_TEST(absolutePath("..///", reference) == absolutePathJoin(parent, ""));
+
+	BOOST_TEST(absolutePath("../a", reference) == absolutePathJoin(parent, "a"));
+	BOOST_TEST(absolutePath("../a/", reference) == absolutePathJoin(parent, "a"));
+	BOOST_TEST(absolutePath("../a/b", reference) == absolutePathJoin(parent, "a/b"));
+	BOOST_TEST(absolutePath("../a/b/", reference) == absolutePathJoin(parent, "a/b"));
+
+	BOOST_TEST(absolutePath("../@", reference) == absolutePathJoin(parent, "@"));
+	BOOST_TEST(absolutePath("../:", reference) == absolutePathJoin(parent, ":"));
+	BOOST_TEST(absolutePath("../|", reference) == absolutePathJoin(parent, "|"));
+	BOOST_TEST(absolutePath("../<>", reference) == absolutePathJoin(parent, "<>"));
+	BOOST_TEST(absolutePath("../123", reference) == absolutePathJoin(parent, "123"));
+	BOOST_TEST(absolutePath("../https://example.com", reference) == absolutePathJoin(parent, "https:/example.com"));
+
+	BOOST_TEST(absolutePath("../a/..", reference) == absolutePathJoin(parent, ""));
+	BOOST_TEST(absolutePath("../a/b/..", reference) == absolutePathJoin(parent, "a"));
+	BOOST_TEST(absolutePath("../a/b/../..", reference) == absolutePathJoin(parent, ""));
+	BOOST_TEST(absolutePath("../a/../b/..", reference) == absolutePathJoin(parent, ""));
+
+	BOOST_TEST(absolutePath("./../a/..", reference) == absolutePathJoin(parent, ""));
+	BOOST_TEST(absolutePath("./../a/b/..", reference) == absolutePathJoin(parent, "a"));
+	BOOST_TEST(absolutePath("./../a/b/../..", reference) == absolutePathJoin(parent, ""));
+	BOOST_TEST(absolutePath("./../a/../b/..", reference) == absolutePathJoin(parent, ""));
+
+	BOOST_TEST(absolutePath("./a/../..", reference) == absolutePathJoin(parent, ""));
+	BOOST_TEST(absolutePath("./a/b/../../..", reference) == absolutePathJoin(parent, ""));
+	BOOST_TEST(absolutePath("./a/../b/../..", reference) == absolutePathJoin(parent, ""));
+	BOOST_TEST(absolutePath("./a/../../b/..", reference) == absolutePathJoin(parent, ""));
+
+	BOOST_TEST(absolutePath("./a/../../c", reference) == absolutePathJoin(parent, "c"));
+	BOOST_TEST(absolutePath("./a/b/../../../c", reference) == absolutePathJoin(parent, "c"));
+	BOOST_TEST(absolutePath("./a/../b/../../c", reference) == absolutePathJoin(parent, "c"));
+	BOOST_TEST(absolutePath("./a/../../b/../c/d", reference) == absolutePathJoin(parent, "c/d"));
+
+	BOOST_TEST(absolutePath("..//a", reference) == absolutePathJoin(parent, "a"));
+	BOOST_TEST(absolutePath("..//a//", reference) == absolutePathJoin(parent, "a"));
+	BOOST_TEST(absolutePath(".//a//..//..//b", reference) == absolutePathJoin(parent, "b"));
+}
+
+BOOST_AUTO_TEST_CASE(absolutePath_relative_import_with_backtracking_multiple_levels_level_into_reference)
+{
+	BOOST_TEST(absolutePath("..", "x/y/z/") == "x/y");
+	BOOST_TEST(absolutePath("../..", "x/y/z/") == "x");
+	BOOST_TEST(absolutePath("../../..", "x/y/z/") == "");
+	BOOST_TEST(absolutePath("../../../..", "x/y/z/") == "");
+
+	BOOST_TEST(absolutePath("..", "/x/y/z/") == "/x/y");
+	BOOST_TEST(absolutePath("../..", "/x/y/z/") == "/x");
+	BOOST_TEST(absolutePath("../../..", "/x/y/z/") == "/");
+	BOOST_TEST(absolutePath("../../../..", "/x/y/z/") == "");
+
+	BOOST_TEST(absolutePath("../../../../a", "x/y/z/") == "a");
+	BOOST_TEST(absolutePath("../../../../a/..", "x/y/z/") == "");
+	BOOST_TEST(absolutePath("../../../../a/../a", "x/y/z/") == "a");
+
+	BOOST_TEST(absolutePath("../.", "x/y/z/") == "x/y");
+	BOOST_TEST(absolutePath(".././..", "x/y/z/") == "x");
+	BOOST_TEST(absolutePath(".././.././..", "x/y/z/") == "");
+	BOOST_TEST(absolutePath("./../././.././.././..", "x/y/z/") == "");
+}
+
+BOOST_AUTO_TEST_CASE(absolutePath_relative_import_and_relative_segments_in_reference)
+{
+	BOOST_TEST(absolutePath(".", "x/../y/./z/") == "x/../y/./z");
+	BOOST_TEST(absolutePath("..", "x/../y/./z/") == "x/../y/.");
+	BOOST_TEST(absolutePath("../..", "x/../y/./z/") == "x/../y");
+	BOOST_TEST(absolutePath("../../..", "x/../y/./z/") == "x/..");
+	BOOST_TEST(absolutePath("../../../..", "x/../y/./z/") == "x");
+	BOOST_TEST(absolutePath("../../../../..", "x/../y/./z/") == "");
+	BOOST_TEST(absolutePath("../../../../../..", "x/../y/./z/") == "");
+}
+
+BOOST_AUTO_TEST_CASE(absolutePath_relative_import_and_consecutive_slashes_in_reference)
+{
+	BOOST_TEST(absolutePath(".", "/x/") == "/x");
+	BOOST_TEST(absolutePath("..", "/x/") == "/");
+	BOOST_TEST(absolutePath("../..", "/x/") == "");
+
+	BOOST_TEST(absolutePath(".", "//x//") == "//x//");
+	BOOST_TEST(absolutePath("..", "//x//") == "//x");
+	BOOST_TEST(absolutePath("../..", "//x//") == "");
+
+	BOOST_TEST(absolutePath(".", "///x///") == "///x");
+	BOOST_TEST(absolutePath("..", "///x///") == "/");
+	BOOST_TEST(absolutePath("../..", "///x///") == "");
+}
+
+BOOST_AUTO_TEST_CASE(absolutePath_relative_import_and_unnormalized_slashes_in_reference)
+{
+	BOOST_TEST(absolutePath(".", "//x//y\\z/\\//") == "//x//y\\z/\\");
+	BOOST_TEST(absolutePath("..", "//x//y\\z/\\//") == "//x//y\\z");
+	BOOST_TEST(absolutePath("../..", "//x//y\\z/\\//") == "//x/");
+	BOOST_TEST(absolutePath("../../..", "//x//y\\z/\\//") == "//x");
+	BOOST_TEST(absolutePath("../../../..", "//x//y\\z/\\//") == "");
+}
+
+BOOST_AUTO_TEST_CASE(sanitizePath_direct_import)
+{
+	BOOST_TEST(sanitizePath("") == "");
+	BOOST_TEST(sanitizePath("/") == "/");
+	BOOST_TEST(sanitizePath("//") == "//");
+	BOOST_TEST(sanitizePath("///") == "///");
+
+	BOOST_TEST(sanitizePath("\\") == "\\");
+	BOOST_TEST(sanitizePath("\\\\") == "\\\\");
+	BOOST_TEST(sanitizePath("\\\\\\") == "\\\\\\");
+
+	BOOST_TEST(sanitizePath(".\\") == ".\\");
+	BOOST_TEST(sanitizePath(".\\\\") == ".\\\\");
+	BOOST_TEST(sanitizePath(".\\\\\\") == ".\\\\\\");
+
+	BOOST_TEST(sanitizePath("..\\") == "..\\");
+	BOOST_TEST(sanitizePath("..\\\\") == "..\\\\");
+	BOOST_TEST(sanitizePath("..\\\\\\") == "..\\\\\\");
+
+	BOOST_TEST(sanitizePath("...") == "...");
+	BOOST_TEST(sanitizePath("....") == "....");
+	BOOST_TEST(sanitizePath("...a") == "...a");
+
+	BOOST_TEST(sanitizePath("/./") == "/./");
+	BOOST_TEST(sanitizePath("/././") == "/././");
+	BOOST_TEST(sanitizePath("/../") == "/../");
+	BOOST_TEST(sanitizePath("/../../") == "/../../");
+	BOOST_TEST(sanitizePath("//..//..//") == "//..//..//");
+	BOOST_TEST(sanitizePath("///..///..///") == "///..///..///");
+
+	BOOST_TEST(sanitizePath("@") == "@");
+	BOOST_TEST(sanitizePath(":") == ":");
+	BOOST_TEST(sanitizePath("|") == "|");
+	BOOST_TEST(sanitizePath("<>") == "<>");
+	BOOST_TEST(sanitizePath("123") == "123");
+	BOOST_TEST(sanitizePath("https://example.com") == "https://example.com");
+
+	BOOST_TEST(sanitizePath("a") == "a");
+	BOOST_TEST(sanitizePath("a/") == "a/");
+	BOOST_TEST(sanitizePath("/a") == "/a");
+	BOOST_TEST(sanitizePath("/a/") == "/a/");
+
+	BOOST_TEST(sanitizePath("a/b") == "a/b");
+	BOOST_TEST(sanitizePath("a/b/") == "a/b/");
+	BOOST_TEST(sanitizePath("/a/b") == "/a/b");
+	BOOST_TEST(sanitizePath("/a/b/") == "/a/b/");
+
+	BOOST_TEST(sanitizePath("/.") == "/.");
+	BOOST_TEST(sanitizePath("a.") == "a.");
+	BOOST_TEST(sanitizePath("a/.") == "a/.");
+	BOOST_TEST(sanitizePath("/a/.") == "/a/.");
+	BOOST_TEST(sanitizePath("a/./") == "a/./");
+	BOOST_TEST(sanitizePath("/a/./") == "/a/./");
+
+	BOOST_TEST(sanitizePath("/..") == "/..");
+	BOOST_TEST(sanitizePath("a..") == "a..");
+	BOOST_TEST(sanitizePath("a/..") == "a/..");
+	BOOST_TEST(sanitizePath("/a/..") == "/a/..");
+	BOOST_TEST(sanitizePath("a/../") == "a/../");
+	BOOST_TEST(sanitizePath("/a/../") == "/a/../");
+
+	BOOST_TEST(sanitizePath("a//") == "a//");
+	BOOST_TEST(sanitizePath("//a") == "//a");
+	BOOST_TEST(sanitizePath("//a//") == "//a//");
+
+	BOOST_TEST(sanitizePath("a//b") == "a//b");
+	BOOST_TEST(sanitizePath("a//b//") == "a//b//");
+	BOOST_TEST(sanitizePath("//a//b") == "//a//b");
+	BOOST_TEST(sanitizePath("//a//b//") == "//a//b//");
+
+	BOOST_TEST(sanitizePath("a\\b") == "a\\b");
+	BOOST_TEST(sanitizePath("a\\b\\") == "a\\b\\");
+	BOOST_TEST(sanitizePath("\\a\\b") == "\\a\\b");
+	BOOST_TEST(sanitizePath("\\a\\b\\") == "\\a\\b\\");
+}
+
+BOOST_AUTO_TEST_CASE(sanitizePath_relative_import)
+{
+	BOOST_TEST(sanitizePath(".") == ".");
+	BOOST_TEST(sanitizePath("./") == "./");
+	BOOST_TEST(sanitizePath(".//") == ".//");
+	BOOST_TEST(sanitizePath(".///") == ".///");
+
+	BOOST_TEST(sanitizePath("./.") == "./.");
+	BOOST_TEST(sanitizePath("././") == "././");
+	BOOST_TEST(sanitizePath(".//./") == ".//./");
+
+	BOOST_TEST(sanitizePath("./a") == "./a");
+	BOOST_TEST(sanitizePath("./a/") == "./a/");
+	BOOST_TEST(sanitizePath("./a/b") == "./a/b");
+	BOOST_TEST(sanitizePath("./a/b/") == "./a/b/");
+
+	BOOST_TEST(sanitizePath("./@") == "./@");
+	BOOST_TEST(sanitizePath("./:") == "./:");
+	BOOST_TEST(sanitizePath("./|") == "./|");
+	BOOST_TEST(sanitizePath("./<>") == "./<>");
+	BOOST_TEST(sanitizePath("./123") == "./123");
+	BOOST_TEST(sanitizePath("./https://example.com") == "./https://example.com");
+
+	BOOST_TEST(sanitizePath(".//a") == ".//a");
+	BOOST_TEST(sanitizePath(".//a//") == ".//a//");
+	BOOST_TEST(sanitizePath(".//a//b") == ".//a//b");
+	BOOST_TEST(sanitizePath(".//a//b//") == ".//a//b//");
+
+	BOOST_TEST(sanitizePath("./a\\") == "./a\\");
+	BOOST_TEST(sanitizePath("./a\\b") == "./a\\b");
+	BOOST_TEST(sanitizePath("./a\\b\\") == "./a\\b\\");
+
+	BOOST_TEST(sanitizePath("./a/.") == "./a/.");
+	BOOST_TEST(sanitizePath("./a/b/.") == "./a/b/.");
+	BOOST_TEST(sanitizePath("./a/./b/.") == "./a/./b/.");
+
+	BOOST_TEST(sanitizePath("./a/..") == "./a/..");
+	BOOST_TEST(sanitizePath("./a/b/..") == "./a/b/..");
+	BOOST_TEST(sanitizePath("./a/../b/../") == "./a/../b/../");
+
+	BOOST_TEST(sanitizePath("./a\\..\\b\\..\\") == "./a\\..\\b\\..\\");
+	BOOST_TEST(sanitizePath("./a\\../..") == "./a\\../..");
+
+	BOOST_TEST(sanitizePath("..") == "..");
+	BOOST_TEST(sanitizePath("../") == "../");
+	BOOST_TEST(sanitizePath("..//") == "..//");
+	BOOST_TEST(sanitizePath("..///") == "..///");
+
+	BOOST_TEST(sanitizePath("../..") == "../..");
+	BOOST_TEST(sanitizePath("../../") == "../../");
+	BOOST_TEST(sanitizePath("../../../") == "../../../");
+	BOOST_TEST(sanitizePath("../../../../") == "../../../../");
+
+	BOOST_TEST(sanitizePath("../a") == "../a");
+	BOOST_TEST(sanitizePath("../a/..") == "../a/..");
+	BOOST_TEST(sanitizePath("./a/../../b/../c/d") == "./a/../../b/../c/d");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
We use these two functions for resolving relative imports and remappings. The transformation performed by the former can really be considered a part of the language and must be platform-independent. I doubt it's actually true in practice since these functions use `boost::filesystem` and are not covered with tests, which makes them susceptible to silent changes in behavior of the library. There were many such changes between versions or platforms.

Since I finally got around to fixing #14396, I thought I'd also add some coverage here. This is a key missing piece if we want to migrate to `std::filesystem` at some point and be sure we do not accidentally introduce tiny breaking changes to the way imports work.

I actually thought we had more filesystem code like that, but looks like apart from `FileReader`, this is the only bit where we really cares about how paths look like.