### PR TITLE
SMTCommand: Remember to flush query before calling solver

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ Compiler Features:
 Bugfixes:
  * Assembler: Prevent incorrect calculation of tag sizes.
  * SMTChecker: Fix internal error caused by not respecting the sign of an integer type when constructing zero-value SMT expressions.
+ * SMTChecker: Ensure query is properly flushed to a file before calling solver when using SMT-LIB interface.
 
 
 ### 0.8.24 (2024-01-25)

--- a/libsolidity/interface/SMTSolverCommand.cpp
+++ b/libsolidity/interface/SMTSolverCommand.cpp
@@ -51,7 +51,7 @@ ReadCallback::Result SMTSolverCommand::solve(std::string const& _kind, std::stri
 		auto queryFileName = tempDir.path() / ("query_" + queryHash.hex() + ".smt2");
 
 		auto queryFile = boost::filesystem::ofstream(queryFileName);
-		queryFile << _query;
+		queryFile << _query << std::flush;
 
 		auto eldBin = boost::process::search_path(m_solverCmd);
 


### PR DESCRIPTION
On MacOS I often experienced a problem that the solver reported SMT-LIB file as malformed. It appears that the whole query was not written to the file and using std::flush fixed the problem.