### PR TITLE
solidity grammar: add a new rule `usingAliases` for `usingDirective`

### DIFF
--- a/docs/grammar/SolidityParser.g4
+++ b/docs/grammar/SolidityParser.g4
@@ -337,7 +337,14 @@ userDefinableOperator:
  * Using directive to attach library functions and free functions to types.
  * Can occur within contracts and libraries and at the file level.
  */
-usingDirective: Using (identifierPath | (LBrace identifierPath (As userDefinableOperator)? (Comma identifierPath (As userDefinableOperator)?)* RBrace)) For (Mul | typeName) Global? Semicolon;
+usingDirective:
+  Using (
+    identifierPath
+    | (LBrace usingAliases (Comma usingAliases)* RBrace)
+  ) For (Mul | typeName) Global? Semicolon;
+
+usingAliases: identifierPath (As userDefinableOperator)?;
+
 /**
  * A type name can be an elementary type, a function type, a mapping type, a user-defined type
  * (e.g. a contract or struct) or an array type.


### PR DESCRIPTION
Thank you very much for providing the perfect solidity antlr4 grammar in the official repository, I encountered some problems when using it to build the [solidity-antlr4](https://github.com/jeasonstudio/solidity-antlr4) project (ast parser). This Pull-Request fixes the issue.

In the original grammar definition, `usingDirective` is hard to parse by the parser runtime:
https://github.com/ethereum/solidity/blob/ec563a12cb9247d985df1e52cfacd9d03520fa2c/docs/grammar/SolidityParser.g4#L336-L340

For example, my code is like this:
```solidity
using { A, B as + } for uint;
```

Here is how my parser handles it (using antlr4 typescript as an example):
```ts
const visitUsingDirective = (ctx: UsingDirectiveContext) => {
  const isUsingAlias = !!ctx.LBrace() && !!ctx.RBrace(); // not good.
  if (!isUsingAlias) {
    const name = ctx.identifierPath(0); // shouldn't be an array.
  } else {
    const names = ctx.identifierPath(); // symbols.
    const alias = ctx.userDefinableOperator(); // aliases(operators), but it can't correspond with symbol one by one.
  }
};
```

So I added a new rule `usingAliases` to solve this problem, and the rule designed refer to the definition of `importDirective`:
```g4
usingDirective:
  Using (
    identifierPath
    | (LBrace usingAliases (Comma usingAliases)* RBrace)
  ) For (Mul | typeName) Global? Semicolon;

usingAliases: identifierPath (As userDefinableOperator)?;
```

Hope it can be processed soon, thanks.