### PR TITLE
Rename `TypeInference::typeAnnotation()` back to `type()`

### DIFF
--- a/libsolidity/experimental/analysis/TypeInference.cpp
+++ b/libsolidity/experimental/analysis/TypeInference.cpp
@@ -676,7 +676,7 @@ bool TypeInference::visit(TypeClassInstantiation const& _typeClassInstantiation)
 		}
 	}
 
-	Type type{TypeConstant{*typeConstructor, arguments}};
+	Type instanceType{TypeConstant{*typeConstructor, arguments}};
 
 	std::map<std::string, Type> functionTypes;
 
@@ -689,13 +689,13 @@ bool TypeInference::visit(TypeClassInstantiation const& _typeClassInstantiation)
 			m_errorReporter.typeError(3654_error, subNode->location(), "Duplicate definition of function " + functionDefinition->name() + " during type class instantiation.");
 	}
 
-	if (auto error = m_typeSystem.instantiateClass(type, arity))
+	if (auto error = m_typeSystem.instantiateClass(instanceType, arity))
 		m_errorReporter.typeError(5094_error, _typeClassInstantiation.location(), *error);
 
 	auto const& classFunctions = annotation().typeClassFunctions.at(*typeClass);
 
 	TypeEnvironment newEnv = m_env->clone();
-	if (!newEnv.unify(m_typeSystem.typeClassVariable(*typeClass), type).empty())
+	if (!newEnv.unify(m_typeSystem.typeClassVariable(*typeClass), instanceType).empty())
 	{
 		m_errorReporter.typeError(4686_error, _typeClassInstantiation.location(), "Unification of class and instance variable failed.");
 		return false;

--- a/libsolidity/experimental/analysis/TypeInference.h
+++ b/libsolidity/experimental/analysis/TypeInference.h
@@ -103,7 +103,7 @@ private:
 	Type m_boolType;
 	std::optional<Type> m_currentFunctionType;
 
-	Type typeAnnotation(ASTNode const& _node) const;
+	Type type(ASTNode const& _node) const;
 
 	Annotation& annotation(ASTNode const& _node);
 	Annotation const& annotation(ASTNode const& _node) const;


### PR DESCRIPTION
See [the discussion on `#solidity-dev`](https://app.element.io/#/room/#ethereum_solidity-dev:gitter.im/$kcWffrukBtJ3lICAE0oJak-p1Jc7q2awYovTDrdLD-Y) for context.

I still think that `typeAnnotation()` is better as long as this is a private helper in the context of `TypeInference`, but I don't want to spend any more time arguing about it so I'm renaming it back. And I'm going to submit some PRs to add/improve helpers later which may make the point moot anyway.