### PR TITLE
Fix coloring of info messages in isoltest

### DIFF
--- a/liblangutil/Exceptions.cpp
+++ b/liblangutil/Exceptions.cpp
@@ -29,6 +29,26 @@
 using namespace solidity;
 using namespace solidity::langutil;
 
+std::map<Error::Type, std::string> const Error::m_errorTypeNames = {
+	{Error::Type::IOError, "IOError"},
+	{Error::Type::FatalError, "FatalError"},
+	{Error::Type::JSONError, "JSONError"},
+	{Error::Type::InternalCompilerError, "InternalCompilerError"},
+	{Error::Type::CompilerError, "CompilerError"},
+	{Error::Type::Exception, "Exception"},
+	{Error::Type::CodeGenerationError, "CodeGenerationError"},
+	{Error::Type::DeclarationError, "DeclarationError"},
+	{Error::Type::DocstringParsingError, "DocstringParsingError"},
+	{Error::Type::ParserError, "ParserError"},
+	{Error::Type::SyntaxError, "SyntaxError"},
+	{Error::Type::TypeError, "TypeError"},
+	{Error::Type::UnimplementedFeatureError, "UnimplementedFeatureError"},
+	{Error::Type::YulException, "YulException"},
+	{Error::Type::SMTLogicException, "SMTLogicException"},
+	{Error::Type::Warning, "Warning"},
+	{Error::Type::Info, "Info"},
+};
+
 Error::Error(
 	ErrorId _errorId, Error::Type _type,
 	std::string const& _description,

--- a/liblangutil/Exceptions.h
+++ b/liblangutil/Exceptions.h
@@ -33,11 +33,11 @@
 #include <boost/preprocessor/facilities/overload.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 
+#include <optional>
 #include <string>
 #include <utility>
-#include <vector>
-#include <memory>
 #include <variant>
+#include <vector>
 
 namespace solidity::langutil
 {
@@ -269,27 +269,17 @@ public:
 
 	static std::string formatErrorType(Type _type)
 	{
-		switch (_type)
-		{
-		case Type::IOError: return "IOError";
-		case Type::FatalError: return "FatalError";
-		case Type::JSONError: return "JSONError";
-		case Type::InternalCompilerError: return "InternalCompilerError";
-		case Type::CompilerError: return "CompilerError";
-		case Type::Exception: return "Exception";
-		case Type::CodeGenerationError: return "CodeGenerationError";
-		case Type::DeclarationError: return "DeclarationError";
-		case Type::DocstringParsingError: return "DocstringParsingError";
-		case Type::ParserError: return "ParserError";
-		case Type::SyntaxError: return "SyntaxError";
-		case Type::TypeError: return "TypeError";
-		case Type::UnimplementedFeatureError: return "UnimplementedFeatureError";
-		case Type::YulException: return "YulException";
-		case Type::SMTLogicException: return "SMTLogicException";
-		case Type::Warning: return "Warning";
-		case Type::Info: return "Info";
-		}
-		util::unreachable();
+		return m_errorTypeNames.at(_type);
+	}
+
+	static std::optional<Type> parseErrorType(std::string _name)
+	{
+		static std::map<std::string, Error::Type> const m_errorTypesByName = util::invertMap(m_errorTypeNames);
+
+		if (m_errorTypesByName.count(_name) == 0)
+			return std::nullopt;
+
+		return m_errorTypesByName.at(_name);
 	}
 
 	static std::string formatTypeOrSeverity(std::variant<Error::Type, Error::Severity> _typeOrSeverity)
@@ -309,6 +299,8 @@ public:
 private:
 	ErrorId m_errorId;
 	Type m_type;
+
+	static std::map<Type, std::string> const m_errorTypeNames;
 };
 
 }

--- a/liblangutil/SourceReferenceFormatter.cpp
+++ b/liblangutil/SourceReferenceFormatter.cpp
@@ -55,6 +55,28 @@ std::string SourceReferenceFormatter::formatErrorInformation(Error const& _error
 	);
 }
 
+char const* SourceReferenceFormatter::errorTextColor(Error::Severity _severity)
+{
+	switch (_severity)
+	{
+	case Error::Severity::Error: return RED;
+	case Error::Severity::Warning: return YELLOW;
+	case Error::Severity::Info: return WHITE;
+	}
+	util::unreachable();
+}
+
+char const* SourceReferenceFormatter::errorHighlightColor(Error::Severity _severity)
+{
+	switch (_severity)
+	{
+	case Error::Severity::Error: return RED_BACKGROUND;
+	case Error::Severity::Warning: return ORANGE_BACKGROUND_256;
+	case Error::Severity::Info: return GRAY_BACKGROUND;
+	}
+	util::unreachable();
+}
+
 AnsiColorized SourceReferenceFormatter::normalColored() const
 {
 	return AnsiColorized(m_stream, m_colored, {WHITE});
@@ -67,18 +89,7 @@ AnsiColorized SourceReferenceFormatter::frameColored() const
 
 AnsiColorized SourceReferenceFormatter::errorColored(std::ostream& _stream, bool _colored, Error::Severity _severity)
 {
-	// We used to color messages of any severity as errors so this seems like a good default
-	// for cases where severity cannot be determined.
-	char const* textColor = RED;
-
-	switch (_severity)
-	{
-	case Error::Severity::Error: textColor = RED; break;
-	case Error::Severity::Warning: textColor = YELLOW; break;
-	case Error::Severity::Info: textColor = WHITE; break;
-	}
-
-	return AnsiColorized(_stream, _colored, {BOLD, textColor});
+	return AnsiColorized(_stream, _colored, {BOLD, errorTextColor(_severity)});
 }
 
 AnsiColorized SourceReferenceFormatter::messageColored(std::ostream& _stream, bool _colored)

--- a/liblangutil/SourceReferenceFormatter.h
+++ b/liblangutil/SourceReferenceFormatter.h
@@ -127,6 +127,16 @@ public:
 		bool _withErrorIds = false
 	);
 
