### PR TITLE
Add header include for docker builds.

### DIFF
--- a/liblangutil/Token.h
+++ b/liblangutil/Token.h
@@ -42,6 +42,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iosfwd>
 #include <string>
 #include <tuple>


### PR DESCRIPTION
Can be confirmed by running
``scripts/docker_deploy_manual.sh dockertest``
(while ``scripts/docker_deploy_manual.sh develop`` fails currently)