### PR TITLE
Transport debug data through block flattener

### DIFF
--- a/.circleci/parallel_bytecode_report.sh
+++ b/.circleci/parallel_bytecode_report.sh
@@ -45,7 +45,7 @@ echo "Preparing input files"
 python3 ../scripts/isolate_tests.py ../test/
 
 # FIXME: These cases crash because of https://github.com/ethereum/solidity/issues/13583
-rm ./*_bytecode_too_large_*.sol ./*_combined_too_large_*.sol
+rm ./*_bytecode_too_large_*.sol ./*_combined_too_large_*.sol ./*_initcode_too_large_*.sol
 
 if [[ $binary_type == native || $binary_type == "osx_intel" ]]; then
     interface=$(echo -e "standard-json\ncli" | circleci tests split)

--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -62,6 +62,7 @@ AssemblyItem const& Assembly::append(AssemblyItem _i)
 	if (!m_items.back().location().isValid() && m_currentSourceLocation.isValid())
 		m_items.back().setLocation(m_currentSourceLocation);
 	m_items.back().m_modifierDepth = m_currentModifierDepth;
+	m_items.back().setDebugAttributes(m_currentDebugAttributes);
 	return m_items.back();
 }
 
@@ -313,6 +314,9 @@ public:
 		}
 
 		std::string expression = _item.toAssemblyText(m_assembly);
+
+		if (!_item.debugData()->attributes.empty())
+			expression += m_prefix + "  // @debug.set " + _item.debugData()->attributes.dump();
 
 		if (!(
 			_item.canBeFunctional() &&

--- a/libevmasm/Assembly.h
+++ b/libevmasm/Assembly.h
@@ -111,6 +111,11 @@ public:
 	/// Changes the source location used for each appended item.
 	void setSourceLocation(langutil::SourceLocation const& _location) { m_currentSourceLocation = _location; }
 	langutil::SourceLocation const& currentSourceLocation() const { return m_currentSourceLocation; }
+
+	/// Changes debug data used for each appended item.
+	void setDebugAttributes(Json const& _debugAttributes) { m_currentDebugAttributes = _debugAttributes; }
+	Json currentDebugAttributes() const { return m_currentDebugAttributes; }
+
 	langutil::EVMVersion const& evmVersion() const { return m_evmVersion; }
 
 	/// Assembles the assembly into bytecode. The assembly should not be modified after this call, since the assembled version is cached.
@@ -246,6 +251,7 @@ protected:
 	/// currently
 	std::string m_name;
 	langutil::SourceLocation m_currentSourceLocation;
+	Json m_currentDebugAttributes;
 
 	// FIXME: This being static means that the strings won't be freed when they're no longer needed
 	static std::map<std::string, std::shared_ptr<std::string const>> s_sharedSourceNames;

--- a/libevmasm/AssemblyItem.h
+++ b/libevmasm/AssemblyItem.h
@@ -194,6 +194,15 @@ public:
 		m_debugData = std::move(_debugData);
 	}
 
+	void setDebugAttributes(Json const& _debugAttributes)
+	{
+		if (!m_debugData)
+			m_debugData = langutil::DebugData::create({}, {}, {}, _debugAttributes);
+		else
+			m_debugData = langutil::DebugData::create(m_debugData->nativeLocation, m_debugData->originLocation, m_debugData->astID, _debugAttributes);
+	}
+
+
 	langutil::DebugData::ConstPtr debugData() const { return m_debugData; }
 
 	void setJumpType(JumpType _jumpType) { m_jumpType = _jumpType; }

--- a/liblangutil/DebugData.h
+++ b/liblangutil/DebugData.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <liblangutil/SourceLocation.h>
+#include <libsolutil/JSON.h>
 #include <optional>
 #include <memory>
 
@@ -32,23 +33,27 @@ struct DebugData
 	explicit DebugData(
 		langutil::SourceLocation _nativeLocation = {},
 		langutil::SourceLocation _originLocation = {},
-		std::optional<int64_t> _astID = {}
+		std::optional<int64_t> _astID = {},
+		Json _attributes = {}
 	):
 		nativeLocation(std::move(_nativeLocation)),
 		originLocation(std::move(_originLocation)),
-		astID(_astID)
+		astID(_astID),
+		attributes(std::move(_attributes))
 	{}
 
 	static DebugData::ConstPtr create(
 		langutil::SourceLocation _nativeLocation,
 		langutil::SourceLocation _originLocation = {},
-		std::optional<int64_t> _astID = {}
+		std::optional<int64_t> _astID = {},
+		Json _attributes = {}
 	)
 	{
 		return std::make_shared<DebugData>(
 			std::move(_nativeLocation),
 			std::move(_originLocation),
-			_astID
+			_astID,
+			std::move(_attributes)
 		);
 	}
 
@@ -65,6 +70,8 @@ struct DebugData
 	langutil::SourceLocation originLocation;
 	/// ID in the (Solidity) source AST.
 	std::optional<int64_t> astID;
+	/// Additional debug data attributes.
+	Json attributes;
 };
 
 } // namespace solidity::langutil

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -143,7 +143,7 @@ langutil::Token Parser::advance()
 void Parser::fetchDebugDataFromComment()
 {
 	static std::regex const tagRegex = std::regex(
-		R"~~((?:^|\s+)(@[a-zA-Z0-9\-_]+)(?:\s+|$))~~", // tag, e.g: @src
+		R"~~((?:^|\s+)(@[a-zA-Z0-9\-\._]+)(?:\s+|$))~~", // tag, e.g: @src
 		std::regex_constants::ECMAScript | std::regex_constants::optimize
 	);
 
@@ -176,13 +176,24 @@ void Parser::fetchDebugDataFromComment()
 			else
 				break;
 		}
-		else if (match[1] == "@attribute")
+		else if (match[1] == "@debug.patch")
 		{
 			if (auto parseResult = parseDebugDataAttributeOperationComment(commentLiteral, m_scanner->currentCommentLocation()))
 			{
 				commentLiteral = parseResult->first;
 				if (parseResult->second.has_value())
 					applyDebugDataAttributePatch(parseResult->second.value());
+			}
+			else
+				break;
+		}
+		else if (match[1] == "@debug.set")
+		{
+			if (auto parseResult = parseDebugDataAttributeOperationComment(commentLiteral, m_scanner->currentCommentLocation()))
+			{
+				commentLiteral = parseResult->first;
+				if (parseResult->second.has_value())
+					m_currentDebugDataAttributes = parseResult->second.value();
 			}
 			else
 				break;

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -176,17 +176,6 @@ void Parser::fetchDebugDataFromComment()
 			else
 				break;
 		}
-		else if (match[1] == "@debug.patch")
-		{
-			if (auto parseResult = parseDebugDataAttributeOperationComment(commentLiteral, m_scanner->currentCommentLocation()))
-			{
-				commentLiteral = parseResult->first;
-				if (parseResult->second.has_value())
-					applyDebugDataAttributePatch(parseResult->second.value());
-			}
-			else
-				break;
-		}
 		else if (match[1] == "@debug.set")
 		{
 			if (auto parseResult = parseDebugDataAttributeOperationComment(commentLiteral, m_scanner->currentCommentLocation()))
@@ -194,6 +183,28 @@ void Parser::fetchDebugDataFromComment()
 				commentLiteral = parseResult->first;
 				if (parseResult->second.has_value())
 					m_currentDebugDataAttributes = parseResult->second.value();
+			}
+			else
+				break;
+		}
+		else if (match[1] == "@debug.merge")
+		{
+			if (auto parseResult = parseDebugDataAttributeOperationComment(commentLiteral, m_scanner->currentCommentLocation()))
+			{
+				commentLiteral = parseResult->first;
+				if (parseResult->second.has_value())
+					m_currentDebugDataAttributes.merge_patch(parseResult->second.value());
+			}
+			else
+				break;
+		}
+		else if (match[1] == "@debug.patch")
+		{
+			if (auto parseResult = parseDebugDataAttributeOperationComment(commentLiteral, m_scanner->currentCommentLocation()))
+			{
+				commentLiteral = parseResult->first;
+				if (parseResult->second.has_value())
+					applyDebugDataAttributePatch(parseResult->second.value());
 			}
 			else
 				break;

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -182,7 +182,7 @@ void Parser::fetchDebugDataFromComment()
 			{
 				commentLiteral = parseResult->first;
 				if (parseResult->second.has_value())
-					applyDebugDataAttributeOperation(m_currentDebugDataAttributes,  parseResult->second.value());
+					applyDebugDataAttributePatch(parseResult->second.value());
 			}
 			else
 				break;
@@ -220,11 +220,16 @@ std::optional<std::pair<std::string_view, std::optional<Json>>> Parser::parseDeb
 	return {{_arguments, jsonData}};
 }
 
-void Parser::applyDebugDataAttributeOperation(Json& _attributes, Json const& _attributeOperation)
+void Parser::applyDebugDataAttributePatch(Json const& _jsonPatch)
 {
-	(void)_attributes;
-	(void)_attributeOperation;
-	std::cout << "attributes='" << _attributes.dump(2) << "' attributeOperation='" << _attributeOperation.dump(2) << "'" << std::endl;
+	if (_jsonPatch.is_object())
+	{
+		Json array = Json::array();
+		array.push_back(_jsonPatch);
+		m_currentDebugDataAttributes = m_currentDebugDataAttributes.patch(array);
+	}
+	else
+		m_currentDebugDataAttributes = m_currentDebugDataAttributes.patch(_jsonPatch);
 }
 
 std::optional<std::pair<std::string_view, SourceLocation>> Parser::parseSrcComment(

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -118,11 +118,12 @@ protected:
 	);
 
 	std::optional<std::pair<std::string_view, std::optional<Json>>> parseDebugDataAttributeOperationComment(
+		std::string const& _command,
 		std::string_view _arguments,
 		langutil::SourceLocation const& _commentLocation
 	);
 
-	void applyDebugDataAttributePatch(Json const& _jsonPatch);
+	void applyDebugDataAttributePatch(Json const& _jsonPatch, langutil::SourceLocation const& _location);
 
 	/// Creates a DebugData object with the correct source location set.
 	langutil::DebugData::ConstPtr createDebugData() const;

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -122,7 +122,7 @@ protected:
 		langutil::SourceLocation const& _commentLocation
 	);
 
-	void applyDebugDataAttributeOperation(Json& _attributes, Json const& _attributeOperation);
+	void applyDebugDataAttributePatch(Json const& _jsonPatch);
 
 	/// Creates a DebugData object with the correct source location set.
 	langutil::DebugData::ConstPtr createDebugData() const;

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -117,6 +117,13 @@ protected:
 		langutil::SourceLocation const& _commentLocation
 	);
 
+	std::optional<std::pair<std::string_view, std::optional<Json>>> parseDebugDataAttributeOperationComment(
+		std::string_view _arguments,
+		langutil::SourceLocation const& _commentLocation
+	);
+
+	void applyDebugDataAttributeOperation(Json& _attributes, Json const& _attributeOperation);
+
 	/// Creates a DebugData object with the correct source location set.
 	langutil::DebugData::ConstPtr createDebugData() const;
 
@@ -163,6 +170,7 @@ private:
 	UseSourceLocationFrom m_useSourceLocationFrom = UseSourceLocationFrom::Scanner;
 	ForLoopComponent m_currentForLoopComponent = ForLoopComponent::None;
 	bool m_insideFunction = false;
+	Json m_currentDebugDataAttributes = Json::object();
 };
 
 }

--- a/libyul/AsmPrinter.h
+++ b/libyul/AsmPrinter.h
@@ -106,6 +106,7 @@ private:
 	langutil::SourceLocation m_lastLocation = {};
 	langutil::DebugInfoSelection m_debugInfoSelection = {};
 	langutil::CharStreamProvider const* m_soliditySourceProvider = nullptr;
+	Json m_currentDebugAttributes;
 };
 
 }

--- a/libyul/backends/evm/AbstractAssembly.h
+++ b/libyul/backends/evm/AbstractAssembly.h
@@ -26,9 +26,9 @@
 #include <libyul/ASTForward.h>
 
 #include <libsolutil/Common.h>
-#include <libsolutil/CommonData.h>
 #include <libsolutil/Numeric.h>
 #include <liblangutil/EVMVersion.h>
+#include <liblangutil/DebugData.h>
 
 #include <functional>
 #include <memory>
@@ -62,6 +62,8 @@ public:
 
 	/// Set a new source location valid starting from the next instruction.
 	virtual void setSourceLocation(langutil::SourceLocation const& _location) = 0;
+	/// Set a new debug attributes for next instruction.
+	virtual void setDebugAttributes(Json const& _debugAttributes) = 0;
 	/// Retrieve the current height of the stack. This does not have to be zero
 	/// at the beginning.
 	virtual int stackHeight() const = 0;

--- a/libyul/backends/evm/EVMCodeTransform.cpp
+++ b/libyul/backends/evm/EVMCodeTransform.cpp
@@ -148,12 +148,14 @@ void CodeTransform::operator()(VariableDeclaration const& _varDecl)
 	else
 	{
 		m_assembly.setSourceLocation(originLocationOf(_varDecl));
+		m_assembly.setDebugAttributes(debugDataOf(_varDecl)->attributes);
 		size_t variablesLeft = numVariables;
 		while (variablesLeft--)
 			m_assembly.appendConstant(u256(0));
 	}
 
 	m_assembly.setSourceLocation(originLocationOf(_varDecl));
+	m_assembly.setDebugAttributes(debugDataOf(_varDecl)->attributes);
 	bool atTopOfStack = true;
 	for (size_t varIndex = 0; varIndex < numVariables; ++varIndex)
 	{
@@ -216,12 +218,14 @@ void CodeTransform::operator()(Assignment const& _assignment)
 	expectDeposit(static_cast<int>(_assignment.variableNames.size()), height);
 
 	m_assembly.setSourceLocation(originLocationOf(_assignment));
+	m_assembly.setDebugAttributes(debugDataOf(_assignment)->attributes);
 	generateMultiAssignment(_assignment.variableNames);
 }
 
 void CodeTransform::operator()(ExpressionStatement const& _statement)
 {
 	m_assembly.setSourceLocation(originLocationOf(_statement));
+	m_assembly.setDebugAttributes(debugDataOf(_statement)->attributes);
 	std::visit(*this, _statement.expression);
 }
 
@@ -230,12 +234,14 @@ void CodeTransform::operator()(FunctionCall const& _call)
 	yulAssert(m_scope, "");
 
 	m_assembly.setSourceLocation(originLocationOf(_call));
+	m_assembly.setDebugAttributes(debugDataOf(_call)->attributes);
 	if (BuiltinFunctionForEVM const* builtin = m_dialect.builtin(_call.functionName.name))
 	{
 		for (auto&& [i, arg]: _call.arguments | ranges::views::enumerate | ranges::views::reverse)
 			if (!builtin->literalArgument(i))
 				visitExpression(arg);
 		m_assembly.setSourceLocation(originLocationOf(_call));
+		m_assembly.setDebugAttributes(debugDataOf(_call)->attributes);
 		builtin->generateCode(_call, m_assembly, m_builtinContext);
 	}
 	else
@@ -253,6 +259,7 @@ void CodeTransform::operator()(FunctionCall const& _call)
 		for (auto const& arg: _call.arguments | ranges::views::reverse)
 			visitExpression(arg);
 		m_assembly.setSourceLocation(originLocationOf(_call));
+		m_assembly.setDebugAttributes(debugDataOf(_call)->attributes);
 		m_assembly.appendJumpTo(
 			functionEntryID(*function),
 			static_cast<int>(function->returns.size() - function->arguments.size()) - 1,
@@ -265,6 +272,7 @@ void CodeTransform::operator()(FunctionCall const& _call)
 void CodeTransform::operator()(Identifier const& _identifier)
 {
 	m_assembly.setSourceLocation(originLocationOf(_identifier));
+	m_assembly.setDebugAttributes(debugDataOf(_identifier)->attributes);
 	// First search internals, then externals.
 	yulAssert(m_scope, "");
 	if (m_scope->lookup(_identifier.name, GenericVisitor{
@@ -297,6 +305,7 @@ void CodeTransform::operator()(Identifier const& _identifier)
 void CodeTransform::operator()(Literal const& _literal)
 {
 	m_assembly.setSourceLocation(originLocationOf(_literal));
+	m_assembly.setDebugAttributes(debugDataOf(_literal)->attributes);
 	m_assembly.appendConstant(valueOfLiteral(_literal));
 }
 
@@ -304,11 +313,13 @@ void CodeTransform::operator()(If const& _if)
 {
 	visitExpression(*_if.condition);
 	m_assembly.setSourceLocation(originLocationOf(_if));
+	m_assembly.setDebugAttributes(debugDataOf(_if)->attributes);
 	m_assembly.appendInstruction(evmasm::Instruction::ISZERO);
 	AbstractAssembly::LabelID end = m_assembly.newLabelId();
 	m_assembly.appendJumpToIf(end);
 	(*this)(_if.body);
 	m_assembly.setSourceLocation(originLocationOf(_if));
+	m_assembly.setDebugAttributes(debugDataOf(_if)->attributes);
 	m_assembly.appendLabel(end);
 }
 
@@ -324,6 +335,7 @@ void CodeTransform::operator()(Switch const& _switch)
 		{
 			(*this)(*c.value);
 			m_assembly.setSourceLocation(originLocationOf(c));
+			m_assembly.setDebugAttributes(debugDataOf(c)->attributes);
 			AbstractAssembly::LabelID bodyLabel = m_assembly.newLabelId();
 			caseBodies[&c] = bodyLabel;
 			yulAssert(m_assembly.stackHeight() == expressionHeight + 1, "");
@@ -336,23 +348,27 @@ void CodeTransform::operator()(Switch const& _switch)
 			(*this)(c.body);
 	}
 	m_assembly.setSourceLocation(originLocationOf(_switch));
+	m_assembly.setDebugAttributes(debugDataOf(_switch)->attributes);
 	m_assembly.appendJumpTo(end);
 
 	size_t numCases = caseBodies.size();
 	for (auto const& c: caseBodies)
 	{
 		m_assembly.setSourceLocation(originLocationOf(*c.first));
+		m_assembly.setDebugAttributes(debugDataOf(*c.first)->attributes);
 		m_assembly.appendLabel(c.second);
 		(*this)(c.first->body);
 		// Avoid useless "jump to next" for the last case.
 		if (--numCases > 0)
 		{
 			m_assembly.setSourceLocation(originLocationOf(*c.first));
+			m_assembly.setDebugAttributes(debugDataOf(*c.first)->attributes);
 			m_assembly.appendJumpTo(end);
 		}
 	}
 
 	m_assembly.setSourceLocation(originLocationOf(_switch));
+	m_assembly.setDebugAttributes(debugDataOf(_switch)->attributes);
 	m_assembly.appendLabel(end);
 	m_assembly.appendInstruction(evmasm::Instruction::POP);
 }
@@ -374,6 +390,7 @@ void CodeTransform::operator()(FunctionDefinition const& _function)
 	}
 
 	m_assembly.setSourceLocation(originLocationOf(_function));
+	m_assembly.setDebugAttributes(debugDataOf(_function)->attributes);
 	int const stackHeightBefore = m_assembly.stackHeight();
 
 	m_assembly.appendLabel(functionEntryID(function));
@@ -414,6 +431,7 @@ void CodeTransform::operator()(FunctionDefinition const& _function)
 	m_assignedNamedLabels = std::move(subTransform.m_assignedNamedLabels);
 
 	m_assembly.setSourceLocation(originLocationOf(_function));
+	m_assembly.setDebugAttributes(debugDataOf(_function)->attributes);
 	if (!subTransform.m_stackErrors.empty())
 	{
 		m_assembly.markAsInvalid();
@@ -505,10 +523,12 @@ void CodeTransform::operator()(ForLoop const& _forLoop)
 	AbstractAssembly::LabelID loopEnd = m_assembly.newLabelId();
 
 	m_assembly.setSourceLocation(originLocationOf(_forLoop));
+	m_assembly.setDebugAttributes(debugDataOf(_forLoop)->attributes);
 	m_assembly.appendLabel(loopStart);
 
 	visitExpression(*_forLoop.condition);
 	m_assembly.setSourceLocation(originLocationOf(_forLoop));
+	m_assembly.setDebugAttributes(debugDataOf(_forLoop)->attributes);
 	m_assembly.appendInstruction(evmasm::Instruction::ISZERO);
 	m_assembly.appendJumpToIf(loopEnd);
 
@@ -517,11 +537,13 @@ void CodeTransform::operator()(ForLoop const& _forLoop)
 	(*this)(_forLoop.body);
 
 	m_assembly.setSourceLocation(originLocationOf(_forLoop));
+	m_assembly.setDebugAttributes(debugDataOf(_forLoop)->attributes);
 	m_assembly.appendLabel(postPart);
 
 	(*this)(_forLoop.post);
 
 	m_assembly.setSourceLocation(originLocationOf(_forLoop));
+	m_assembly.setDebugAttributes(debugDataOf(_forLoop)->attributes);
 	m_assembly.appendJumpTo(loopStart);
 	m_assembly.appendLabel(loopEnd);
 
@@ -542,6 +564,7 @@ void CodeTransform::operator()(Break const& _break)
 {
 	yulAssert(!m_context->forLoopStack.empty(), "Invalid break-statement. Requires surrounding for-loop in code generation.");
 	m_assembly.setSourceLocation(originLocationOf(_break));
+	m_assembly.setDebugAttributes(debugDataOf(_break)->attributes);
 
 	Context::JumpInfo const& jump = m_context->forLoopStack.top().done;
 	m_assembly.appendJumpTo(jump.label, appendPopUntil(jump.targetStackHeight));
@@ -551,6 +574,7 @@ void CodeTransform::operator()(Continue const& _continue)
 {
 	yulAssert(!m_context->forLoopStack.empty(), "Invalid continue-statement. Requires surrounding for-loop in code generation.");
 	m_assembly.setSourceLocation(originLocationOf(_continue));
+	m_assembly.setDebugAttributes(debugDataOf(_continue)->attributes);
 
 	Context::JumpInfo const& jump = m_context->forLoopStack.top().post;
 	m_assembly.appendJumpTo(jump.label, appendPopUntil(jump.targetStackHeight));
@@ -561,6 +585,7 @@ void CodeTransform::operator()(Leave const& _leaveStatement)
 	yulAssert(m_functionExitLabel, "Invalid leave-statement. Requires surrounding function in code generation.");
 	yulAssert(m_functionExitStackHeight, "");
 	m_assembly.setSourceLocation(originLocationOf(_leaveStatement));
+	m_assembly.setDebugAttributes(debugDataOf(_leaveStatement)->attributes);
 	m_assembly.appendJumpTo(*m_functionExitLabel, appendPopUntil(*m_functionExitStackHeight));
 }
 
@@ -697,6 +722,7 @@ void CodeTransform::visitStatements(std::vector<Statement> const& _statements)
 		if (functionDefinition && !jumpTarget)
 		{
 			m_assembly.setSourceLocation(originLocationOf(*functionDefinition));
+			m_assembly.setDebugAttributes(debugDataOf(*functionDefinition)->attributes);
 			jumpTarget = m_assembly.newLabelId();
 			m_assembly.appendJumpTo(*jumpTarget, 0);
 		}
@@ -718,6 +744,7 @@ void CodeTransform::visitStatements(std::vector<Statement> const& _statements)
 void CodeTransform::finalizeBlock(Block const& _block, std::optional<int> blockStartStackHeight)
 {
 	m_assembly.setSourceLocation(originLocationOf(_block));
+	m_assembly.setDebugAttributes(debugDataOf(_block)->attributes);
 
 	freeUnusedVariables();
 

--- a/libyul/backends/evm/EthAssemblyAdapter.cpp
+++ b/libyul/backends/evm/EthAssemblyAdapter.cpp
@@ -48,6 +48,11 @@ void EthAssemblyAdapter::setSourceLocation(SourceLocation const& _location)
 	m_assembly.setSourceLocation(_location);
 }
 
+void EthAssemblyAdapter::setDebugAttributes(Json const& _debugAttributes)
+{
+	m_assembly.setDebugAttributes(_debugAttributes);
+}
+
 int EthAssemblyAdapter::stackHeight() const
 {
 	return m_assembly.deposit();

--- a/libyul/backends/evm/EthAssemblyAdapter.h
+++ b/libyul/backends/evm/EthAssemblyAdapter.h
@@ -41,6 +41,7 @@ class EthAssemblyAdapter: public AbstractAssembly
 public:
 	explicit EthAssemblyAdapter(evmasm::Assembly& _assembly);
 	void setSourceLocation(langutil::SourceLocation const& _location) override;
+	void setDebugAttributes(Json const& _debugAttributes) override;
 	int stackHeight() const override;
 	void setStackHeight(int height) override;
 	void appendInstruction(evmasm::Instruction _instruction) override;

--- a/libyul/backends/evm/NoOutputAssembly.h
+++ b/libyul/backends/evm/NoOutputAssembly.h
@@ -49,6 +49,7 @@ public:
 	~NoOutputAssembly() override = default;
 
 	void setSourceLocation(langutil::SourceLocation const&) override {}
+	void setDebugAttributes(Json const&) override {}
 	int stackHeight() const override { return m_stackHeight; }
 	void setStackHeight(int height) override { m_stackHeight = height; }
 	void appendInstruction(evmasm::Instruction _instruction) override;

--- a/libyul/backends/evm/OptimizedEVMCodeTransform.cpp
+++ b/libyul/backends/evm/OptimizedEVMCodeTransform.cpp
@@ -90,6 +90,7 @@ void OptimizedEVMCodeTransform::operator()(CFG::FunctionCall const& _call)
 	// Emit code.
 	{
 		m_assembly.setSourceLocation(originLocationOf(_call));
+		m_assembly.setDebugAttributes(debugDataOf(_call)->attributes);
 		m_assembly.appendJumpTo(
 			getFunctionLabel(_call.function),
 			static_cast<int>(_call.function.get().returns.size() - _call.function.get().arguments.size()) - (_call.canContinue ? 1 : 0),
@@ -134,6 +135,7 @@ void OptimizedEVMCodeTransform::operator()(CFG::BuiltinCall const& _call)
 	// Emit code.
 	{
 		m_assembly.setSourceLocation(originLocationOf(_call));
+		m_assembly.setDebugAttributes(debugDataOf(_call)->attributes);
 		static_cast<BuiltinFunctionForEVM const&>(_call.builtin.get()).generateCode(
 			_call.functionCall,
 			m_assembly,
@@ -249,7 +251,9 @@ void OptimizedEVMCodeTransform::createStackLayout(langutil::DebugData::ConstPtr 
 	yulAssert(m_assembly.stackHeight() == static_cast<int>(m_stack.size()), "");
 	// ::createStackLayout asserts that it has successfully achieved the target layout.
 	langutil::SourceLocation sourceLocation = _debugData ? _debugData->originLocation : langutil::SourceLocation{};
+	Json debugAttributes = _debugData ? _debugData->attributes : Json::object();
 	m_assembly.setSourceLocation(sourceLocation);
+	m_assembly.setDebugAttributes(debugAttributes);
 	::createStackLayout(
 		m_stack,
 		_targetStack | ranges::to<Stack>,
@@ -317,8 +321,10 @@ void OptimizedEVMCodeTransform::createStackLayout(langutil::DebugData::ConstPtr 
 				[&](LiteralSlot const& _literal)
 				{
 					m_assembly.setSourceLocation(originLocationOf(_literal));
+					m_assembly.setDebugAttributes(debugDataOf(_literal)->attributes);
 					m_assembly.appendConstant(_literal.value);
 					m_assembly.setSourceLocation(sourceLocation);
+					m_assembly.setDebugAttributes(debugAttributes);
 				},
 				[&](FunctionReturnLabelSlot const&)
 				{
@@ -329,16 +335,20 @@ void OptimizedEVMCodeTransform::createStackLayout(langutil::DebugData::ConstPtr 
 					if (!m_returnLabels.count(&_returnLabel.call.get()))
 						m_returnLabels[&_returnLabel.call.get()] = m_assembly.newLabelId();
 					m_assembly.setSourceLocation(originLocationOf(_returnLabel.call.get()));
+					m_assembly.setDebugAttributes(debugDataOf(_returnLabel.call.get())->attributes);
 					m_assembly.appendLabelReference(m_returnLabels.at(&_returnLabel.call.get()));
 					m_assembly.setSourceLocation(sourceLocation);
+					m_assembly.setDebugAttributes(debugAttributes);
 				},
 				[&](VariableSlot const& _variable)
 				{
 					if (m_currentFunctionInfo && util::contains(m_currentFunctionInfo->returnVariables, _variable))
 					{
 						m_assembly.setSourceLocation(originLocationOf(_variable));
+						m_assembly.setDebugAttributes(debugDataOf(_variable)->attributes);
 						m_assembly.appendConstant(0);
 						m_assembly.setSourceLocation(sourceLocation);
+						m_assembly.setDebugAttributes(debugAttributes);
 						return;
 					}
 					yulAssert(false, "Variable not found on stack.");
@@ -372,6 +382,7 @@ void OptimizedEVMCodeTransform::operator()(CFG::BasicBlock const& _block)
 	yulAssert(m_generated.insert(&_block).second, "");
 
 	m_assembly.setSourceLocation(originLocationOf(_block));
+	m_assembly.setDebugAttributes(debugDataOf(_block)->attributes);
 	auto const& blockInfo = m_stackLayout.blockInfos.at(&_block);
 
 	// Assert that the stack is valid for entering the block.
@@ -412,6 +423,7 @@ void OptimizedEVMCodeTransform::operator()(CFG::BasicBlock const& _block)
 
 	// Exit the block.
 	m_assembly.setSourceLocation(originLocationOf(_block));
+	m_assembly.setDebugAttributes(debugDataOf(_block)->attributes);
 	std::visit(util::GenericVisitor{
 		[&](CFG::BasicBlock::MainExit const&)
 		{
@@ -531,6 +543,7 @@ void OptimizedEVMCodeTransform::operator()(CFG::FunctionInfo const& _functionInf
 	m_assembly.setStackHeight(static_cast<int>(m_stack.size()));
 
 	m_assembly.setSourceLocation(originLocationOf(_functionInfo));
+	m_assembly.setDebugAttributes(debugDataOf(_functionInfo)->attributes);
 	m_assembly.appendLabel(getFunctionLabel(_functionInfo.function));
 
 	// Create the entry layout of the function body block and visit.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -158,6 +158,8 @@ set(libyul_sources
     libyul/SyntaxTest.cpp
     libyul/YulInterpreterTest.cpp
     libyul/YulInterpreterTest.h
+    libyul/YulOptimizerAssemblyTest.cpp
+    libyul/YulOptimizerAssemblyTest.h
     libyul/YulOptimizerTest.cpp
     libyul/YulOptimizerTest.h
     libyul/YulOptimizerTestCommon.cpp

--- a/test/InteractiveTests.h
+++ b/test/InteractiveTests.h
@@ -31,6 +31,7 @@
 #include <test/libsolidity/SMTCheckerTest.h>
 #include <test/libyul/ControlFlowGraphTest.h>
 #include <test/libyul/EVMCodeTransformTest.h>
+#include <test/libyul/YulOptimizerAssemblyTest.h>
 #include <test/libyul/YulOptimizerTest.h>
 #include <test/libyul/YulInterpreterTest.h>
 #include <test/libyul/ObjectCompilerTest.h>
@@ -63,6 +64,7 @@ Testsuite const g_interactiveTestsuites[] = {
 /*
 	Title                           Path           Subpath                          SMT   NeedsVM Creator function */
 	{"Yul Optimizer",               "libyul",      "yulOptimizerTests",             false, false, &yul::test::YulOptimizerTest::create},
