### PR TITLE
Fixed type variables in function definitions in experimental analysis

### DIFF
--- a/libsolidity/experimental/analysis/TypeClassRegistration.cpp
+++ b/libsolidity/experimental/analysis/TypeClassRegistration.cpp
@@ -43,7 +43,7 @@ bool TypeClassRegistration::analyze(SourceUnit const& _sourceUnit)
 bool TypeClassRegistration::visit(TypeClassDefinition const& _typeClassDefinition)
 {
 	std::variant<TypeClass, std::string> typeClassOrError = m_typeSystem.declareTypeClass(
-		m_typeSystem.freshTypeVariable({}),
+		m_typeSystem.freshGenericTypeVariable({}),
 		_typeClassDefinition.name(),
 		&_typeClassDefinition
 	);

--- a/libsolidity/experimental/analysis/TypeClassRegistration.cpp
+++ b/libsolidity/experimental/analysis/TypeClassRegistration.cpp
@@ -43,7 +43,6 @@ bool TypeClassRegistration::analyze(SourceUnit const& _sourceUnit)
 bool TypeClassRegistration::visit(TypeClassDefinition const& _typeClassDefinition)
 {
 	std::variant<TypeClass, std::string> typeClassOrError = m_typeSystem.declareTypeClass(
-		m_typeSystem.freshGenericTypeVariable({}),
 		_typeClassDefinition.name(),
 		&_typeClassDefinition
 	);

--- a/libsolidity/experimental/analysis/TypeInference.cpp
+++ b/libsolidity/experimental/analysis/TypeInference.cpp
@@ -479,7 +479,10 @@ experimental::Type TypeInference::handleIdentifierByReferencedDeclaration(langut
 		else if (dynamic_cast<FunctionDefinition const*>(&_declaration))
 			return m_env->fresh(*declarationAnnotation.type);
 		else if (dynamic_cast<TypeClassDefinition const*>(&_declaration))
-			return m_env->fresh(*declarationAnnotation.type);
+		{
+			solAssert(TypeEnvironmentHelpers{*m_env}.typeVars(*declarationAnnotation.type).size() == 0);
+			return *declarationAnnotation.type;
+		}
 		else if (dynamic_cast<TypeDefinition const*>(&_declaration))
 		{
 			// TODO: can we avoid this?

--- a/libsolidity/experimental/analysis/TypeInference.cpp
+++ b/libsolidity/experimental/analysis/TypeInference.cpp
@@ -170,6 +170,15 @@ bool TypeInference::visit(FunctionDefinition const& _functionDefinition)
 	return false;
 }
 
+void TypeInference::endVisit(FunctionDefinition const& _functionDefinition)
+{
+	solAssert(m_expressionContext == ExpressionContext::Term);
+	solAssert(annotation(_functionDefinition).type.has_value());
+
+	Type& functionType = annotation(_functionDefinition).type.value();
+	functionType = m_env->fixTypeVariables(m_env->resolveRecursive(functionType));
+}
+
 void TypeInference::endVisit(Return const& _return)
 {
 	solAssert(m_currentFunctionType);

--- a/libsolidity/experimental/analysis/TypeInference.cpp
+++ b/libsolidity/experimental/analysis/TypeInference.cpp
@@ -215,8 +215,7 @@ bool TypeInference::visit(TypeClassDefinition const& _typeClassDefinition)
 		subNode->accept(*this);
 		auto const* functionDefinition = dynamic_cast<FunctionDefinition const*>(subNode.get());
 		solAssert(functionDefinition);
-		// TODO: need polymorphicInstance?
-		auto functionType = polymorphicInstance(typeAnnotation(*functionDefinition));
+		auto functionType = typeAnnotation(*functionDefinition);
 		if (!functionTypes.emplace(functionDefinition->name(), functionType).second)
 			m_errorReporter.fatalTypeError(3195_error, functionDefinition->location(), "Function in type class declared multiple times.");
 		auto typeVars = TypeEnvironmentHelpers{*m_env}.typeVars(functionType);

--- a/libsolidity/experimental/analysis/TypeInference.h
+++ b/libsolidity/experimental/analysis/TypeInference.h
@@ -57,6 +57,7 @@ public:
 	bool visit(VariableDeclaration const& _variableDeclaration) override;
 
 	bool visit(FunctionDefinition const& _functionDefinition) override;
+	void endVisit(FunctionDefinition const& _functionDefinition) override;
 	bool visit(ParameterList const&) override { return true; }
 	void endVisit(ParameterList const& _parameterList) override;
 	bool visit(SourceUnit const&) override { return true; }

--- a/libsolidity/experimental/analysis/TypeInference.h
+++ b/libsolidity/experimental/analysis/TypeInference.h
@@ -110,8 +110,6 @@ private:
 	GlobalAnnotation& annotation();
 
 	void unify(Type _a, Type _b, langutil::SourceLocation _location = {});
-	void unifyGeneralized(Type _type, Type _scheme, std::vector<Type> _monomorphicTypes, langutil::SourceLocation _location = {});
-	Type polymorphicInstance(Type _scheme, langutil::SourceLocation _location = {});
 	Type memberType(Type _type, std::string _memberName, langutil::SourceLocation _location = {});
 	enum class ExpressionContext { Term, Type, Sort };
 	Type handleIdentifierByReferencedDeclaration(langutil::SourceLocation _location, Declaration const& _declaration);

--- a/libsolidity/experimental/ast/Type.h
+++ b/libsolidity/experimental/ast/Type.h
@@ -28,9 +28,13 @@ namespace solidity::frontend::experimental
 class TypeSystem;
 
 struct TypeConstant;
-struct TypeVariable;
+struct GenericTypeVariable;
 
-using Type = std::variant<std::monostate, TypeConstant, TypeVariable>;
+using Type = std::variant<
+	std::monostate,
+	TypeConstant,
+	GenericTypeVariable
+>;
 
 enum class PrimitiveType
 {
@@ -147,7 +151,7 @@ struct Arity
 	TypeClass typeClass;
 };
 
-struct TypeVariable
+struct GenericTypeVariable
 {
 	std::size_t index() const { return m_index; }
 	Sort const& sort() const { return m_sort; }
@@ -155,7 +159,7 @@ struct TypeVariable
 private:
 	friend class TypeSystem;
 
-	TypeVariable(std::size_t _index, Sort _sort):
+	GenericTypeVariable(std::size_t _index, Sort _sort):
 		m_index(_index),
 		m_sort(std::move(_sort))
 	{}

--- a/libsolidity/experimental/ast/Type.h
+++ b/libsolidity/experimental/ast/Type.h
@@ -29,11 +29,13 @@ class TypeSystem;
 
 struct TypeConstant;
 struct GenericTypeVariable;
+struct FixedTypeVariable;
 
 using Type = std::variant<
 	std::monostate,
 	TypeConstant,
-	GenericTypeVariable
+	GenericTypeVariable,
+	FixedTypeVariable
 >;
 
 enum class PrimitiveType
@@ -151,21 +153,33 @@ struct Arity
 	TypeClass typeClass;
 };
 
-struct GenericTypeVariable
+struct TypeVariable
 {
 	std::size_t index() const { return m_index; }
 	Sort const& sort() const { return m_sort; }
 
-private:
+protected:
 	friend class TypeSystem;
 
-	GenericTypeVariable(std::size_t _index, Sort _sort):
+	TypeVariable(std::size_t _index, Sort _sort):
 		m_index(_index),
 		m_sort(std::move(_sort))
 	{}
 
 	std::size_t m_index{};
 	Sort m_sort;
+};
+
+struct GenericTypeVariable: public TypeVariable
+{
+private:
+	using TypeVariable::TypeVariable;
+};
+
+struct FixedTypeVariable: public TypeVariable
+{
+private:
+	using TypeVariable::TypeVariable;
 };
 
 }

--- a/libsolidity/experimental/ast/TypeSystem.cpp
+++ b/libsolidity/experimental/ast/TypeSystem.cpp
@@ -146,7 +146,7 @@ TypeSystem::TypeSystem()
 				solAssert(false, _error);
 			},
 			[](TypeClass _class) -> TypeClass { return _class; }
-		}, declareTypeClass(freshGenericVariable({}), _name, nullptr));
+		}, declareTypeClass(_name, nullptr, true /* _primitive */));
 	};
 
 	m_primitiveTypeClasses.emplace(PrimitiveClass::Type, declarePrimitiveClass("type"));
@@ -310,16 +310,15 @@ TypeConstructor TypeSystem::declareTypeConstructor(std::string _name, std::strin
 	return constructor;
 }
 
