### PR TITLE
Update cheatsheet.rst

### DIFF
--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -23,7 +23,7 @@ ABI Encoding and Decoding Functions
 - ``abi.encodeWithSelector(bytes4 selector, ...) returns (bytes memory)``: :ref:`ABI <ABI>`-encodes
   the given arguments starting from the second and prepends the given four-byte selector
 - ``abi.encodeCall(function functionPointer, (...)) returns (bytes memory)``: ABI-encodes a call to ``functionPointer`` with the arguments found in the
-  tuple. Performs a full type-check, ensuring the types match the function signature. Result equals ``abi.encodeWithSelector(functionPointer.selector, (...))``
+  tuple. Performs a full type-check, ensuring the types match the function signature. Result equals ``abi.encodeWithSelector(functionPointer.selector, ...)``
 - ``abi.encodeWithSignature(string memory signature, ...) returns (bytes memory)``: Equivalent
   to ``abi.encodeWithSelector(bytes4(keccak256(bytes(signature))), ...)``
 


### PR DESCRIPTION
The documentation currently says:

````
``abi.encodeCall(function functionPointer, (...)) returns (bytes memory)``: ABI-encodes a call to ``functionPointer`` with the arguments found in the
  tuple. Performs a full type-check, ensuring the types match the function signature. Result equals ``abi.encodeWithSelector(functionPointer.selector, (...))``
````

However, this is not correct.

`abi.encodeWithSelector` does not take a tuple as a second argument, instead, it takes an unended list of arguments. Saying these two are identical, is then not correct:

- `abi.encodeCall(function functionPointer, (...)) `
- `abi.encodeWithSelector(functionPointer.selector, (...))`

It should be that these two are identical:

- `abi.encodeCall(function functionPointer, (...)) `
- `abi.encodeWithSelector(functionPointer.selector, ...)`

subtle, but maybe there is a clearer way to say that `encodeWithSelector` is the same as the unpacked tuple from `encodeCall`.