### PR TITLE
Add hardhat networks settings external tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1919,11 +1919,13 @@ workflows:
       - t_ext: *job_native_test_ext_elementfi
       - t_ext: *job_native_test_ext_brink
       - t_ext: *job_native_compile_ext_gp2
-      - t_ext: *job_native_compile_ext_trident
       - t_ext: *job_native_compile_ext_euler
-      - t_ext: *job_native_compile_ext_bleeps
       - t_ext: *job_native_compile_ext_pool_together
-      - t_ext: *job_native_compile_ext_chainlink
+      # TODO: Dropping the external tests below since they are based on old forks and
+      # fail after update the default evm version to cancun.
+      #- t_ext: *job_native_compile_ext_trident
+      #- t_ext: *job_native_compile_ext_chainlink
+      #- t_ext: *job_native_compile_ext_bleeps
 
       - c_ext_benchmarks:
           <<: *requires_nothing
@@ -1941,11 +1943,13 @@ workflows:
             # TODO: Dropping prb-math from the benchmarks since it is not implemented yet
             # in the new Foundry external testing infrastructure.
             # - t_native_test_ext_prb_math
-            - t_native_compile_ext_trident
             - t_native_compile_ext_euler
-            - t_native_compile_ext_bleeps
             - t_native_compile_ext_pool_together
-            - t_native_compile_ext_chainlink
+            # TODO: Dropping the external tests below since they are based on old forks and
+            # fail after update the default evm version to cancun.
+            #- t_native_compile_ext_trident
+            #- t_native_compile_ext_chainlink
+            #- t_native_compile_ext_bleeps
 
       # Windows build and tests
       - b_win: *requires_nothing

--- a/scripts/externalTests/common.sh
+++ b/scripts/externalTests/common.sh
@@ -332,12 +332,16 @@ function force_hardhat_compiler_settings
         echo "require('hardhat-gas-reporter');"
         echo "module.exports.gasReporter = ${gas_reporter_settings};"
         echo "module.exports.solidity = ${compiler_settings};"
+        echo "module.exports.networks.hardhat = module.exports.networks.hardhat || { hardfork: '${evm_version}' }"
+        echo "module.exports.networks.hardhat.hardfork = '${evm_version}'"
     else
         [[ $config_file == *\.ts ]] || assertFail
         [[ $config_var_name != "" ]] || assertFail
         echo 'import "hardhat-gas-reporter";'
         echo "${config_var_name}.gasReporter = ${gas_reporter_settings};"
         echo "${config_var_name}.solidity = {compilers: [${compiler_settings}]};"
+        echo "${config_var_name}.networks!.hardhat = ${config_var_name}.networks!.hardhat ?? { hardfork: '${evm_version}' };"
+        echo "${config_var_name}.networks!.hardhat!.hardfork = '${evm_version}'"
     fi >> "$config_file"
 }
 

--- a/test/externalTests/brink.sh
+++ b/test/externalTests/brink.sh
@@ -64,6 +64,7 @@ function brink_test
     # TODO: Remove this when Brink merges https://github.com/brinktrade/brink-core/pull/52
     sed -i "s|\(function isValidSignature(bytes \)calldata\( _data, bytes \)calldata\( _signature)\)|\1memory\2memory\3|g" src/Test/MockEIP1271Validator.sol
 
+    neutralize_package_lock
     neutralize_package_json_hooks
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")" "$config_var" "$CURRENT_EVM_VERSION" "$extra_settings" "$extra_optimizer_settings"

--- a/test/externalTests/elementfi.sh
+++ b/test/externalTests/elementfi.sh
@@ -99,9 +99,7 @@ function elementfi_test
     # "ProviderError: Too Many Requests error received from eth-mainnet.alchemyapi.io"
     rm test/mockERC20YearnVaultTest.ts
 
-    # Several tests fail unless we use the exact versions hard-coded in package-lock.json
-    #neutralize_package_lock
-
+    neutralize_package_lock
     neutralize_package_json_hooks
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")" "$config_var"

--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -76,6 +76,7 @@ function gnosis_safe_test
     sed -i "s|\(it\)\((\"can be used only via DELEGATECALL opcode\"\)|\1.skip\2|g" test/libraries/SignMessageLib.spec.ts
     sed -i "s|it\((\"can only be called from Safe itself\"\)|it.skip\1|g" test/libraries/Migration.spec.ts
 
+    neutralize_package_lock
     neutralize_package_json_hooks
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")" "$config_var"

--- a/test/externalTests/pool-together.sh
+++ b/test/externalTests/pool-together.sh
@@ -66,6 +66,9 @@ function pool_together_test
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")" "$config_var"
     yarn install
+    # Hardhat 2.20.0 is the last version that works. Newer versions throw this error:
+    # Unexpected config HardhatConfig.networks.hardhat.initialBaseFeePerGas found - This field is only valid for networks with EIP-1559. Try a newer hardfork or remove it.
+    yarn add hardhat@2.20.0
 
     # These come with already compiled artifacts. We want them recompiled with latest compiler.
     rm -r node_modules/@pooltogether/yield-source-interface/artifacts/


### PR DESCRIPTION
Note that `t_ems_ext_hardhat` will be fixed by PR https://github.com/ethereum/solidity/pull/14933 when we switch evm version to cancun by default.