### PR TITLE
Add missing dependencies and extra info to optimizer step docs

### DIFF
--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -168,3 +168,44 @@ Modifiers
 - ``override``: States that this function, modifier or public state variable changes
   the behavior of a function or modifier in a base contract.
 
+Optimizer Step Dependencies
+===========================
+
+=========================================== ===================================================== =============================================================== ===========================================
+Step                                        Hard prerequisites                                    Steps that should run before                                    Steps that should run after
+=========================================== ===================================================== =============================================================== ===========================================
+:ref:`a <ssa-transform>`                    Disambiguator, ForLoopInitRewriter                    ExpressionSplitter, CommonSubexpressionEliminator               UnusedAssignEliminator
+:ref:`C <conditional-simplifier>`           Disambiguator                                         SSATransform, DeadCodeEliminator
+:ref:`c <common-subexpression-eliminator>`  Disambiguator, ForLoopInitRewriter                    ExpressionSplitter, SSATransform [#]_                           UnusedPruner, UnusedAssignEliminator
+:ref:`D <dead-code-eliminator>`             ForLoopInitRewriter, FunctionHoister, FunctionGrouper
+:ref:`d <var-decl-initializer>`
+:ref:`E <equal-store-eliminator>`           Disambiguator, ForLoopInitRewriter                    ExpressionSplitter, SSATransform, CommonSubexpressionEliminator
+:ref:`e <expression-inliner>`               Disambiguator
+:ref:`F <function-specializer>`             Disambiguator, FunctionHoister                        LiteralRematerialiser
+:ref:`f <block-flattener>`                  Disambiguator, FunctionGrouper
+:ref:`g <function-grouper>`                 Disambiguator, FunctionHoister
+:ref:`h <function-hoister>`                 Disambiguator
+:ref:`I <for-loop-condition-into-body>`     Disambiguator                                         StructuralSimplifier
+:ref:`i <full-inliner>`                     Disambiguator                                         FunctionHoister, ExpressionSplitter
+:ref:`j <expression-joiner>`                Disambiguator
+:ref:`L <load-resolver>`                    Disambiguator, ForLoopInitRewriter                    SSATransform
+:ref:`l <circular-references-pruner>`       Disambiguator, FunctionHoister
+:ref:`M <loop-invariant-code-motion>`       Disambiguator, ForLoopInitRewriter, FunctionHoister   ExpressionSplitter, SSATransform, ForLoopConditionIntoBody
+:ref:`m <rematerialiser>`                   Disambiguator, ForLoopInitRewriter
+:ref:`n <control-flow-simplifier>`          Disambiguator, ForLoopInitRewriter, FunctionHoister
+:ref:`O <for-loop-condition-out-of-body>`                                                         LiteralRematerialiser
+:ref:`o <for-loop-init-rewriter>`           Disambiguator
+:ref:`p <unused-function-parameter-pruner>` Disambiguator, FunctionHoister                        LiteralRematerialiser                                           FullInliner, UnusedPruner
+:ref:`r <unused-assign-eliminator>`         Disambiguator, ForLoopInitRewriter
+:ref:`S <unused-store-eliminator>`          Disambiguator, ForLoopInitRewriter                    SSATransform
+:ref:`s <expression-simplifier>`            Disambiguator, ForLoopInitRewriter                    ExpressionSplitter, SSATransform, CommonSubexpressionEliminator
+:ref:`T <literal-rematerialiser>`           Disambiguator, ForLoopInitRewriter
+:ref:`t <structural-simplifier>`            Disambiguator                                         LiteralRematerialiser
+:ref:`U <conditional-unsimplifier>`
+:ref:`u <unused-pruner>`                    Disambiguator
+:ref:`V <ssa-reverser>`                     Disambiguator                                                                                                         CommonSubexpressionEliminator, UnusedPruner
+:ref:`v <equivalent-function-combiner>`     Disambiguator, FunctionHoister                                                                                        UnusedPruner
+:ref:`x <expression-splitter>`                                                                    ForLoopConditionIntoBody
+=========================================== ===================================================== =============================================================== ===========================================
+
+.. [#] It is enough if SSATransform was used once at any point before running the step.

--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -171,41 +171,41 @@ Modifiers
 Optimizer Step Dependencies
 ===========================
 
-=========================================== ===================================================== =============================================================== ===========================================
-Step                                        Hard prerequisites                                    Steps that should run before                                    Steps that should run after
-=========================================== ===================================================== =============================================================== ===========================================
-:ref:`a <ssa-transform>`                    Disambiguator, ForLoopInitRewriter                    ExpressionSplitter, CommonSubexpressionEliminator               UnusedAssignEliminator
-:ref:`C <conditional-simplifier>`           Disambiguator                                         SSATransform, DeadCodeEliminator
-:ref:`c <common-subexpression-eliminator>`  Disambiguator, ForLoopInitRewriter                    ExpressionSplitter, SSATransform [#]_                           UnusedPruner, UnusedAssignEliminator
-:ref:`D <dead-code-eliminator>`             ForLoopInitRewriter, FunctionHoister, FunctionGrouper
+=========================================== =============================================================== ===========================================
+Step                                        Steps that should run before                                    Steps that should run after
+=========================================== =============================================================== ===========================================
+:ref:`a <ssa-transform>`                    ExpressionSplitter, CommonSubexpressionEliminator               UnusedAssignEliminator
+:ref:`C <conditional-simplifier>`           SSATransform, DeadCodeEliminator
+:ref:`c <common-subexpression-eliminator>`  ExpressionSplitter, SSATransform [#]_                           UnusedPruner, UnusedAssignEliminator
+:ref:`D <dead-code-eliminator>`
 :ref:`d <var-decl-initializer>`
-:ref:`E <equal-store-eliminator>`           Disambiguator, ForLoopInitRewriter                    ExpressionSplitter, SSATransform, CommonSubexpressionEliminator
-:ref:`e <expression-inliner>`               Disambiguator
-:ref:`F <function-specializer>`             Disambiguator, FunctionHoister                        LiteralRematerialiser
-:ref:`f <block-flattener>`                  Disambiguator, FunctionGrouper
-:ref:`g <function-grouper>`                 Disambiguator, FunctionHoister
-:ref:`h <function-hoister>`                 Disambiguator
-:ref:`I <for-loop-condition-into-body>`     Disambiguator                                         StructuralSimplifier
-:ref:`i <full-inliner>`                     Disambiguator                                         FunctionHoister, ExpressionSplitter
-:ref:`j <expression-joiner>`                Disambiguator
-:ref:`L <load-resolver>`                    Disambiguator, ForLoopInitRewriter                    SSATransform
-:ref:`l <circular-references-pruner>`       Disambiguator, FunctionHoister
-:ref:`M <loop-invariant-code-motion>`       Disambiguator, ForLoopInitRewriter, FunctionHoister   ExpressionSplitter, SSATransform, ForLoopConditionIntoBody
-:ref:`m <rematerialiser>`                   Disambiguator, ForLoopInitRewriter
-:ref:`n <control-flow-simplifier>`          Disambiguator, ForLoopInitRewriter, FunctionHoister
-:ref:`O <for-loop-condition-out-of-body>`                                                         LiteralRematerialiser
-:ref:`o <for-loop-init-rewriter>`           Disambiguator
-:ref:`p <unused-function-parameter-pruner>` Disambiguator, FunctionHoister                        LiteralRematerialiser                                           FullInliner, UnusedPruner
-:ref:`r <unused-assign-eliminator>`         Disambiguator, ForLoopInitRewriter
-:ref:`S <unused-store-eliminator>`          Disambiguator, ForLoopInitRewriter                    SSATransform
-:ref:`s <expression-simplifier>`            Disambiguator, ForLoopInitRewriter                    ExpressionSplitter, SSATransform, CommonSubexpressionEliminator
-:ref:`T <literal-rematerialiser>`           Disambiguator, ForLoopInitRewriter
-:ref:`t <structural-simplifier>`            Disambiguator                                         LiteralRematerialiser
+:ref:`E <equal-store-eliminator>`           ExpressionSplitter, SSATransform, CommonSubexpressionEliminator
+:ref:`e <expression-inliner>`
+:ref:`F <function-specializer>`             LiteralRematerialiser
+:ref:`f <block-flattener>`
+:ref:`g <function-grouper>`
+:ref:`h <function-hoister>`
+:ref:`I <for-loop-condition-into-body>`     StructuralSimplifier
+:ref:`i <full-inliner>`                     FunctionHoister, ExpressionSplitter
+:ref:`j <expression-joiner>`
+:ref:`L <load-resolver>`                    SSATransform
+:ref:`l <circular-references-pruner>`
+:ref:`M <loop-invariant-code-motion>`       ExpressionSplitter, SSATransform, ForLoopConditionIntoBody
+:ref:`m <rematerialiser>`
+:ref:`n <control-flow-simplifier>`
+:ref:`O <for-loop-condition-out-of-body>`   LiteralRematerialiser
+:ref:`o <for-loop-init-rewriter>`
+:ref:`p <unused-function-parameter-pruner>` LiteralRematerialiser                                           FullInliner, UnusedPruner
+:ref:`r <unused-assign-eliminator>`
+:ref:`S <unused-store-eliminator>`          SSATransform
+:ref:`s <expression-simplifier>`            ExpressionSplitter, SSATransform, CommonSubexpressionEliminator
+:ref:`T <literal-rematerialiser>`
+:ref:`t <structural-simplifier>`            LiteralRematerialiser
 :ref:`U <conditional-unsimplifier>`
-:ref:`u <unused-pruner>`                    Disambiguator
-:ref:`V <ssa-reverser>`                     Disambiguator                                                                                                         CommonSubexpressionEliminator, UnusedPruner
-:ref:`v <equivalent-function-combiner>`     Disambiguator, FunctionHoister                                                                                        UnusedPruner
-:ref:`x <expression-splitter>`                                                                    ForLoopConditionIntoBody
-=========================================== ===================================================== =============================================================== ===========================================
+:ref:`u <unused-pruner>`
+:ref:`V <ssa-reverser>`                                                                                     CommonSubexpressionEliminator, UnusedPruner
+:ref:`v <equivalent-function-combiner>`                                                                     UnusedPruner
+:ref:`x <expression-splitter>`              ForLoopConditionIntoBody
+=========================================== =============================================================== ===========================================
 
 .. [#] It is enough if SSATransform was used once at any point before running the step.

--- a/docs/internals/optimizer.rst
+++ b/docs/internals/optimizer.rst
@@ -1,4 +1,4 @@
-.. index:: optimizer, optimiser, common subexpression elimination, constant propagation
+.. index:: ! optimizer, ! optimiser, ! common subexpression elimination, ! constant propagation
 .. _optimizer:
 
 *************

--- a/docs/internals/optimizer.rst
+++ b/docs/internals/optimizer.rst
@@ -466,6 +466,8 @@ Loops that already have a literal constant as iteration condition are not transf
 
 To avoid unnecessary rewriting, it is recommended to run this step after StructuralSimplifier.
 
+May destroy the :ref:`expression-split <expression-splitter>` form.
+
 Prerequisites: Disambiguator.
 
 .. _for-loop-init-rewriter:
@@ -884,6 +886,8 @@ Since variable references are always movable, even if their current
 value might not be, the ExpressionSimplifier is again more powerful
 in :ref:`expression-split <expression-splitter>` or :ref:`pseudo-SSA <ssa-transform>` form.
 
+Some of the simplifications destroy the :ref:`expression-split <expression-splitter>` form.
+
 Prerequisites: Disambiguator, ForLoopInitRewriter.
 
 .. _literal-rematerialiser:
@@ -895,6 +899,10 @@ If a variable referenced in an expression is known to have a literal value, repl
 the variable with the literal.
 
 This is mostly used so that other components do not have to rely on the DataflowAnalyzer.
+
+While the step destroys the :ref:`expression-split <expression-splitter>` form in the strict sense,
+it does not introduce any nested function calls, which may be good enough for many steps that require
+this property.
 
 Prerequisites: Disambiguator, ForLoopInitRewriter.
 
@@ -934,7 +942,7 @@ ConditionalSimplifier
 The ConditionalSimplifier inserts assignments to condition variables if the value can be determined
 from the control-flow.
 
-Destroys SSA form.
+Destroys the :ref:`SSA <ssa-transform>` form.
 
 Currently, this tool is very limited, mostly because we do not yet have support
 for boolean types. Since conditions only check for expressions being nonzero,
@@ -1384,6 +1392,8 @@ Because of that, the snippet ``let x := add(0, 2) let y := mul(x, 3)`` is
 transformed to ``let y := mul(add(0, 2), 3)``, even though the ``add`` opcode
 would be executed after the evaluation of the literal ``3``.
 
+Destroys the :ref:`expression-split <expression-splitter>` form.
+
 Prerequisites: Disambiguator.
 
 .. _ssa-reverser:
@@ -1436,6 +1446,8 @@ by ``a`` (until ``a`` is re-assigned). The UnusedPruner will then
 eliminate the variable ``a_1`` altogether and thus fully reverse the
 SSATransform.
 
+Destroys the :ref:`SSA <ssa-transform>` form.
+
 Prerequisites: Disambiguator.
 
 .. _stack-compressor:
@@ -1473,6 +1485,8 @@ The Rematerialiser uses the DataflowAnalyzer to track the current values of vari
 which are always movable.
 If the value is very cheap or the variable was explicitly requested to be eliminated,
 the variable reference is replaced by its current value.
+
+Destroys the :ref:`expression-split <expression-splitter>` form.
 
 Prerequisites: Disambiguator, ForLoopInitRewriter.
 

--- a/docs/yul.rst
+++ b/docs/yul.rst
@@ -1023,6 +1023,8 @@ option.
 
 See :ref:`Using the Commandline Compiler <commandline-compiler>` for details about the Solidity linker.
 
+.. _yul-memoryguard:
+
 memoryguard
 ^^^^^^^^^^^
 

--- a/libyul/optimiser/ControlFlowSimplifier.h
+++ b/libyul/optimiser/ControlFlowSimplifier.h
@@ -45,8 +45,6 @@ class TypeInfo;
  * and ``continue`` statements during its traversal.
  *
  * Prerequisite: Disambiguator, FunctionHoister, ForLoopInitRewriter.
- *
- * Important: Introduces EVM opcodes and thus can only be used on EVM code for now.
  */
 class ControlFlowSimplifier: public ASTModifier
 {

--- a/libyul/optimiser/StructuralSimplifier.h
+++ b/libyul/optimiser/StructuralSimplifier.h
@@ -34,8 +34,6 @@ namespace solidity::yul
  * The LiteralRematerialiser should be run before this.
  *
  * Prerequisite: Disambiguator.
- *
- * Important: Can only be used on EVM code.
  */
 class StructuralSimplifier: public ASTModifier
 {


### PR DESCRIPTION
~Depends on #15053.~ Merged.

The current optimizer docs are pretty incomplete when it comes to documenting prerequisites and recommended steps to run before/after. I need up to date info to verify that the new sequence (#15030) satisfies these requirements so I went over the docs and the docstrings of the steps in the code, compared them and amended the docs where necessary.

I also compiled a table listing them, which is what I will actually refer to when analyzing the sequence - doing it by reading the docs is too unwieldy.