### PR TITLE
Make CommonSubExpression Eliminator consider gas costs as well as code size

### DIFF
--- a/libevmasm/CommonSubexpressionEliminator.h
+++ b/libevmasm/CommonSubexpressionEliminator.h
@@ -77,6 +77,8 @@ public:
 	/// @returns the resulting items after optimization.
 	AssemblyItems getOptimizedItems();
 
+	KnownState const& getKnownState() const { return m_state; }
+
 private:
 	/// Feeds the item into the system for analysis.
 	void feedItem(AssemblyItem const& _item, bool _copyItem = false);

--- a/test/libsolidity/semanticTests/abiEncoderV2/calldata_overlapped_dynamic_arrays.sol
+++ b/test/libsolidity/semanticTests/abiEncoderV2/calldata_overlapped_dynamic_arrays.sol
@@ -33,8 +33,8 @@ contract C {
 // f_which(uint256[],uint256[2],uint256): 0x40, 1, 2, 1, 5, 6 -> 0x20, 0x40, 5, 2
 // f_which(uint256[],uint256[2],uint256): 0x40, 1, 2, 1 -> FAILURE
 // f_storage(uint256[],uint256[2]): 0x20, 1, 2 -> 0x20, 0x60, 0x20, 1, 2
-// gas irOptimized: 111395
-// gas legacy: 112709
-// gas legacyOptimized: 111852
+// gas irOptimized: 111642
+// gas legacy: 112944
+// gas legacyOptimized: 112090
 // f_storage(uint256[],uint256[2]): 0x40, 1, 2, 5, 6 -> 0x20, 0x80, 0x20, 2, 5, 6
 // f_storage(uint256[],uint256[2]): 0x40, 1, 2, 5 -> FAILURE

--- a/test/libsolidity/semanticTests/events/event_dynamic_array_storage.sol
+++ b/test/libsolidity/semanticTests/events/event_dynamic_array_storage.sol
@@ -14,5 +14,5 @@ contract C {
 // createEvent(uint256): 42 ->
 // ~ emit E(uint256[]): 0x20, 0x03, 0x2a, 0x2b, 0x2c
 // gas irOptimized: 113485
-// gas legacy: 116314
-// gas legacyOptimized: 114407
+// gas legacy: 116313
+// gas legacyOptimized: 114405

--- a/test/libsolidity/semanticTests/events/event_dynamic_array_storage_v2.sol
+++ b/test/libsolidity/semanticTests/events/event_dynamic_array_storage_v2.sol
@@ -15,5 +15,5 @@ contract C {
 // createEvent(uint256): 42 ->
 // ~ emit E(uint256[]): 0x20, 0x03, 0x2a, 0x2b, 0x2c
 // gas irOptimized: 113485
-// gas legacy: 116314
-// gas legacyOptimized: 114407
+// gas legacy: 116313
+// gas legacyOptimized: 114405


### PR DESCRIPTION
The CSE only checks for the code size when trying to decide if it should apply its optimizations.
This PR has the objective of improving this decision process by also considering the gas costs together with the code size.
Suggested [here](https://github.com/ethereum/solidity/pull/14117#discussion_r1499716808).