### PR TITLE
Remove superflous language features category from Changelog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,14 +4,9 @@ Important Bugfixes:
  * Optimizer: Fix block deduplicator bug which led to blocks which are identical apart from the contents of ``verbatim`` instructions to be treated as equivalent and thus collapsed into a single one.
 
 
-Language Features:
-
-
 Compiler Features:
  * Commandline Interface: An empty ``--yul-optimizations`` sequence can now be always provided.
  * Standard JSON Interface: An empty ``optimizerSteps`` sequence can now always be provided.
-
-Bugfixes:
 
 
 ### 0.8.22 (2023-10-25)


### PR DESCRIPTION
Given that we have no new language features for the 0.8.23 release, I'm removing the category for this release.