-std::variant<TypeClass, std::string> TypeSystem::declareTypeClass(GenericTypeVariable _typeVariable, std::string _name, Declaration const* _declaration)
+std::variant<TypeClass, std::string> TypeSystem::declareTypeClass(std::string _name, Declaration const* _declaration, bool _primitive)
 {
-	size_t index = m_typeClasses.size();
+	TypeClass typeClass{m_typeClasses.size()};
+	FixedTypeVariable typeVariable = (_primitive ? freshFixedVariable({{typeClass}}) : freshFixedTypeVariable({{typeClass}}));
 	m_typeClasses.emplace_back(TypeClassInfo{
-		_typeVariable,
+		typeVariable,
 		_name,
 		_declaration
 	});
-	TypeClass typeClass{index};
-
 	return typeClass;
 }
 

--- a/libsolidity/experimental/ast/TypeSystem.h
+++ b/libsolidity/experimental/ast/TypeSystem.h
@@ -157,11 +157,14 @@ public:
 	[[nodiscard]] std::optional<std::string> instantiateClass(Type _instanceVariable, Arity _arity);
 
 	GenericTypeVariable freshGenericTypeVariable(Sort _sort);
+	FixedTypeVariable freshFixedTypeVariable(Sort _sort);
 
 	TypeEnvironment const& env() const { return m_globalTypeEnvironment; }
 	TypeEnvironment& env() { return m_globalTypeEnvironment; }
 
 	GenericTypeVariable freshGenericVariable(Sort _sort);
+	FixedTypeVariable freshFixedVariable(Sort _sort);
+
 	std::string typeClassName(TypeClass _class) const { return m_typeClasses.at(_class.m_index).name; }
 	Declaration const* typeClassDeclaration(TypeClass _class) const { return m_typeClasses.at(_class.m_index).classDeclaration; }
 	GenericTypeVariable const& typeClassVariable(TypeClass _class) const
@@ -178,6 +181,7 @@ private:
 	friend class TypeEnvironment;
 
 	size_t m_numGenericTypeVariables = 0;
+	size_t m_numFixedTypeVariables = 0;
 	std::map<PrimitiveType, TypeConstructor> m_primitiveTypeConstructors;
 	std::map<PrimitiveClass, TypeClass> m_primitiveTypeClasses;
 	std::set<std::string> m_canonicalTypeNames;

--- a/libsolidity/experimental/ast/TypeSystem.h
+++ b/libsolidity/experimental/ast/TypeSystem.h
@@ -112,7 +112,7 @@ public:
 
 	struct TypeClassInfo
 	{
-		GenericTypeVariable typeVariable;
+		FixedTypeVariable typeVariable;
 		std::string name;
 		Declaration const* classDeclaration = nullptr;
 	};
@@ -160,7 +160,7 @@ public:
 		return constructorInfo(constructor(_typeConstructor));
 	}
 
-	std::variant<TypeClass, std::string> declareTypeClass(GenericTypeVariable _typeVariable, std::string _name, Declaration const* _declaration);
+	std::variant<TypeClass, std::string> declareTypeClass(std::string _name, Declaration const* _declaration, bool _primitive = false);
 	[[nodiscard]] std::optional<std::string> instantiateClass(Type _instanceVariable, Arity _arity);
 
 	GenericTypeVariable freshGenericTypeVariable(Sort _sort);
@@ -174,7 +174,7 @@ public:
 
 	std::string typeClassName(TypeClass _class) const { return m_typeClasses.at(_class.m_index).name; }
 	Declaration const* typeClassDeclaration(TypeClass _class) const { return m_typeClasses.at(_class.m_index).classDeclaration; }
-	GenericTypeVariable const& typeClassVariable(TypeClass _class) const
+	FixedTypeVariable const& typeClassVariable(TypeClass _class) const
 	{
 		return m_typeClasses.at(_class.m_index).typeVariable;
 	}

--- a/libsolidity/experimental/ast/TypeSystem.h
+++ b/libsolidity/experimental/ast/TypeSystem.h
@@ -77,13 +77,13 @@ public:
 private:
 	TypeEnvironment(TypeEnvironment&& _env):
 		m_typeSystem(_env.m_typeSystem),
-		m_typeVariables(std::move(_env.m_typeVariables))
+		m_genericTypeVariables(std::move(_env.m_genericTypeVariables))
 	{}
 
-	[[nodiscard]] std::vector<TypeEnvironment::UnificationFailure> instantiate(TypeVariable _variable, Type _type);
+	[[nodiscard]] std::vector<TypeEnvironment::UnificationFailure> instantiate(GenericTypeVariable _variable, Type _type);
 
 	TypeSystem& m_typeSystem;
-	std::map<size_t, Type> m_typeVariables;
+	std::map<size_t, Type> m_genericTypeVariables;
 };
 
 class TypeSystem
@@ -105,7 +105,7 @@ public:
 
 	struct TypeClassInfo
 	{
-		TypeVariable typeVariable;
+		GenericTypeVariable typeVariable;
 		std::string name;
 		Declaration const* classDeclaration = nullptr;
 	};
@@ -153,18 +153,18 @@ public:
 		return constructorInfo(constructor(_typeConstructor));
 	}
 
-	std::variant<TypeClass, std::string> declareTypeClass(TypeVariable _typeVariable, std::string _name, Declaration const* _declaration);
+	std::variant<TypeClass, std::string> declareTypeClass(GenericTypeVariable _typeVariable, std::string _name, Declaration const* _declaration);
 	[[nodiscard]] std::optional<std::string> instantiateClass(Type _instanceVariable, Arity _arity);
 
-	TypeVariable freshTypeVariable(Sort _sort);
+	GenericTypeVariable freshGenericTypeVariable(Sort _sort);
 
 	TypeEnvironment const& env() const { return m_globalTypeEnvironment; }
 	TypeEnvironment& env() { return m_globalTypeEnvironment; }
 
-	TypeVariable freshVariable(Sort _sort);
+	GenericTypeVariable freshGenericVariable(Sort _sort);
 	std::string typeClassName(TypeClass _class) const { return m_typeClasses.at(_class.m_index).name; }
 	Declaration const* typeClassDeclaration(TypeClass _class) const { return m_typeClasses.at(_class.m_index).classDeclaration; }
-	TypeVariable const& typeClassVariable(TypeClass _class) const
+	GenericTypeVariable const& typeClassVariable(TypeClass _class) const
 	{
 		return m_typeClasses.at(_class.m_index).typeVariable;
 	}
@@ -177,7 +177,7 @@ public:
 private:
 	friend class TypeEnvironment;
 
-	size_t m_numTypeVariables = 0;
+	size_t m_numGenericTypeVariables = 0;
 	std::map<PrimitiveType, TypeConstructor> m_primitiveTypeConstructors;
 	std::map<PrimitiveClass, TypeClass> m_primitiveTypeClasses;
 	std::set<std::string> m_canonicalTypeNames;

--- a/libsolidity/experimental/ast/TypeSystem.h
+++ b/libsolidity/experimental/ast/TypeSystem.h
@@ -67,6 +67,13 @@ public:
 	Type resolve(Type _type) const;
 	Type resolveRecursive(Type _type) const;
 	Type fresh(Type _type);
+
+	/// Recursively replaces all generic type variables with fresh fixed type variables, preserving
+	/// sorts. All uses of a given variable in the input are guaranteed to still be represented
+	/// by a single variable in the output.
+	/// Existing fixed type variables remain unchanged.
+	Type fixTypeVariables(Type const& _type);
+
 	[[nodiscard]] std::vector<UnificationFailure> unify(Type _a, Type _b);
 	Sort sort(Type _type) const;
 	bool typeEquals(Type _lhs, Type _rhs) const;

