### PR TITLE
SMTChecker: Relax assertions regarding sort compatibility when creating expressions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * SMTChecker: Fix internal error on mapping access caused by too strong requirements on sort compatibility of the index and mapping domain.
  * SMTChecker: Fix internal error when using bitwise operators with an array element as argument.
 
 

--- a/libsmtutil/SolverInterface.h
+++ b/libsmtutil/SolverInterface.h
@@ -229,7 +229,7 @@ public:
 		smtAssert(arraySort, "");
 		smtAssert(_index.sort, "");
 		smtAssert(_element.sort, "");
-		smtAssert(*arraySort->domain == *_index.sort, "");
+		smtAssert(areCompatible(*arraySort->domain, *_index.sort));
 		smtAssert(areCompatible(*arraySort->range, *_element.sort));
 		return Expression(
 			"store",

--- a/test/libsolidity/smtCheckerTests/types/mapping_integer_signedness_compatibility.sol
+++ b/test/libsolidity/smtCheckerTests/types/mapping_integer_signedness_compatibility.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0
+
+
+// Regression for handling signedness, see issue #14792
+contract C {
+    mapping(int => int) v1;
+    mapping(int => uint) v2;
+    mapping(uint => int) v3;
+    mapping(uint => uint) v4;
+    mapping(bytes12 => int) v5;
+    uint[5] a1;
+    int[5] a2;
+
+    function f() public {
+        delete v1[0];
+        delete v2[0];
+        delete v3[0];
+        delete v4[0];
+        delete v5[0];
+        delete a1[0];
+        delete a2[0];
+    }
+}
+// ----
+// Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.


### PR DESCRIPTION
This finishes the work started by #14180, which relaxed most of the assertions related to checking compatibility of sorts to allow mixing signed and unsigned `Int` sorts. 

This PR has two parts:
1. Introduces a helper method that expresses the intent of the check and replaces if-then-else branches with this method call.
2.  Relaxes one more assertion: in creating array store expression, we are checking if the array's domain sort and access index sort are compatible instead of equal.

Fixes #14792.