### PR TITLE
`forall` quantifier and mandatory declarations for type variables in new analysis

### DIFF
--- a/liblangutil/Token.h
+++ b/liblangutil/Token.h
@@ -276,6 +276,7 @@ namespace solidity::langutil
 	K(Itself, "itself", 0)                                             \
 	K(StaticAssert, "static_assert", 0)                                \
 	K(Builtin, "__builtin", 0)                                         \
+	K(ForAll, "forall", 0)                                             \
 	T(ExperimentalEnd, nullptr, 0) /* used as experimental enum end marker */ \
 	\
 	/* Illegal token - not able to scan. */                            \

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -2625,6 +2625,38 @@ private:
 	SourceLocation m_nameParameterLocation;
 };
 
+// TODO: NatSpec used on the quantifier should be recognized as applying to the function.
+class ForAllQuantifier: public ASTNode, public Scopable, public ScopeOpener
+{
+public:
+	ForAllQuantifier(
+		int64_t _id,
+		SourceLocation _location,
+		ASTPointer<ParameterList> _typeVariableDeclarations,
+		ASTPointer<FunctionDefinition> _quantifiedDeclaration
+	):
+		ASTNode(_id, std::move(_location)),
+		m_typeVariableDeclarations(std::move(_typeVariableDeclarations)),
+		m_quantifiedDeclaration(std::move(_quantifiedDeclaration))
+	{
+		solAssert(m_typeVariableDeclarations);
+		solAssert(m_quantifiedDeclaration);
+	}
+
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
+	ForAllQuantifierAnnotation& annotation() const override { return initAnnotation<ForAllQuantifierAnnotation>(); }
+
+	bool experimentalSolidityOnly() const override { return true; }
+
+	ParameterList const& typeVariableDeclarations() const { return *m_typeVariableDeclarations; }
+	FunctionDefinition const& quantifiedDeclaration() const { return *m_quantifiedDeclaration; }
+
+private:
+	ASTPointer<ParameterList> m_typeVariableDeclarations;
+	ASTPointer<FunctionDefinition> m_quantifiedDeclaration;
+};
+
 /// @}
 
 }

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -350,6 +350,10 @@ struct FunctionCallAnnotation: ExpressionAnnotation
 struct TypeClassDefinitionAnnotation: TypeDeclarationAnnotation, StructurallyDocumentedAnnotation
 {
 };
+
+struct ForAllQuantifierAnnotation: StatementAnnotation, ScopableAnnotation
+{
+};
 /// @}
 
 }

--- a/libsolidity/ast/ASTForward.h
+++ b/libsolidity/ast/ASTForward.h
@@ -106,6 +106,7 @@ class TypeClassInstantiation;
 class TypeClassName;
 class TypeDefinition;
 class Builtin;
+class ForAllQuantifier;
 /// @}
 
 class VariableScope;

--- a/libsolidity/ast/ASTVisitor.h
+++ b/libsolidity/ast/ASTVisitor.h
@@ -116,6 +116,7 @@ public:
 	virtual bool visit(TypeDefinition& _node) { return visitNode(_node); }
 	virtual bool visit(TypeClassName& _node) { return visitNode(_node); }
 	virtual bool visit(Builtin& _node) { return visitNode(_node); }
+	virtual bool visit(ForAllQuantifier& _node) { return visitNode(_node); }
 	///  @}
 
 	virtual void endVisit(SourceUnit& _node) { endVisitNode(_node); }
@@ -180,6 +181,7 @@ public:
 	virtual void endVisit(TypeDefinition& _node) { endVisitNode(_node); }
 	virtual void endVisit(TypeClassName& _node) { endVisitNode(_node); }
 	virtual void endVisit(Builtin& _node) { endVisitNode(_node); }
+	virtual void endVisit(ForAllQuantifier& _node) { endVisitNode(_node); }
 	///  @}
 
 protected:
@@ -266,6 +268,7 @@ public:
 	virtual bool visit(TypeDefinition const& _node) { return visitNode(_node); }
 	virtual bool visit(TypeClassName const& _node) { return visitNode(_node); }
 	virtual bool visit(Builtin const& _node) { return visitNode(_node); }
