### PR TITLE
Fix openzeppelin external test

### DIFF
--- a/test/externalTests/zeppelin.sh
+++ b/test/externalTests/zeppelin.sh
@@ -106,6 +106,10 @@ function zeppelin_test
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")"
     npm install
 
+    # TODO: We fix the version to 2.0.3 instead of 2.0.4 since the latter does not work with ethers.js 6.10.0
+    # Maybe related to the use of dynamic imports here: https://github.com/NomicFoundation/hardhat/commit/16ae15642951ac324ef7093a3342f7cf3a2a49a4
+    npm install @nomicfoundation/hardhat-chai-matchers@2.0.3
+
     replace_version_pragmas
 
     for preset in $SELECTED_PRESETS; do


### PR DESCRIPTION
Fix openzeppelin external test that started to fail. See: https://app.circleci.com/pipelines/github/ethereum/solidity/32755/workflows/23dee02b-197d-4522-a3ae-1c31e43afffa/jobs/1468409

Not really sure about the cause, it appears related to version incompatibility between `ethers` version `6.10.0` and `@nomicfoundation/hardhat-chai-matchers` version `2.0.4`, which are used by our external test script, since we remove the `package-lock.json` file.