### PR TITLE
Move builtin type class registration to `TypeClassRegistration` pass

### DIFF
--- a/libsolidity/experimental/analysis/TypeClassRegistration.cpp
+++ b/libsolidity/experimental/analysis/TypeClassRegistration.cpp
@@ -32,6 +32,14 @@ TypeClassRegistration::TypeClassRegistration(Analysis& _analysis):
 	m_errorReporter(_analysis.errorReporter()),
 	m_typeSystem(_analysis.typeSystem())
 {
+	declareBuiltinClass("integer", BuiltinClass::Integer);
+	declareBuiltinClass("*", BuiltinClass::Mul);
+	declareBuiltinClass("+", BuiltinClass::Add);
+	declareBuiltinClass("==", BuiltinClass::Equal);
+	declareBuiltinClass("<", BuiltinClass::Less);
+	declareBuiltinClass("<=", BuiltinClass::LessOrEqual);
+	declareBuiltinClass(">", BuiltinClass::Greater);
+	declareBuiltinClass(">=", BuiltinClass::GreaterOrEqual);
 }
 
 bool TypeClassRegistration::analyze(SourceUnit const& _sourceUnit)
@@ -59,4 +67,16 @@ bool TypeClassRegistration::visit(TypeClassDefinition const& _typeClassDefinitio
 	);
 
 	return true;
+}
+
+TypeClass TypeClassRegistration::declareBuiltinClass(std::string _name, BuiltinClass _class)
+{
+	auto result = m_typeSystem.declareTypeClass(_name, nullptr);
+	if (std::string const* error = std::get_if<std::string>(&result))
+		solAssert(!error, *error);
+	TypeClass declaredClass = std::get<TypeClass>(result);
+	// TODO: validation?
+	auto& annotation = m_analysis.annotation<TypeClassRegistration>();
+	solAssert(annotation.builtinClassesByName.emplace(_name, _class).second);
+	return annotation.builtinClasses.emplace(_class, declaredClass).first->second;
 }

--- a/libsolidity/experimental/analysis/TypeClassRegistration.h
+++ b/libsolidity/experimental/analysis/TypeClassRegistration.h
@@ -41,6 +41,8 @@ public:
 	};
 	struct GlobalAnnotation
 	{
+		std::map<BuiltinClass, TypeClass> builtinClasses;
+		std::map<std::string, BuiltinClass> builtinClassesByName;
 	};
 
 	TypeClassRegistration(Analysis& _analysis);
@@ -49,6 +51,8 @@ public:
 
 private:
 	bool visit(TypeClassDefinition const& _typeClassDefinition) override;
+
+	TypeClass declareBuiltinClass(std::string _name, BuiltinClass _class);
 
 	Analysis& m_analysis;
 	langutil::ErrorReporter& m_errorReporter;

--- a/libsolidity/experimental/analysis/TypeInference.h
+++ b/libsolidity/experimental/analysis/TypeInference.h
@@ -45,8 +45,6 @@ public:
 	};
 	struct GlobalAnnotation
 	{
-		std::map<BuiltinClass, TypeClass> builtinClasses;
-		std::map<std::string, BuiltinClass> builtinClassesByName;
 		std::map<TypeClass, std::map<std::string, Type>> typeClassFunctions;
 		std::map<Token, std::tuple<TypeClass, std::string>> operators;
 		std::map<TypeConstructor, std::map<std::string, TypeMember>> members;

--- a/libsolidity/experimental/codegen/IRGeneratorForStatements.cpp
+++ b/libsolidity/experimental/codegen/IRGeneratorForStatements.cpp
@@ -219,7 +219,7 @@ TypeRegistration::TypeClassInstantiations const& typeClassInstantiations(IRGener
 		return _context.analysis.annotation<TypeRegistration>(*typeClassDeclaration).instantiations;
 	// TODO: better mechanism than fetching by name.
 	auto& instantiations = _context.analysis.annotation<TypeRegistration>().builtinClassInstantiations;
-	auto& builtinClassesByName = _context.analysis.annotation<TypeInference>().builtinClassesByName;
+	auto& builtinClassesByName = _context.analysis.annotation<TypeClassRegistration>().builtinClassesByName;
 	return instantiations.at(builtinClassesByName.at(_context.analysis.typeSystem().typeClassName(_class)));
 }
 }

