### PR TITLE
Clean up docs to with regards to changes in SELFDESTRUCT opcode

### DIFF
--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -118,7 +118,7 @@ Contract-related
 
 - ``this`` (current contract's type): the current contract, explicitly convertible to ``address`` or ``address payable``
 - ``super``: a contract one level higher in the inheritance hierarchy
-- ``selfdestruct(address payable recipient)``: destroy the current contract, sending its funds to the given address
+- ``selfdestruct(address payable recipient)``: send all funds to the given address and (only on EVMs before Cancun or when invoked within the transaction creating the contract) destroy the contract.
 
 .. index:: type;name, type;creationCode, type;runtimeCode, type;interfaceId, type;min, type;max
 

--- a/docs/contracts/function-modifiers.rst
+++ b/docs/contracts/function-modifiers.rst
@@ -19,7 +19,6 @@ if they are marked ``virtual``. For details, please see
 
     // SPDX-License-Identifier: GPL-3.0
     pragma solidity >=0.7.1 <0.9.0;
-    // This will report a warning due to deprecated selfdestruct
 
     contract owned {
         constructor() { owner = payable(msg.sender); }
@@ -41,16 +40,6 @@ if they are marked ``virtual``. For details, please see
         }
     }
 
-    contract destructible is owned {
-        // This contract inherits the `onlyOwner` modifier from
-        // `owned` and applies it to the `destroy` function, which
-        // causes that calls to `destroy` only have an effect if
-        // they are made by the stored owner.
-        function destroy() public onlyOwner {
-            selfdestruct(owner);
-        }
-    }
-
     contract priced {
         // Modifiers can receive arguments:
         modifier costs(uint price) {
@@ -60,7 +49,7 @@ if they are marked ``virtual``. For details, please see
         }
     }
 
