### PR TITLE
docs: add the onlyBuyer modifier in function confirmPurchase()

### DIFF
--- a/docs/examples/safe-remote.rst
+++ b/docs/examples/safe-remote.rst
@@ -106,6 +106,7 @@ you can use state machine-like constructs inside a contract.
         /// is called.
         function confirmPurchase()
             external
+            onlyBuyer
             inState(State.Created)
             condition(msg.value == (2 * value))
             payable


### PR DESCRIPTION
in the `function confirmPurchase()`, the annotation said 'Confirm the purchase as buyer.' but it doesn't add the `onlyBuyer` modifier