### PR TITLE
Fix unnecessary compilation when `--via-ir` is used on its own

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ Compiler Features:
 
 Bugfixes:
  * Assembler: Prevent incorrect calculation of tag sizes.
+ * Commandline Interface: Do not run IR pipeline when ``--via-ir`` is used but no output that depends on the IR is requested.
  * EVM Assembly Import: Fix handling of missing source locations during import.
  * SMTChecker: Fix internal error caused by not respecting the sign of an integer type when constructing zero-value SMT expressions.
  * SMTChecker: Ensure query is properly flushed to a file before calling solver when using SMT-LIB interface.

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -736,7 +736,7 @@ bool CompilerStack::compile(State _stopAfter)
 				{
 					try
 					{
-						if (m_viaIR || m_generateIR)
+						if ((m_generateEvmBytecode && m_viaIR) || m_generateIR)
 							generateIR(*contract);
 						if (m_generateEvmBytecode)
 						{

--- a/test/cmdlineTests/abi_via_ir/args
+++ b/test/cmdlineTests/abi_via_ir/args
@@ -1,0 +1,1 @@
+--abi --via-ir --pretty-json --json-indent 4

--- a/test/cmdlineTests/abi_via_ir/input.sol
+++ b/test/cmdlineTests/abi_via_ir/input.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+
+error fileLevelError(uint z);
+
+library L {
+	event libraryEvent(uint r);
+	error libraryError(uint r);
+	error libraryErrorUnused(uint u);
+	event libraryEventUnused(uint u);
+}
+
+contract C {
+	struct S { uint x; }
+
+	event ev(uint y);
+	event anon_ev(uint y) anonymous;
+
+	error err(uint z, uint w);
+
+	function f(S memory s) public {
+		emit L.libraryEvent(3);
+		if (s.x > 1)
+			revert fileLevelError(3);
+		else
+			revert L.libraryError(4);
+	}
+}

--- a/test/cmdlineTests/abi_via_ir/output
+++ b/test/cmdlineTests/abi_via_ir/output
@@ -1,0 +1,167 @@
+
+======= abi_via_ir/input.sol:C =======
+Contract JSON ABI
+[
+    {
+        "inputs":
+        [
+            {
+                "internalType": "uint256",
+                "name": "z",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "w",
+                "type": "uint256"
+            }
+        ],
+        "name": "err",
+        "type": "error"
+    },
+    {
+        "inputs":
+        [
+            {
+                "internalType": "uint256",
+                "name": "z",
+                "type": "uint256"
+            }
+        ],
+        "name": "fileLevelError",
+        "type": "error"
+    },
+    {
+        "inputs":
+        [
+            {
+                "internalType": "uint256",
+                "name": "r",
+                "type": "uint256"
+            }
+        ],
+        "name": "libraryError",
+        "type": "error"
+    },
+    {
+        "anonymous": true,
+        "inputs":
+        [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "y",
+                "type": "uint256"
+            }
+        ],
+        "name": "anon_ev",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs":
+        [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "y",
+                "type": "uint256"
+            }
+        ],
+        "name": "ev",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs":
+        [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "r",
+                "type": "uint256"
+            }
+        ],
+        "name": "libraryEvent",
+        "type": "event"
+    },
+    {
+        "inputs":
+        [
+            {
+                "components":
+                [
+                    {
+                        "internalType": "uint256",
+                        "name": "x",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct C.S",
+                "name": "s",
+                "type": "tuple"
+            }
+        ],
+        "name": "f",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+]
+
+======= abi_via_ir/input.sol:L =======
+Contract JSON ABI
+[
+    {
+        "inputs":
+        [
+            {
+                "internalType": "uint256",
+                "name": "r",
+                "type": "uint256"
+            }
+        ],
+        "name": "libraryError",
+        "type": "error"
+    },
+    {
+        "inputs":
+        [
+            {
+                "internalType": "uint256",
+                "name": "u",
+                "type": "uint256"
+            }
+        ],
+        "name": "libraryErrorUnused",
+        "type": "error"
+    },
+    {
+        "anonymous": false,
+        "inputs":
+        [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "r",
+                "type": "uint256"
+            }
+        ],
+        "name": "libraryEvent",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs":
+        [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "u",
+                "type": "uint256"
+            }
+        ],
+        "name": "libraryEventUnused",
+        "type": "event"
+    }
+]


### PR DESCRIPTION
Fixes #14917.