### PR TITLE
Stop using the deprecated `large` class for macOS jobs on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -448,14 +448,6 @@ defaults:
         MAKEFLAGS: -j5
         CPUs: 5
 
-  - base_osx_large: &base_osx_large
-      <<: *base_osx
-      resource_class: large
-      environment: &base_osx_large_env
-        <<: *base_osx_env
-        MAKEFLAGS: -j10
-        CPUs: 10
-
   - base_python_small: &base_python_small
       docker:
         - image: cimg/python:3.6
@@ -1099,9 +1091,9 @@ jobs:
       - matrix_notify_failure_unless_pr
 
   b_osx:
-    <<: *base_osx_large
+    <<: *base_osx
     environment:
-      <<: *base_osx_large_env
+      <<: *base_osx_env
       CMAKE_BUILD_TYPE: Release
     steps:
       - checkout


### PR DESCRIPTION
Looks like the `large` resource class is no longer available since Monday:

[macOS Resource Deprecation Update](https://discuss.circleci.com/t/macos-resource-deprecation-update/46891)

> 2. Phase 2 - October 2, 2023
> a. The macOS `medium` and `large` resource classes are no longer available.
> b. Any jobs specifying `medium` and `large` will fail with an `Invalid resource class` error.
> c. If your project config doesn’t specify a macOS resource class, jobs will be defaulted to `macos.x86.medium.gen2`.

Our `b_osx` was using it and is failing now so I'm switching it to medium.