### PR TITLE
Fix modifier order in a style guide example

### DIFF
--- a/docs/style-guide.rst
+++ b/docs/style-guide.rst
@@ -662,7 +662,7 @@ Yes:
         return balanceOf[from];
     }
 
-    function increment(uint x) public onlyOwner pure returns (uint) {
+    function increment(uint x) public pure onlyOwner returns (uint) {
         return x + 1;
     }
 


### PR DESCRIPTION
According to the modifier order for a function, custom modifier should placed behind of Mutability