### PR TITLE
Update documentation about `codehash` behaviour according to EIP-1052 and EIP-161

### DIFF
--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -338,6 +338,13 @@ You can query the deployed code for any smart contract. Use ``.code`` to get the
 ``bytes memory``, which might be empty. Use ``.codehash`` to get the Keccak-256 hash of that code
 (as a ``bytes32``). Note that ``addr.codehash`` is cheaper than using ``keccak256(addr.code)``.
 
+.. warning::
+    The output of ``addr.codehash`` may be ``0`` if the account associated with ``addr`` is empty or non-existent
+    (i.e., it has no code, zero balance, and zero nonce as defined by `EIP-161 <https://eips.ethereum.org/EIPS/eip-161>`_).
+    If the account has no code but a non-zero balance or nonce, then ``addr.codehash`` will output the Keccak-256 hash of empty data
+    (i.e., ``keccak256("")`` which is equal to ``c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470``), as defined by
+    `EIP-1052 <https://eips.ethereum.org/EIPS/eip-1052>`_.
+
 .. note::
     All contracts can be converted to ``address`` type, so it is possible to query the balance of the
     current contract using ``address(this).balance``.


### PR DESCRIPTION
Fixes https://github.com/ethereum/solidity/issues/14794 by adding a warning for the `codehash` usage.