### PR TITLE
Install eldarica on ubuntu base images and osx machines

### DIFF
--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -55,6 +55,9 @@ then
   brew install coreutils
   brew install diffutils
   brew install grep
+  # JRE is required to run eldarica solver
+  brew install openjdk@11
+  brew install unzip
 
   # writing to /usr/local/lib need administrative privileges.
   sudo ./scripts/install_obsolete_jsoncpp_1_7_4.sh
@@ -72,6 +75,14 @@ then
   sudo ./b2 -a address-model=64 architecture=arm+x86 install
   cd ..
   sudo rm -rf "$boost_dir"
+
+  # eldarica
+  eldarica_version="2.1"
+  wget "https://github.com/uuverifiers/eldarica/releases/download/v${eldarica_version}/eldarica-bin-${eldarica_version}.zip" -O /tmp/eld_binaries.zip
+  validate_checksum /tmp/eld_binaries.zip 0ac43f45c0925383c9d2077f62bbb515fd792375f3b2b101b30c9e81dcd7785c
+  unzip /tmp/eld_binaries.zip -d /tmp
+  sudo mv /tmp/eldarica/{eld,eld-client,target,eldEnv} /usr/local/bin
+  rm -rf /tmp/{eldarica,eld_binaries.zip}
 
   # z3
   z3_version="4.12.1"

--- a/.github/workflows/buildpack-deps.yml
+++ b/.github/workflows/buildpack-deps.yml
@@ -26,7 +26,7 @@ jobs:
         image_variant: [emscripten, ubuntu.clang.ossfuzz, ubuntu2004, ubuntu2204.clang, ubuntu2204]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
@@ -22,14 +22,14 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:focal AS base
-LABEL version="21"
+LABEL version="22"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN set -ex; \
-        dist=$(grep DISTRIB_CODENAME /etc/lsb-release | cut -d= -f2); \
-        echo "deb http://ppa.launchpad.net/ethereum/cpp-build-deps/ubuntu $dist main" >> /etc/apt/sources.list ; \
-        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1c52189c923f6ca9 ; \
+	dist=$(grep DISTRIB_CODENAME /etc/lsb-release | cut -d= -f2); \
+	echo "deb http://ppa.launchpad.net/ethereum/cpp-build-deps/ubuntu $dist main" >> /etc/apt/sources.list ; \
+	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1c52189c923f6ca9 ; \
 	apt-get update; \
 	apt-get install -qqy --no-install-recommends \
 		build-essential sudo \
@@ -40,7 +40,20 @@ RUN set -ex; \
 		libcvc4-dev libz3-static-dev z3-static jq \
 		; \
 	apt-get install -qy python3-pip python3-sphinx; \
-	pip3 install codecov; \
+	pip3 install codecov;
+
+# Eldarica
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -qy unzip openjdk-11-jre; \
+	eldarica_version="2.1"; \
+	wget "https://github.com/uuverifiers/eldarica/releases/download/v${eldarica_version}/eldarica-bin-${eldarica_version}.zip" -O /opt/eld_binaries.zip; \
+	test "$(sha256sum /opt/eld_binaries.zip)" = "0ac43f45c0925383c9d2077f62bbb515fd792375f3b2b101b30c9e81dcd7785c  /opt/eld_binaries.zip"; \
+	unzip /opt/eld_binaries.zip -d /opt; \
+	rm -f /opt/eld_binaries.zip;
+
+# Cleanup
+RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*
 
 FROM base AS libraries
@@ -57,3 +70,5 @@ FROM base
 COPY --from=libraries /usr/lib /usr/lib
 COPY --from=libraries /usr/bin /usr/bin
 COPY --from=libraries /usr/include /usr/include
+COPY --from=libraries /opt/eldarica /opt/eldarica
+ENV PATH="$PATH:/opt/eldarica"

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204
@@ -22,14 +22,14 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:jammy AS base
-LABEL version="6"
+LABEL version="7"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN set -ex; \
-        dist=$(grep DISTRIB_CODENAME /etc/lsb-release | cut -d= -f2); \
-        echo "deb http://ppa.launchpad.net/ethereum/cpp-build-deps/ubuntu $dist main" >> /etc/apt/sources.list ; \
-        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1c52189c923f6ca9 ; \
+	dist=$(grep DISTRIB_CODENAME /etc/lsb-release | cut -d= -f2); \
+	echo "deb http://ppa.launchpad.net/ethereum/cpp-build-deps/ubuntu $dist main" >> /etc/apt/sources.list ; \
+	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1c52189c923f6ca9 ; \
 	apt-get update; \
 	apt-get install -qqy --no-install-recommends \
 		build-essential sudo \
@@ -40,7 +40,20 @@ RUN set -ex; \
 		libcvc4-dev libz3-static-dev z3-static jq \
 		libcln-dev zip locales-all; \
 	apt-get install -qy python3-pip python3-sphinx; \
-	pip3 install codecov; \
+	pip3 install codecov;
+
+# Eldarica
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -qy unzip openjdk-11-jre; \
+	eldarica_version="2.1"; \
+	wget "https://github.com/uuverifiers/eldarica/releases/download/v${eldarica_version}/eldarica-bin-${eldarica_version}.zip" -O /opt/eld_binaries.zip; \
+	test "$(sha256sum /opt/eld_binaries.zip)" = "0ac43f45c0925383c9d2077f62bbb515fd792375f3b2b101b30c9e81dcd7785c  /opt/eld_binaries.zip"; \
+	unzip /opt/eld_binaries.zip -d /opt; \
+	rm -f /opt/eld_binaries.zip;
+
+# Cleanup
+RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*
 
 FROM base AS libraries
@@ -61,3 +74,5 @@ FROM base
 COPY --from=libraries /usr/lib /usr/lib
 COPY --from=libraries /usr/bin /usr/bin
 COPY --from=libraries /usr/include /usr/include
+COPY --from=libraries /opt/eldarica /opt/eldarica
+ENV PATH="$PATH:/opt/eldarica"


### PR DESCRIPTION
This PR also bumps the version of `actions/checkout` action used by `.github/workflows/buildpack-deps.yml` to fix nodejs version deprecation warnings, see: https://github.com/ethereum/solidity/actions/runs/8419464009