### PR TITLE
Defining built-ins in experimental analysis

### DIFF
--- a/liblangutil/Token.h
+++ b/liblangutil/Token.h
@@ -269,18 +269,13 @@ namespace solidity::langutil
 	T(Leave, "leave", 0)                                               \
 	\
 	T(NonExperimentalEnd, nullptr, 0) /* used as non-experimental enum end marker */ \
-    /* Experimental Solidity specific keywords. */                     \
+	/* Experimental Solidity specific keywords. */                     \
 	K(Class, "class", 0)                                               \
 	K(Instantiation, "instantiation", 0)                               \
-	K(Word, "word", 0)                                                 \
-	K(IntegerType, "integer", 0)                                       \
 	K(Integer, "Integer", 0)                                           \
 	K(Itself, "itself", 0)                                             \
-	K(Void, "void", 0)                                                 \
-	K(Pair, "pair", 0)                                                 \
-	K(Fun, "fun", 0)                                                   \
-	K(Unit, "unit", 0)                                                 \
 	K(StaticAssert, "static_assert", 0)                                \
+	K(Builtin, "__builtin", 0)                                         \
 	T(ExperimentalEnd, nullptr, 0) /* used as experimental enum end marker */ \
 	\
 	/* Illegal token - not able to scan. */                            \
@@ -305,12 +300,7 @@ namespace TokenTraits
 	constexpr size_t count() { return static_cast<size_t>(Token::NUM_TOKENS); }
 
 	// Predicates
-	constexpr bool isElementaryTypeName(Token tok)
-	{
-		return (Token::Int <= tok && tok < Token::TypesEnd) ||
-			tok == Token::Word || tok == Token::Void || tok == Token::IntegerType ||
-			tok == Token::Pair || tok == Token::Unit || tok == Token::Fun;
-	}
+	constexpr bool isElementaryTypeName(Token tok) { return Token::Int <= tok && tok < Token::TypesEnd; }
 	constexpr bool isAssignmentOp(Token tok) { return Token::Assign <= tok && tok <= Token::AssignMod; }
 	constexpr bool isBinaryOp(Token op) { return Token::Comma <= op && op <= Token::Exp; }
 	constexpr bool isCommutativeOp(Token op) { return op == Token::BitOr || op == Token::BitXor || op == Token::BitAnd ||
@@ -351,7 +341,7 @@ namespace TokenTraits
 	{
 		return tok == Token::Assembly || tok == Token::Contract || tok == Token::External || tok == Token::Fallback ||
 			tok == Token::Pragma || tok == Token::Import || tok == Token::As || tok == Token::Function || tok == Token::Let ||
-			tok == Token::Return || tok == Token::Type || tok == Token::Bool || tok == Token::If || tok == Token::Else ||
+			tok == Token::Return || tok == Token::Type || tok == Token::If || tok == Token::Else ||
 			tok == Token::Do || tok == Token::While || tok == Token::For || tok == Token::Continue || tok == Token::Break ||
 			(tok > Token::NonExperimentalEnd && tok < Token::ExperimentalEnd);
 	}

--- a/liblangutil/Token.h
+++ b/liblangutil/Token.h
@@ -273,7 +273,8 @@ namespace solidity::langutil
 	K(Class, "class", 0)                                               \
 	K(Instantiation, "instantiation", 0)                               \
 	K(Word, "word", 0)                                                 \
-	K(Integer, "integer", 0)                                           \
+	K(IntegerType, "integer", 0)                                       \
+	K(Integer, "Integer", 0)                                           \
 	K(Itself, "itself", 0)                                             \
 	K(Void, "void", 0)                                                 \
 	K(Pair, "pair", 0)                                                 \
@@ -307,7 +308,7 @@ namespace TokenTraits
 	constexpr bool isElementaryTypeName(Token tok)
 	{
 		return (Token::Int <= tok && tok < Token::TypesEnd) ||
-			tok == Token::Word || tok == Token::Void || tok == Token::Integer ||
+			tok == Token::Word || tok == Token::Void || tok == Token::IntegerType ||
 			tok == Token::Pair || tok == Token::Unit || tok == Token::Fun;
 	}
 	constexpr bool isAssignmentOp(Token tok) { return Token::Assign <= tok && tok <= Token::AssignMod; }

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -2596,6 +2596,35 @@ private:
 	std::variant<Token, ASTPointer<IdentifierPath>> m_name;
 };
 
