### PR TITLE
SMTChecker: Fix crash on mappings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * SMTChecker: Fix internal error caused by not respecting the sign of an integer type when constructing zero-value SMT expressions.
 
 
 ### 0.8.24 (2024-01-25)

--- a/libsmtutil/SolverInterface.h
+++ b/libsmtutil/SolverInterface.h
@@ -124,7 +124,7 @@ public:
 	explicit Expression(std::string _name, std::vector<Expression> _arguments, SortPointer _sort):
 		name(std::move(_name)), arguments(std::move(_arguments)), sort(std::move(_sort)) {}
 	Expression(size_t _number): Expression(std::to_string(_number), {}, SortProvider::uintSort) {}
-	Expression(u256 const& _number): Expression(_number.str(), {}, SortProvider::sintSort) {}
+	Expression(u256 const& _number): Expression(_number.str(), {}, SortProvider::uintSort) {}
 	Expression(s256 const& _number): Expression(
 		_number >= 0 ? _number.str() : "-",
 		_number >= 0 ?

--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -476,7 +476,7 @@ smtutil::Expression zeroValue(frontend::Type const* _type)
 	if (isSupportedType(*_type))
 	{
 		if (isNumber(*_type))
-			return 0;
+			return isSigned(_type) ? smtutil::Expression(s256(0)) : smtutil::Expression(static_cast<size_t>(0));
 		if (isBool(*_type))
 			return smtutil::Expression(false);
 		if (isArray(*_type) || isMapping(*_type))

--- a/test/libsolidity/smtCheckerTests/types/mapping_6.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_6.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0
+
+
+// Regression for handling signedness, see issues #14791 and #14792
+contract C {
+    mapping(bool => int240) internal v1;
+    mapping(bytes14 => bytes15) internal v;
+
+    function f() public payable {
+        delete v["A"];
+    }
+}


### PR DESCRIPTION
Previously, creating zero value expression for integer type (`solidity::frontend::IntegerType`) did not respect signedness of the type. This led to an assertion violation in methods creating SMT representation of array expressions, which have strict type checks.
We fix the issues by correctly constructing either signed or unsigned SMT expression representing zero based on the sign of the provided integer type.

Fixes #14791.
Fixes #14792.