### PR TITLE
Remove BuiltinClass from experimental type system

### DIFF
--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -2619,10 +2619,13 @@ public:
 
 	ASTString const& nameParameter() const { return *m_nameParameter; }
 	SourceLocation const& nameParameterLocation() const { return m_nameParameterLocation; }
+	std::optional<ASTPointer<IdentifierPath>> const& typeClassFunctionParameter() const { return m_typeClassFunctionParameter; }
+	void setTypeClassFunctionParameter(ASTPointer<IdentifierPath> _typeClassFunctionParameter) { m_typeClassFunctionParameter = _typeClassFunctionParameter; }
 
 private:
 	ASTPointer<ASTString> m_nameParameter;
 	SourceLocation m_nameParameterLocation;
+	std::optional<ASTPointer<IdentifierPath>> m_typeClassFunctionParameter;
 };
 
 /// @}

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -2576,13 +2576,11 @@ public:
 	TypeClassName(
 		int64_t _id,
 		SourceLocation const& _location,
-		std::variant<Token, ASTPointer<IdentifierPath>> _name
+		ASTPointer<IdentifierPath> _name
 	):
 		ASTNode(_id, _location),
 		m_name(std::move(_name))
 	{
-		if (Token const* token = std::get_if<Token>(&_name))
-			solAssert(TokenTraits::isBuiltinTypeClassName(*token));
 	}
 
 	void accept(ASTVisitor& _visitor) override;
@@ -2590,10 +2588,10 @@ public:
 
 	bool experimentalSolidityOnly() const override { return true; }
 
-	std::variant<Token, ASTPointer<IdentifierPath>> name() const { return m_name; }
+	ASTPointer<IdentifierPath> name() const { return m_name; }
 
 private:
-	std::variant<Token, ASTPointer<IdentifierPath>> m_name;
+	ASTPointer<IdentifierPath> m_name;
 };
 
 class Builtin: public Expression

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -2601,11 +2601,13 @@ public:
 		int64_t _id,
 		SourceLocation _location,
 		ASTPointer<ASTString> _nameParameter,
-		SourceLocation _nameParameterLocation
+		SourceLocation _nameParameterLocation,
+		std::optional<ASTPointer<Expression>> _functionParameter = std::nullopt
 	):
 		Expression(_id, std::move(_location)),
 		m_nameParameter(std::move(_nameParameter)),
-		m_nameParameterLocation(std::move(_nameParameterLocation))
+		m_nameParameterLocation(std::move(_nameParameterLocation)),
+		m_functionParameter(std::move(_functionParameter))
 	{
 		solAssert(m_nameParameter);
 	}
@@ -2617,13 +2619,12 @@ public:
 
 	ASTString const& nameParameter() const { return *m_nameParameter; }
 	SourceLocation const& nameParameterLocation() const { return m_nameParameterLocation; }
-	std::optional<ASTPointer<IdentifierPath>> const& typeClassFunctionParameter() const { return m_typeClassFunctionParameter; }
-	void setTypeClassFunctionParameter(ASTPointer<IdentifierPath> _typeClassFunctionParameter) { m_typeClassFunctionParameter = _typeClassFunctionParameter; }
+	std::optional<ASTPointer<Expression>> const& functionParameter() const { return m_functionParameter; }
 
 private:
 	ASTPointer<ASTString> m_nameParameter;
 	SourceLocation m_nameParameterLocation;
-	std::optional<ASTPointer<IdentifierPath>> m_typeClassFunctionParameter;
+	std::optional<ASTPointer<Expression>> m_functionParameter;
 };
 
 /// @}

--- a/libsolidity/ast/AST_accept.h
+++ b/libsolidity/ast/AST_accept.h
@@ -1112,20 +1112,14 @@ void TypeDefinition::accept(ASTConstVisitor& _visitor) const
 void TypeClassName::accept(ASTVisitor& _visitor)
 {
 	if (_visitor.visit(*this))
-	{
-		if (auto* path = std::get_if<ASTPointer<IdentifierPath>>(&m_name))
-			(*path)->accept(_visitor);
-	}
+		m_name->accept(_visitor);
 	_visitor.endVisit(*this);
 }
 
 void TypeClassName::accept(ASTConstVisitor& _visitor) const
 {
 	if (_visitor.visit(*this))
-	{
-		if (auto* path = std::get_if<ASTPointer<IdentifierPath>>(&m_name))
-			(*path)->accept(_visitor);
-	}
+		m_name->accept(_visitor);
 	_visitor.endVisit(*this);
 }
 

