### PR TITLE
Update precompiled contract address range

### DIFF
--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -603,7 +603,7 @@ Precompiled Contracts
 =====================
 
 There is a small set of contract addresses that are special:
-The address range between ``1`` and (including) ``8`` contains
+The address range between ``1`` and (including) ``0x0a`` contains
 "precompiled contracts" that can be called as any other contract
 but their behavior (and their gas consumption) is not defined
 by EVM code stored at that address (they do not contain code)


### PR DESCRIPTION
This PR updates the precompiled contract address range noted in the ["Introduction to Smart Contracts"](https://docs.soliditylang.org/en/v0.8.25/introduction-to-smart-contracts.html#precompiledcontracts) page from:

> ... between `1` and (including) `8` ...

to:

> ... between `1` and (including) `0x0a` ...

to reflect the [`blake2f` (`0x09`)](https://eips.ethereum.org/EIPS/eip-152) and [`point evaluation` (`0x0a`)](https://eips.ethereum.org/EIPS/eip-4844#point-evaluation-precompile) precompiles.