+	virtual bool visit(ForAllQuantifier const& _node) { return visitNode(_node); }
 	///  @}
 
 	virtual void endVisit(SourceUnit const& _node) { endVisitNode(_node); }
@@ -330,6 +333,7 @@ public:
 	virtual void endVisit(TypeDefinition const& _node) { endVisitNode(_node); }
 	virtual void endVisit(TypeClassName const& _node) { endVisitNode(_node); }
 	virtual void endVisit(Builtin const& _node) { endVisitNode(_node); }
+	virtual void endVisit(ForAllQuantifier const& _node) { endVisitNode(_node); }
 	///  @}
 
 protected:

--- a/libsolidity/ast/AST_accept.h
+++ b/libsolidity/ast/AST_accept.h
@@ -1140,6 +1140,26 @@ void Builtin::accept(ASTConstVisitor& _visitor) const
 	_visitor.visit(*this);
 	_visitor.endVisit(*this);
 }
+
+void ForAllQuantifier::accept(ASTVisitor& _visitor)
+{
+	if (_visitor.visit(*this))
+	{
+		m_typeVariableDeclarations->accept(_visitor);
+		m_quantifiedDeclaration->accept(_visitor);
+	}
+	_visitor.endVisit(*this);
+}
+
+void ForAllQuantifier::accept(ASTConstVisitor& _visitor) const
+{
+	if (_visitor.visit(*this))
+	{
+		m_typeVariableDeclarations->accept(_visitor);
+		m_quantifiedDeclaration->accept(_visitor);
+	}
+	_visitor.endVisit(*this);
+}
 /// @}
 
 }

--- a/libsolidity/experimental/analysis/TypeInference.cpp
+++ b/libsolidity/experimental/analysis/TypeInference.cpp
@@ -129,6 +129,19 @@ bool TypeInference::analyze(SourceUnit const& _sourceUnit)
 	return !m_errorReporter.hasErrors();
 }
 
