### PR TITLE
Add verification target for BMC engine: check if type conversion truncates a value

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ Compiler Features:
  * Code Generator: Use ``MCOPY`` instead of ``MLOAD``/``MSTORE`` loop when copying byte arrays.
  * EVM: Set default EVM version to ``cancun``.
  * Yul Analyzer: Emit transient storage warning only for the first occurrence of ``tstore``.
+ * SMTChecker: Add ``typeConversionTruncation`` verification target for BMC engine. Type conversion of array slices is not supported.
 
 
 Bugfixes:

--- a/libsolidity/formal/BMC.cpp
+++ b/libsolidity/formal/BMC.cpp
@@ -725,13 +725,11 @@ void BMC::visitTypeConversion(FunctionCall const& _funCall)
 	if (smt::isStringLiteral(*argType) && smt::isFixedBytes(*resultType))
 		return;
 
-	ArrayType const* arrayType = dynamic_cast<ArrayType const*>(argType);
-
 	// no support for array slice
 	if (dynamic_cast<ArraySliceType const*>(argType))
 		return;
 
-	if (arrayType && arrayType->isByteArrayOrString() && smt::isFixedBytes(*resultType))
+	if (ArrayType const* arrayType = dynamic_cast<ArrayType const*>(argType); arrayType && arrayType->isByteArrayOrString() && smt::isFixedBytes(*resultType))
 	{
 		auto const& fixed = dynamic_cast<FixedBytesType const&>(*resultType);
 		size_t n = fixed.numBytes();

--- a/libsolidity/formal/BMC.h
+++ b/libsolidity/formal/BMC.h
@@ -109,6 +109,7 @@ private:
 	//@{
 	void visitAssert(FunctionCall const& _funCall);
 	void visitRequire(FunctionCall const& _funCall);
+	void visitTypeConversion(FunctionCall const& _funCall);
 	void visitAddMulMod(FunctionCall const& _funCall) override;
 	void assignment(smt::SymbolicVariable& _symVar, smtutil::Expression const& _value) override;
 	/// Visits the FunctionDefinition of the called function
@@ -162,6 +163,8 @@ private:
 	void checkDivByZero(BMCVerificationTarget& _target);
 	void checkBalance(BMCVerificationTarget& _target);
 	void checkAssert(BMCVerificationTarget& _target);
+	void checkTypeConversionTruncation(BMCVerificationTarget& _target);
+
 	void addVerificationTarget(
 		VerificationTargetType _type,
 		smtutil::Expression const& _value,

--- a/libsolidity/formal/ModelCheckerSettings.cpp
+++ b/libsolidity/formal/ModelCheckerSettings.cpp
@@ -67,7 +67,8 @@ std::map<std::string, TargetType> const ModelCheckerTargets::targetStrings{
 	{"balance", TargetType::Balance},
 	{"assert", TargetType::Assert},
 	{"popEmptyArray", TargetType::PopEmptyArray},
-	{"outOfBounds", TargetType::OutOfBounds}
+	{"outOfBounds", TargetType::OutOfBounds},
+	{"typeConversionTruncation", TargetType::TypeConversionTruncation}
 };
 
 std::map<TargetType, std::string> const ModelCheckerTargets::targetTypeToString{
@@ -78,7 +79,8 @@ std::map<TargetType, std::string> const ModelCheckerTargets::targetTypeToString{
 	{TargetType::Balance, "Insufficient balance"},
 	{TargetType::Assert, "Assertion failed"},
 	{TargetType::PopEmptyArray, "Empty array pop"},
-	{TargetType::OutOfBounds, "Out of bounds access"}
+	{TargetType::OutOfBounds, "Out of bounds access"},
+	{TargetType::TypeConversionTruncation, "typeConversionTruncation"}
 };
 
 std::optional<ModelCheckerTargets> ModelCheckerTargets::fromString(std::string const& _targets)

--- a/libsolidity/formal/ModelCheckerSettings.h
+++ b/libsolidity/formal/ModelCheckerSettings.h
@@ -113,7 +113,7 @@ struct ModelCheckerInvariants
 	std::set<InvariantType> invariants;
 };
 
-enum class VerificationTargetType { ConstantCondition, Underflow, Overflow, UnderOverflow, DivByZero, Balance, Assert, PopEmptyArray, OutOfBounds };
+enum class VerificationTargetType { ConstantCondition, Underflow, Overflow, UnderOverflow, DivByZero, Balance, Assert, PopEmptyArray, OutOfBounds, TypeConversionTruncation };
 
 struct ModelCheckerTargets
 {

--- a/scripts/error_codes.py
+++ b/scripts/error_codes.py
@@ -207,6 +207,7 @@ def examine_id_coverage(top_dir, source_id_to_file_names, new_ids_only=False):
         "2961", # SMTChecker, covered by CL tests
         "6240", # SMTChecker, covered by CL tests
         "9576", # SMTChecker, covered by CL tests
+        "9371", # SMTChecker, typeTruncationConversion target
     }
     assert len(test_ids & white_ids) == 0, "The sets are not supposed to intersect"
     test_ids |= white_ids

--- a/test/cmdlineTests/model_checker_targets_type_conversion_truncation/args
+++ b/test/cmdlineTests/model_checker_targets_type_conversion_truncation/args
@@ -1,0 +1,1 @@
+--model-checker-engine bmc --model-checker-targets typeConversionTruncation

--- a/test/cmdlineTests/model_checker_targets_type_conversion_truncation/err
+++ b/test/cmdlineTests/model_checker_targets_type_conversion_truncation/err
@@ -1,0 +1,12 @@
+Warning: BMC: Truncated value in type conversion happens here.
+ --> model_checker_targets_type_conversion_truncation/input.sol:5:10:
+  |
+5 | 		return uint8(a);
+  | 		       ^^^^^^^^
+Note: Counterexample:
+   = 0
+  <result> = false
+  a = 256
+
+Note: Callstack:
+Note:

--- a/test/cmdlineTests/model_checker_targets_type_conversion_truncation/input.sol
+++ b/test/cmdlineTests/model_checker_targets_type_conversion_truncation/input.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+contract test {
+	function f(uint256 a) public pure returns (uint8) {
+		return uint8(a);
+	}
+}

--- a/test/cmdlineTests/standard_model_checker_targets_type_conversion_truncation/input.json
+++ b/test/cmdlineTests/standard_model_checker_targets_type_conversion_truncation/input.json
@@ -1,0 +1,24 @@
+{
+	"language": "Solidity",
+	"sources":
+	{
+		"A":
+		{
+			"content": "// SPDX-License-Identifier: GPL-3.0
+			pragma solidity >=0.0;
+			contract test {
+                function f(uint256 a) public pure returns (uint8) {
+                    return uint8(a);
+                }
+                }"
+		}
+	},
+	"settings":
+	{
+		"modelChecker":
+		{
+			"engine": "bmc",
+			"targets": ["typeConversionTruncation"]
+		}
+	}
+}

--- a/test/cmdlineTests/standard_model_checker_targets_type_conversion_truncation/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_type_conversion_truncation/output.json
@@ -1,0 +1,55 @@
+{
+    "errors":
+    [
+        {
+            "component": "general",
+            "errorCode": "3260",
+            "formattedMessage": "Warning: BMC: Truncated value in type conversion happens here.
+ --> A:5:28:
+  |
+5 |                     return uint8(a);
+  |                            ^^^^^^^^
+Note: Counterexample:
+   = 0
+  <result> = false
+  a = 256
+
+Note: Callstack:
+Note:
+
+",
+            "message": "BMC: Truncated value in type conversion happens here.",
+            "secondarySourceLocations":
+            [
+                {
+                    "message": "Counterexample:
+   = 0
+  <result> = false
+  a = 256
+"
+                },
+                {
+                    "message": "Callstack:"
+                },
+                {
+                    "message": ""
+                }
+            ],
+            "severity": "warning",
+            "sourceLocation":
+            {
+                "end": 184,
+                "file": "A",
+                "start": 176
+            },
+            "type": "Warning"
+        }
+    ],
+    "sources":
+    {
+        "A":
+        {
+            "id": 0
+        }
+    }
+}

--- a/test/libsolidity/smtCheckerTests/abi/abi_encode_with_selector_vs_sig.sol
+++ b/test/libsolidity/smtCheckerTests/abi/abi_encode_with_selector_vs_sig.sol
@@ -12,4 +12,5 @@ contract C {
 // SMTIgnoreOS: macos
 // ----
 // Warning 6328: (330-360): CHC: Assertion violation might happen here.
-// Warning 7812: (330-360): BMC: Assertion violation might happen here.
+// Warning 3260: (182-211): BMC: Truncated value in type conversion happens here.
+// Warning 4661: (330-360): BMC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/array_members/array_push_string_literal.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/array_push_string_literal.sol
@@ -18,3 +18,4 @@ contract C {
 // Warning 6328: (139-161): CHC: Assertion violation happens here.
 // Warning 6328: (263-290): CHC: Assertion violation happens here.
 // Info 1391: CHC: 6 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/array_members/push_as_lhs_and_rhs_bytes.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_as_lhs_and_rhs_bytes.sol
@@ -16,3 +16,4 @@ contract C {
 // ----
 // Warning 6328: (203-244): CHC: Assertion violation happens here.
 // Info 1391: CHC: 11 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/array_members/push_as_lhs_bytes.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_as_lhs_bytes.sol
@@ -22,3 +22,4 @@ contract C {
 // ----
 // Warning 6328: (265-310): CHC: Assertion violation happens here.
 // Info 1391: CHC: 7 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 8 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/array_members/push_as_lhs_bytes_2d.sol
+++ b/test/libsolidity/smtCheckerTests/array_members/push_as_lhs_bytes_2d.sol
@@ -26,3 +26,4 @@ contract C {
 // ----
 // Warning 6328: (435-508): CHC: Assertion violation happens here.
 // Info 1391: CHC: 23 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 6 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/bmc_coverage/range_check.sol
+++ b/test/libsolidity/smtCheckerTests/bmc_coverage/range_check.sol
@@ -62,4 +62,4 @@ contract D {
 // Warning 8417: (598-614): Since the VM version paris, "difficulty" was replaced by "prevrandao", which now returns a random number based on the beacon chain.
 // Warning 8417: (1447-1463): Since the VM version paris, "difficulty" was replaced by "prevrandao", which now returns a random number based on the beacon chain.
 // Warning 8417: (1481-1497): Since the VM version paris, "difficulty" was replaced by "prevrandao", which now returns a random number based on the beacon chain.
-// Info 6002: BMC: 44 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 56 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/bytes_concat/equals.sol
+++ b/test/libsolidity/smtCheckerTests/bytes_concat/equals.sol
@@ -50,3 +50,4 @@ contract C {
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 6 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/complex/slither/external_function.sol
+++ b/test/libsolidity/smtCheckerTests/complex/slither/external_function.sol
@@ -86,3 +86,4 @@ contract InternalCall {
 // Warning 8729: (681-716): Contract deployment is only supported in the trusted mode for external calls with the CHC engine.
 // Warning 8729: (854-886): Contract deployment is only supported in the trusted mode for external calls with the CHC engine.
 // Warning 5729: (1370-1375): BMC does not yet implement this type of function call.
+// Warning 3260: (749-780): BMC: Truncated value in type conversion happens here.

--- a/test/libsolidity/smtCheckerTests/complex/warn_on_typecast.sol
+++ b/test/libsolidity/smtCheckerTests/complex/warn_on_typecast.sol
@@ -6,3 +6,4 @@ contract C {
 // ====
 // SMTEngine: all
 // ----
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_branch.sol
+++ b/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_branch.sol
@@ -16,3 +16,4 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_branch_2.sol
+++ b/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_branch_2.sol
@@ -21,3 +21,4 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_branch_3.sol
+++ b/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_branch_3.sol
@@ -21,3 +21,4 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_branch_4.sol
+++ b/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_branch_4.sol
@@ -26,3 +26,4 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_else_branch.sol
+++ b/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_else_branch.sol
@@ -17,3 +17,4 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_modifier_branch.sol
+++ b/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_modifier_branch.sol
@@ -20,3 +20,4 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_placeholder_inside_modifier_branch.sol
+++ b/test/libsolidity/smtCheckerTests/control_flow/function_call_inside_placeholder_inside_modifier_branch.sol
@@ -21,3 +21,4 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/external_calls/external_call_with_gas_1.sol
+++ b/test/libsolidity/smtCheckerTests/external_calls/external_call_with_gas_1.sol
@@ -7,3 +7,4 @@ library L {
 // ====
 // SMTEngine: all
 // ----
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/external_calls/external_hash_known_code_pure.sol
+++ b/test/libsolidity/smtCheckerTests/external_calls/external_hash_known_code_pure.sol
@@ -31,3 +31,4 @@ contract C {
 // ----
 // Warning 6328: (398-420): CHC: Assertion violation happens here.
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/external_calls/external_hash_known_code_pure_trusted.sol
+++ b/test/libsolidity/smtCheckerTests/external_calls/external_hash_known_code_pure_trusted.sol
@@ -31,3 +31,4 @@ contract C {
 // SMTExtCalls: trusted
 // ----
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/external_calls/external_hash_known_code_state.sol
+++ b/test/libsolidity/smtCheckerTests/external_calls/external_hash_known_code_state.sol
@@ -37,3 +37,4 @@ contract C {
 // ----
 // Warning 6328: (495-532): CHC: Assertion violation happens here.
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/external_calls/external_hash_known_code_state_reentrancy_indirect.sol
+++ b/test/libsolidity/smtCheckerTests/external_calls/external_hash_known_code_state_reentrancy_indirect.sol
@@ -46,3 +46,4 @@ contract C {
 // ----
 // Warning 6328: (419-433): CHC: Assertion violation happens here.
 // Warning 6328: (437-463): CHC: Assertion violation happens here.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/external_calls/external_hash_known_code_state_reentrancy_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/external_calls/external_hash_known_code_state_reentrancy_unsafe.sol
@@ -38,3 +38,4 @@ contract C {
 // ----
 // Warning 6328: (348-362): CHC: Assertion violation happens here.
 // Warning 6328: (366-392): CHC: Assertion violation happens here.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/external_calls/external_hash_known_code_state_unsafe.sol
+++ b/test/libsolidity/smtCheckerTests/external_calls/external_hash_known_code_state_unsafe.sol
@@ -41,3 +41,4 @@ contract C {
 // ----
 // Warning 6328: (402-428): CHC: Assertion violation happens here.
 // Warning 6328: (561-598): CHC: Assertion violation happens here.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/external_calls/external_reentrancy_1.sol
+++ b/test/libsolidity/smtCheckerTests/external_calls/external_reentrancy_1.sol
@@ -18,3 +18,4 @@ contract C {
 // SMTIgnoreOS: macos
 // ----
 // Warning 6328: (206-220): CHC: Assertion violation happens here.\nCounterexample:\nlocked = false\ntarget = 0x0\n\nTransaction trace:\nC.constructor()\nState: locked = true\nC.call(0x0)\n    D(target).e() -- untrusted external call, synthesized as:\n        C.broken() -- reentrant call
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/external_calls/external_reentrancy_2.sol
+++ b/test/libsolidity/smtCheckerTests/external_calls/external_reentrancy_2.sol
@@ -15,3 +15,4 @@ contract C {
 // SMTIgnoreCex: no
 // ----
 // Warning 6328: (117-131): CHC: Assertion violation happens here.\nCounterexample:\nlocked = false\ntarget = 0x0\n\nTransaction trace:\nC.constructor()\nState: locked = true\nC.call(0x0)\n    D(target).e() -- untrusted external call, synthesized as:\n        C.call(0x0) -- reentrant call
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/file_level/constants_at_file_level_referencing.sol
+++ b/test/libsolidity/smtCheckerTests/file_level/constants_at_file_level_referencing.sol
@@ -64,3 +64,4 @@ contract C {
 // Warning 6328: (s2.sol:890-911): CHC: Assertion violation happens here.
 // Warning 6328: (s2.sol:980-994): CHC: Assertion violation happens here.
 // Info 1391: CHC: 24 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/functions/function_external_call_should_not_inline_1.sol
+++ b/test/libsolidity/smtCheckerTests/functions/function_external_call_should_not_inline_1.sol
@@ -15,3 +15,4 @@ contract C {
 // SMTEngine: all
 // ----
 // Warning 6321: (53-57): Unnamed return variable can remain unassigned. Add an explicit return with value to all non-reverting code paths or name the variable.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/functions/function_external_call_should_not_inline_2.sol
+++ b/test/libsolidity/smtCheckerTests/functions/function_external_call_should_not_inline_2.sol
@@ -14,3 +14,4 @@ contract C {
 // ====
 // SMTEngine: all
 // ----
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/functions/this_external_call_sender.sol
+++ b/test/libsolidity/smtCheckerTests/functions/this_external_call_sender.sol
@@ -28,3 +28,4 @@ contract C {
 // Warning 6328: (314-346): CHC: Assertion violation happens here.
 // Warning 6328: (356-388): CHC: Assertion violation happens here.
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_inline_function_inside_branch.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_inline_function_inside_branch.sol
@@ -17,3 +17,4 @@ contract C
 // ====
 // SMTEngine: all
 // ----
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/operators/bitwise_and_fixed_bytes.sol
+++ b/test/libsolidity/smtCheckerTests/operators/bitwise_and_fixed_bytes.sol
@@ -11,3 +11,4 @@ contract C {
 // ----
 // Warning 6328: (237-285): CHC: Assertion violation happens here.
 // Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 10 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/operators/bitwise_or_fixed_bytes.sol
+++ b/test/libsolidity/smtCheckerTests/operators/bitwise_or_fixed_bytes.sol
@@ -11,3 +11,4 @@ contract C {
 // ----
 // Warning 6328: (150-175): CHC: Assertion violation happens here.
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/operators/bitwise_xor_fixed_bytes.sol
+++ b/test/libsolidity/smtCheckerTests/operators/bitwise_xor_fixed_bytes.sol
@@ -12,3 +12,4 @@ contract Simp {
 // ----
 // Warning 6328: (140-171): CHC: Assertion violation happens here.
 // Info 1391: CHC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/operators/fixed_point_add.sol
+++ b/test/libsolidity/smtCheckerTests/operators/fixed_point_add.sol
@@ -7,3 +7,4 @@ contract test {
 // SMTEngine: all
 // ----
 // Warning 2072: (48-56): Unused local variable.
+// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/operators/index_access_for_bytesNN.sol
+++ b/test/libsolidity/smtCheckerTests/operators/index_access_for_bytesNN.sol
@@ -10,3 +10,4 @@ contract C {
 // ----
 // Warning 6368: (76-90): CHC: Out of bounds access might happen here.
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/special/block_vars_bmc_internal.sol
+++ b/test/libsolidity/smtCheckerTests/special/block_vars_bmc_internal.sol
@@ -43,4 +43,4 @@ contract C {
 // Warning 4661: (752-781): BMC: Assertion violation happens here.
 // Warning 4661: (809-839): BMC: Assertion violation happens here.
 // Warning 4661: (867-903): BMC: Assertion violation happens here.
-// Info 6002: BMC: 12 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 13 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/special/msg_sender_2.sol
+++ b/test/libsolidity/smtCheckerTests/special/msg_sender_2.sol
@@ -11,3 +11,5 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+

--- a/test/libsolidity/smtCheckerTests/special/msg_sender_3.sol
+++ b/test/libsolidity/smtCheckerTests/special/msg_sender_3.sol
@@ -21,3 +21,4 @@ contract D {
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/special/msg_sender_range.sol
+++ b/test/libsolidity/smtCheckerTests/special/msg_sender_range.sol
@@ -9,3 +9,4 @@ contract C {
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/special/msg_vars_bmc_internal.sol
+++ b/test/libsolidity/smtCheckerTests/special/msg_vars_bmc_internal.sol
@@ -30,4 +30,4 @@ contract C {
 // Warning 4661: (460-488): BMC: Assertion violation happens here.
 // Warning 4661: (516-538): BMC: Assertion violation happens here.
 // Warning 4661: (566-592): BMC: Assertion violation happens here.
-// Info 6002: BMC: 8 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 10 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/special/range_check.sol
+++ b/test/libsolidity/smtCheckerTests/special/range_check.sol
@@ -63,3 +63,4 @@ contract D {
 // Warning 8417: (1447-1463): Since the VM version paris, "difficulty" was replaced by "prevrandao", which now returns a random number based on the beacon chain.
 // Warning 8417: (1481-1497): Since the VM version paris, "difficulty" was replaced by "prevrandao", which now returns a random number based on the beacon chain.
 // Info 1391: CHC: 44 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 12 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/special/shadowing_1.sol
+++ b/test/libsolidity/smtCheckerTests/special/shadowing_1.sol
@@ -23,3 +23,4 @@ contract C {
 // Warning 2319: (189-203): This declaration shadows a builtin symbol.
 // Warning 6328: (274-297): CHC: Assertion violation happens here.
 // Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/special/tx_vars_bmc_internal.sol
+++ b/test/libsolidity/smtCheckerTests/special/tx_vars_bmc_internal.sol
@@ -20,4 +20,4 @@ contract C {
 // ----
 // Warning 4661: (233-259): BMC: Assertion violation happens here.
 // Warning 4661: (287-314): BMC: Assertion violation happens here.
-// Info 6002: BMC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 5 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/try_catch/try_string_literal_to_bytes_array.sol
+++ b/test/libsolidity/smtCheckerTests/try_catch/try_string_literal_to_bytes_array.sol
@@ -17,3 +17,4 @@ contract C {
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/try_catch/try_string_literal_to_fixed_bytes.sol
+++ b/test/libsolidity/smtCheckerTests/try_catch/try_string_literal_to_fixed_bytes.sol
@@ -18,3 +18,4 @@ contract C {
 // ----
 // Warning 6328: (218-262): CHC: Assertion violation happens here.
 // Info 1391: CHC: 5 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/typecast/address_literal.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/address_literal.sol
@@ -24,3 +24,4 @@ contract C {
 // ----
 // Warning 6328: (454-468): CHC: Assertion violation happens here.
 // Info 1391: CHC: 5 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 7 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/typecast/bytes_to_fixed_bytes_1.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/bytes_to_fixed_bytes_1.sol
@@ -16,3 +16,7 @@ contract C {
 // SMTIgnoreCex: yes
 // ----
 // Info 1391: CHC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 3260: (162-171): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (237-247): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (314-324): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (422-432): BMC: Truncated value in type conversion happens here.

--- a/test/libsolidity/smtCheckerTests/typecast/bytes_to_fixed_bytes_1_fail.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/bytes_to_fixed_bytes_1_fail.sol
@@ -23,3 +23,7 @@ contract C {
 // Warning 6328: (356-403): CHC: Assertion violation happens here.
 // Warning 6328: (532-595): CHC: Assertion violation happens here.
 // Warning 6328: (740-819): CHC: Assertion violation happens here.
+// Warning 3260: (162-171): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (289-299): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (434-444): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (626-636): BMC: Truncated value in type conversion happens here.

--- a/test/libsolidity/smtCheckerTests/typecast/cast_address_1.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/cast_address_1.sol
@@ -9,3 +9,4 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/typecast/cast_different_size_1.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/cast_different_size_1.sol
@@ -16,3 +16,6 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 3260: (228-244): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (303-312): BMC: Truncated value in type conversion happens here.
+// Info 6002: BMC: 5 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/typecast/cast_larger_1.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/cast_larger_1.sol
@@ -10,3 +10,4 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/typecast/cast_larger_2.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/cast_larger_2.sol
@@ -11,3 +11,4 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/typecast/cast_larger_2_fail.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/cast_larger_2_fail.sol
@@ -10,3 +10,4 @@ contract C
 // SMTEngine: all
 // ----
 // Warning 6328: (116-130): CHC: Assertion violation happens here.\nCounterexample:\n\na = 4660\nb = 4660\n\nTransaction trace:\nC.constructor()\nC.f()
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/typecast/cast_larger_3.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/cast_larger_3.sol
@@ -14,3 +14,4 @@ contract C
 // ----
 // Warning 6328: (240-254): CHC: Assertion violation happens here.
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/typecast/cast_smaller_1.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/cast_smaller_1.sol
@@ -10,3 +10,4 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 3260: (61-69): BMC: Truncated value in type conversion happens here.

--- a/test/libsolidity/smtCheckerTests/typecast/cast_smaller_2.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/cast_smaller_2.sol
@@ -10,3 +10,4 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 3260: (79-88): BMC: Truncated value in type conversion happens here.

--- a/test/libsolidity/smtCheckerTests/typecast/cast_smaller_3.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/cast_smaller_3.sol
@@ -10,3 +10,4 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 3260: (75-84): BMC: Truncated value in type conversion happens here.

--- a/test/libsolidity/smtCheckerTests/typecast/downcast.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/downcast.sol
@@ -47,3 +47,17 @@ contract C {
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 20 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 3260: (315-339): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (367-391): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (454-477): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (449-478): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (557-581): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (640-663): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (697-713): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (747-763): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (741-764): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (817-843): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (881-915): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (874-916): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (947-981): BMC: Truncated value in type conversion happens here.
+// Info 6002: BMC: 20 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/typecast/enum_from_uint.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/enum_from_uint.sol
@@ -11,3 +11,4 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/typecast/enum_to_uint_max_value.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/enum_to_uint_max_value.sol
@@ -10,3 +10,4 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/typecast/number_literal.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/number_literal.sol
@@ -31,3 +31,6 @@ contract C {
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 9 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 3260: (361-368): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (582-591): BMC: Truncated value in type conversion happens here.
+// Info 6002: BMC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/typecast/same_size.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/same_size.sol
@@ -72,3 +72,14 @@ contract C {
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 27 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 3260: (116-132): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (167-195): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (241-266): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (385-431): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (477-520): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (554-606): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (878-895): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (930-949): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (1008-1029): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (1153-1182): BMC: Truncated value in type conversion happens here.
+// Info 6002: BMC: 44 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/typecast/string_literal_to_dynamic_bytes.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/string_literal_to_dynamic_bytes.sol
@@ -11,3 +11,4 @@ contract C {
 // ----
 // Warning 6328: (173-207): CHC: Assertion violation happens here.
 // Info 1391: CHC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/typecast/type_conversion_truncation.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/type_conversion_truncation.sol
@@ -1,0 +1,44 @@
+contract C
+{
+	function uint_to_uint(uint8 u8, uint256 u256) public pure {
+		uint256 b = uint256(u8);
+		uint8 c = uint8(u8);
+		b = uint256(u256);
+		uint256 d = 1;
+		c = uint8(d); // no truncation
+		c = uint8(u256); // big cast to small - truncation
+	}
+
+	function fixed_bytes_to_fixed_bytes(bytes2 b2, bytes32 b32) public pure {
+		bytes32 c = bytes32(b2);
+		bytes2 d = bytes2(b2);
+		c = bytes32(b32);
+
+		d = bytes2(b32); // big cast to small - truncation
+	}
+
+	function array_to_fixed_bytes(bytes calldata c, bytes memory m) public pure returns (bytes16) {
+		require(c.length == 16, "");
+		bytes16 b = bytes16(c); // no truncation
+		b = bytes16(m); // truncation possible
+		return b;
+	}
+
+	function array_slice_to_fixed_bytes(bytes calldata c) public pure returns (bytes16) {
+		require(c.length == 16, "");
+		bytes8 b = bytes8(c[:7]); // not supported in BMC
+		b = bytes8(c[:10]); // not supported in BMC
+		return b;
+	}
+
+	function address_conversion_for_contract() public view returns (bytes20) {
+		return bytes20(address(this)); // truncation not reported
+	}
+}
+// ====
+// SMTEngine: bmc
+// ----
+// Warning 3260: (201-212): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (406-417): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (634-644): BMC: Truncated value in type conversion happens here.
+// Info 6002: BMC: 9 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/typecast/upcast.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/upcast.sol
@@ -68,3 +68,16 @@ contract C {
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 23 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 3260: (196-211): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (240-256): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (296-304): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (409-427): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (470-491): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (650-672): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (644-673): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (751-765): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (907-928): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (962-984): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (1069-1091): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (1128-1151): BMC: Truncated value in type conversion happens here.
+// Info 6002: BMC: 42 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/types/array_literal_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/array_literal_1.sol
@@ -11,3 +11,4 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 6 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/types/array_literal_2.sol
+++ b/test/libsolidity/smtCheckerTests/types/array_literal_2.sol
@@ -14,3 +14,4 @@ contract C
 // ----
 // Warning 6328: (167-187): CHC: Assertion violation happens here.\nCounterexample:\n\na = [1, 2, 3]\nb = [1, 2, 4]\n\nTransaction trace:\nC.constructor()\nC.f()
 // Info 1391: CHC: 8 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/types/array_literal_3.sol
+++ b/test/libsolidity/smtCheckerTests/types/array_literal_3.sol
@@ -13,3 +13,4 @@ contract C
 // ----
 // Warning 6328: (168-188): CHC: Assertion violation happens here.
 // Info 1391: CHC: 8 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/types/array_literal_4.sol
+++ b/test/libsolidity/smtCheckerTests/types/array_literal_4.sol
@@ -12,3 +12,4 @@ contract C
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 9 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/types/array_literal_5.sol
+++ b/test/libsolidity/smtCheckerTests/types/array_literal_5.sol
@@ -16,3 +16,4 @@ contract C
 // ----
 // Warning 6328: (176-196): CHC: Assertion violation happens here.\nCounterexample:\ns = [1, 2, 3]\na = [1, 2, 3]\n\nTransaction trace:\nC.constructor()\nState: s = []\nC.f()
 // Info 1391: CHC: 9 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/types/array_literal_6.sol
+++ b/test/libsolidity/smtCheckerTests/types/array_literal_6.sol
@@ -18,3 +18,4 @@ contract C
 // Warning 6328: (146-174): CHC: Assertion violation happens here.\nCounterexample:\n\na = [1, 2, 3]\nb = [1, 2, 4, 3]\nc = [1, 2, 4, 3]\n\nTransaction trace:\nC.constructor()\nC.f()
 // Warning 6328: (235-255): CHC: Assertion violation happens here.\nCounterexample:\n\na = [1, 2, 3]\nb = [1, 2, 4, 3]\nc = [1, 2, 4, 3]\n\nTransaction trace:\nC.constructor()\nC.f()
 // Info 1391: CHC: 11 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/types/array_literal_7.sol
+++ b/test/libsolidity/smtCheckerTests/types/array_literal_7.sol
@@ -23,3 +23,4 @@ contract C
 // Warning 6328: (226-254): CHC: Assertion violation happens here.
 // Warning 6328: (315-335): CHC: Assertion violation happens here.
 // Info 1391: CHC: 13 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/types/fixed_bytes_range.sol
+++ b/test/libsolidity/smtCheckerTests/types/fixed_bytes_range.sol
@@ -10,3 +10,4 @@ contract C {
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/types/struct/struct_constructor_fixed_bytes_from_string_1.sol
+++ b/test/libsolidity/smtCheckerTests/types/struct/struct_constructor_fixed_bytes_from_string_1.sol
@@ -13,3 +13,4 @@ contract C {
 // Warning 5523: (0-31): The SMTChecker pragma has been deprecated and will be removed in the future. Please use the "model checker engine" compiler setting to activate the SMTChecker instead. If the pragma is enabled, all engines will be used.
 // Warning 6328: (178-207): CHC: Assertion violation happens here.
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/types/tuple_extra_parens_7.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_extra_parens_7.sol
@@ -13,3 +13,4 @@ contract C {
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/userTypes/constant.sol
+++ b/test/libsolidity/smtCheckerTests/userTypes/constant.sol
@@ -18,3 +18,4 @@ contract C {
 // ----
 // Warning 6328: (531-555): CHC: Assertion violation happens here.\nCounterexample:\nu = 165521356710917456517261742455526507355687727119203895813322792776\n\nTransaction trace:\nC.constructor()\nState: u = 165521356710917456517261742455526507355687727119203895813322792776\nC.f()
 // Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/userTypes/conversion_1.sol
+++ b/test/libsolidity/smtCheckerTests/userTypes/conversion_1.sol
@@ -33,3 +33,7 @@ contract C {
 // Warning 6328: (428-465): CHC: Assertion violation happens here.
 // Warning 6328: (665-700): CHC: Assertion violation happens here.
 // Info 1391: CHC: 7 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 3260: (179-187): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (271-277): BMC: Truncated value in type conversion happens here.
+// Warning 3260: (266-278): BMC: Truncated value in type conversion happens here.
+// Info 6002: BMC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/userTypes/conversion_2.sol
+++ b/test/libsolidity/smtCheckerTests/userTypes/conversion_2.sol
@@ -30,3 +30,5 @@ contract C {
 // Warning 6328: (497-545): CHC: Assertion violation happens here.
 // Warning 6328: (652-702): CHC: Assertion violation happens here.
 // Info 1391: CHC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 3260: (181-204): BMC: Truncated value in type conversion happens here.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/userTypes/conversion_4.sol
+++ b/test/libsolidity/smtCheckerTests/userTypes/conversion_4.sol
@@ -22,3 +22,5 @@ contract C {
 // ----
 // Warning 6328: (407-457): CHC: Assertion violation happens here.
 // Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 3260: (184-209): BMC: Truncated value in type conversion happens here.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/userTypes/multisource.sol
+++ b/test/libsolidity/smtCheckerTests/userTypes/multisource.sol
@@ -20,3 +20,4 @@ contract A {
 // Warning 6328: (B:296-332): CHC: Assertion violation happens here.
 // Warning 6328: (B:409-463): CHC: Assertion violation happens here.
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 6 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/userTypes/simple.sol
+++ b/test/libsolidity/smtCheckerTests/userTypes/simple.sol
@@ -22,3 +22,4 @@ contract C {
 // Warning 6328: (255-285): CHC: Assertion violation happens here.
 // Warning 6328: (364-392): CHC: Assertion violation happens here.
 // Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/userTypes/user_type_as_array_elem_1.sol
+++ b/test/libsolidity/smtCheckerTests/userTypes/user_type_as_array_elem_1.sol
@@ -17,3 +17,4 @@ contract C {
 // Warning 6328: (204-243): CHC: Assertion violation might happen here.
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
 // Warning 4661: (204-243): BMC: Assertion violation happens here.
+// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/userTypes/user_type_as_array_elem_2.sol
+++ b/test/libsolidity/smtCheckerTests/userTypes/user_type_as_array_elem_2.sol
@@ -15,3 +15,4 @@ contract C {
 // ----
 // Warning 6328: (200-238): CHC: Assertion violation happens here.
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/userTypes/user_type_as_mapping_index_2.sol
+++ b/test/libsolidity/smtCheckerTests/userTypes/user_type_as_mapping_index_2.sol
@@ -19,3 +19,4 @@ contract C {
 // ----
 // Warning 6328: (352-370): CHC: Assertion violation happens here.
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/userTypes/user_type_as_struct_member_1.sol
+++ b/test/libsolidity/smtCheckerTests/userTypes/user_type_as_struct_member_1.sol
@@ -25,3 +25,4 @@ contract C {
 }
 // ----
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.


### PR DESCRIPTION
Implements a piece of https://github.com/ethereum/solidity/issues/5808.
Verification target for CHC engine will be added in a seperate PR.