--- a/libsolidity/experimental/ast/TypeSystemHelper.cpp
+++ b/libsolidity/experimental/ast/TypeSystemHelper.cpp
@@ -271,7 +271,7 @@ bool TypeSystemHelpers::isTypeFunctionType(Type _type) const
 
 std::vector<experimental::Type> TypeEnvironmentHelpers::typeVars(Type _type) const
 {
-	std::set<size_t> indices;
+	std::set<size_t> genericVarIndices;
 	std::vector<Type> typeVars;
 	auto typeVarsImpl = [&](Type _type, auto _recurse) -> void {
 		std::visit(util::GenericVisitor{
@@ -279,8 +279,8 @@ std::vector<experimental::Type> TypeEnvironmentHelpers::typeVars(Type _type) con
 				for (auto arg: _type.arguments)
 					_recurse(arg, _recurse);
 			},
-			[&](TypeVariable const& _var) {
-				if (indices.emplace(_var.index()).second)
+			[&](GenericTypeVariable const& _var) {
+				if (genericVarIndices.emplace(_var.index()).second)
 					typeVars.emplace_back(_var);
 			},
 			[](std::monostate) { solAssert(false); }
@@ -327,7 +327,7 @@ std::string TypeEnvironmentHelpers::canonicalTypeName(Type _type) const
 			}
 			return stream.str();
 		},
-		[](TypeVariable const&) -> std::string {
+		[](GenericTypeVariable const&) -> std::string {
 			solAssert(false);
 		},
 		[](std::monostate) -> std::string {
@@ -395,8 +395,8 @@ std::string TypeEnvironmentHelpers::typeToString(Type const& _type, bool _resolv
 				}))
 			);
 		},
-		[&](TypeVariable const& _typeVar) {
-			return "'" + base26Encode(_typeVar.index()) + formatSortSuffix(_typeVar.sort(), env);
+		[&](GenericTypeVariable const& _genericTypeVar) {
+			return "'" + base26Encode(_genericTypeVar.index()) + formatSortSuffix(_genericTypeVar.sort(), env);
 		},
 		[](std::monostate) -> std::string { solAssert(false); }
 	}, _resolve ? env.resolve(_type) : _type);

--- a/libsolidity/experimental/ast/TypeSystemHelper.cpp
+++ b/libsolidity/experimental/ast/TypeSystemHelper.cpp
@@ -271,6 +271,7 @@ bool TypeSystemHelpers::isTypeFunctionType(Type _type) const
 
 std::vector<experimental::Type> TypeEnvironmentHelpers::typeVars(Type _type) const
 {
+	std::set<size_t> fixedVarIndices;
 	std::set<size_t> genericVarIndices;
 	std::vector<Type> typeVars;
 	auto typeVarsImpl = [&](Type _type, auto _recurse) -> void {
@@ -281,6 +282,10 @@ std::vector<experimental::Type> TypeEnvironmentHelpers::typeVars(Type _type) con
 			},
 			[&](GenericTypeVariable const& _var) {
 				if (genericVarIndices.emplace(_var.index()).second)
+					typeVars.emplace_back(_var);
+			},
+			[&](FixedTypeVariable const& _var) {
+				if (fixedVarIndices.emplace(_var.index()).second)
 					typeVars.emplace_back(_var);
 			},
 			[](std::monostate) { solAssert(false); }
@@ -328,6 +333,9 @@ std::string TypeEnvironmentHelpers::canonicalTypeName(Type _type) const
 			return stream.str();
 		},
 		[](GenericTypeVariable const&) -> std::string {
+			solAssert(false);
+		},
+		[](FixedTypeVariable const&) -> std::string {
 			solAssert(false);
 		},
 		[](std::monostate) -> std::string {
@@ -397,6 +405,9 @@ std::string TypeEnvironmentHelpers::typeToString(Type const& _type, bool _resolv
 		},
 		[&](GenericTypeVariable const& _genericTypeVar) {
 			return "'" + base26Encode(_genericTypeVar.index()) + formatSortSuffix(_genericTypeVar.sort(), env);
+		},
+		[&](FixedTypeVariable const& _fixedTypeVar) {
+			return "\"" + base26Encode(_fixedTypeVar.index()) + formatSortSuffix(_fixedTypeVar.sort(), env);
 		},
 		[](std::monostate) -> std::string { solAssert(false); }
 	}, _resolve ? env.resolve(_type) : _type);

--- a/libsolidity/experimental/ast/TypeSystemHelper.h
+++ b/libsolidity/experimental/ast/TypeSystemHelper.h
@@ -30,6 +30,9 @@ enum class BuiltinClass;
 //std::optional<TypeClass> typeClassFromTypeClassName(TypeClassName const& _typeClass);
 std::optional<BuiltinClass> builtinClassFromToken(langutil::Token _token);
 
