### PR TITLE
Remove redundant prerequisite steps from the default optimizer sequence

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Language Features:
 
 Compiler Features:
+* Yul Optimizer: Remove redundant prerequisite steps from the default optimizer sequence.
 
 Bugfixes:
 

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -349,7 +349,7 @@ Input Description
               // In particular if the whole value consists only of the delimiter, both sequences are empty.
               // Note that there are several hard-coded steps that always run, even when both sequences are empty.
               // For more information see "The Optimizer > Selecting Optimizations".
-              "optimizerSteps": "dhfoDgvulfnTUtnIf..."
+              "optimizerSteps": "dfDvulfnTUtnIf..."
             }
           }
         },

--- a/libsolidity/interface/OptimiserSettings.h
+++ b/libsolidity/interface/OptimiserSettings.h
@@ -42,7 +42,7 @@ enum class OptimisationPreset
 struct OptimiserSettings
 {
 	static char constexpr DefaultYulOptimiserSteps[] =
-		"dhfoDgvulfnTUtnIf"            // None of these can make stack problems worse
+		"dfDvulfnTUtnIf"               // None of these can make stack problems worse
 
 		"xa[r]EscLM"                   // Turn into SSA and simplify
 		"Vcul [j]"                     // Reverse SSA
@@ -51,13 +51,13 @@ struct OptimiserSettings
 
 		"Trpeul"                       // Run functional expression inliner
 		"xa[r]cL"                      // Turn into SSA again and simplify
-		"gvifM"                        // Run full inliner
+		"vifM"                         // Run full inliner
 		"CTUca[r]LSsTFOtfDnca[r]Iulc"  // SSA plus simplify
 
 		"scCTUt"
-		"gvifM"                        // Run full inliner
+		"vifM"                         // Run full inliner
 		"x[scCTUt] TOntnfDIul"         // Perform structural simplification
-		"gvifM"                        // Run full inliner
+		"vifM"                         // Run full inliner
 
 		"jmul[jul] VcTOcul jmul";      // Make source short and pretty
 


### PR DESCRIPTION
Since `gho` steps are hard-coded as prerequisites, there's not much point in having them in the default sequence. All other steps are supposed to preserve these properties.

For now this is just to verify that removing them does not really change generated bytecode in a meaningful way.

If this is true, we might consider merging it, though that would probably be better done only after rebasing it on the new sequence (#15030). Otherwise merging it would just revert it.