### PR TITLE
Make JS version of bytecode report indicate progress on stdout to prevent CI timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,6 @@ commands:
     steps:
       - run:
           name: Generate bytecode reports for the selected preset
-          no_output_timeout: 30m
           command: |
             .circleci/parallel_bytecode_report.sh \
                 "<< parameters.label >>" \

--- a/.circleci/parallel_bytecode_report.sh
+++ b/.circleci/parallel_bytecode_report.sh
@@ -75,5 +75,5 @@ else
     # shellcheck disable=SC2035
     ./prepare_report.js \
         --preset "$preset" \
-        *.sol > "../bytecode-report-${label}-${preset}.txt"
+        *.sol --report-file "../bytecode-report-${label}-${preset}.txt"
 fi

--- a/scripts/bytecodecompare/prepare_report.js
+++ b/scripts/bytecodecompare/prepare_report.js
@@ -130,8 +130,11 @@ for (const preset of presets)
             Object.keys(result['contracts']).length === 0 ||
             Object.keys(result['contracts']).every(file => Object.keys(result['contracts'][file]).length === 0)
         )
+        {
             // NOTE: do not exit here because this may be run on source which cannot be compiled
             reportFile.write(filename + ': <ERROR>\n')
+            process.stdout.write('E')
+        }
         else
             for (const contractFile in result['contracts'])
                 for (const contractName in result['contracts'][contractFile])
@@ -140,6 +143,12 @@ for (const preset of presets)
 
                     let bytecode = '<NO BYTECODE>'
                     let metadata = '<NO METADATA>'
+                    let progressIndicator = '.'
+
+                    if ('metadata' in contractResults && cleanString(contractResults.metadata) !== undefined)
+                        metadata = contractResults.metadata
+                    else
+                        progressIndicator = 'M'
 
                     if (
                         'evm' in contractResults &&
@@ -148,12 +157,12 @@ for (const preset of presets)
                         cleanString(contractResults.evm.bytecode.object) !== undefined
                     )
                         bytecode = cleanString(contractResults.evm.bytecode.object)
-
-                    if ('metadata' in contractResults && cleanString(contractResults.metadata) !== undefined)
-                        metadata = contractResults.metadata
+                    else
+                        progressIndicator = 'B'
 
                     reportFile.write(filename + ':' + contractName + ' ' + bytecode + '\n')
                     reportFile.write(filename + ':' + contractName + ' ' + metadata + '\n')
+                    process.stdout.write(progressIndicator)
                 }
     }
 }

--- a/scripts/solc-bin/bytecode_reports_for_modified_binaries.sh
+++ b/scripts/solc-bin/bytecode_reports_for_modified_binaries.sh
@@ -160,7 +160,7 @@ for binary_name in $platform_binaries; do
                 "$solidity_version_and_commit"
 
             # shellcheck disable=SC2035
-            ./prepare_report.js --strip-smt-pragmas *.sol > "${report_dir}/report-${binary_name}.txt"
+            ./prepare_report.js --strip-smt-pragmas *.sol --report-file "${report_dir}/report-${binary_name}.txt"
         else
             yul_optimizer_flags=()
             if [[ $solidity_version == 0.6.0 ]] || [[ $solidity_version == 0.6.1 ]]; then


### PR DESCRIPTION
This addresses the issue of [`b_bytecode_ems-via-ir-optimize` timing out](https://app.circleci.com/pipelines/github/ethereum/solidity/31770/workflows/54cbef20-50ed-4b79-a86e-df23d522b25a/jobs/1418789) during releases. Also, makes its output and parameters more consistent with the Python version.