+	{"Yul Optimizer with Assembly", "libyul",      "yulOptimizerAssemblyTests",     false, false, &yul::test::YulOptimizerAssemblyTest::create},
 	{"Yul Interpreter",             "libyul",      "yulInterpreterTests",           false, false, &yul::test::YulInterpreterTest::create},
 	{"Yul Object Compiler",         "libyul",      "objectCompiler",                false, false, &yul::test::ObjectCompilerTest::create},
 	{"Yul Control Flow Graph",      "libyul",      "yulControlFlowGraph",           false, false, &yul::test::ControlFlowGraphTest::create},

--- a/test/cmdlineTests/strict_asm_debug_attributes_merge/args
+++ b/test/cmdlineTests/strict_asm_debug_attributes_merge/args
@@ -1,0 +1,1 @@
+--strict-assembly --ir-optimized --asm

--- a/test/cmdlineTests/strict_asm_debug_attributes_merge/input.yul
+++ b/test/cmdlineTests/strict_asm_debug_attributes_merge/input.yul
@@ -1,0 +1,29 @@
+object "object" {
+    code {
+        {
+            /// @debug.merge {"scope": 1}
+            let a
+            /// @debug.merge {"assignment": 1}
+            a := z()
+            /// @debug.merge {"assignment": null}
+            let b
+            /// @debug.merge {"assignment": 2}
+            b := z_1()
+            /// @debug.merge {"assignment": null}
+            sstore(a, b)
+            /// @debug.merge {"scope": null}
+        }
+        function z() -> y
+        {
+            /// @debug.merge {"scope": 2}
+            y := calldataload(0)
+            /// @debug.merge {"scope": null}
+        }
+        function z_1() -> y
+        {
+            /// @debug.merge {"scope": 3}
+            y := calldataload(0x20)
+            /// @debug.merge {"scope": null}
+        }
+    }
+}

