### PR TITLE
Prevent pnpm frozen lockfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1452,7 +1452,7 @@ jobs:
           name: Install dependencies
           command: |
             cd hardhat
-            pnpm install
+            pnpm install --no-frozen-lockfile
       - run:
           name: Run hardhat-core test suite
           command: |

--- a/test/externalTests/prb-math.py
+++ b/test/externalTests/prb-math.py
@@ -43,7 +43,7 @@ class PRBMathRunner(FoundryRunner):
         # Starting from version v4.0.2, the default installation method for PRBMath dependencies
         # has transitioned from Foundry to Node.js.
         subprocess.run(
-            ["pnpm", "install"],
+            ["pnpm", "install", "--no-frozen-lockfile"],
             env=self.env,
             check=True
         )


### PR DESCRIPTION
Fix current errors in CI https://app.circleci.com/jobs/github/ethereum/solidity/1522260 due to broken lockfile. May be related to this change: https://github.com/pnpm/pnpm/releases/tag/v9.0.1, since the CI uses that pnpm version:
```
circleci@cad008d41f62:~$ pnpm --version
9.0.1
```

Adding the `--no-frozen-lockfile` allows pnpm to fix the broken entry in the lockfile.