### PR TITLE
SMTChecker: Add command-line test for Eldarica

### DIFF
--- a/test/cmdlineTests/model_checker_solvers_eld/args
+++ b/test/cmdlineTests/model_checker_solvers_eld/args
@@ -1,0 +1,1 @@
+--model-checker-engine chc --model-checker-solvers eld

--- a/test/cmdlineTests/model_checker_solvers_eld/err
+++ b/test/cmdlineTests/model_checker_solvers_eld/err
@@ -1,0 +1,5 @@
+Warning: CHC: Assertion violation happens here.
+ --> model_checker_solvers_eld/input.sol:5:3:
+  |
+5 | 		assert(x > 0);
+  | 		^^^^^^^^^^^^^

--- a/test/cmdlineTests/model_checker_solvers_eld/input.sol
+++ b/test/cmdlineTests/model_checker_solvers_eld/input.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+contract test {
+	function f(uint x) public pure {
+		assert(x > 0);
+	}
+}


### PR DESCRIPTION
This adds a very basic test to verify that Eldarica can be used as the CHC backend.

Depends on #14964.