+	/// The default text color for printing error messages of a given severity in the terminal.
+	/// Assumes a dark background color.
+	static char const* errorTextColor(Error::Severity _severity);
+
+	/// The default background color for highlighting source fragments corresponding to an error
+	/// of a given severity in the terminal. Assumes a light text color.
+	/// @note This is *not* meant to be used for the same text in combination with @a errorTextColor().
+	///       It's an alternative way to highlight it, while preserving the original text color.
+	static char const* errorHighlightColor(Error::Severity _severity);
+
 private:
 	util::AnsiColorized normalColored() const;
 	util::AnsiColorized frameColored() const;

--- a/libsolutil/AnsiColorized.h
+++ b/libsolutil/AnsiColorized.h
@@ -52,6 +52,7 @@ static constexpr char const* BLUE_BACKGROUND = "\033[44m";
 static constexpr char const* MAGENTA_BACKGROUND = "\033[45m";
 static constexpr char const* CYAN_BACKGROUND = "\033[46m";
 static constexpr char const* WHITE_BACKGROUND = "\033[47m";
+static constexpr char const* GRAY_BACKGROUND = "\033[100m";
 
 // 256-bit-colors (incomplete set)
 static constexpr char const* RED_BACKGROUND_256 = "\033[48;5;160m";

--- a/test/CommonSyntaxTest.cpp
+++ b/test/CommonSyntaxTest.cpp
@@ -115,11 +115,18 @@ void CommonSyntaxTest::printSource(ostream& _stream, string const& _linePrefix, 
 				{
 					assert(static_cast<size_t>(error.locationStart) <= source.length());
 					assert(static_cast<size_t>(error.locationEnd) <= source.length());
-					bool isWarning = (error.type == Error::Type::Warning);
 					for (int i = error.locationStart; i < error.locationEnd; i++)
-						if (isWarning)
+						if (error.type == Error::Type::Info)
 						{
 							if (sourceFormatting[static_cast<size_t>(i)] == util::formatting::RESET)
+								sourceFormatting[static_cast<size_t>(i)] = util::formatting::GRAY_BACKGROUND;
+						}
+						else if (error.type == Error::Type::Warning)
+						{
+							if (
+								sourceFormatting[static_cast<size_t>(i)] == util::formatting::RESET ||
+								sourceFormatting[static_cast<size_t>(i)] == util::formatting::GRAY_BACKGROUND
+							)
 								sourceFormatting[static_cast<size_t>(i)] = util::formatting::ORANGE_BACKGROUND_256;
 						}
 						else
@@ -190,7 +197,11 @@ void CommonSyntaxTest::printErrorList(
 		for (auto const& error: _errorList)
 		{
 			{
-				util::AnsiColorized scope(_stream, _formatted, {BOLD, (error.type == Error::Type::Warning) ? YELLOW : RED});
+				util::AnsiColorized scope(
+					_stream,
+					_formatted,
+					{BOLD, error.type == Error::Type::Info ? WHITE : (error.type == Error::Type::Warning ? YELLOW : RED)}
+				);
 				_stream << _linePrefix << Error::formatErrorType(error.type);
 				if (error.errorId.has_value())
 					_stream << ' ' << error.errorId->error;

--- a/test/CommonSyntaxTest.h
+++ b/test/CommonSyntaxTest.h
@@ -34,7 +34,7 @@ namespace solidity::test
 
 struct SyntaxTestError
 {
-	std::string type;
+	langutil::Error::Type type;
 	std::optional<langutil::ErrorId> errorId;
 	std::string message;
 	std::string sourceName;

--- a/test/libsolidity/SyntaxTest.cpp
+++ b/test/libsolidity/SyntaxTest.cpp
@@ -91,7 +91,7 @@ void SyntaxTest::parseAndAnalyze()
 	catch (UnimplementedFeatureError const& _e)
 	{
 		m_errorList.emplace_back(SyntaxTestError{
-			"UnimplementedFeatureError",
+			Error::Type::UnimplementedFeatureError,
 			std::nullopt,
 			errorMessage(_e),
 			"",
@@ -140,7 +140,7 @@ void SyntaxTest::filterObtainedErrors()
 			}
 		}
 		m_errorList.emplace_back(SyntaxTestError{
-			Error::formatErrorType(currentError->type()),
+			currentError->type(),
 			currentError->errorId(),
 			errorMessage(*currentError),
 			sourceName,

--- a/test/libyul/SyntaxTest.cpp
+++ b/test/libyul/SyntaxTest.cpp
@@ -61,7 +61,7 @@ void SyntaxTest::parseAndAnalyze()
 		}
 
 		m_errorList.emplace_back(SyntaxTestError{
-			Error::formatErrorType(error->type()),
+			error->type(),
 			error->errorId(),
 			errorMessage(*error),
 			name,


### PR DESCRIPTION
~Depends on #14585.~ Merged.

Isoltest prints "info" messages colored as errors. Apparently we missed that when we introduced the new level, probably because we still have very few such messages.

Now that #14510 is printing a lot of them, it's getting really annoying. This PR fix that and does some small refactors to prevent this getting out of sync so easily in the future.