### PR TITLE
Use type class as a sort for its type variable

### DIFF
--- a/libsolidity/experimental/analysis/TypeClassRegistration.cpp
+++ b/libsolidity/experimental/analysis/TypeClassRegistration.cpp
@@ -42,10 +42,7 @@ bool TypeClassRegistration::analyze(SourceUnit const& _sourceUnit)
 
 bool TypeClassRegistration::visit(TypeClassDefinition const& _typeClassDefinition)
 {
-	Type typeVar = m_typeSystem.freshTypeVariable({});
-
 	std::variant<TypeClass, std::string> typeClassOrError = m_typeSystem.declareTypeClass(
-		typeVar,
 		_typeClassDefinition.name(),
 		&_typeClassDefinition
 	);

--- a/libsolidity/experimental/analysis/TypeInference.cpp
+++ b/libsolidity/experimental/analysis/TypeInference.cpp
@@ -54,12 +54,7 @@ TypeInference::TypeInference(Analysis& _analysis):
 	TypeSystemHelpers helper{m_typeSystem};
 
 	auto declareBuiltinClass = [&](std::string _name, BuiltinClass _class) -> TypeClass {
-		Type type = m_typeSystem.freshTypeVariable({});
-		auto result = m_typeSystem.declareTypeClass(
-			type,
-			_name,
-			nullptr
-		);
+		auto result = m_typeSystem.declareTypeClass(_name, nullptr);
 		if (auto error = std::get_if<std::string>(&result))
 			solAssert(!error, *error);
 		TypeClass declaredClass = std::get<TypeClass>(result);

--- a/libsolidity/experimental/ast/TypeSystem.cpp
+++ b/libsolidity/experimental/ast/TypeSystem.cpp
@@ -127,7 +127,7 @@ TypeSystem::TypeSystem()
 				solAssert(false, _error);
 			},
 			[](TypeClass _class) -> TypeClass { return _class; }
-		}, declareTypeClass(freshVariable({}), _name, nullptr));
+		}, declareTypeClass(_name, nullptr, true /* _primitive */));
 	};
 
 	m_primitiveTypeClasses.emplace(PrimitiveClass::Type, declarePrimitiveClass("type"));
@@ -274,20 +274,18 @@ TypeConstructor TypeSystem::declareTypeConstructor(std::string _name, std::strin
 	return constructor;
 }
 
-std::variant<TypeClass, std::string> TypeSystem::declareTypeClass(Type _typeVariable, std::string _name, Declaration const* _declaration)
+std::variant<TypeClass, std::string> TypeSystem::declareTypeClass(std::string _name, Declaration const* _declaration, bool _primitive)
 {
-	TypeVariable const* typeVariable = std::get_if<TypeVariable>(&_typeVariable);
-	if (!typeVariable)
-		return "Invalid type variable.";
+	TypeClass typeClass{m_typeClasses.size()};
 
-	size_t index = m_typeClasses.size();
+	Type typeVariable = (_primitive ? freshVariable({{typeClass}}) : freshTypeVariable({{typeClass}}));
+	solAssert(std::holds_alternative<TypeVariable>(typeVariable));
+
 	m_typeClasses.emplace_back(TypeClassInfo{
-		_typeVariable,
+		typeVariable,
 		_name,
 		_declaration
 	});
-	TypeClass typeClass{index};
-
 	return typeClass;
 }
 

--- a/libsolidity/experimental/ast/TypeSystem.h
+++ b/libsolidity/experimental/ast/TypeSystem.h
@@ -149,7 +149,7 @@ public:
 		return constructorInfo(constructor(_typeConstructor));
 	}
 
-	std::variant<TypeClass, std::string> declareTypeClass(Type _typeVariable, std::string _name, Declaration const* _declaration);
+	std::variant<TypeClass, std::string> declareTypeClass(std::string _name, Declaration const* _declaration, bool _primitive = false);
 	[[nodiscard]] std::optional<std::string> instantiateClass(Type _instanceVariable, Arity _arity);
 
 	Type freshTypeVariable(Sort _sort);


### PR DESCRIPTION
Depends on #14635 (could be independent, but I want to be sure it passes its tests).

Extracted from #14606. Adds each type class to the sort of its type variable.