### PR TITLE
Move deprecated evm versions to nightly CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,11 +220,18 @@ commands:
           command: .circleci/soltest.sh
 
   run_soltest_all:
+    parameters:
+      # NOTE: If not specified, soltest_all.sh will use the default values as specified in the script.
+      # In other words, it will execute for all EVM versions that are not marked as deprecated.
+      evm_versions:
+        description: "List of EVM versions (separated by space)."
+        type: string
+        default: ""
     steps:
       - run:
           name: soltest_all
           no_output_timeout: 30m
-          command: .circleci/soltest_all.sh
+          command: .circleci/soltest_all.sh "<< parameters.evm_versions >>"
 
   run_cmdline_tests:
     steps:
@@ -1267,6 +1274,20 @@ jobs:
     steps:
       - soltest_all
 
+  t_ubu_soltest_deprecated_evm_versions: &t_ubu_soltest_deprecated_evm_versions
+    <<: *base_ubuntu2204_large
+    parallelism: 50
+    steps:
+      - checkout
+      - attach_workspace:
+          at: build
+      - run_soltest_all:
+          evm_versions: homestead byzantium
+      - store_test_results:
+          path: test_results/
+      - store_artifacts_test_results
+      - matrix_notify_failure_unless_pr
+
   t_ubu_lsp: &t_ubu_lsp
     <<: *base_ubuntu2204_small
     steps:
@@ -2003,6 +2024,10 @@ workflows:
       - b_ubu_san_clang: *job_b_ubu_ubsan_clang
       - t_ubu_ubsan_clang_soltest: *requires_b_ubu_ubsan_clang
       - t_ubu_ubsan_clang_cli: *requires_b_ubu_ubsan_clang
+
+      # Deprecated EVM versions tests
+      - b_ubu: *requires_nothing
+      - t_ubu_soltest_deprecated_evm_versions: *requires_b_ubu
 
   nightly-ossfuzz:
 

--- a/.circleci/soltest_all.sh
+++ b/.circleci/soltest_all.sh
@@ -31,9 +31,12 @@ REPODIR="$(realpath "$(dirname "$0")"/..)"
 # shellcheck source=scripts/common.sh
 source "${REPODIR}/scripts/common.sh"
 
-EVM_VALUES=(homestead byzantium constantinople petersburg istanbul berlin london paris shanghai cancun)
+DEFAULT_EVM_VALUES=(constantinople petersburg istanbul berlin london paris shanghai cancun)
+# Deserialize the EVM_VALUES array if it was provided as argument or
+# set EVM_VALUES to the default values.
+IFS=" " read -ra EVM_VALUES <<< "${1:-${DEFAULT_EVM_VALUES[@]}}"
+
 DEFAULT_EVM=shanghai
-[[ " ${EVM_VALUES[*]} " =~ $DEFAULT_EVM ]]
 OPTIMIZE_VALUES=(0 1)
 
 # Run for ABI encoder v1, without SMTChecker tests.


### PR DESCRIPTION
As recommended in the discussion here: https://github.com/ethereum/solidity/pull/14705#discussion_r1407879318, this PR moves the soltest to run exclusively on nightly jobs for Homestead and Byzantium EVM versions, which are now deprecated.