### PR TITLE
Update bytecode size test for byzantium.

### DIFF
--- a/test/libsolidity/syntaxTests/sizeLimits/bytecode_too_large_byzantium.sol
+++ b/test/libsolidity/syntaxTests/sizeLimits/bytecode_too_large_byzantium.sol
@@ -7,4 +7,4 @@ contract test {
 // ====
 // EVMVersion: =byzantium
 // ----
-// Warning 5574: (0-27133): Contract code size is 27221 bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on Mainnet. Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.
+// Warning 5574: (0-27133): Contract code size is 27220 bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on Mainnet. Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.


### PR DESCRIPTION
Should fix the nightly CI failure.
https://circleci.com/gh/ethereum/solidity/1542038

Depends on the deprecated EVM version test run passing in https://github.com/ethereum/solidity/pull/15101