### PR TITLE
Assorted bugfixes for new analysis

### DIFF
--- a/libsolidity/experimental/analysis/DebugWarner.cpp
+++ b/libsolidity/experimental/analysis/DebugWarner.cpp
@@ -39,19 +39,12 @@ bool DebugWarner::analyze(ASTNode const& _astRoot)
 
 bool DebugWarner::visitNode(ASTNode const& _node)
 {
-	auto const& typeInferenceAnnotation = m_analysis.annotation<TypeInference>(_node);
-	if (typeInferenceAnnotation.type)
-	{
-		Type type = *typeInferenceAnnotation.type;
-		Sort sort = m_analysis.typeSystem().env().sort(type);
-		std::string sortString;
-		if (sort.classes.size() != 1 || *sort.classes.begin() != m_analysis.typeSystem().primitiveClass(PrimitiveClass::Type))
-			sortString = ":" + TypeSystemHelpers{m_analysis.typeSystem()}.sortToString(m_analysis.typeSystem().env().sort(type));
+	std::optional<Type> const& inferredType = m_analysis.annotation<TypeInference>(_node).type;
+	if (inferredType.has_value())
 		m_errorReporter.info(
 			4164_error,
 			_node.location(),
-			"Inferred type: " + TypeEnvironmentHelpers{m_analysis.typeSystem().env()}.typeToString(type) + sortString
+			"Inferred type: " + TypeEnvironmentHelpers{m_analysis.typeSystem().env()}.typeToString(*inferredType)
 		);
-	}
 	return true;
 }

--- a/libsolidity/experimental/ast/TypeSystem.cpp
+++ b/libsolidity/experimental/ast/TypeSystem.cpp
@@ -171,9 +171,10 @@ experimental::Type TypeSystem::freshTypeVariable(Sort _sort)
 
 std::vector<TypeEnvironment::UnificationFailure> TypeEnvironment::instantiate(TypeVariable _variable, Type _type)
 {
-	for (auto typeVar: TypeEnvironmentHelpers{*this}.typeVars(_type))
-		if (typeVar.index() == _variable.index())
-			return {UnificationFailure{RecursiveUnification{_variable, _type}}};
+	for (auto const& maybeTypeVar: TypeEnvironmentHelpers{*this}.typeVars(_type))
+		if (auto const* typeVar = std::get_if<TypeVariable>(&maybeTypeVar))
+			if (typeVar->index() == _variable.index())
+				return {UnificationFailure{RecursiveUnification{_variable, _type}}};
 	Sort typeSort = sort(_type);
 	if (!(_variable.sort() <= typeSort))
 	{

--- a/libsolidity/experimental/ast/TypeSystem.cpp
+++ b/libsolidity/experimental/ast/TypeSystem.cpp
@@ -49,10 +49,7 @@ std::vector<TypeEnvironment::UnificationFailure> TypeEnvironment::unify(Type _a,
 	std::visit(util::GenericVisitor{
 		[&](TypeVariable _left, TypeVariable _right) {
 			if (_left.index() == _right.index())
-			{
-				if (_left.sort() != _right.sort())
-					unificationFailure();
-			}
+				solAssert(_left.sort() == _right.sort());
 			else
 			{
 				if (_left.sort() <= _right.sort())

--- a/libsolidity/experimental/ast/TypeSystem.cpp
+++ b/libsolidity/experimental/ast/TypeSystem.cpp
@@ -154,7 +154,7 @@ TypeSystem::TypeSystem()
 	Sort typeSort{{classType}};
 	m_typeConstructors.at(m_primitiveTypeConstructors.at(PrimitiveType::TypeFunction).m_index).arities = {Arity{std::vector<Sort>{{typeSort},{typeSort}}, classType}};
 	m_typeConstructors.at(m_primitiveTypeConstructors.at(PrimitiveType::Function).m_index).arities = {Arity{std::vector<Sort>{{typeSort, typeSort}}, classType}};
-	m_typeConstructors.at(m_primitiveTypeConstructors.at(PrimitiveType::Function).m_index).arities = {Arity{std::vector<Sort>{{typeSort, typeSort}}, classType}};
+	m_typeConstructors.at(m_primitiveTypeConstructors.at(PrimitiveType::Itself).m_index).arities = {Arity{std::vector<Sort>{{typeSort, typeSort}}, classType}};
 }
 
 experimental::Type TypeSystem::freshVariable(Sort _sort)

--- a/libsolidity/experimental/ast/TypeSystem.cpp
+++ b/libsolidity/experimental/ast/TypeSystem.cpp
@@ -307,7 +307,7 @@ experimental::Type TypeSystem::type(TypeConstructor _constructor, std::vector<Ty
 
 experimental::Type TypeEnvironment::fresh(Type _type)
 {
-	std::unordered_map<uint64_t, Type> mapping;
+	std::unordered_map<size_t, Type> mapping;
 	auto freshImpl = [&](Type _type, auto _recurse) -> Type {
 		return std::visit(util::GenericVisitor{
 			[&](TypeConstant const& _type) -> Type {

--- a/libsolidity/experimental/ast/TypeSystem.cpp
+++ b/libsolidity/experimental/ast/TypeSystem.cpp
@@ -195,19 +195,19 @@ experimental::Type TypeEnvironment::resolve(Type _type) const
 experimental::Type TypeEnvironment::resolveRecursive(Type _type) const
 {
 	return std::visit(util::GenericVisitor{
-		[&](TypeConstant const& _type) -> Type {
+		[&](TypeConstant const& _typeConstant) -> Type {
 			return TypeConstant{
-				_type.constructor,
-				_type.arguments | ranges::views::transform([&](Type _argType) {
+				_typeConstant.constructor,
+				_typeConstant.arguments | ranges::views::transform([&](Type const& _argType) {
 					return resolveRecursive(_argType);
 				}) | ranges::to<std::vector<Type>>
 			};
 		},
-		[&](TypeVariable const&) -> Type {
-			return _type;
+		[](TypeVariable const& _typeVar) -> Type {
+			return _typeVar;
 		},
-		[&](std::monostate) -> Type {
-			return _type;
+		[](std::monostate _nothing) -> Type {
+			return _nothing;
 		}
 	}, resolve(_type));
 }


### PR DESCRIPTION
Moved here from my fixups into `newAnalysis`:
1. [Two `Function` types being created, instead of `Function` and `Itself`](https://github.com/ethereum/solidity/pull/14510#pullrequestreview-1650886537).
1. [`resolveRecursive()` not resolving type variables](https://github.com/ethereum/solidity/pull/14510#discussion_r1358883716).
1. [`index()` being used on the `Type` variant rather than `TypeVariable`](https://github.com/ethereum/solidity/pull/14510#pullrequestreview-1674931569)
    - Should were rename `index` to `id`? The current name seems very prone to this kind of error.
1. [Sorts being printed twice by `DebugWarner`](https://github.com/ethereum/solidity/pull/14510#pullrequestreview-1677322514).
1. [Unnecessary sort comparison in `unify()` - should have been an assert.](https://github.com/ethereum/solidity/pull/14510#pullrequestreview-1664238270)
1. `uint64_t` instead of `size_t` used for the index in `TypeEnvironment::fresh()`.
    - This is the only use I found and it's `size_t` everywhere else. This is part of compiler output though, so a portable type like `uint64_t` is probably a better choice though. Should we switch?