### PR TITLE
Update PPA release script.

### DIFF
--- a/scripts/deps-ppa/static_z3.sh
+++ b/scripts/deps-ppa/static_z3.sh
@@ -41,7 +41,7 @@ sourcePPAConfig
 # Sanity check
 checkDputEntries "\[cpp-build-deps\]"
 
-DISTRIBUTIONS="focal jammy mantic"
+DISTRIBUTIONS="focal jammy mantic noble"
 
 for distribution in $DISTRIBUTIONS
 do

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -68,7 +68,7 @@ packagename=solc
 # This needs to be a still active release
 static_build_distribution=focal
 
-DISTRIBUTIONS="focal jammy mantic"
+DISTRIBUTIONS="focal jammy mantic noble"
 
 if is_release
 then
@@ -125,7 +125,8 @@ mv solidity solc
 
 # Fetch dependencies
 mkdir -p ./solc/deps/downloads/ 2>/dev/null || true
-wget -O ./solc/deps/downloads/jsoncpp-1.9.3.tar.gz https://github.com/open-source-parsers/jsoncpp/archive/1.9.3.tar.gz
+mkdir -p ./solc/deps/nlohmann/nlohmann/ 2>/dev/null || true
+wget -O ./solc/deps/nlohmann/nlohmann/json.hpp https://github.com/nlohmann/json/releases/download/v3.11.3/json.hpp
 wget -O ./solc/deps/downloads/range-v3-0.12.0.tar.gz https://github.com/ericniebler/range-v3/archive/0.12.0.tar.gz
 wget -O ./solc/deps/downloads/fmt-9.1.0.tar.gz https://github.com/fmtlib/fmt/archive/9.1.0.tar.gz
 


### PR DESCRIPTION
We can do this after the release if need be and just locally use this copy of the script, although having it merged would be nicer.
Mantic, Jammy and Focal builds have passed.
Update: Noble also passed, so all is good.