--- a/test/libsolidity/syntaxTests/experimental/inference/polymorphic_type.sol
+++ b/test/libsolidity/syntaxTests/experimental/inference/polymorphic_type.sol
@@ -24,9 +24,9 @@ function run() {
 // Info 4164: (48-55): Inferred type: U
 // Info 4164: (56-63): Inferred type: V
 // Info 4164: (65-81): Inferred type: C
-// Info 4164: (71-75): Inferred type: 'k:(type, C)
+// Info 4164: (71-75): Inferred type: 's:(type, C)
 // Info 4164: (82-98): Inferred type: D
-// Info 4164: (88-92): Inferred type: 'l:(type, D)
+// Info 4164: (88-92): Inferred type: 't:(type, D)
 // Info 4164: (100-170): Inferred type: () -> ()
 // Info 4164: (112-114): Inferred type: ()
 // Info 4164: (125-141): Inferred type: T(U, ?bh:type, ?bj:(type, C))

--- a/test/libsolidity/syntaxTests/experimental/inference/polymorphic_type_instantiation_and_operators.sol
+++ b/test/libsolidity/syntaxTests/experimental/inference/polymorphic_type_instantiation_and_operators.sol
@@ -57,22 +57,22 @@ function fun(a: T(int: P3), b: T(str: P4)) {
 // Info 4164: (74-83): Inferred type: int
 // Info 4164: (84-93): Inferred type: str
 // Info 4164: (95-156): Inferred type: C
-// Info 4164: (101-105): Inferred type: 'k:(type, C)
-// Info 4164: (115-154): Inferred type: ('k:(type, C), 'k:(type, C)) -> 'k:(type, C)
-// Info 4164: (127-145): Inferred type: ('k:(type, C), 'k:(type, C))
-// Info 4164: (128-135): Inferred type: 'k:(type, C)
-// Info 4164: (131-135): Inferred type: 'k:(type, C)
-// Info 4164: (137-144): Inferred type: 'k:(type, C)
-// Info 4164: (140-144): Inferred type: 'k:(type, C)
-// Info 4164: (149-153): Inferred type: 'k:(type, C)
+// Info 4164: (101-105): Inferred type: 's:(type, C)
+// Info 4164: (115-154): Inferred type: ('s:(type, C), 's:(type, C)) -> 's:(type, C)
+// Info 4164: (127-145): Inferred type: ('s:(type, C), 's:(type, C))
+// Info 4164: (128-135): Inferred type: 's:(type, C)
+// Info 4164: (131-135): Inferred type: 's:(type, C)
+// Info 4164: (137-144): Inferred type: 's:(type, C)
+// Info 4164: (140-144): Inferred type: 's:(type, C)
+// Info 4164: (149-153): Inferred type: 's:(type, C)
 // Info 4164: (158-175): Inferred type: P1
-// Info 4164: (164-168): Inferred type: 'l:(type, P1)
+// Info 4164: (164-168): Inferred type: 't:(type, P1)
 // Info 4164: (176-193): Inferred type: P2
-// Info 4164: (182-186): Inferred type: 'm:(type, P2)
+// Info 4164: (182-186): Inferred type: 'u:(type, P2)
 // Info 4164: (194-211): Inferred type: P3
-// Info 4164: (200-204): Inferred type: 'n:(type, P3)
+// Info 4164: (200-204): Inferred type: 'v:(type, P3)
 // Info 4164: (212-229): Inferred type: P4
-// Info 4164: (218-222): Inferred type: 'o:(type, P4)
+// Info 4164: (218-222): Inferred type: 'w:(type, P4)
 // Info 4164: (231-255): Inferred type: void
 // Info 4164: (256-280): Inferred type: void
 // Info 4164: (281-305): Inferred type: void


### PR DESCRIPTION
This is something I should have done already in #14558. This puts both built-in and user-defined classes in the same pass.

I need it to be able to move instantiation registration out of `TypeInference`. The new pass has to access the `builtinClasses` annotation, which is in `TypeInference`.