### PR TITLE
SMTChecker: Parse invariants from SMT-LIB response

### DIFF
--- a/libsmtutil/CHCSmtLib2Interface.cpp
+++ b/libsmtutil/CHCSmtLib2Interface.cpp
@@ -56,7 +56,7 @@ void CHCSmtLib2Interface::reset()
 	m_accumulatedOutput.clear();
 	m_variables.clear();
 	m_unhandledQueries.clear();
-	m_sortNames.clear();
+	m_smtlib2->reset();
 }
 
 void CHCSmtLib2Interface::registerRelation(Expression const& _expr)
@@ -115,24 +115,18 @@ void CHCSmtLib2Interface::declareVariable(std::string const& _name, SortPointer 
 	else if (!m_variables.count(_name))
 	{
 		m_variables.insert(_name);
-		write("(declare-var |" + _name + "| " + toSmtLibSort(*_sort) + ')');
+		write("(declare-var |" + _name + "| " + toSmtLibSort(_sort) + ')');
 	}
 }
 
-std::string CHCSmtLib2Interface::toSmtLibSort(Sort const& _sort)
+std::string CHCSmtLib2Interface::toSmtLibSort(SortPointer _sort)
 {
-	if (!m_sortNames.count(&_sort))
-		m_sortNames[&_sort] = m_smtlib2->toSmtLibSort(_sort);
-	return m_sortNames.at(&_sort);
+	return m_smtlib2->toSmtLibSort(_sort);
 }
 
 std::string CHCSmtLib2Interface::toSmtLibSort(std::vector<SortPointer> const& _sorts)
 {
-	std::string ssort("(");
-	for (auto const& sort: _sorts)
-		ssort += toSmtLibSort(*sort) + " ";
-	ssort += ")";
-	return ssort;
+	return m_smtlib2->toSmtLibSort(_sorts);
 }
 
 std::string CHCSmtLib2Interface::forall()
@@ -142,7 +136,7 @@ std::string CHCSmtLib2Interface::forall()
 	{
 		solAssert(sort, "");
 		if (sort->kind != Kind::Function)
-			vars += " (" + name + " " + toSmtLibSort(*sort) + ")";
+			vars += " (" + name + " " + toSmtLibSort(sort) + ")";
 	}
 	vars += ")";
 	return vars;
