### PR TITLE
Enable parser to accept `transient` as data location or identifier

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.8.27 (unreleased)
 
 Language Features:
+ * Accept declarations of state variables with ``transient`` data location (parser support only, no code generation yet).
 
 
 Compiler Features:

--- a/docs/grammar/SolidityLexer.g4
+++ b/docs/grammar/SolidityLexer.g4
@@ -85,6 +85,7 @@ SignedIntegerType:
 Storage: 'storage';
 String: 'string';
 Struct: 'struct';
+Transient: 'transient';  // not a real keyword
 True: 'true';
 Try: 'try';
 Type: 'type';

--- a/docs/grammar/SolidityParser.g4
+++ b/docs/grammar/SolidityParser.g4
@@ -262,7 +262,7 @@ userDefinedValueTypeDefinition:
  * The declaration of a state variable.
  */
 stateVariableDeclaration
-locals [boolean constantnessSet = false, boolean visibilitySet = false, boolean overrideSpecifierSet = false]
+locals [boolean constantnessSet = false, boolean visibilitySet = false, boolean overrideSpecifierSet = false, boolean locationSet = false]
 :
 	type=typeName
 	(
@@ -272,6 +272,7 @@ locals [boolean constantnessSet = false, boolean visibilitySet = false, boolean 
 		| {!$constantnessSet}? Constant {$constantnessSet = true;}
 		| {!$overrideSpecifierSet}? overrideSpecifier {$overrideSpecifierSet = true;}
 		| {!$constantnessSet}? Immutable {$constantnessSet = true;}
+		| {!$locationSet}? Transient {$locationSet = true;}
 	)*
 	name=identifier
 	(Assign initialValue=expression)?
@@ -419,7 +420,7 @@ inlineArrayExpression: LBrack (expression ( Comma expression)* ) RBrack;
 /**
  * Besides regular non-keyword Identifiers, some keywords like 'from' and 'error' can also be used as identifiers.
  */
-identifier: Identifier | From | Error | Revert | Global;
+identifier: Identifier | From | Error | Revert | Global | Transient;
 
 literal: stringLiteral | numberLiteral | booleanLiteral | hexStringLiteral | unicodeStringLiteral;
 

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -816,7 +816,9 @@ std::set<VariableDeclaration::Location> VariableDeclaration::allowedDataLocation
 {
 	using Location = VariableDeclaration::Location;
 
-	if (!hasReferenceOrMappingType() || isStateVariable() || isEventOrErrorParameter())
+	if (isStateVariable())
+		return std::set<Location>{Location::Unspecified, Location::Transient};
+	else if (!hasReferenceOrMappingType() || isEventOrErrorParameter())
 		return std::set<Location>{ Location::Unspecified };
 	else if (isCallableOrCatchParameter())
 	{

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -1052,7 +1052,7 @@ private:
 class VariableDeclaration: public Declaration, public StructurallyDocumented
 {
 public:
-	enum Location { Unspecified, Storage, Memory, CallData };
+	enum Location { Unspecified, Storage, Transient, Memory, CallData };
 	enum class Mutability { Mutable, Immutable, Constant };
 	static std::string mutabilityToString(Mutability _mutability)
 	{

--- a/libsolidity/ast/ASTJsonExporter.cpp
+++ b/libsolidity/ast/ASTJsonExporter.cpp
@@ -1058,6 +1058,8 @@ std::string ASTJsonExporter::location(VariableDeclaration::Location _location)
 		return "memory";
 	case VariableDeclaration::Location::CallData:
 		return "calldata";
+	case VariableDeclaration::Location::Transient:
+		return "transient";
 	}
 	// To make the compiler happy
 	return {};

--- a/libsolidity/ast/ASTJsonImporter.cpp
+++ b/libsolidity/ast/ASTJsonImporter.cpp
@@ -1190,6 +1190,8 @@ VariableDeclaration::Location ASTJsonImporter::location(Json const& _node)
 		return VariableDeclaration::Location::Memory;
 	else if (storageLocStr == "calldata")
 		return VariableDeclaration::Location::CallData;
+	else if (storageLocStr == "transient")
+		return VariableDeclaration::Location::Transient;
 	else
 		astAssert(false, "Unknown location declaration");
 

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1544,6 +1544,8 @@ TypeResult ReferenceType::unaryOperatorResult(Token _operator) const
 		return TypeProvider::emptyTuple();
 	case DataLocation::Storage:
 		return isPointer() ? nullptr : TypeProvider::emptyTuple();
+	case DataLocation::Transient:
+		solUnimplemented("Transient data location is only supported for value types.");
 	}
 	return nullptr;
 }
@@ -1571,6 +1573,9 @@ std::string ReferenceType::stringForReferencePart() const
 		return "calldata";
 	case DataLocation::Memory:
 		return "memory";
+	case DataLocation::Transient:
+		solUnimplemented("Transient data location is only supported for value types.");
+		break;
 	}
 	solAssert(false, "");
 	return "";
@@ -1583,6 +1588,9 @@ std::string ReferenceType::identifierLocationSuffix() const
 	{
 	case DataLocation::Storage:
 		id += "_storage";
+		break;
+	case DataLocation::Transient:
+		solUnimplemented("Transient data location is only supported for value types.");
 		break;
 	case DataLocation::Memory:
 		id += "_memory";
@@ -1748,6 +1756,9 @@ BoolResult ArrayType::validForLocation(DataLocation _loc) const
 			if (storageSizeUpperBound() >= bigint(1) << 256)
 				return BoolResult::err("Type too large for storage.");
 			break;
+		case DataLocation::Transient:
+			solUnimplemented("Transient data location is only supported for value types.");
+			break;
 	}
 	return true;
 }
