### PR TITLE
Fix `prepare_report.py` ignoring compiler exit code

### DIFF
--- a/scripts/bytecodecompare/prepare_report.py
+++ b/scripts/bytecodecompare/prepare_report.py
@@ -315,7 +315,7 @@ def run_compiler(
             input=compiler_input,
             encoding='utf8',
             capture_output=True,
-            check=exit_on_error,
+            check=True,
         )
 
         return parse_standard_json_output(Path(source_file_name), process.stdout)

--- a/scripts/bytecodecompare/prepare_report.py
+++ b/scripts/bytecodecompare/prepare_report.py
@@ -183,7 +183,10 @@ def parse_standard_json_output(source_file_name: Path, standard_json_output: str
     return file_report
 
 
-def parse_cli_output(source_file_name: Path, cli_output: str) -> FileReport:
+def parse_cli_output(source_file_name: Path, cli_output: str, exit_code: int) -> FileReport:
+    if exit_code != 0:
+        return FileReport(file_name=source_file_name, contract_reports=None)
+
     # re.split() returns a list containing the text between pattern occurrences but also inserts the
     # content of matched groups in between. It also never omits the empty elements so the number of
     # list items is predictable (3 per match + the text before the first match)
@@ -345,7 +348,7 @@ def run_compiler(
             check=exit_on_error,
         )
 
-        return parse_cli_output(Path(source_file_name), process.stdout)
+        return parse_cli_output(Path(source_file_name), process.stdout, process.returncode)
 
 
 def generate_report(

--- a/scripts/common/cmdline_helpers.py
+++ b/scripts/common/cmdline_helpers.py
@@ -48,7 +48,7 @@ def solc_bin_report(solc_binary: str, input_files: List[Path], via_ir: bool) -> 
         (['--via-ir'] if via_ir else []),
         encoding='utf8',
     )
-    return parse_cli_output('', output)
+    return parse_cli_output('', output, 0)
 
 
 def save_bytecode(bytecode_path: Path, reports: FileReport, contract: Optional[str] = None):

--- a/test/scripts/test_bytecodecompare_prepare_report.py
+++ b/test/scripts/test_bytecodecompare_prepare_report.py
@@ -487,19 +487,19 @@ class TestParseCLIOutput(PrepareReportTestBase):
             ]
         )
 
-        report = parse_cli_output(Path('syntaxTests/scoping/library_inherited2.sol'), LIBRARY_INHERITED2_SOL_CLI_OUTPUT)
+        report = parse_cli_output(Path('syntaxTests/scoping/library_inherited2.sol'), LIBRARY_INHERITED2_SOL_CLI_OUTPUT, 0)
         self.assertEqual(report, expected_report)
 
     def test_parse_cli_output_should_report_error_on_compiler_errors(self):
         expected_report = FileReport(file_name=Path('syntaxTests/pragma/unknown_pragma.sol'), contract_reports=None)
 
-        report = parse_cli_output(Path('syntaxTests/pragma/unknown_pragma.sol'), UNKNOWN_PRAGMA_SOL_CLI_OUTPUT)
+        report = parse_cli_output(Path('syntaxTests/pragma/unknown_pragma.sol'), UNKNOWN_PRAGMA_SOL_CLI_OUTPUT, 0)
         self.assertEqual(report, expected_report)
 
     def test_parse_cli_output_should_report_error_on_empty_output(self):
         expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
 