--- a/libsolidity/experimental/analysis/TypeClassMemberRegistration.cpp
+++ b/libsolidity/experimental/analysis/TypeClassMemberRegistration.cpp
@@ -35,56 +35,6 @@ TypeClassMemberRegistration::TypeClassMemberRegistration(Analysis& _analysis):
 	m_errorReporter(_analysis.errorReporter()),
 	m_typeSystem(_analysis.typeSystem())
 {
-	TypeSystemHelpers helper{m_typeSystem};
-
-	auto registeredTypeClass = [&](BuiltinClass _builtinClass) -> TypeClass {
-		return m_analysis.annotation<TypeClassRegistration>().builtinClasses.at(_builtinClass);
-	};
-
-	auto defineConversion = [&](BuiltinClass _builtinClass, PrimitiveType _fromType, std::string _functionName) {
-		annotation().typeClassFunctions[registeredTypeClass(_builtinClass)] = {{
-			std::move(_functionName),
-			helper.functionType(
-				m_typeSystem.type(_fromType, {}),
-				m_typeSystem.typeClassInfo(registeredTypeClass(_builtinClass)).typeVariable
-			),
-		}};
-	};
-
-	auto defineBinaryMonoidalOperator = [&](BuiltinClass _builtinClass, Token _token, std::string _functionName) {
-		Type typeVar = m_typeSystem.typeClassInfo(registeredTypeClass(_builtinClass)).typeVariable;
-		annotation().operators.emplace(_token, std::make_tuple(registeredTypeClass(_builtinClass), _functionName));
-		annotation().typeClassFunctions[registeredTypeClass(_builtinClass)] = {{
-			std::move(_functionName),
-			helper.functionType(
-				helper.tupleType({typeVar, typeVar}),
-				typeVar
-			)
-		}};
-	};
-
-	auto defineBinaryCompareOperator = [&](BuiltinClass _builtinClass, Token _token, std::string _functionName) {
-		Type typeVar = m_typeSystem.typeClassInfo(registeredTypeClass(_builtinClass)).typeVariable;
-		annotation().operators.emplace(_token, std::make_tuple(registeredTypeClass(_builtinClass), _functionName));
-		annotation().typeClassFunctions[registeredTypeClass(_builtinClass)] = {{
-			std::move(_functionName),
-			helper.functionType(
-				helper.tupleType({typeVar, typeVar}),
-				m_typeSystem.type(PrimitiveType::Bool, {})
-			)
-		}};
-	};
-
-	defineConversion(BuiltinClass::Integer, PrimitiveType::Integer, "fromInteger");
-
-	defineBinaryMonoidalOperator(BuiltinClass::Mul, Token::Mul, "mul");
-	defineBinaryMonoidalOperator(BuiltinClass::Add, Token::Add, "add");
-
-	defineBinaryCompareOperator(BuiltinClass::Equal, Token::Equal, "eq");
-	defineBinaryCompareOperator(BuiltinClass::Less, Token::LessThan, "lt");
-	defineBinaryCompareOperator(BuiltinClass::LessOrEqual, Token::LessThanOrEqual, "leq");
-	defineBinaryCompareOperator(BuiltinClass::Greater, Token::GreaterThan, "gt");
-	defineBinaryCompareOperator(BuiltinClass::GreaterOrEqual, Token::GreaterThanOrEqual, "geq");
 }
 
 bool TypeClassMemberRegistration::analyze(SourceUnit const& _sourceUnit)