--- a/test/cmdlineTests/strict_asm_debug_attributes_merge/output
+++ b/test/cmdlineTests/strict_asm_debug_attributes_merge/output
@@ -1,0 +1,66 @@
+
+======= strict_asm_debug_attributes_merge/input.yul (EVM) =======
+
+Pretty printed source:
+object "object" {
+    code {
+        {
+            /// @debug.set {"scope":1}
+            let a
+            /// @debug.set {"assignment":1,"scope":1}
+            a := z()
+            /// @debug.set {"scope":1}
+            let b
+            /// @debug.set {"assignment":2,"scope":1}
+            b := z_1()
+            /// @debug.set {"scope":1}
+            sstore(a, b)
+        }
+        function z() -> y
+        {
+            /// @debug.set {"scope":2}
+            y := calldataload(0)
+        }
+        function z_1() -> y
+        {
+            /// @debug.set {"scope":3}
+            y := calldataload(0x20)
+        }
+    }
+}
+
+
+Text representation:
+    /* "strict_asm_debug_attributes_merge/input.yul":163:166   */
+  tag_3  // @debug.set {"assignment":1,"scope":1}
+  tag_1  // @debug.set {"assignment":1,"scope":1}
+  jump	// in  // @debug.set {"assignment":1,"scope":1}
+tag_3:  // @debug.set {"assignment":1,"scope":1}
+    /* "strict_asm_debug_attributes_merge/input.yul":299:304   */
+  tag_4  // @debug.set {"assignment":2,"scope":1}
+  tag_2  // @debug.set {"assignment":2,"scope":1}
+  jump	// in  // @debug.set {"assignment":2,"scope":1}
+tag_4:  // @debug.set {"assignment":2,"scope":1}
+    /* "strict_asm_debug_attributes_merge/input.yul":367:379   */
+  swap1  // @debug.set {"scope":1}
+  sstore  // @debug.set {"scope":1}
+    /* "strict_asm_debug_attributes_merge/input.yul":27:777   */
+  stop
+    /* "strict_asm_debug_attributes_merge/input.yul":443:600   */
+tag_1:
+    /* "strict_asm_debug_attributes_merge/input.yul":543:544   */
+  0x00  // @debug.set {"scope":2}
+    /* "strict_asm_debug_attributes_merge/input.yul":530:545   */
+  calldataload  // @debug.set {"scope":2}
+    /* "strict_asm_debug_attributes_merge/input.yul":443:600   */
+  swap1
+  jump	// out
+    /* "strict_asm_debug_attributes_merge/input.yul":609:771   */
+tag_2:
+    /* "strict_asm_debug_attributes_merge/input.yul":711:715   */
+  0x20  // @debug.set {"scope":3}
+    /* "strict_asm_debug_attributes_merge/input.yul":698:716   */
+  calldataload  // @debug.set {"scope":3}
+    /* "strict_asm_debug_attributes_merge/input.yul":609:771   */
+  swap1
+  jump	// out

