### PR TITLE
Timing benchmark tweaks and fixes

### DIFF
--- a/test/benchmarks/run.sh
+++ b/test/benchmarks/run.sh
@@ -51,7 +51,7 @@ do
     solc_command_via_ir=("${solc}" --via-ir --optimize --bin --color "${input_path}")
 
     # Legacy can fail.
-    "${time_bin_path}" --output "${result_legacy_file}" --format "%e" "${solc_command_legacy[@]}" >/dev/null 2>>"${warnings_and_errors_file}"
+    "${time_bin_path}" --output "${result_legacy_file}" --format "%e" "${solc_command_legacy[@]}" >/dev/null 2>>"${warnings_and_errors_file}" || true
     "${time_bin_path}" --output "${result_via_ir_file}" --format "%e" "${solc_command_via_ir[@]}" >/dev/null 2>>"${warnings_and_errors_file}"
 
     time_legacy=$(<"${result_legacy_file}")

--- a/test/benchmarks/run.sh
+++ b/test/benchmarks/run.sh
@@ -55,7 +55,7 @@ function bytecode_size {
 }
 
 benchmarks_dir="${REPO_ROOT}/test/benchmarks"
-benchmarks=("chains.sol" "OptimizorClub.sol" "verifier.sol")
+benchmarks=("verifier.sol" "OptimizorClub.sol" "chains.sol")
 time_bin_path=$(type -P time)
 
 echo "| File                 | Pipeline | Bytecode size | Time     | Exit code |"

--- a/test/benchmarks/run.sh
+++ b/test/benchmarks/run.sh
@@ -26,8 +26,15 @@ set -euo pipefail
 REPO_ROOT=$(cd "$(dirname "$0")/../../" && pwd)
 SOLIDITY_BUILD_DIR=${SOLIDITY_BUILD_DIR:-${REPO_ROOT}/build}
 
+# shellcheck source=scripts/common.sh
+source "${REPO_ROOT}/scripts/common.sh"
 # shellcheck source=scripts/common_cmdline.sh
 source "${REPO_ROOT}/scripts/common_cmdline.sh"
+
+(( $# <= 1 )) || fail "Too many arguments. Usage: run.sh [<solc-path>]"
+
+solc="${1:-${SOLIDITY_BUILD_DIR}/solc/solc}"
+command_available "$solc" --version
 
 output_dir=$(mktemp -d -t solc-benchmark-XXXXXX)
 result_legacy_file="${output_dir}/benchmark-legacy.txt"
@@ -47,7 +54,6 @@ function bytecode_size {
     echo $(( bytecode_chars / 2 ))
 }
 
-solc="${SOLIDITY_BUILD_DIR}/solc/solc"
 benchmarks_dir="${REPO_ROOT}/test/benchmarks"
 benchmarks=("chains.sol" "OptimizorClub.sol" "verifier.sol")
 time_bin_path=$(type -P time)


### PR DESCRIPTION
This is a bunch of independent tweaks to the `test/benchmarks/` runner script to make using it for evaluating optimizer sequences a little less tedious. Each could really be a separate small  PR.
- The script would not continue when legacy compilation failed with "Stack too deep".
- Bytecode size is a useful additional data point that we can easily get here.
- Putting the values manually in a table gets old quickly. Now the script prints a table I can just copy paste into a comment on Github.
- The lighter tests now run first so you can start seeing results immediately. Also, now the script does not wait with printing legacy results until IR finishes.
- solc binary is now a parameter so that I can easily use system-wide solc. For testing sequences I find it easier to use the release binary and just give it different `--yul-optimizations`.