### PR TITLE
SMTChecker: Fix usage of Eldarica with SMT callback

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,8 +11,9 @@ Compiler Features:
 Bugfixes:
  * Assembler: Prevent incorrect calculation of tag sizes.
  * EVM Assembly Import: Fix handling of missing source locations during import.
- * SMTChecker: Fix internal error caused by not respecting the sign of an integer type when constructing zero-value SMT expressions.
  * SMTChecker: Ensure query is properly flushed to a file before calling solver when using SMT-LIB interface.
+ * SMTChecker: Fix internal error caused by not respecting the sign of an integer type when constructing zero-value SMT expressions.
+ * SMTChecker: Run Eldarica only when explicitly requested with `--model-checker-solvers eld`, even when it is present on the system.
 
 
 ### 0.8.24 (2024-01-25)

--- a/libsolidity/formal/ModelCheckerSettings.h
+++ b/libsolidity/formal/ModelCheckerSettings.h
@@ -175,7 +175,7 @@ struct ModelCheckerSettings
 	bool showUnsupported = false;
 	smtutil::SMTSolverChoice solvers = smtutil::SMTSolverChoice::Z3();
 	ModelCheckerTargets targets = ModelCheckerTargets::Default();
-	std::optional<unsigned> timeout;
+	std::optional<unsigned> timeout; // in milliseconds
 
 	bool operator!=(ModelCheckerSettings const& _other) const noexcept { return !(*this == _other); }
 	bool operator==(ModelCheckerSettings const& _other) const noexcept

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -53,6 +53,7 @@
 #include <libsolidity/interface/Natspec.h>
 #include <libsolidity/interface/GasEstimator.h>
 #include <libsolidity/interface/StorageLayout.h>
+#include <libsolidity/interface/UniversalCallback.h>
 #include <libsolidity/interface/Version.h>
 #include <libsolidity/parsing/Parser.h>
 
@@ -654,7 +655,12 @@ bool CompilerStack::analyzeLegacy(bool _noErrorsSoFar)
 		// m_modelCheckerSettings is spread to engines and solver interfaces,
 		// so we need to check whether the enabled ones are available before building the classes.
 		if (m_modelCheckerSettings.engine.any())
+		{
 			m_modelCheckerSettings.solvers = ModelChecker::checkRequestedSolvers(m_modelCheckerSettings.solvers, m_errorReporter);
+			if (auto* universalCallback = m_readFile.target<frontend::UniversalCallback>())
+				if (m_modelCheckerSettings.solvers.eld)
+					universalCallback->smtCommand().setEldarica(m_modelCheckerSettings.timeout);
+		}
 
 		ModelChecker modelChecker(m_errorReporter, *this, m_smtlib2Responses, m_modelCheckerSettings, m_readFile);
 		modelChecker.checkRequestedSourcesAndContracts(allSources);

--- a/libsolidity/interface/SMTSolverCommand.h
+++ b/libsolidity/interface/SMTSolverCommand.h
@@ -28,8 +28,6 @@ namespace solidity::frontend
 class SMTSolverCommand
 {
 public:
-	SMTSolverCommand(std::string _solverCmd);
-
 	/// Calls an SMT solver with the given query.
 	frontend::ReadCallback::Result solve(std::string const& _kind, std::string const& _query);
 
@@ -38,9 +36,12 @@ public:
 		return [this](std::string const& _kind, std::string const& _query) { return solve(_kind, _query); };
 	}
 
+	void setEldarica(std::optional<unsigned int> timeoutInMilliseconds);
+
 private:
 	/// The name of the solver's binary.
-	std::string const m_solverCmd;
+	std::string m_solverCmd;
+	std::vector<std::string> m_arguments;
 };
 
 }

--- a/solc/CommandLineInterface.h
+++ b/solc/CommandLineInterface.h
@@ -147,7 +147,7 @@ private:
 	std::ostream& m_serr;
 	bool m_hasOutput = false;
 	FileReader m_fileReader;
-	SMTSolverCommand m_solverCommand{"eld"};
+	SMTSolverCommand m_solverCommand;
 	UniversalCallback m_universalCallback{&m_fileReader, m_solverCommand};
 	std::optional<std::string> m_standardJsonInput;
 	std::unique_ptr<frontend::CompilerStack> m_compiler;


### PR DESCRIPTION
Previously, CHC engine with SMT interface would always call Eldarica if
it was present in the system, regardless whether user specified
`model-checker-solver` as `smtlib2` or `eld`.
Here we make sure Eldarica is called only when it is specified as the
solver of choice.

The proposed solution is to make SMTSolverCommand modifiable and set it
up properly based on the user settings. This requires changes also in
UniversalCallback, because in the compiler we must be able to check if
the given callback is UniversalCallback provided by CommandLineInterface.

This mechanism can be used to migrate also other solvers to the SMTLIB
interface by further extending/adapting SMTSolverCommand.
Its advantage is that meaning of the callback stays the same, thus there
is not need to change anything on the side of solc-js.