### PR TITLE
Improve readability of voted check in Voting example

### DIFF
--- a/docs/examples/voting.rst
+++ b/docs/examples/voting.rst
@@ -98,7 +98,7 @@ of votes.
                 "Only chairperson can give right to vote."
             );
             require(
-                !voters[voter].voted,
+                voters[voter].voted == false,
                 "The voter already voted."
             );
             require(voters[voter].weight == 0);


### PR DESCRIPTION
Switch to an explicit comparison for clearer understanding and reduce ambiguity.