### PR TITLE
Update PRB-Math external test installation process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -737,7 +737,7 @@ defaults:
       name: t_native_test_ext_prb_math
       project: prb-math
       binary_type: native
-      image: cimg/rust:1.70
+      image: cimg/rust:1.74.0-node
 
   - job_native_test_ext_elementfi: &job_native_test_ext_elementfi
       <<: *requires_b_ubu_static
@@ -1373,6 +1373,12 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - install_foundry
+      - run:
+          name: Ensure pnpm is installed if npm is present
+          command: |
+            if command -v npm &> /dev/null; then
+              sudo npm install -g pnpm
+            fi
       - install_python3:
           packages: requests
       - run:

--- a/scripts/externalTests/runners/foundry.py
+++ b/scripts/externalTests/runners/foundry.py
@@ -69,8 +69,7 @@ class FoundryRunner(BaseRunner):
             yul = {yul}
         """).format(**profile_fields)
 
-    @BaseRunner.enter_test_dir
-    def configure(self):
+    def setup_presets_profiles(self):
         """Configure forge tests profiles"""
 
         profiles = []
@@ -93,6 +92,10 @@ class FoundryRunner(BaseRunner):
             for profile in profiles:
                 f.write(profile)
 
+    @BaseRunner.enter_test_dir
+    def configure(self):
+        """Install project dependencies"""
+        self.setup_presets_profiles()
         run_forge_command("forge install", self.env)
 
     @BaseRunner.enter_test_dir

--- a/test/externalTests/prb-math.py
+++ b/test/externalTests/prb-math.py
@@ -20,7 +20,9 @@
 # ------------------------------------------------------------------------------
 
 import sys
+import subprocess
 from pathlib import Path
+from shutil import which
 
 # Our scripts/ is not a proper Python package so we need to modify PYTHONPATH to import from it
 # pragma pylint: disable=import-error,wrong-import-position
@@ -31,6 +33,20 @@ from runners.base import run_test
 from runners.base import TestConfig
 from runners.foundry import FoundryRunner
 from test_helpers import SettingsPreset
+
+class PRBMathRunner(FoundryRunner):
+    def configure(self):
+        if which("pnpm") is None:
+            raise RuntimeError("pnpm not found.")
+
+        self.setup_presets_profiles()
+        # Starting from version v4.0.2, the default installation method for PRBMath dependencies
+        # has transitioned from Foundry to Node.js.
+        subprocess.run(
+            ["pnpm", "install"],
+            env=self.env,
+            check=True
+        )
 
 test_config = TestConfig(
     name="PRBMath",
@@ -50,4 +66,4 @@ test_config = TestConfig(
     ],
 )
 
-sys.exit(run_test(FoundryRunner(argv=sys.argv[1:], config=test_config)))
+sys.exit(run_test(PRBMathRunner(argv=sys.argv[1:], config=test_config)))


### PR DESCRIPTION
Starting from version v4.0.2, the default installation method for PRBMath has transitioned from Foundry to Node.js. See: https://github.com/PaulRBerg/prb-math/releases/tag/v4.0.2. Consequently, using `forge install` will no longer work, and attempting to do so will result in the following error: https://app.circleci.com/pipelines/github/ethereum/solidity/31936/workflows/0c1a232e-df4e-44f3-a3f5-e34340a9a98e/jobs/1427254