### PR TITLE
Add optional library installation and FindSolidity.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,13 +133,12 @@ if (NOT (${Z3_FOUND} OR ${CVC4_FOUND}))
   \nPlease install Z3 or CVC4 or remove the option disabling them (USE_Z3, USE_CVC4).")
 endif()
 
-add_subdirectory(libsolutil)
-add_subdirectory(liblangutil)
-add_subdirectory(libsmtutil)
-add_subdirectory(libevmasm)
-add_subdirectory(libyul)
-add_subdirectory(libsolidity)
-add_subdirectory(libsolc)
+set(ETH_COMPONENTS "libsolutil;liblangutil;libsmtutil;libevmasm;libyul;libsolidity;libsolc")
+
+foreach (ETH_COMPONENT IN LISTS ETH_COMPONENTS)
+  add_subdirectory(${ETH_COMPONENT})
+endforeach()
+
 add_subdirectory(libstdlib)
 add_subdirectory(tools)
 
@@ -150,3 +149,9 @@ endif()
 if (TESTS AND NOT EMSCRIPTEN)
 	add_subdirectory(test)
 endif()
+
+if (INSTALL_INTERNAL_LIBS)
+  message(STATUS "INSTALL_INTERNAL_LIBS turned on. This feature is expected to work, but NOT supported.")
+  include(EthInstallation)
+endif()
+