@@ -158,7 +152,7 @@ void CHCSmtLib2Interface::declareFunction(std::string const& _name, SortPointer 
 		auto fSort = std::dynamic_pointer_cast<FunctionSort>(_sort);
 		smtAssert(fSort->codomain);
 		std::string domain = toSmtLibSort(fSort->domain);
-		std::string codomain = toSmtLibSort(*fSort->codomain);
+		std::string codomain = toSmtLibSort(fSort->codomain);
 		m_variables.insert(_name);
 		write(
 			"(declare-fun |" +

--- a/libsmtutil/CHCSmtLib2Interface.cpp
+++ b/libsmtutil/CHCSmtLib2Interface.cpp
@@ -18,11 +18,17 @@
 
 #include <libsmtutil/CHCSmtLib2Interface.h>
 
+#include <libsmtutil/SMTLib2Parser.h>
+
 #include <libsolutil/Keccak256.h>
+#include <libsolutil/StringUtils.h>
+#include <libsolutil/Visitor.h>
 
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
+#include <range/v3/algorithm/find_if.hpp>
+#include <range/v3/algorithm/all_of.hpp>
 #include <range/v3/view.hpp>
 
 #include <array>
@@ -96,7 +102,10 @@ std::tuple<CheckResult, Expression, CHCSolverInterface::CexGraph> CHCSmtLib2Inte
 	CheckResult result;
 	// TODO proper parsing
 	if (boost::starts_with(response, "sat"))
-		result = CheckResult::UNSATISFIABLE;
+	{
+		auto maybeInvariants = invariantsFromSolverResponse(response);
+		return {CheckResult::UNSATISFIABLE, maybeInvariants.value_or(Expression(true)), {}};
+	}
 	else if (boost::starts_with(response, "unsat"))
 		result = CheckResult::SATISFIABLE;
 	else if (boost::starts_with(response, "unknown"))
@@ -217,3 +226,276 @@ std::string CHCSmtLib2Interface::createHeaderAndDeclarations() {
 std::string CHCSmtLib2Interface::createQueryAssertion(std::string name) {
 	return "(assert\n(forall " + forall() + "\n" + "(=> " + name + " false)))";
 }
+
+class SMTLibTranslationContext
+{
+	CHCSmtLib2Interface const& m_chcInterface;
+	std::map<std::string, SortPointer> m_knownVariables;
+
+	static bool isNumber(std::string const& _expr)
+	{
+		return ranges::all_of(_expr, [](char c) { return isDigit(c) || c == '.'; });
+	}
+
+
+public:
+	explicit SMTLibTranslationContext(CHCSmtLib2Interface const& _chcInterface) : m_chcInterface(_chcInterface)
+	{
+		// fill user defined sorts and constructors
+		auto const& userSorts = m_chcInterface.smtlib2Interface()->userSorts();
+		for (auto const& declaration: userSorts | ranges::views::values)
+		{
+			std::stringstream ss(declaration);
+			SMTLib2Parser parser(ss);
+			auto expr = parser.parseExpression();
+			smtAssert(parser.isEOF());
+			smtAssert(!isAtom(expr));
+			auto const& args = asSubExpressions(expr);
+			smtAssert(args.size() == 3);
+			smtAssert(isAtom(args[0]) && asAtom(args[0]) == "declare-datatypes");
+			// args[1] is the name of the type
+			// args[2] is the constructor with the members
+			smtAssert(!isAtom(args[2]) && asSubExpressions(args[2]).size() == 1 && !isAtom(asSubExpressions(args[2])[0]));
+			auto const& constructors = asSubExpressions(asSubExpressions(args[2])[0]);
+			smtAssert(constructors.size() == 1);
+			auto const& constructor = constructors[0];
+			// constructor is a list: name + members
+			smtAssert(!isAtom(constructor));
+			auto const& constructorArgs = asSubExpressions(constructor);
+			for (unsigned i = 1u; i < constructorArgs.size(); ++i)
+			{
+				auto const& carg = constructorArgs[i];
+				smtAssert(!isAtom(carg) && asSubExpressions(carg).size() == 2);
+				auto const& nameSortPair = asSubExpressions(carg);
+				m_knownVariables.emplace(asAtom(nameSortPair[0]), toSort(nameSortPair[1]));
+			}
+		}
+	}
+
+	void addVariableDeclaration(std::string name, SortPointer sort)
+	{
+		smtAssert(m_knownVariables.find(name) == m_knownVariables.end());
+		m_knownVariables.emplace(std::move(name), std::move(sort));
+	}
+
+	std::optional<SortPointer> lookupKnownTupleSort(std::string const& name) {
+		auto const& userSorts = m_chcInterface.sortNames();
+		std::string quotedName = "|" + name + "|";
+		auto it = ranges::find_if(userSorts, [&](auto const& entry) { return entry.second == quotedName; });
+		if (it != userSorts.end() && it->first->kind == Kind::Tuple)
+		{
+			auto tupleSort = std::dynamic_pointer_cast<TupleSort>(it->first);
+			smtAssert(tupleSort);
+			return tupleSort;
+		}
+		return {};
+	}
+
+	SortPointer toSort(SMTLib2Expression const& expr)
+	{
+		if (isAtom(expr))
+		{
+			auto const& name = asAtom(expr);
+			if (name == "Int")
+				return SortProvider::sintSort;
+			if (name == "Bool")
+				return SortProvider::boolSort;
+			auto tupleSort = lookupKnownTupleSort(name);
+			if (tupleSort)
+				return tupleSort.value();
+		} else {
+			auto const& args = asSubExpressions(expr);
+			if (asAtom(args[0]) == "Array")
+			{
+				smtAssert(args.size() == 3);
+				auto domainSort = toSort(args[1]);
+				auto codomainSort = toSort(args[2]);
+				return std::make_shared<ArraySort>(std::move(domainSort), std::move(codomainSort));
+			}
+			if (args.size() == 3 && isAtom(args[0]) && asAtom(args[0]) == "_" && isAtom(args[1]) && asAtom(args[1]) == "int2bv")
+				return std::make_shared<BitVectorSort>(std::stoul(asAtom(args[2])));
+		}
+		smtAssert(false, "Unknown sort encountered");
+	}
+
+	smtutil::Expression parseQuantifier(
+		std::string const& quantifierName,
+		std::vector<SMTLib2Expression> const& varList,
+		SMTLib2Expression const& coreExpression
+	)
+	{
+		std::vector<std::pair<std::string, SortPointer>> boundVariables;
+		for (auto const& sortedVar: varList)
+		{
+			smtAssert(!isAtom(sortedVar));
+			auto varSortPair = asSubExpressions(sortedVar);
+			smtAssert(varSortPair.size() == 2);
+			boundVariables.emplace_back(asAtom(varSortPair[0]), toSort(varSortPair[1]));
+		}
+		for (auto const& [var, sort] : boundVariables)
+		{
+			smtAssert(m_knownVariables.find(var) == m_knownVariables.end()); // TODO: deal with shadowing?
+			m_knownVariables.emplace(var, sort);
+		}
+		auto core = toSMTUtilExpression(coreExpression);
+		for (auto const& [var, sort] : boundVariables)
+		{
+			smtAssert(m_knownVariables.find(var) != m_knownVariables.end());
+			m_knownVariables.erase(var);
+		}
+		return Expression(quantifierName, {core}, SortProvider::boolSort); // TODO: what about the bound variables?
+
+	}
+
+	smtutil::Expression toSMTUtilExpression(SMTLib2Expression const& _expr)
+	{
+		return std::visit(
+			GenericVisitor{
+				[&](std::string const& _atom)
+				{
+					if (_atom == "true" || _atom == "false")
+						return smtutil::Expression(_atom == "true");
+					else if (isNumber(_atom))
+						return smtutil::Expression(_atom, {}, SortProvider::sintSort);
+					else if (auto it = m_knownVariables.find(_atom); it != m_knownVariables.end())
+						return smtutil::Expression(_atom, {}, it->second);
+					else // assume this is a predicate with sort bool; TODO: Context should be aware of predicates!
+						return smtutil::Expression(_atom, {}, SortProvider::boolSort);
+				},
+				[&](std::vector<SMTLib2Expression> const& _subExpr)
+				{
+					SortPointer sort;
+					std::vector<smtutil::Expression> arguments;
+					if (isAtom(_subExpr.front()))
+					{
+						std::string const& op = asAtom(_subExpr.front());
+						if (op == "!")
+						{
+							// named term, we ignore the name
+							smtAssert(_subExpr.size() > 2);
+							return toSMTUtilExpression(_subExpr[1]);
+						}
+						if (op == "exists" || op == "forall")
+						{
+							smtAssert(_subExpr.size() == 3);
+							smtAssert(!isAtom(_subExpr[1]));
+							return parseQuantifier(op, asSubExpressions(_subExpr[1]), _subExpr[2]);
+						}
+						for (size_t i = 1; i < _subExpr.size(); i++)
+							arguments.emplace_back(toSMTUtilExpression(_subExpr[i]));
+						if (auto tupleSort = lookupKnownTupleSort(op); tupleSort)
+						{
+							auto sortSort = std::make_shared<SortSort>(tupleSort.value());
+							return Expression::tuple_constructor(Expression(sortSort), arguments);
+						}
+						if (auto it = m_knownVariables.find(op); it != m_knownVariables.end())
+							return smtutil::Expression(op, std::move(arguments), it->second);
+						else
+						{
+							std::set<std::string>
+								boolOperators{"and", "or", "not", "=", "<", ">", "<=", ">=", "=>"};
+							sort = contains(boolOperators, op) ? SortProvider::boolSort : arguments.back().sort;
+							return smtutil::Expression(op, std::move(arguments), std::move(sort));
+						}
+						smtAssert(false, "Unhandled case in expression conversion");
+					}
+					else
+					{
+						// check for const array
+						if (_subExpr.size() == 2 and !isAtom(_subExpr[0]))
+						{
+							auto const& typeArgs = asSubExpressions(_subExpr.front());
+							if (typeArgs.size() == 3 && typeArgs[0].toString() == "as"
+								&& typeArgs[1].toString() == "const")
+							{
+								auto arraySort = toSort(typeArgs[2]);
+								auto sortSort = std::make_shared<SortSort>(arraySort);
+								return smtutil::Expression::
+									const_array(Expression(sortSort), toSMTUtilExpression(_subExpr[1]));
+							}
+							if (typeArgs.size() == 3 && typeArgs[0].toString() == "_"
+								&& typeArgs[1].toString() == "int2bv")
+							{
+								auto bvSort = std::dynamic_pointer_cast<BitVectorSort>(toSort(_subExpr[0]));
+								smtAssert(bvSort);
+								return smtutil::Expression::int2bv(toSMTUtilExpression(_subExpr[1]), bvSort->size);
+							}
+							if (typeArgs.size() == 4 && typeArgs[0].toString() == "_"
+								&& typeArgs[1].toString() == "extract")
+								return smtutil::Expression(
+									"extract",
+									{toSMTUtilExpression(typeArgs[2]), toSMTUtilExpression(typeArgs[3])},
+									SortProvider::bitVectorSort // TODO: Compute bit size properly?
+								);
+						}
+						smtAssert(false, "Unhandled case in expression conversion");
+					}
+				}
+			},
+			_expr.data
+		);
+	}
+};
+
+
+#define precondition(CONDITION) if (!(CONDITION)) return {}
+std::optional<smtutil::Expression> CHCSmtLib2Interface::invariantsFromSolverResponse(std::string const& _response) const
+{
+	std::stringstream ss(_response);
+	std::string answer;
+	ss >> answer;
+	precondition(answer == "sat");
+	SMTLib2Parser parser(ss);
+	precondition(!parser.isEOF()); // There has to be a model
+	std::vector<SMTLib2Expression> parsedOutput;
+	try
+	{
+		while (!parser.isEOF())
+			parsedOutput.push_back(parser.parseExpression());
+	}
+	catch(SMTLib2Parser::ParsingException&)
+	{
+		return {};
+	}
+	smtAssert(parser.isEOF());
+	precondition(!parsedOutput.empty());
+	auto& commands = parsedOutput.size() == 1 ? asSubExpressions(parsedOutput[0]) : parsedOutput;
+	std::vector<Expression> definitions;
+	for (auto& command: commands)
+	{
+		auto& args = asSubExpressions(command);
+		precondition(args.size() == 5);
+		// args[0] = "define-fun"
+		// args[1] = predicate name
+		// args[2] = formal arguments of the predicate
+		// args[3] = return sort
+		// args[4] = body of the predicate's interpretation
+		precondition(isAtom(args[0]) && asAtom(args[0]) == "define-fun");
+		precondition(isAtom(args[1]));
+		precondition(!isAtom(args[2]));
+		precondition(isAtom(args[3]) && asAtom(args[3]) == "Bool");
+		auto& interpretation = args[4];
+//		inlineLetExpressions(interpretation);
+		SMTLibTranslationContext context(*this);
+		auto const& formalArguments = asSubExpressions(args[2]);
+		std::vector<Expression> predicateArgs;
+		for (auto const& formalArgument: formalArguments)
+		{
+			precondition(!isAtom(formalArgument));
+			auto const& nameSortPair = asSubExpressions(formalArgument);
+			precondition(nameSortPair.size() == 2);
+			precondition(isAtom(nameSortPair[0]));
+			SortPointer varSort = context.toSort(nameSortPair[1]);
+			context.addVariableDeclaration(asAtom(nameSortPair[0]), varSort);
+			Expression arg = context.toSMTUtilExpression(nameSortPair[0]);
+			predicateArgs.push_back(arg);
+		}
+
+		auto parsedInterpretation = context.toSMTUtilExpression(interpretation);
+
+		Expression predicate(asAtom(args[1]), predicateArgs, SortProvider::boolSort);
+		definitions.push_back(predicate == parsedInterpretation);
+	}
+	return Expression::mkAnd(std::move(definitions));
+}
+#undef precondition

--- a/libsmtutil/CHCSmtLib2Interface.h
+++ b/libsmtutil/CHCSmtLib2Interface.h
@@ -76,6 +76,9 @@ private:
 	/// Communicates with the solver via the callback. Throws SMTSolverError on error.
 	std::string querySolver(std::string const& _input);
 
+	/// Translates CHC solver response with a model to our representation of invariants. Returns None on error.
+	std::optional<smtutil::Expression> invariantsFromSolverResponse(std::string const& response) const;
+
 	/// Used to access toSmtLibSort, SExpr, and handle variables.
 	std::unique_ptr<SMTLib2Interface> m_smtlib2;
 

--- a/libsmtutil/CHCSmtLib2Interface.h
+++ b/libsmtutil/CHCSmtLib2Interface.h
@@ -57,8 +57,10 @@ public:
 
 	SMTLib2Interface* smtlib2Interface() const { return m_smtlib2.get(); }
 
+	auto const& sortNames() const { return m_smtlib2->sortNames(); }
+
 private:
-	std::string toSmtLibSort(Sort const& _sort);
+	std::string toSmtLibSort(SortPointer _sort);
 	std::string toSmtLibSort(std::vector<SortPointer> const& _sort);
 
 	void writeHeader();
@@ -85,8 +87,6 @@ private:
 
 	frontend::ReadCallback::Callback m_smtCallback;
 	SMTSolverChoice m_enabledSolvers;
-
-	std::map<Sort const*, std::string> m_sortNames;
 };
 
 }

--- a/libsmtutil/CMakeLists.txt
+++ b/libsmtutil/CMakeLists.txt
@@ -4,6 +4,8 @@ set(sources
 	Exceptions.h
 	SMTLib2Interface.cpp
 	SMTLib2Interface.h
+	SMTLib2Parser.cpp
+	SMTLib2Parser.h
 	SMTPortfolio.cpp
 	SMTPortfolio.h
 	SolverInterface.h

--- a/libsmtutil/SMTLib2Interface.h
+++ b/libsmtutil/SMTLib2Interface.h
@@ -61,12 +61,13 @@ public:
 
 	// Used by CHCSmtLib2Interface
 	std::string toSExpr(Expression const& _expr);
-	std::string toSmtLibSort(Sort const& _sort);
+	std::string toSmtLibSort(SortPointer _sort);
 	std::string toSmtLibSort(std::vector<SortPointer> const& _sort);
 
 	std::map<std::string, SortPointer> variables() { return m_variables; }
 
 	std::vector<std::pair<std::string, std::string>> const& userSorts() const { return m_userSorts; }
+	std::map<SortPointer, std::string> const& sortNames() const { return m_sortNames; }
 
 	std::string dumpQuery(std::vector<Expression> const& _expressionsToEvaluate);
 
@@ -81,6 +82,8 @@ private:
 	/// Communicates with the solver via the callback. Throws SMTSolverError on error.
 	std::string querySolver(std::string const& _input);
 
+	std::string toSmtLibSortInternal(SortPointer _sort);
+
 	std::vector<std::string> m_accumulatedOutput;
 	std::map<std::string, SortPointer> m_variables;
 
@@ -89,6 +92,10 @@ private:
 	/// It needs to be a vector so that the declaration order is kept,
 	/// otherwise solvers cannot parse the queries.
 	std::vector<std::pair<std::string, std::string>> m_userSorts;
+
+	/// Maps a user sort to SMT-LIB2 sort.
+	/// Remembers all declared sorts and is used as a cache as well.
+	std::map<SortPointer, std::string> m_sortNames;
 
 	std::map<util::h256, std::string> m_queryResponses;
 	std::vector<std::string> m_unhandledQueries;

--- a/libsmtutil/SMTLib2Parser.cpp
+++ b/libsmtutil/SMTLib2Parser.cpp
@@ -1,0 +1,97 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libsmtutil/SMTLib2Parser.h>
+
+#include <liblangutil/Common.h>
+
+#include <libsolutil/Visitor.h>
+#include <libsolutil/StringUtils.h>
+
+
+using namespace solidity::langutil;
+using namespace solidity::smtutil;
+
+std::string SMTLib2Expression::toString() const {
+	return std::visit(solidity::util::GenericVisitor{
+			[](std::string const& _sv) { return _sv; },
+			[](std::vector<SMTLib2Expression> const& _subExpr) {
+				std::vector<std::string> formatted;
+				for (auto const& item: _subExpr)
+					formatted.emplace_back(item.toString());
+				return "(" + solidity::util::joinHumanReadable(formatted, " ") + ")";
+			}
+	}, data);
+}
+
+SMTLib2Expression SMTLib2Parser::parseExpression() {
+	skipWhitespace();
+	if (token() == '(')
+	{
+		advance();
+		skipWhitespace();
+		std::vector<SMTLib2Expression> subExpressions;
+		while (token() != 0 && token() != ')')
+		{
+			subExpressions.emplace_back(parseExpression());
+			skipWhitespace();
+		}
+		if (token() != ')')
+			throw ParsingException{};
+		// Simulate whitespace because we do not want to read the next token since it might block.
+		m_token = ' ';
+		return {std::move(subExpressions)};
+	} else
+		return {parseToken()};
+}
+
+std::string SMTLib2Parser::parseToken() {
+	std::string result;
+
+	skipWhitespace();
+	bool isPipe = token() == '|';
+	if (isPipe)
+		advance();
+	while (token() != 0)
+	{
+		char c = token();
+		if (isPipe && c == '|')
+		{
+			advance();
+			break;
+		} else if (!isPipe && (isWhiteSpace(c) || c == '(' || c == ')'))
+			break;
+		result.push_back(c);
+		advance();
+	}
+	return result;
+}
+
+void SMTLib2Parser::advance() {
+	if (!m_input.good())
+		throw ParsingException{};
+	m_token = static_cast<char>(m_input.get());
+	if (token() == ';')
+		while (token() != '\n' && token() != 0)
+			m_token = static_cast<char>(m_input.get());
+}
+
+void SMTLib2Parser::skipWhitespace() {
+	while (isWhiteSpace(token()))
+		advance();
+}

--- a/libsmtutil/SMTLib2Parser.h
+++ b/libsmtutil/SMTLib2Parser.h
@@ -1,0 +1,96 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libsmtutil/Exceptions.h>
+
+#include <iostream>
+#include <string>
+#include <variant>
+#include <vector>
+
+/**
+ * The following is a parser for SMT-LIB2 expressions developed originally by @chriseth as part of solsmt.
+ */
+
+namespace solidity::smtutil
+{
+
+struct SMTLib2Expression {
+	using args_t = std::vector<SMTLib2Expression>;
+	std::variant<std::string, args_t> data;
+
+	[[nodiscard]] std::string toString() const;
+};
+
+inline bool isAtom(SMTLib2Expression const& expr)
+{
+	return std::holds_alternative<std::string>(expr.data);
+}
+
+inline std::string const& asAtom(SMTLib2Expression const& expr)
+{
+	smtAssert(isAtom(expr));
+	return std::get<std::string>(expr.data);
+}
+
+inline auto const& asSubExpressions(SMTLib2Expression const& expr)
+{
+	smtAssert(!isAtom(expr));
+	return std::get<SMTLib2Expression::args_t>(expr.data);
+}
+
+inline auto& asSubExpressions(SMTLib2Expression& expr)
+{
+	smtAssert(!isAtom(expr));
+	return std::get<SMTLib2Expression::args_t>(expr.data);
+}
+
+class SMTLib2Parser {
+public:
+	class ParsingException {};
+
+	explicit SMTLib2Parser(std::istream& _input) :
+			m_input(_input),
+			m_token(static_cast<char>(m_input.get())) {}
+
+	SMTLib2Expression parseExpression();
+
+	bool isEOF()
+	{
+		skipWhitespace();
+		return m_input.eof();
+	}
+
+private:
+	std::string parseToken();
+
+	void skipWhitespace();
+
+	[[nodiscard]] char token() const
+	{
+		return m_token;
+	}
+
+	void advance();
+
+	std::istream& m_input;
+	char m_token = 0;
+};
+}

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -659,7 +659,7 @@ bool CompilerStack::analyzeLegacy(bool _noErrorsSoFar)
 			m_modelCheckerSettings.solvers = ModelChecker::checkRequestedSolvers(m_modelCheckerSettings.solvers, m_errorReporter);
 			if (auto* universalCallback = m_readFile.target<frontend::UniversalCallback>())
 				if (m_modelCheckerSettings.solvers.eld)
-					universalCallback->smtCommand().setEldarica(m_modelCheckerSettings.timeout);
+					universalCallback->smtCommand().setEldarica(m_modelCheckerSettings.timeout, m_modelCheckerSettings.invariants != ModelCheckerInvariants::None());
 		}
 
 		ModelChecker modelChecker(m_errorReporter, *this, m_smtlib2Responses, m_modelCheckerSettings, m_readFile);

--- a/libsolidity/interface/SMTSolverCommand.cpp
+++ b/libsolidity/interface/SMTSolverCommand.cpp
@@ -37,7 +37,7 @@ using solidity::util::errinfo_comment;
 namespace solidity::frontend
 {
 
-void SMTSolverCommand::setEldarica(std::optional<unsigned int> timeoutInMilliseconds)
+void SMTSolverCommand::setEldarica(std::optional<unsigned int> timeoutInMilliseconds, bool computeInvariants)
 {
 	m_arguments.clear();
 	m_solverCmd = "eld";
@@ -47,6 +47,8 @@ void SMTSolverCommand::setEldarica(std::optional<unsigned int> timeoutInMillisec
 		timeoutInSeconds = timeoutInSeconds == 0 ? 1 : timeoutInSeconds;
 		m_arguments.push_back("-t:" + std::to_string(timeoutInSeconds));
 	}
+	if (computeInvariants)
+		m_arguments.emplace_back("-ssol");
 }
 
 ReadCallback::Result SMTSolverCommand::solve(std::string const& _kind, std::string const& _query)

--- a/libsolidity/interface/SMTSolverCommand.h
+++ b/libsolidity/interface/SMTSolverCommand.h
@@ -36,7 +36,7 @@ public:
 		return [this](std::string const& _kind, std::string const& _query) { return solve(_kind, _query); };
 	}
 
-	void setEldarica(std::optional<unsigned int> timeoutInMilliseconds);
+	void setEldarica(std::optional<unsigned int> timeoutInMilliseconds, bool computeInvariants);
 
 private:
 	/// The name of the solver's binary.

--- a/test/cmdlineTests/model_checker_invariants_contract_eld/args
+++ b/test/cmdlineTests/model_checker_invariants_contract_eld/args
@@ -1,0 +1,1 @@
+--model-checker-engine chc --model-checker-invariants contract --model-checker-solvers eld

--- a/test/cmdlineTests/model_checker_invariants_contract_eld/err
+++ b/test/cmdlineTests/model_checker_invariants_contract_eld/err
@@ -1,0 +1,4 @@
+Info: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+
+Info: Contract invariant(s) for model_checker_invariants_contract_eld/input.sol:test:
+(x = 0)

--- a/test/cmdlineTests/model_checker_invariants_contract_eld/input.sol
+++ b/test/cmdlineTests/model_checker_invariants_contract_eld/input.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+contract test {
+	uint x;
+	function f() public view {
+		assert(x < 10);
+	}
+}


### PR DESCRIPTION
This PR adds initial support for parsing invariants, computed by CHC solver, in SMT-LIB format.

This is done in a few separate steps (found in individual commits):

1. Introduction of a basic SMT-LIB parser that parses string representation and creates S-expression representation. This parser was originally developed by @chriseth (for solsmt) and we only updated it slightly to handle malformed SMT-LIB strings.
2. Instructing Eldarica to produce model (invariants) when this is requested by the user.
3. Reorganization of where we remember declared SMT-LIB sorts. This is necessary for proper parsing of the solver response and creation of our representation of the invariants.
4. The actual translation from SMT-LIB S-expressions to our `Expression` representation of the invariants.

**Note:** This is only initial support and will require more iterations as we add more tests.