--- a/test/cmdlineTests/strict_asm_debug_attributes_patch/args
+++ b/test/cmdlineTests/strict_asm_debug_attributes_patch/args
@@ -1,0 +1,1 @@
+--strict-assembly --ir-optimized --asm

--- a/test/cmdlineTests/strict_asm_debug_attributes_patch/input.yul
+++ b/test/cmdlineTests/strict_asm_debug_attributes_patch/input.yul
@@ -1,0 +1,29 @@
+object "object" {
+    code {
+        {
+            /// @debug.patch  {"op": "add", "path": "/scope", "value": 1}
+            let a
+            /// @debug.patch  {"op": "add", "path": "/assignment", "value": 1}
+            a := z()
+            /// @debug.patch  {"op": "remove", "path": "/assignment"}
+            let b
+            /// @debug.patch  {"op": "add", "path": "/assignment", "value": 2}
+            b := z_1()
+            /// @debug.patch  {"op": "remove", "path": "/assignment"}
+            sstore(a, b)
+            /// @debug.patch  {"op": "remove", "path": "/scope"}
+        }
+        function z() -> y
+        {
+            /// @debug.patch  {"op": "add", "path": "/scope", "value": 2}
+            y := calldataload(0)
+            /// @debug.patch  {"op": "remove", "path": "/scope"}
+        }
+        function z_1() -> y
+        {
+            /// @debug.patch  {"op": "add", "path": "/scope", "value": 3}
+            y := calldataload(0x20)
+            /// @debug.patch  {"op": "remove", "path": "/scope"}
+        }
+    }
+}