--- a/cmake/EthInstallation.cmake
+++ b/cmake/EthInstallation.cmake
@@ -1,0 +1,41 @@
+# Install internal libraries.
+#
+# Installation will install the internal libraries, headers AND dependencies to the configured locations
+# After installation, the libraries can be linked against using `find_package(Solidity)`.
+# Note that this feature is expected to work, but unsupported.
+
+# Installing internal libraries
+install(TARGETS evmasm DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+install(TARGETS langutil DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+install(TARGETS smtutil DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+install(TARGETS libsolc DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+install(TARGETS solidity DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+install(TARGETS solutil DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+install(TARGETS yul DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+
+# Install internal headers
+foreach(ETH_COMPONENT IN LISTS ETH_COMPONENTS)
+  install(DIRECTORY ${CMAKE_SOURCE_DIR}/${ETH_COMPONENT}
+          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+          PATTERN "*.cpp" EXCLUDE
+          PATTERN "CMakeLists.txt" EXCLUDE
+          PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+  )
+endforeach()
+
+# install deps headers
+foreach(DEP_DIR concepts json meta range std)
+  install(DIRECTORY ${CMAKE_BINARY_DIR}/deps/include/${DEP_DIR}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    PATTERN "*.cpp" EXCLUDE
+    PATTERN "*.txt" EXCLUDE
+    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+  )
+endforeach()
+
+install(DIRECTORY ${CMAKE_BINARY_DIR}/_deps/fmtlib-src/include/fmt
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  PATTERN "*.cpp" EXCLUDE
+  PATTERN "*.txt" EXCLUDE
+  PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+)

--- a/cmake/EthOptions.cmake
+++ b/cmake/EthOptions.cmake
@@ -12,6 +12,9 @@ macro(configure_project)
 	eth_default_option(TESTS ON)
 	eth_default_option(TOOLS ON)
 
+	# installation
+	eth_default_option(INSTALL_INTERNAL_LIBS OFF)
+
 	# Define a matching property name of each of the "features".
 	foreach(FEATURE ${ARGN})
 		set(SUPPORT_${FEATURE} TRUE)
@@ -41,6 +44,8 @@ if (SUPPORT_TOOLS)
 endif()
 	message("------------------------------------------------------------------ flags")
 	message("-- OSSFUZZ                                                   ${OSSFUZZ}")
+	message("----------------------------------------------------------  installation")
+	message("-- INSTALL_INTERNAL_LIBS                                     ${INSTALL_INTERNAL_LIBS}")
 	message("------------------------------------------------------------------------")
 	message("")
 endmacro()

--- a/cmake/FindSolidity.cmake
+++ b/cmake/FindSolidity.cmake
@@ -1,0 +1,136 @@
+#[=======================================================================[.rst:
+FindSolidity
+--------
+
+Find the Solidity internal includes and library.
+
+IMPORTED Targets
+^^^^^^^^^^^^^^^^
+
+This module defines the following :prop_tgt:`IMPORTED` targets, if
+Solidity has been found.
+
+``Solidity``
+  Target for solidity static libraries and includes.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+::
+
+  Solidity_INCLUDE_DIRS   - where to find Solidity internal headers
+  Solidity_LIBRARIES      - List of internal libraries when using Solidity.
+  Solidity_FOUND          - True if Solidity found.
+
+Backward Compatibility
+^^^^^^^^^^^^^^^^^^^^^^
+
+The following variable are provided for backward compatibility
+
+::
+
+    TODO
+
+Hints
+^^^^^
+
+Setting ``Solidity_ROOT`` or ``Solidity_LIB_DIR`` and ``Solidity_INCLUDE_DIRS`` respectively to solidity installation dirs to tell this
+module where to look is suggested. Otherwise, this modules looks for solidity products in default paths.
+#]=======================================================================]
+
+
+set(_SOLIDITY_LIB_SEARCHES)
+set(_SOLIDITY_INCLUDE_SEARCHES)
+
+# Check if environment variables are set, also look for SOLIDITY_ROOT and SOLIDITYROOT as alternatives.
+if ("$ENV{Solidity_ROOT}" STREQUAL "")
+    if (NOT "$ENV{SOLIDITY_ROOT}" STREQUAL "")
+        message(STATUS "Using SOLIDITY_ROOT: $ENV{SOLIDITY_ROOT}")
+        list(APPEND _SOLIDITY_LIB_SEARCHES $ENV{SOLIDITY_ROOT})
+        list(APPEND _SOLIDITY_INCLUDE_SEARCHES $ENV{SOLIDITY_ROOT})
+    elseif (NOT "$ENV{SOLIDITYROOT}" STREQUAL "")
+        message(STATUS "Using SOLIDITYROOT: $ENV{SOLIDITYROOT}")
+        list(APPEND _SOLIDITY_LIB_SEARCHES $ENV{SOLIDITYROOT})
+        list(APPEND _SOLIDITY_INCLUDE_SEARCHES $ENV{SOLIDITYROOT})
+    else() # Check whether respective lib and include dirs are set
+        if (NOT "$ENV{Solidity_LIB_DIR}" STREQUAL "")
+            message(STATUS "Using Solidity_LIB_DIR: $ENV{Solidity_LIB_DIR}")
+            list(APPEND _SOLIDITY_LIB_SEARCHES $ENV{Solidity_LIB_DIR})
+        endif()
+
+        if (NOT "$ENV{Solidity_INCLUDE_DIRS}" STREQUAL "")
+            message(STATUS "Using Solidity_INCLUDE_DIRS: $ENV{Solidity_INCLUDE_DIRS}")
+            list(APPEND _SOLIDITY_INCLUDE_SEARCHES $ENV{Solidity_INCLUDE_DIRS})
+        endif()
+    endif()
+else()
+    message(STATUS "Using Solidity_ROOT: $ENV{Solidity_ROOT}")
+    list(APPEND _SOLIDITY_LIB_SEARCHES $ENV{Solidity_ROOT})
+    list(APPEND _SOLIDITY_INCLUDE_SEARCHES $ENV{Solidity_ROOT})
+endif()
+
+# Find Solidity header files
+if (_SOLIDITY_INCLUDE_SEARCHES)
+    foreach(search ${_SOLIDITY_INCLUDE_SEARCHES})
+        find_path(Solidity_INCLUDE_DIRS
+            NAMES libsolidity
+            HINTS ${search}
+            NO_DEFAULT_PATH
+            PATH_SUFFIXES include
+        )
+    endforeach()
+else()
+    find_path(Solidity_INCLUDE_DIRS NAMES libsolidity PATH_SUFFIXES include)
+endif()
+
+# Find Solidity static libraries
+foreach(LIB_NAME evmasm langutil smtutil solc solidity solutil yul jsoncpp)
+    if(_SOLIDITY_LIB_SEARCHES)
+        foreach(search ${_SOLIDITY_LIB_SEARCHES})
+            find_library(SOLIDITY_FOUND_LIB_${LIB_NAME}
+                NAMES ${LIB_NAME}
+                HINTS ${search}
+                NO_DEFAULT_PATH
+                PATH_SUFFIXES lib
+            )
+            if(SOLIDITY_FOUND_LIB_${LIB_NAME})
+                list(APPEND Solidity_LIBRARIES ${SOLIDITY_FOUND_LIB_${LIB_NAME}})
+            endif()
+        endforeach()
+    else()
+        find_library(SOLIDITY_FOUND_LIB_${LIB_NAME}
+            NAMES ${LIB_NAME}
+            PATH_SUFFIXES lib
+        )
+        if(SOLIDITY_FOUND_LIB_${LIB_NAME})
+            list(APPEND Solidity_LIBRARIES ${SOLIDITY_FOUND_LIB_${LIB_NAME}})
+        endif()
+    endif()
+endforeach()
+
+include(FindPackageHandleStandardArgs)
+# Handle the QUIETLY and REQUIRED arguments and set the SOLIDITY_FOUND variable
+find_package_handle_standard_args(Solidity DEFAULT_MSG
+    Solidity_LIBRARIES
+    Solidity_INCLUDE_DIRS
+)
+
+if(Solidity_FOUND)
+    message(STATUS "Found Solidity_LIBRARIES: ${Solidity_LIBRARIES}")
+    message(STATUS "Found Solidity_INCLUDE_DIRS: ${Solidity_INCLUDE_DIRS}")
+else()
+    message(FATAL_ERROR "Could not find Solidity libraries and headers")
+endif()
+
+add_library(Solidity INTERFACE IMPORTED)
+if(Solidity_INCLUDE_DIRS)
+    set_target_properties(Solidity PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${Solidity_INCLUDE_DIRS}")
+endif()
+
+if(Solidity_LIBRARIES)
+    set_target_properties(Solidity PROPERTIES
+    INTERFACE_LINK_LIBRARIES "${Solidity_LIBRARIES}")
+endif()


### PR DESCRIPTION
Feature request #14669 

+ Added `INSTALL_INTERNAL_LIBS` options(default OFF). If turned on, internal libs will be installed under configured locations.  
+ Added `cmake/FindSolidity.cmake` so that Solidity can be linked as a dependency by external projects.
+ To properly link built libraries, external projects should have the same compiler & linker configurations as is configured in `cmake/EthCompilerSettings.cmake`