### PR TITLE
Timing info in external test JSON reports

### DIFF
--- a/scripts/externalTests/common.sh
+++ b/scripts/externalTests/common.sh
@@ -505,14 +505,14 @@ function compile_and_run_test
     [[ $preset != *" "* ]] || assertFail "Preset names must not contain spaces."
 
     printLog "Running compile function..."
-    time $compile_fn
-    $verify_fn "$SOLCVERSION_SHORT" "$SOLCVERSION"
+    time_to_json_file "$(compilation_time_report_path "$preset")" "$compile_fn"
+    "$verify_fn" "$SOLCVERSION_SHORT" "$SOLCVERSION"
 
     if [[ "$COMPILE_ONLY" == 1 || " $compile_only_presets " == *" $preset "* ]]; then
         printLog "Skipping test function..."
     else
         printLog "Running test function..."
-        $test_fn
+        "$test_fn"
     fi
 }
 
@@ -570,6 +570,13 @@ function gas_report_path
     local preset="$1"
 
     echo "${DIR}/gas-report-${preset}.rst"
+}
+
+function compilation_time_report_path
+{
+    local preset="$1"
+
+    echo "${DIR}/compilation-time-report-${preset}.json"
 }
 
 function gas_report_to_json
@@ -679,5 +686,6 @@ function store_benchmark_report
 
         "bytecode_size_json_from_${framework}_artifacts" | combine_artifact_json
         project_info_json "$project_url"
+        echo "{\"compilation_time\": $(cat "$(compilation_time_report_path "$preset")")}"
     } | jq --slurp "{\"${project_name}\": {\"${preset}\": add}}" --indent 4 --sort-keys > "$output_file"
 }


### PR DESCRIPTION
Gathering info about compilation time in external tests to create a comparison like https://github.com/ethereum/solidity/pull/14909#issuecomment-1981534920 is incredibly time consuming. I have to navigate to 10-15 CI pages, locate `time` output in the long CI log for each, copy it and manually format it info something human-readable, like a table. This PRs is the first step toward automating this somewhat.

Now that info will be present in the combined JSON report from all external tests and I'll be able to pull it out with a simple script. This is just the bare minimum to make it less annoying for me. The extra data is not yet processed by the scripts that format gas tables or diff them. For now I'm planning to create a quick, hacky script to do further processing but if it's reusable enough I might submit it in a follow-up PR.

The new info can be found in the `reports/externalTests/all-benchmarks.json` artifact of the `c_ext_benchmarks` job, under the `<project>.<preset>.compilation_time` keys. It's also present in the same form in individual reports attached as artifacts to each parallel run of each external test job.