### PR TITLE
Install python dependencies on buildpack-deps images

### DIFF
--- a/scripts/docker/buildpack-deps/Dockerfile.emscripten
+++ b/scripts/docker/buildpack-deps/Dockerfile.emscripten
@@ -37,9 +37,13 @@ LABEL version="17"
 
 ADD emscripten.jam /usr/src
 RUN set -ex && \
-	\
 	apt-get update && \
-	apt-get install lz4 sudo lsof python3 python3-pip --no-install-recommends && \
+	apt-get install -qqy --no-install-recommends \
+		lsof \
+		lz4 \
+		python3 \
+		python3-pip \
+		sudo && \
 	pip3 install requests && \
 	\
 	cd /usr/src && \

--- a/scripts/docker/buildpack-deps/Dockerfile.emscripten
+++ b/scripts/docker/buildpack-deps/Dockerfile.emscripten
@@ -33,13 +33,14 @@
 # Using $(em-config CACHE)/sysroot/usr seems to work, though, and still has cmake find the
 # dependencies automatically.
 FROM emscripten/emsdk:3.1.19 AS base
-LABEL version="16"
+LABEL version="17"
 
 ADD emscripten.jam /usr/src
 RUN set -ex && \
 	\
 	apt-get update && \
-	apt-get install lz4 sudo --no-install-recommends && \
+	apt-get install lz4 sudo lsof python3 python3-pip --no-install-recommends && \
+	pip3 install requests && \
 	\
 	cd /usr/src && \
 	git clone https://github.com/Z3Prover/z3.git -b z3-4.12.1 --depth 1 && \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu.clang.ossfuzz
@@ -22,19 +22,20 @@
 # (c) 2016-2021 solidity contributors.
 #------------------------------------------------------------------------------
 FROM gcr.io/oss-fuzz-base/base-clang:latest as base
-LABEL version="5"
+LABEL version="6"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update; \
 	apt-get -qqy install --no-install-recommends \
 		automake libtool bison texinfo \
-		build-essential sudo \
+		build-essential sudo lsof \
 		software-properties-common \
-		ninja-build git wget \
-		libbz2-dev zlib1g-dev git curl uuid-dev \
+		ninja-build git wget python3-pip \
+		libbz2-dev zlib1g-dev curl uuid-dev \
 		pkg-config openjdk-8-jdk liblzma-dev unzip mlton m4 jq; \
-    apt-get install -qy python3-pip;
+	pip3 install codecov parsec tabulate pylint z3-solver \
+	pygments-lexer-solidity deepdiff colorama requests;
 
 # Install cmake 3.21.2 (minimum requirement is cmake 3.10)
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-Linux-x86_64.sh; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu.clang.ossfuzz
@@ -173,10 +173,6 @@ RUN set -ex; \
     cp abicoder.hpp /usr/include; \
     rm -rf /usr/src/Yul-Isabelle
 
