### PR TITLE
Testing enhancements for `MCOPY`

### DIFF
--- a/test/Common.cpp
+++ b/test/Common.cpp
@@ -289,6 +289,13 @@ bool isValidSemanticTestPath(boost::filesystem::path const& _testPath)
 	return true;
 }
 
+boost::unit_test::precondition::predicate_t minEVMVersionCheck(langutil::EVMVersion _minEVMVersion)
+{
+	return [_minEVMVersion](boost::unit_test::test_unit_id) {
+		return test::CommonOptions::get().evmVersion() >= _minEVMVersion;
+	};
+}
+
 bool loadVMs(CommonOptions const& _options)
 {
 	if (_options.disableSemanticTests)

--- a/test/Common.h
+++ b/test/Common.h
@@ -27,6 +27,7 @@
 
 #include <boost/filesystem/path.hpp>
 #include <boost/program_options.hpp>
+#include <boost/test/unit_test.hpp>
 
 namespace solidity::test
 {
@@ -99,6 +100,11 @@ private:
 /// I.e. if the test is located in the semantic test directory and is not excluded due to being a part of external sources.
 /// Note: @p _testPath can be relative but must include at least the `/test/libsolidity/semanticTests/` part
 bool isValidSemanticTestPath(boost::filesystem::path const& _testPath);
+
+/// Helper that can be used to skip tests when the EVM version selected on the command line
+/// is older than @p _minEVMVersion.
+/// @return A predicate (function) that can be passed into @a boost::unit_test::precondition().
+boost::unit_test::precondition::predicate_t minEVMVersionCheck(langutil::EVMVersion _minEVMVersion);
 
 bool loadVMs(CommonOptions const& _options);
 

--- a/test/libsolidity/FunctionDependencyGraphTest.cpp
+++ b/test/libsolidity/FunctionDependencyGraphTest.cpp
@@ -20,8 +20,11 @@
 
 #include <libsolidity/experimental/analysis/Analysis.h>
 #include <libsolidity/experimental/analysis/FunctionDependencyAnalysis.h>
+
 #include <libyul/backends/evm/EVMDialect.h>
 #include <libyul/optimiser/FunctionCallFinder.h>
+
+#include <libsolutil/StringUtils.h>
 
 #include <fstream>
 #include <stdexcept>
@@ -41,7 +44,7 @@ TestCase::TestResult FunctionDependencyGraphTest::run(std::ostream& _stream, std
 	compiler().setOptimiserSettings(OptimiserSettings::none());
 	if (!compiler().compile(CompilerStack::AnalysisSuccessful))
 	{
-		_stream << formatErrors(filteredErrors(), _formatted);
+		printPrefixed(_stream, formatErrors(filteredErrors(), _formatted), _linePrefix);
 		return TestResult::FatalError;
 	}
 

--- a/test/libsolidity/GasMeter.cpp
+++ b/test/libsolidity/GasMeter.cpp
@@ -61,14 +61,9 @@ public:
 		// costs for transaction
 		gas += gasForTransaction(m_compiler.object(m_compiler.lastContractName()).bytecode, true);
 
-		// Skip the tests when we use ABIEncoderV2.
-		// TODO: We should enable this again once the yul optimizer is activated.
-		if (solidity::test::CommonOptions::get().useABIEncoderV1)
-		{
-			BOOST_REQUIRE(!gas.isInfinite);
-			BOOST_CHECK_LE(m_gasUsed, gas.value);
-			BOOST_CHECK_LE(gas.value - _tolerance, m_gasUsed);
-		}
+		BOOST_REQUIRE(!gas.isInfinite);
+		BOOST_CHECK_LE(m_gasUsed, gas.value);
+		BOOST_CHECK_LE(gas.value - _tolerance, m_gasUsed);
 	}
 
 	/// Compares the gas computed by PathGasMeter for the given signature (but unknown arguments)
@@ -90,14 +85,9 @@ public:
 			*m_compiler.runtimeAssemblyItems(m_compiler.lastContractName()),
 			_sig
 		);
-		// Skip the tests when we use ABIEncoderV2.
-		// TODO: We should enable this again once the yul optimizer is activated.
-		if (solidity::test::CommonOptions::get().useABIEncoderV1)
-		{
-			BOOST_REQUIRE(!gas.isInfinite);
-			BOOST_CHECK_LE(m_gasUsed, gas.value);
-			BOOST_CHECK_LE(gas.value - _tolerance, m_gasUsed);
-		}
+		BOOST_REQUIRE(!gas.isInfinite);
+		BOOST_CHECK_LE(m_gasUsed, gas.value);
+		BOOST_CHECK_LE(gas.value - _tolerance, m_gasUsed);
 	}
 
 	static GasMeter::GasConsumption gasForTransaction(bytes const& _data, bool _isCreation)
