### PR TITLE
[DOCS] Updating copyright year to 2024

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Solidity'
-project_copyright = '2016-2023, The Solidity Authors'
+project_copyright = '2016-2024, The Solidity Authors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
This PR has the goal of simply changing the copyright year from 2023 to 2024.

Plus, I would suggest to update the following from the [soliditylang.org](https://soliditylang.org/) website:

 - [ ] 2023 date in the website footer:
 
![image](https://github.com/ethereum/solidity/assets/5428251/c566ad2a-9c43-403e-9c91-e70fcd240d2a)

 - [ ] Twitter logo to X logo.

