### PR TITLE
Use move ctor instead of copy ctor in stringOrDefault

### DIFF
--- a/libsolutil/Assertions.h
+++ b/libsolutil/Assertions.h
@@ -28,6 +28,7 @@
 #include <libsolutil/Exceptions.h>
 
 #include <string>
+#include <utility>
 
 namespace solidity::util
 {
@@ -69,7 +70,7 @@ inline std::string stringOrDefault(std::string _string, std::string _defaultStri
 {
 	// NOTE: Putting this in a function rather than directly in a macro prevents the string from
 	// being evaluated multiple times if it's not just a literal.
-	return (!_string.empty() ? _string : _defaultString);
+	return (!_string.empty() ? std::move(_string) : std::move(_defaultString));
 }
 
 }


### PR DESCRIPTION
Since the parameter is passed by value, we can use `std::move` to construct the return value by rvalue ctor, e.g.
```
std::string f();
std::string g();

stringOrDefault(f(), g());
// parameter `_string`: constructed by move ctor from `f()`
// parameter `_defaultString`: constructed by move ctor from `g()`
// return value: constructed by move ctor from `_string` or `_defaultString`
```