### PR TITLE
Better error message when consecutive underscores

### DIFF
--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -300,7 +300,7 @@ bool SyntaxChecker::visit(Literal const& _literal)
 
 	if (value.find("__") != ASTString::npos)
 	{
-		m_errorReporter.syntaxError(2990_error, _literal.location(), "Invalid use of underscores in number literal. Only one consecutive underscores between digits allowed.");
+		m_errorReporter.syntaxError(2990_error, _literal.location(), "Invalid use of underscores in number literal. Only one consecutive underscore between digits is allowed.");
 		return true;
 	}
 

--- a/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_decimal_fail.sol
+++ b/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_decimal_fail.sol
@@ -8,6 +8,6 @@ contract C {
 }
 // ----
 // SyntaxError 2090: (56-61): Invalid use of underscores in number literal. No trailing underscores allowed.
-// SyntaxError 2990: (77-83): Invalid use of underscores in number literal. Only one consecutive underscores between digits allowed.
+// SyntaxError 2990: (77-83): Invalid use of underscores in number literal. Only one consecutive underscore between digits is allowed.
 // SyntaxError 6415: (99-105): Invalid use of underscores in number literal. No underscore at the end of the mantissa allowed.
 // SyntaxError 6165: (121-127): Invalid use of underscores in number literal. No underscore in front of exponent allowed.

--- a/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_fixed_fail.sol
+++ b/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_fixed_fail.sol
@@ -10,7 +10,7 @@ contract C {
 }
 // ----
 // SyntaxError 2090: (57-64): Invalid use of underscores in number literal. No trailing underscores allowed.
-// SyntaxError 2990: (81-91): Invalid use of underscores in number literal. Only one consecutive underscores between digits allowed.
+// SyntaxError 2990: (81-91): Invalid use of underscores in number literal. Only one consecutive underscore between digits is allowed.
 // SyntaxError 1023: (108-112): Invalid use of underscores in number literal. No underscores in front of the fraction part allowed.
 // SyntaxError 3891: (129-133): Invalid use of underscores in number literal. No underscores in front of the fraction part allowed.
 // SyntaxError 6165: (150-157): Invalid use of underscores in number literal. No underscore in front of exponent allowed.

--- a/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_hex_fail.sol
+++ b/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_hex_fail.sol
@@ -4,4 +4,4 @@ contract C {
   }
 }
 // ----
-// SyntaxError 2990: (56-79): Invalid use of underscores in number literal. Only one consecutive underscores between digits allowed.
+// SyntaxError 2990: (56-79): Invalid use of underscores in number literal. Only one consecutive underscore between digits is allowed.


### PR DESCRIPTION
Better grammer in err msg suggested by @nikola-matic at https://github.com/ethereum/solidity/pull/15046#discussion_r1575156369.