+bool TypeInference::visit(ForAllQuantifier const& _quantifier)
+{
+	solAssert(m_expressionContext == ExpressionContext::Term);
+
+	{
+		ScopedSaveAndRestore expressionContext{m_expressionContext, ExpressionContext::Type};
+		_quantifier.typeVariableDeclarations().accept(*this);
+	}
+
+	_quantifier.quantifiedDeclaration().accept(*this);
+	return false;
+}
+
 bool TypeInference::visit(FunctionDefinition const& _functionDefinition)
 {
 	solAssert(m_expressionContext == ExpressionContext::Term);

--- a/libsolidity/experimental/analysis/TypeInference.cpp
+++ b/libsolidity/experimental/analysis/TypeInference.cpp
@@ -580,9 +580,11 @@ bool TypeInference::visit(Identifier const& _identifier)
 		solAssert(false);
 		break;
 	case ExpressionContext::Type:
-		// TODO: register free type variable name!
+		m_errorReporter.typeError(5934_error, _identifier.location(), "Undeclared type variable.");
+
+		// Assign it a fresh variable anyway just so that we can continue analysis.
 		identifierAnnotation.type = m_typeSystem.freshTypeVariable({});
-		return false;
+		break;
 	case ExpressionContext::Sort:
 		// TODO: error handling
 		solAssert(false);

--- a/libsolidity/experimental/analysis/TypeInference.h
+++ b/libsolidity/experimental/analysis/TypeInference.h
@@ -56,6 +56,7 @@ public:
 	void endVisit(VariableDeclarationStatement const& _variableDeclarationStatement) override;
 	bool visit(VariableDeclaration const& _variableDeclaration) override;
 
+	bool visit(ForAllQuantifier const& _forAllQuantifier) override;
 	bool visit(FunctionDefinition const& _functionDefinition) override;
 	void endVisit(FunctionDefinition const& _functionDefinition) override;
 	bool visit(ParameterList const&) override { return true; }

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -627,7 +627,7 @@ Parser::FunctionHeaderParserResult Parser::parseFunctionHeader(bool _isStateVari
 	return result;
 }
 
-ASTPointer<ASTNode> Parser::parseFunctionDefinition(bool _freeFunction, bool _allowBody)
+ASTPointer<FunctionDefinition> Parser::parseFunctionDefinition(bool _freeFunction, bool _allowBody)
 {
 	RecursionGuard recursionGuard(*this);
 	ASTNodeFactory nodeFactory(*this);

--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -102,6 +102,7 @@ private:
 	ASTPointer<OverrideSpecifier> parseOverrideSpecifier();
 	StateMutability parseStateMutability();
 	FunctionHeaderParserResult parseFunctionHeader(bool _isStateVariable);
+	ASTPointer<ForAllQuantifier> parseQuantifiedFunctionDefinition();
 	ASTPointer<FunctionDefinition> parseFunctionDefinition(bool _freeFunction = false, bool _allowBody = true);
 	ASTPointer<StructDefinition> parseStructDefinition();
 	ASTPointer<EnumDefinition> parseEnumDefinition();

--- a/libsolidity/parsing/Parser.h
+++ b/libsolidity/parsing/Parser.h
@@ -102,7 +102,7 @@ private:
 	ASTPointer<OverrideSpecifier> parseOverrideSpecifier();
 	StateMutability parseStateMutability();
 	FunctionHeaderParserResult parseFunctionHeader(bool _isStateVariable);
-	ASTPointer<ASTNode> parseFunctionDefinition(bool _freeFunction = false, bool _allowBody = true);
+	ASTPointer<FunctionDefinition> parseFunctionDefinition(bool _freeFunction = false, bool _allowBody = true);
 	ASTPointer<StructDefinition> parseStructDefinition();
 	ASTPointer<EnumDefinition> parseEnumDefinition();
 	ASTPointer<UserDefinedValueTypeDefinition> parseUserDefinedValueTypeDefinition();

--- a/test/libsolidity/syntaxTests/experimental/forall/undeclared_type_variable_in_function.sol
+++ b/test/libsolidity/syntaxTests/experimental/forall/undeclared_type_variable_in_function.sol
@@ -1,0 +1,17 @@
+pragma experimental solidity;
+
+type T(X);
+
+function f(p: P, q: T(Q)) {
+    let r: (R, S);
+    let s: S;
+}
+// ====
+// EVMVersion: >=constantinople
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError 5934: (57-58): Undeclared type variable.
+// TypeError 5934: (65-66): Undeclared type variable.
+// TypeError 5934: (83-84): Undeclared type variable.
+// TypeError 5934: (86-87): Undeclared type variable.
+// TypeError 5934: (101-102): Undeclared type variable.

--- a/test/libsolidity/syntaxTests/experimental/forall/undeclared_type_variable_in_quantified_function.sol
+++ b/test/libsolidity/syntaxTests/experimental/forall/undeclared_type_variable_in_quantified_function.sol
@@ -1,0 +1,12 @@
+pragma experimental solidity;
+
+forall A
+function f(b: B) {
+    let c: C;
+}
+// ====
+// EVMVersion: >=constantinople
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError 5934: (54-55): Undeclared type variable.
+// TypeError 5934: (70-71): Undeclared type variable.

--- a/test/libsolidity/syntaxTests/experimental/forall/undeclared_type_variable_in_type_class.sol
+++ b/test/libsolidity/syntaxTests/experimental/forall/undeclared_type_variable_in_type_class.sol
@@ -1,0 +1,17 @@
+pragma experimental solidity;
+
+type T(X);
+
+class Self: C {
+    function f(self: Self);
+}
+
+instantiation T(Y): C {
+    function f(self: T(Z)) {}
+}
+// ====
+// EVMVersion: >=constantinople
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError 5934: (137-138): Undeclared type variable.
+// TypeError 7428: (90-145): Instantiation function 'f' does not match the declaration in the type class (T('bc:type) -> () != T('y:type) -> ()).

--- a/test/libsolidity/syntaxTests/experimental/inference/polymorphic_function_call.sol
+++ b/test/libsolidity/syntaxTests/experimental/inference/polymorphic_function_call.sol
@@ -3,6 +3,7 @@ pragma experimental solidity;
 type T;
 type U(A);
 
+forall (X, Y)
 function f(x, y: X, z: U(Y)) {}
 
 function run(a: T, b: U(T), c: U(U(T))) {
@@ -18,36 +19,39 @@ function run(a: T, b: U(T), c: U(U(T))) {
 // Info 4164: (39-49): Inferred type: tfun('t:type, U('t:type))
 // Info 4164: (45-48): Inferred type: 't:type
 // Info 4164: (46-47): Inferred type: 't:type
-// Info 4164: (51-82): Inferred type: ('w:type, 'x:type, U('z:type)) -> ()
-// Info 4164: (61-79): Inferred type: ('w:type, 'x:type, U('z:type))
-// Info 4164: (62-63): Inferred type: 'w:type
-// Info 4164: (65-69): Inferred type: 'x:type
-// Info 4164: (68-69): Inferred type: 'x:type
-// Info 4164: (71-78): Inferred type: U('z:type)
-// Info 4164: (74-78): Inferred type: U('z:type)
-// Info 4164: (74-75): Inferred type: tfun('z:type, U('z:type))
-// Info 4164: (76-77): Inferred type: 'z:type
-// Info 4164: (84-159): Inferred type: (T, U(T), U(U(T))) -> ()
-// Info 4164: (96-123): Inferred type: (T, U(T), U(U(T)))
-// Info 4164: (97-101): Inferred type: T
-// Info 4164: (100-101): Inferred type: T
-// Info 4164: (103-110): Inferred type: U(T)
-// Info 4164: (106-110): Inferred type: U(T)
-// Info 4164: (106-107): Inferred type: tfun(T, U(T))
-// Info 4164: (108-109): Inferred type: T
-// Info 4164: (112-122): Inferred type: U(U(T))
-// Info 4164: (115-122): Inferred type: U(U(T))
-// Info 4164: (115-116): Inferred type: tfun(U(T), U(U(T)))
-// Info 4164: (117-121): Inferred type: U(T)
-// Info 4164: (117-118): Inferred type: tfun(T, U(T))
-// Info 4164: (119-120): Inferred type: T
-// Info 4164: (130-140): Inferred type: ()
-// Info 4164: (130-131): Inferred type: (T, T, U(T)) -> ()
-// Info 4164: (132-133): Inferred type: T
-// Info 4164: (135-136): Inferred type: T
-// Info 4164: (138-139): Inferred type: U(T)
-// Info 4164: (146-156): Inferred type: ()
-// Info 4164: (146-147): Inferred type: (U(T), U(T), U(U(T))) -> ()
-// Info 4164: (148-149): Inferred type: U(T)
-// Info 4164: (151-152): Inferred type: U(T)
-// Info 4164: (154-155): Inferred type: U(U(T))
+// Info 4164: (58-64): Inferred type: ('u:type, 'v:type)
+// Info 4164: (59-60): Inferred type: 'u:type
+// Info 4164: (62-63): Inferred type: 'v:type
+// Info 4164: (65-96): Inferred type: ('y:type, 'u:type, U('v:type)) -> ()
+// Info 4164: (75-93): Inferred type: ('y:type, 'u:type, U('v:type))
+// Info 4164: (76-77): Inferred type: 'y:type
+// Info 4164: (79-83): Inferred type: 'u:type
+// Info 4164: (82-83): Inferred type: 'u:type
+// Info 4164: (85-92): Inferred type: U('v:type)
+// Info 4164: (88-92): Inferred type: U('v:type)
+// Info 4164: (88-89): Inferred type: tfun('v:type, U('v:type))
+// Info 4164: (90-91): Inferred type: 'v:type
+// Info 4164: (98-173): Inferred type: (T, U(T), U(U(T))) -> ()
+// Info 4164: (110-137): Inferred type: (T, U(T), U(U(T)))
+// Info 4164: (111-115): Inferred type: T
+// Info 4164: (114-115): Inferred type: T
+// Info 4164: (117-124): Inferred type: U(T)
+// Info 4164: (120-124): Inferred type: U(T)
+// Info 4164: (120-121): Inferred type: tfun(T, U(T))
+// Info 4164: (122-123): Inferred type: T
+// Info 4164: (126-136): Inferred type: U(U(T))
+// Info 4164: (129-136): Inferred type: U(U(T))
+// Info 4164: (129-130): Inferred type: tfun(U(T), U(U(T)))
+// Info 4164: (131-135): Inferred type: U(T)
+// Info 4164: (131-132): Inferred type: tfun(T, U(T))
+// Info 4164: (133-134): Inferred type: T
+// Info 4164: (144-154): Inferred type: ()
+// Info 4164: (144-145): Inferred type: (T, T, U(T)) -> ()
+// Info 4164: (146-147): Inferred type: T
+// Info 4164: (149-150): Inferred type: T
+// Info 4164: (152-153): Inferred type: U(T)
+// Info 4164: (160-170): Inferred type: ()
+// Info 4164: (160-161): Inferred type: (U(T), U(T), U(U(T))) -> ()
+// Info 4164: (162-163): Inferred type: U(T)
+// Info 4164: (165-166): Inferred type: U(T)
+// Info 4164: (168-169): Inferred type: U(U(T))

--- a/test/libsolidity/syntaxTests/experimental/inference/polymorphic_type.sol
+++ b/test/libsolidity/syntaxTests/experimental/inference/polymorphic_type.sol
@@ -7,6 +7,7 @@ type V;
 class Self: C {}
 class Self: D {}
 
+forall (X, Y, Z)
 function run() {
     let x: T(U, X, Z: C);
     let y: T(V, Y, Z: D);
@@ -27,21 +28,25 @@ function run() {
 // Info 4164: (71-75): Inferred type: 'k:(type, C)
 // Info 4164: (82-98): Inferred type: D
 // Info 4164: (88-92): Inferred type: 'l:(type, D)
-// Info 4164: (100-170): Inferred type: () -> ()
-// Info 4164: (112-114): Inferred type: ()
-// Info 4164: (125-141): Inferred type: T(U, ?bh:type, ?bj:(type, C))
-// Info 4164: (128-141): Inferred type: T(U, ?bh:type, ?bj:(type, C))
-// Info 4164: (128-129): Inferred type: tfun((U, ?bh:type, ?bj:(type, C)), T(U, ?bh:type, ?bj:(type, C)))
-// Info 4164: (130-131): Inferred type: U
-// Info 4164: (133-134): Inferred type: ?bh:type
-// Info 4164: (136-140): Inferred type: ?bj:(type, C)
-// Info 4164: (136-137): Inferred type: ?bj:(type, C)
-// Info 4164: (139-140): Inferred type: ?bj:(type, C)
-// Info 4164: (151-167): Inferred type: T(V, ?bo:type, ?bq:(type, D))
-// Info 4164: (154-167): Inferred type: T(V, ?bo:type, ?bq:(type, D))
-// Info 4164: (154-155): Inferred type: tfun((V, ?bo:type, ?bq:(type, D)), T(V, ?bo:type, ?bq:(type, D)))
-// Info 4164: (156-157): Inferred type: V
-// Info 4164: (159-160): Inferred type: ?bo:type
-// Info 4164: (162-166): Inferred type: ?bq:(type, D)
-// Info 4164: (162-163): Inferred type: ?bq:(type, D)
-// Info 4164: (165-166): Inferred type: ?bq:(type, D)
+// Info 4164: (107-116): Inferred type: (?bc:type, ?bd:type, ?bq:(type, C, D))
+// Info 4164: (108-109): Inferred type: ?bc:type
+// Info 4164: (111-112): Inferred type: ?bd:type
+// Info 4164: (114-115): Inferred type: ?bq:(type, C, D)
+// Info 4164: (117-187): Inferred type: () -> ()
+// Info 4164: (129-131): Inferred type: ()
+// Info 4164: (142-158): Inferred type: T(U, ?bc:type, ?bq:(type, C, D))
+// Info 4164: (145-158): Inferred type: T(U, ?bc:type, ?bq:(type, C, D))
+// Info 4164: (145-146): Inferred type: tfun((U, ?bc:type, ?bq:(type, C, D)), T(U, ?bc:type, ?bq:(type, C, D)))
+// Info 4164: (147-148): Inferred type: U
+// Info 4164: (150-151): Inferred type: ?bc:type
+// Info 4164: (153-157): Inferred type: ?bq:(type, C, D)
+// Info 4164: (153-154): Inferred type: ?bq:(type, C, D)
+// Info 4164: (156-157): Inferred type: ?bq:(type, C, D)
+// Info 4164: (168-184): Inferred type: T(V, ?bd:type, ?bq:(type, C, D))
+// Info 4164: (171-184): Inferred type: T(V, ?bd:type, ?bq:(type, C, D))
+// Info 4164: (171-172): Inferred type: tfun((V, ?bd:type, ?bq:(type, C, D)), T(V, ?bd:type, ?bq:(type, C, D)))
+// Info 4164: (173-174): Inferred type: V
+// Info 4164: (176-177): Inferred type: ?bd:type
+// Info 4164: (179-183): Inferred type: ?bq:(type, C, D)
+// Info 4164: (179-180): Inferred type: ?bq:(type, C, D)
+// Info 4164: (182-183): Inferred type: ?bq:(type, C, D)

--- a/test/libsolidity/syntaxTests/experimental/inference/type_variable_multi_use_function_parameter_and_return.sol
+++ b/test/libsolidity/syntaxTests/experimental/inference/type_variable_multi_use_function_parameter_and_return.sol
@@ -1,0 +1,16 @@
+pragma experimental solidity;
+
+type T;
+type U;
+
+forall X
+function f(x: X) -> X {}
+
+function test(t: T, u: U) {
+    t = f(u);
+}
+// ====
+// EVMVersion: >=constantinople
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError 8456: (115-123): Cannot unify T and U.

--- a/test/libsolidity/syntaxTests/experimental/inference/type_variable_multi_use_function_parameters.sol
+++ b/test/libsolidity/syntaxTests/experimental/inference/type_variable_multi_use_function_parameters.sol
@@ -1,0 +1,16 @@
+pragma experimental solidity;
+
+type T;
+type U;
+
+forall X
+function f(x: X, y: X) {}
+
+function test(t: T, u: U) {
+    f(t, u);
+}
+// ====
+// EVMVersion: >=constantinople
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
+// TypeError 8456: (116-123): Cannot unify T and U.

--- a/test/libsolidity/syntaxTests/experimental/parsing/forall_free_function.sol
+++ b/test/libsolidity/syntaxTests/experimental/parsing/forall_free_function.sol
@@ -1,0 +1,27 @@
+pragma experimental solidity;
+
+forall (A)
+function f(a: A) {}
+
+forall (A, B)
+function g(a: A, b: B) {}
+// ====
+// EVMVersion: >=constantinople
+// compileViaYul: true
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
+// Info 4164: (38-41): Inferred type: 's:type
+// Info 4164: (39-40): Inferred type: 's:type
+// Info 4164: (42-61): Inferred type: 's:type -> ()
+// Info 4164: (52-58): Inferred type: 's:type
+// Info 4164: (53-57): Inferred type: 's:type
+// Info 4164: (56-57): Inferred type: 's:type
+// Info 4164: (70-76): Inferred type: ('v:type, 'w:type)
+// Info 4164: (71-72): Inferred type: 'v:type
+// Info 4164: (74-75): Inferred type: 'w:type
+// Info 4164: (77-102): Inferred type: ('v:type, 'w:type) -> ()
+// Info 4164: (87-99): Inferred type: ('v:type, 'w:type)
+// Info 4164: (88-92): Inferred type: 'v:type
+// Info 4164: (91-92): Inferred type: 'v:type
+// Info 4164: (94-98): Inferred type: 'w:type
+// Info 4164: (97-98): Inferred type: 'w:type

--- a/test/libsolidity/syntaxTests/experimental/parsing/forall_free_function_no_type_var.sol
+++ b/test/libsolidity/syntaxTests/experimental/parsing/forall_free_function_no_type_var.sol
@@ -1,0 +1,14 @@
+pragma experimental solidity;
+
+forall ()
+function f(x: ()) {}
+// ====
+// EVMVersion: >=constantinople
+// compileViaYul: true
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
+// Info 4164: (38-40): Inferred type: ()
+// Info 4164: (41-61): Inferred type: () -> ()
+// Info 4164: (51-58): Inferred type: ()
+// Info 4164: (52-57): Inferred type: ()
+// Info 4164: (55-57): Inferred type: ()

--- a/test/libsolidity/syntaxTests/experimental/parsing/forall_free_function_with_sorts.sol
+++ b/test/libsolidity/syntaxTests/experimental/parsing/forall_free_function_with_sorts.sol
@@ -1,0 +1,43 @@
+pragma experimental solidity;
+
+class Self: Class1 {}
+class Self: Class2 {}
+
+forall (A: (Class1, Class2), B: Class1)
+function f(a: A: Class1, b: B: Class1) {}
+
+forall A: Class1
+function g(a: A) {}
+// ====
+// EVMVersion: >=constantinople
+// compileViaYul: true
+// ----
+// Warning 2264: (0-29): Experimental features are turned on. Do not use experimental features on live deployments.
+// Info 4164: (31-52): Inferred type: Class1
+// Info 4164: (37-41): Inferred type: 'k:(type, Class1)
+// Info 4164: (53-74): Inferred type: Class2
+// Info 4164: (59-63): Inferred type: 'l:(type, Class2)
+// Info 4164: (83-115): Inferred type: ('ba:(type, Class1, Class2), 'bg:(type, Class1))
+// Info 4164: (84-103): Inferred type: 'ba:(type, Class1, Class2)
+// Info 4164: (87-103): Inferred type: 'ba:(type, Class1, Class2)
+// Info 4164: (88-94): Inferred type: 'ba:(type, Class1, Class2)
+// Info 4164: (96-102): Inferred type: 'ba:(type, Class1, Class2)
+// Info 4164: (105-114): Inferred type: 'bg:(type, Class1)
+// Info 4164: (108-114): Inferred type: 'bg:(type, Class1)
+// Info 4164: (116-157): Inferred type: ('ba:(type, Class1, Class2), 'bg:(type, Class1)) -> ()
+// Info 4164: (126-154): Inferred type: ('ba:(type, Class1, Class2), 'bg:(type, Class1))
+// Info 4164: (127-139): Inferred type: 'ba:(type, Class1, Class2)
+// Info 4164: (130-139): Inferred type: 'ba:(type, Class1, Class2)
+// Info 4164: (130-131): Inferred type: 'ba:(type, Class1, Class2)
+// Info 4164: (133-139): Inferred type: 'ba:(type, Class1, Class2)
+// Info 4164: (141-153): Inferred type: 'bg:(type, Class1)
+// Info 4164: (144-153): Inferred type: 'bg:(type, Class1)
+// Info 4164: (144-145): Inferred type: 'bg:(type, Class1)
+// Info 4164: (147-153): Inferred type: 'bg:(type, Class1)
+// Info 4164: (166-175): Inferred type: 'bi:(type, Class1)
+// Info 4164: (166-175): Inferred type: 'bi:(type, Class1)
+// Info 4164: (169-175): Inferred type: 'bi:(type, Class1)
+// Info 4164: (176-195): Inferred type: 'bi:(type, Class1) -> ()
+// Info 4164: (186-192): Inferred type: 'bi:(type, Class1)
+// Info 4164: (187-191): Inferred type: 'bi:(type, Class1)
+// Info 4164: (190-191): Inferred type: 'bi:(type, Class1)

--- a/test/libsolidity/syntaxTests/experimental/parsing/forall_type_class.sol
+++ b/test/libsolidity/syntaxTests/experimental/parsing/forall_type_class.sol
@@ -1,0 +1,8 @@
+pragma experimental solidity;
+
+forall (A, B)
+class Self: C {}
+// ====
+// EVMVersion: >=constantinople
+// ----
+// ParserError 5709: (45-50): Expected a function definition.

--- a/test/libsolidity/syntaxTests/experimental/parsing/forall_type_class_instantiation.sol
+++ b/test/libsolidity/syntaxTests/experimental/parsing/forall_type_class_instantiation.sol
@@ -1,0 +1,12 @@
+pragma experimental solidity;
+
+type T;
+
+class Self: C {}
+
+forall (A, B)
+instantiation T: C {}
+// ====
+// EVMVersion: >=constantinople
+// ----
+// ParserError 5709: (72-85): Expected a function definition.


### PR DESCRIPTION
~Depends on #14655.~ Merged.
Fixes #14570.

This PR introduces the new `forall` quantifier, which can be used to declare type variables used by a function.

Currently it's usable only on free functions. We may want to consider using it for types and instantiations as well, but those already allow declaring variables and I did not touch their syntax. We may also want to allow it inside blocks to get let-polymorphism, but that's also out of scope of this PR.

Having the quantifier, we can start requiring declarations for all type variables. Thanks to this it is now possible to refer to existing type variables and also use type variables in function return types.