### PR TITLE
Fix hardhat version to 2.20.0 on uniswap and perpetual_pools external tests

### DIFF
--- a/test/externalTests/perpetual-pools.sh
+++ b/test/externalTests/perpetual-pools.sh
@@ -69,7 +69,12 @@ function perpetual_pools_test
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")" "$config_var"
     force_hardhat_unlimited_contract_size "$config_file" "$config_var"
+
     yarn install
+    # We set hardhat version to 2.20.0 since version 2.21.0 has issues with solidity-coverage plugin
+    # that often causes out-of-memory errors.
+    # See hardhat note about the issue here: https://github.com/NomicFoundation/hardhat/releases/tag/hardhat@2.21.0
+    yarn add hardhat@2.20.0
 
     replace_version_pragmas
 

--- a/test/externalTests/uniswap.sh
+++ b/test/externalTests/uniswap.sh
@@ -90,6 +90,11 @@ function uniswap_test
     # TODO: Remove when https://github.com/ethers-io/ethers.js/discussions/2849 is resolved.
     yarn add ethers@5.6.1
 
+    # We set hardhat version to 2.20.0 since version 2.21.0 has issues with solidity-coverage plugin
+    # that often causes out-of-memory errors.
+    # See hardhat note about the issue here: https://github.com/NomicFoundation/hardhat/releases/tag/hardhat@2.21.0
+    yarn add hardhat@2.20.0
+
     replace_version_pragmas
 
     for preset in $SELECTED_PRESETS; do


### PR DESCRIPTION
Workaround for the OOM Killer errors caused by hardhat on external tests.