### PR TITLE
Drop Ubuntu Lunar Lobster from distribution list in PPA scripts

### DIFF
--- a/scripts/deps-ppa/static_z3.sh
+++ b/scripts/deps-ppa/static_z3.sh
@@ -41,7 +41,7 @@ sourcePPAConfig
 # Sanity check
 checkDputEntries "\[cpp-build-deps\]"
 
-DISTRIBUTIONS="focal jammy lunar mantic"
+DISTRIBUTIONS="focal jammy mantic"
 
 for distribution in $DISTRIBUTIONS
 do

--- a/scripts/deps-ppa/static_z3.sh
+++ b/scripts/deps-ppa/static_z3.sh
@@ -9,10 +9,10 @@
 ## This requires the following entries in /etc/dput.cf:
 ##
 ##  [cpp-build-deps]
-##  fqdn			= ppa.launchpad.net
-##  method			= ftp
-##  incoming		= ~ethereum/cpp-build-deps
-##  login			= anonymous
+##  fqdn            = ppa.launchpad.net
+##  method          = ftp
+##  incoming        = ~ethereum/cpp-build-deps
+##  login           = anonymous
 ##
 ## To interact with launchpad, you need to set the variables $LAUNCHPAD_EMAIL
 ## and $LAUNCHPAD_KEYID in the file .release_ppa_auth in the root directory of

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -23,22 +23,22 @@
 ## Additionally the following entries in /etc/dput.cf are required:
 ##
 ##  [ethereum-dev]
-##  fqdn			= ppa.launchpad.net
-##  method			= ftp
-##  incoming		= ~ethereum/ethereum-dev
-##  login			= anonymous
+##  fqdn            = ppa.launchpad.net
+##  method          = ftp
+##  incoming        = ~ethereum/ethereum-dev
+##  login           = anonymous
 ##
 ##  [ethereum]
-##  fqdn			= ppa.launchpad.net
-##  method			= ftp
-##  incoming		= ~ethereum/ethereum
-##  login			= anonymous
+##  fqdn            = ppa.launchpad.net
+##  method          = ftp
+##  incoming        = ~ethereum/ethereum
+##  login           = anonymous
 ##
 ##  [ethereum-static]
-##  fqdn			= ppa.launchpad.net
-##  method			= ftp
-##  incoming		= ~ethereum/ethereum-static
-##  login			= anonymous
+##  fqdn            = ppa.launchpad.net
+##  method          = ftp
+##  incoming        = ~ethereum/ethereum-static
+##  login           = anonymous
 ##
 ##############################################################################
 

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -68,7 +68,7 @@ packagename=solc
 # This needs to be a still active release
 static_build_distribution=focal
 
-DISTRIBUTIONS="focal jammy lunar mantic"
+DISTRIBUTIONS="focal jammy mantic"
 
 if is_release
 then


### PR DESCRIPTION
Launchpad no longer accepts packages targeting Lunar. I got this message during the release yesterday:

```
Subject: [~ethereum/ubuntu/ethereum] solc_0.8.25-0ubuntu1~lunar_source.changes (Rejected)
From: Launchpad PPA <noreply@launchpad.net>
Date: 14 Mar 2024, 13:40

Rejected:
lunar is obsolete and will not accept new uploads.

solc (1:0.8.25-0ubuntu1~lunar) lunar; urgency=low

  * git build of b61c2a91

===
```

This PR removes it from the distribution list in our scripts.