### PR TITLE
Fix docutils deprecated set_class method

### DIFF
--- a/docs/ext/remix_code_links.py
+++ b/docs/ext/remix_code_links.py
@@ -27,10 +27,10 @@ def remix_code_url(source_code, language, solidity_version):
 
 def build_remix_link_node(url):
     reference_node = docutils.nodes.reference('', 'open in Remix', internal=False, refuri=url, target='_blank')
-    reference_node.set_class('remix-link')
+    reference_node['classes'].append('remix-link')
 
     paragraph_node = docutils.nodes.paragraph()
-    paragraph_node.set_class('remix-link-container')
+    paragraph_node['classes'].append('remix-link-container')
     paragraph_node.append(reference_node)
     return paragraph_node
 


### PR DESCRIPTION
```
def set_class(self, name):
    """Add a new class to the "classes" attribute."""
    warnings.warn('docutils.nodes.Element.set_class() is deprecated; '
                  ' and will be removed in Docutils 0.21 or later.'
                  "Append to Element['classes'] list attribute directly",
                  DeprecationWarning, stacklevel=2)
    assert ' ' not in name
    self['classes'].append(name.lower())
```

Didn't find a mention of the deprecation in their docs, so dug it out in code. Also, the `spinx-build` output is pretty useless, so for future reference, add a `-T` option for more verbose output when necessary.