### PR TITLE
Consistent severity and color for CLI error messages

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Language Features:
 
 
 Compiler Features:
+ * Commandline Interface: Use proper severity and coloring also for error messages produced outside of the compilation pipeline.
  * Parser: Remove the experimental error recovery mode (``--error-recovery`` / ``settings.parserErrorRecovery``).
  * Yul Optimizer: If ``PUSH0`` is supported, favor zero literals over storing zero values in variables.
  * Yul Optimizer: Run the ``Rematerializer`` and ``UnusedPruner`` steps at the end of the default clean-up sequence.

--- a/liblangutil/SourceReferenceFormatter.cpp
+++ b/liblangutil/SourceReferenceFormatter.cpp
@@ -65,7 +65,7 @@ AnsiColorized SourceReferenceFormatter::frameColored() const
 	return AnsiColorized(m_stream, m_colored, {BOLD, BLUE});
 }
 
-AnsiColorized SourceReferenceFormatter::errorColored(Error::Severity _severity) const
+AnsiColorized SourceReferenceFormatter::errorColored(std::ostream& _stream, bool _colored, Error::Severity _severity)
 {
 	// We used to color messages of any severity as errors so this seems like a good default
 	// for cases where severity cannot be determined.
@@ -78,12 +78,12 @@ AnsiColorized SourceReferenceFormatter::errorColored(Error::Severity _severity) 
 	case Error::Severity::Info: textColor = WHITE; break;
 	}
 
-	return AnsiColorized(m_stream, m_colored, {BOLD, textColor});
+	return AnsiColorized(_stream, _colored, {BOLD, textColor});
 }
 
-AnsiColorized SourceReferenceFormatter::messageColored() const
+AnsiColorized SourceReferenceFormatter::messageColored(std::ostream& _stream, bool _colored)
 {
-	return AnsiColorized(m_stream, m_colored, {BOLD, WHITE});
+	return AnsiColorized(_stream, _colored, {BOLD, WHITE});
 }
 
 AnsiColorized SourceReferenceFormatter::secondaryColored() const
@@ -175,14 +175,26 @@ void SourceReferenceFormatter::printSourceLocation(SourceReference const& _ref)
 	}
 }
 
+void SourceReferenceFormatter::printPrimaryMessage(
+	std::ostream& _stream,
+	std::string _message,
+	std::variant<Error::Type, Error::Severity> _typeOrSeverity,
+	std::optional<ErrorId> _errorId,
+	bool _colored,
+	bool _withErrorIds
+)
+{
+	errorColored(_stream, _colored, Error::errorSeverityOrType(_typeOrSeverity)) << Error::formatTypeOrSeverity(_typeOrSeverity);
+
+	if (_withErrorIds && _errorId.has_value())
+		errorColored(_stream, _colored, Error::errorSeverityOrType(_typeOrSeverity)) << " (" << _errorId.value().error << ")";
+
+	messageColored(_stream, _colored) << ": " << _message << '\n';
+}
+
 void SourceReferenceFormatter::printExceptionInformation(SourceReferenceExtractor::Message const& _msg)
 {
-	errorColored(Error::errorSeverityOrType(_msg._typeOrSeverity)) << Error::formatTypeOrSeverity(_msg._typeOrSeverity);
-
-	if (m_withErrorIds && _msg.errorId.has_value())
-		errorColored(Error::errorSeverityOrType(_msg._typeOrSeverity)) << " (" << _msg.errorId.value().error << ")";
-
-	messageColored() << ": " << _msg.primary.message << '\n';
+	printPrimaryMessage(m_stream, _msg.primary.message, _msg._typeOrSeverity, _msg.errorId, m_colored, m_withErrorIds);
 	printSourceLocation(_msg.primary);
 
 	for (auto const& secondary: _msg.secondary)

--- a/liblangutil/SourceReferenceFormatter.h
+++ b/liblangutil/SourceReferenceFormatter.h
@@ -118,14 +118,26 @@ public:
 
 	static std::string formatErrorInformation(Error const& _error, CharStream const& _charStream);
 
+	static void printPrimaryMessage(
+		std::ostream& _stream,
+		std::string _message,
+		std::variant<Error::Type, Error::Severity> _typeOrSeverity,
+		std::optional<ErrorId> _errorId = std::nullopt,
+		bool _colored = false,
+		bool _withErrorIds = false
+	);
+
 private:
 	util::AnsiColorized normalColored() const;
 	util::AnsiColorized frameColored() const;
-	util::AnsiColorized errorColored(langutil::Error::Severity _severity) const;
-	util::AnsiColorized messageColored() const;
+	util::AnsiColorized errorColored(Error::Severity _severity) const { return errorColored(m_stream, m_colored, _severity); }
+	util::AnsiColorized messageColored() const { return messageColored(m_stream, m_colored); }
 	util::AnsiColorized secondaryColored() const;
 	util::AnsiColorized highlightColored() const;
 	util::AnsiColorized diagColored() const;
+
+	static util::AnsiColorized errorColored(std::ostream& _stream, bool _colored, langutil::Error::Severity _severity);
+	static util::AnsiColorized messageColored(std::ostream& _stream, bool _colored);
 
 private:
 	std::ostream& m_stream;

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -658,7 +658,19 @@ bool CommandLineInterface::parseArguments(int _argc, char const* const* _argv)
 		return false;
 	}
 
