### PR TITLE
Fix chai to version 4.4.0 in Brink external test

### DIFF
--- a/test/externalTests/brink.sh
+++ b/test/externalTests/brink.sh
@@ -73,7 +73,9 @@ function brink_test
     yarn add hardhat-gas-reporter
 
     # TODO: Remove when https://github.com/brinktrade/brink-core/issues/48 is fixed.
-    yarn add chai
+    # TODO: Chai is ESM-only since version 5.x (see: https://github.com/chaijs/chai/issues/1561#issuecomment-1871134261),
+    # thus, we should stick to version 4.x until Brink and other dependencies also migrate to ESM.
+    yarn add chai@4.4.0
 
     replace_version_pragmas
 


### PR DESCRIPTION
Brink is a CommonJS project and currently depends on [Chai version 4.x](https://github.com/brinktrade/brink-core/blob/master/package.json#L21). However, the recent transition of Chai to ESM-only starting from version 5.x (see: https://github.com/chaijs/chai/issues/1561#issuecomment-1871134261) has led to CI failures in our external tests (see: https://app.circleci.com/pipelines/github/ethereum/solidity/32302/workflows/998b76e7-be1f-4e17-843e-9d8e212a4df6/jobs/1444699).

Given that our external tests always run with the latest dependencies, it seems fine to temporarily fix the Chai version to 4.x until Brink migrates to ESM.
