### PR TITLE
Exclude function dependency graph tests from ast import export

### DIFF
--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -59,6 +59,7 @@ then
   brew install wget
   brew install coreutils
   brew install diffutils
+  brew install grep
   ./scripts/install_obsolete_jsoncpp_1_7_4.sh
 
   # z3

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -313,3 +313,14 @@ function command_available
         fail "'${program}' not found or not executed successfully with parameter(s) '${parameters}'. aborting."
     fi
 }
+
+function gnu_grep
+{
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        command_available ggrep --version
+        ggrep "$@"
+    else
+        command_available grep --version
+        grep "$@"
+    fi
+}

--- a/test/cmdlineTests/~soljson_via_fuzzer/test.sh
+++ b/test/cmdlineTests/~soljson_via_fuzzer/test.sh
@@ -10,7 +10,7 @@ cd "$SOLTMPDIR"
 "$REPO_ROOT"/scripts/isolate_tests.py "$REPO_ROOT"/test/
 "$REPO_ROOT"/scripts/isolate_tests.py "$REPO_ROOT"/docs/
 
-echo ./*.sol | xargs -P 4 -n 50 "${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer" --quiet --input-files
-echo ./*.sol | xargs -P 4 -n 50 "${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer" --without-optimizer --quiet --input-files
+echo ./*.sol | xargs grep -L "pragma experimental solidity;" | xargs -P 4 -n 50 "${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer" --quiet --input-files
+echo ./*.sol | xargs grep -L "pragma experimental solidity;" | xargs -P 4 -n 50 "${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer" --without-optimizer --quiet --input-files
 
 rm -r "$SOLTMPDIR"

--- a/test/cmdlineTests/~soljson_via_fuzzer/test.sh
+++ b/test/cmdlineTests/~soljson_via_fuzzer/test.sh
@@ -10,7 +10,7 @@ cd "$SOLTMPDIR"
 "$REPO_ROOT"/scripts/isolate_tests.py "$REPO_ROOT"/test/
 "$REPO_ROOT"/scripts/isolate_tests.py "$REPO_ROOT"/docs/
 
-grep -L --include="*.sol" "pragma experimental solidity;" * | xargs -P 4 -n 50 "${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer" --quiet --input-files
-grep -L --include="*.sol" "pragma experimental solidity;" * | xargs -P 4 -n 50 "${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer" --without-optimizer --quiet --input-files
+gnu_grep -L --include="*.sol" "^pragma experimental solidity;$" ./* | xargs -P 4 -n 50 "${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer" --quiet --input-files
+gnu_grep -L --include="*.sol" "^pragma experimental solidity;$" ./* | xargs -P 4 -n 50 "${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer" --without-optimizer --quiet --input-files
 
 rm -r "$SOLTMPDIR"

--- a/test/cmdlineTests/~soljson_via_fuzzer/test.sh
+++ b/test/cmdlineTests/~soljson_via_fuzzer/test.sh
@@ -10,7 +10,7 @@ cd "$SOLTMPDIR"
 "$REPO_ROOT"/scripts/isolate_tests.py "$REPO_ROOT"/test/
 "$REPO_ROOT"/scripts/isolate_tests.py "$REPO_ROOT"/docs/
 
-echo ./*.sol | xargs grep -L "pragma experimental solidity;" | xargs -P 4 -n 50 "${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer" --quiet --input-files
-echo ./*.sol | xargs grep -L "pragma experimental solidity;" | xargs -P 4 -n 50 "${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer" --without-optimizer --quiet --input-files
+grep -L --include="*.sol" "pragma experimental solidity;" * | xargs -P 4 -n 50 "${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer" --quiet --input-files
+grep -L --include="*.sol" "pragma experimental solidity;" * | xargs -P 4 -n 50 "${SOLIDITY_BUILD_DIR}/test/tools/solfuzzer" --without-optimizer --quiet --input-files
 
 rm -r "$SOLTMPDIR"

--- a/test/stopAfterParseTests.sh
+++ b/test/stopAfterParseTests.sh
@@ -70,5 +70,5 @@ while read -r file; do
 		echo "$file"
 		exit 1
 	fi
-done < <(find "${REPO_ROOT}/test" -iname "*.sol" -and -not -name "documentation.sol" -and -not -name "boost_filesystem_bug.sol" -not -path "*/experimental/*")
+done < <(find "${REPO_ROOT}/test" -iname "*.sol" -and -not -name "documentation.sol" -and -not -name "boost_filesystem_bug.sol" -not -path "*/experimental/*" -not -path "*/functionDependencyGraphTests/*")
 echo


### PR DESCRIPTION
This should help with the failing CLI tests in `newAnalysis`; we've already excluded experimental tests, but `functionDependencyGraphTests` were added at a later point, and I didn't notice them amongst a ton of other failures.