+class Builtin: public Expression
+{
+public:
+	Builtin(
+		int64_t _id,
+		SourceLocation _location,
+		ASTPointer<ASTString> _nameParameter,
+		SourceLocation _nameParameterLocation
+	):
+		Expression(_id, std::move(_location)),
+		m_nameParameter(std::move(_nameParameter)),
+		m_nameParameterLocation(std::move(_nameParameterLocation))
+	{
+		solAssert(m_nameParameter);
+	}
+
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
+
+	bool experimentalSolidityOnly() const override { return true; }
+
+	ASTString const& nameParameter() const { return *m_nameParameter; }
+	SourceLocation const& nameParameterLocation() const { return m_nameParameterLocation; }
+
+private:
+	ASTPointer<ASTString> m_nameParameter;
+	SourceLocation m_nameParameterLocation;
+};
+
 /// @}
 
 }

--- a/libsolidity/ast/ASTForward.h
+++ b/libsolidity/ast/ASTForward.h
@@ -105,6 +105,7 @@ class TypeClassDefinition;
 class TypeClassInstantiation;
 class TypeClassName;
 class TypeDefinition;
+class Builtin;
 /// @}
 
 class VariableScope;

--- a/libsolidity/ast/ASTVisitor.h
+++ b/libsolidity/ast/ASTVisitor.h
@@ -115,6 +115,7 @@ public:
 	virtual bool visit(TypeClassInstantiation& _node) { return visitNode(_node); }
 	virtual bool visit(TypeDefinition& _node) { return visitNode(_node); }
 	virtual bool visit(TypeClassName& _node) { return visitNode(_node); }
+	virtual bool visit(Builtin& _node) { return visitNode(_node); }
 	///  @}
 
 	virtual void endVisit(SourceUnit& _node) { endVisitNode(_node); }
@@ -178,6 +179,7 @@ public:
 	virtual void endVisit(TypeClassInstantiation& _node) { endVisitNode(_node); }
 	virtual void endVisit(TypeDefinition& _node) { endVisitNode(_node); }
 	virtual void endVisit(TypeClassName& _node) { endVisitNode(_node); }
+	virtual void endVisit(Builtin& _node) { endVisitNode(_node); }
 	///  @}
 
 protected:
@@ -263,6 +265,7 @@ public:
 	virtual bool visit(TypeClassInstantiation const& _node) { return visitNode(_node); }
 	virtual bool visit(TypeDefinition const& _node) { return visitNode(_node); }
 	virtual bool visit(TypeClassName const& _node) { return visitNode(_node); }
+	virtual bool visit(Builtin const& _node) { return visitNode(_node); }
 	///  @}
 
 	virtual void endVisit(SourceUnit const& _node) { endVisitNode(_node); }
@@ -326,6 +329,7 @@ public:
 	virtual void endVisit(TypeClassInstantiation const& _node) { endVisitNode(_node); }
 	virtual void endVisit(TypeDefinition const& _node) { endVisitNode(_node); }
 	virtual void endVisit(TypeClassName const& _node) { endVisitNode(_node); }
+	virtual void endVisit(Builtin const& _node) { endVisitNode(_node); }
 	///  @}
 
 protected:

--- a/libsolidity/ast/AST_accept.h
+++ b/libsolidity/ast/AST_accept.h
@@ -1128,6 +1128,18 @@ void TypeClassName::accept(ASTConstVisitor& _visitor) const
 	}
 	_visitor.endVisit(*this);
 }
+
+void Builtin::accept(ASTVisitor& _visitor)
+{
+	_visitor.visit(*this);
+	_visitor.endVisit(*this);
+}
+
+void Builtin::accept(ASTConstVisitor& _visitor) const
+{
+	_visitor.visit(*this);
+	_visitor.endVisit(*this);
+}
 /// @}
 
 }

--- a/libsolidity/experimental/analysis/TypeInference.cpp
+++ b/libsolidity/experimental/analysis/TypeInference.cpp
@@ -125,22 +125,6 @@ TypeInference::TypeInference(Analysis& _analysis):
 	defineBinaryCompareOperator(BuiltinClass::LessOrEqual, Token::LessThanOrEqual, "leq");
 	defineBinaryCompareOperator(BuiltinClass::Greater, Token::GreaterThan, "gt");
 	defineBinaryCompareOperator(BuiltinClass::GreaterOrEqual, Token::GreaterThanOrEqual, "geq");