--- a/test/cmdlineTests/strict_asm_debug_attributes_patch/output
+++ b/test/cmdlineTests/strict_asm_debug_attributes_patch/output
@@ -1,0 +1,66 @@
+
+======= strict_asm_debug_attributes_patch/input.yul (EVM) =======
+
+Pretty printed source:
+object "object" {
+    code {
+        {
+            /// @debug.set {"scope":1}
+            let a
+            /// @debug.set {"assignment":1,"scope":1}
+            a := z()
+            /// @debug.set {"scope":1}
+            let b
+            /// @debug.set {"assignment":2,"scope":1}
+            b := z_1()
+            /// @debug.set {"scope":1}
+            sstore(a, b)
+        }
+        function z() -> y
+        {
+            /// @debug.set {"scope":2}
+            y := calldataload(0)
+        }
+        function z_1() -> y
+        {
+            /// @debug.set {"scope":3}
+            y := calldataload(0x20)
+        }
+    }
+}
+
+
+Text representation:
+    /* "strict_asm_debug_attributes_patch/input.yul":227:230   */
+  tag_3  // @debug.set {"assignment":1,"scope":1}
+  tag_1  // @debug.set {"assignment":1,"scope":1}
+  jump	// in  // @debug.set {"assignment":1,"scope":1}
+tag_3:  // @debug.set {"assignment":1,"scope":1}
+    /* "strict_asm_debug_attributes_patch/input.yul":415:420   */
+  tag_4  // @debug.set {"assignment":2,"scope":1}
+  tag_2  // @debug.set {"assignment":2,"scope":1}
+  jump	// in  // @debug.set {"assignment":2,"scope":1}
+tag_4:  // @debug.set {"assignment":2,"scope":1}
+    /* "strict_asm_debug_attributes_patch/input.yul":503:515   */
+  swap1  // @debug.set {"scope":1}
+  sstore  // @debug.set {"scope":1}
+    /* "strict_asm_debug_attributes_patch/input.yul":27:1037   */
+  stop
+    /* "strict_asm_debug_attributes_patch/input.yul":599:808   */
+tag_1:
+    /* "strict_asm_debug_attributes_patch/input.yul":731:732   */
+  0x00  // @debug.set {"scope":2}
+    /* "strict_asm_debug_attributes_patch/input.yul":718:733   */
+  calldataload  // @debug.set {"scope":2}
+    /* "strict_asm_debug_attributes_patch/input.yul":599:808   */
+  swap1
+  jump	// out
+    /* "strict_asm_debug_attributes_patch/input.yul":817:1031   */
+tag_2:
+    /* "strict_asm_debug_attributes_patch/input.yul":951:955   */
+  0x20  // @debug.set {"scope":3}
+    /* "strict_asm_debug_attributes_patch/input.yul":938:956   */
+  calldataload  // @debug.set {"scope":3}
+    /* "strict_asm_debug_attributes_patch/input.yul":817:1031   */
+  swap1
+  jump	// out

