### PR TITLE
Use latest release instead of main branch on external tests

### DIFF
--- a/scripts/externalTests/runners/base.py
+++ b/scripts/externalTests/runners/base.py
@@ -47,7 +47,6 @@ CURRENT_EVM_VERSION: str = "shanghai"
 class TestConfig:
     name: str
     repo_url: str
-    ref_type: str
     ref: str
     compile_only_presets: List[SettingsPreset] = field(default_factory=list)
     settings_presets: List[SettingsPreset] = field(default_factory=lambda: list(SettingsPreset))
@@ -134,7 +133,7 @@ def run_test(runner: BaseRunner):
     print(f"Using compiler version {solc_version}")
 
     # Download project
-    download_project(runner.test_dir, runner.config.repo_url, runner.config.ref_type, runner.config.ref)
+    download_project(runner.test_dir, runner.config.repo_url, runner.config.ref)
 
     # Configure run environment
     runner.setup_environment()

--- a/test/externalTests/bleeps.sh
+++ b/test/externalTests/bleeps.sh
@@ -38,7 +38,6 @@ function test_fn { HARDHAT_DEPLOY_FIXTURE=true npx --no hardhat --no-compile tes
 function bleeps_test
 {
     local repo="https://github.com/wighawag/bleeps"
-    local ref_type=branch
     local ref=main
     local config_file="hardhat.config.ts"
     local config_var=config
@@ -58,7 +57,7 @@ function bleeps_test
     print_presets_or_exit "$SELECTED_PRESETS"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$ref_type" "$ref" "$DIR"
+    download_project "$repo" "$ref" "$DIR"
 
     pushd "common-lib/"
     neutralize_package_json_hooks

--- a/test/externalTests/brink.sh
+++ b/test/externalTests/brink.sh
@@ -37,8 +37,7 @@ function test_fn { SNAPSHOT_UPDATE=1 npx --no hardhat test; }
 function brink_test
 {
     local repo="https://github.com/brinktrade/brink-core"
-    local ref_type=branch
-    local ref=master
+    local ref="<latest-release>"
     local config_file="hardhat.config.js"
     local config_var=""
     local extra_settings="metadata: {bytecodeHash: 'none'}"
@@ -60,25 +59,18 @@ function brink_test
     print_presets_or_exit "$SELECTED_PRESETS"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$ref_type" "$ref" "$DIR"
+    download_project "$repo" "$ref" "$DIR"
 
     # TODO: Remove this when Brink merges https://github.com/brinktrade/brink-core/pull/52
     sed -i "s|\(function isValidSignature(bytes \)calldata\( _data, bytes \)calldata\( _signature)\)|\1memory\2memory\3|g" src/Test/MockEIP1271Validator.sol
 
-    neutralize_package_lock
     neutralize_package_json_hooks
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")" "$config_var" "$CURRENT_EVM_VERSION" "$extra_settings" "$extra_optimizer_settings"
     yarn install
     yarn add hardhat-gas-reporter
 
-    # TODO: Remove when https://github.com/brinktrade/brink-core/issues/48 is fixed.
-    # TODO: Chai is ESM-only since version 5.x (see: https://github.com/chaijs/chai/issues/1561#issuecomment-1871134261),
-    # thus, we should stick to version 4.x until Brink and other dependencies also migrate to ESM.
-    yarn add chai@4.4.0
-
     replace_version_pragmas
-
     for preset in $SELECTED_PRESETS; do
         hardhat_run_test "$config_file" "$preset" "${compile_only_presets[*]}" compile_fn test_fn "$config_var" "$extra_settings" "$extra_optimizer_settings"
         store_benchmark_report hardhat brink "$repo" "$preset"

--- a/test/externalTests/chainlink.sh
+++ b/test/externalTests/chainlink.sh
@@ -37,7 +37,6 @@ function test_fn { yarn test; }
 function chainlink_test
 {
     local repo="https://github.com/solidity-external-tests/chainlink"
-    local ref_type=branch
     local ref=develop_080
     local config_file="hardhat.config.ts"
     local config_var=config
@@ -58,7 +57,7 @@ function chainlink_test
     print_presets_or_exit "$SELECTED_PRESETS"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$ref_type" "$ref" "$DIR"
+    download_project "$repo" "$ref" "$DIR"
 
     cd "contracts/"
 

--- a/test/externalTests/colony.sh
+++ b/test/externalTests/colony.sh
@@ -37,7 +37,6 @@ function test_fn { yarn run test:contracts; }
 function colony_test
 {
     local repo="https://github.com/solidity-external-tests/colonyNetwork.git"
-    local ref_type=branch
     local ref="develop_080"
     local config_file="truffle.js"
 
@@ -57,7 +56,7 @@ function colony_test
     print_presets_or_exit "$SELECTED_PRESETS"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$ref_type" "$ref" "$DIR"
+    download_project "$repo" "$ref" "$DIR"
     [[ $BINARY_TYPE == native ]] && replace_global_solc "$BINARY_PATH"
 
     neutralize_package_json_hooks

--- a/test/externalTests/elementfi.sh
+++ b/test/externalTests/elementfi.sh
@@ -37,8 +37,7 @@ function test_fn { npm run test; }
 function elementfi_test
 {
     local repo="https://github.com/element-fi/elf-contracts"
-    local ref_type=branch
-    local ref=main
+    local ref="<latest-release>"
     local config_file="hardhat.config.ts"
     local config_var=config
 
@@ -60,7 +59,7 @@ function elementfi_test
     print_presets_or_exit "$SELECTED_PRESETS"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$ref_type" "$ref" "$DIR"
+    download_project "$repo" "$ref" "$DIR"
 
     chmod +x scripts/load-balancer-contracts.sh
     scripts/load-balancer-contracts.sh

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -37,7 +37,6 @@ function test_fn { yarn test; }
 function ens_test
 {
     local repo="https://github.com/ensdomains/ens-contracts.git"
-    local ref_type=commit
     local ref="083d29a2c50cd0a8307386abf8fadc217b256256"
     local config_file="hardhat.config.js"
 
@@ -57,7 +56,7 @@ function ens_test
     print_presets_or_exit "$SELECTED_PRESETS"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$ref_type" "$ref" "$DIR"
+    download_project "$repo" "$ref" "$DIR"
 
     neutralize_package_lock
     neutralize_package_json_hooks

--- a/test/externalTests/euler.sh
+++ b/test/externalTests/euler.sh
@@ -40,7 +40,6 @@ function test_fn {
 function euler_test
 {
     local repo="https://github.com/euler-xyz/euler-contracts"
-    local ref_type=branch
     local ref="master"
     local config_file="hardhat.config.js"
 
@@ -59,7 +58,7 @@ function euler_test
     print_presets_or_exit "$SELECTED_PRESETS"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$ref_type" "$ref" "$DIR"
+    download_project "$repo" "$ref" "$DIR"
 
     # Disable tests that won't pass on the ir presets due to Hardhat heuristics. Note that this also disables
     # them for other presets but that's fine - we want same code run for benchmarks to be comparable.

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -37,8 +37,7 @@ function test_fn { npm test; }
 function gnosis_safe_test
 {
     local repo="https://github.com/safe-global/safe-contracts.git"
-    local ref_type=branch
-    local ref=main
+    local ref="<latest-release>"
     local config_file="hardhat.config.ts"
     local config_var=userConfig
 
@@ -58,7 +57,7 @@ function gnosis_safe_test
     print_presets_or_exit "$SELECTED_PRESETS"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$ref_type" "$ref" "$DIR"
+    download_project "$repo" "$ref" "$DIR"
     [[ $BINARY_TYPE == native ]] && replace_global_solc "$BINARY_PATH"
 
     # NOTE: The patterns below intentionally have hard-coded versions.
@@ -77,7 +76,6 @@ function gnosis_safe_test
     sed -i "s|\(it\)\((\"can be used only via DELEGATECALL opcode\"\)|\1.skip\2|g" test/libraries/SignMessageLib.spec.ts
     sed -i "s|it\((\"can only be called from Safe itself\"\)|it.skip\1|g" test/libraries/Migration.spec.ts
 
-    neutralize_package_lock
     neutralize_package_json_hooks
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")" "$config_var"

--- a/test/externalTests/perpetual-pools.sh
+++ b/test/externalTests/perpetual-pools.sh
@@ -37,7 +37,6 @@ function test_fn { yarn test; }
 function perpetual_pools_test
 {
     local repo="https://github.com/solidity-external-tests/perpetual-pools-contracts"
-    local ref_type=branch
     local ref=pools-v2
     local config_file="hardhat.config.ts"
     local config_var="config"
@@ -57,7 +56,7 @@ function perpetual_pools_test
     print_presets_or_exit "$SELECTED_PRESETS"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$ref_type" "$ref" "$DIR"
+    download_project "$repo" "$ref" "$DIR"
 
     # Disable tests that won't pass on the ir presets due to Hardhat heuristics. Note that this also disables
     # them for other presets but that's fine - we want same code run for benchmarks to be comparable.

--- a/test/externalTests/pool-together.sh
+++ b/test/externalTests/pool-together.sh
@@ -36,9 +36,8 @@ function test_fn { yarn test; }
 
 function pool_together_test
 {
-    local repo="https://github.com/pooltogether/v4-core"
-    local ref_type=branch
-    local ref=master
+    local repo="https://github.com/pooltogether/v4-core.git"
+    local ref="<latest-release>"
     local config_file="hardhat.config.ts"
     local config_var="config"
 
@@ -57,13 +56,12 @@ function pool_together_test
     print_presets_or_exit "$SELECTED_PRESETS"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$ref_type" "$ref" "$DIR"
+    download_project "$repo" "$ref" "$DIR"
 
     # TODO: Remove this when https://github.com/NomicFoundation/hardhat/issues/3365 gets fixed.
     sed -i "s|it\(('should fail to return value if value passed does not fit in [0-9]\+ bits'\)|it.skip\1|g" test/libraries/ExtendedSafeCast.test.ts
     sed -i "s|it\(('should require an rng to be requested'\)|it.skip\1|g" test/DrawBeacon.test.ts
 
-    neutralize_package_lock
     neutralize_package_json_hooks
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")" "$config_var"

--- a/test/externalTests/prb-math.py
+++ b/test/externalTests/prb-math.py
@@ -51,8 +51,7 @@ class PRBMathRunner(FoundryRunner):
 test_config = TestConfig(
     name="PRBMath",
     repo_url="https://github.com/PaulRBerg/prb-math.git",
-    ref_type="branch",
-    ref="main",
+    ref="<latest-release>",
     compile_only_presets=[
         # pylint: disable=line-too-long
         # SettingsPreset.IR_NO_OPTIMIZE,       # Error: Yul exception:Variable expr_15699_address is 2 slot(s) too deep inside the stack. Stack too deep.

--- a/test/externalTests/trident.sh
+++ b/test/externalTests/trident.sh
@@ -45,7 +45,6 @@ function test_fn {
 function trident_test
 {
     local repo="https://github.com/sushiswap/trident"
-    local ref_type=commit
     # FIXME: Switch back to master branch when https://github.com/sushiswap/trident/issues/303 gets fixed.
     local ref="0cab5ae884cc9a41223d52791be775c3a053cb26" # master as of 2021-12-16
     local config_file="hardhat.config.ts"
@@ -66,7 +65,7 @@ function trident_test
     print_presets_or_exit "$SELECTED_PRESETS"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$ref_type" "$ref" "$DIR"
+    download_project "$repo" "$ref" "$DIR"
 
     # TODO: Currently tests work only with the exact versions from yarn.lock.
     # Re-enable this when https://github.com/sushiswap/trident/issues/284 is fixed.

--- a/test/externalTests/uniswap.sh
+++ b/test/externalTests/uniswap.sh
@@ -37,7 +37,6 @@ function test_fn { UPDATE_SNAPSHOT=1 npx hardhat test; }
 function uniswap_test
 {
     local repo="https://github.com/solidity-external-tests/uniswap-v3-core.git"
-    local ref_type=branch
     local ref=main_080
     local config_file="hardhat.config.ts"
     local config_var=config
@@ -57,7 +56,7 @@ function uniswap_test
     print_presets_or_exit "$SELECTED_PRESETS"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$ref_type" "$ref" "$DIR"
+    download_project "$repo" "$ref" "$DIR"
 
     # Disable tests that won't pass on the ir presets due to Hardhat heuristics. Note that this also disables
     # them for other presets but that's fine - we want same code run for benchmarks to be comparable.

--- a/test/externalTests/yield-liquidator.sh
+++ b/test/externalTests/yield-liquidator.sh
@@ -37,7 +37,6 @@ function test_fn { npm run test; }
 function yield_liquidator_test
 {
     local repo="https://github.com/yieldprotocol/yield-liquidator-v2"
-    local ref_type=branch
     local ref="master"
     local config_file="hardhat.config.ts"
     local config_var="module.exports"
@@ -57,7 +56,7 @@ function yield_liquidator_test
     print_presets_or_exit "$SELECTED_PRESETS"
 
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
-    download_project "$repo" "$ref_type" "$ref" "$DIR"
+    download_project "$repo" "$ref" "$DIR"
 
     neutralize_package_lock
     neutralize_package_json_hooks


### PR DESCRIPTION
This PR modifies most of the external tests to utilize their latest releases, determined by the repository's Git tags, instead of their main branch. However, it retains the external tests that depend on specific branches or don't have releases/tags, such as `yield-liquidator-v2`.