-
-	{
-		auto [members, newlyInserted] = annotation().members.emplace(m_typeSystem.constructor(PrimitiveType::Bool), std::map<std::string, TypeMember>{});
-		solAssert(newlyInserted);
-		members->second.emplace("abs", TypeMember{helper.functionType(m_wordType, m_boolType)});
-		members->second.emplace("rep", TypeMember{helper.functionType(m_boolType, m_wordType)});
-	}
-	{
-		Type first = m_typeSystem.freshTypeVariable({});
-		Type second = m_typeSystem.freshTypeVariable({});
-		Type pairType = m_typeSystem.type(PrimitiveType::Pair, {first, second});
-		auto [members, newlyInserted] = annotation().members.emplace(m_typeSystem.constructor(PrimitiveType::Pair), std::map<std::string, TypeMember>{});
-		solAssert(newlyInserted);
-		members->second.emplace("first", TypeMember{helper.functionType(pairType, first)});
-		members->second.emplace("second", TypeMember{helper.functionType(pairType, second)});
-	}
 }
 
 bool TypeInference::analyze(SourceUnit const& _sourceUnit)
@@ -304,48 +288,6 @@ bool TypeInference::visit(InlineAssembly const& _inlineAssembly)
 	);
 	if (!analyzer.analyze(_inlineAssembly.operations()))
 		solAssert(m_errorReporter.hasErrors());
-	return false;
-}
-
-bool TypeInference::visit(ElementaryTypeNameExpression const& _expression)
-{
-	auto& expressionAnnotation = annotation(_expression);
-	solAssert(!expressionAnnotation.type);
-
-	switch (m_expressionContext)
-	{
-	case ExpressionContext::Term:
-	case ExpressionContext::Type:
-		if (auto constructor = m_analysis.annotation<TypeRegistration>(_expression).typeConstructor)
-		{
-			std::vector<Type> arguments;
-			std::generate_n(std::back_inserter(arguments), m_typeSystem.constructorInfo(*constructor).arguments(), [&]() {
-				return m_typeSystem.freshTypeVariable({});
-			});
-			// TODO: get rid of the distinction (assign a function on unit for the empty case)? Ambiguity?
-			if (arguments.empty() || m_expressionContext == ExpressionContext::Term)
-				expressionAnnotation.type = m_typeSystem.type(*constructor, arguments);
-			else
-			{
-				TypeSystemHelpers helper{m_typeSystem};
-				expressionAnnotation.type =
-					helper.typeFunctionType(
-						helper.tupleType(arguments),
-						m_typeSystem.type(*constructor, arguments)
-					);
-			}
-		}
-		else
-		{
-			m_errorReporter.typeError(4107_error, _expression.location(), "No type constructor registered for elementary type name.");
-			expressionAnnotation.type = m_typeSystem.freshTypeVariable({});
-		}
-		break;
-	case ExpressionContext::Sort:
-		m_errorReporter.typeError(2024_error, _expression.location(), "Elementary type name expression not supported in sort context.");
-		expressionAnnotation.type = m_typeSystem.freshTypeVariable({});
-		break;
-	}
 	return false;
 }
 
