### PR TITLE
Minor fixes in handling `selfdestruct` in `EVMHost`

### DIFF
--- a/test/EVMHost.cpp
+++ b/test/EVMHost.cpp
@@ -359,6 +359,7 @@ evmc::Result EVMHost::call(evmc_message const& _message) noexcept
 	auto& destination = accounts[message.recipient];
 	if (message.kind == EVMC_CREATE || message.kind == EVMC_CREATE2)
 		// Mark account as created if it is a CREATE or CREATE2 call
+		// TODO: Should we roll changes back on failure like we do for `accounts`?
 		m_newlyCreatedAccounts.emplace(message.recipient);
 
 	if (value != 0 && message.kind != EVMC_DELEGATECALL && message.kind != EVMC_CALLCODE)

--- a/test/EVMHost.cpp
+++ b/test/EVMHost.cpp
@@ -198,12 +198,12 @@ void EVMHost::newTransactionFrame()
 	}
 	// Process selfdestruct list
 	for (auto& [address, _]: recorded_selfdestructs)
-		if (m_evmVersion < langutil::EVMVersion::cancun() || newlyCreatedAccounts.count(address))
+		if (m_evmVersion < langutil::EVMVersion::cancun() || m_newlyCreatedAccounts.count(address))
 			// EIP-6780: If SELFDESTRUCT is executed in a transaction different from the one
 			// in which it was created, we do NOT record it or clear any data.
 			// Otherwise, the previous behavior (pre-Cancun) is maintained.
 			accounts.erase(address);
-	newlyCreatedAccounts.clear();
+	m_newlyCreatedAccounts.clear();
 	m_totalCodeDepositGas = 0;
 	recorded_selfdestructs.clear();
 }
@@ -358,7 +358,7 @@ evmc::Result EVMHost::call(evmc_message const& _message) noexcept
 	auto& destination = accounts[message.recipient];
 	if (message.kind == EVMC_CREATE || message.kind == EVMC_CREATE2)
 		// Mark account as created if it is a CREATE or CREATE2 call
-		newlyCreatedAccounts.emplace(message.recipient);
+		m_newlyCreatedAccounts.emplace(message.recipient);
 
 	if (value != 0 && message.kind != EVMC_DELEGATECALL && message.kind != EVMC_CALLCODE)
 	{

--- a/test/EVMHost.cpp
+++ b/test/EVMHost.cpp
@@ -161,6 +161,7 @@ void EVMHost::reset()
 	recorded_calls.clear();
 	// Clear EIP-2929 account access indicator
 	recorded_account_accesses.clear();
+	m_newlyCreatedAccounts.clear();
 	m_totalCodeDepositGas = 0;
 
 	// Mark all precompiled contracts as existing. Existing here means to have a balance (as per EIP-161).

--- a/test/EVMHost.h
+++ b/test/EVMHost.h
@@ -131,14 +131,14 @@ private:
 	static evmc::Result resultWithGas(int64_t gas_limit, int64_t gas_required, bytes const& _data) noexcept;
 	static evmc::Result resultWithFailure() noexcept;
 
-	/// Store the accounts that have been created in the current transaction.
-	std::unordered_set<evmc::address> newlyCreatedAccounts;
-
 	evmc::VM& m_vm;
 	/// EVM version requested by the testing tool
 	langutil::EVMVersion m_evmVersion;
 	/// EVM version requested from EVMC (matches the above)
 	evmc_revision m_evmRevision;
+
+	/// Store the accounts that have been created in the current transaction.
+	std::unordered_set<evmc::address> m_newlyCreatedAccounts;
 
 	/// The part of the total cost of the current transaction that paid for the code deposits.
 	/// I.e. GAS_CODE_DEPOSIT times the total size of deployed code of all newly created contracts,


### PR DESCRIPTION
Some minor things I missed in the review of #14785. In #14843 I was touching code directly next to it so I thought I'd fix those.

- `EVMHost::reset()` does not reset the list of new accounts.
- Naming convention.