-	parser.parse(_argc, _argv);
+	try
+	{
+		parser.parse(_argc, _argv);
+	}
+	catch (...)
+	{
+		// Even if the overall CLI parsing fails, the --color/--no-color options may have been
+		// successfully parsed, and if so, should be taken into account when printing errors.
+		// If no value is present, it's possible that --no-color is still there but parsing failed
+		// due to other, unrecognized options so play it safe and disable color in that case.
+		m_options.formatting.coloredOutput = parser.options().formatting.coloredOutput.value_or(false);
+		throw;
+	}
 	m_options = parser.options();
 
 	return true;

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -136,6 +136,8 @@ private:
 	/// stream has ever been used unless @arg _markAsUsed is set to false.
 	std::ostream& serr(bool _markAsUsed = true);
 
+	void report(langutil::Error::Severity _severity, std::string _message);
+
 	std::istream& m_sin;
 	std::ostream& m_sout;
 	std::ostream& m_serr;

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -896,6 +896,9 @@ void CommandLineParser::parseArgs(int _argc, char const* const* _argv)
 	po::options_description allOptions = optionsDescription();
 	po::positional_options_description filesPositions = positionalOptionsDescription();
 
+	m_options = {};
+	m_args = {};
+
 	// parse the compiler arguments
 	try
 	{

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -917,10 +917,10 @@ void CommandLineParser::parseArgs(int _argc, char const* const* _argv)
 
 void CommandLineParser::processArgs()
 {
-	if (m_args.count(g_strColor) > 0)
-		m_options.formatting.coloredOutput = true;
-	else if (m_args.count(g_strNoColor) > 0)
+	if (m_args.count(g_strNoColor) > 0)
 		m_options.formatting.coloredOutput = false;
+	else if (m_args.count(g_strColor) > 0)
+		m_options.formatting.coloredOutput = true;
 
 	checkMutuallyExclusive({
 		g_strHelp,

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -917,6 +917,11 @@ void CommandLineParser::parseArgs(int _argc, char const* const* _argv)
 
 void CommandLineParser::processArgs()
 {
+	if (m_args.count(g_strColor) > 0)
+		m_options.formatting.coloredOutput = true;
+	else if (m_args.count(g_strNoColor) > 0)
+		m_options.formatting.coloredOutput = false;
+
 	checkMutuallyExclusive({
 		g_strHelp,
 		g_strLicense,
@@ -1030,11 +1035,6 @@ void CommandLineParser::processArgs()
 				"Option --" + g_strDebugInfo + " is only valid in compiler and assembler modes."
 			);
 	}
-
-	if (m_args.count(g_strColor) > 0)
-		m_options.formatting.coloredOutput = true;
-	else if (m_args.count(g_strNoColor) > 0)
-		m_options.formatting.coloredOutput = false;
 
 	m_options.formatting.withErrorIds = m_args.count(g_strErrorIds);
 

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -318,14 +318,14 @@ EOF
 ## RUN
 
 printTask "Testing passing files that are not found..."
-test_solc_behaviour "file_not_found.sol" "" "" "" 1 "" "\"file_not_found.sol\" is not found." "" ""
+test_solc_behaviour "file_not_found.sol" "" "" "" 1 "" "Error: \"file_not_found.sol\" is not found." "" ""
 
 printTask "Testing passing files that are not files..."
-test_solc_behaviour "." "" "" "" 1 "" "\".\" is not a valid file." "" ""
+test_solc_behaviour "." "" "" "" 1 "" "Error: \".\" is not a valid file." "" ""
 
 printTask "Testing passing empty remappings..."
-test_solc_behaviour "${0}" "=/some/remapping/target" "" "" 1 "" "Invalid remapping: \"=/some/remapping/target\"." "" ""
-test_solc_behaviour "${0}" "ctx:=/some/remapping/target" "" "" 1 "" "Invalid remapping: \"ctx:=/some/remapping/target\"." "" ""
+test_solc_behaviour "${0}" "=/some/remapping/target" "" "" 1 "" "Error: Invalid remapping: \"=/some/remapping/target\"." "" ""
+test_solc_behaviour "${0}" "ctx:=/some/remapping/target" "" "" 1 "" "Error: Invalid remapping: \"ctx:=/some/remapping/target\"." "" ""
 
 printTask "Running general commandline tests..."
 (

--- a/test/cmdlineTests/ast_json_import_wrong_evmVersion/err
+++ b/test/cmdlineTests/ast_json_import_wrong_evmVersion/err
@@ -1,1 +1,1 @@
-Failed to import AST: Imported tree evm version differs from configured evm version!
+Error: Failed to import AST: Imported tree evm version differs from configured evm version!

--- a/test/cmdlineTests/debug_info_in_yul_and_evm_asm_print_all_and_none/err
+++ b/test/cmdlineTests/debug_info_in_yul_and_evm_asm_print_all_and_none/err
@@ -1,1 +1,1 @@
-Invalid value for --debug-info option: location,all,none
+Error: Invalid value for --debug-info option: location,all,none

--- a/test/cmdlineTests/debug_info_in_yul_and_evm_asm_print_snippet_only/err
+++ b/test/cmdlineTests/debug_info_in_yul_and_evm_asm_print_snippet_only/err
@@ -1,1 +1,1 @@
-To use 'snippet' with --debug-info you must select also 'location'.
+Error: To use 'snippet' with --debug-info you must select also 'location'.

--- a/test/cmdlineTests/linker_mode_invalid_option_no_optimize_yul/err
+++ b/test/cmdlineTests/linker_mode_invalid_option_no_optimize_yul/err
@@ -1,1 +1,1 @@
-Option --no-optimize-yul is only valid in compiler and assembler modes.
+Error: Option --no-optimize-yul is only valid in compiler and assembler modes.

--- a/test/cmdlineTests/linker_mode_invalid_option_optimize/err
+++ b/test/cmdlineTests/linker_mode_invalid_option_optimize/err
@@ -1,1 +1,1 @@
-Option --optimize is only valid in compiler and assembler modes.
+Error: Option --optimize is only valid in compiler and assembler modes.

--- a/test/cmdlineTests/linker_mode_invalid_option_optimize_runs/err
+++ b/test/cmdlineTests/linker_mode_invalid_option_optimize_runs/err
@@ -1,1 +1,1 @@
-Option --optimize-runs is only valid in compiler and assembler modes.
+Error: Option --optimize-runs is only valid in compiler and assembler modes.

--- a/test/cmdlineTests/linker_mode_invalid_option_optimize_yul/err
+++ b/test/cmdlineTests/linker_mode_invalid_option_optimize_yul/err
@@ -1,1 +1,1 @@
-Option --optimize-yul is only valid in compiler and assembler modes.
+Error: Option --optimize-yul is only valid in compiler and assembler modes.

--- a/test/cmdlineTests/linker_mode_invalid_option_yul_optimizations/err
+++ b/test/cmdlineTests/linker_mode_invalid_option_yul_optimizations/err
@@ -1,1 +1,1 @@
-Option --yul-optimizations is only valid in compiler and assembler modes.
+Error: Option --yul-optimizations is only valid in compiler and assembler modes.

--- a/test/cmdlineTests/linker_mode_output_selection_invalid/err
+++ b/test/cmdlineTests/linker_mode_output_selection_invalid/err
@@ -1,1 +1,1 @@
-The following outputs are not supported in linker mode: --abi, --asm, --asm-json, --bin, --bin-runtime, --devdoc, --hashes, --ir, --ir-optimized, --metadata, --opcodes, --storage-layout, --userdoc.
+Error: The following outputs are not supported in linker mode: --abi, --asm, --asm-json, --bin, --bin-runtime, --devdoc, --hashes, --ir, --ir-optimized, --metadata, --opcodes, --storage-layout, --userdoc.

--- a/test/cmdlineTests/linking_strict_assembly_duplicate_library_name/err
+++ b/test/cmdlineTests/linking_strict_assembly_duplicate_library_name/err
@@ -1,1 +1,1 @@
-Address specified more than once for library "library.sol:L".
+Error: Address specified more than once for library "library.sol:L".

--- a/test/cmdlineTests/model_checker_bmc_loop_iterations_invalid_arg/err
+++ b/test/cmdlineTests/model_checker_bmc_loop_iterations_invalid_arg/err
@@ -1,1 +1,1 @@
-the argument ('bmc') for option '--model-checker-bmc-loop-iterations' is invalid
+Error: the argument ('bmc') for option '--model-checker-bmc-loop-iterations' is invalid

--- a/test/cmdlineTests/model_checker_bmc_loop_iterations_no_argument/err
+++ b/test/cmdlineTests/model_checker_bmc_loop_iterations_no_argument/err
@@ -1,1 +1,1 @@
-the argument ('model_checker_bmc_loop_iterations_no_argument/input.sol') for option '--model-checker-bmc-loop-iterations' is invalid
+Error: the argument ('model_checker_bmc_loop_iterations_no_argument/input.sol') for option '--model-checker-bmc-loop-iterations' is invalid

--- a/test/cmdlineTests/model_checker_contracts_contract_missing/err
+++ b/test/cmdlineTests/model_checker_contracts_contract_missing/err
@@ -1,1 +1,1 @@
-Invalid option for --model-checker-contracts: model_checker_contracts_inexistent_contract/input.sol:
+Error: Invalid option for --model-checker-contracts: model_checker_contracts_inexistent_contract/input.sol:

--- a/test/cmdlineTests/model_checker_contracts_empty_contract/err
+++ b/test/cmdlineTests/model_checker_contracts_empty_contract/err
@@ -1,1 +1,1 @@
-Invalid option for --model-checker-contracts: a.sol:
+Error: Invalid option for --model-checker-contracts: a.sol:

--- a/test/cmdlineTests/model_checker_contracts_empty_source/err
+++ b/test/cmdlineTests/model_checker_contracts_empty_source/err
@@ -1,1 +1,1 @@
-Invalid option for --model-checker-contracts: :A
+Error: Invalid option for --model-checker-contracts: :A

--- a/test/cmdlineTests/model_checker_contracts_one_contract_missing/err
+++ b/test/cmdlineTests/model_checker_contracts_one_contract_missing/err
@@ -1,1 +1,1 @@
-Invalid option for --model-checker-contracts: model_checker_contracts_all_explicit/input.sol:,model_checker_contracts_all_explicit/input.sol:A
+Error: Invalid option for --model-checker-contracts: model_checker_contracts_all_explicit/input.sol:,model_checker_contracts_all_explicit/input.sol:A

--- a/test/cmdlineTests/model_checker_contracts_source_missing/err
+++ b/test/cmdlineTests/model_checker_contracts_source_missing/err
@@ -1,1 +1,1 @@
-Invalid option for --model-checker-contracts: :C
+Error: Invalid option for --model-checker-contracts: :C

--- a/test/cmdlineTests/model_checker_ext_calls_empty_arg/err
+++ b/test/cmdlineTests/model_checker_ext_calls_empty_arg/err
@@ -1,1 +1,1 @@
-No input files given. If you wish to use the standard input please specify "-" explicitly.
+Error: No input files given. If you wish to use the standard input please specify "-" explicitly.

--- a/test/cmdlineTests/model_checker_ext_calls_wrong_arg/err
+++ b/test/cmdlineTests/model_checker_ext_calls_wrong_arg/err
@@ -1,1 +1,1 @@
-Invalid option for --model-checker-ext-calls: what
+Error: Invalid option for --model-checker-ext-calls: what

--- a/test/cmdlineTests/model_checker_invariants_wrong/err
+++ b/test/cmdlineTests/model_checker_invariants_wrong/err
@@ -1,1 +1,1 @@
-Invalid option for --model-checker-invariants: what
+Error: Invalid option for --model-checker-invariants: what

--- a/test/cmdlineTests/model_checker_print_query_no_smtlib2_solver_bmc/err
+++ b/test/cmdlineTests/model_checker_print_query_no_smtlib2_solver_bmc/err
@@ -1,1 +1,1 @@
-Only SMTLib2 solver can be enabled to print queries
+Error: Only SMTLib2 solver can be enabled to print queries

--- a/test/cmdlineTests/model_checker_print_query_no_smtlib2_solver_chc/err
+++ b/test/cmdlineTests/model_checker_print_query_no_smtlib2_solver_chc/err
@@ -1,1 +1,1 @@
-Only SMTLib2 solver can be enabled to print queries
+Error: Only SMTLib2 solver can be enabled to print queries

--- a/test/cmdlineTests/model_checker_print_query_superflous_solver/err
+++ b/test/cmdlineTests/model_checker_print_query_superflous_solver/err
@@ -1,1 +1,1 @@
-Only SMTLib2 solver can be enabled to print queries
+Error: Only SMTLib2 solver can be enabled to print queries

--- a/test/cmdlineTests/model_checker_solvers_wrong/err
+++ b/test/cmdlineTests/model_checker_solvers_wrong/err
@@ -1,1 +1,1 @@
-Invalid option for --model-checker-solvers: ultraSolver
+Error: Invalid option for --model-checker-solvers: ultraSolver

--- a/test/cmdlineTests/model_checker_solvers_wrong2/err
+++ b/test/cmdlineTests/model_checker_solvers_wrong2/err
@@ -1,1 +1,1 @@
-"smtlib2" is not found.
+Error: "smtlib2" is not found.

--- a/test/cmdlineTests/model_checker_targets_error/err
+++ b/test/cmdlineTests/model_checker_targets_error/err
@@ -1,1 +1,1 @@
-Invalid option for --model-checker-targets: aaa,bbb
+Error: Invalid option for --model-checker-targets: aaa,bbb

--- a/test/cmdlineTests/no_cbor_metadata_with_metadata_hash/err
+++ b/test/cmdlineTests/no_cbor_metadata_with_metadata_hash/err
@@ -1,1 +1,1 @@
-Cannot specify a metadata hashing method when --no-cbor-metadata is set.
+Error: Cannot specify a metadata hashing method when --no-cbor-metadata is set.

--- a/test/cmdlineTests/optimizer_enabled_invalid_yul_optimizer_enabled_and_disabled/err
+++ b/test/cmdlineTests/optimizer_enabled_invalid_yul_optimizer_enabled_and_disabled/err
@@ -1,1 +1,1 @@
-Options --optimize-yul and --no-optimize-yul cannot be used together.
+Error: Options --optimize-yul and --no-optimize-yul cannot be used together.

--- a/test/cmdlineTests/standard_cli_output_selection_invalid/err
+++ b/test/cmdlineTests/standard_cli_output_selection_invalid/err
@@ -1,1 +1,1 @@
-The following outputs are not supported in standard JSON mode: --abi, --asm, --asm-json, --ast-compact-json, --bin, --bin-runtime, --devdoc, --hashes, --ir, --ir-optimized, --metadata, --opcodes, --storage-layout, --userdoc.
+Error: The following outputs are not supported in standard JSON mode: --abi, --asm, --asm-json, --ast-compact-json, --bin, --bin-runtime, --devdoc, --hashes, --ir, --ir-optimized, --metadata, --opcodes, --storage-layout, --userdoc.

--- a/test/cmdlineTests/standard_file_not_found/err
+++ b/test/cmdlineTests/standard_file_not_found/err
@@ -1,1 +1,1 @@
-"input.sol" is not found.
+Error: "input.sol" is not found.

--- a/test/cmdlineTests/standard_invalid_option_no_optimize_yul/err
+++ b/test/cmdlineTests/standard_invalid_option_no_optimize_yul/err
@@ -1,1 +1,1 @@
-Option --no-optimize-yul is only valid in compiler and assembler modes.
+Error: Option --no-optimize-yul is only valid in compiler and assembler modes.

--- a/test/cmdlineTests/standard_invalid_option_optimize/err
+++ b/test/cmdlineTests/standard_invalid_option_optimize/err
@@ -1,1 +1,1 @@
-Option --optimize is only valid in compiler and assembler modes.
+Error: Option --optimize is only valid in compiler and assembler modes.

--- a/test/cmdlineTests/standard_invalid_option_optimize_runs/err
+++ b/test/cmdlineTests/standard_invalid_option_optimize_runs/err
@@ -1,1 +1,1 @@
-Option --optimize-runs is only valid in compiler and assembler modes.
+Error: Option --optimize-runs is only valid in compiler and assembler modes.

--- a/test/cmdlineTests/standard_invalid_option_optimize_yul/err
+++ b/test/cmdlineTests/standard_invalid_option_optimize_yul/err
@@ -1,1 +1,1 @@
-Option --optimize-yul is only valid in compiler and assembler modes.
+Error: Option --optimize-yul is only valid in compiler and assembler modes.

--- a/test/cmdlineTests/standard_invalid_option_yul_optimizations/err
+++ b/test/cmdlineTests/standard_invalid_option_yul_optimizations/err
@@ -1,1 +1,1 @@
-Option --yul-optimizations is only valid in compiler and assembler modes.
+Error: Option --yul-optimizations is only valid in compiler and assembler modes.

--- a/test/cmdlineTests/stop_after_parsing_abi/err
+++ b/test/cmdlineTests/stop_after_parsing_abi/err
@@ -1,1 +1,1 @@
-The following options are mutually exclusive: --stop-after, --abi. Select at most one.
+Error: The following options are mutually exclusive: --stop-after, --abi. Select at most one.

--- a/test/cmdlineTests/strict_asm_debug_info_print_snippet_only/err
+++ b/test/cmdlineTests/strict_asm_debug_info_print_snippet_only/err
@@ -1,1 +1,1 @@
-To use 'snippet' with --debug-info you must select also 'location'.
+Error: To use 'snippet' with --debug-info you must select also 'location'.

--- a/test/cmdlineTests/strict_asm_invalid_option_output_dir/err
+++ b/test/cmdlineTests/strict_asm_invalid_option_output_dir/err
@@ -1,1 +1,1 @@
-The following options are invalid in assembly mode: --output-dir.
+Error: The following options are invalid in assembly mode: --output-dir.

--- a/test/cmdlineTests/strict_asm_optimizer_invalid_yul_optimizer_enabled_and_disabled/err
+++ b/test/cmdlineTests/strict_asm_optimizer_invalid_yul_optimizer_enabled_and_disabled/err
@@ -1,1 +1,1 @@
-Options --optimize-yul and --no-optimize-yul cannot be used together.
+Error: Options --optimize-yul and --no-optimize-yul cannot be used together.

--- a/test/cmdlineTests/strict_asm_options_in_non_asm_mode/err
+++ b/test/cmdlineTests/strict_asm_options_in_non_asm_mode/err
@@ -1,1 +1,1 @@
---yul-dialect and --machine are only valid in assembly mode.
+Error: --yul-dialect and --machine are only valid in assembly mode.

--- a/test/cmdlineTests/strict_asm_output_selection_invalid/err
+++ b/test/cmdlineTests/strict_asm_output_selection_invalid/err
@@ -1,1 +1,1 @@
-The following outputs are not supported in assembler mode: --abi, --asm-json, --bin-runtime, --devdoc, --hashes, --ir, --metadata, --opcodes, --storage-layout, --userdoc.
+Error: The following outputs are not supported in assembler mode: --abi, --asm-json, --bin-runtime, --devdoc, --hashes, --ir, --metadata, --opcodes, --storage-layout, --userdoc.

--- a/test/cmdlineTests/yul_optimizer_steps_disabled/err
+++ b/test/cmdlineTests/yul_optimizer_steps_disabled/err
@@ -1,1 +1,1 @@
---yul-optimizations is invalid if Yul optimizer is disabled
+Error: --yul-optimizations is invalid if Yul optimizer is disabled

--- a/test/cmdlineTests/yul_optimizer_steps_invalid_abbreviation/err
+++ b/test/cmdlineTests/yul_optimizer_steps_invalid_abbreviation/err
@@ -1,1 +1,1 @@
-Invalid optimizer step sequence in --yul-optimizations: 'b' is not a valid step abbreviation
+Error: Invalid optimizer step sequence in --yul-optimizations: 'b' is not a valid step abbreviation

--- a/test/cmdlineTests/yul_optimizer_steps_nesting_too_deep/err
+++ b/test/cmdlineTests/yul_optimizer_steps_nesting_too_deep/err
@@ -1,1 +1,1 @@
-Invalid optimizer step sequence in --yul-optimizations: Brackets nested too deep
+Error: Invalid optimizer step sequence in --yul-optimizations: Brackets nested too deep

--- a/test/cmdlineTests/yul_optimizer_steps_unbalanced_closing_bracket/err
+++ b/test/cmdlineTests/yul_optimizer_steps_unbalanced_closing_bracket/err
@@ -1,1 +1,1 @@
-Invalid optimizer step sequence in --yul-optimizations: Unbalanced brackets
+Error: Invalid optimizer step sequence in --yul-optimizations: Unbalanced brackets

--- a/test/cmdlineTests/yul_optimizer_steps_unbalanced_opening_bracket/err
+++ b/test/cmdlineTests/yul_optimizer_steps_unbalanced_opening_bracket/err
@@ -1,1 +1,1 @@
-Invalid optimizer step sequence in --yul-optimizations: Unbalanced brackets
+Error: Invalid optimizer step sequence in --yul-optimizations: Unbalanced brackets

--- a/test/cmdlineTests/~unknown_options/test.sh
+++ b/test/cmdlineTests/~unknown_options/test.sh
@@ -9,7 +9,7 @@ output=$("$SOLC" --allow=test 2>&1)
 failed=$?
 set -e
 
-if [[ $output != "unrecognised option '--allow=test'" ]] || (( failed == 0 ))
+if [[ $output != "Error: unrecognised option '--allow=test'" ]] || (( failed == 0 ))
 then
     fail "Incorrect response to unknown options: $output"
 fi

--- a/test/solc/CommandLineInterface.cpp
+++ b/test/solc/CommandLineInterface.cpp
@@ -241,9 +241,10 @@ BOOST_AUTO_TEST_CASE(cli_ignore_missing_some_files_exist)
 		(tempDir1.path() / "input1.sol").string(),
 		(tempDir2.path() / "input2.sol").string(),
 		"--ignore-missing",
+		"--no-color",
 	});
 	BOOST_TEST(result.success);
-	BOOST_TEST(result.stderrContent == "\"" + (tempDir2.path() / "input2.sol").string() + "\" is not found. Skipping.\n");
+	BOOST_TEST(result.stderrContent == "Info: \"" + (tempDir2.path() / "input2.sol").string() + "\" is not found. Skipping.\n");
 	BOOST_TEST(result.options.input.mode == InputMode::Compiler);
 	BOOST_TEST(!result.options.input.addStdin);
 	BOOST_CHECK_EQUAL(result.reader.sourceUnits(), expectedSources);
@@ -255,15 +256,16 @@ BOOST_AUTO_TEST_CASE(cli_ignore_missing_no_files_exist)
 	TemporaryDirectory tempDir(TEST_CASE_NAME);
 
 	string expectedMessage =
-		"\"" + (tempDir.path() / "input1.sol").string() + "\" is not found. Skipping.\n"
-		"\"" + (tempDir.path() / "input2.sol").string() + "\" is not found. Skipping.\n"
-		"All specified input files either do not exist or are not regular files.\n";
+		"Info: \"" + (tempDir.path() / "input1.sol").string() + "\" is not found. Skipping.\n"
+		"Info: \"" + (tempDir.path() / "input2.sol").string() + "\" is not found. Skipping.\n"
+		"Error: All specified input files either do not exist or are not regular files.\n";
 
 	OptionsReaderAndMessages result = runCLI({
 		"solc",
 		(tempDir.path() / "input1.sol").string(),
 		(tempDir.path() / "input2.sol").string(),
 		"--ignore-missing",
+		"--no-color",
 	});
 	BOOST_TEST(!result.success);
 	BOOST_TEST(result.stderrContent == expectedMessage);


### PR DESCRIPTION
Currently errors reported directly by `CommandLineInterface` are just plain text, not styled consistently with the ones from the error reporter. This makes the warning I need to add in #14475 somewhat hard to notice. I decided to refactor it to make the style consistent.