@@ -825,6 +767,8 @@ void TypeInference::endVisit(MemberAccess const& _memberAccess)
 
 bool TypeInference::visit(TypeDefinition const& _typeDefinition)
 {
+	bool isBuiltIn = dynamic_cast<Builtin const*>(_typeDefinition.typeExpression());
+
 	TypeSystemHelpers helper{m_typeSystem};
 	auto& typeDefinitionAnnotation = annotation(_typeDefinition);
 	if (typeDefinitionAnnotation.type)
@@ -832,14 +776,6 @@ bool TypeInference::visit(TypeDefinition const& _typeDefinition)
 
 	if (_typeDefinition.arguments())
 		_typeDefinition.arguments()->accept(*this);
-
-	std::optional<Type> underlyingType;
-	if (_typeDefinition.typeExpression())
-	{
-		ScopedSaveAndRestore expressionContext{m_expressionContext, ExpressionContext::Type};
-		_typeDefinition.typeExpression()->accept(*this);
-		underlyingType = annotation(*_typeDefinition.typeExpression()).type;
-	}
 
 	std::vector<Type> arguments;
 	if (_typeDefinition.arguments())
@@ -852,6 +788,19 @@ bool TypeInference::visit(TypeDefinition const& _typeDefinition)
 	else
 		typeDefinitionAnnotation.type = helper.typeFunctionType(helper.tupleType(arguments), definedType);
 
+	std::optional<Type> underlyingType;
+
+	if (isBuiltIn)
+		// TODO: This special case should eventually become user-definable.
+		underlyingType = m_wordType;
+	else if (_typeDefinition.typeExpression())
+	{
+		ScopedSaveAndRestore expressionContext{m_expressionContext, ExpressionContext::Type};
+		_typeDefinition.typeExpression()->accept(*this);
+
+		underlyingType = annotation(*_typeDefinition.typeExpression()).type;
+	}
+
 	TypeConstructor constructor = typeConstructor(&_typeDefinition);
 	auto [members, newlyInserted] = annotation().members.emplace(constructor, std::map<std::string, TypeMember>{});
 	solAssert(newlyInserted, fmt::format("Members of type '{}' are already defined.", m_typeSystem.constructorInfo(constructor).name));
@@ -860,6 +809,15 @@ bool TypeInference::visit(TypeDefinition const& _typeDefinition)
 		members->second.emplace("abs", TypeMember{helper.functionType(*underlyingType, definedType)});
 		members->second.emplace("rep", TypeMember{helper.functionType(definedType, *underlyingType)});
 	}
+
+	if (helper.isPrimitiveType(definedType, PrimitiveType::Pair))
+	{
+		solAssert(isBuiltIn);
+		solAssert(arguments.size() == 2);
+		members->second.emplace("first", TypeMember{helper.functionType(definedType, arguments[0])});
+		members->second.emplace("second", TypeMember{helper.functionType(definedType, arguments[1])});
+	}
+
 	return false;
 }
 

--- a/libsolidity/experimental/analysis/TypeInference.h
+++ b/libsolidity/experimental/analysis/TypeInference.h
@@ -79,7 +79,6 @@ public:
 
 	bool visit(MemberAccess const& _memberAccess) override;
 	void endVisit(MemberAccess const& _memberAccess) override;
-	bool visit(ElementaryTypeNameExpression const& _expression) override;
 
 	bool visit(TypeClassDefinition const& _typeClassDefinition) override;
 	bool visit(TypeClassInstantiation const& _typeClassInstantiation) override;

--- a/libsolidity/experimental/analysis/TypeRegistration.cpp
+++ b/libsolidity/experimental/analysis/TypeRegistration.cpp
@@ -73,7 +73,7 @@ bool TypeRegistration::visit(ElementaryTypeName const& _typeName)
 			return m_typeSystem.constructor(PrimitiveType::Pair);
 		case Token::Word:
 			return m_typeSystem.constructor(PrimitiveType::Word);
-		case Token::Integer:
+		case Token::IntegerType:
 			return m_typeSystem.constructor(PrimitiveType::Integer);
 		case Token::Bool:
 			return m_typeSystem.constructor(PrimitiveType::Bool);

--- a/libsolidity/experimental/analysis/TypeRegistration.h
+++ b/libsolidity/experimental/analysis/TypeRegistration.h
@@ -42,6 +42,7 @@ public:
 	{
 		std::map<PrimitiveClass, TypeClassInstantiations> primitiveClassInstantiations;
 		std::map<BuiltinClass, TypeClassInstantiations> builtinClassInstantiations;
+		std::map<std::string, TypeDefinition const*> builtinTypeDefinitions;
 	};
 	TypeRegistration(Analysis& _analysis);
 

--- a/libsolidity/experimental/analysis/TypeRegistration.h
+++ b/libsolidity/experimental/analysis/TypeRegistration.h
@@ -35,7 +35,7 @@ public:
 	{
 		// For type class definitions.
 		TypeClassInstantiations instantiations;
-		// For type definitions, type class definitions, type names and type name expressions.
+		// For builtins, type definitions, type class definitions, type names and type name expressions.
 		std::optional<TypeConstructor> typeConstructor;
 	};
 	struct GlobalAnnotation
@@ -50,9 +50,10 @@ private:
 	bool visit(TypeClassDefinition const& _typeClassDefinition) override;
 	bool visit(TypeClassInstantiation const& _typeClassInstantiation) override;
 	bool visit(TypeDefinition const& _typeDefinition) override;
