### PR TITLE
Reduce default font weight for readability

### DIFF
--- a/docs/_static/css/toggle.css
+++ b/docs/_static/css/toggle.css
@@ -88,5 +88,6 @@ html.transition *:after {
 }
 
 body {
-    font-weight: 200;
+    font-weight: 300;
+    letter-spacing: 0.5px;
 }

--- a/docs/_static/css/toggle.css
+++ b/docs/_static/css/toggle.css
@@ -86,3 +86,7 @@ html.transition *:after {
 .wy-menu-vertical a:hover {
     background-color: #0002;
 }
+
+body {
+    font-weight: 200;
+}


### PR DESCRIPTION
Fixes #14942
The texts in the Solidity documentation are all rendered with a bold font face. This makes it hard to read and emphasized content is no longer recognizable as such.
Changed the default body font weight from 400 to 200 at the toggle.css (as per specified on the conf.py: html_css_files = ["css/toggle.css"])