### PR TITLE
Allow enforcing gas expectations with non-standard settings

### DIFF
--- a/test/Common.cpp
+++ b/test/Common.cpp
@@ -143,18 +143,16 @@ void CommonOptions::validate() const
 		"Selected batch has to be less than number of batches."
 	);
 
-	if (enforceGasTest)
+	if (!enforceGasTest)
+		cout << endl << "WARNING :: Gas cost expectations are not being enforced" << endl << endl;
+	else if (evmVersion() != langutil::EVMVersion{} || useABIEncoderV1)
 	{
-		assertThrow(
-			evmVersion() == langutil::EVMVersion{},
-			ConfigException,
-			"Gas costs can only be enforced on latest evm version."
-		);
-		assertThrow(
-			useABIEncoderV1 == false,
-			ConfigException,
-			"Gas costs can only be enforced on abi encoder v2."
-		);
+		cout << endl << "WARNING :: Enforcing gas cost expectations with non-standard settings:" << endl;
+		if (evmVersion() != langutil::EVMVersion{})
+			cout << "- EVM version: " << evmVersion().name() << " (default: " << langutil::EVMVersion{}.name() << ")" << endl;
+		if (useABIEncoderV1)
+			cout << "- ABI coder: v1 (default: v2)" << endl;
+		cout << endl << "DO NOT COMMIT THE UPDATED EXPECTATIONS." << endl << endl;
 	}
 }
 

--- a/test/soltest.cpp
+++ b/test/soltest.cpp
@@ -238,9 +238,6 @@ test_suite* init_unit_test_suite(int /*argc*/, char* /*argv*/[])
 		if (solidity::test::CommonOptions::get().disableSemanticTests)
 			cout << endl << "--- SKIPPING ALL SEMANTICS TESTS ---" << endl << endl;
 
-		if (!solidity::test::CommonOptions::get().enforceGasTest)
-			cout << endl << "WARNING :: Gas Cost Expectations are not being enforced" << endl << endl;
-
 		Batcher batcher(CommonOptions::get().selectedBatch, CommonOptions::get().batches);
 		if (CommonOptions::get().batches > 1)
 			cout << "Batch " << CommonOptions::get().selectedBatch << " out of " << CommonOptions::get().batches << endl;

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -448,9 +448,6 @@ int main(int argc, char const *argv[])
 		if (options.disableSemanticTests)
 			cout << endl << "--- SKIPPING ALL SEMANTICS TESTS ---" << endl << endl;
 
-		if (!options.enforceGasTest)
-			cout << "WARNING :: Gas Cost Expectations are not being enforced" << endl << endl;
-
 		TestStats global_stats{0, 0};
 		cout << "Running tests..." << endl << endl;
 


### PR DESCRIPTION
Currently isoltest/soltest refuses to update costs with non-standard settings, like non-default EVM version or with ABI coder v1. It would be convenient to bypass this, e.g. in #14834 where we're really interested in seeing how costs change on Cancun.

This PR replaces this validation with a warning.