-    contract Register is priced, destructible {
+    contract Register is priced, owned {
         mapping(address => bool) registeredAddresses;
         uint price;
 
@@ -73,6 +62,9 @@ if they are marked ``virtual``. For details, please see
             registeredAddresses[msg.sender] = true;
         }
 
+        // This contract inherits the `onlyOwner` modifier from
+        // the `owned` contract. As a result, calls to `changePrice` will
+        // only take effect if they are made by the stored owner.
         function changePrice(uint price_) public onlyOwner {
             price = price_;
         }

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -563,9 +563,23 @@ idea, but it is potentially dangerous, as if someone sends Ether to removed
 contracts, the Ether is forever lost.
 
 .. warning::
-    From version 0.8.18 and up, the use of ``selfdestruct`` in both Solidity and Yul will trigger a
-    deprecation warning, since the ``SELFDESTRUCT`` opcode will eventually undergo breaking changes in behavior
-    as stated in `EIP-6049 <https://eips.ethereum.org/EIPS/eip-6049>`_.
+    From ``EVM >= Cancun`` onwards, ``selfdestruct`` will **only** send all Ether in the account to the given recipient and not destroy the contract.
+    However, when ``selfdestruct`` is called in the same transaction that creates the contract calling it,
+    the behaviour of ``selfdestruct`` before Cancun hardfork (i.e., ``EVM <= Shanghai``) is preserved and will destroy the current contract,
+    deleting any data, including storage keys, code and the account itself.
+    See `EIP-6780 <https://eips.ethereum.org/EIPS/eip-6780>`_ for more details.
+
+    The new behaviour is the result of a network-wide change that affects all contracts present on
+    the Ethereum mainnet and testnets.
+    It is important to note that this change is dependent on the EVM version of the chain on which
+    the contract is deployed.
+    The ``--evm-version`` setting used when compiling the contract has no bearing on it.
+
+    Also, note that the ``selfdestruct`` opcode has been deprecated in Solidity version 0.8.18,
+    as recommended by `EIP-6049 <https://eips.ethereum.org/EIPS/eip-6049>`_.
+    The deprecation is still in effect and the compiler will still emit warnings on its use.
+    Any use in newly deployed contracts is strongly discouraged even if the new behavior is taken into account.
+    Future changes to the EVM might further reduce the functionality of the opcode.
 
 .. warning::
     Even if a contract is removed by ``selfdestruct``, it is still part of the

--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -175,9 +175,9 @@ explanatory purposes.
       },
       // Required: Compilation source files/source units, keys are file paths
       "sources": {
-        "destructible": {
+        "settable": {
           // Required (unless "url" is used): literal contents of the source file
-          "content": "contract destructible is owned { function destroy() { if (msg.sender == owner) selfdestruct(owner); } }",
+          "content": "contract settable is owned { uint256 private x = 0; function set(uint256 _x) public { if (msg.sender == owner) x = _x; } }",
           // Required: keccak256 hash of the source file
           "keccak256": "0x234..."
         },

--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -662,9 +662,10 @@ Yes:
         return balanceOf[from];
     }
 
-    function shutdown() public onlyOwner {
-        selfdestruct(owner);
+    function increment(uint x) public onlyOwner pure returns (uint) {
+        return x + 1;
     }
+
 
 No:
 
@@ -674,8 +675,8 @@ No:
         return balanceOf[from];
     }
 
-    function shutdown() onlyOwner public {
-        selfdestruct(owner);
+    function increment(uint x) onlyOwner public pure returns (uint) {
+        return x + 1;
     }
 
 For long function declarations, it is recommended to drop each argument onto

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -339,9 +339,23 @@ Contract-related
 Furthermore, all functions of the current contract are callable directly including the current function.
 
 .. warning::
-    From version 0.8.18 and up, the use of ``selfdestruct`` in both Solidity and Yul will trigger a
-    deprecation warning, since the ``SELFDESTRUCT`` opcode will eventually undergo breaking changes in behavior
-    as stated in `EIP-6049 <https://eips.ethereum.org/EIPS/eip-6049>`_.
+    From ``EVM >= Cancun`` onwards, ``selfdestruct`` will **only** send all Ether in the account to the given recipient and not destroy the contract.
+    However, when ``selfdestruct`` is called in the same transaction that creates the contract calling it,
+    the behaviour of ``selfdestruct`` before Cancun hardfork (i.e., ``EVM <= Shanghai``) is preserved and will destroy the current contract,
+    deleting any data, including storage keys, code and the account itself.
+    See `EIP-6780 <https://eips.ethereum.org/EIPS/eip-6780>`_ for more details.
+
+    The new behaviour is the result of a network-wide change that affects all contracts present on
+    the Ethereum mainnet and testnets.
+    It is important to note that this change is dependent on the EVM version of the chain on which
+    the contract is deployed.
+    The ``--evm-version`` setting used when compiling the contract has no bearing on it.
+
+    Also, note that the ``selfdestruct`` opcode has been deprecated in Solidity version 0.8.18,
+    as recommended by `EIP-6049 <https://eips.ethereum.org/EIPS/eip-6049>`_.
+    The deprecation is still in effect and the compiler will still emit warnings on its use.
+    Any use in newly deployed contracts is strongly discouraged even if the new behavior is taken into account.
+    Future changes to the EVM might further reduce the functionality of the opcode.
 
 .. note::
     Prior to version 0.5.0, there was a function called ``suicide`` with the same

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -236,12 +236,12 @@ Input Description
             // `--allow-paths <path>`.
           ]
         },
-        "destructible":
+        "settable":
         {
           // Optional: keccak256 hash of the source file
           "keccak256": "0x234...",
           // Required (unless "urls" is used): literal contents of the source file
-          "content": "contract destructible is owned { function shutdown() { if (msg.sender == owner) selfdestruct(owner); } }"
+          "content": "contract settable is owned { uint256 private x = 0; function set(uint256 _x) public { if (msg.sender == owner) x = _x; } }"
         },
         "myFile.sol_json.ast":
         {


### PR DESCRIPTION
Clean up docs to reflect changes in the behaviour of `SELFDESTRUCT` as per [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780).

Fixes #13889 

Checklist for docs files to be changed:

- [x] docs/cheatsheet.rst
- [x] docs/contracts/function-modifiers.rst
- [x] docs/contracts/functions.rst 
    -  no changes seem to be needed regarding the mention of `selfdestruct` there.
- [x] docs/contracts/inheritance.rst
- [x] docs/examples/micropayment.rst
- [x] docs/internals/optimizer.rst
    -  no changes seem to be needed regarding the mention of `selfdestruct` there.
- [x] docs/metadata.rst
- [x] docs/security-considerations.rst
    -  no changes seem to be needed regarding the mention of `selfdestruct` there.
- [x] docs/smtchecker.rst 
    -  no changes seem to be needed regarding the mention of `selfdestruct` there. However, we may need to account for the semantic change of `selfdestruct` in our tests when Cancun becomes the default EVM version.
- [x] docs/style-guide.rst
- [x] docs/using-the-compiler.rst