--- a/libsolidity/experimental/analysis/TypeClassMemberRegistration.cpp
+++ b/libsolidity/experimental/analysis/TypeClassMemberRegistration.cpp
@@ -48,7 +48,7 @@ bool TypeClassMemberRegistration::analyze(SourceUnit const& _sourceUnit)
 void TypeClassMemberRegistration::endVisit(Builtin const& _builtin)
 {
 	// Builtin may be used to register user defined types, which is handled earlier at TypeRegistration step
-	if (!_builtin.typeClassFunctionParameter().has_value())
+	if (!_builtin.functionParameter().has_value())
 		return;
 
 	// TODO: consider using a map of string-Token and ranges::find instead of ifs
@@ -71,32 +71,30 @@ void TypeClassMemberRegistration::endVisit(Builtin const& _builtin)
 			"Only operators +, *, ==, <, <=, >, >= are allowed as members of a type class."
 		);
 
-	ASTPointer<IdentifierPath> typeClassFunctionName = *_builtin.typeClassFunctionParameter();
-	solAssert(typeClassFunctionName->path().size() == 2);
-	std::string const& typeClassName = typeClassFunctionName->path()[0];
-	std::string const& functionName = typeClassFunctionName->path()[1];
+	ASTPointer<Expression> functionParameter = *_builtin.functionParameter();
+	// TODO: Remove
+	// solAssert(typeClassFunctionName->path().size() == 2);
+	// std::string const& typeClassName = typeClassFunctionName->path()[0];
+	// std::string const& functionName = typeClassFunctionName->path()[1];
+	//
+	// std::optional<TypeClass> typeClass = m_typeSystem.typeClass(typeClassName);
+	//
+	// if (!typeClass.has_value())
+	// 	m_errorReporter.fatalTypeError(
+	// 		78_error,
+	// 		typeClassFunctionName->pathLocations()[0],
+	// 		"Cannot find type class named " + typeClassName + '.'
+	// 	);
 
-	std::optional<TypeClass> typeClass = m_typeSystem.typeClass(typeClassName);
-
-	if (!typeClass.has_value())
-		m_errorReporter.fatalTypeError(
-			78_error,
-			typeClassFunctionName->pathLocations()[0],
-			"Cannot find type class named " + typeClassName + '.'
-		);
-
-	auto registrationResult = annotation().operators.emplace(
-		operatorToken.value(),
-		std::make_tuple(typeClass.value(),
-		functionName)
-	);
+	auto registrationResult = annotation().operators.emplace(operatorToken.value(),	functionParameter);
 	if (!registrationResult.second)
 		m_errorReporter.fatalTypeError(
 			79_error,
 			_builtin.location(),
+			// TODO: registrationResult.first->second->location(),
 			fmt::format(
-				"Type class {} already has a previous definition for {}",
-				typeClassName, functionName
+				"Previous expression already associated with operator {}.",
+				_builtin.nameParameter()
 			)
 		);
 }

--- a/libsolidity/experimental/analysis/TypeClassMemberRegistration.h
+++ b/libsolidity/experimental/analysis/TypeClassMemberRegistration.h
@@ -40,7 +40,7 @@ public:
 	struct GlobalAnnotation
 	{
 		std::map<TypeClass, std::map<std::string, Type>> typeClassFunctions;
-		std::map<Token, std::tuple<TypeClass, std::string>> operators;
+		std::map<Token, ASTPointer<Expression>> operators;
 	};
 
 	TypeClassMemberRegistration(Analysis& _analysis);

--- a/libsolidity/experimental/analysis/TypeClassMemberRegistration.h
+++ b/libsolidity/experimental/analysis/TypeClassMemberRegistration.h
@@ -49,6 +49,7 @@ public:
 
 private:
 	void endVisit(TypeClassDefinition const& _typeClassDefinition) override;
+	void endVisit(Builtin const& _builtin) override;
 
 	Annotation& annotation(ASTNode const& _node);
 	Annotation const& annotation(ASTNode const& _node) const;

