### PR TITLE
Transport debug data through common subexpression eliminator

### DIFF
--- a/libyul/optimiser/CommonSubexpressionEliminator.cpp
+++ b/libyul/optimiser/CommonSubexpressionEliminator.cpp
@@ -120,6 +120,25 @@ void CommonSubexpressionEliminator::visit(Expression& _e)
 				// We check for syntactic equality again because the value might have changed.
 				if (inScope(variable) && SyntacticallyEqual{}(_e, *value->value))
 				{
+					if (debugDataOf(*value->value))
+					{
+						langutil::DebugData::Attributes mergedDebugAttributes;
+						if (debugDataOf(*value->value)->attributes.has_value())
+							mergedDebugAttributes = debugDataOf(*value->value)->attributes;
+						if (debugDataOf(_e) && mergedDebugAttributes.has_value())
+						{
+							for (auto const& i: debugDataOf(_e)->attributes.value())
+								mergedDebugAttributes->emplace_back(i);
+							_e = Identifier{
+								langutil::DebugData::create(
+									debugDataOf(_e)->nativeLocation,
+									debugDataOf(_e)->originLocation,
+									debugDataOf(_e)->astID,
+									mergedDebugAttributes),
+								variable};
+							break;
+						}
+					}
 					_e = Identifier{debugDataOf(_e), variable};
 					break;
 				}

--- a/test/libyul/YulOptimizerAssemblyTest.h
+++ b/test/libyul/YulOptimizerAssemblyTest.h
@@ -48,7 +48,16 @@ public:
 
 	TestResult run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
 private:
+	std::pair<std::shared_ptr<Object>, std::shared_ptr<AsmAnalysisInfo>> parse(
+		std::ostream& _stream, std::string const& _linePrefix, bool const _formatted, std::string const& _source
+	);
+
 	std::string m_optimizerStep;
+
+	Dialect const* m_dialect = nullptr;
+
+	std::shared_ptr<Object> m_object;
+	std::shared_ptr<AsmAnalysisInfo> m_analysisInfo;
 };
 
 }

--- a/test/libyul/yulOptimizerAssemblyTests/commonSubexpressionEliminator/basic.yul
+++ b/test/libyul/yulOptimizerAssemblyTests/commonSubexpressionEliminator/basic.yul
@@ -1,0 +1,24 @@
+{
+    let a := /** @debug.set {"assignment":"a"} */ mul(1, codesize()) /** @debug.set {} */
+    let b := /** @debug.set {"assignment":"b"} */ mul(1, codesize()) /** @debug.set {} */
+}
+// ----
+// step: commonSubexpressionEliminator
+//
+// {
+//     let a := /** @debug.set {"assignment":"a"} */ mul(1, codesize())
+//     let b := a
+// }
+//
+// Assembly:
+//     /* "":59:69   */
+//   codesize   // @debug.set {"assignment":"a"}
+//     /* "":56:57   */
+//   0x01   // @debug.set {"assignment":"a"}
+//     /* "":52:70   */
+//   mul   // @debug.set {"assignment":"a"}
+//     /* "":142:160   */
+//   dup1   // @debug.set [{"assignment":"a"},{"assignment":"b"}]
+//     /* "":0:183   */
+//   pop
+//   pop

--- a/test/libyul/yulOptimizerAssemblyTests/commonSubexpressionEliminator/function.yul
+++ b/test/libyul/yulOptimizerAssemblyTests/commonSubexpressionEliminator/function.yul
@@ -1,0 +1,66 @@
+{
+    function f(a, b)
+    {
+    }
+    let x := /** @debug.set {"id": 0} */ 42 /** @debug.set {} */
+    let y := /** @debug.set {"id":" 1"} */ add(sload(42), calldataload(0)) /** @debug.set {} */
+    let z := /** @debug.set {"id":"2"} */ 42 /** @debug.set {} */
+    f(/** @debug.set {"f": 0} */ 42, /** @debug.set {"f": 1} */add(sload(42), /** @debug.set {"f": 2} */calldataload(0))) /** @debug.set {} */
+}
+// ----
+// step: commonSubexpressionEliminator
+//
+// {
+//     let x := /** @debug.set {"id":0} */ 42
+//     let y := /** @debug.set {"id":" 1"} */ add(sload(x), /** @debug.set {"id":" 1"} */ calldataload(0))
+//     let z := x
+//     f(x, /** @debug.set {"f":1} */ add(sload(x), /** @debug.set {"f":2} */ calldataload(0)))
+//     function f(a, b)
+//     { }
+// }
+//
+// Assembly:
+//     /* "":76:78   */
+//   0x2a   // @debug.set {"id":0}
+//     /* "":171:172   */
+//   0x00   // @debug.set {"id":" 1"}
+//     /* "":158:173   */
+//   calldataload   // @debug.set {"id":" 1"}
+//     /* "":153:155   */
+//   dup2   // @debug.set [{"id":0},{"id":" 1"}]
+//     /* "":147:156   */
+//   sload   // @debug.set {"id":" 1"}
+//     /* "":143:174   */
+//   add   // @debug.set {"id":" 1"}
+//     /* "":238:240   */
+//   dup2   // @debug.set [{"id":0},{"id":"2"}]
+//     /* "":266:383   */
+//   tag_2
+//     /* "":379:380   */
+//   0x00   // @debug.set {"f":2}
+//     /* "":366:381   */
+//   calldataload   // @debug.set {"f":2}
+//     /* "":335:337   */
+//   dup5   // @debug.set [{"id":0},{"f":1}]
+//     /* "":329:338   */
+//   sload   // @debug.set {"f":1}
+//     /* "":325:382   */
+//   add   // @debug.set {"f":1}
+//     /* "":295:297   */
+//   dup5   // @debug.set [{"id":0},{"f":0}]
+//     /* "":266:383   */
+//   tag_1
+//   jump	// in
+// tag_2:
+//     /* "":6:34   */
+//   jump(tag_3)
+// tag_1:
+//   pop
+//   pop
+// tag_4:
+//   jump	// out
+// tag_3:
+//     /* "":0:406   */
+//   pop
+//   pop
+//   pop


### PR DESCRIPTION
Depends on #14969 and #15009.

(#15009 is just cherry-picked here and should be removed once merged)

See https://notes.ethereum.org/lznAP49lRj6zrLJdLpkqwg.

# CommonSubExpressionEliminator
## Effect
```
{
    let x := 42
    let y := add(sload(42), calldataload(0))
    ....
    let z := 42
    ....
    
    f(42, add(sload(42), calldataload(0)))
}
```
---->
```
{
    let x := 42
    let y := add(sload(42), calldataload(0))
    ....
    let z := x
    ...    
    f(x, y)
}
```
Arbitrarily complex expressions that we know to evaluate to a value currently in a yul variable can be replaced by a yul variable. This can happen through complex control flow (into branches, across loops, etc.) and across arbitrary distances.

## Relevance
Very High. This is one of the main aspects of moving things around together with Rematerializing (see below). Especially when done in sequence, we loose a strict division between variable and value. For the optimizer the concepts fuse.
TODO: need to elaborate in more complex examples. There may appear to be simple solutions like only preserving the debugging info of the replaced expression, but in more complex examples it should become apparent that the distinction cannot be reasonably kept up across multiple optimizations.

## Implementation
TBD.