### PR TITLE
Pass vector of SMT expressions to SymbolicFunctionVariable function operator by const ref instead of by value.

### DIFF
--- a/libsolidity/formal/SymbolicVariables.cpp
+++ b/libsolidity/formal/SymbolicVariables.cpp
@@ -203,7 +203,7 @@ smtutil::Expression SymbolicFunctionVariable::increaseIndex()
 	return m_abstract.currentValue();
 }
 
-smtutil::Expression SymbolicFunctionVariable::operator()(std::vector<smtutil::Expression> _arguments) const
+smtutil::Expression SymbolicFunctionVariable::operator()(std::vector<smtutil::Expression> const& _arguments) const
 {
 	return m_declaration(_arguments);
 }

--- a/libsolidity/formal/SymbolicVariables.h
+++ b/libsolidity/formal/SymbolicVariables.h
@@ -62,7 +62,7 @@ public:
 	virtual smtutil::Expression resetIndex();
 	virtual smtutil::Expression setIndex(unsigned _index);
 	virtual smtutil::Expression increaseIndex();
-	virtual smtutil::Expression operator()(std::vector<smtutil::Expression> /*_arguments*/) const
+	virtual smtutil::Expression operator()(std::vector<smtutil::Expression> const& /*_arguments*/) const
 	{
 		solAssert(false, "Function application to non-function.");
 	}
@@ -177,7 +177,7 @@ public:
 	smtutil::Expression setIndex(unsigned _index) override;
 	smtutil::Expression increaseIndex() override;
 
-	smtutil::Expression operator()(std::vector<smtutil::Expression> _arguments) const override;
+	smtutil::Expression operator()(std::vector<smtutil::Expression> const& _arguments) const override;
 
 private:
 	/// Creates a new function declaration.


### PR DESCRIPTION
To avoid the cost of copying the vector.