### PR TITLE
Fix docs for string/hex string literal conversion to bytesNN

### DIFF
--- a/docs/types/conversion.rst
+++ b/docs/types/conversion.rst
@@ -174,15 +174,14 @@ converted to any fixed-size bytes type:
     bytes4 g = 0x0; // fine
 
 String literals and hex string literals can be implicitly converted to fixed-size byte arrays,
-if their number of characters matches the size of the bytes type:
+if their number of characters is less than or equal to the size of the bytes type:
 
 .. code-block:: solidity
 
     bytes2 a = hex"1234"; // fine
     bytes2 b = "xy"; // fine
-    bytes2 c = hex"12"; // not allowed
-    bytes2 d = hex"123"; // not allowed
-    bytes2 e = "x"; // not allowed
+    bytes2 c = hex"12"; // fine
+    bytes2 e = "x"; // fine
     bytes2 f = "xyz"; // not allowed
 
 .. index:: literal;address
@@ -199,4 +198,4 @@ An ``address a`` can be converted explicitly to ``address payable`` via ``payabl
 
 .. note::
     Prior to version 0.8.0, it was possible to explicitly convert from any integer type (of any size, signed or unsigned) to  ``address`` or ``address payable``.
-    Starting with in 0.8.0 only conversion from ``uint160`` is allowed.
+    Starting with 0.8.0 only conversion from ``uint160`` is allowed.

--- a/test/libsolidity/syntaxTests/types/hex_string_to_bytesNN_different_size_implicit.sol
+++ b/test/libsolidity/syntaxTests/types/hex_string_to_bytesNN_different_size_implicit.sol
@@ -1,0 +1,20 @@
+contract C {
+   function f() public pure {
+     bytes1 b1 = hex"";
+     bytes1 b2 = hex"1234";
+     bytes2 b3 = hex"12";
+     bytes2 b4 = hex"1234";
+     bytes2 b5 = hex"123456";
+     bytes3 b6 = hex"1234";
+     bytes3 b7 = hex"123456";
+     bytes3 b8 = hex"12345678";
+     bytes4 b9 = hex"123456";
+     bytes4 b10 = hex"12345678";
+     bytes4 b11 = hex"1234567890";
+   }
+}
+// ----
+// TypeError 9574: (72-93): Type literal_string hex"1234" is not implicitly convertible to expected type bytes1. Literal is larger than the type.
+// TypeError 9574: (154-177): Type literal_string hex"123456" is not implicitly convertible to expected type bytes2. Literal is larger than the type.
+// TypeError 9574: (242-267): Type literal_string hex"12345678" is not implicitly convertible to expected type bytes3. Literal is larger than the type.
+// TypeError 9574: (337-365): Type literal_string hex"1234567890" is not implicitly convertible to expected type bytes4. Literal is larger than the type.


### PR DESCRIPTION
Implicit/Explicit conversion from string/hex string literals to bytesNNs are allowed. [hex_string_to_bytesNN_different_size_explicit.sol](https://github.com/ethereum/solidity/blob/e54110ff173f8903acc098f25a416085d9e507ae/test/libsolidity/syntaxTests/types/hex_string_to_bytesNN_different_size_explicit.sol) shows that these conversions are allowed.

Fixed wrong documentation of type conversion.

Added test case for checking implicit conversion from string/hex string literals to bytesNNs.