### PR TITLE
Make Yul proto mutator mutations deterministic.

### DIFF
--- a/test/tools/ossfuzz/protomutators/YulProtoMutator.h
+++ b/test/tools/ossfuzz/protomutators/YulProtoMutator.h
@@ -96,13 +96,13 @@ struct YulProtoMutator
 	static constexpr unsigned s_highIP = 23;
 	/// Add control-flow statement to basic block.
 	template <typename T>
-	static void addControlFlow(T* _msg);
+	static void addControlFlow(T* _msg, unsigned _seed);
 	/// Obtain basic block for statement type.
 	template <typename T>
-	static Block* basicBlock(T* _msg);
+	static Block* basicBlock(T* _msg, unsigned _seed);
 	/// Obtain a basic block in a for stmt uniformly
 	/// at random
-	static Block* randomBlock(ForStmt* _msg);
+	static Block* randomBlock(ForStmt* _msg, unsigned _seed);
 	/// Obtain a basic block in global scope.
 	static Block* globalBlock(Program* _program);
 };


### PR DESCRIPTION
The Yul proto mutator is a set of libprotobuf-mutator callbacks that mutates Yul protobuf inputs using custom mutations e.g., add a store here, flip a bool there etc.

The mutator itself would statically initialize a random number generator to eventually produce mutations. However, this would mean that depending on how many times the mutator has been called, the mutation would differ. Meaning that when debugging a crash, it may no longer reproduce because the statically initialized RNG would not cause a mutation or cause a different one.

This PR fixes this non-determinism by making use of (deterministic) seeds provided by the libprotobuf mutator library. Now, crashes should be reproducible outside fuzzing runs.