@@ -1828,6 +1839,9 @@ std::vector<std::tuple<std::string, Type const*>> ArrayType::makeStackItems() co
 		case DataLocation::Storage:
 			// byte offset inside storage value is omitted
 			return {std::make_tuple("slot", TypeProvider::uint256())};
+		case DataLocation::Transient:
+			solUnimplemented("Transient data location is only supported for value types.");
+			break;
 	}
 	solAssert(false, "");
 }
@@ -2568,6 +2582,9 @@ std::vector<std::tuple<std::string, Type const*>> StructType::makeStackItems() c
 			return {std::make_tuple("mpos", TypeProvider::uint256())};
 		case DataLocation::Storage:
 			return {std::make_tuple("slot", TypeProvider::uint256())};
+		case DataLocation::Transient:
+			solUnimplemented("Transient data location is only supported for value types.");
+			break;
 	}
 	solAssert(false, "");
 }

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -70,7 +70,7 @@ inline rational makeRational(bigint const& _numerator, bigint const& _denominato
 		return rational(_numerator, _denominator);
 }
 
-enum class DataLocation { Storage, CallData, Memory };
+enum class DataLocation { Storage, Transient, CallData, Memory };
 
 
 /**

--- a/libsolidity/codegen/ArrayUtils.cpp
+++ b/libsolidity/codegen/ArrayUtils.cpp
@@ -1021,6 +1021,9 @@ void ArrayUtils::retrieveLength(ArrayType const& _arrayType, unsigned _stackDept
 			if (_arrayType.isByteArrayOrString())
 				m_context.callYulFunction(m_context.utilFunctions().extractByteArrayLengthFunction(), 1, 1);
 			break;
+		case DataLocation::Transient:
+			solUnimplemented("Transient data location is only supported for value types.");
+			break;
 		}
 	}
 }
@@ -1118,6 +1121,9 @@ void ArrayUtils::accessIndex(ArrayType const& _arrayType, bool _doBoundsCheck, b
 		m_context << endTag;
 		break;
 	}
+	case DataLocation::Transient:
+		solUnimplemented("Transient data location is only supported for value types.");
+		break;
 	}
 }
 

--- a/libsolidity/codegen/CompilerUtils.cpp
+++ b/libsolidity/codegen/CompilerUtils.cpp
@@ -1024,6 +1024,9 @@ void CompilerUtils::convertType(
 				"Invalid conversion to storage type."
 			);
 			break;
+		case DataLocation::Transient:
+			solUnimplemented("Transient data location is only supported for value types.");
+			break;
 		case DataLocation::Memory:
 		{
 			// Copy the array to a free position in memory, unless it is already in memory.
@@ -1168,6 +1171,9 @@ void CompilerUtils::convertType(
 				"Invalid conversion to storage type."
 			);
 			break;
+		case DataLocation::Transient:
+			solUnimplemented("Transient data location is only supported for value types.");
+			break;
 		case DataLocation::Memory:
 			// Copy the array to a free position in memory, unless it is already in memory.
 			switch (typeOnStack.location())
@@ -1207,6 +1213,9 @@ void CompilerUtils::convertType(
 					conversionImpl(m_context);
 				break;
 			}
+			case DataLocation::Transient:
+				solUnimplemented("Transient data location is only supported for value types.");
+				break;
 			case DataLocation::CallData:
 			{
 				if (typeOnStack.isDynamicallyEncoded())

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -592,6 +592,7 @@ void ContractCompiler::initializeStateVariables(ContractDefinition const& _contr
 bool ContractCompiler::visit(VariableDeclaration const& _variableDeclaration)
 {
 	solAssert(_variableDeclaration.isStateVariable(), "Compiler visit to non-state variable declaration.");
+	solUnimplementedAssert(_variableDeclaration.referenceLocation() != VariableDeclaration::Location::Transient, "Transient storage variables not supported.");
 	CompilerContext::LocationSetter locationSetter(m_context, _variableDeclaration);
 
 	m_context.startFunction(_variableDeclaration);

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -2047,6 +2047,9 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 					ArrayUtils(m_context).retrieveLength(type);
 					m_context << Instruction::SWAP1 << Instruction::POP;
 					break;
+				case DataLocation::Transient:
+					solUnimplemented("Transient data location is only supported for value types.");
+					break;
 				case DataLocation::Memory:
 					m_context << Instruction::MLOAD;
 					break;
@@ -2192,6 +2195,9 @@ bool ExpressionCompiler::visit(IndexAccess const& _indexAccess)
 					}
 					else
 						setLValueToStorageItem(_indexAccess);
+					break;
+				case DataLocation::Transient:
+					solUnimplemented("Transient data location is only supported for value types.");
 					break;
 				case DataLocation::Memory:
 					ArrayUtils(m_context).accessIndex(arrayType);

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -2563,6 +2563,9 @@ std::string YulUtilFunctions::nextArrayElementFunction(ArrayType const& _type)
 			templ("advance", toCompactHexWithPrefix(size));
 			break;
 		}
+		case DataLocation::Transient:
+			solUnimplemented("Transient data location is only supported for value types.");
+			break;
 		case DataLocation::CallData:
 		{
 			u256 size = _type.calldataStride();

--- a/libsolidity/formal/BMC.cpp
+++ b/libsolidity/formal/BMC.cpp
@@ -184,6 +184,9 @@ bool BMC::shouldInlineFunctionCall(
 
 bool BMC::visit(ContractDefinition const& _contract)
 {
+	// Raises UnimplementedFeatureError in the presence of transient storage variables
+	TransientDataLocationChecker checker(_contract);
+
 	initContract(_contract);
 
 	SMTEncoder::visit(_contract);

--- a/libsolidity/formal/CHC.cpp
+++ b/libsolidity/formal/CHC.cpp
@@ -143,6 +143,9 @@ bool CHC::visit(ContractDefinition const& _contract)
 	if (!shouldAnalyze(_contract))
 		return false;
 
+	// Raises UnimplementedFeatureError in the presence of transient storage variables
+	TransientDataLocationChecker checker(_contract);
+
 	resetContractAnalysis();
 	initContract(_contract);
 	clearIndices(&_contract);

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -129,6 +129,19 @@ public:
 	static std::set<SourceUnit const*, ASTNode::CompareByID> sourceDependencies(SourceUnit const& _source);
 
 protected:
+	struct TransientDataLocationChecker: ASTConstVisitor
+	{
+		TransientDataLocationChecker(ContractDefinition const& _contract) { _contract.accept(*this); }
+
+		void endVisit(VariableDeclaration const& _var)
+		{
+			solUnimplementedAssert(
+				_var.referenceLocation() != VariableDeclaration::Location::Transient,
+				"Transient storage variables are not supported."
+			);
+		}
+	};
+
 	void resetSourceAnalysis();
 
 	// TODO: Check that we do not have concurrent reads and writes to a variable,

--- a/libsolidity/interface/StorageLayout.cpp
+++ b/libsolidity/interface/StorageLayout.cpp
@@ -46,6 +46,7 @@ Json StorageLayout::generate(ContractDefinition const& _contractDef)
 
 Json StorageLayout::generate(VariableDeclaration const& _var, u256 const& _slot, unsigned _offset)
 {
+	solUnimplementedAssert(_var.referenceLocation() != VariableDeclaration::Location::Transient, "Transient storage layout is not supported yet.");
 	Json varEntry;
 	Type const* varType = _var.type();
 

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -885,6 +885,19 @@ ASTPointer<VariableDeclaration> Parser::parseVariableDeclaration(
 					}
 				}
 			}
+			else if (
+				_options.kind == VarDeclKind::State &&
+				token == Token::Identifier &&
+				m_scanner->currentLiteral() == "transient" &&
+				m_scanner->peekNextToken() != Token::Assign &&
+				m_scanner->peekNextToken() != Token::Semicolon
+			)
+			{
+				if (location != VariableDeclaration::Location::Unspecified)
+					parserError(ErrorId{3548}, "Location already specified.");
+				else
+					location = VariableDeclaration::Location::Transient;
+			}
 			else
 				break;
 			nodeFactory.markEndPosition();

--- a/scripts/error_codes.py
+++ b/scripts/error_codes.py
@@ -202,6 +202,7 @@ def examine_id_coverage(top_dir, source_id_to_file_names, new_ids_only=False):
         "4591", # "There are more than 256 warnings. Ignoring the rest."
                 # Due to 3805, the warning lists look different for different compiler builds.
         "1920", # Unimplemented feature error from YulStack (currently there are no UnimplementedFeatureErrors thrown by libyul)
+        "7053", # Unimplemented feature error (parsing stage), currently has no tests
         "1180", # SMTChecker, covered by CL tests
         "2339", # SMTChecker, covered by CL tests
         "2961", # SMTChecker, covered by CL tests

--- a/test/cmdlineTests/storage_layout_transient_value_types/in.sol
+++ b/test/cmdlineTests/storage_layout_transient_value_types/in.sol
@@ -1,0 +1,10 @@
+//SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+contract A {
+    uint transient x;
+    uint y;
+    bytes32 transient b;
+    bytes32 c;
+    address transient a;
+    address z;
+}

--- a/test/cmdlineTests/storage_layout_transient_value_types/input.json
+++ b/test/cmdlineTests/storage_layout_transient_value_types/input.json
@@ -1,0 +1,13 @@
+{
+	"language": "Solidity",
+	"sources": {
+		"fileA": {"urls": ["storage_layout_transient_value_types/in.sol"]}
+	},
+	"settings": {
+		"outputSelection": {
+			"fileA": {
+				"A": ["storageLayout"]
+			}
+		}
+	}
+}

--- a/test/cmdlineTests/storage_layout_transient_value_types/output.json
+++ b/test/cmdlineTests/storage_layout_transient_value_types/output.json
@@ -1,0 +1,11 @@
+{
+    "errors": [
+        {
+            "component": "general",
+            "formattedMessage": "Transient storage layout is not supported yet.",
+            "message": "Transient storage layout is not supported yet.",
+            "severity": "error",
+            "type": "UnimplementedFeatureError"
+        }
+    ]
+}

--- a/test/libsolidity/astPropertyTests/transient_data_location.sol
+++ b/test/libsolidity/astPropertyTests/transient_data_location.sol
@@ -1,0 +1,8 @@
+contract C {
+    /// TestVarDataLocation: storageLocation
+    /// TestVarName: name
+    uint transient transient;
+}
+// ----
+// TestVarDataLocation: transient
+// TestVarName: transient

--- a/test/libsolidity/smtCheckerTests/unsupported/transient_storage_state_variable.sol
+++ b/test/libsolidity/smtCheckerTests/unsupported/transient_storage_state_variable.sol
@@ -1,0 +1,8 @@
+contract C {
+    uint transient x = 42;
+    function test() public view { assert(x == 42); }
+}
+// ====
+// SMTEngine: all
+// ----
+// UnimplementedFeatureError 1834: Transient storage variables are not supported.

--- a/test/libsolidity/syntaxTests/constants/constant_state_variable_named_transient.sol
+++ b/test/libsolidity/syntaxTests/constants/constant_state_variable_named_transient.sol
@@ -1,0 +1,4 @@
+contract C {
+    int constant public transient = 0;
+}
+// ----

--- a/test/libsolidity/syntaxTests/constants/constant_transient_state_variable.sol
+++ b/test/libsolidity/syntaxTests/constants/constant_transient_state_variable.sol
@@ -1,0 +1,5 @@
+contract C {
+    int constant public transient x = 0;
+}
+// ----
+// DeclarationError 2197: (17-52): Transient cannot be used as data location for constant or immutable variables.

--- a/test/libsolidity/syntaxTests/dataLocations/data_location_in_function_type_fail.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/data_location_in_function_type_fail.sol
@@ -2,7 +2,10 @@ library L {
     struct Nested { uint y; }
     function b(function(Nested calldata) external returns (uint)[] storage) external pure {}
     function d(function(Nested storage) external returns (uint)[] storage) external pure {}
+    function f(function(Nested transient) external returns (uint)[] storage) external pure {}
 }
 
 // ----
+// Warning 6162: (251-267): Naming function type parameters is deprecated.
 // TypeError 6651: (159-173): Data location must be "memory" or "calldata" for parameter in function, but "storage" was given.
+// TypeError 6651: (251-267): Data location must be "memory" or "calldata" for parameter in function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/externalFunction/function_argument_location_specifier_test_external_transient.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/externalFunction/function_argument_location_specifier_test_external_transient.sol
@@ -1,0 +1,5 @@
+contract test {
+    function f(bytes transient) external;
+}
+// ----
+// TypeError 6651: (31-46): Data location must be "memory" or "calldata" for parameter in external function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/internalFunction/function_argument_location_specifier_test_internal_transient.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/internalFunction/function_argument_location_specifier_test_internal_transient.sol
@@ -1,0 +1,5 @@
+contract test {
+    function f(bytes transient) internal {}
+}
+// ----
+// TypeError 6651: (31-46): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/libraries/library_function_with_data_location_transient.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/libraries/library_function_with_data_location_transient.sol
@@ -1,0 +1,19 @@
+library L {
+    function f1(uint[] transient) private pure { }
+    function f2() private pure returns (uint[] transient) { }
+    function g1(uint[] transient) internal pure { }
+    function g2() internal pure returns (uint[] transient) { }
+    function h1(uint[] transient) public pure { }
+    function h2() public pure returns (uint[] transient) { }
+    function i1(uint[] transient) external pure { }
+    function i2() external pure returns (uint[] transient) { }
+}
+// ----
+// TypeError 6651: (28-44): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.
+// TypeError 6651: (103-119): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
+// TypeError 6651: (141-157): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.
+// TypeError 6651: (218-234): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
+// TypeError 6651: (256-272): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.
+// TypeError 6651: (329-345): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.
+// TypeError 6651: (367-383): Data location must be "storage", "memory" or "calldata" for parameter in external function, but none was given.
+// TypeError 6651: (444-460): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/libraryExternalFunction/function_argument_location_specifier_test_external_transient.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/libraryExternalFunction/function_argument_location_specifier_test_external_transient.sol
@@ -1,0 +1,5 @@
+library test {
+    function f(bytes transient) external {}
+}
+// ----
+// TypeError 6651: (30-45): Data location must be "storage", "memory" or "calldata" for parameter in external function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/libraryInternalFunction/function_argument_location_specifier_test_internal_transient.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/libraryInternalFunction/function_argument_location_specifier_test_internal_transient.sol
@@ -1,0 +1,5 @@
+library test {
+    function f(bytes transient) internal pure {}
+}
+// ----
+// TypeError 6651: (30-45): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/multiple_transient_data_location_function_parameter.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/multiple_transient_data_location_function_parameter.sol
@@ -1,0 +1,6 @@
+contract C {
+    function f(uint[] transient transient x) public pure { }
+}
+
+// ----
+// ParserError 2314: (45-54): Expected ',' but got identifier

--- a/test/libsolidity/syntaxTests/dataLocations/privateFunction/private_function_parameters_location_transient.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/privateFunction/private_function_parameters_location_transient.sol
@@ -1,0 +1,5 @@
+contract C {
+    function f(uint[] transient) private pure {}
+}
+// ----
+// TypeError 6651: (28-44): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/privateFunction/private_function_return_parameters_location_transient.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/privateFunction/private_function_return_parameters_location_transient.sol
@@ -1,0 +1,5 @@
+contract C {
+    function f() private pure returns (uint[] transient) {}
+}
+// ----
+// TypeError 6651: (52-68): Data location must be "storage", "memory" or "calldata" for return parameter in function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/publicFunction/function_argument_location_specifier_test_public_transient.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/publicFunction/function_argument_location_specifier_test_public_transient.sol
@@ -1,0 +1,5 @@
+contract test {
+    function f(bytes transient) public;
+}
+// ----
+// TypeError 6651: (31-46): Data location must be "memory" or "calldata" for parameter in function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/publicFunction/public_function_return_parameters_location_transient.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/publicFunction/public_function_return_parameters_location_transient.sol
@@ -1,0 +1,5 @@
+contract C {
+    function h() public pure returns(uint[] transient) {}
+}
+// ----
+// TypeError 6651: (50-66): Data location must be "memory" or "calldata" for return parameter in function, but none was given.

--- a/test/libsolidity/syntaxTests/dataLocations/state_variable_storage_named_transient.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/state_variable_storage_named_transient.sol
@@ -1,0 +1,5 @@
+contract C {
+    uint storage transient;
+}
+// ----
+// ParserError 2314: (22-29): Expected identifier but got 'storage'

--- a/test/libsolidity/syntaxTests/dataLocations/state_variable_storage_transient.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/state_variable_storage_transient.sol
@@ -1,0 +1,5 @@
+contract C {
+    uint storage transient x;
+}
+// ----
+// ParserError 2314: (22-29): Expected identifier but got 'storage'

--- a/test/libsolidity/syntaxTests/dataLocations/state_variable_transient_storage.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/state_variable_transient_storage.sol
@@ -1,0 +1,5 @@
+contract C {
+    uint transient storage x;
+}
+// ----
+// ParserError 2314: (32-39): Expected identifier but got 'storage'

--- a/test/libsolidity/syntaxTests/dataLocations/transient_dynamic_array_state_variable.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_dynamic_array_state_variable.sol
@@ -1,0 +1,7 @@
+contract C {
+	uint[] transient x;
+}
+// ====
+// stopAfter: analysis
+// ----
+// UnimplementedFeatureError 1834: Transient data location is only supported for value types.

--- a/test/libsolidity/syntaxTests/dataLocations/transient_fixed_array_state_variable.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_fixed_array_state_variable.sol
@@ -1,0 +1,7 @@
+contract C {
+	uint[3] transient x;
+}
+// ====
+// stopAfter: analysis
+// ----
+// UnimplementedFeatureError 1834: Transient data location is only supported for value types.

--- a/test/libsolidity/syntaxTests/dataLocations/transient_function_type.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_function_type.sol
@@ -1,0 +1,11 @@
+contract C {
+    function () transient f;
+    function (uint) external transient y;
+    function () transient internal fti;
+    function () internal transient fit;
+    function () internal transient internal fiti;
+    function () internal internal transient fiit;
+}
+// ====
+// stopAfter: analysis
+// ----

--- a/test/libsolidity/syntaxTests/dataLocations/transient_function_type_parameter.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_function_type_parameter.sol
@@ -1,0 +1,5 @@
+contract C {
+    function (uint transient) external y;
+}
+// ----
+// Warning 6162: (27-41): Naming function type parameters is deprecated.

--- a/test/libsolidity/syntaxTests/dataLocations/transient_local_variable.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_local_variable.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        uint transient x = 0;
+    }
+}
+// ----
+// ParserError 2314: (67-68): Expected ';' but got identifier

--- a/test/libsolidity/syntaxTests/dataLocations/transient_mapping_state_variable.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_mapping_state_variable.sol
@@ -1,0 +1,7 @@
+contract C {
+	mapping(uint => uint) transient y;
+}
+// ====
+// stopAfter: analysis
+// ----
+// UnimplementedFeatureError 1834: Transient data location is only supported for value types.

--- a/test/libsolidity/syntaxTests/dataLocations/transient_state_variable_visibility.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_state_variable_visibility.sol
@@ -1,0 +1,12 @@
+contract C {
+    uint public transient pubt;
+    uint internal transient it;
+    uint private transient prvt;
+
+    uint transient public tpub;
+    uint transient internal ti;
+    uint transient private tprv;
+}
+// ====
+// stopAfter: parsing
+// ----

--- a/test/libsolidity/syntaxTests/dataLocations/transient_struct_state_variable.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_struct_state_variable.sol
@@ -1,0 +1,12 @@
+struct S {
+	uint x;
+	address a;
+}
+
+contract C {
+	S transient s;
+}
+// ====
+// stopAfter: analysis
+// ----
+// UnimplementedFeatureError 1834: Transient data location is only supported for value types.

--- a/test/libsolidity/syntaxTests/dataLocations/transient_value_type_state_variables.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_value_type_state_variables.sol
@@ -1,0 +1,12 @@
+contract D { }
+
+contract C {
+	address transient a;
+	bool transient b;
+	D transient d;
+	uint transient x;
+	bytes32 transient y;
+}
+// ====
+// stopAfter: parsing
+// ----

--- a/test/libsolidity/syntaxTests/dataLocations/transient_value_type_state_variables_assignment.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_value_type_state_variables_assignment.sol
@@ -1,0 +1,10 @@
+contract D { }
+
+contract C {
+	int transient x = -99;
+	address transient a = address(0xABC);
+	bool transient b = x > 0 ? false : true;
+}
+// ====
+// stopAfter: parsing
+// ----

--- a/test/libsolidity/syntaxTests/errors/invalid_parameter_location.sol
+++ b/test/libsolidity/syntaxTests/errors/invalid_parameter_location.sol
@@ -10,7 +10,12 @@ contract test {
 contract test {
     error e1(string calldata a);
 }
+==== Source: D ====
+contract test {
+    error e1(string transient a);
+}
 // ----
 // ParserError 2314: (A:36-43): Expected ',' but got 'storage'
 // ParserError 2314: (B:36-42): Expected ',' but got 'memory'
 // ParserError 2314: (C:36-44): Expected ',' but got 'calldata'
+// ParserError 2314: (D:46-47): Expected ',' but got identifier

--- a/test/libsolidity/syntaxTests/events/invalid_parameter_location.sol
+++ b/test/libsolidity/syntaxTests/events/invalid_parameter_location.sol
@@ -10,7 +10,12 @@ contract test {
 contract test {
     event e1(string calldata a);
 }
+==== Source: D ====
+contract test {
+    event e1(string transient a);
+}
 // ----
 // ParserError 2314: (A:36-43): Expected ',' but got 'storage'
 // ParserError 2314: (B:36-42): Expected ',' but got 'memory'
 // ParserError 2314: (C:36-44): Expected ',' but got 'calldata'
+// ParserError 2314: (D:46-47): Expected ',' but got identifier

--- a/test/libsolidity/syntaxTests/events/transient_indexed_parameter.sol
+++ b/test/libsolidity/syntaxTests/events/transient_indexed_parameter.sol
@@ -1,0 +1,5 @@
+contract C {
+    event e(string indexed transient a);
+}
+// ----
+// ParserError 2314: (50-51): Expected ',' but got identifier

--- a/test/libsolidity/syntaxTests/functionTypes/function_type_with_transient_param.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/function_type_with_transient_param.sol
@@ -1,0 +1,8 @@
+contract C {
+    function (uint transient) external y;
+    function (uint[] transient) external z;
+}
+// ----
+// Warning 6162: (27-41): Naming function type parameters is deprecated.
+// Warning 6162: (69-85): Naming function type parameters is deprecated.
+// TypeError 6651: (69-85): Data location must be "memory" or "calldata" for parameter in function, but none was given.

--- a/test/libsolidity/syntaxTests/functionTypes/transient_function_type_with_param_named_transient.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/transient_function_type_with_param_named_transient.sol
@@ -1,0 +1,6 @@
+contract C {
+    function (uint transient) external transient y;
+}
+// ====
+// stopAfter: parsing
+// ----

--- a/test/libsolidity/syntaxTests/functionTypes/transient_function_type_with_transient_param.sol
+++ b/test/libsolidity/syntaxTests/functionTypes/transient_function_type_with_transient_param.sol
@@ -1,0 +1,5 @@
+contract C {
+    function (uint transient x) external transient y;
+}
+// ----
+// ParserError 2314: (42-43): Expected ',' but got identifier

--- a/test/libsolidity/syntaxTests/immutable/immutable_state_var_named_transient.sol
+++ b/test/libsolidity/syntaxTests/immutable/immutable_state_var_named_transient.sol
@@ -1,0 +1,4 @@
+contract C {
+    address public immutable transient;
+}
+// ----

--- a/test/libsolidity/syntaxTests/immutable/state_var_transient_data_location.sol
+++ b/test/libsolidity/syntaxTests/immutable/state_var_transient_data_location.sol
@@ -1,0 +1,5 @@
+contract C {
+    uint public immutable transient x;
+}
+// ----
+// DeclarationError 2197: (17-50): Transient cannot be used as data location for constant or immutable variables.

--- a/test/libsolidity/syntaxTests/modifiers/multiple_parameter_location.sol
+++ b/test/libsolidity/syntaxTests/modifiers/multiple_parameter_location.sol
@@ -8,6 +8,12 @@ contract A {
     modifier mod7(string calldata storage a) { _; }
     modifier mod8(string calldata memory a) { _; }
     modifier mod9(string calldata calldata a) { _; }
+    modifier modA(string transient storage a) { _; }
+    modifier modB(string transient memory a) { _; }
+    modifier modC(string transient calldata a) { _; }
+    modifier modD(string storage transient a) { _; }
+    modifier modE(string memory transient a) { _; }
+    modifier modF(string calldata transient a) { _; }
 }
 // ----
 // ParserError 3548: (46-53): Location already specified.
@@ -19,3 +25,4 @@ contract A {
 // ParserError 3548: (350-357): Location already specified.
 // ParserError 3548: (402-408): Location already specified.
 // ParserError 3548: (453-461): Location already specified.
+// ParserError 2314: (507-514): Expected ',' but got 'storage'

--- a/test/libsolidity/syntaxTests/modifiers/transient_parameter.sol
+++ b/test/libsolidity/syntaxTests/modifiers/transient_parameter.sol
@@ -1,0 +1,5 @@
+contract A {
+    modifier mod2(uint[] transient) { _; }
+}
+// ----
+// TypeError 6651: (31-47): Data location must be "storage", "memory" or "calldata" for parameter in function, but none was given.

--- a/test/libsolidity/syntaxTests/operators/transient_value_type.sol
+++ b/test/libsolidity/syntaxTests/operators/transient_value_type.sol
@@ -1,0 +1,11 @@
+contract C {
+    int transient x;
+    function f() public view returns (int) {
+        int y = x;
+        int w = -x;
+        return (x + w) * (y / x);
+    }
+}
+// ====
+// stopAfter: parsing
+// ----

--- a/test/libsolidity/syntaxTests/parsing/contract_named_transient.sol
+++ b/test/libsolidity/syntaxTests/parsing/contract_named_transient.sol
@@ -1,0 +1,1 @@
+contract transient {}

--- a/test/libsolidity/syntaxTests/structs/transient_data_location_member.sol
+++ b/test/libsolidity/syntaxTests/structs/transient_data_location_member.sol
@@ -1,0 +1,5 @@
+struct S {
+    int transient x;
+}
+// ----
+// ParserError 2314: (29-30): Expected ';' but got identifier

--- a/test/libsolidity/syntaxTests/types/address/state_variable_address_payable_transient.sol
+++ b/test/libsolidity/syntaxTests/types/address/state_variable_address_payable_transient.sol
@@ -1,0 +1,6 @@
+contract C {
+    address payable transient a;
+}
+// ====
+// stopAfter: parsing
+// ----

--- a/test/libsolidity/syntaxTests/types/address/state_variable_address_transient_payable.sol
+++ b/test/libsolidity/syntaxTests/types/address/state_variable_address_transient_payable.sol
@@ -1,0 +1,5 @@
+contract C {
+    address transient payable a;
+}
+// ----
+// ParserError 2314: (35-42): Expected identifier but got 'payable'

--- a/test/libsolidity/syntaxTests/variableDeclaration/transient_as_identifier.sol
+++ b/test/libsolidity/syntaxTests/variableDeclaration/transient_as_identifier.sol
@@ -1,0 +1,25 @@
+contract C {
+    function transient() public pure { }
+}
+
+error CustomError(uint transient);
+event e1(uint transient);
+event e2(uint indexed transient);
+
+struct S {
+    int transient;
+}
+
+contract D {
+    function f() public pure returns (uint) {
+        uint transient = 1;
+        return transient;
+    }
+
+    function g(int transient) public pure { }
+
+    modifier m(address transient) {
+        _;
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/variableDeclaration/transient_as_identifier_and_data_location.sol
+++ b/test/libsolidity/syntaxTests/variableDeclaration/transient_as_identifier_and_data_location.sol
@@ -1,0 +1,6 @@
+contract C {
+	uint transient transient;
+}
+// ====
+// stopAfter: parsing
+// ----


### PR DESCRIPTION
First step on providing Solidity high-level support for transient storage.
closes #15006.

depends on #15121 (Merged).
depends on #15168.