--- a/test/cmdlineTests/strict_asm_debug_attributes_set/args
+++ b/test/cmdlineTests/strict_asm_debug_attributes_set/args
@@ -1,0 +1,1 @@
+--strict-assembly --ir-optimized --asm

--- a/test/cmdlineTests/strict_asm_debug_attributes_set/input.yul
+++ b/test/cmdlineTests/strict_asm_debug_attributes_set/input.yul
@@ -1,0 +1,29 @@
+object "object" {
+    code {
+        {
+            /// @debug.set {"scope": 1}
+            let a
+            /// @debug.set {"scope": 1, "assignment": 1}
+            a := z()
+            /// @debug.set {"scope": 1}
+            let b
+            /// @debug.set {"scope": 1, "assignment": 2}
+            b := z_1()
+            /// @debug.set {"scope": 1}
+            sstore(a, b)
+            /// @debug.set {}
+        }
+        function z() -> y
+        {
+            /// @debug.set {"scope": 2}
+            y := calldataload(0)
+            /// @debug.set {}
+        }
+        function z_1() -> y
+        {
+            /// @debug.set {"scope": 3}
+            y := calldataload(0x20)
+            /// @debug.set {}
+        }
+    }
+}

--- a/test/cmdlineTests/strict_asm_debug_attributes_set/output
+++ b/test/cmdlineTests/strict_asm_debug_attributes_set/output
@@ -1,0 +1,66 @@
+
+======= strict_asm_debug_attributes_set/input.yul (EVM) =======
+
+Pretty printed source:
+object "object" {
+    code {
+        {
+            /// @debug.set {"scope":1}
+            let a
+            /// @debug.set {"assignment":1,"scope":1}
+            a := z()
+            /// @debug.set {"scope":1}
+            let b
+            /// @debug.set {"assignment":2,"scope":1}
+            b := z_1()
+            /// @debug.set {"scope":1}
+            sstore(a, b)
+        }
+        function z() -> y
+        {
+            /// @debug.set {"scope":2}
+            y := calldataload(0)
+        }
+        function z_1() -> y
+        {
+            /// @debug.set {"scope":3}
+            y := calldataload(0x20)
+        }
+    }
+}
+
+
+Text representation:
+    /* "strict_asm_debug_attributes_set/input.yul":171:174   */
+  tag_3  // @debug.set {"assignment":1,"scope":1}
+  tag_1  // @debug.set {"assignment":1,"scope":1}
+  jump	// in  // @debug.set {"assignment":1,"scope":1}
+tag_3:  // @debug.set {"assignment":1,"scope":1}
+    /* "strict_asm_debug_attributes_set/input.yul":307:312   */
+  tag_4  // @debug.set {"assignment":2,"scope":1}
+  tag_2  // @debug.set {"assignment":2,"scope":1}
+  jump	// in  // @debug.set {"assignment":2,"scope":1}
+tag_4:  // @debug.set {"assignment":2,"scope":1}
+    /* "strict_asm_debug_attributes_set/input.yul":365:377   */
+  swap1  // @debug.set {"scope":1}
+  sstore  // @debug.set {"scope":1}
+    /* "strict_asm_debug_attributes_set/input.yul":27:726   */
+  stop
+    /* "strict_asm_debug_attributes_set/input.yul":426:566   */
+tag_1:
+    /* "strict_asm_debug_attributes_set/input.yul":524:525   */
+  0x00  // @debug.set {"scope":2}
+    /* "strict_asm_debug_attributes_set/input.yul":511:526   */
+  calldataload  // @debug.set {"scope":2}
+    /* "strict_asm_debug_attributes_set/input.yul":426:566   */
+  swap1
+  jump	// out
+    /* "strict_asm_debug_attributes_set/input.yul":575:720   */
+tag_2:
+    /* "strict_asm_debug_attributes_set/input.yul":675:679   */
+  0x20  // @debug.set {"scope":3}
+    /* "strict_asm_debug_attributes_set/input.yul":662:680   */
+  calldataload  // @debug.set {"scope":3}
+    /* "strict_asm_debug_attributes_set/input.yul":575:720   */
+  swap1
+  jump	// out

