### PR TITLE
Fix passing of string input parameter to Enable method of DebugInfoSelection struct

### DIFF
--- a/liblangutil/DebugInfoSelection.cpp
+++ b/liblangutil/DebugInfoSelection.cpp
@@ -83,7 +83,7 @@ std::optional<DebugInfoSelection> DebugInfoSelection::fromComponents(
 	return selection;
 }
 
-bool DebugInfoSelection::enable(std::string _component)
+bool DebugInfoSelection::enable(std::string const& _component)
 {
 	auto memberIt = componentMap().find(boost::trim_copy(_component));
 	if (memberIt == componentMap().end())

--- a/liblangutil/DebugInfoSelection.h
+++ b/liblangutil/DebugInfoSelection.h
@@ -49,7 +49,7 @@ struct DebugInfoSelection
 		std::vector<std::string> const& _componentNames,
 		bool _acceptWildcards = false
 	);
-	bool enable(std::string _component);
+	bool enable(std::string const& _component);
 
 	bool all() const noexcept;
 	bool any() const noexcept;


### PR DESCRIPTION
Here we can use a const ref to the input string instead of incurring the cost of copying the input string