### PR TITLE
Upgrade homebrew packages

### DIFF
--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -52,6 +52,8 @@ function validate_checksum {
 
 if [ ! -f /usr/local/lib/libz3.a ] # if this file does not exists (cache was not restored), rebuild dependencies
 then
+  brew update
+  brew upgrade
   brew install boost
   brew install cmake
   brew install wget


### PR DESCRIPTION
I don't know the exact reason why this started to happen, but osx jobs started to fail due to a broken dependency (see: https://app.circleci.com/pipelines/github/ethereum/solidity/31172/workflows/4adb64fc-8445-4dbd-97de-8a8aa29bb878/jobs/1387485)

It seems that it is because `wget` depends on `libidn2` which in turn depends on `libunistring`, but `libunistring.2.dylib` does not exist anymore under `/usr/local/opt/libunistring/lib`, it seems that `libidn2` and `libunistring` were updated but `libidn2` is still trying to link to an older version of `libunistring`. If you reinstall `libidn2` (`brew reinstall libidn2`) and re-run the `.circleci/osx_install_dependencies.sh` it works as expected.

I logged in to the machine and checked the following:

```
static:~ distiller$ ls /usr/local/opt/libunistring/lib
libunistring.5.dylib	libunistring.a		libunistring.dylib
```

You can see that `libidn2` still linking to an older version of `libunisring` (i.e. `/usr/local/opt/libunistring/lib/libunistring.2.dylib`)

```
static:project distiller$ otool -L /usr/local/opt/libidn2/lib/libidn2.0.dylib
/usr/local/opt/libidn2/lib/libidn2.0.dylib:
	/usr/local/opt/libidn2/lib/libidn2.0.dylib (compatibility version 4.0.0, current version 4.8.0)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/local/opt/libunistring/lib/libunistring.2.dylib (compatibility version 5.0.0, current version 5.0.0)
	/usr/local/opt/gettext/lib/libintl.8.dylib (compatibility version 12.0.0, current version 12.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1858.112.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.100.3)
```

After reinstalling `libidn2` I got:

```
static:project distiller$ brew reinstall libidn2
==> Downloading https://ghcr.io/v2/homebrew/core/libidn2/manifests/2.3.4_1-
Already downloaded: /Users/distiller/Library/Caches/Homebrew/downloads/03ad193177f4e7d05ee2ed19a455028cb5fbf7ea1a812d88f18f5e9e8b4a4d43--libidn2-2.3.4_1-1.bottle_manifest.json
==> Fetching libidn2
==> Downloading https://ghcr.io/v2/homebrew/core/libidn2/blobs/sha256:5dcfc
#################################################################### 100.0%
==> Reinstalling libidn2
==> Pouring libidn2--2.3.4_1.monterey.bottle.1.tar.gz
🍺  /usr/local/Cellar/libidn2/2.3.4_1: 79 files, 1003.4KB
==> Running `brew cleanup libidn2`...
```

And it now links to the correct installed version of `libunistring`:

```
static:project distiller$ otool -L /usr/local/opt/libidn2/lib/libidn2.0.dylib
/usr/local/opt/libidn2/lib/libidn2.0.dylib:
	/usr/local/opt/libidn2/lib/libidn2.0.dylib (compatibility version 4.0.0, current version 4.8.0)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/local/opt/libunistring/lib/libunistring.5.dylib (compatibility version 6.0.0, current version 6.0.0)
	/usr/local/opt/gettext/lib/libintl.8.dylib (compatibility version 12.0.0, current version 12.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1858.112.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1311.100.3)
```

On Matrix @cameel proposed to upgrade the packages before installing, which indeed solved the issue as well. Thus, this PR does exactly that, and runs`brew update` to fetch the latest formulas and `brew upgrade` to upgrade the packages, including:
```
libidn2 2.3.4 -> 2.3.4_1
libunistring 1.0 -> 1.1
```