--- a/test/libyul/YulOptimizerAssemblyTest.cpp
+++ b/test/libyul/YulOptimizerAssemblyTest.cpp
@@ -1,0 +1,146 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <test/libyul/YulOptimizerAssemblyTest.h>
+#include <test/libyul/YulOptimizerTestCommon.h>
+
+#include <test/libsolidity/util/SoltestErrors.h>
+#include <test/libyul/Common.h>
+#include <test/Common.h>
+
+#include <libyul/Object.h>
+#include <libyul/AsmPrinter.h>
+
+#include <liblangutil/CharStreamProvider.h>
+#include <liblangutil/SourceReferenceFormatter.h>
+#include <liblangutil/Scanner.h>
+
+#include <libsolutil/AnsiColorized.h>
+#include <libsolutil/StringUtils.h>
+
+#include <libyul/YulStack.h>
+#include <libyul/AsmAnalysis.h>
+#include <libyul/AsmAnalysisInfo.h>
+#include <libyul/backends/evm/EVMDialect.h>
+#include <libyul/backends/evm/EthAssemblyAdapter.h>
+#include <libyul/backends/evm/EVMObjectCompiler.h>
+
+#include <libevmasm/Assembly.h>
+
+#include <fstream>
+
+using namespace solidity;
+using namespace solidity::util;
+using namespace solidity::langutil;
+using namespace solidity::yul;
+using namespace solidity::yul::test;
+using namespace solidity::frontend;
+using namespace solidity::frontend::test;
+
+YulOptimizerAssemblyTest::YulOptimizerAssemblyTest(std::string const& _filename):
+	EVMVersionRestrictedTestCase(_filename)
+{
+	boost::filesystem::path path(_filename);
+
+	if (path.empty() || std::next(path.begin()) == path.end() || std::next(std::next(path.begin())) == path.end())
+		BOOST_THROW_EXCEPTION(std::runtime_error("Filename path has to contain a directory: \"" + _filename + "\"."));
+	m_optimizerStep = std::prev(std::prev(path.end()))->string();
+
+	m_source = m_reader.source();
+
+	auto dialectName = m_reader.stringSetting("dialect", "evm");
+	m_dialect = &dialect(dialectName, solidity::test::CommonOptions::get().evmVersion());
+
+	m_expectation = m_reader.simpleExpectations();
+}
+
+TestCase::TestResult YulOptimizerAssemblyTest::run(std::ostream& _stream, std::string const& _linePrefix, bool const _formatted)
+{
+	std::tie(m_object, m_analysisInfo) = parse(_stream, _linePrefix, _formatted, m_source);
+	if (!m_object)
+		return TestResult::FatalError;
+
+	soltestAssert(m_dialect, "Dialect not set.");
+
+	m_object->analysisInfo = m_analysisInfo;
+	YulOptimizerTestCommon tester(m_object, *m_dialect);
+	tester.setStep(m_optimizerStep);
+
+	if (!tester.runStep())
+	{
+		AnsiColorized(_stream, _formatted, {formatting::BOLD, formatting::RED}) << _linePrefix << "Invalid optimizer step: " << m_optimizerStep << std::endl;
+		return TestResult::FatalError;
+	}
+
+	auto const printed = (m_object->subObjects.empty() ? AsmPrinter{ *m_dialect }(*m_object->code) : m_object->toString(m_dialect));
+
+	// Re-parse new code for compilability
+	// TODO: support for wordSizeTransform which needs different input and output dialects
+	if (m_optimizerStep != "wordSizeTransform" && !std::get<0>(parse(_stream, _linePrefix, _formatted, printed)))
+	{
+		util::AnsiColorized(_stream, _formatted, {util::formatting::BOLD, util::formatting::CYAN})
+			<< _linePrefix << "Result after the optimiser:" << std::endl;
+		printPrefixed(_stream, printed, _linePrefix + "  ");
+		return TestResult::FatalError;
+	}
+
+	m_obtainedResult = "step: " + m_optimizerStep + "\n\n" + printed + "\n";
+
+	m_object->analysisInfo = std::make_shared<AsmAnalysisInfo>(
+		AsmAnalyzer::analyzeStrictAssertCorrect(EVMDialect::strictAssemblyForEVMObjects(solidity::test::CommonOptions::get().evmVersion()), *m_object)
+	);
+
+	evmasm::Assembly assembly{solidity::test::CommonOptions::get().evmVersion(), false, {}};
+	EthAssemblyAdapter adapter(assembly);
+	EVMObjectCompiler::compile(
+		*m_object,
+		adapter,
+		EVMDialect::strictAssemblyForEVMObjects(EVMVersion{}),
+		false,
+		std::nullopt
+	);
+
+	std::ostringstream output;
+	output << assembly;
+	m_obtainedResult += "\nAssembly:\n" + output.str();
+
+	return checkResult(_stream, _linePrefix, _formatted);
+}
+
+std::pair<std::shared_ptr<Object>, std::shared_ptr<AsmAnalysisInfo>> YulOptimizerAssemblyTest::parse(
+	std::ostream& _stream,
+	std::string const& _linePrefix,
+	bool const _formatted,
+	std::string const& _source
+)
+{
+	ErrorList errors;
+	soltestAssert(m_dialect, "");
+	std::shared_ptr<Object> object;
+	std::shared_ptr<AsmAnalysisInfo> analysisInfo;
+	std::tie(object, analysisInfo) = yul::test::parse(_source, *m_dialect, errors);
+	if (!object || !analysisInfo || Error::containsErrors(errors))
+	{
+		AnsiColorized(_stream, _formatted, {formatting::BOLD, formatting::RED}) << _linePrefix << "Error parsing source." << std::endl;
+		CharStream charStream(_source, "");
+		SourceReferenceFormatter{_stream, SingletonCharStreamProvider(charStream), true, false}
+			.printErrorInformation(errors);
+		return {};
+	}
+	return {std::move(object), std::move(analysisInfo)};
+}

--- a/test/libyul/YulOptimizerAssemblyTest.h
+++ b/test/libyul/YulOptimizerAssemblyTest.h
@@ -1,0 +1,63 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <test/TestCase.h>
+
+namespace solidity::langutil
+{
+class Error;
+using ErrorList = std::vector<std::shared_ptr<Error const>>;
+}
+
+namespace solidity::yul
+{
+struct AsmAnalysisInfo;
+struct Object;
+struct Dialect;
+}
+
+namespace solidity::yul::test
+{
+
+class YulOptimizerAssemblyTest: public solidity::frontend::test::EVMVersionRestrictedTestCase
+{
+public:
+	static std::unique_ptr<TestCase> create(Config const& _config)
+	{
+		return std::make_unique<YulOptimizerAssemblyTest>(_config.filename);
+	}
+
+	explicit YulOptimizerAssemblyTest(std::string const& _filename);
+
+	TestResult run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
+private:
+	std::pair<std::shared_ptr<Object>, std::shared_ptr<AsmAnalysisInfo>> parse(
+		std::ostream& _stream, std::string const& _linePrefix, bool const _formatted, std::string const& _source
+	);
+
+	std::string m_optimizerStep;
+
+	Dialect const* m_dialect = nullptr;
+
+	std::shared_ptr<Object> m_object;
+	std::shared_ptr<AsmAnalysisInfo> m_analysisInfo;
+};
+
+}

