### PR TITLE
Fix `detect_hardhat_artifact_dir` in externalTests scripts

### DIFF
--- a/scripts/externalTests/common.sh
+++ b/scripts/externalTests/common.sh
@@ -570,17 +570,15 @@ function gas_report_to_json
     cat - | "${REPO_ROOT}/scripts/externalTests/parse_eth_gas_report.py" | jq '{gas: .}'
 }
 
-function detect_hardhat_artifact_dir
+function detect_hardhat_artifact_dirs
 {
-    if [[ -e build/ && -e artifacts/ ]]; then
-        fail "Cannot determine Hardhat artifact location. Both build/ and artifacts/ exist"
-    elif [[ -e build/ ]]; then
-        echo -n build/artifacts
-    elif [[ -e artifacts/ ]]; then
-        echo -n artifacts
-    else
-        fail "Hardhat build artifacts not found."
-    fi
+    # NOTE: The artifacts path is a configured parameter in Hardhat, so the below may fail for new external tests
+    # See: https://hardhat.org/hardhat-runner/docs/config#path-configuration
+    local artifact_dir=()
+    [[ -e build/artifacts ]] && artifact_dir+=("build/artifacts")
+    [[ -e artifacts/ ]] && artifact_dir+=("artifacts")
+    (( ${#artifact_dir[@]} != 0 )) || assertFail
+    echo -n "${artifact_dir[@]}"
 }
 
 function bytecode_size_json_from_truffle_artifacts
@@ -605,16 +603,17 @@ function bytecode_size_json_from_truffle_artifacts
 function bytecode_size_json_from_hardhat_artifacts
 {
     # NOTE: The output of this function is a series of concatenated JSON dicts rather than a list.
-
-    for artifact in "$(detect_hardhat_artifact_dir)"/build-info/*.json; do
-        # Each artifact contains Standard JSON output under the `output` key.
-        # Process it into a dict of the form `{"<file>": {"<contract>": <size>}}`,
-        # Note that one Hardhat artifact often represents multiple input files.
-        jq '.output.contracts | to_entries[] | {
-            "\(.key)": .value | to_entries[] | {
-                "\(.key)": (.value.evm.bytecode.object | length / 2)
-            }
-        }' "$artifact"
+    for artifact_dir in $(detect_hardhat_artifact_dirs); do
+        for artifact in "$artifact_dir"/build-info/*.json; do
+            # Each artifact contains Standard JSON output under the `output` key.
+            # Process it into a dict of the form `{"<file>": {"<contract>": <size>}}`,
+            # Note that one Hardhat artifact often represents multiple input files.
+            jq '.output.contracts | to_entries[] | {
+                "\(.key)": .value | to_entries[] | {
+                    "\(.key)": (.value.evm.bytecode.object | length / 2)
+                }
+            }' "$artifact"
+        done
     done
 }
 

--- a/test/externalTests/ens.sh
+++ b/test/externalTests/ens.sh
@@ -81,7 +81,7 @@ function ens_test
     sed -i "s|it\(('Cannot be called if CANNOT_CREATE_SUBDOMAIN is burned and is a new subdomain',\)|it.skip\1|g" test/wrapper/NameWrapper.js
     sed -i "s|it\(('Cannot be called if PARENT_CANNOT_CONTROL is burned and is an existing subdomain',\)|it.skip\1|g" test/wrapper/NameWrapper.js
 
-    find . -name "*.sol" -exec sed -i -e 's/^\(\s*\)\(assembly\)/\1\/\/\/ @solidity memory-safe-assembly\n\1\2/' '{}' \;
+    find . -name "*.sol" -type f -exec sed -i -e 's/^\(\s*\)\(assembly\)/\1\/\/\/ @solidity memory-safe-assembly\n\1\2/' '{}' \;
 
     for preset in $SELECTED_PRESETS; do
         hardhat_run_test "$config_file" "$preset" "${compile_only_presets[*]}" compile_fn test_fn


### PR DESCRIPTION
While working on https://github.com/ethereum/solidity/pull/14880, I noticed that the ENS external test has been failing silently for quite some time. 

The issue is from the fact that the `detect_hardhat_artifact_dir function` was returning an empty string, causing `bytecode_size_json_from_hardhat_artifacts` to use an incorrect path. This PR addresses that and also another issue within the same external test script, where it was attempting to run `sed` on a directory instead of a file.

See:  https://app.circleci.com/pipelines/github/ethereum/solidity/32974/workflows/f902a748-59ab-4eac-8367-8d71095744be/jobs/1480350?invite=true#step-110-61165_76
```
Skipping test function...
Cannot determine Hardhat artifact location. Both build/ and artifacts/ exist
jq: error: Could not open file /build-info/*.json: No such file or directory
Done.
```

And: https://app.circleci.com/pipelines/github/ethereum/solidity/32974/workflows/f902a748-59ab-4eac-8367-8d71095744be/jobs/1480350?invite=true#step-110-17512_102
```
sed: couldn't edit ./node_modules/@ensdomains/buffer/artifacts/hardhat/console.sol: not a regular file
sed: couldn't edit ./node_modules/@ensdomains/buffer/artifacts/contracts/Buffer.sol: not a regular file
sed: couldn't edit ./node_modules/@ensdomains/buffer/artifacts/contracts/Migrations.sol: not a regular file
sed: couldn't edit ./node_modules/@ensdomains/buffer/artifacts/test/TestBuffer.sol: not a regular file
sed: couldn't edit ./node_modules/@ensdomains/solsha1/artifacts/contracts/SHA1.sol: not a regular file
sed: couldn't edit ./node_modules/@ensdomains/solsha1/artifacts/test/mocks/SHA1Test.sol: not a regular file
```