@@ -129,6 +119,9 @@ BOOST_AUTO_TEST_CASE(simple_contract)
 BOOST_AUTO_TEST_CASE(store_keccak256)
 {
 	char const* sourceCode = R"(
+		// TODO: We should enable v2 again once the yul optimizer is activated.
+		pragma abicoder v1;
+
 		contract test {
 			bytes32 public shaValue;
 			constructor() {
@@ -205,6 +198,9 @@ BOOST_AUTO_TEST_CASE(function_calls)
 BOOST_AUTO_TEST_CASE(multiple_external_functions)
 {
 	char const* sourceCode = R"(
+		// TODO: We should enable v2 again once the yul optimizer is activated.
+		pragma abicoder v1;
+
 		contract test {
 			uint data;
 			uint data2;
@@ -236,6 +232,9 @@ BOOST_AUTO_TEST_CASE(multiple_external_functions)
 BOOST_AUTO_TEST_CASE(exponent_size)
 {
 	char const* sourceCode = R"(
+		// TODO: We should enable v2 again once the yul optimizer is activated.
+		pragma abicoder v1;
+
 		contract A {
 			function f(uint x) public returns (uint) {
 				unchecked { return x ** 0; }
@@ -302,6 +301,9 @@ BOOST_AUTO_TEST_CASE(complex_control_flow)
 	// Now we do not follow branches if they start out with lower gas costs than the ones
 	// we previously considered. This of course reduces accuracy.
 	char const* sourceCode = R"(
+		// TODO: We should enable v2 again once the yul optimizer is activated.
+		pragma abicoder v1;
+
 		contract log {
 			function ln(int128 x) public pure returns (int128 result) {
 				unchecked {

--- a/test/libsolidity/GasTest.cpp
+++ b/test/libsolidity/GasTest.cpp
@@ -21,6 +21,7 @@
 #include <test/Common.h>
 #include <libsolutil/CommonIO.h>
 #include <libsolutil/JSON.h>
+#include <libsolutil/StringUtils.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem.hpp>
@@ -123,7 +124,7 @@ TestCase::TestResult GasTest::run(std::ostream& _stream, std::string const& _lin
 {
 	if (!runFramework(withPreamble(m_source), PipelineStage::Compilation))
 	{
-		_stream << formatErrors(filteredErrors(), _formatted);
+		util::printPrefixed(_stream, formatErrors(filteredErrors(), _formatted), _linePrefix);
 		return TestResult::FatalError;
 	}
 

--- a/test/libsolidity/MemoryGuardTest.cpp
+++ b/test/libsolidity/MemoryGuardTest.cpp
@@ -65,7 +65,8 @@ TestCase::TestResult MemoryGuardTest::run(std::ostream& _stream, std::string con
 
 		if (!object || !analysisInfo || Error::containsErrors(errors))
 		{
-			AnsiColorized(_stream, _formatted, {formatting::BOLD, formatting::RED}) << _linePrefix << "Error parsing IR." << std::endl;
+			AnsiColorized(_stream, _formatted, {formatting::BOLD, formatting::RED}) << _linePrefix << "Error parsing IR:" << std::endl;
+			printPrefixed(_stream, formatErrors(filterErrors(errors), _formatted), _linePrefix);
 			return TestResult::FatalError;
 		}
 

--- a/test/libsolidity/MemoryGuardTest.cpp
+++ b/test/libsolidity/MemoryGuardTest.cpp
@@ -18,6 +18,7 @@
 
 #include <test/libsolidity/MemoryGuardTest.h>
 
+#include <test/Common.h>
 #include <test/libyul/Common.h>
 #include <libsolidity/codegen/ir/Common.h>
 #include <libsolutil/Algorithms.h>
@@ -35,6 +36,7 @@ using namespace solidity::util::formatting;
 using namespace solidity::langutil;
 using namespace solidity::frontend;
 using namespace solidity::frontend::test;
+using namespace solidity::test;
 using namespace yul;
 
 void MemoryGuardTest::setupCompiler(CompilerStack& _compiler)
@@ -59,7 +61,7 @@ TestCase::TestResult MemoryGuardTest::run(std::ostream& _stream, std::string con
 		ErrorList errors;
 		auto [object, analysisInfo] = yul::test::parse(
 			compiler().yulIR(contractName),
-			EVMDialect::strictAssemblyForEVMObjects({}),
+			EVMDialect::strictAssemblyForEVMObjects(CommonOptions::get().evmVersion()),
 			errors
 		);
 

--- a/test/libsolidity/MemoryGuardTest.cpp
+++ b/test/libsolidity/MemoryGuardTest.cpp
@@ -21,6 +21,7 @@
 #include <test/libyul/Common.h>
 #include <libsolidity/codegen/ir/Common.h>
 #include <libsolutil/Algorithms.h>
+#include <libsolutil/StringUtils.h>
 #include <libyul/Object.h>
 #include <libyul/backends/evm/EVMDialect.h>
 #include <libyul/optimiser/FunctionCallFinder.h>
@@ -48,7 +49,7 @@ TestCase::TestResult MemoryGuardTest::run(std::ostream& _stream, std::string con
 {
 	if (!runFramework(m_source, PipelineStage::Compilation))
 	{
-		_stream << formatErrors(filteredErrors(), _formatted);
+		printPrefixed(_stream, formatErrors(filteredErrors(), _formatted), _linePrefix);
 		return TestResult::FatalError;
 	}
 

--- a/test/libsolidity/MemoryGuardTest.h
+++ b/test/libsolidity/MemoryGuardTest.h
@@ -34,14 +34,14 @@ namespace solidity::frontend::test
 
 using solidity::test::SyntaxTestError;
 
-class MemoryGuardTest: public AnalysisFramework, public TestCase
+class MemoryGuardTest: public AnalysisFramework, public EVMVersionRestrictedTestCase
 {
 public:
 	static std::unique_ptr<TestCase> create(Config const& _config)
 	{
 		return std::make_unique<MemoryGuardTest>(_config.filename);
 	}
-	MemoryGuardTest(std::string const& _filename): TestCase(_filename)
+	MemoryGuardTest(std::string const& _filename): EVMVersionRestrictedTestCase(_filename)
 	{
 		m_source = m_reader.source();
 		m_expectation = m_reader.simpleExpectations();

--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.h
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.h
@@ -49,8 +49,11 @@ namespace solidity::yul::test
 /// @a _target at offset @a _targetOffset. Behaves as if @a _source would
 /// continue with an infinite sequence of zero bytes beyond its end.
 void copyZeroExtended(
-	std::map<u256, uint8_t>& _target, bytes const& _source,
-	size_t _targetOffset, size_t _sourceOffset, size_t _size
+	std::map<u256, uint8_t>& _target,
+	bytes const& _source,
+	size_t _targetOffset,
+	size_t _sourceOffset,
+	size_t _size
 );
 
 struct InterpreterState;


### PR DESCRIPTION
Prerequisite for #14779.

A bunch of enhancements to the test framework that I did while working on `MSIZE`. Some of my tests depend on them:
- Restricting minimum EVM version in boost tests and memory guard tests.
- Memory guard tests were ignoring EVM version selected on the command line.
- Memory guard tests were hiding the errors from Yul parsing, which includes ones you get when you try to use an opcode that's not available on the selected EVM version.
- All tests in `GasMeter.cpp` were apparently disabled on abicoder v2 in #5102. Most of them work fine though, so I changed it back so that both v1 and v2 run by default and only those few tests that are broken have a bypass.
- Small formatting tweak in a few `AnalysisFramework` based test to make them print errors properly prefixed with the right indent.
- Small `EVMInstructionInterpreter.h` refactors that I originally had in #14779.