--- a/test/libyul/yulOptimizerAssemblyTests/blockFlattener/basic.yul
+++ b/test/libyul/yulOptimizerAssemblyTests/blockFlattener/basic.yul
@@ -1,0 +1,62 @@
+{
+    {
+        let _1 := mload(0)
+        let f_a := mload(1)
+        let f_r
+        {
+            f_a := mload(f_a)
+            f_r := add(f_a, calldatasize())
+        }
+        let z := mload(2)
+    }
+}
+// ----
+// step: blockFlattener
+//
+// {
+//     {
+//         let _1 := mload(0)
+//         let f_a := mload(1)
+//         let f_r
+//         f_a := mload(f_a)
+//         f_r := add(f_a, calldatasize())
+//         let z := mload(2)
+//     }
+// }
+//
+// Assembly:
+//     /* "":32:33   */
+//   0x00
+//     /* "":26:34   */
+//   mload
+//     /* "":60:61   */
+//   0x01
+//     /* "":54:62   */
+//   mload
+//     /* "":71:78   */
+//   0x00
+//     /* "":114:117   */
+//   dup2
+//     /* "":108:118   */
+//   mload
+//     /* "":101:118   */
+//   swap2
+//   pop
+//     /* "":147:161   */
+//   calldatasize
+//     /* "":142:145   */
+//   dup3
+//     /* "":138:162   */
+//   add
+//     /* "":131:162   */
+//   swap1
+//   pop
+//     /* "":196:197   */
+//   0x02
+//     /* "":190:198   */
+//   mload
+//     /* "":6:204   */
+//   pop
+//   pop
+//   pop
+//   pop

--- a/test/libyul/yulOptimizerAssemblyTests/blockFlattener/ethdebug_attributes.yul
+++ b/test/libyul/yulOptimizerAssemblyTests/blockFlattener/ethdebug_attributes.yul
@@ -1,0 +1,68 @@
+{
+    {
+        let _1 := mload(0)
+        let f_a := mload(1)
+        let f_r
+        {
+            /// @debug.set {"scope":1}
+            f_a := mload(f_a)
+            f_r := add(f_a, calldatasize())
+        }
+        {
+            /// @debug.set {"scope":2}
+            let z := mload(2)
+        }
+    }
+}
+// ----
+// step: blockFlattener
+//
+// {
+//     {
+//         let _1 := mload(0)
+//         let f_a := mload(1)
+//         let f_r
+//         /// @debug.set {"scope":1}
+//         f_a := mload(f_a)
+//         f_r := add(f_a, calldatasize())
+//         /// @debug.set {"scope":2}
+//         let z := mload(2)
+//     }
+// }
+//
+// Assembly:
+//     /* "":32:33   */
+//   0x00
+//     /* "":26:34   */
+//   mload
+//     /* "":60:61   */
+//   0x01
+//     /* "":54:62   */
+//   mload
+//     /* "":71:78   */
+//   0x00
+//     /* "":153:156   */
+//   dup2  // @debug.set {"scope":1}
+//     /* "":147:157   */
+//   mload  // @debug.set {"scope":1}
+//     /* "":140:157   */
+//   swap2  // @debug.set {"scope":1}
+//   pop  // @debug.set {"scope":1}
+//     /* "":186:200   */
+//   calldatasize  // @debug.set {"scope":1}
+//     /* "":181:184   */
+//   dup3  // @debug.set {"scope":1}
+//     /* "":177:201   */
+//   add  // @debug.set {"scope":1}
+//     /* "":170:201   */
+//   swap1  // @debug.set {"scope":1}
+//   pop  // @debug.set {"scope":1}
+//     /* "":288:289   */
+//   0x02  // @debug.set {"scope":2}
+//     /* "":282:290   */
+//   mload  // @debug.set {"scope":2}
+//     /* "":6:306   */
+//   pop
+//   pop
+//   pop
+//   pop

--- a/test/libyul/yulSyntaxTests/invalid/invalid_debug_merge.yul
+++ b/test/libyul/yulSyntaxTests/invalid/invalid_debug_merge.yul
@@ -1,0 +1,7 @@
+object "object" {
+    code {
+        /// @debug.merge {"HELLO": 2
+    }
+}
+// ----
+// SyntaxError 5721: (37-65): @debug.merge: Could not parse debug data: parse error at line 1, column 12: syntax error while parsing object - unexpected end of input; expected '}'

--- a/test/libyul/yulSyntaxTests/invalid/invalid_debug_patch.yul
+++ b/test/libyul/yulSyntaxTests/invalid/invalid_debug_patch.yul
@@ -1,0 +1,7 @@
+object "object" {
+    code {
+        /// @debug.patch {"HELLO": invalid
+    }
+}
+// ----
+// SyntaxError 5721: (37-71): @debug.patch: Could not parse debug data: parse error at line 1, column 11: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal

--- a/test/libyul/yulSyntaxTests/invalid/invalid_debug_patch_patch_object.yul
+++ b/test/libyul/yulSyntaxTests/invalid/invalid_debug_patch_patch_object.yul
@@ -1,0 +1,7 @@
+object "object" {
+    code {
+        /// @debug.patch { "op": "unknown_operation", "path": "/variable_a", "value": ["test"] }
+    }
+}
+// ----
+// SyntaxError 9426: (37-125): @debug.patch: Could not patch debug data: parse error: operation value 'unknown_operation' is invalid

--- a/test/libyul/yulSyntaxTests/invalid/invalid_debug_set.yul
+++ b/test/libyul/yulSyntaxTests/invalid/invalid_debug_set.yul
@@ -1,0 +1,7 @@
+object "object" {
+    code {
+        /// @debug.set {"HELLO": "WORLD
+    }
+}
+// ----
+// SyntaxError 5721: (37-68): @debug.set: Could not parse debug data: parse error at line 1, column 17: syntax error while parsing value - invalid string: missing closing quote; last read: '"WORLD'

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(isoltest
 	../libyul/StackShufflingTest.cpp
 	../libyul/StackLayoutGeneratorTest.cpp
 	../libyul/YulOptimizerTest.cpp
+	../libyul/YulOptimizerAssemblyTest.cpp
 	../libyul/YulOptimizerTestCommon.cpp
 	../libyul/YulInterpreterTest.cpp
 )


### PR DESCRIPTION
Depends on #14969 and #15009.

(#15009 is just cherry-picked here and should be removed once merged)

See https://notes.ethereum.org/lznAP49lRj6zrLJdLpkqwg.

# Block Flattening
## Effect
```
{
    {   
        ...A...
    }
    {
        ...B...
    }
}
```
--->
```
{
    ...A...
    ...B...
}
```

## Relevance
None. Scopes in yul don't carry any information relevant to ethdebug.

## Implementation
This PR just adds a simple test. No additional logic for the treatment of debug attributes needed.