-# Cleanup
-RUN set -ex; \
-	rm -rf /var/lib/apt/lists/*
-
 FROM base
 COPY --from=libraries /usr/lib /usr/lib
 COPY --from=libraries /usr/bin /usr/bin

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu.clang.ossfuzz
@@ -28,14 +28,39 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update; \
 	apt-get -qqy install --no-install-recommends \
-		automake libtool bison texinfo \
-		build-essential sudo lsof \
+		automake \
+		bison \
+		build-essential \
+		curl \
+		git \
+		jq \
+		libbz2-dev \
+		liblzma-dev \
+		libtool \
+		lsof \
+		m4 \
+		mlton \
+		ninja-build \
+		openjdk-8-jdk \
+		pkg-config \
+		python3-pip \
 		software-properties-common \
-		ninja-build git wget python3-pip \
-		libbz2-dev zlib1g-dev curl uuid-dev \
-		pkg-config openjdk-8-jdk liblzma-dev unzip mlton m4 jq; \
-	pip3 install codecov parsec tabulate pylint z3-solver \
-	pygments-lexer-solidity deepdiff colorama requests;
+		sudo \
+		texinfo \
+		unzip \
+		uuid-dev \
+		wget \
+		zlib1g-dev; \
+	pip3 install \
+		codecov \
+		colorama \
+		deepdiff \
+		parsec \
+		pygments-lexer-solidity \
+		pylint \
+		requests \
+		tabulate \
+		z3-solver;
 
 # Install cmake 3.21.2 (minimum requirement is cmake 3.10)
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-Linux-x86_64.sh; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:focal AS base
-LABEL version="22"
+LABEL version="23"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -34,13 +34,14 @@ RUN set -ex; \
 	apt-get install -qqy --no-install-recommends \
 		build-essential sudo \
 		software-properties-common \
-		cmake ninja-build \
+		cmake ninja-build lsof \
 		libboost-filesystem-dev libboost-test-dev libboost-system-dev \
 		libboost-program-options-dev \
 		libcvc4-dev libz3-static-dev z3-static jq \
 		; \
 	apt-get install -qy python3-pip python3-sphinx; \
-	pip3 install codecov;
+	pip3 install codecov parsec tabulate pylint z3-solver \
+	pygments-lexer-solidity deepdiff colorama requests;
 
 # Eldarica
 RUN set -ex; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
@@ -32,21 +32,39 @@ RUN set -ex; \
 	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1c52189c923f6ca9 ; \
 	apt-get update; \
 	apt-get install -qqy --no-install-recommends \
-		build-essential sudo \
-		software-properties-common \
-		cmake ninja-build lsof \
-		libboost-filesystem-dev libboost-test-dev libboost-system-dev \
+		build-essential \
+		cmake \
+		jq \
+		libboost-filesystem-dev \
 		libboost-program-options-dev \
-		libcvc4-dev libz3-static-dev z3-static jq \
-		; \
-	apt-get install -qy python3-pip python3-sphinx; \
-	pip3 install codecov parsec tabulate pylint z3-solver \
-	pygments-lexer-solidity deepdiff colorama requests;
+		libboost-system-dev \
+		libboost-test-dev \
+		libcvc4-dev \
+		libz3-static-dev \
+		lsof \
+		ninja-build \
+		python3-pip \
+		python3-sphinx \
+		software-properties-common \
+		sudo \
+		z3-static; \
+	pip3 install \
+		codecov \
+		colorama \
+		deepdiff \
+		parsec \
+		pygments-lexer-solidity \
+		pylint \
+		requests \
+		tabulate \
+		z3-solver;
 
 # Eldarica
 RUN set -ex; \
 	apt-get update; \
-	apt-get install -qy unzip openjdk-11-jre; \
+	apt-get install -qqy \
+		openjdk-11-jre \
+		unzip; \
 	eldarica_version="2.1"; \
 	wget "https://github.com/uuverifiers/eldarica/releases/download/v${eldarica_version}/eldarica-bin-${eldarica_version}.zip" -O /opt/eld_binaries.zip; \
 	test "$(sha256sum /opt/eld_binaries.zip)" = "0ac43f45c0925383c9d2077f62bbb515fd792375f3b2b101b30c9e81dcd7785c  /opt/eld_binaries.zip"; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
@@ -71,10 +71,6 @@ RUN set -ex; \
 	unzip /opt/eld_binaries.zip -d /opt; \
 	rm -f /opt/eld_binaries.zip;
 
-# Cleanup
-RUN set -ex; \
-	rm -rf /var/lib/apt/lists/*
-
 FROM base AS libraries
 
 # EVMONE

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:jammy AS base
-LABEL version="7"
+LABEL version="8"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -34,13 +34,14 @@ RUN set -ex; \
 	apt-get install -qqy --no-install-recommends \
 		build-essential sudo \
 		software-properties-common \
-		cmake ninja-build \
+		cmake ninja-build lsof \
 		libboost-filesystem-dev libboost-test-dev libboost-system-dev \
 		libboost-program-options-dev \
 		libcvc4-dev libz3-static-dev z3-static jq \
 		libcln-dev zip locales-all; \
 	apt-get install -qy python3-pip python3-sphinx; \
-	pip3 install codecov;
+	pip3 install codecov parsec tabulate pylint z3-solver \
+	pygments-lexer-solidity deepdiff colorama requests;
 
 # Eldarica
 RUN set -ex; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204
@@ -74,10 +74,6 @@ RUN set -ex; \
 	unzip /opt/eld_binaries.zip -d /opt; \
 	rm -f /opt/eld_binaries.zip;
 
-# Cleanup
-RUN set -ex; \
-	rm -rf /var/lib/apt/lists/*
-
 FROM base AS libraries
 
 # EVMONE

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204
@@ -32,21 +32,42 @@ RUN set -ex; \
 	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1c52189c923f6ca9 ; \
 	apt-get update; \
 	apt-get install -qqy --no-install-recommends \
-		build-essential sudo \
-		software-properties-common \
-		cmake ninja-build lsof \
-		libboost-filesystem-dev libboost-test-dev libboost-system-dev \
+		build-essential \
+		cmake \
+		jq \
+		libboost-filesystem-dev \
 		libboost-program-options-dev \
-		libcvc4-dev libz3-static-dev z3-static jq \
-		libcln-dev zip locales-all; \
-	apt-get install -qy python3-pip python3-sphinx; \
-	pip3 install codecov parsec tabulate pylint z3-solver \
-	pygments-lexer-solidity deepdiff colorama requests;
+		libboost-system-dev \
+		libboost-test-dev \
+		libcln-dev \
+		libcvc4-dev \
+		libz3-static-dev \
+		locales-all \
+		lsof \
+		ninja-build \
+		python3-pip \
+		python3-sphinx \
+		software-properties-common \
+		sudo \
+		z3-static \
+		zip; \
+	pip3 install \
+		codecov \
+		colorama \
+		deepdiff \
+		parsec \
+		pygments-lexer-solidity \
+		pylint \
+		requests \
+		tabulate \
+		z3-solver;
 
 # Eldarica
 RUN set -ex; \
 	apt-get update; \
-	apt-get install -qy unzip openjdk-11-jre; \
+	apt-get install -qqy \
+		openjdk-11-jre \
+		unzip; \
 	eldarica_version="2.1"; \
 	wget "https://github.com/uuverifiers/eldarica/releases/download/v${eldarica_version}/eldarica-bin-${eldarica_version}.zip" -O /opt/eld_binaries.zip; \
 	test "$(sha256sum /opt/eld_binaries.zip)" = "0ac43f45c0925383c9d2077f62bbb515fd792375f3b2b101b30c9e81dcd7785c  /opt/eld_binaries.zip"; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204.clang
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204.clang
@@ -71,10 +71,6 @@ RUN set -ex; \
 	unzip /opt/eld_binaries.zip -d /opt; \
 	rm -f /opt/eld_binaries.zip;
 
-# Cleanup
-RUN set -ex; \
-	rm -rf /var/lib/apt/lists/*
-
 FROM base AS libraries
 
 ENV CC clang

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204.clang
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204.clang
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:jammy AS base
-LABEL version="6"
+LABEL version="7"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -34,12 +34,14 @@ RUN set -ex; \
 	apt-get install -qqy --no-install-recommends \
 		build-essential sudo \
 		software-properties-common \
-		cmake ninja-build \
+		cmake ninja-build lsof \
 		libboost-filesystem-dev libboost-test-dev libboost-system-dev \
 		libboost-program-options-dev \
 		clang \
 		libz3-static-dev z3-static jq \
-		libcln-dev;
+		libcln-dev python3-pip; \
+	pip3 install codecov parsec tabulate pylint z3-solver \
+	pygments-lexer-solidity deepdiff colorama requests;
 
 # Eldarica
 RUN set -ex; \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204.clang
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2204.clang
@@ -32,21 +32,39 @@ RUN set -ex; \
 	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1c52189c923f6ca9 ; \
 	apt-get update; \
 	apt-get install -qqy --no-install-recommends \
-		build-essential sudo \
-		software-properties-common \
-		cmake ninja-build lsof \
-		libboost-filesystem-dev libboost-test-dev libboost-system-dev \
-		libboost-program-options-dev \
+		build-essential \
 		clang \
-		libz3-static-dev z3-static jq \
-		libcln-dev python3-pip; \
-	pip3 install codecov parsec tabulate pylint z3-solver \
-	pygments-lexer-solidity deepdiff colorama requests;
+		cmake \
+		jq \
+		lsof \
+		libboost-filesystem-dev \
+		libboost-program-options-dev \
+		libboost-system-dev \
+		libboost-test-dev \
+		libcln-dev \
+		libz3-static-dev \
+		ninja-build \
+		python3-pip \
+		software-properties-common \
+		sudo \
+		z3-static; \
+	pip3 install \
+		codecov \
+		colorama \
+		deepdiff \
+		parsec \
+		pygments-lexer-solidity \
+		pylint \
+		requests \
+		tabulate \
+		z3-solver;
 
 # Eldarica
 RUN set -ex; \
 	apt-get update; \
-	apt-get install -qy unzip openjdk-11-jre; \
+	apt-get install -qy \
+		openjdk-11-jre \
+		unzip; \
 	eldarica_version="2.1"; \
 	wget "https://github.com/uuverifiers/eldarica/releases/download/v${eldarica_version}/eldarica-bin-${eldarica_version}.zip" -O /opt/eld_binaries.zip; \
 	test "$(sha256sum /opt/eld_binaries.zip)" = "0ac43f45c0925383c9d2077f62bbb515fd792375f3b2b101b30c9e81dcd7785c  /opt/eld_binaries.zip"; \


### PR DESCRIPTION
Install python packages and other common dependencies used by Linux machines on docker buildpack-deps images.

The PR also split the installation commands by line and sorts the packages by name, so we can easily detect changes and duplicates (note that `git` was duplicated in one of the dockerfiles).

And it also removes a superfluous cleanup step from previous PR, see: https://github.com/ethereum/solidity/pull/14976#discussion_r1552296048