### PR TITLE
Document the possibility of high-level external calls to precompiled contracts

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -111,21 +111,34 @@ otherwise, the ``value`` option would not be available.
   the ``value`` and ``gas`` settings are lost, only
   ``feed.info{value: 10, gas: 800}()`` performs the function call.
 
-Due to the fact that the EVM considers a call to a non-existing contract to
-always succeed, Solidity uses the ``extcodesize`` opcode to check that
-the contract that is about to be called actually exists (it contains code)
-and causes an exception if it does not. This check is skipped if the return
-data will be decoded after the call and thus the ABI decoder will catch the
-case of a non-existing contract.
+.. warning::
+    Due to the fact that the EVM considers a call to a non-existing contract to
+    always succeed, Solidity uses the ``extcodesize`` opcode to check that
+    the contract that is about to be called actually exists (it contains code)
+    and causes an exception if it does not. This check is skipped if the return
+    data will be decoded after the call and thus the ABI decoder will catch the
+    case of a non-existing contract.
 
-Note that this check is not performed in case of :ref:`low-level calls <address_related>` which
-operate on addresses rather than contract instances.
+    This check is not performed in case of :ref:`low-level calls <address_related>` which
+    operate on addresses rather than contract instances.
 
-.. note::
+.. warning::
     Be careful when using high-level calls to
     :ref:`precompiled contracts <precompiledContracts>`,
     since the compiler considers them non-existing according to the
     above logic even though they execute code and can return data.
+
+.. note::
+    Since the version 0.8.10, the compiler does not check ``extcodesize`` on
+    high-level external calls if return data is expected, because an empty code
+    will be unable to return data, and the ABI decoder will revert.
+    As a consequence, this allows high-level external calls to precompiled
+    contracts, since they can return data despite having no code
+    associated with their addresses.
+
+    Read about :ref:`precompiled contracts <precompiledContracts>` and
+    :ref:`low-level calls <address_related>`
+    for more information.
 
 Function calls also cause exceptions if the called contract itself
 throws an exception or goes out of gas.


### PR DESCRIPTION
Hi! I'm trying to add a bit more clarity about something that has been somewhat recently documented but wasn't as easy as I expected to understand from the docs.

A few weeks ago, while checking out the code of Blast (L2), we learned that you can do external calls over precompiled contracts without failing and were wondering how that could be possible. After debugging the compiler and, as the suggestion states, from v0.8.10, the extcodesize check is removed from external calls if there's return data to decode, since it would fail anyway at the time of decoding.

We thought this behavior should be noted on different occasions, particularly while working with precompiled contracts (we thought it wouldn't work). So, without modifying much and reusing what was already written (in the docs and in the commit message), I added a few references and included a note that was outside a callout inside of another.