--- a/libsolidity/experimental/analysis/TypeClassRegistration.cpp
+++ b/libsolidity/experimental/analysis/TypeClassRegistration.cpp
@@ -32,30 +32,6 @@ TypeClassRegistration::TypeClassRegistration(Analysis& _analysis):
 	m_errorReporter(_analysis.errorReporter()),
 	m_typeSystem(_analysis.typeSystem())
 {
-	auto declareBuiltinClass = [&](std::string _name, BuiltinClass _class) -> TypeClass {
-		Type type = m_typeSystem.freshTypeVariable({});
-		auto result = m_typeSystem.declareTypeClass(
-			type,
-			_name,
-			nullptr
-		);
-		if (auto error = std::get_if<std::string>(&result))
-			solAssert(!error, *error);
-		TypeClass declaredClass = std::get<TypeClass>(result);
-		// TODO: validation?
-		GlobalAnnotation& annotation = m_analysis.annotation<TypeClassRegistration>();
-		solAssert(annotation.builtinClassesByName.emplace(_name, _class).second);
-		return annotation.builtinClasses.emplace(_class, declaredClass).first->second;
-	};
-
-	declareBuiltinClass("integer", BuiltinClass::Integer);
-	declareBuiltinClass("*", BuiltinClass::Mul);
-	declareBuiltinClass("+", BuiltinClass::Add);
-	declareBuiltinClass("==", BuiltinClass::Equal);
-	declareBuiltinClass("<", BuiltinClass::Less);
-	declareBuiltinClass("<=", BuiltinClass::LessOrEqual);
-	declareBuiltinClass(">", BuiltinClass::Greater);
-	declareBuiltinClass(">=", BuiltinClass::GreaterOrEqual);
 }
 
 bool TypeClassRegistration::analyze(SourceUnit const& _sourceUnit)

--- a/libsolidity/experimental/analysis/TypeClassRegistration.h
+++ b/libsolidity/experimental/analysis/TypeClassRegistration.h
@@ -41,8 +41,6 @@ public:
 	};
 	struct GlobalAnnotation
 	{
-		std::map<BuiltinClass, TypeClass> builtinClasses;
-		std::map<std::string, BuiltinClass> builtinClassesByName;
 	};
 
 	TypeClassRegistration(Analysis& _analysis);

--- a/libsolidity/experimental/analysis/TypeInference.cpp
+++ b/libsolidity/experimental/analysis/TypeInference.cpp
@@ -804,6 +804,8 @@ void TypeInference::endVisit(FunctionCall const& _functionCall)
 	}
 }
 
