### PR TITLE
Install Eldarica on Ubuntu Clang images

### DIFF
--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu.clang.ossfuzz
@@ -22,7 +22,7 @@
 # (c) 2016-2021 solidity contributors.
 #------------------------------------------------------------------------------
 FROM gcr.io/oss-fuzz-base/base-clang:latest as base
-LABEL version="4"
+LABEL version="5"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -72,6 +72,16 @@ RUN set -ex; \
     make libz3 -j; \
     make install; \
     rm -rf /usr/src/z3
+
+# Eldarica
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -qy unzip openjdk-11-jre; \
+	eldarica_version="2.1"; \
+	wget "https://github.com/uuverifiers/eldarica/releases/download/v${eldarica_version}/eldarica-bin-${eldarica_version}.zip" -O /opt/eld_binaries.zip; \
+	test "$(sha256sum /opt/eld_binaries.zip)" = "0ac43f45c0925383c9d2077f62bbb515fd792375f3b2b101b30c9e81dcd7785c  /opt/eld_binaries.zip"; \
+	unzip /opt/eld_binaries.zip -d /opt; \
+	rm -f /opt/eld_binaries.zip;
 
 # OSSFUZZ: libprotobuf-mutator
 RUN set -ex; \
@@ -137,7 +147,13 @@ RUN set -ex; \
     cp abicoder.hpp /usr/include; \
     rm -rf /usr/src/Yul-Isabelle
 
+# Cleanup
+RUN set -ex; \
+	rm -rf /var/lib/apt/lists/*
+
 FROM base
 COPY --from=libraries /usr/lib /usr/lib
 COPY --from=libraries /usr/bin /usr/bin
 COPY --from=libraries /usr/include /usr/include
+COPY --from=libraries /opt/eldarica /opt/eldarica
+ENV PATH="$PATH:/opt/eldarica"

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204.clang
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204.clang
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:jammy AS base
-LABEL version="5"
+LABEL version="6"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -39,7 +39,20 @@ RUN set -ex; \
 		libboost-program-options-dev \
 		clang \
 		libz3-static-dev z3-static jq \
-		libcln-dev; \
+		libcln-dev;
+
+# Eldarica
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -qy unzip openjdk-11-jre; \
+	eldarica_version="2.1"; \
+	wget "https://github.com/uuverifiers/eldarica/releases/download/v${eldarica_version}/eldarica-bin-${eldarica_version}.zip" -O /opt/eld_binaries.zip; \
+	test "$(sha256sum /opt/eld_binaries.zip)" = "0ac43f45c0925383c9d2077f62bbb515fd792375f3b2b101b30c9e81dcd7785c  /opt/eld_binaries.zip"; \
+	unzip /opt/eld_binaries.zip -d /opt; \
+	rm -f /opt/eld_binaries.zip;
+
+# Cleanup
+RUN set -ex; \
 	rm -rf /var/lib/apt/lists/*
 
 FROM base AS libraries
@@ -63,3 +76,5 @@ FROM base
 COPY --from=libraries /usr/lib /usr/lib
 COPY --from=libraries /usr/bin /usr/bin
 COPY --from=libraries /usr/include /usr/include
+COPY --from=libraries /opt/eldarica /opt/eldarica
+ENV PATH="$PATH:/opt/eldarica"


### PR DESCRIPTION
I forgot to add Eldarica to the `ubuntu-clang` images, and those run the tests with smt enable on nightly builds: https://app.circleci.com/pipelines/github/ethereum/solidity/33569/workflows/26e587dd-8b83-4b93-ba99-dc0f98d4910c/jobs/1512378. This PR fix that.