### PR TITLE
Fix error msg for hex number combined with unit denomination

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -3874,7 +3874,7 @@ void TypeChecker::endVisit(Literal const& _literal)
 			5145_error,
 			_literal.location(),
 			"Hexadecimal numbers cannot be used with unit denominations. "
-			"You can use an expression of the form \"0x1234 * 1 day\" instead."
+			"You can use an expression of the form \"0x1234 * 1 days\" instead."
 		);
 
 	if (_literal.subDenomination() == Literal::SubDenomination::Year)

--- a/test/libsolidity/syntaxTests/denominations/combining_hex_and_denomination.sol
+++ b/test/libsolidity/syntaxTests/denominations/combining_hex_and_denomination.sol
@@ -2,4 +2,4 @@ contract C {
 	uint constant x = 0x01 wei;
 }
 // ----
-// TypeError 5145: (32-40): Hexadecimal numbers cannot be used with unit denominations. You can use an expression of the form "0x1234 * 1 day" instead.
+// TypeError 5145: (32-40): Hexadecimal numbers cannot be used with unit denominations. You can use an expression of the form "0x1234 * 1 days" instead.

--- a/test/libsolidity/syntaxTests/denominations/invalid_denomination_address.sol
+++ b/test/libsolidity/syntaxTests/denominations/invalid_denomination_address.sol
@@ -2,4 +2,4 @@ contract C {
 	address a = 0x11111122222333334444455555666667777788888 wei;
 }
 // ----
-// TypeError 5145: (26-73): Hexadecimal numbers cannot be used with unit denominations. You can use an expression of the form "0x1234 * 1 day" instead.
+// TypeError 5145: (26-73): Hexadecimal numbers cannot be used with unit denominations. You can use an expression of the form "0x1234 * 1 days" instead.


### PR DESCRIPTION
`days` is the correct time unit.