+bool TypeInference::visit(Builtin const&) { return false; }
+
 // TODO: clean up rational parsing
 namespace
 {

--- a/libsolidity/experimental/analysis/TypeInference.cpp
+++ b/libsolidity/experimental/analysis/TypeInference.cpp
@@ -228,11 +228,14 @@ bool TypeInference::visit(BinaryOperation const& _binaryOperation)
 	switch (m_expressionContext)
 	{
 	case ExpressionContext::Term:
-		if (auto* operatorInfo = util::valueOrNullptr(memberRegistrationAnnotation.operators, _binaryOperation.getOperator()))
+		if (auto* operatorFunction = util::valueOrNullptr(memberRegistrationAnnotation.operators, _binaryOperation.getOperator()))
 		{
-			auto [typeClass, functionName] = *operatorInfo;
-			// TODO: error robustness?
-			Type functionType = m_env->fresh(memberRegistrationAnnotation.typeClassFunctions.at(typeClass).at(functionName));
+			auto& functionExpressionAnnotation = annotation(**operatorFunction);
+			if (!functionExpressionAnnotation.type)
+				(*operatorFunction)->accept(*this);
+
+			solAssert(functionExpressionAnnotation.type);
+			Type functionType = functionExpressionAnnotation.type.value();
 
 			_binaryOperation.leftExpression().accept(*this);
 			_binaryOperation.rightExpression().accept(*this);

--- a/libsolidity/experimental/analysis/TypeInference.h
+++ b/libsolidity/experimental/analysis/TypeInference.h
@@ -87,6 +87,8 @@ public:
 	bool visit(BinaryOperation const& _operation) override;
 
 	bool visit(Literal const& _literal) override;
+
+	bool visit(Builtin const&) override;
 private:
 	Analysis& m_analysis;
 	langutil::ErrorReporter& m_errorReporter;

--- a/libsolidity/experimental/analysis/TypeRegistration.cpp
+++ b/libsolidity/experimental/analysis/TypeRegistration.cpp
@@ -59,7 +59,7 @@ bool TypeRegistration::visit(TypeClassDefinition const& _typeClassDefinition)
 bool TypeRegistration::visit(Builtin const& _builtin)
 {
 	if (
-		_builtin.typeClassFunctionParameter().has_value() ||
+		_builtin.functionParameter().has_value() ||
 		annotation(_builtin).typeConstructor
 	)
 		return false;

--- a/libsolidity/experimental/analysis/TypeRegistration.cpp
+++ b/libsolidity/experimental/analysis/TypeRegistration.cpp
@@ -58,7 +58,10 @@ bool TypeRegistration::visit(TypeClassDefinition const& _typeClassDefinition)
 
 bool TypeRegistration::visit(Builtin const& _builtin)
 {
-	if (annotation(_builtin).typeConstructor)
+	if (
+		_builtin.typeClassFunctionParameter().has_value() ||
+		annotation(_builtin).typeConstructor
+	)
 		return false;
 
 	auto primitiveType = [&](std::string _name) -> std::optional<PrimitiveType> {

--- a/libsolidity/experimental/analysis/TypeRegistration.cpp
+++ b/libsolidity/experimental/analysis/TypeRegistration.cpp
@@ -131,22 +131,12 @@ bool TypeRegistration::visit(TypeClassInstantiation const& _typeClassInstantiati
 		m_errorReporter.typeError(5577_error, _typeClassInstantiation.typeConstructor().location(), "Invalid type name.");
 		return false;
 	}
-	auto* instantiations = std::visit(util::GenericVisitor{
-		[&](ASTPointer<IdentifierPath> _path) -> TypeClassInstantiations*
-		{
-			if (TypeClassDefinition const* classDefinition = dynamic_cast<TypeClassDefinition const*>(_path->annotation().referencedDeclaration))
-				return &annotation(*classDefinition).instantiations;
-			m_errorReporter.typeError(3570_error, _typeClassInstantiation.typeClass().location(), "Expected a type class.");
-			return nullptr;
-		},
-		[&](Token _token) -> TypeClassInstantiations*
-		{
-			if (auto typeClass = builtinClassFromToken(_token))
-				return &annotation().builtinClassInstantiations[*typeClass];
-			m_errorReporter.typeError(5262_error, _typeClassInstantiation.typeClass().location(), "Expected a type class.");
-			return nullptr;
-		}
-	}, _typeClassInstantiation.typeClass().name());
+	auto* instantiations = [&](ASTPointer<IdentifierPath> _path) -> TypeClassInstantiations* {
+		if (TypeClassDefinition const* classDefinition = dynamic_cast<TypeClassDefinition const*>(_path->annotation().referencedDeclaration))
+			return &annotation(*classDefinition).instantiations;
+		m_errorReporter.typeError(3570_error, _typeClassInstantiation.typeClass().location(), "Expected a type class.");
+		return nullptr;
+	}(_typeClassInstantiation.typeClass().name());
 
 	if (!instantiations)
 		return false;

--- a/libsolidity/experimental/analysis/TypeRegistration.h
+++ b/libsolidity/experimental/analysis/TypeRegistration.h
@@ -41,7 +41,6 @@ public:
 	struct GlobalAnnotation
 	{
 		std::map<PrimitiveClass, TypeClassInstantiations> primitiveClassInstantiations;
-		std::map<BuiltinClass, TypeClassInstantiations> builtinClassInstantiations;
 		std::map<std::string, TypeDefinition const*> builtinTypeDefinitions;
 	};
 	TypeRegistration(Analysis& _analysis);

--- a/libsolidity/experimental/ast/Type.h
+++ b/libsolidity/experimental/ast/Type.h
@@ -51,19 +51,6 @@ enum class PrimitiveClass
 	Type
 };
 
-// TODO: move elsewhere?
-enum class BuiltinClass
-{
-	Integer,
-	Mul,
-	Add,
-	Equal,
-	Less,
-	LessOrEqual,
-	Greater,
-	GreaterOrEqual
-};
-
 struct TypeConstructor
 {
 public:

--- a/libsolidity/experimental/ast/TypeSystem.cpp
+++ b/libsolidity/experimental/ast/TypeSystem.cpp
@@ -24,6 +24,8 @@
 
 #include <libsolutil/Visitor.h>
 
+#include <range/v3/algorithm/find_if.hpp>
+#include <range/v3/iterator/operations.hpp>
 #include <range/v3/to_container.hpp>
 #include <range/v3/view/drop_exactly.hpp>
 #include <range/v3/view/drop_last.hpp>
@@ -347,5 +349,16 @@ std::optional<std::string> TypeSystem::instantiateClass(Type _instanceVariable, 
 
 	typeConstructorInfo.arities.emplace_back(_arity);
 
+	return std::nullopt;
+}
+
+std::optional<TypeClass> TypeSystem::typeClass(std::string _typeClassName) const
+{
+	auto typeClassInfoIterator = ranges::find_if(m_typeClasses, [&](TypeClassInfo const& _typeClassInfo) {
+		return _typeClassInfo.name == _typeClassName;
+	});
+
+	if (typeClassInfoIterator != ranges::end(m_typeClasses))
+		return TypeClass{static_cast<size_t>(ranges::distance(ranges::begin(m_typeClasses), typeClassInfoIterator))};
 	return std::nullopt;
 }

--- a/libsolidity/experimental/ast/TypeSystem.h
+++ b/libsolidity/experimental/ast/TypeSystem.h
@@ -170,6 +170,8 @@ public:
 		return m_typeClasses.at(_class.m_index);
 	}
 
+	std::optional<TypeClass> typeClass(std::string _typeClassName) const;
+
 private:
 	friend class TypeEnvironment;
 	size_t m_numTypeVariables = 0;

--- a/libsolidity/experimental/ast/TypeSystemHelper.cpp
+++ b/libsolidity/experimental/ast/TypeSystemHelper.cpp
@@ -74,31 +74,6 @@ std::optional<TypeConstructor> experimental::typeConstructorFromToken(Analysis c
 		return nullopt;
 	}
 }*/
-
-std::optional<BuiltinClass> experimental::builtinClassFromToken(langutil::Token _token)
-{
-	switch (_token)
-	{
-	case Token::Integer:
-		return BuiltinClass::Integer;
-	case Token::Mul:
-		return BuiltinClass::Mul;
-	case Token::Add:
-		return BuiltinClass::Add;
-	case Token::Equal:
-		return BuiltinClass::Equal;
-	case Token::LessThan:
-		return BuiltinClass::Less;
-	case Token::LessThanOrEqual:
-		return BuiltinClass::LessOrEqual;
-	case Token::GreaterThan:
-		return BuiltinClass::Greater;
-	case Token::GreaterThanOrEqual:
-		return BuiltinClass::GreaterOrEqual;
-	default:
-		return std::nullopt;
-	}
-}
 /*
 std::optional<TypeClass> experimental::typeClassFromTypeClassName(TypeClassName const& _typeClass)
 {

--- a/libsolidity/experimental/ast/TypeSystemHelper.h
+++ b/libsolidity/experimental/ast/TypeSystemHelper.h
@@ -24,11 +24,9 @@
 namespace solidity::frontend::experimental
 {
 class Analysis;
-enum class BuiltinClass;
 //std::optional<TypeConstructor> typeConstructorFromTypeName(Analysis const& _analysis, TypeName const& _typeName);
 //std::optional<TypeConstructor> typeConstructorFromToken(Analysis const& _analysis, langutil::Token _token);
 //std::optional<TypeClass> typeClassFromTypeClassName(TypeClassName const& _typeClass);
-std::optional<BuiltinClass> builtinClassFromToken(langutil::Token _token);
 
 struct TypeSystemHelpers
 {

--- a/libsolidity/experimental/codegen/IRGeneratorForStatements.cpp
+++ b/libsolidity/experimental/codegen/IRGeneratorForStatements.cpp
@@ -216,12 +216,8 @@ namespace
 TypeRegistration::TypeClassInstantiations const& typeClassInstantiations(IRGenerationContext const& _context, TypeClass _class)
 {
 	auto const* typeClassDeclaration = _context.analysis.typeSystem().typeClassDeclaration(_class);
-	if (typeClassDeclaration)
-		return _context.analysis.annotation<TypeRegistration>(*typeClassDeclaration).instantiations;
-	// TODO: better mechanism than fetching by name.
-	auto& instantiations = _context.analysis.annotation<TypeRegistration>().builtinClassInstantiations;
-	auto& builtinClassesByName = _context.analysis.annotation<TypeClassRegistration>().builtinClassesByName;
-	return instantiations.at(builtinClassesByName.at(_context.analysis.typeSystem().typeClassName(_class)));
+	solAssert(typeClassDeclaration);
+	return _context.analysis.annotation<TypeRegistration>(*typeClassDeclaration).instantiations;
 }
 }
 

--- a/libsolidity/experimental/codegen/IRGeneratorForStatements.h
+++ b/libsolidity/experimental/codegen/IRGeneratorForStatements.h
@@ -66,6 +66,7 @@ private:
 	Type type(ASTNode const& _node) const;
 
 	FunctionDefinition const& resolveTypeClassFunction(TypeClass _class, std::string _name, Type _type);
+	FunctionDefinition const& resolveFunctionExpression(Expression const& _expression, Type _type);
 };
 
 }

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1769,19 +1769,9 @@ ASTPointer<TypeClassName> Parser::parseTypeClassName()
 {
 	RecursionGuard recursionGuard(*this);
 	ASTNodeFactory nodeFactory(*this);
-	std::variant<Token, ASTPointer<IdentifierPath>> name;
-	if (TokenTraits::isBuiltinTypeClassName(m_scanner->currentToken()))
-	{
-		nodeFactory.markEndPosition();
-		name = m_scanner->currentToken();
-		advance();
-	}
-	else
-	{
-		auto identifierPath = parseIdentifierPath();
-		name = identifierPath;
-		nodeFactory.setEndPositionFromNode(identifierPath);
-	}
+	ASTPointer<IdentifierPath> name = parseIdentifierPath();
+	nodeFactory.setEndPositionFromNode(name);
+
 	return nodeFactory.createNode<TypeClassName>(name);
 }
 

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1852,32 +1852,25 @@ ASTPointer<Builtin> Parser::parseBuiltin()
 	expectToken(Token::Builtin);
 	expectToken(Token::LParen);
 
-	auto builtin = nodeFactory.createNode<Builtin>(
-		std::make_shared<std::string>(m_scanner->currentLiteral()),
-		m_scanner->currentLocation()
-	);
-
+	ASTPointer<ASTString> name = std::make_shared<std::string>(m_scanner->currentLiteral());
+	SourceLocation nameLocation = m_scanner->currentLocation();
 	expectToken(Token::StringLiteral);
 
+	std::optional<ASTPointer<Expression>> functionParameter;
 	if (m_scanner->currentToken() == Token::Comma)
 	{
 		expectToken(Token::Comma);
-		// TODO: Consider if other ASTNode would be more adequate (MemberAccess?)
-		auto typeClassFunctionNameParameter = parseIdentifierPath();
-		// TODO: write a decent error message
-		if (typeClassFunctionNameParameter->path().size() != 2)
-			m_errorReporter.fatalParserError(
-				42_error,
-				typeClassFunctionNameParameter->location(),
-				"Invalid function! Expected <TypeClassName.FunctionName> format."
-			);
-
-		builtin->setTypeClassFunctionParameter(typeClassFunctionNameParameter);
+		functionParameter = parseExpression();
+		// TODO: validation ?
 	}
 
 	expectToken(Token::RParen);
 
-	return builtin;
+	return nodeFactory.createNode<Builtin>(
+		name,
+		nameLocation,
+		functionParameter
+	);
 }
 
 ASTPointer<Statement> Parser::parseSimpleStatement(ASTPointer<ASTString> const& _docString)

--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -180,6 +180,7 @@ private:
 	ASTPointer<TypeClassInstantiation> parseTypeClassInstantiation();
 	ASTPointer<TypeDefinition> parseTypeDefinition();
 	ASTPointer<TypeClassName> parseTypeClassName();
+	ASTPointer<Builtin> parseBuiltin();
 	///@}
 
 	///@{


### PR DESCRIPTION
depends on #14578.
Removes the concept of builtin class from the new experimental type system.