### PR TITLE
Increase resource_class of prb-math external test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -738,6 +738,7 @@ defaults:
       project: prb-math
       binary_type: native
       image: cimg/rust:1.74.0-node
+      resource_class: medium
 
   - job_native_test_ext_elementfi: &job_native_test_ext_elementfi
       <<: *requires_b_ubu_static


### PR DESCRIPTION
The external tests for PRB-Math have started failing and are consuming all the memory of the CI Docker image. You can view the details of the issue [here](https://app.circleci.com/pipelines/github/ethereum/solidity/32143/workflows/a5118a82-64ef-4dab-b758-a875e9a60605/jobs/1437064/resources).

The problem may be related to a recent change made in this commit: https://github.com/PaulRBerg/prb-math/commit/5aa88e73a9f9ef2a5aebd9f319e391797759ab55. However, I haven't delved deeply into the specifics of the updated dependencies. 