### PR TITLE
[test] Add /usr/local/lib to search paths on macOS.

### DIFF
--- a/test/Common.cpp
+++ b/test/Common.cpp
@@ -78,7 +78,10 @@ std::optional<fs::path> findInDefaultPath(std::string const& lib_name)
 		fs::current_path() / ".." / "deps" / "lib",
 		fs::current_path() / ".." / ".." / "deps",
 		fs::current_path() / ".." / ".." / "deps" / "lib",
-		fs::current_path()
+		fs::current_path(),
+#ifdef __APPLE__
+		fs::current_path().root_path() / fs::path("usr") / "local" / "lib",
+#endif
 	};
 	for (auto const& basePath: searchPath)
 	{


### PR DESCRIPTION
Under macOS `/usr/local/lib` is not in the default search path, where the `/usr/lib` is protected - they call it `System Integrity Protection`. However, I would prefer to not touch `/usr/lib` and to use `/usr/local/lib` directly, without the need of setting special environment variables (e.g. `ETH_EVMONE`)