+	void endVisit(TypeDefinition const& _typeDefinition) override;
 	bool visit(UserDefinedTypeName const& _typeName) override;
 	void endVisit(ElementaryTypeNameExpression const& _typeName) override;
-	bool visit(ElementaryTypeName const& _typeName) override;
+	bool visit(Builtin const& _builtin) override;
 	Annotation& annotation(ASTNode const& _node);
 	GlobalAnnotation& annotation();
 

--- a/libsolidity/experimental/ast/TypeSystemHelper.cpp
+++ b/libsolidity/experimental/ast/TypeSystemHelper.cpp
@@ -66,7 +66,7 @@ std::optional<TypeConstructor> experimental::typeConstructorFromToken(Analysis c
 		return typeSystem.builtinConstructor(BuiltinType::Pair);
 	case Token::Word:
 		return typeSystem.builtinConstructor(BuiltinType::Word);
-	case Token::Integer:
+	case Token::IntegerType:
 		return typeSystem.builtinConstructor(BuiltinType::Integer);
 	case Token::Bool:
 		return typeSystem.builtinConstructor(BuiltinType::Bool);

--- a/libsolidity/experimental/ast/TypeSystemHelper.cpp
+++ b/libsolidity/experimental/ast/TypeSystemHelper.cpp
@@ -224,6 +224,14 @@ bool TypeSystemHelpers::isTypeConstant(Type _type) const
 	}, _type);
 }
 
