### PR TITLE
Patch codegen issues enough to make tests pass in experimental analysis

### DIFF
--- a/libsolidity/experimental/codegen/IRGeneratorForStatements.cpp
+++ b/libsolidity/experimental/codegen/IRGeneratorForStatements.cpp
@@ -323,7 +323,10 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 	functionType = m_context.env->resolveRecursive(functionType);
 	m_context.enqueueFunctionDefinition(functionDefinition, functionType);
 	// TODO: account for return stack size
-	m_code << "let " << IRNames::localVariable(_functionCall) << " := " << IRNames::function(*m_context.env, *functionDefinition, functionType) << "(";
+	solAssert(!functionDefinition->returnParameterList());
+	if (functionDefinition->experimentalReturnExpression())
+		m_code << "let " << IRNames::localVariable(_functionCall) << " := ";
+	m_code << IRNames::function(*m_context.env, *functionDefinition, functionType) << "(";
 	auto const& arguments = _functionCall.arguments();
 	if (arguments.size() > 1)
 		for (auto arg: arguments | ranges::views::drop_last(1))

--- a/libsolidity/experimental/codegen/IRGeneratorForStatements.cpp
+++ b/libsolidity/experimental/codegen/IRGeneratorForStatements.cpp
@@ -299,6 +299,7 @@ bool IRGeneratorForStatements::visit(ElementaryTypeNameExpression const&)
 void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 {
 	Type functionType = type(_functionCall.expression());
+	solUnimplementedAssert(m_expressionDeclaration.count(&_functionCall.expression()) != 0, "No support for calling functions pointers yet.");
 	auto declaration = m_expressionDeclaration.at(&_functionCall.expression());
 	if (auto builtin = std::get_if<Builtins>(&declaration))
 	{

--- a/test/libsolidity/syntaxTests/experimental/builtin/builtin_type_definition.sol
+++ b/test/libsolidity/syntaxTests/experimental/builtin/builtin_type_definition.sol
@@ -33,6 +33,7 @@ contract C {
 // EVMVersion: >=constantinople
 // compileViaYul: true
 // ----
+// UnimplementedFeatureError: No support for calling functions pointers yet.
 // Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
 // Info 4164: (31-61): Inferred type: void
 // Info 4164: (63-93): Inferred type: bool


### PR DESCRIPTION
Merging this should let us finally get rid of the hack that disables the codegen in syntax tests. Note that the codegen won't actually run until we remove the hack commit from `newAnalysis` branch.

The PR patches two issues that prevent all current test cases from pass through codegen successfully:
1. `builtin_type_definition.sol`: Calls via function pointers seem unimplemented. I added a proper `solUnimplementedAssert()` against that.
1. `import_and_call_stdlib_function.sol`: Codegen unconditionally assigns function result to a variable even if the function does not return anything (which is invalid Yul). Added an `if` to skip that for functions without return parameters.

These are not proper fixes, but should be good enough until we address the issues properly. Especially the second one should be addressed by #14620.