-        self.assertEqual(parse_cli_output(Path('file.sol'), ''), expected_report)
+        self.assertEqual(parse_cli_output(Path('file.sol'), '', 0), expected_report)
 
     def test_parse_cli_output_should_report_missing_bytecode_and_metadata(self):
         compiler_output = dedent("""\
@@ -541,22 +541,25 @@ class TestParseCLIOutput(PrepareReportTestBase):
             ]
         )
 
-        self.assertEqual(parse_cli_output(Path('syntaxTests/scoping/library_inherited2.sol'), compiler_output), expected_report)
+        self.assertEqual(
+            parse_cli_output(Path('syntaxTests/scoping/library_inherited2.sol'), compiler_output, 0),
+            expected_report
+        )
 
     def test_parse_cli_output_should_report_error_on_unimplemented_feature_error(self):
         expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
 
-        self.assertEqual(parse_cli_output(Path('file.sol'), UNIMPLEMENTED_FEATURE_CLI_OUTPUT), expected_report)
+        self.assertEqual(parse_cli_output(Path('file.sol'), UNIMPLEMENTED_FEATURE_CLI_OUTPUT, 0), expected_report)
 
     def test_parse_cli_output_should_report_error_on_stack_too_deep_error(self):
         expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
 
-        self.assertEqual(parse_cli_output(Path('file.sol'), STACK_TOO_DEEP_CLI_OUTPUT), expected_report)
+        self.assertEqual(parse_cli_output(Path('file.sol'), STACK_TOO_DEEP_CLI_OUTPUT, 0), expected_report)
 
     def test_parse_cli_output_should_report_error_on_code_generation_error(self):
         expected_report = FileReport(file_name=Path('file.sol'), contract_reports=None)
 
-        self.assertEqual(parse_cli_output(Path('file.sol'), CODE_GENERATION_ERROR_CLI_OUTPUT), expected_report)
+        self.assertEqual(parse_cli_output(Path('file.sol'), CODE_GENERATION_ERROR_CLI_OUTPUT, 0), expected_report)
 
     def test_parse_cli_output_should_handle_output_from_solc_0_4_0(self):
         expected_report = FileReport(
@@ -571,7 +574,7 @@ class TestParseCLIOutput(PrepareReportTestBase):
             ]
         )
 
-        self.assertEqual(parse_cli_output(Path('contract.sol'), SOLC_0_4_0_CLI_OUTPUT), expected_report)
+        self.assertEqual(parse_cli_output(Path('contract.sol'), SOLC_0_4_0_CLI_OUTPUT, 0), expected_report)
 
     def test_parse_cli_output_should_handle_output_from_solc_0_4_8(self):
         expected_report = FileReport(
@@ -588,7 +591,7 @@ class TestParseCLIOutput(PrepareReportTestBase):
             ]
         )
 
-        self.assertEqual(parse_cli_output(Path('contract.sol'), SOLC_0_4_8_CLI_OUTPUT), expected_report)
+        self.assertEqual(parse_cli_output(Path('contract.sol'), SOLC_0_4_8_CLI_OUTPUT, 0), expected_report)
 
     def test_parse_cli_output_should_handle_leading_and_trailing_spaces(self):
         compiler_output = (
@@ -606,7 +609,7 @@ class TestParseCLIOutput(PrepareReportTestBase):
             ]
         )
 
-        self.assertEqual(parse_cli_output(Path('contract.sol'), compiler_output), expected_report)
+        self.assertEqual(parse_cli_output(Path('contract.sol'), compiler_output, 0), expected_report)
 
     def test_parse_cli_output_should_handle_empty_bytecode_and_metadata_lines(self):
         compiler_output = dedent("""\
@@ -640,7 +643,7 @@ class TestParseCLIOutput(PrepareReportTestBase):
             ]
         )
 
-        self.assertEqual(parse_cli_output(Path('contract.sol'), compiler_output), expected_report)
+        self.assertEqual(parse_cli_output(Path('contract.sol'), compiler_output, 0), expected_report)
 
     def test_parse_cli_output_should_handle_link_references_in_bytecode(self):
         compiler_output = dedent("""\
@@ -662,4 +665,4 @@ class TestParseCLIOutput(PrepareReportTestBase):
         )
         # pragma pylint: enable=line-too-long
 
-        self.assertEqual(parse_cli_output(Path('contract.sol'), compiler_output), expected_report)
+        self.assertEqual(parse_cli_output(Path('contract.sol'), compiler_output, 0), expected_report)


### PR DESCRIPTION
Closes #14729.

After taking a closer look at the bytecode comparison failures in newAnalysis, turns out that it's not #13925 that's breaking the bytecode comparison. There's actually a small bug in the report script that went undiscovered until now.

The script was not taking into account the exit code from the compiler (which is irrelevant for Standard JSON interface but not for CLI). It went unnoticed because it does not make any difference under normal circumstances. If the compiler does not produce any outputs it's interpreted as an error anyway. Even with ICEs like `UnimplementedFeatureError` as long as the ICE happened before the compilation ended, it worked as expected.

The new element in `newAnalysis` is that after #14659 we get an ICE only at the point where we request metadata. At this point the bytecode has already been successfully compiled and printed to the output so it looks to the script like a successful compilation missing metadata. The failure can only be detected by looking at the exit-code or trying to parse out the ICE from the CLI output (which the script intentionally does not do).