+bool TypeSystemHelpers::isPrimitiveType(Type _type, PrimitiveType _primitiveType) const
+{
+	if (!isTypeConstant(_type))
+		return false;
+	auto constructor = std::get<0>(destTypeConstant(_type));
+	return constructor == typeSystem.constructor(_primitiveType);
+}
+
 experimental::Type TypeSystemHelpers::functionType(experimental::Type _argType, experimental::Type _resultType) const
 {
 	return typeSystem.type(PrimitiveType::Function, {_argType, _resultType});
@@ -239,10 +247,7 @@ std::tuple<experimental::Type, experimental::Type> TypeSystemHelpers::destFuncti
 
 bool TypeSystemHelpers::isFunctionType(Type _type) const
 {
-	if (!isTypeConstant(_type))
-		return false;
-	auto constructor = std::get<0>(destTypeConstant(_type));
-	return constructor == typeSystem.constructor(PrimitiveType::Function);
+	return isPrimitiveType(_type, PrimitiveType::Function);
 }
 
 experimental::Type TypeSystemHelpers::typeFunctionType(experimental::Type _argType, experimental::Type _resultType) const
@@ -260,10 +265,7 @@ std::tuple<experimental::Type, experimental::Type> TypeSystemHelpers::destTypeFu
 
 bool TypeSystemHelpers::isTypeFunctionType(Type _type) const
 {
-	if (!isTypeConstant(_type))
-		return false;
-	auto constructor = std::get<0>(destTypeConstant(_type));
-	return constructor == typeSystem.constructor(PrimitiveType::TypeFunction);
+	return isPrimitiveType(_type, PrimitiveType::TypeFunction);
 }
 
 std::vector<experimental::Type> TypeEnvironmentHelpers::typeVars(Type _type) const

--- a/libsolidity/experimental/ast/TypeSystemHelper.h
+++ b/libsolidity/experimental/ast/TypeSystemHelper.h
@@ -35,6 +35,7 @@ struct TypeSystemHelpers
 	TypeSystem const& typeSystem;
 	std::tuple<TypeConstructor, std::vector<Type>> destTypeConstant(Type _type) const;
 	bool isTypeConstant(Type _type) const;
+	bool isPrimitiveType(Type _type, PrimitiveType _primitiveType) const;
 	Type tupleType(std::vector<Type> _elements) const;
 	std::vector<Type> destTupleType(Type _tupleType) const;
 	Type sumType(std::vector<Type> _elements) const;

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1831,7 +1831,22 @@ ASTPointer<TypeDefinition> Parser::parseTypeDefinition()
 	if (m_scanner->currentToken() == Token::Assign)
 	{
 		expectToken(Token::Assign);
-		expression = parseExpression();
+
+		if (m_scanner->currentToken() != Token::Builtin)
+			expression = parseExpression();
+		else
+		{
+			expectToken(Token::Builtin);
+			expectToken(Token::LParen);
+
+			expression = nodeFactory.createNode<Builtin>(
+				std::make_shared<std::string>(m_scanner->currentLiteral()),
+				m_scanner->currentLocation()
+			);
+
+			expectToken(Token::StringLiteral);
+			expectToken(Token::RParen);
+		}
 	}
 	nodeFactory.markEndPosition();
 	expectToken(Token::Semicolon);

--- a/test/libsolidity/semanticTests/experimental/stub.sol
+++ b/test/libsolidity/semanticTests/experimental/stub.sol
@@ -1,5 +1,9 @@
 pragma experimental solidity;
 
+type word = __builtin("word");
+type bool = __builtin("bool");
+type integer = __builtin("integer");
+
 type uint256 = word;
 
 instantiation uint256: + {

--- a/test/libsolidity/semanticTests/experimental/stub.sol
+++ b/test/libsolidity/semanticTests/experimental/stub.sol
@@ -34,7 +34,7 @@ instantiation word: * {
     }
 }
 
-instantiation word: integer {
+instantiation word: Integer {
     function fromInteger(x:integer) -> word {
         //x + x;
     }

--- a/test/libsolidity/semanticTests/experimental/type_class.sol
+++ b/test/libsolidity/semanticTests/experimental/type_class.sol
@@ -1,5 +1,8 @@
 pragma experimental solidity;
 
+type word = __builtin("word");
+type bool = __builtin("bool");
+
 type Cat = word;
 type Dog = word;
 
@@ -59,7 +62,6 @@ contract C {
 
 // ====
 // EVMVersion: >=constantinople
-// ====
 // compileViaYul: true
 // ----
 // () -> 1, 0

--- a/test/libsolidity/syntaxTests/experimental/builtin/builtin_type_definition.sol
+++ b/test/libsolidity/syntaxTests/experimental/builtin/builtin_type_definition.sol
@@ -1,0 +1,67 @@
+pragma experimental solidity;
+
+contract C {
+    fallback() external {
+        let v: void;
+
+        let b: bool;
+        bool.abs(bool.rep(b));
+
+        let w: word;
+        let i: integer;
+        let u: unit;
+
+        let f: fun(word, bool);
+        b = f(w);
+
+        let p: pair(bool, word);
+        pair.first(p);
+        pair.second(p);
+    }
+}
+// ====
+// EVMVersion: >=constantinople
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
+// Info 4164: (48-348): Inferred type: () -> ()
+// Info 4164: (56-58): Inferred type: ()
+// Info 4164: (82-89): Inferred type: void
+// Info 4164: (85-89): Inferred type: void
+// Info 4164: (104-111): Inferred type: bool
+// Info 4164: (107-111): Inferred type: bool
+// Info 4164: (121-142): Inferred type: bool
+// Info 4164: (121-129): Inferred type: word -> bool
+// Info 4164: (121-125): Inferred type: bool
+// Info 4164: (130-141): Inferred type: word
+// Info 4164: (130-138): Inferred type: bool -> word
+// Info 4164: (130-134): Inferred type: bool
+// Info 4164: (139-140): Inferred type: bool
+// Info 4164: (157-164): Inferred type: word
+// Info 4164: (160-164): Inferred type: word
+// Info 4164: (178-188): Inferred type: integer
+// Info 4164: (181-188): Inferred type: integer
+// Info 4164: (202-209): Inferred type: ()
+// Info 4164: (205-209): Inferred type: ()
+// Info 4164: (224-242): Inferred type: word -> bool
+// Info 4164: (227-242): Inferred type: word -> bool
+// Info 4164: (227-230): Inferred type: tfun((word, bool), word -> bool)
+// Info 4164: (231-235): Inferred type: word
+// Info 4164: (237-241): Inferred type: bool
+// Info 4164: (252-260): Inferred type: bool
+// Info 4164: (252-253): Inferred type: bool
+// Info 4164: (256-260): Inferred type: bool
+// Info 4164: (256-257): Inferred type: word -> bool
+// Info 4164: (258-259): Inferred type: word
+// Info 4164: (275-294): Inferred type: (bool, word)
+// Info 4164: (278-294): Inferred type: (bool, word)
+// Info 4164: (278-282): Inferred type: tfun((bool, word), (bool, word))
+// Info 4164: (283-287): Inferred type: bool
+// Info 4164: (289-293): Inferred type: word
+// Info 4164: (304-317): Inferred type: bool
+// Info 4164: (304-314): Inferred type: (bool, word) -> bool
+// Info 4164: (304-308): Inferred type: ('bh:type, 'bi:type)
+// Info 4164: (315-316): Inferred type: (bool, word)
+// Info 4164: (327-341): Inferred type: word
+// Info 4164: (327-338): Inferred type: (bool, word) -> word
+// Info 4164: (327-331): Inferred type: ('bn:type, 'bo:type)
+// Info 4164: (339-340): Inferred type: (bool, word)

--- a/test/libsolidity/syntaxTests/experimental/builtin/builtin_type_definition.sol
+++ b/test/libsolidity/syntaxTests/experimental/builtin/builtin_type_definition.sol
@@ -1,5 +1,15 @@
 pragma experimental solidity;
 
+type void = __builtin("void");
+
+type bool = __builtin("bool");
+type word = __builtin("word");
+type integer = __builtin("integer");
+type unit = __builtin("unit");
+
+type fun(T, U) = __builtin("fun");
+type pair(T, U) = __builtin("pair");
+
 contract C {
     fallback() external {
         let v: void;
@@ -23,45 +33,58 @@ contract C {
 // EVMVersion: >=constantinople
 // ----
 // Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
-// Info 4164: (48-348): Inferred type: () -> ()
-// Info 4164: (56-58): Inferred type: ()
-// Info 4164: (82-89): Inferred type: void
-// Info 4164: (85-89): Inferred type: void
-// Info 4164: (104-111): Inferred type: bool
-// Info 4164: (107-111): Inferred type: bool
-// Info 4164: (121-142): Inferred type: bool
-// Info 4164: (121-129): Inferred type: word -> bool
-// Info 4164: (121-125): Inferred type: bool
-// Info 4164: (130-141): Inferred type: word
-// Info 4164: (130-138): Inferred type: bool -> word
-// Info 4164: (130-134): Inferred type: bool
-// Info 4164: (139-140): Inferred type: bool
-// Info 4164: (157-164): Inferred type: word
-// Info 4164: (160-164): Inferred type: word
-// Info 4164: (178-188): Inferred type: integer
-// Info 4164: (181-188): Inferred type: integer
-// Info 4164: (202-209): Inferred type: ()
-// Info 4164: (205-209): Inferred type: ()
-// Info 4164: (224-242): Inferred type: word -> bool
-// Info 4164: (227-242): Inferred type: word -> bool
-// Info 4164: (227-230): Inferred type: tfun((word, bool), word -> bool)
-// Info 4164: (231-235): Inferred type: word
-// Info 4164: (237-241): Inferred type: bool
-// Info 4164: (252-260): Inferred type: bool
-// Info 4164: (252-253): Inferred type: bool
-// Info 4164: (256-260): Inferred type: bool
-// Info 4164: (256-257): Inferred type: word -> bool
-// Info 4164: (258-259): Inferred type: word
-// Info 4164: (275-294): Inferred type: (bool, word)
-// Info 4164: (278-294): Inferred type: (bool, word)
-// Info 4164: (278-282): Inferred type: tfun((bool, word), (bool, word))
-// Info 4164: (283-287): Inferred type: bool
-// Info 4164: (289-293): Inferred type: word
-// Info 4164: (304-317): Inferred type: bool
-// Info 4164: (304-314): Inferred type: (bool, word) -> bool
-// Info 4164: (304-308): Inferred type: ('bh:type, 'bi:type)
-// Info 4164: (315-316): Inferred type: (bool, word)
-// Info 4164: (327-341): Inferred type: word
-// Info 4164: (327-338): Inferred type: (bool, word) -> word
-// Info 4164: (327-331): Inferred type: ('bn:type, 'bo:type)
-// Info 4164: (339-340): Inferred type: (bool, word)
+// Info 4164: (31-61): Inferred type: void
+// Info 4164: (63-93): Inferred type: bool
+// Info 4164: (94-124): Inferred type: word
+// Info 4164: (125-161): Inferred type: integer
+// Info 4164: (162-192): Inferred type: ()
+// Info 4164: (194-228): Inferred type: tfun(('u:type, 'v:type), 'u:type -> 'v:type)
+// Info 4164: (202-208): Inferred type: ('s:type, 't:type)
+// Info 4164: (203-204): Inferred type: 's:type
+// Info 4164: (206-207): Inferred type: 't:type
+// Info 4164: (229-265): Inferred type: tfun(('y:type, 'z:type), ('y:type, 'z:type))
+// Info 4164: (238-244): Inferred type: ('w:type, 'x:type)
+// Info 4164: (239-240): Inferred type: 'w:type
+// Info 4164: (242-243): Inferred type: 'x:type
+// Info 4164: (284-584): Inferred type: () -> ()
+// Info 4164: (292-294): Inferred type: ()
+// Info 4164: (318-325): Inferred type: void
+// Info 4164: (321-325): Inferred type: void
+// Info 4164: (340-347): Inferred type: bool
+// Info 4164: (343-347): Inferred type: bool
+// Info 4164: (357-378): Inferred type: bool
+// Info 4164: (357-365): Inferred type: word -> bool
+// Info 4164: (357-361): Inferred type: bool
+// Info 4164: (366-377): Inferred type: word
+// Info 4164: (366-374): Inferred type: bool -> word
+// Info 4164: (366-370): Inferred type: bool
+// Info 4164: (375-376): Inferred type: bool
+// Info 4164: (393-400): Inferred type: word
+// Info 4164: (396-400): Inferred type: word
+// Info 4164: (414-424): Inferred type: integer
+// Info 4164: (417-424): Inferred type: integer
+// Info 4164: (438-445): Inferred type: ()
+// Info 4164: (441-445): Inferred type: ()
+// Info 4164: (460-478): Inferred type: word -> bool
+// Info 4164: (463-478): Inferred type: word -> bool
+// Info 4164: (463-466): Inferred type: tfun((word, bool), word -> bool)
+// Info 4164: (467-471): Inferred type: word
+// Info 4164: (473-477): Inferred type: bool
+// Info 4164: (488-496): Inferred type: bool
+// Info 4164: (488-489): Inferred type: bool
+// Info 4164: (492-496): Inferred type: bool
+// Info 4164: (492-493): Inferred type: word -> bool
+// Info 4164: (494-495): Inferred type: word
+// Info 4164: (511-530): Inferred type: (bool, word)
+// Info 4164: (514-530): Inferred type: (bool, word)
+// Info 4164: (514-518): Inferred type: tfun((bool, word), (bool, word))
+// Info 4164: (519-523): Inferred type: bool
+// Info 4164: (525-529): Inferred type: word
+// Info 4164: (540-553): Inferred type: bool
+// Info 4164: (540-550): Inferred type: (bool, word) -> bool
+// Info 4164: (540-544): Inferred type: ('cb:type, 'cc:type)
+// Info 4164: (551-552): Inferred type: (bool, word)
+// Info 4164: (563-577): Inferred type: word
+// Info 4164: (563-574): Inferred type: (bool, word) -> word
+// Info 4164: (563-567): Inferred type: ('ci:type, 'cj:type)
+// Info 4164: (575-576): Inferred type: (bool, word)

--- a/test/libsolidity/syntaxTests/experimental/builtin/builtin_type_definition_duplicate.sol
+++ b/test/libsolidity/syntaxTests/experimental/builtin/builtin_type_definition_duplicate.sol
@@ -1,0 +1,17 @@
+pragma experimental solidity;
+
+type void1 = __builtin("void");
+type void2 = __builtin("void");
+
+type word1 = __builtin("word");
+type word2 = __builtin("word");
+
+type fun1(T, U) = __builtin("fun");
+type fun2(T, U) = __builtin("fun");
+// ====
+// EVMVersion: >=constantinople
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError 9609: (63-94): Duplicate builtin type definition.
+// TypeError 9609: (128-159): Duplicate builtin type definition.
+// TypeError 9609: (197-232): Duplicate builtin type definition.

--- a/test/libsolidity/syntaxTests/experimental/builtin/builtin_type_definition_unknown.sol
+++ b/test/libsolidity/syntaxTests/experimental/builtin/builtin_type_definition_unknown.sol
@@ -1,0 +1,8 @@
+pragma experimental solidity;
+
+type someUnknownType = __builtin("someUnknownType");
+// ====
+// EVMVersion: >=constantinople
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError 7758: (31-81): Expected the name of a built-in primitive type.


### PR DESCRIPTION
This PR removes hard-coded built-in type definitions and introduces the `__builtin()` construct for explicitly registering them.

It also renames the `integer` class to `Integer` to resolve the ambiguity with the `integer` type.

### To do:
- [x] Builtin-types
- [x] Decide how to parse `__builtin()`