+// TODO: Extend to allow replacing arbitrary types, not just type variables.
+Type substitute(Type const& _type, FixedTypeVariable const& _variableToReplace, Type const& _replacement);
+
 struct TypeSystemHelpers
 {
 	TypeSystem const& typeSystem;

--- a/test/libsolidity/syntaxTests/experimental/builtin/builtin_type_definition.sol
+++ b/test/libsolidity/syntaxTests/experimental/builtin/builtin_type_definition.sol
@@ -39,14 +39,14 @@ contract C {
 // Info 4164: (94-124): Inferred type: word
 // Info 4164: (125-161): Inferred type: integer
 // Info 4164: (162-192): Inferred type: ()
-// Info 4164: (194-228): Inferred type: tfun(('u:type, 'v:type), 'u:type -> 'v:type)
-// Info 4164: (202-208): Inferred type: ('s:type, 't:type)
-// Info 4164: (203-204): Inferred type: 's:type
-// Info 4164: (206-207): Inferred type: 't:type
-// Info 4164: (229-265): Inferred type: tfun(('y:type, 'z:type), ('y:type, 'z:type))
-// Info 4164: (238-244): Inferred type: ('w:type, 'x:type)
-// Info 4164: (239-240): Inferred type: 'w:type
-// Info 4164: (242-243): Inferred type: 'x:type
+// Info 4164: (194-228): Inferred type: tfun(('l:type, 'm:type), 'l:type -> 'm:type)
+// Info 4164: (202-208): Inferred type: ('j:type, 'k:type)
+// Info 4164: (203-204): Inferred type: 'j:type
+// Info 4164: (206-207): Inferred type: 'k:type
+// Info 4164: (229-265): Inferred type: tfun(('p:type, 'q:type), ('p:type, 'q:type))
+// Info 4164: (238-244): Inferred type: ('n:type, 'o:type)
+// Info 4164: (239-240): Inferred type: 'n:type
+// Info 4164: (242-243): Inferred type: 'o:type
 // Info 4164: (284-584): Inferred type: () -> ()
 // Info 4164: (292-294): Inferred type: ()
 // Info 4164: (318-325): Inferred type: void
@@ -83,9 +83,9 @@ contract C {
 // Info 4164: (525-529): Inferred type: word
 // Info 4164: (540-553): Inferred type: bool
 // Info 4164: (540-550): Inferred type: (bool, word) -> bool
-// Info 4164: (540-544): Inferred type: ('bl:type, 'bm:type)
+// Info 4164: (540-544): Inferred type: ('bc:type, 'bd:type)
 // Info 4164: (551-552): Inferred type: (bool, word)
 // Info 4164: (563-577): Inferred type: word
 // Info 4164: (563-574): Inferred type: (bool, word) -> word
-// Info 4164: (563-567): Inferred type: ('bq:type, 'br:type)
+// Info 4164: (563-567): Inferred type: ('bh:type, 'bi:type)
 // Info 4164: (575-576): Inferred type: (bool, word)

--- a/test/libsolidity/syntaxTests/experimental/builtin/builtin_type_definition.sol
+++ b/test/libsolidity/syntaxTests/experimental/builtin/builtin_type_definition.sol
@@ -83,9 +83,9 @@ contract C {
 // Info 4164: (525-529): Inferred type: word
 // Info 4164: (540-553): Inferred type: bool
 // Info 4164: (540-550): Inferred type: (bool, word) -> bool
-// Info 4164: (540-544): Inferred type: ('cb:type, 'cc:type)
+// Info 4164: (540-544): Inferred type: ('bl:type, 'bm:type)
 // Info 4164: (551-552): Inferred type: (bool, word)
 // Info 4164: (563-577): Inferred type: word
 // Info 4164: (563-574): Inferred type: (bool, word) -> word
-// Info 4164: (563-567): Inferred type: ('ci:type, 'cj:type)
+// Info 4164: (563-567): Inferred type: ('bq:type, 'br:type)
 // Info 4164: (575-576): Inferred type: (bool, word)

--- a/test/libsolidity/syntaxTests/experimental/inference/monomorphic_function_call_type_mismatch.sol
+++ b/test/libsolidity/syntaxTests/experimental/inference/monomorphic_function_call_type_mismatch.sol
@@ -1,0 +1,14 @@
+pragma experimental solidity;
+
+type T;
+type U;
+
+function f(x: T, y: U) {}
+
+function run(a: U, b: T) {
+    f(a, b);
+}
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError 8456: (106-113): Cannot unify T and U.
+// TypeError 8456: (106-113): Cannot unify U and T.

--- a/test/libsolidity/syntaxTests/experimental/inference/polymorphic_function_call.sol
+++ b/test/libsolidity/syntaxTests/experimental/inference/polymorphic_function_call.sol
@@ -1,0 +1,50 @@
+pragma experimental solidity;
+
+type T;
+type U(A);
+
+function f(x, y: X, z: U(Y)) {}
+
+function run(a: T, b: U(T), c: U(U(T))) {
+    f(a, a, b);
+    f(b, b, c);
+}
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
+// Info 4164: (31-38): Inferred type: T
+// Info 4164: (39-49): Inferred type: tfun('u:type, U('u:type))
+// Info 4164: (45-48): Inferred type: 't:type
+// Info 4164: (46-47): Inferred type: 't:type
+// Info 4164: (51-82): Inferred type: ('x:type, 'y:type, U('ba:type)) -> ()
+// Info 4164: (61-79): Inferred type: ('x:type, 'y:type, U('ba:type))
+// Info 4164: (62-63): Inferred type: 'x:type
+// Info 4164: (65-69): Inferred type: 'y:type
+// Info 4164: (68-69): Inferred type: 'y:type
+// Info 4164: (71-78): Inferred type: U('ba:type)
+// Info 4164: (74-78): Inferred type: U('ba:type)
+// Info 4164: (74-75): Inferred type: tfun('ba:type, U('ba:type))
+// Info 4164: (76-77): Inferred type: 'ba:type
+// Info 4164: (84-159): Inferred type: (T, U(T), U(U(T))) -> ()
+// Info 4164: (96-123): Inferred type: (T, U(T), U(U(T)))
+// Info 4164: (97-101): Inferred type: T
+// Info 4164: (100-101): Inferred type: T
+// Info 4164: (103-110): Inferred type: U(T)
+// Info 4164: (106-110): Inferred type: U(T)
+// Info 4164: (106-107): Inferred type: tfun(T, U(T))
+// Info 4164: (108-109): Inferred type: T
+// Info 4164: (112-122): Inferred type: U(U(T))
+// Info 4164: (115-122): Inferred type: U(U(T))
+// Info 4164: (115-116): Inferred type: tfun(U(T), U(U(T)))
+// Info 4164: (117-121): Inferred type: U(T)
+// Info 4164: (117-118): Inferred type: tfun(T, U(T))
+// Info 4164: (119-120): Inferred type: T
+// Info 4164: (130-140): Inferred type: ()
+// Info 4164: (130-131): Inferred type: (T, T, U(T)) -> ()
+// Info 4164: (132-133): Inferred type: T
+// Info 4164: (135-136): Inferred type: T
+// Info 4164: (138-139): Inferred type: U(T)
+// Info 4164: (146-156): Inferred type: ()
+// Info 4164: (146-147): Inferred type: (U(T), U(T), U(U(T))) -> ()
+// Info 4164: (148-149): Inferred type: U(T)
+// Info 4164: (151-152): Inferred type: U(T)
+// Info 4164: (154-155): Inferred type: U(U(T))

--- a/test/libsolidity/syntaxTests/experimental/inference/polymorphic_function_call.sol
+++ b/test/libsolidity/syntaxTests/experimental/inference/polymorphic_function_call.sol
@@ -12,18 +12,18 @@ function run(a: T, b: U(T), c: U(U(T))) {
 // ----
 // Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
 // Info 4164: (31-38): Inferred type: T
-// Info 4164: (39-49): Inferred type: tfun('u:type, U('u:type))
-// Info 4164: (45-48): Inferred type: 't:type
-// Info 4164: (46-47): Inferred type: 't:type
-// Info 4164: (51-82): Inferred type: ('x:type, 'y:type, U('ba:type)) -> ()
-// Info 4164: (61-79): Inferred type: ('x:type, 'y:type, U('ba:type))
-// Info 4164: (62-63): Inferred type: 'x:type
-// Info 4164: (65-69): Inferred type: 'y:type
-// Info 4164: (68-69): Inferred type: 'y:type
-// Info 4164: (71-78): Inferred type: U('ba:type)
-// Info 4164: (74-78): Inferred type: U('ba:type)
-// Info 4164: (74-75): Inferred type: tfun('ba:type, U('ba:type))
-// Info 4164: (76-77): Inferred type: 'ba:type
+// Info 4164: (39-49): Inferred type: tfun('l:type, U('l:type))
+// Info 4164: (45-48): Inferred type: 'k:type
+// Info 4164: (46-47): Inferred type: 'k:type
+// Info 4164: (51-82): Inferred type: ("j:type, "k:type, U("l:type)) -> ()
+// Info 4164: (61-79): Inferred type: ('o:type, 'p:type, U('r:type))
+// Info 4164: (62-63): Inferred type: 'o:type
+// Info 4164: (65-69): Inferred type: 'p:type
+// Info 4164: (68-69): Inferred type: 'p:type
+// Info 4164: (71-78): Inferred type: U('r:type)
+// Info 4164: (74-78): Inferred type: U('r:type)
+// Info 4164: (74-75): Inferred type: tfun('r:type, U('r:type))
+// Info 4164: (76-77): Inferred type: 'r:type
 // Info 4164: (84-159): Inferred type: (T, U(T), U(U(T))) -> ()
 // Info 4164: (96-123): Inferred type: (T, U(T), U(U(T)))
 // Info 4164: (97-101): Inferred type: T

--- a/test/libsolidity/syntaxTests/experimental/inference/polymorphic_function_call_type_mismatch.sol
+++ b/test/libsolidity/syntaxTests/experimental/inference/polymorphic_function_call_type_mismatch.sol
@@ -1,0 +1,14 @@
+pragma experimental solidity;
+
+type T(A);
+type U;
+type V;
+
+function f(x: T(U)) {}
+
+function run(a: T(V)) {
+    f(a);
+}
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError 8456: (111-115): Cannot unify U and V.

--- a/test/libsolidity/syntaxTests/experimental/inference/polymorphic_function_call_via_variable.sol
+++ b/test/libsolidity/syntaxTests/experimental/inference/polymorphic_function_call_via_variable.sol
@@ -1,0 +1,20 @@
+pragma experimental solidity;
+
+type T;
+type U(A);
+
+function f(x, y: X, z: U(Y)) {}
+
+function run(a: T, b: U(T), c: U(U(T))) {
+    let fRef = f;
+
+    // FIXME: The second call does not unify. Apparently the call via a function pointer does not
+    // get fresh type variables like a direct call.
+    fRef(a, a, b);
+    fRef(b, b, c);
+}
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError 8456: (318-331): Cannot unify T and U(T).
+// TypeError 8456: (318-331): Cannot unify T and U(T).
+// TypeError 8456: (318-331): Cannot unify T and U(T).

--- a/test/libsolidity/syntaxTests/experimental/inference/polymorphic_type.sol
+++ b/test/libsolidity/syntaxTests/experimental/inference/polymorphic_type.sol
@@ -1,0 +1,44 @@
+pragma experimental solidity;
+
+type T(P, Q, R);
+type U;
+type V;
+
+class Self: C {}
+class Self: D {}
+
+function run() {
+    let x: T(U, X, Z: C);
+    let y: T(V, Y, Z: D);
+}
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
+// Info 4164: (31-47): Inferred type: tfun(('ba:type, 'bb:type, 'bc:type), T('ba:type, 'bb:type, 'bc:type))
+// Info 4164: (37-46): Inferred type: ('x:type, 'y:type, 'z:type)
+// Info 4164: (38-39): Inferred type: 'x:type
+// Info 4164: (41-42): Inferred type: 'y:type
+// Info 4164: (44-45): Inferred type: 'z:type
+// Info 4164: (48-55): Inferred type: U
+// Info 4164: (56-63): Inferred type: V
+// Info 4164: (65-81): Inferred type: C
+// Info 4164: (71-75): Inferred type: 'be:(type, C)
+// Info 4164: (82-98): Inferred type: D
+// Info 4164: (88-92): Inferred type: 'bg:(type, D)
+// Info 4164: (100-170): Inferred type: () -> ()
+// Info 4164: (112-114): Inferred type: ()
+// Info 4164: (125-141): Inferred type: T(U, 'bm:type, 'bo:(type, C))
+// Info 4164: (128-141): Inferred type: T(U, 'bm:type, 'bo:(type, C))
+// Info 4164: (128-129): Inferred type: tfun((U, 'bm:type, 'bo:(type, C)), T(U, 'bm:type, 'bo:(type, C)))
+// Info 4164: (130-131): Inferred type: U
+// Info 4164: (133-134): Inferred type: 'bm:type
+// Info 4164: (136-140): Inferred type: 'bo:(type, C)
+// Info 4164: (136-137): Inferred type: 'bo:(type, C)
+// Info 4164: (139-140): Inferred type: 'bo:(type, C)
+// Info 4164: (151-167): Inferred type: T(V, 'bt:type, 'bv:(type, D))
+// Info 4164: (154-167): Inferred type: T(V, 'bt:type, 'bv:(type, D))
+// Info 4164: (154-155): Inferred type: tfun((V, 'bt:type, 'bv:(type, D)), T(V, 'bt:type, 'bv:(type, D)))
+// Info 4164: (156-157): Inferred type: V
+// Info 4164: (159-160): Inferred type: 'bt:type
+// Info 4164: (162-166): Inferred type: 'bv:(type, D)
+// Info 4164: (162-163): Inferred type: 'bv:(type, D)
+// Info 4164: (165-166): Inferred type: 'bv:(type, D)

--- a/test/libsolidity/syntaxTests/experimental/inference/polymorphic_type.sol
+++ b/test/libsolidity/syntaxTests/experimental/inference/polymorphic_type.sol
@@ -13,32 +13,32 @@ function run() {
 }
 // ----
 // Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
-// Info 4164: (31-47): Inferred type: tfun(('ba:type, 'bb:type, 'bc:type), T('ba:type, 'bb:type, 'bc:type))
-// Info 4164: (37-46): Inferred type: ('x:type, 'y:type, 'z:type)
-// Info 4164: (38-39): Inferred type: 'x:type
-// Info 4164: (41-42): Inferred type: 'y:type
-// Info 4164: (44-45): Inferred type: 'z:type
+// Info 4164: (31-47): Inferred type: tfun(('p:type, 'q:type, 'r:type), T('p:type, 'q:type, 'r:type))
+// Info 4164: (37-46): Inferred type: ('m:type, 'n:type, 'o:type)
+// Info 4164: (38-39): Inferred type: 'm:type
+// Info 4164: (41-42): Inferred type: 'n:type
+// Info 4164: (44-45): Inferred type: 'o:type
 // Info 4164: (48-55): Inferred type: U
 // Info 4164: (56-63): Inferred type: V
 // Info 4164: (65-81): Inferred type: C
-// Info 4164: (71-75): Inferred type: 'be:(type, C)
+// Info 4164: (71-75): Inferred type: "b:(type, C)
 // Info 4164: (82-98): Inferred type: D
-// Info 4164: (88-92): Inferred type: 'bg:(type, D)
+// Info 4164: (88-92): Inferred type: "c:(type, D)
 // Info 4164: (100-170): Inferred type: () -> ()
 // Info 4164: (112-114): Inferred type: ()
-// Info 4164: (125-141): Inferred type: T(U, 'bm:type, 'bo:(type, C))
-// Info 4164: (128-141): Inferred type: T(U, 'bm:type, 'bo:(type, C))
-// Info 4164: (128-129): Inferred type: tfun((U, 'bm:type, 'bo:(type, C)), T(U, 'bm:type, 'bo:(type, C)))
+// Info 4164: (125-141): Inferred type: T(U, 'z:type, 'bb:(type, C))
+// Info 4164: (128-141): Inferred type: T(U, 'z:type, 'bb:(type, C))
+// Info 4164: (128-129): Inferred type: tfun((U, 'z:type, 'bb:(type, C)), T(U, 'z:type, 'bb:(type, C)))
 // Info 4164: (130-131): Inferred type: U
-// Info 4164: (133-134): Inferred type: 'bm:type
-// Info 4164: (136-140): Inferred type: 'bo:(type, C)
-// Info 4164: (136-137): Inferred type: 'bo:(type, C)
-// Info 4164: (139-140): Inferred type: 'bo:(type, C)
-// Info 4164: (151-167): Inferred type: T(V, 'bt:type, 'bv:(type, D))
-// Info 4164: (154-167): Inferred type: T(V, 'bt:type, 'bv:(type, D))
-// Info 4164: (154-155): Inferred type: tfun((V, 'bt:type, 'bv:(type, D)), T(V, 'bt:type, 'bv:(type, D)))
+// Info 4164: (133-134): Inferred type: 'z:type
+// Info 4164: (136-140): Inferred type: 'bb:(type, C)
+// Info 4164: (136-137): Inferred type: 'bb:(type, C)
+// Info 4164: (139-140): Inferred type: 'bb:(type, C)
+// Info 4164: (151-167): Inferred type: T(V, 'bg:type, 'bi:(type, D))
+// Info 4164: (154-167): Inferred type: T(V, 'bg:type, 'bi:(type, D))
+// Info 4164: (154-155): Inferred type: tfun((V, 'bg:type, 'bi:(type, D)), T(V, 'bg:type, 'bi:(type, D)))
 // Info 4164: (156-157): Inferred type: V
-// Info 4164: (159-160): Inferred type: 'bt:type
-// Info 4164: (162-166): Inferred type: 'bv:(type, D)
-// Info 4164: (162-163): Inferred type: 'bv:(type, D)
-// Info 4164: (165-166): Inferred type: 'bv:(type, D)
+// Info 4164: (159-160): Inferred type: 'bg:type
+// Info 4164: (162-166): Inferred type: 'bi:(type, D)
+// Info 4164: (162-163): Inferred type: 'bi:(type, D)
+// Info 4164: (165-166): Inferred type: 'bi:(type, D)

--- a/test/libsolidity/syntaxTests/experimental/inference/polymorphic_type_abs_and_rep.sol
+++ b/test/libsolidity/syntaxTests/experimental/inference/polymorphic_type_abs_and_rep.sol
@@ -1,0 +1,66 @@
+pragma experimental solidity;
+
+type uint;
+type string;
+
+type T(A);
+type U(B) = T(B);
+
+function fun() {
+    let w: U(uint);
+    let v: T(uint);
+    U.rep(w);
+    U.abs(v);
+
+    let s: U(string);
+    let t: T(string);
+    U.rep(s);
+    U.abs(t);
+}
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
+// Info 4164: (31-41): Inferred type: uint
+// Info 4164: (42-54): Inferred type: string
+// Info 4164: (56-66): Inferred type: tfun('v:type, T('v:type))
+// Info 4164: (62-65): Inferred type: 'u:type
+// Info 4164: (63-64): Inferred type: 'u:type
+// Info 4164: (67-84): Inferred type: tfun('x:type, U('x:type))
+// Info 4164: (73-76): Inferred type: 'w:type
+// Info 4164: (74-75): Inferred type: 'w:type
+// Info 4164: (79-83): Inferred type: T('w:type)
+// Info 4164: (79-80): Inferred type: tfun('w:type, T('w:type))
+// Info 4164: (81-82): Inferred type: 'w:type
+// Info 4164: (86-245): Inferred type: () -> ()
+// Info 4164: (98-100): Inferred type: ()
+// Info 4164: (111-121): Inferred type: U(uint)
+// Info 4164: (114-121): Inferred type: U(uint)
+// Info 4164: (114-115): Inferred type: tfun(uint, U(uint))
+// Info 4164: (116-120): Inferred type: uint
+// Info 4164: (131-141): Inferred type: T(uint)
+// Info 4164: (134-141): Inferred type: T(uint)
+// Info 4164: (134-135): Inferred type: tfun(uint, T(uint))
+// Info 4164: (136-140): Inferred type: uint
+// Info 4164: (147-155): Inferred type: T('bi:type)
+// Info 4164: (147-152): Inferred type: U(uint) -> T('bi:type)
+// Info 4164: (147-148): Inferred type: U('bg:type)
+// Info 4164: (153-154): Inferred type: U(uint)
+// Info 4164: (161-169): Inferred type: U('bm:type)
+// Info 4164: (161-166): Inferred type: T(uint) -> U('bm:type)
+// Info 4164: (161-162): Inferred type: U('bk:type)
+// Info 4164: (167-168): Inferred type: T(uint)
+// Info 4164: (180-192): Inferred type: U(string)
+// Info 4164: (183-192): Inferred type: U(string)
+// Info 4164: (183-184): Inferred type: tfun(string, U(string))
+// Info 4164: (185-191): Inferred type: string
+// Info 4164: (202-214): Inferred type: T(string)
+// Info 4164: (205-214): Inferred type: T(string)
+// Info 4164: (205-206): Inferred type: tfun(string, T(string))
+// Info 4164: (207-213): Inferred type: string
+// Info 4164: (220-228): Inferred type: T('bu:type)
+// Info 4164: (220-225): Inferred type: U(string) -> T('bu:type)
+// Info 4164: (220-221): Inferred type: U('bs:type)
+// Info 4164: (226-227): Inferred type: U(string)
+// Info 4164: (234-242): Inferred type: U('by:type)
+// Info 4164: (234-239): Inferred type: T(string) -> U('by:type)
+// Info 4164: (234-235): Inferred type: U('bw:type)
+// Info 4164: (240-241): Inferred type: T(string)

--- a/test/libsolidity/syntaxTests/experimental/inference/polymorphic_type_abs_and_rep.sol
+++ b/test/libsolidity/syntaxTests/experimental/inference/polymorphic_type_abs_and_rep.sol
@@ -21,15 +21,15 @@ function fun() {
 // Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
 // Info 4164: (31-41): Inferred type: uint
 // Info 4164: (42-54): Inferred type: string
-// Info 4164: (56-66): Inferred type: tfun('v:type, T('v:type))
-// Info 4164: (62-65): Inferred type: 'u:type
-// Info 4164: (63-64): Inferred type: 'u:type
-// Info 4164: (67-84): Inferred type: tfun('x:type, U('x:type))
-// Info 4164: (73-76): Inferred type: 'w:type
-// Info 4164: (74-75): Inferred type: 'w:type
-// Info 4164: (79-83): Inferred type: T('w:type)
-// Info 4164: (79-80): Inferred type: tfun('w:type, T('w:type))
-// Info 4164: (81-82): Inferred type: 'w:type
+// Info 4164: (56-66): Inferred type: tfun('m:type, T('m:type))
+// Info 4164: (62-65): Inferred type: 'l:type
+// Info 4164: (63-64): Inferred type: 'l:type
+// Info 4164: (67-84): Inferred type: tfun('o:type, U('o:type))
+// Info 4164: (73-76): Inferred type: 'n:type
+// Info 4164: (74-75): Inferred type: 'n:type
+// Info 4164: (79-83): Inferred type: T('n:type)
+// Info 4164: (79-80): Inferred type: tfun('n:type, T('n:type))
+// Info 4164: (81-82): Inferred type: 'n:type
 // Info 4164: (86-245): Inferred type: () -> ()
 // Info 4164: (98-100): Inferred type: ()
 // Info 4164: (111-121): Inferred type: U(uint)
@@ -40,13 +40,13 @@ function fun() {
 // Info 4164: (134-141): Inferred type: T(uint)
 // Info 4164: (134-135): Inferred type: tfun(uint, T(uint))
 // Info 4164: (136-140): Inferred type: uint
-// Info 4164: (147-155): Inferred type: T('bi:type)
-// Info 4164: (147-152): Inferred type: U(uint) -> T('bi:type)
-// Info 4164: (147-148): Inferred type: U('bg:type)
+// Info 4164: (147-155): Inferred type: T('z:type)
+// Info 4164: (147-152): Inferred type: U(uint) -> T('z:type)
+// Info 4164: (147-148): Inferred type: U('x:type)
 // Info 4164: (153-154): Inferred type: U(uint)
-// Info 4164: (161-169): Inferred type: U('bm:type)
-// Info 4164: (161-166): Inferred type: T(uint) -> U('bm:type)
-// Info 4164: (161-162): Inferred type: U('bk:type)
+// Info 4164: (161-169): Inferred type: U('bd:type)
+// Info 4164: (161-166): Inferred type: T(uint) -> U('bd:type)
+// Info 4164: (161-162): Inferred type: U('bb:type)
 // Info 4164: (167-168): Inferred type: T(uint)
 // Info 4164: (180-192): Inferred type: U(string)
 // Info 4164: (183-192): Inferred type: U(string)
@@ -56,11 +56,11 @@ function fun() {
 // Info 4164: (205-214): Inferred type: T(string)
 // Info 4164: (205-206): Inferred type: tfun(string, T(string))
 // Info 4164: (207-213): Inferred type: string
-// Info 4164: (220-228): Inferred type: T('bu:type)
-// Info 4164: (220-225): Inferred type: U(string) -> T('bu:type)
-// Info 4164: (220-221): Inferred type: U('bs:type)
+// Info 4164: (220-228): Inferred type: T('bl:type)
+// Info 4164: (220-225): Inferred type: U(string) -> T('bl:type)
+// Info 4164: (220-221): Inferred type: U('bj:type)
 // Info 4164: (226-227): Inferred type: U(string)
-// Info 4164: (234-242): Inferred type: U('by:type)
-// Info 4164: (234-239): Inferred type: T(string) -> U('by:type)
-// Info 4164: (234-235): Inferred type: U('bw:type)
+// Info 4164: (234-242): Inferred type: U('bp:type)
+// Info 4164: (234-239): Inferred type: T(string) -> U('bp:type)
+// Info 4164: (234-235): Inferred type: U('bn:type)
 // Info 4164: (240-241): Inferred type: T(string)

--- a/test/libsolidity/syntaxTests/experimental/inference/polymorphic_type_instantiation_and_operators.sol
+++ b/test/libsolidity/syntaxTests/experimental/inference/polymorphic_type_instantiation_and_operators.sol
@@ -1,0 +1,165 @@
+pragma experimental solidity;
+
+type bool = __builtin("bool");
+
+type T(A);
+type int;
+type str;
+
+class Self: C {
+    function foo(a: Self, b: Self) -> Self;
+}
+
+class Self: P1 {}
+class Self: P2 {}
+class Self: P3 {}
+class Self: P4 {}
+
+instantiation int: P1 {}
+instantiation int: P2 {}
+instantiation int: P3 {}
+
+instantiation str: P1 {}
+instantiation str: P2 {}
+instantiation str: P4 {}
+
+instantiation T(A: P1): + {
+    function add(x: T(A), y: T(A)) -> T(A) {}
+}
+
+instantiation T(A: P2): == {
+    function eq(x: T(A), y: T(A)) -> bool {}
+}
+
+instantiation T(A: (P1, P2)): C {
+    function foo(x: T(A), y: T(A)) -> T(A) {}
+}
+
+function fun(a: T(int: P3), b: T(str: P4)) {
+    a + a;
+    b + b;
+
+    a == a;
+    b == b;
+
+    C.foo(a, a);
+    C.foo(b, b);
+}
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
+// Info 4164: (31-61): Inferred type: bool
+// Info 4164: (63-73): Inferred type: tfun('z:type, T('z:type))
+// Info 4164: (69-72): Inferred type: 'y:type
+// Info 4164: (70-71): Inferred type: 'y:type
+// Info 4164: (74-83): Inferred type: int
+// Info 4164: (84-93): Inferred type: str
+// Info 4164: (95-156): Inferred type: C
+// Info 4164: (101-105): Inferred type: 'bd:(type, C)
+// Info 4164: (115-154): Inferred type: ('bd:(type, C), 'bd:(type, C)) -> 'bd:(type, C)
+// Info 4164: (127-145): Inferred type: ('bd:(type, C), 'bd:(type, C))
+// Info 4164: (128-135): Inferred type: 'bd:(type, C)
+// Info 4164: (131-135): Inferred type: 'bd:(type, C)
+// Info 4164: (137-144): Inferred type: 'bd:(type, C)
+// Info 4164: (140-144): Inferred type: 'bd:(type, C)
+// Info 4164: (149-153): Inferred type: 'bd:(type, C)
+// Info 4164: (158-175): Inferred type: P1
+// Info 4164: (164-168): Inferred type: 'bg:(type, P1)
+// Info 4164: (176-193): Inferred type: P2
+// Info 4164: (182-186): Inferred type: 'bj:(type, P2)
+// Info 4164: (194-211): Inferred type: P3
+// Info 4164: (200-204): Inferred type: 'bw:(type, P3)
+// Info 4164: (212-229): Inferred type: P4
+// Info 4164: (218-222): Inferred type: 'by:(type, P4)
+// Info 4164: (231-255): Inferred type: void
+// Info 4164: (256-280): Inferred type: void
+// Info 4164: (281-305): Inferred type: void
+// Info 4164: (307-331): Inferred type: void
+// Info 4164: (332-356): Inferred type: void
+// Info 4164: (357-381): Inferred type: void
+// Info 4164: (383-458): Inferred type: void
+// Info 4164: (398-405): Inferred type: 'ca:(type, P1)
+// Info 4164: (399-404): Inferred type: 'ca:(type, P1)
+// Info 4164: (402-404): Inferred type: 'ca:(type, P1)
+// Info 4164: (415-456): Inferred type: (T('ca:(type, P1)), T('ca:(type, P1))) -> T('ca:(type, P1))
+// Info 4164: (427-445): Inferred type: (T('ca:(type, P1)), T('ca:(type, P1)))
+// Info 4164: (428-435): Inferred type: T('ca:(type, P1))
+// Info 4164: (431-435): Inferred type: T('ca:(type, P1))
+// Info 4164: (431-432): Inferred type: tfun('ca:(type, P1), T('ca:(type, P1)))
+// Info 4164: (433-434): Inferred type: 'ca:(type, P1)
+// Info 4164: (437-444): Inferred type: T('ca:(type, P1))
+// Info 4164: (440-444): Inferred type: T('ca:(type, P1))
+// Info 4164: (440-441): Inferred type: tfun('ca:(type, P1), T('ca:(type, P1)))
+// Info 4164: (442-443): Inferred type: 'ca:(type, P1)
+// Info 4164: (449-453): Inferred type: T('ca:(type, P1))
+// Info 4164: (449-450): Inferred type: tfun('ca:(type, P1), T('ca:(type, P1)))
+// Info 4164: (451-452): Inferred type: 'ca:(type, P1)
+// Info 4164: (460-535): Inferred type: void
+// Info 4164: (475-482): Inferred type: 'ck:(type, P2)
+// Info 4164: (476-481): Inferred type: 'ck:(type, P2)
+// Info 4164: (479-481): Inferred type: 'ck:(type, P2)
+// Info 4164: (493-533): Inferred type: (T('ck:(type, P2)), T('ck:(type, P2))) -> bool
+// Info 4164: (504-522): Inferred type: (T('ck:(type, P2)), T('ck:(type, P2)))
+// Info 4164: (505-512): Inferred type: T('ck:(type, P2))
+// Info 4164: (508-512): Inferred type: T('ck:(type, P2))
+// Info 4164: (508-509): Inferred type: tfun('ck:(type, P2), T('ck:(type, P2)))
+// Info 4164: (510-511): Inferred type: 'ck:(type, P2)
+// Info 4164: (514-521): Inferred type: T('ck:(type, P2))
+// Info 4164: (517-521): Inferred type: T('ck:(type, P2))
+// Info 4164: (517-518): Inferred type: tfun('ck:(type, P2), T('ck:(type, P2)))
+// Info 4164: (519-520): Inferred type: 'ck:(type, P2)
+// Info 4164: (526-530): Inferred type: bool
+// Info 4164: (537-618): Inferred type: void
+// Info 4164: (552-565): Inferred type: 'bm:(type, P1, P2)
+// Info 4164: (553-564): Inferred type: 'bm:(type, P1, P2)
+// Info 4164: (556-564): Inferred type: 'bm:(type, P1, P2)
+// Info 4164: (557-559): Inferred type: 'bm:(type, P1, P2)
+// Info 4164: (561-563): Inferred type: 'bm:(type, P1, P2)
+// Info 4164: (575-616): Inferred type: (T('bm:(type, P1, P2)), T('bm:(type, P1, P2))) -> T('bm:(type, P1, P2))
+// Info 4164: (587-605): Inferred type: (T('bm:(type, P1, P2)), T('bm:(type, P1, P2)))
+// Info 4164: (588-595): Inferred type: T('bm:(type, P1, P2))
+// Info 4164: (591-595): Inferred type: T('bm:(type, P1, P2))
+// Info 4164: (591-592): Inferred type: tfun('bm:(type, P1, P2), T('bm:(type, P1, P2)))
+// Info 4164: (593-594): Inferred type: 'bm:(type, P1, P2)
+// Info 4164: (597-604): Inferred type: T('bm:(type, P1, P2))
+// Info 4164: (600-604): Inferred type: T('bm:(type, P1, P2))
+// Info 4164: (600-601): Inferred type: tfun('bm:(type, P1, P2), T('bm:(type, P1, P2)))
+// Info 4164: (602-603): Inferred type: 'bm:(type, P1, P2)
+// Info 4164: (609-613): Inferred type: T('bm:(type, P1, P2))
+// Info 4164: (609-610): Inferred type: tfun('bm:(type, P1, P2), T('bm:(type, P1, P2)))
+// Info 4164: (611-612): Inferred type: 'bm:(type, P1, P2)
+// Info 4164: (620-748): Inferred type: (T(int), T(str)) -> ()
+// Info 4164: (632-662): Inferred type: (T(int), T(str))
+// Info 4164: (633-646): Inferred type: T(int)
+// Info 4164: (636-646): Inferred type: T(int)
+// Info 4164: (636-637): Inferred type: tfun(int, T(int))
+// Info 4164: (638-645): Inferred type: int
+// Info 4164: (638-641): Inferred type: int
+// Info 4164: (643-645): Inferred type: int
+// Info 4164: (648-661): Inferred type: T(str)
+// Info 4164: (651-661): Inferred type: T(str)
+// Info 4164: (651-652): Inferred type: tfun(str, T(str))
+// Info 4164: (653-660): Inferred type: str
+// Info 4164: (653-656): Inferred type: str
+// Info 4164: (658-660): Inferred type: str
+// Info 4164: (669-674): Inferred type: T(int)
+// Info 4164: (669-670): Inferred type: T(int)
+// Info 4164: (673-674): Inferred type: T(int)
+// Info 4164: (680-685): Inferred type: T(str)
+// Info 4164: (680-681): Inferred type: T(str)
+// Info 4164: (684-685): Inferred type: T(str)
+// Info 4164: (692-698): Inferred type: bool
+// Info 4164: (692-693): Inferred type: T(int)
+// Info 4164: (697-698): Inferred type: T(int)
+// Info 4164: (704-710): Inferred type: bool
+// Info 4164: (704-705): Inferred type: T(str)
+// Info 4164: (709-710): Inferred type: T(str)
+// Info 4164: (717-728): Inferred type: T(int)
+// Info 4164: (717-722): Inferred type: (T(int), T(int)) -> T(int)
+// Info 4164: (717-718): Inferred type: C
+// Info 4164: (723-724): Inferred type: T(int)
+// Info 4164: (726-727): Inferred type: T(int)
+// Info 4164: (734-745): Inferred type: T(str)
+// Info 4164: (734-739): Inferred type: (T(str), T(str)) -> T(str)
+// Info 4164: (734-735): Inferred type: C
+// Info 4164: (740-741): Inferred type: T(str)
+// Info 4164: (743-744): Inferred type: T(str)

--- a/test/libsolidity/syntaxTests/experimental/inference/polymorphic_type_instantiation_and_operators.sol
+++ b/test/libsolidity/syntaxTests/experimental/inference/polymorphic_type_instantiation_and_operators.sol
@@ -24,6 +24,8 @@ instantiation str: P2 {}
 instantiation str: P4 {}
 
 instantiation T(A: P1): + {
+    // FIXME: Type comparison with type class function fails because we get
+    // two different variables for A.
     function add(x: T(A), y: T(A)) -> T(A) {}
 }
 
@@ -47,119 +49,6 @@ function fun(a: T(int: P3), b: T(str: P4)) {
 }
 // ----
 // Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
-// Info 4164: (31-61): Inferred type: bool
-// Info 4164: (63-73): Inferred type: tfun('z:type, T('z:type))
-// Info 4164: (69-72): Inferred type: 'y:type
-// Info 4164: (70-71): Inferred type: 'y:type
-// Info 4164: (74-83): Inferred type: int
-// Info 4164: (84-93): Inferred type: str
-// Info 4164: (95-156): Inferred type: C
-// Info 4164: (101-105): Inferred type: 'bd:(type, C)
-// Info 4164: (115-154): Inferred type: ('bd:(type, C), 'bd:(type, C)) -> 'bd:(type, C)
-// Info 4164: (127-145): Inferred type: ('bd:(type, C), 'bd:(type, C))
-// Info 4164: (128-135): Inferred type: 'bd:(type, C)
-// Info 4164: (131-135): Inferred type: 'bd:(type, C)
-// Info 4164: (137-144): Inferred type: 'bd:(type, C)
-// Info 4164: (140-144): Inferred type: 'bd:(type, C)
-// Info 4164: (149-153): Inferred type: 'bd:(type, C)
-// Info 4164: (158-175): Inferred type: P1
-// Info 4164: (164-168): Inferred type: 'bg:(type, P1)
-// Info 4164: (176-193): Inferred type: P2
-// Info 4164: (182-186): Inferred type: 'bj:(type, P2)
-// Info 4164: (194-211): Inferred type: P3
-// Info 4164: (200-204): Inferred type: 'bw:(type, P3)
-// Info 4164: (212-229): Inferred type: P4
-// Info 4164: (218-222): Inferred type: 'by:(type, P4)
-// Info 4164: (231-255): Inferred type: void
-// Info 4164: (256-280): Inferred type: void
-// Info 4164: (281-305): Inferred type: void
-// Info 4164: (307-331): Inferred type: void
-// Info 4164: (332-356): Inferred type: void
-// Info 4164: (357-381): Inferred type: void
-// Info 4164: (383-458): Inferred type: void
-// Info 4164: (398-405): Inferred type: 'ca:(type, P1)
-// Info 4164: (399-404): Inferred type: 'ca:(type, P1)
-// Info 4164: (402-404): Inferred type: 'ca:(type, P1)
-// Info 4164: (415-456): Inferred type: (T('ca:(type, P1)), T('ca:(type, P1))) -> T('ca:(type, P1))
-// Info 4164: (427-445): Inferred type: (T('ca:(type, P1)), T('ca:(type, P1)))
-// Info 4164: (428-435): Inferred type: T('ca:(type, P1))
-// Info 4164: (431-435): Inferred type: T('ca:(type, P1))
-// Info 4164: (431-432): Inferred type: tfun('ca:(type, P1), T('ca:(type, P1)))
-// Info 4164: (433-434): Inferred type: 'ca:(type, P1)
-// Info 4164: (437-444): Inferred type: T('ca:(type, P1))
-// Info 4164: (440-444): Inferred type: T('ca:(type, P1))
-// Info 4164: (440-441): Inferred type: tfun('ca:(type, P1), T('ca:(type, P1)))
-// Info 4164: (442-443): Inferred type: 'ca:(type, P1)
-// Info 4164: (449-453): Inferred type: T('ca:(type, P1))
-// Info 4164: (449-450): Inferred type: tfun('ca:(type, P1), T('ca:(type, P1)))
-// Info 4164: (451-452): Inferred type: 'ca:(type, P1)
-// Info 4164: (460-535): Inferred type: void
-// Info 4164: (475-482): Inferred type: 'ck:(type, P2)
-// Info 4164: (476-481): Inferred type: 'ck:(type, P2)
-// Info 4164: (479-481): Inferred type: 'ck:(type, P2)
-// Info 4164: (493-533): Inferred type: (T('ck:(type, P2)), T('ck:(type, P2))) -> bool
-// Info 4164: (504-522): Inferred type: (T('ck:(type, P2)), T('ck:(type, P2)))
-// Info 4164: (505-512): Inferred type: T('ck:(type, P2))
-// Info 4164: (508-512): Inferred type: T('ck:(type, P2))
-// Info 4164: (508-509): Inferred type: tfun('ck:(type, P2), T('ck:(type, P2)))
-// Info 4164: (510-511): Inferred type: 'ck:(type, P2)
-// Info 4164: (514-521): Inferred type: T('ck:(type, P2))
-// Info 4164: (517-521): Inferred type: T('ck:(type, P2))
-// Info 4164: (517-518): Inferred type: tfun('ck:(type, P2), T('ck:(type, P2)))
-// Info 4164: (519-520): Inferred type: 'ck:(type, P2)
-// Info 4164: (526-530): Inferred type: bool
-// Info 4164: (537-618): Inferred type: void
-// Info 4164: (552-565): Inferred type: 'bm:(type, P1, P2)
-// Info 4164: (553-564): Inferred type: 'bm:(type, P1, P2)
-// Info 4164: (556-564): Inferred type: 'bm:(type, P1, P2)
-// Info 4164: (557-559): Inferred type: 'bm:(type, P1, P2)
-// Info 4164: (561-563): Inferred type: 'bm:(type, P1, P2)
-// Info 4164: (575-616): Inferred type: (T('bm:(type, P1, P2)), T('bm:(type, P1, P2))) -> T('bm:(type, P1, P2))
-// Info 4164: (587-605): Inferred type: (T('bm:(type, P1, P2)), T('bm:(type, P1, P2)))
-// Info 4164: (588-595): Inferred type: T('bm:(type, P1, P2))
-// Info 4164: (591-595): Inferred type: T('bm:(type, P1, P2))
-// Info 4164: (591-592): Inferred type: tfun('bm:(type, P1, P2), T('bm:(type, P1, P2)))
-// Info 4164: (593-594): Inferred type: 'bm:(type, P1, P2)
-// Info 4164: (597-604): Inferred type: T('bm:(type, P1, P2))
-// Info 4164: (600-604): Inferred type: T('bm:(type, P1, P2))
-// Info 4164: (600-601): Inferred type: tfun('bm:(type, P1, P2), T('bm:(type, P1, P2)))
-// Info 4164: (602-603): Inferred type: 'bm:(type, P1, P2)
-// Info 4164: (609-613): Inferred type: T('bm:(type, P1, P2))
-// Info 4164: (609-610): Inferred type: tfun('bm:(type, P1, P2), T('bm:(type, P1, P2)))
-// Info 4164: (611-612): Inferred type: 'bm:(type, P1, P2)
-// Info 4164: (620-748): Inferred type: (T(int), T(str)) -> ()
-// Info 4164: (632-662): Inferred type: (T(int), T(str))
-// Info 4164: (633-646): Inferred type: T(int)
-// Info 4164: (636-646): Inferred type: T(int)
-// Info 4164: (636-637): Inferred type: tfun(int, T(int))
-// Info 4164: (638-645): Inferred type: int
-// Info 4164: (638-641): Inferred type: int
-// Info 4164: (643-645): Inferred type: int
-// Info 4164: (648-661): Inferred type: T(str)
-// Info 4164: (651-661): Inferred type: T(str)
-// Info 4164: (651-652): Inferred type: tfun(str, T(str))
-// Info 4164: (653-660): Inferred type: str
-// Info 4164: (653-656): Inferred type: str
-// Info 4164: (658-660): Inferred type: str
-// Info 4164: (669-674): Inferred type: T(int)
-// Info 4164: (669-670): Inferred type: T(int)
-// Info 4164: (673-674): Inferred type: T(int)
-// Info 4164: (680-685): Inferred type: T(str)
-// Info 4164: (680-681): Inferred type: T(str)
-// Info 4164: (684-685): Inferred type: T(str)
-// Info 4164: (692-698): Inferred type: bool
-// Info 4164: (692-693): Inferred type: T(int)
-// Info 4164: (697-698): Inferred type: T(int)
-// Info 4164: (704-710): Inferred type: bool
-// Info 4164: (704-705): Inferred type: T(str)
-// Info 4164: (709-710): Inferred type: T(str)
-// Info 4164: (717-728): Inferred type: T(int)
-// Info 4164: (717-722): Inferred type: (T(int), T(int)) -> T(int)
-// Info 4164: (717-718): Inferred type: C
-// Info 4164: (723-724): Inferred type: T(int)
-// Info 4164: (726-727): Inferred type: T(int)
-// Info 4164: (734-745): Inferred type: T(str)
-// Info 4164: (734-739): Inferred type: (T(str), T(str)) -> T(str)
-// Info 4164: (734-735): Inferred type: C
-// Info 4164: (740-741): Inferred type: T(str)
-// Info 4164: (743-744): Inferred type: T(str)
+// TypeError 7428: (651-732): Instantiation function 'foo' does not match the declaration in the type class ((T("o:(type, P1, P2)), T("o:(type, P1, P2))) -> T("o:(type, P1, P2)) != (T('v:(type, P1, P2)), T('v:(type, P1, P2))) -> T('v:(type, P1, P2))).
+// TypeError 7428: (383-572): Instantiation function 'add' does not match the declaration in the type class ((T("p:(type, P1)), T("p:(type, P1))) -> T("p:(type, P1)) != (T('bh:(type, P1)), T('bh:(type, P1))) -> T('bh:(type, P1))).
+// TypeError 7428: (574-649): Instantiation function 'eq' does not match the declaration in the type class ((T("q:(type, P2)), T("q:(type, P2))) -> bool != (T('br:(type, P2)), T('br:(type, P2))) -> bool).


### PR DESCRIPTION
Part of #14570.
Depends on #14635.

The PR introduces fixed free type variables and implements unification for them. Then replaces generic variables with fixed ones in a function definition once it's processed. It does not yet use fixed type variables for anything else.