### PR TITLE
syntax: Reject semver version individual parts in strings

### DIFF
--- a/liblangutil/SemVerHandler.cpp
+++ b/liblangutil/SemVerHandler.cpp
@@ -240,6 +240,8 @@ SemVerMatchExpression::MatchComponent SemVerMatchExpressionParser::parseMatchCom
 		component.prefix = Token::Assign;
 	}
 
+	auto const partsStartPos = m_pos;
+
 	component.levelsPresent = 0;
 	while (component.levelsPresent < 3)
 	{
@@ -250,6 +252,18 @@ SemVerMatchExpression::MatchComponent SemVerMatchExpressionParser::parseMatchCom
 		else
 			break;
 	}
+
+	// Validate that the parsed version parts are either a single string literal or multiple bare tokens,
+	// i.e. "1.2.3" or 1.2.3 but not 1."2.3", "1".2.3 or 1"."2.3.
+	auto const partsEndPos = std::min(m_pos, unsigned(m_tokens.size()) - 1);
+	for (auto i = partsStartPos; i <= partsEndPos; ++i)
+	{
+		if (m_tokens[i] == Token::StringLiteral && partsStartPos != partsEndPos)
+		{
+			solThrow(SemVerError, "String literals are only allowed as the only component in a version pragma.");
+		}
+	}
+
 	// TODO we do not support pre and build version qualifiers for now in match expressions
 	// (but we do support them in the actual versions)
 	return component;

--- a/liblangutil/SemVerHandler.cpp
+++ b/liblangutil/SemVerHandler.cpp
@@ -255,10 +255,10 @@ SemVerMatchExpression::MatchComponent SemVerMatchExpressionParser::parseMatchCom
 
 	// Validate that the parsed version parts are either a single string literal or multiple bare tokens,
 	// i.e. "1.2.3" or 1.2.3 but not 1."2.3", "1".2.3 or 1"."2.3.
-	auto const partsEndPos = std::min(m_pos, unsigned(m_tokens.size()) - 1);
-	for (auto i = partsStartPos; i <= partsEndPos; ++i)
+	auto const partsEndPos = m_pos; // Points *after* the last version part
+	for (auto i = partsStartPos; i < partsEndPos; ++i)
 	{
-		if (m_tokens[i] == Token::StringLiteral && partsStartPos != partsEndPos)
+		if (m_tokens[i] == Token::StringLiteral && partsStartPos != partsEndPos - 1)
 		{
 			solThrow(SemVerError, "String literals are only allowed as the only component in a version pragma.");
 		}

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -312,7 +312,7 @@ private:
 };
 
 /**
- * Pragma directive, only version requirements in the form `pragma solidity "^0.4.0";` are
+ * Pragma directive, only version requirements in the form `pragma solidity ^"0.4.0";` are
  * supported for now.
  */
 class PragmaDirective: public ASTNode

--- a/test/libsolidity/syntaxTests/pragma/broken_version_strings_digit.sol
+++ b/test/libsolidity/syntaxTests/pragma/broken_version_strings_digit.sol
@@ -1,0 +1,3 @@
+pragma solidity ^"0"."8"."2";
+// ----
+// ParserError 1684: (0-29): Invalid version pragma. String literals are only allowed as the only component in a version pragma.

--- a/test/libsolidity/syntaxTests/pragma/broken_version_strings_dots.sol
+++ b/test/libsolidity/syntaxTests/pragma/broken_version_strings_dots.sol
@@ -1,0 +1,3 @@
+pragma solidity ^ 0 "." 8 "." 2;
+// ----
+// ParserError 1684: (0-32): Invalid version pragma. String literals are only allowed as the only component in a version pragma.

--- a/test/libsolidity/syntaxTests/pragma/broken_version_strings_part.sol
+++ b/test/libsolidity/syntaxTests/pragma/broken_version_strings_part.sol
@@ -1,0 +1,3 @@
+pragma solidity ^ 0."8.0";
+// ----
+// ParserError 1684: (0-26): Invalid version pragma. String literals are only allowed as the only component in a version pragma.

--- a/test/libsolidity/syntaxTests/pragma/broken_version_strings_prefix.sol
+++ b/test/libsolidity/syntaxTests/pragma/broken_version_strings_prefix.sol
@@ -1,0 +1,3 @@
+pragma solidity "^0.8.0";
+// ----
+// ParserError 1684: (0-25): Invalid version pragma. Expected the start of a version number but instead found character '^'. Version number is invalid or the pragma is not terminated with a semicolon.

--- a/test/libsolidity/syntaxTests/pragma/version_component_string_mixed.sol
+++ b/test/libsolidity/syntaxTests/pragma/version_component_string_mixed.sol
@@ -1,0 +1,1 @@
+pragma solidity >= 0.0 <= "123456";

--- a/test/libsolidity/syntaxTests/pragma/version_component_string_prefix.sol
+++ b/test/libsolidity/syntaxTests/pragma/version_component_string_prefix.sol
@@ -1,0 +1,1 @@
+pragma solidity <= "123456";


### PR DESCRIPTION
This seems like an oversight from the initial implementation that supported versions such as "^0.4.0" but which now has a side effect of converting individual string literals to their token values, allowing for syntax such as:
- `0 "." 8 "." 0`
- `"1".2.3"`
- `"1"."2"."3"`

and so on.

This fix aims to address the unintentional acceptance of such syntax, primarily to simplify the logic of external parsers and to more clearly establish what constitutes valid syntax for a crucial element like the version pragma statement.

I haven't written C++ in ages, so let me know if I'm doing anything dumb or if it could be written better.

Closes #14826