### PR TITLE
#14628 fix combined output --asm and asm-json opt

### DIFF
--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -1205,7 +1205,7 @@ void CommandLineInterface::outputCompilationResults()
 				if (m_options.compiler.outputs.asmJson)
 					retJson = util::jsonPrint(removeNullMembers(m_compiler->assemblyJSON(contract)), m_options.formatting.json);
 
-				if (!m_options.output.dir.empty()) 
+				if (!m_options.output.dir.empty())
 				{
 					if (m_options.compiler.outputs.asm_)
 						createFile(m_compiler->filesystemFriendlyName(contract) + ".evm", ret);

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -1205,7 +1205,8 @@ void CommandLineInterface::outputCompilationResults()
 				if (m_options.compiler.outputs.asmJson)
 					retJson = util::jsonPrint(removeNullMembers(m_compiler->assemblyJSON(contract)), m_options.formatting.json);
 
-				if (!m_options.output.dir.empty()) {
+				if (!m_options.output.dir.empty()) 
+				{
 					if (m_options.compiler.outputs.asm_)
 						createFile(m_compiler->filesystemFriendlyName(contract) + ".evm", ret);
 					if (m_options.compiler.outputs.asmJson)

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -1198,16 +1198,21 @@ void CommandLineInterface::outputCompilationResults()
 			// do we need EVM assembly?
 			if (m_options.compiler.outputs.asm_ || m_options.compiler.outputs.asmJson)
 			{
-				std::string ret;
-				if (m_options.compiler.outputs.asmJson)
-					ret = util::jsonPrint(removeNullMembers(m_compiler->assemblyJSON(contract)), m_options.formatting.json);
-				else
+				std::string ret = "";
+				std::string retJson = "";
+				if (m_options.compiler.outputs.asm_)
 					ret = m_compiler->assemblyString(contract, m_fileReader.sourceUnits());
-
-				if (!m_options.output.dir.empty())
-					createFile(m_compiler->filesystemFriendlyName(contract) + (m_options.compiler.outputs.asmJson ? "_evm.json" : ".evm"), ret);
+				if (m_options.compiler.outputs.asmJson)
+					retJson = util::jsonPrint(removeNullMembers(m_compiler->assemblyJSON(contract)), m_options.formatting.json);
+				
+				if (!m_options.output.dir.empty()) {
+					if (m_options.compiler.outputs.asm_)
+						createFile(m_compiler->filesystemFriendlyName(contract) + ".evm", ret);
+					if (m_options.compiler.outputs.asmJson)	
+						createFile(m_compiler->filesystemFriendlyName(contract) + "_evm.json", retJson);
+				}
 				else
-					sout() << "EVM assembly:" << std::endl << ret << std::endl;
+					sout() << "EVM assembly:" << std::endl << ret << std::endl << retJson << std::endl;
 			}
 
 			if (m_options.compiler.estimateGas)

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -1204,11 +1204,11 @@ void CommandLineInterface::outputCompilationResults()
 					ret = m_compiler->assemblyString(contract, m_fileReader.sourceUnits());
 				if (m_options.compiler.outputs.asmJson)
 					retJson = util::jsonPrint(removeNullMembers(m_compiler->assemblyJSON(contract)), m_options.formatting.json);
-				
+
 				if (!m_options.output.dir.empty()) {
 					if (m_options.compiler.outputs.asm_)
 						createFile(m_compiler->filesystemFriendlyName(contract) + ".evm", ret);
-					if (m_options.compiler.outputs.asmJson)	
+					if (m_options.compiler.outputs.asmJson)
 						createFile(m_compiler->filesystemFriendlyName(contract) + "_evm.json", retJson);
 				}
 				else


### PR DESCRIPTION
Tiny change.
We were only accepting either asm output or asm-json. However, we could be able to chain options and generate both output.
Example : 

`echo 'contract C {}' | solc - --asm --asm-json`

```
--> <stdin>


======= <stdin>:C =======
EVM assembly:
    /* "<stdin>":0:13  contract C {} */
  mstore(0x40, 0x80)
  callvalue
  dup1
  iszero
  tag_1
  jumpi
  0x00
  dup1
  revert
tag_1:
  pop
  dataSize(sub_0)
  dup1
  dataOffset(sub_0)
  0x00
  codecopy
  0x00
  return
stop

sub_0: assembly {
        /* "<stdin>":0:13  contract C {} */
      mstore(0x40, 0x80)
      0x00
      dup1
      revert

    auxdata: 0xa2646970667358221220369f1c0adbfce56ae85ac3eac2be7e8a65b61677d90975b5d15fe0b7973ebf1764736f6c63782d302e382e32322d646576656c6f702e323032332e31302e32312b636f6d6d69742e64646230643839352e6d6f64005e
}

{".code":[{"begin":0,"end":13,"name":"PUSH","source":0,"value":"80"},{"begin":0,"end":13,"name":"PUSH","source":0,"value":"40"},{"begin":0,"end":13,"name":"MSTORE","source":0},{"begin":0,"end":13,"name":"CALLVALUE","source":0},{"begin":0,"end":13,"name":"DUP1","source":0},{"begin":0,"end":13,"name":"ISZERO","source":0},{"begin":0,"end":13,"name":"PUSH [tag]","source":0,"value":"1"},{"begin":0,"end":13,"name":"JUMPI","source":0},{"begin":0,"end":13,"name":"PUSH","source":0,"value":"0"},{"begin":0,"end":13,"name":"DUP1","source":0},{"begin":0,"end":13,"name":"REVERT","source":0},{"begin":0,"end":13,"name":"tag","source":0,"value":"1"},{"begin":0,"end":13,"name":"JUMPDEST","source":0},{"begin":0,"end":13,"name":"POP","source":0},{"begin":0,"end":13,"name":"PUSH #[$]","source":0,"value":"0000000000000000000000000000000000000000000000000000000000000000"},{"begin":0,"end":13,"name":"DUP1","source":0},{"begin":0,"end":13,"name":"PUSH [$]","source":0,"value":"0000000000000000000000000000000000000000000000000000000000000000"},{"begin":0,"end":13,"name":"PUSH","source":0,"value":"0"},{"begin":0,"end":13,"name":"CODECOPY","source":0},{"begin":0,"end":13,"name":"PUSH","source":0,"value":"0"},{"begin":0,"end":13,"name":"RETURN","source":0}],".data":{"0":{".auxdata":"a2646970667358221220369f1c0adbfce56ae85ac3eac2be7e8a65b61677d90975b5d15fe0b7973ebf1764736f6c63782d302e382e32322d646576656c6f702e323032332e31302e32312b636f6d6d69742e64646230643839352e6d6f64005e",".code":[{"begin":0,"end":13,"name":"PUSH","source":0,"value":"80"},{"begin":0,"end":13,"name":"PUSH","source":0,"value":"40"},{"begin":0,"end":13,"name":"MSTORE","source":0},{"begin":0,"end":13,"name":"PUSH","source":0,"value":"0"},{"begin":0,"end":13,"name":"DUP1","source":0},{"begin":0,"end":13,"name":"REVERT","source":0}]}},"sourceList":["<stdin>","#utility.yul"]}
```