### PR TITLE
Work around uniswap and perpetual-pools ext tests failing OOM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -783,6 +783,8 @@ defaults:
       project: perpetual-pools
       binary_type: native
       image: cimg/node:18.16
+      # FIXME: This used to work with small, but now runs out of memory on anything below xlarge.
+      resource_class: xlarge
 
   - job_native_test_ext_uniswap: &job_native_test_ext_uniswap
       <<: *requires_b_ubu_static
@@ -790,6 +792,8 @@ defaults:
       project: uniswap
       binary_type: native
       image: cimg/node:18.16
+      # FIXME: This used to work with small, but now runs out of memory on anything below xlarge.
+      resource_class: xlarge
 
   - job_native_test_ext_prb_math: &job_native_test_ext_prb_math
       <<: *requires_b_ubu_static

--- a/test/externalTests/perpetual-pools.sh
+++ b/test/externalTests/perpetual-pools.sh
@@ -64,6 +64,10 @@ function perpetual_pools_test
     sed -i 's|\(it\)\(("Should not allow commits that are too large"\)|\1.skip\2|g' test/PoolCommitter/commit.spec.ts
     sed -i 's|\(it\)\(("Should not allow for too many commitments (that bring amount over a user'\''s balance)"\)|\1.skip\2|g' test/PoolCommitter/commit.spec.ts
 
+    # Disable a test failing due to a non-deterministic order of keys in a returned dict.
+    # TODO: Figure out why it's failing and re-enable.
+    sed -i 's|\(it\)\(("Rotates the observations array"\)|\1.skip\2|g' test/PriceObserver.spec.ts
+
     neutralize_package_lock
     neutralize_package_json_hooks
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"


### PR DESCRIPTION
As we agreed on the call, I'm submitting my workaround as a PR, but hopefully @r0qs will come up with a better fix. Mine just massively increases the machine size to make it still work despite the huge memory leak and disables tests that fail due to some non-determinism.