### PR TITLE
Remove `using namespace std` from testing tools, ossfuzz and yulPhaser

### DIFF
--- a/scripts/check_style.sh
+++ b/scripts/check_style.sh
@@ -50,8 +50,12 @@ NAMESPACE_STD_FREE_FILES=(
     test/libsolidity/util/*
     test/libyul/*
     test/solc/*
+    test/tools/*
+    test/tools/ossfuzz/*
+    test/tools/ossfuzz/protomutators/*
     test/tools/yulInterpreter/*
     test/yulPhaser/*
+    tools/yulPhaser/*
 )
 
 (

--- a/test/tools/afl_fuzzer.cpp
+++ b/test/tools/afl_fuzzer.cpp
@@ -28,7 +28,6 @@
 #include <string>
 #include <iostream>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::util;
 
@@ -60,11 +59,11 @@ Allowed options)",
 		)
 		(
 			"input-file",
-			po::value<string>(),
+			po::value<std::string>(),
 			"input file"
 		)(
 			"input-files",
-			po::value<std::vector<string>>()->multitoken(),
+			po::value<std::vector<std::string>>()->multitoken(),
 			"input files"
 		)
 		(
@@ -86,7 +85,7 @@ Allowed options)",
 	}
 	catch (po::error const& _exception)
 	{
-		cerr << _exception.what() << endl;
+		std::cerr << _exception.what() << std::endl;
 		return 1;
 	}
 
@@ -95,26 +94,26 @@ Allowed options)",
 
 	if (arguments.count("help"))
 	{
-		cout << options;
+		std::cout << options;
 		return 0;
 	}
 
-	vector<string> inputs;
+	std::vector<std::string> inputs;
 	if (arguments.count("input-file"))
-		inputs.push_back(arguments["input-file"].as<string>());
+		inputs.push_back(arguments["input-file"].as<std::string>());
 	else if (arguments.count("input-files"))
-		inputs = arguments["input-files"].as<vector<string>>();
+		inputs = arguments["input-files"].as<std::vector<std::string>>();
 	else
 		inputs.emplace_back("");
 
 	bool optimize = !arguments.count("without-optimizer");
 	int retResult = 0;
 
-	for (string const& inputFile: inputs)
+	for (std::string const& inputFile: inputs)
 	{
-		string input;
+		std::string input;
 		if (inputFile.size() == 0)
-			input = readUntilEnd(cin);
+			input = readUntilEnd(std::cin);
 		else
 			input = readFileAsString(inputFile);
 
@@ -134,7 +133,7 @@ Allowed options)",
 			if (inputFile.size() == 0)
 				throw;
 
-			cerr << "Fuzzer "
+			std::cerr << "Fuzzer "
 				<< (optimize ? "" : "(without optimizer) ")
 				<< "failed on "
 				<< inputFile;

--- a/test/tools/fuzzer_common.cpp
+++ b/test/tools/fuzzer_common.cpp
@@ -33,14 +33,13 @@
 
 #include <sstream>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::evmasm;
 using namespace solidity::frontend;
 using namespace solidity::langutil;
 using namespace solidity::util;
 
-static vector<EVMVersion> s_evmVersions = {
+static std::vector<EVMVersion> s_evmVersions = {
 	EVMVersion::homestead(),
 	EVMVersion::tangerineWhistle(),
 	EVMVersion::spuriousDragon(),
@@ -53,10 +52,10 @@ static vector<EVMVersion> s_evmVersions = {
 	EVMVersion::paris()
 };
 
-void FuzzerUtil::testCompilerJsonInterface(string const& _input, bool _optimize, bool _quiet)
+void FuzzerUtil::testCompilerJsonInterface(std::string const& _input, bool _optimize, bool _quiet)
 {
 	if (!_quiet)
-		cout << "Testing compiler " << (_optimize ? "with" : "without") << " optimizer." << endl;
+		std::cout << "Testing compiler " << (_optimize ? "with" : "without") << " optimizer." << std::endl;
 
 	Json config;
 	config["language"] = "Solidity";
@@ -82,7 +81,7 @@ void FuzzerUtil::forceSMT(StringMap& _input)
 	// Add SMT checker pragma if not already present in source
 	static auto constexpr smtPragma = "pragma experimental SMTChecker;";
 	for (auto &sourceUnit: _input)
-		if (sourceUnit.second.find(smtPragma) == string::npos)
+		if (sourceUnit.second.find(smtPragma) == std::string::npos)
 			sourceUnit.second += smtPragma;
 }
 
@@ -144,13 +143,13 @@ void FuzzerUtil::testCompiler(
 	}
 }
 
-void FuzzerUtil::runCompiler(string const& _input, bool _quiet)
+void FuzzerUtil::runCompiler(std::string const& _input, bool _quiet)
 {
 	if (!_quiet)
-		cout << "Input JSON: " << _input << endl;
-	string outputString(solidity_compile(_input.c_str(), nullptr, nullptr));
+		std::cout << "Input JSON: " << _input << std::endl;
+	std::string outputString(solidity_compile(_input.c_str(), nullptr, nullptr));
 	if (!_quiet)
-		cout << "Output JSON: " << outputString << endl;
+		std::cout << "Output JSON: " << outputString << std::endl;
 
 	// This should be safe given the above copies the output.
 	solidity_reset();
@@ -158,32 +157,32 @@ void FuzzerUtil::runCompiler(string const& _input, bool _quiet)
 	Json output;
 	if (!jsonParseStrict(outputString, output))
 	{
-		string msg{"Compiler produced invalid JSON output."};
-		cout << msg << endl;
+		std::string msg{"Compiler produced invalid JSON output."};
+		std::cout << msg << std::endl;
 		BOOST_THROW_EXCEPTION(std::runtime_error(std::move(msg)));
 	}
 	if (output.contains("errors"))
 		for (auto const& error: output["errors"])
 		{
-			string invalid = findAnyOf(error["type"].get<std::string>(), vector<string>{
+			std::string invalid = findAnyOf(error["type"].get<std::string>(), std::vector<std::string>{
 					"Exception",
 					"InternalCompilerError"
 			});
 			if (!invalid.empty())
 			{
-				string msg = "Invalid error: \"" + error["type"].get<std::string>() + "\"";
-				cout << msg << endl;
+				std::string msg = "Invalid error: \"" + error["type"].get<std::string>() + "\"";
+				std::cout << msg << std::endl;
 				BOOST_THROW_EXCEPTION(std::runtime_error(std::move(msg)));
 			}
 		}
 }
 
-void FuzzerUtil::testConstantOptimizer(string const& _input, bool _quiet)
+void FuzzerUtil::testConstantOptimizer(std::string const& _input, bool _quiet)
 {
 	if (!_quiet)
-		cout << "Testing constant optimizer" << endl;
-	vector<u256> numbers;
-	stringstream sin(_input);
+		std::cout << "Testing constant optimizer" << std::endl;
+	std::vector<u256> numbers;
+	std::stringstream sin(_input);
 
 	while (!sin.eof())
 	{
@@ -192,7 +191,7 @@ void FuzzerUtil::testConstantOptimizer(string const& _input, bool _quiet)
 		numbers.push_back(u256(data));
 	}
 	if (!_quiet)
-		cout << "Got " << numbers.size() << " inputs:" << endl;
+		std::cout << "Got " << numbers.size() << " inputs:" << std::endl;
 
 	for (bool isCreation: {false, true})
 	{
@@ -200,7 +199,7 @@ void FuzzerUtil::testConstantOptimizer(string const& _input, bool _quiet)
 		for (u256 const& n: numbers)
 		{
 			if (!_quiet)
-				cout << n << endl;
+				std::cout << n << std::endl;
 			assembly.append(n);
 		}
 		for (unsigned runs: {1u, 2u, 3u, 20u, 40u, 100u, 200u, 400u, 1000u})
@@ -217,10 +216,10 @@ void FuzzerUtil::testConstantOptimizer(string const& _input, bool _quiet)
 	}
 }
 
-void FuzzerUtil::testStandardCompiler(string const& _input, bool _quiet)
+void FuzzerUtil::testStandardCompiler(std::string const& _input, bool _quiet)
 {
 	if (!_quiet)
-		cout << "Testing compiler via JSON interface." << endl;
+		std::cout << "Testing compiler via JSON interface." << std::endl;
 
 	runCompiler(_input, _quiet);
 }

--- a/test/tools/ossfuzz/AbiV2IsabelleFuzzer.cpp
+++ b/test/tools/ossfuzz/AbiV2IsabelleFuzzer.cpp
@@ -29,7 +29,6 @@ using namespace solidity::test::abiv2fuzzer;
 using namespace solidity::test;
 using namespace solidity::util;
 using namespace solidity;
-using namespace std;
 
 static constexpr size_t abiCoderHeapSize = 1024 * 512;
 static evmc::VM evmone = evmc::VM{evmc_create_evmone()};
@@ -37,18 +36,18 @@ static evmc::VM evmone = evmc::VM{evmc_create_evmone()};
 DEFINE_PROTO_FUZZER(Contract const& _contract)
 {
 	ProtoConverter converter(_contract.seed());
-	string contractSource = converter.contractToString(_contract);
+	std::string contractSource = converter.contractToString(_contract);
 
 	if (const char* dump_path = getenv("PROTO_FUZZER_DUMP_PATH"))
 	{
 		// With libFuzzer binary run this to generate the solidity source file x.sol from a proto input:
 		// PROTO_FUZZER_DUMP_PATH=x.sol ./a.out proto-input
-		ofstream of(dump_path);
+		std::ofstream of(dump_path);
 		of << contractSource;
 	}
 
-	string typeString = converter.isabelleTypeString();
-	string valueString = converter.isabelleValueString();
+	std::string typeString = converter.isabelleTypeString();
+	std::string valueString = converter.isabelleValueString();
 	abicoder::ABICoder coder(abiCoderHeapSize);
 	if (!typeString.empty() && converter.coderFunction())
 	{
@@ -58,7 +57,7 @@ DEFINE_PROTO_FUZZER(Contract const& _contract)
 		// We target the default EVM which is the latest
 		langutil::EVMVersion version;
 		EVMHost hostContext(version, evmone);
-		string contractName = "C";
+		std::string contractName = "C";
 		StringMap source({{"test.sol", contractSource}});
 		CompilerInput cInput(version, source, contractName, OptimiserSettings::minimal(), {});
 		EvmoneUtility evmoneUtil(

--- a/test/tools/ossfuzz/SolidityCustomMutatorInterface.cpp
+++ b/test/tools/ossfuzz/SolidityCustomMutatorInterface.cpp
@@ -21,7 +21,6 @@
 
 #include <liblangutil/Exceptions.h>
 
-using namespace std;
 using namespace solidity::test::fuzzer::mutator;
 
 // Prototype as we can't use the FuzzerInterface.h header.
@@ -54,17 +53,17 @@ SolidityCustomMutatorInterface::SolidityCustomMutatorInterface(
 	data(_data),
 	size(_size),
 	maxMutantSize(_maxSize),
-	generator(make_shared<SolidityGenerator>(_seed))
+	generator(std::make_shared<SolidityGenerator>(_seed))
 {}
 
 size_t SolidityCustomMutatorInterface::generate()
 {
-	string testCase = generator->generateTestProgram();
+	std::string testCase = generator->generateTestProgram();
 	solAssert(
 		!testCase.empty() && data,
 		"Solc custom mutator: Invalid mutant or memory pointer"
 	);
-	size_t mutantSize = min(testCase.size(), maxMutantSize - 1);
+	size_t mutantSize = std::min(testCase.size(), maxMutantSize - 1);
 	mempcpy(data, testCase.data(), mutantSize);
 	return mutantSize;
 }

--- a/test/tools/ossfuzz/SolidityEvmoneInterface.cpp
+++ b/test/tools/ossfuzz/SolidityEvmoneInterface.cpp
@@ -28,9 +28,8 @@ using namespace solidity::test::fuzzer;
 using namespace solidity::frontend;
 using namespace solidity::langutil;
 using namespace solidity::util;
-using namespace std;
 
-optional<CompilerOutput> SolidityCompilationFramework::compileContract()
+std::optional<CompilerOutput> SolidityCompilationFramework::compileContract()
 {
 	m_compiler.setSources(m_compilerInput.sourceCode);
 	m_compiler.setLibraries(m_compilerInput.libraryAddresses);
@@ -41,8 +40,8 @@ optional<CompilerOutput> SolidityCompilationFramework::compileContract()
 	{
 		if (m_compilerInput.debugFailure)
 		{
-			cerr << "Compiling contract failed" << endl;
-			cerr << SourceReferenceFormatter::formatErrorInformation(
+			std::cerr << "Compiling contract failed" << std::endl;
+			std::cerr << SourceReferenceFormatter::formatErrorInformation(
 				m_compiler.errors(),
 				m_compiler
 			);
@@ -51,7 +50,7 @@ optional<CompilerOutput> SolidityCompilationFramework::compileContract()
 	}
 	else
 	{
-		string contractName;
+		std::string contractName;
 		if (m_compilerInput.contractName.empty())
 			contractName = m_compiler.lastContractName();
 		else
@@ -103,7 +102,7 @@ evmc::Result EvmoneUtility::deployContract(bytes const& _code)
 
 evmc::Result EvmoneUtility::deployAndExecute(
 	bytes const& _byteCode,
-	string const& _hexEncodedInput
+	std::string const& _hexEncodedInput
 )
 {
 	// Deploy contract and signal failure if deploy failed
@@ -128,9 +127,9 @@ evmc::Result EvmoneUtility::deployAndExecute(
 	return callResult;
 }
 
-evmc::Result EvmoneUtility::compileDeployAndExecute(string _fuzzIsabelle)
+evmc::Result EvmoneUtility::compileDeployAndExecute(std::string _fuzzIsabelle)
 {
-	map<string, h160> libraryAddressMap;
+	std::map<std::string, h160> libraryAddressMap;
 	// Stage 1: Compile and deploy library if present.
 	if (!m_libraryName.empty())
 	{
@@ -158,7 +157,7 @@ evmc::Result EvmoneUtility::compileDeployAndExecute(string _fuzzIsabelle)
 		"SolidityEvmoneInterface: Invalid compilation output."
 	);
 
-	string methodName;
+	std::string methodName;
 	if (!_fuzzIsabelle.empty())
 		// TODO: Remove this once a cleaner solution is found for querying
 		// isabelle test entry point. At the moment, we are sure that the
@@ -175,7 +174,7 @@ evmc::Result EvmoneUtility::compileDeployAndExecute(string _fuzzIsabelle)
 	);
 }
 
-optional<CompilerOutput> EvmoneUtility::compileContract()
+std::optional<CompilerOutput> EvmoneUtility::compileContract()
 {
 	try
 	{

--- a/test/tools/ossfuzz/SolidityGenerator.cpp
+++ b/test/tools/ossfuzz/SolidityGenerator.cpp
@@ -23,7 +23,6 @@
 
 using namespace solidity::test::fuzzer::mutator;
 using namespace solidity::util;
-using namespace std;
 
 GeneratorBase::GeneratorBase(std::shared_ptr<SolidityGenerator> _mutator)
 {
@@ -32,11 +31,11 @@ GeneratorBase::GeneratorBase(std::shared_ptr<SolidityGenerator> _mutator)
 	uRandDist = mutator->uniformRandomDist();
 }
 
-string GeneratorBase::visitChildren()
+std::string GeneratorBase::visitChildren()
 {
-	ostringstream os;
+	std::ostringstream os;
 	// Randomise visit order
-	vector<GeneratorPtr> randomisedChildren;
+	std::vector<GeneratorPtr> randomisedChildren;
 	for (auto const& child: generators)
 		randomisedChildren.push_back(child);
 	shuffle(randomisedChildren.begin(), randomisedChildren.end(), *uRandDist->randomEngine);
@@ -47,7 +46,7 @@ string GeneratorBase::visitChildren()
 	return os.str();
 }
 
-string TestState::randomPath(set<string> const& _sourceUnitPaths) const
+std::string TestState::randomPath(std::set<std::string> const& _sourceUnitPaths) const
 {
 	auto it = _sourceUnitPaths.begin();
 	/// Advance iterator by n where 0 <= n <= sourceUnitPaths.size() - 1
@@ -60,7 +59,7 @@ string TestState::randomPath(set<string> const& _sourceUnitPaths) const
 	return *it;
 }
 
-string TestState::randomPath() const
+std::string TestState::randomPath() const
 {
 	solAssert(!empty(), "Solc custom mutator: Null test state");
 	return randomPath(sourceUnitPaths);
@@ -73,20 +72,20 @@ void TestState::print(std::ostream& _os) const
 		_os << "Source path: " << item << std::endl;
 }
 
-string TestState::randomNonCurrentPath() const
+std::string TestState::randomNonCurrentPath() const
 {
 	/// To obtain a source path that is not the currently visited
 	/// source unit itself, we require at least one other source
 	/// unit to be previously visited.
 	solAssert(size() >= 2, "Solc custom mutator: Invalid test state");
 
-	set<string> filteredSourcePaths;
-	string currentPath = currentSourceUnitPath;
-	copy_if(
+	std::set<std::string> filteredSourcePaths;
+	std::string currentPath = currentSourceUnitPath;
+	std::copy_if(
 		sourceUnitPaths.begin(),
 		sourceUnitPaths.end(),
 		inserter(filteredSourcePaths, filteredSourcePaths.begin()),
-		[currentPath](string const& _item) {
+		[currentPath](std::string const& _item) {
 			return _item != currentPath;
 		}
 	);
@@ -100,12 +99,12 @@ void TestCaseGenerator::setup()
 	});
 }
 
-string TestCaseGenerator::visit()
+std::string TestCaseGenerator::visit()
 {
-	ostringstream os;
+	std::ostringstream os;
 	for (unsigned i = 0; i < uRandDist->distributionOneToN(s_maxSourceUnits); i++)
 	{
-		string sourcePath = path();
+		std::string sourcePath = path();
 		os << "\n"
 			<< "==== Source: "
 			<< sourcePath
@@ -126,32 +125,32 @@ void SourceUnitGenerator::setup()
 	});
 }
 
-string SourceUnitGenerator::visit()
+std::string SourceUnitGenerator::visit()
 {
 	return visitChildren();
 }
 
-string PragmaGenerator::visit()
+std::string PragmaGenerator::visit()
 {
 	static constexpr const char* preamble = R"(
 		pragma solidity >= 0.0.0;
 		pragma experimental SMTChecker;
 	)";
 	// Choose equally at random from coder v1 and v2
-	string abiPragma = "pragma abicoder v" +
-		to_string(uRandDist->distributionOneToN(2)) +
+	std::string abiPragma = "pragma abicoder v" +
+		std::to_string(uRandDist->distributionOneToN(2)) +
 		";\n";
 	return preamble + abiPragma;
 }
 
-string ImportGenerator::visit()
+std::string ImportGenerator::visit()
 {
 	/*
 	 * Case 1: No source units defined
 	 * Case 2: One source unit defined
 	 * Case 3: At least two source units defined
 	 */
-	ostringstream os;
+	std::ostringstream os;
 	// Self import with a small probability only if
 	// there is one source unit present in test.
 	if (state->size() == 1)
@@ -175,19 +174,19 @@ string ImportGenerator::visit()
 }
 
 template <typename T>
-shared_ptr<T> SolidityGenerator::generator()
+std::shared_ptr<T> SolidityGenerator::generator()
 {
 	for (auto& g: m_generators)
-		if (holds_alternative<shared_ptr<T>>(g))
-			return get<shared_ptr<T>>(g);
+		if (std::holds_alternative<std::shared_ptr<T>>(g))
+			return std::get<std::shared_ptr<T>>(g);
 	solAssert(false, "");
 }
 
 SolidityGenerator::SolidityGenerator(unsigned _seed)
 {
 	m_generators = {};
-	m_urd = make_shared<UniformRandomDistribution>(make_unique<RandomEngine>(_seed));
-	m_state = make_shared<TestState>(m_urd);
+	m_urd = std::make_shared<UniformRandomDistribution>(std::make_unique<RandomEngine>(_seed));
+	m_state = std::make_shared<TestState>(m_urd);
 }
 
 template <size_t I>
@@ -200,14 +199,14 @@ void SolidityGenerator::createGenerators()
 	}
 }
 
-string SolidityGenerator::generateTestProgram()
+std::string SolidityGenerator::generateTestProgram()
 {
 	createGenerators();
 	for (auto& g: m_generators)
 		std::visit(GenericVisitor{
 			[&](auto const& _item) { return _item->setup(); }
 		}, g);
-	string program = generator<TestCaseGenerator>()->generate();
+	std::string program = generator<TestCaseGenerator>()->generate();
 	destroyGenerators();
 	return program;
 }

--- a/test/tools/ossfuzz/StackReuseCodegenFuzzer.cpp
+++ b/test/tools/ossfuzz/StackReuseCodegenFuzzer.cpp
@@ -46,7 +46,6 @@ using namespace solidity::test::fuzzer;
 using namespace solidity::yul;
 using namespace solidity::yul::test::yul_fuzzer;
 using namespace solidity::langutil;
-using namespace std;
 
 static evmc::VM evmone = evmc::VM{evmc_create_evmone()};
 
@@ -80,7 +79,7 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 		filterStatefulInstructions,
 		filterUnboundedLoops
 	);
-	string yul_source = converter.programToString(_input);
+	std::string yul_source = converter.programToString(_input);
 	// Do not fuzz the EVM Version field.
 	// See https://github.com/ethereum/solidity/issues/12590
 	langutil::EVMVersion version;
@@ -89,8 +88,8 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 
 	if (const char* dump_path = getenv("PROTO_FUZZER_DUMP_PATH"))
 	{
-		ofstream of(dump_path);
-		of.write(yul_source.data(), static_cast<streamsize>(yul_source.size()));
+		std::ofstream of(dump_path);
+		of.write(yul_source.data(), static_cast<std::streamsize>(yul_source.size()));
 	}
 
 	YulStringRepository::reset();
@@ -103,7 +102,7 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 	bool unoptimizedStackTooDeep = false;
 	try
 	{
-		YulAssembler assembler{version, nullopt, settings, yul_source};
+		YulAssembler assembler{version, std::nullopt, settings, yul_source};
 		unoptimisedByteCode = assembler.assemble();
 		auto yulObject = assembler.object();
 		recursiveFunction = recursiveFunctionExists(
@@ -116,7 +115,7 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 		unoptimizedStackTooDeep = true;
 	}
 
-	ostringstream unoptimizedState;
+	std::ostringstream unoptimizedState;
 	bool noRevertInSource = true;
 	bool noInvalidInSource = true;
 	if (!unoptimizedStackTooDeep)
@@ -128,8 +127,8 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 		evmc::Result callResult = hostContext.call(callMessage);
 		// If the fuzzer synthesized input does not contain the revert opcode which
 		// we lazily check by string find, the EVM call should not revert.
-		noRevertInSource = yul_source.find("revert") == string::npos;
-		noInvalidInSource = yul_source.find("invalid") == string::npos;
+		noRevertInSource = yul_source.find("revert") == std::string::npos;
+		noInvalidInSource = yul_source.find("invalid") == std::string::npos;
 		if (noInvalidInSource)
 			solAssert(
 				callResult.status_code != EVMC_INVALID_INSTRUCTION,
@@ -157,7 +156,7 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 	bytes optimisedByteCode;
 	try
 	{
-		optimisedByteCode = YulAssembler{version, nullopt, settings, yul_source}.assemble();
+		optimisedByteCode = YulAssembler{version, std::nullopt, settings, yul_source}.assemble();
 	}
 	catch (solidity::yul::StackTooDeepError const&)
 	{
@@ -194,13 +193,13 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 		 (!noInvalidInSource && callResultOpt.status_code == EVMC_INVALID_INSTRUCTION)),
 		"Optimised call failed."
 	);
-	ostringstream optimizedState;
+	std::ostringstream optimizedState;
 	optimizedState << EVMHostPrinter{hostContext, deployResultOpt.create_address}.state();
 
 	if (unoptimizedState.str() != optimizedState.str())
 	{
-		cout << unoptimizedState.str() << endl;
-		cout << optimizedState.str() << endl;
+		std::cout << unoptimizedState.str() << std::endl;
+		std::cout << optimizedState.str() << std::endl;
 		solAssert(
 			false,
 			"State of unoptimised and optimised stack reused code do not match."

--- a/test/tools/ossfuzz/abiV2ProtoFuzzer.cpp
+++ b/test/tools/ossfuzz/abiV2ProtoFuzzer.cpp
@@ -29,27 +29,26 @@ using namespace solidity::test::abiv2fuzzer;
 using namespace solidity::test;
 using namespace solidity::util;
 using namespace solidity;
-using namespace std;
 
 static evmc::VM evmone = evmc::VM{evmc_create_evmone()};
 
 DEFINE_PROTO_FUZZER(Contract const& _input)
 {
-	string contract_source = ProtoConverter{_input.seed()}.contractToString(_input);
+	std::string contract_source = ProtoConverter{_input.seed()}.contractToString(_input);
 
 	if (const char* dump_path = getenv("PROTO_FUZZER_DUMP_PATH"))
 	{
 		// With libFuzzer binary run this to generate the solidity source file x.sol from a proto input:
 		// PROTO_FUZZER_DUMP_PATH=x.sol ./a.out proto-input
-		ofstream of(dump_path);
+		std::ofstream of(dump_path);
 		of << contract_source;
 	}
 
 	// We target the default EVM which is the latest
 	langutil::EVMVersion version;
 	EVMHost hostContext(version, evmone);
-	string contractName = "C";
-	string methodName = "test()";
+	std::string contractName = "C";
+	std::string methodName = "test()";
 	StringMap source({{"test.sol", contract_source}});
 	CompilerInput cInput(version, source, contractName, OptimiserSettings::minimal(), {});
 	EvmoneUtility evmoneUtil(
@@ -67,9 +66,9 @@ DEFINE_PROTO_FUZZER(Contract const& _input)
 		if (!EvmoneUtility::zeroWord(result.output_data, result.output_size))
 		{
 			solidity::bytes res;
-			for (size_t i = 0; i < result.output_size; i++)
+			for (std::size_t i = 0; i < result.output_size; i++)
 				res.push_back(result.output_data[i]);
-			cout << solidity::util::toHex(res) << endl;
+			std::cout << solidity::util::toHex(res) << std::endl;
 			solAssert(
 				false,
 				"Proto ABIv2 fuzzer: ABIv2 coding failure found"

--- a/test/tools/ossfuzz/const_opt_ossfuzz.cpp
+++ b/test/tools/ossfuzz/const_opt_ossfuzz.cpp
@@ -18,8 +18,6 @@
 
 #include <test/tools/fuzzer_common.h>
 
-using namespace std;
-
 // Prototype as we can't use the FuzzerInterface.h header.
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size);
 
@@ -27,7 +25,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 {
 	if (_size <= 250)
 	{
-		string input(reinterpret_cast<char const*>(_data), _size);
+		std::string input(reinterpret_cast<char const*>(_data), _size);
 		FuzzerUtil::testConstantOptimizer(input, /*quiet=*/true);
 	}
 	return 0;

--- a/test/tools/ossfuzz/protoToAbiV2.cpp
+++ b/test/tools/ossfuzz/protoToAbiV2.cpp
@@ -50,14 +50,13 @@ BOOST_PP_REPEAT(32, USINGDECL, 0)
 /// Switch implementation that instantiates case statements for (un)signed
 /// Solidity integer types.
 #define SWITCHIMPL(sign)                                                       \
-	ostringstream stream;                                                      \
+	std::ostringstream stream;                                                      \
 	switch (_intWidth)                                                         \
 	{                                                                          \
 	BOOST_PP_REPEAT(32, CASEIMPL, sign)                                        \
 	}                                                                          \
 	return stream.str();
 
-using namespace std;
 using namespace solidity::util;
 using namespace solidity::test::abiv2fuzzer;
 
@@ -75,17 +74,17 @@ static V integerValue(unsigned _counter)
 		return value;
 }
 
-static string signedIntegerValue(unsigned _counter, unsigned _intWidth)
+static std::string signedIntegerValue(unsigned _counter, unsigned _intWidth)
 {
 	SWITCHIMPL(1)
 }
 
-static string unsignedIntegerValue(unsigned _counter, unsigned _intWidth)
+static std::string unsignedIntegerValue(unsigned _counter, unsigned _intWidth)
 {
 	SWITCHIMPL(0)
 }
 
-static string integerValue(unsigned _counter, unsigned _intWidth, bool _signed)
+static std::string integerValue(unsigned _counter, unsigned _intWidth, bool _signed)
 {
 	if (_signed)
 		return signedIntegerValue(_counter, _intWidth);
@@ -94,10 +93,10 @@ static string integerValue(unsigned _counter, unsigned _intWidth, bool _signed)
 }
 }
 
-string ProtoConverter::getVarDecl(
-	string const& _type,
-	string const& _varName,
-	string const& _qualifier
+std::string ProtoConverter::getVarDecl(
+	std::string const& _type,
+	std::string const& _varName,
+	std::string const& _qualifier
 )
 {
 	// One level of indentation for state variable declarations
@@ -114,7 +113,7 @@ string ProtoConverter::getVarDecl(
 		"\n";
 }
 
-pair<string, string> ProtoConverter::visit(Type const& _type)
+std::pair<std::string, std::string> ProtoConverter::visit(Type const& _type)
 {
 	switch (_type.type_oneof_case())
 	{
@@ -123,11 +122,11 @@ pair<string, string> ProtoConverter::visit(Type const& _type)
 	case Type::kNvtype:
 		return visit(_type.nvtype());
 	case Type::TYPE_ONEOF_NOT_SET:
-		return make_pair("", "");
+		return std::make_pair("", "");
 	}
 }
 
-pair<string, string> ProtoConverter::visit(ValueType const& _type)
+std::pair<std::string, std::string> ProtoConverter::visit(ValueType const& _type)
 {
 	switch (_type.value_type_oneof_case())
 	{
@@ -140,11 +139,11 @@ pair<string, string> ProtoConverter::visit(ValueType const& _type)
 	case ValueType::kAdty:
 		return visit(_type.adty());
 	case ValueType::VALUE_TYPE_ONEOF_NOT_SET:
-		return make_pair("", "");
+		return std::make_pair("", "");
 	}
 }
 
-pair<string, string> ProtoConverter::visit(NonValueType const& _type)
+std::pair<std::string, std::string> ProtoConverter::visit(NonValueType const& _type)
 {
 	switch (_type.nonvalue_type_oneof_case())
 	{
@@ -154,56 +153,56 @@ pair<string, string> ProtoConverter::visit(NonValueType const& _type)
 		if (ValidityVisitor().visit(_type.arrtype()))
 			return visit(_type.arrtype());
 		else
-			return make_pair("", "");
+			return std::make_pair("", "");
 	case NonValueType::kStype:
 		if (ValidityVisitor().visit(_type.stype()))
 			return visit(_type.stype());
 		else
-			return make_pair("", "");
+			return std::make_pair("", "");
 	case NonValueType::NONVALUE_TYPE_ONEOF_NOT_SET:
-		return make_pair("", "");
+		return std::make_pair("", "");
 	}
 }
 
-pair<string, string> ProtoConverter::visit(BoolType const& _type)
+std::pair<std::string, std::string> ProtoConverter::visit(BoolType const& _type)
 {
 	return processType(_type, true);
 }
 
-pair<string, string> ProtoConverter::visit(IntegerType const& _type)
+std::pair<std::string, std::string> ProtoConverter::visit(IntegerType const& _type)
 {
 	return processType(_type, true);
 }
 
-pair<string, string> ProtoConverter::visit(FixedByteType const& _type)
+std::pair<std::string, std::string> ProtoConverter::visit(FixedByteType const& _type)
 {
 	return processType(_type, true);
 }
 
-pair<string, string> ProtoConverter::visit(AddressType const& _type)
+std::pair<std::string, std::string> ProtoConverter::visit(AddressType const& _type)
 {
 	return processType(_type, true);
 }
 
-pair<string, string> ProtoConverter::visit(DynamicByteArrayType const& _type)
+std::pair<std::string, std::string> ProtoConverter::visit(DynamicByteArrayType const& _type)
 {
 	return processType(_type, false);
 }
 
-pair<string, string> ProtoConverter::visit(ArrayType const& _type)
+std::pair<std::string, std::string> ProtoConverter::visit(ArrayType const& _type)
 {
 	return processType(_type, false);
 }
 
-pair<string, string> ProtoConverter::visit(StructType const& _type)
+std::pair<std::string, std::string> ProtoConverter::visit(StructType const& _type)
 {
 	return processType(_type, false);
 }
 
 template <typename T>
-pair<string, string> ProtoConverter::processType(T const& _type, bool _isValueType)
+std::pair<std::string, std::string> ProtoConverter::processType(T const& _type, bool _isValueType)
 {
-	ostringstream local, global;
+	std::ostringstream local, global;
 	auto [varName, paramName] = newVarNames(getNextVarCounter(), m_isStateVar);
 
 	// Add variable name to the argument list of coder function call
@@ -212,7 +211,7 @@ pair<string, string> ProtoConverter::processType(T const& _type, bool _isValueTy
 	else
 		m_argsCoder << ", " << varName;
 
-	string location{};
+	std::string location{};
 	if (!m_isStateVar && !_isValueType)
 		location = "memory";
 
@@ -230,24 +229,24 @@ pair<string, string> ProtoConverter::processType(T const& _type, bool _isValueTy
 	local << assignCheckBuffers.second;
 
 	m_structCounter += m_numStructsAdded;
-	return make_pair(global.str(), local.str());
+	return std::make_pair(global.str(), local.str());
 }
 
 template <typename T>
-pair<string, string> ProtoConverter::varDecl(
-	string const& _varName,
-	string const& _paramName,
+std::pair<std::string, std::string> ProtoConverter::varDecl(
+	std::string const& _varName,
+	std::string const& _paramName,
 	T _type,
 	bool _isValueType,
-	string const& _location
+	std::string const& _location
 )
 {
-	ostringstream local, global;
+	std::ostringstream local, global;
 
 	TypeVisitor tVisitor(m_structCounter);
-	string typeStr = tVisitor.visit(_type);
+	std::string typeStr = tVisitor.visit(_type);
 	if (typeStr.empty())
-		return make_pair("", "");
+		return std::make_pair("", "");
 
 	// Append struct defs
 	global << tVisitor.structDef();
@@ -292,17 +291,17 @@ pair<string, string> ProtoConverter::varDecl(
 	if (tVisitor.isLastDynParamRightPadded())
 		m_isLastDynParamRightPadded = true;
 
-	return make_pair(global.str(), local.str());
+	return std::make_pair(global.str(), local.str());
 }
 
 template <typename T>
-pair<string, string> ProtoConverter::assignChecker(
-	string const& _varName,
-	string const& _paramName,
+std::pair<std::string, std::string> ProtoConverter::assignChecker(
+	std::string const& _varName,
+	std::string const& _paramName,
 	T _type
 )
 {
-	ostringstream local;
+	std::ostringstream local;
 	AssignCheckVisitor acVisitor(
 		_varName,
 		_paramName,
@@ -311,7 +310,7 @@ pair<string, string> ProtoConverter::assignChecker(
 		m_counter,
 		m_structCounter
 	);
-	pair<string, string> assignCheckStrPair = acVisitor.visit(_type);
+	std::pair<std::string, std::string> assignCheckStrPair = acVisitor.visit(_type);
 	m_returnValue += acVisitor.errorStmts();
 	m_counter += acVisitor.counted();
 
@@ -325,10 +324,10 @@ pair<string, string> ProtoConverter::assignChecker(
 	// Therefore, we buffer their assignments and
 	// render them in function scope later.
 	local << assignCheckStrPair.first;
-	return make_pair("", local.str());
+	return std::make_pair("", local.str());
 }
 
-pair<string, string> ProtoConverter::visit(VarDecl const& _x)
+std::pair<std::string, std::string> ProtoConverter::visit(VarDecl const& _x)
 {
 	return visit(_x.type());
 }
@@ -375,11 +374,11 @@ void ProtoConverter::appendTypedParams(
 
 void ProtoConverter::appendTypes(
 	bool _isValueType,
-	string const& _typeString,
+	std::string const& _typeString,
 	Delimiter _delimiter
 )
 {
-	string qualifiedTypeString = (
+	std::string qualifiedTypeString = (
 		_isValueType ?
 		_typeString :
 		_typeString + " memory"
@@ -392,11 +391,11 @@ void ProtoConverter::appendTypes(
 
 void ProtoConverter::appendTypedReturn(
 	bool _isValueType,
-	string const& _typeString,
+	std::string const& _typeString,
 	Delimiter _delimiter
 )
 {
-	string qualifiedTypeString = (
+	std::string qualifiedTypeString = (
 		_isValueType ?
 		_typeString :
 		_typeString + " memory"
@@ -404,7 +403,7 @@ void ProtoConverter::appendTypedReturn(
 	m_typedReturn << Whiskers(R"(<delimiter><type> <varName>)")
 		("delimiter", delimiterToString(_delimiter))
 		("type", qualifiedTypeString)
-		("varName", "lv_" + to_string(m_varCounter - 1))
+		("varName", "lv_" + std::to_string(m_varCounter - 1))
 		.render();
 }
 
@@ -467,16 +466,16 @@ std::string ProtoConverter::typedParametersAsString(CalleeType _calleeType)
 		return m_typedParamsPublic.str();
 	case CalleeType::EXTERNAL:
 	{
-		ostringstream typedParamsExternal;
+		std::ostringstream typedParamsExternal;
 		for (auto const& i: m_externalParamsRep)
 		{
-			Delimiter del = get<0>(i);
-			bool valueType = get<1>(i);
-			string typeString = get<2>(i);
-			string varName = get<3>(i);
+			Delimiter del = std::get<0>(i);
+			bool valueType = std::get<1>(i);
+			std::string typeString = std::get<2>(i);
+			std::string varName = std::get<3>(i);
 			bool isCalldata = randomBool(/*probability=*/0.5);
-			string location = (isCalldata ? "calldata" : "memory");
-			string qualifiedTypeString = (valueType ? typeString : typeString + " " + location);
+			std::string location = (isCalldata ? "calldata" : "memory");
+			std::string qualifiedTypeString = (valueType ? typeString : typeString + " " + location);
 			typedParamsExternal << Whiskers(R"(<delimiter><type> <varName>)")
 				("delimiter", delimiterToString(del))
 				("type", qualifiedTypeString)
@@ -488,17 +487,17 @@ std::string ProtoConverter::typedParametersAsString(CalleeType _calleeType)
 	}
 }
 
-string ProtoConverter::visit(TestFunction const& _x, string const& _storageVarDefs)
+std::string ProtoConverter::visit(TestFunction const& _x, std::string const& _storageVarDefs)
 {
 	// TODO: Support more than one but less than N local variables
 	auto localVarBuffers = visit(_x.local_vars());
 
-	string structTypeDecl = localVarBuffers.first;
-	string localVarDefs = localVarBuffers.second;
+	std::string structTypeDecl = localVarBuffers.first;
+	std::string localVarDefs = localVarBuffers.second;
 
-	ostringstream testBuffer;
+	std::ostringstream testBuffer;
 
-	string testFunction = Whiskers(R"(
+	std::string testFunction = Whiskers(R"(
 	function test() public returns (uint) {
 		<?calldata>return test_calldata_coding();</calldata>
 		<?returndata>return test_returndata_coding();</returndata>
@@ -507,8 +506,8 @@ string ProtoConverter::visit(TestFunction const& _x, string const& _storageVarDe
 	("returndata", m_test == Contract_Test::Contract_Test_RETURNDATA_CODER)
 	.render();
 
-	string functionDeclCalldata = "function test_calldata_coding() internal returns (uint)";
-	string functionDeclReturndata = "function test_returndata_coding() internal returns (uint)";
+	std::string functionDeclCalldata = "function test_calldata_coding() internal returns (uint)";
+	std::string functionDeclReturndata = "function test_returndata_coding() internal returns (uint)";
 
 	testBuffer << Whiskers(R"(<structTypeDecl>
 <testFunction>
@@ -551,7 +550,7 @@ string ProtoConverter::visit(TestFunction const& _x, string const& _storageVarDe
 	return testBuffer.str();
 }
 
-string ProtoConverter::testCallDataFunction(unsigned _invalidLength)
+std::string ProtoConverter::testCallDataFunction(unsigned _invalidLength)
 {
 	return Whiskers(R"(
 		uint returnVal = this.coder_calldata_public(<argumentNames>);
@@ -592,7 +591,7 @@ string ProtoConverter::testCallDataFunction(unsigned _invalidLength)
 		.render();
 }
 
-string ProtoConverter::testReturnDataFunction()
+std::string ProtoConverter::testReturnDataFunction()
 {
 	return Whiskers(R"(
 <?varsPresent>
@@ -607,9 +606,9 @@ string ProtoConverter::testReturnDataFunction()
 		.render();
 }
 
-string ProtoConverter::calldataHelperFunctions()
+std::string ProtoConverter::calldataHelperFunctions()
 {
-	stringstream calldataHelperFuncs;
+	std::stringstream calldataHelperFuncs;
 	calldataHelperFuncs << R"(
 	/// Accepts function selector, correct argument encoding, and length of
 	/// invalid encoding and returns the correct and incorrect abi encoding
@@ -676,12 +675,12 @@ string ProtoConverter::calldataHelperFunctions()
 	})";
 
 	/// These are indirections to test memory-calldata codings more robustly.
-	stringstream indirections;
+	std::stringstream indirections;
 	unsigned numIndirections = randomNumberOneToN(s_maxIndirections);
 	for (unsigned i = 1; i <= numIndirections; i++)
 	{
 		bool finalIndirection = i == numIndirections;
-		string mutability = (finalIndirection ? "pure" : "view");
+		std::string mutability = (finalIndirection ? "pure" : "view");
 		indirections << Whiskers(R"(
 	function coder_calldata_external_i<N>(<parameters>) external <mutability> returns (uint) {
 <?finalIndirection>
@@ -692,12 +691,12 @@ string ProtoConverter::calldataHelperFunctions()
 </finalIndirection>
 	}
 		)")
-		("N", to_string(i))
+		("N", std::to_string(i))
 		("parameters", typedParametersAsString(CalleeType::EXTERNAL))
 		("mutability", mutability)
 		("finalIndirection", finalIndirection)
 		("equality_checks", equalityChecksAsString())
-		("NPlusOne", to_string(i + 1))
+		("NPlusOne", std::to_string(i + 1))
 		("untyped_parameters", m_untypedParamsExternal.str())
 		.render();
 	}
@@ -726,9 +725,9 @@ string ProtoConverter::calldataHelperFunctions()
 	return calldataHelperFuncs.str();
 }
 
-string ProtoConverter::commonHelperFunctions()
+std::string ProtoConverter::commonHelperFunctions()
 {
-	stringstream helperFuncs;
+	std::stringstream helperFuncs;
 	helperFuncs << R"(
 	/// Compares bytes, returning true if they are equal and false otherwise.
 	function bytesCompare(bytes memory a, bytes memory b) internal pure returns (bool) {
@@ -746,7 +745,7 @@ string ProtoConverter::commonHelperFunctions()
 
 void ProtoConverter::visit(Contract const& _x)
 {
-	string pragmas = R"(pragma solidity >=0.0;
+	std::string pragmas = R"(pragma solidity >=0.0;
 pragma experimental ABIEncoderV2;)";
 
 	// Record test spec
@@ -754,10 +753,10 @@ pragma experimental ABIEncoderV2;)";
 
 	// TODO: Support more than one but less than N state variables
 	auto storageBuffers = visit(_x.state_vars());
-	string storageVarDecls = storageBuffers.first;
-	string storageVarDefs = storageBuffers.second;
+	std::string storageVarDecls = storageBuffers.first;
+	std::string storageVarDefs = storageBuffers.second;
 	m_isStateVar = false;
-	string testFunction = visit(_x.testfunction(), storageVarDefs);
+	std::string testFunction = visit(_x.testfunction(), storageVarDefs);
 	/* Structure of contract body
 	 * - Storage variable declarations
 	 * - Struct definitions
@@ -767,7 +766,7 @@ pragma experimental ABIEncoderV2;)";
 	 *     - Test code proper (calls public and external functions)
 	 * - Helper functions
 	 */
-	ostringstream contractBody;
+	std::ostringstream contractBody;
 	contractBody << storageVarDecls
 	             << testFunction
 	             << commonHelperFunctions();
@@ -782,32 +781,32 @@ pragma experimental ABIEncoderV2;)";
 		.render();
 }
 
-string ProtoConverter::isabelleTypeString() const
+std::string ProtoConverter::isabelleTypeString() const
 {
-	string typeString = m_isabelleTypeString.str();
+	std::string typeString = m_isabelleTypeString.str();
 	if (!typeString.empty())
 		return "(" + typeString + ")";
 	else
 		return typeString;
 }
 
-string ProtoConverter::isabelleValueString() const
+std::string ProtoConverter::isabelleValueString() const
 {
-	string valueString = m_isabelleValueString.str();
+	std::string valueString = m_isabelleValueString.str();
 	if (!valueString.empty())
 		return "(" + valueString + ")";
 	else
 		return valueString;
 }
 
-string ProtoConverter::contractToString(Contract const& _input)
+std::string ProtoConverter::contractToString(Contract const& _input)
 {
 	visit(_input);
 	return m_output.str();
 }
 
 /// Type visitor
-void TypeVisitor::StructTupleString::addTypeStringToTuple(string& _typeString)
+void TypeVisitor::StructTupleString::addTypeStringToTuple(std::string& _typeString)
 {
 	index++;
 	if (index > 1)
@@ -815,51 +814,51 @@ void TypeVisitor::StructTupleString::addTypeStringToTuple(string& _typeString)
 	stream << _typeString;
 }
 
-void TypeVisitor::StructTupleString::addArrayBracketToType(string& _arrayBracket)
+void TypeVisitor::StructTupleString::addArrayBracketToType(std::string& _arrayBracket)
 {
 	stream << _arrayBracket;
 }
 
-string TypeVisitor::visit(BoolType const&)
+std::string TypeVisitor::visit(BoolType const&)
 {
 	m_baseType = "bool";
 	m_structTupleString.addTypeStringToTuple(m_baseType);
 	return m_baseType;
 }
 
-string TypeVisitor::visit(IntegerType const& _type)
+std::string TypeVisitor::visit(IntegerType const& _type)
 {
 	m_baseType = getIntTypeAsString(_type);
 	m_structTupleString.addTypeStringToTuple(m_baseType);
 	return m_baseType;
 }
 
-string TypeVisitor::visit(FixedByteType const& _type)
+std::string TypeVisitor::visit(FixedByteType const& _type)
 {
 	m_baseType = getFixedByteTypeAsString(_type);
 	m_structTupleString.addTypeStringToTuple(m_baseType);
 	return m_baseType;
 }
 
-string TypeVisitor::visit(AddressType const&)
+std::string TypeVisitor::visit(AddressType const&)
 {
 	m_baseType = "address";
 	m_structTupleString.addTypeStringToTuple(m_baseType);
 	return m_baseType;
 }
 
-string TypeVisitor::visit(ArrayType const& _type)
+std::string TypeVisitor::visit(ArrayType const& _type)
 {
 	if (!ValidityVisitor().visit(_type))
 		return "";
 
-	string baseType = visit(_type.t());
+	std::string baseType = visit(_type.t());
 	solAssert(!baseType.empty(), "");
-	string arrayBracket = _type.is_static() ?
-	                     string("[") +
-	                     to_string(getStaticArrayLengthFromFuzz(_type.length())) +
-	                     string("]") :
-	                     string("[]");
+	std::string arrayBracket = _type.is_static() ?
+	                     std::string("[") +
+	                     std::to_string(getStaticArrayLengthFromFuzz(_type.length())) +
+	                     std::string("]") :
+	                     std::string("[]");
 	m_baseType += arrayBracket;
 	m_structTupleString.addArrayBracketToType(arrayBracket);
 
@@ -872,7 +871,7 @@ string TypeVisitor::visit(ArrayType const& _type)
 	return baseType + arrayBracket;
 }
 
-string TypeVisitor::visit(DynamicByteArrayType const&)
+std::string TypeVisitor::visit(DynamicByteArrayType const&)
 {
 	m_isLastDynParamRightPadded = true;
 	m_baseType = "bytes";
@@ -893,10 +892,10 @@ void TypeVisitor::structDefinition(StructType const& _type)
 	m_structFieldCounter = 0;
 
 	// Commence struct declaration
-	string structDef = lineString(
+	std::string structDef = lineString(
 		"struct " +
-		string(s_structNamePrefix) +
-		to_string(m_structCounter) +
+		std::string(s_structNamePrefix) +
+		std::to_string(m_structCounter) +
 		" {"
 	);
 	// Start tuple of types with parenthesis
@@ -905,7 +904,7 @@ void TypeVisitor::structDefinition(StructType const& _type)
 	m_indentation++;
 	for (auto const& t: _type.t())
 	{
-		string type{};
+		std::string type{};
 
 		if (!ValidityVisitor().visit(t))
 			continue;
@@ -920,10 +919,10 @@ void TypeVisitor::structDefinition(StructType const& _type)
 		structDef += lineString(
 			Whiskers(R"(<type> <member>;)")
 				("type", type)
-				("member", "m" + to_string(m_structFieldCounter++))
+				("member", "m" + std::to_string(m_structFieldCounter++))
 				.render()
 		);
-		string isabelleTypeStr = tVisitor.isabelleTypeString();
+		std::string isabelleTypeStr = tVisitor.isabelleTypeString();
 		m_structTupleString.addTypeStringToTuple(isabelleTypeStr);
 	}
 	m_indentation--;
@@ -936,7 +935,7 @@ void TypeVisitor::structDefinition(StructType const& _type)
 	m_structFieldCounter = wasFieldCounter;
 }
 
-string TypeVisitor::visit(StructType const& _type)
+std::string TypeVisitor::visit(StructType const& _type)
 {
 	if (ValidityVisitor().visit(_type))
 	{
@@ -945,7 +944,7 @@ string TypeVisitor::visit(StructType const& _type)
 		// Set last dyn param if struct contains a dyn param e.g., bytes, array etc.
 		m_isLastDynParamRightPadded = DynParamVisitor().visit(_type);
 		// If top-level struct is a non-empty struct, assign the name S<suffix>
-		m_baseType = s_structTypeName + to_string(m_structStartCounter);
+		m_baseType = s_structTypeName + std::to_string(m_structStartCounter);
 	}
 	else
 		m_baseType = {};
@@ -954,7 +953,7 @@ string TypeVisitor::visit(StructType const& _type)
 }
 
 /// AssignCheckVisitor implementation
-void AssignCheckVisitor::ValueStream::appendValue(string& _value)
+void AssignCheckVisitor::ValueStream::appendValue(std::string& _value)
 {
 	solAssert(!_value.empty(), "Abiv2 fuzzer: Empty value");
 	index++;
@@ -963,77 +962,77 @@ void AssignCheckVisitor::ValueStream::appendValue(string& _value)
 	stream << _value;
 }
 
-pair<string, string> AssignCheckVisitor::visit(BoolType const& _type)
+std::pair<std::string, std::string> AssignCheckVisitor::visit(BoolType const& _type)
 {
-	string value = ValueGetterVisitor(counter()).visit(_type);
+	std::string value = ValueGetterVisitor(counter()).visit(_type);
 	if (!m_forcedVisit)
 		m_valueStream.appendValue(value);
 	return assignAndCheckStringPair(m_varName, m_paramName, value, value, DataType::VALUE);
 }
 
-pair<string, string> AssignCheckVisitor::visit(IntegerType const& _type)
+std::pair<std::string, std::string> AssignCheckVisitor::visit(IntegerType const& _type)
 {
-	string value = ValueGetterVisitor(counter()).visit(_type);
+	std::string value = ValueGetterVisitor(counter()).visit(_type);
 	if (!m_forcedVisit)
 		m_valueStream.appendValue(value);
 	return assignAndCheckStringPair(m_varName, m_paramName, value, value, DataType::VALUE);
 }
 
-pair<string, string> AssignCheckVisitor::visit(FixedByteType const& _type)
+std::pair<std::string, std::string> AssignCheckVisitor::visit(FixedByteType const& _type)
 {
-	string value = ValueGetterVisitor(counter()).visit(_type);
+	std::string value = ValueGetterVisitor(counter()).visit(_type);
 	if (!m_forcedVisit)
 	{
-		string isabelleValue = ValueGetterVisitor{}.isabelleBytesValueAsString(value);
+		std::string isabelleValue = ValueGetterVisitor{}.isabelleBytesValueAsString(value);
 		m_valueStream.appendValue(isabelleValue);
 	}
 	return assignAndCheckStringPair(m_varName, m_paramName, value, value, DataType::VALUE);
 }
 
-pair<string, string> AssignCheckVisitor::visit(AddressType const& _type)
+std::pair<std::string, std::string> AssignCheckVisitor::visit(AddressType const& _type)
 {
-	string value = ValueGetterVisitor(counter()).visit(_type);
+	std::string value = ValueGetterVisitor(counter()).visit(_type);
 	if (!m_forcedVisit)
 	{
-		string isabelleValue = ValueGetterVisitor{}.isabelleAddressValueAsString(value);
+		std::string isabelleValue = ValueGetterVisitor{}.isabelleAddressValueAsString(value);
 		m_valueStream.appendValue(isabelleValue);
 	}
 	return assignAndCheckStringPair(m_varName, m_paramName, value, value, DataType::VALUE);
 }
 
-pair<string, string> AssignCheckVisitor::visit(DynamicByteArrayType const& _type)
+std::pair<std::string, std::string> AssignCheckVisitor::visit(DynamicByteArrayType const& _type)
 {
-	string value = ValueGetterVisitor(counter()).visit(_type);
+	std::string value = ValueGetterVisitor(counter()).visit(_type);
 	if (!m_forcedVisit)
 	{
-		string isabelleValue = ValueGetterVisitor{}.isabelleBytesValueAsString(value);
+		std::string isabelleValue = ValueGetterVisitor{}.isabelleBytesValueAsString(value);
 		m_valueStream.appendValue(isabelleValue);
 	}
 	DataType dataType = DataType::BYTES;
 	return assignAndCheckStringPair(m_varName, m_paramName, value, value, dataType);
 }
 
-pair<string, string> AssignCheckVisitor::visit(ArrayType const& _type)
+std::pair<std::string, std::string> AssignCheckVisitor::visit(ArrayType const& _type)
 {
 	if (!ValidityVisitor().visit(_type))
-		return make_pair("", "");
+		return std::make_pair("", "");
 
 	// Obtain type of array to be resized and initialized
-	string typeStr{};
+	std::string typeStr{};
 
 	unsigned wasStructCounter = m_structCounter;
 	TypeVisitor tVisitor(m_structCounter);
 	typeStr = tVisitor.visit(_type);
 
-	pair<string, string> resizeBuffer;
-	string lengthStr;
+	std::pair<std::string, std::string> resizeBuffer;
+	std::string lengthStr;
 	unsigned length;
 
 	// Resize dynamic arrays
 	if (!_type.is_static())
 	{
 		length = getDynArrayLengthFromFuzz(_type.length(), counter());
-		lengthStr = to_string(length);
+		lengthStr = std::to_string(length);
 		if (m_stateVar)
 		{
 			// Dynamic storage arrays are resized via the empty push() operation
@@ -1048,7 +1047,7 @@ pair<string, string> AssignCheckVisitor::visit(ArrayType const& _type)
 		else
 		{
 			// Resizing memory arrays via the new operator
-			string resizeOp = Whiskers(R"(new <fullTypeStr>(<length>))")
+			std::string resizeOp = Whiskers(R"(new <fullTypeStr>(<length>))")
 				("fullTypeStr", typeStr)
 				("length", lengthStr)
 				.render();
@@ -1064,22 +1063,22 @@ pair<string, string> AssignCheckVisitor::visit(ArrayType const& _type)
 	else
 	{
 		length = getStaticArrayLengthFromFuzz(_type.length());
-		lengthStr = to_string(length);
+		lengthStr = std::to_string(length);
 		// Add check on length
 		resizeBuffer.second = checkString(m_paramName + ".length", lengthStr, DataType::VALUE);
 	}
 
 	// Add assignCheckBuffer and check statements
-	pair<string, string> assignCheckBuffer;
-	string wasVarName = m_varName;
-	string wasParamName = m_paramName;
+	std::pair<std::string, std::string> assignCheckBuffer;
+	std::string wasVarName = m_varName;
+	std::string wasParamName = m_paramName;
 	if (!m_forcedVisit)
 		m_valueStream.startArray();
 	for (unsigned i = 0; i < length; i++)
 	{
-		m_varName = wasVarName + "[" + to_string(i) + "]";
-		m_paramName = wasParamName + "[" + to_string(i) + "]";
-		pair<string, string> assign = visit(_type.t());
+		m_varName = wasVarName + "[" + std::to_string(i) + "]";
+		m_paramName = wasParamName + "[" + std::to_string(i) + "]";
+		std::pair<std::string, std::string> assign = visit(_type.t());
 		assignCheckBuffer.first += assign.first;
 		assignCheckBuffer.second += assign.second;
 		if (i < length - 1)
@@ -1102,33 +1101,33 @@ pair<string, string> AssignCheckVisitor::visit(ArrayType const& _type)
 	m_paramName = wasParamName;
 
 	// Compose resize and initialization assignment and check
-	return make_pair(
+	return std::make_pair(
 		resizeBuffer.first + assignCheckBuffer.first,
 		resizeBuffer.second + assignCheckBuffer.second
 	);
 }
 
-pair<string, string> AssignCheckVisitor::visit(StructType const& _type)
+std::pair<std::string, std::string> AssignCheckVisitor::visit(StructType const& _type)
 {
 	if (!ValidityVisitor().visit(_type))
-		return make_pair("", "");
+		return std::make_pair("", "");
 
-	pair<string, string> assignCheckBuffer;
+	std::pair<std::string, std::string> assignCheckBuffer;
 	unsigned i = 0;
 
 	// Increment struct counter
 	m_structCounter++;
 
-	string wasVarName = m_varName;
-	string wasParamName = m_paramName;
+	std::string wasVarName = m_varName;
+	std::string wasParamName = m_paramName;
 
 	if (!m_forcedVisit)
 		m_valueStream.startStruct();
 	for (auto const& t: _type.t())
 	{
-		m_varName = wasVarName + ".m" + to_string(i);
-		m_paramName = wasParamName + ".m" + to_string(i);
-		pair<string, string> assign = visit(t);
+		m_varName = wasVarName + ".m" + std::to_string(i);
+		m_paramName = wasParamName + ".m" + std::to_string(i);
+		std::pair<std::string, std::string> assign = visit(t);
 		// If type is not well formed continue without
 		// updating state.
 		if (assign.first.empty() && assign.second.empty())
@@ -1144,29 +1143,29 @@ pair<string, string> AssignCheckVisitor::visit(StructType const& _type)
 	return assignCheckBuffer;
 }
 
-pair<string, string> AssignCheckVisitor::assignAndCheckStringPair(
-	string const& _varRef,
-	string const& _checkRef,
-	string const& _assignValue,
-	string const& _checkValue,
+std::pair<std::string, std::string> AssignCheckVisitor::assignAndCheckStringPair(
+	std::string const& _varRef,
+	std::string const& _checkRef,
+	std::string const& _assignValue,
+	std::string const& _checkValue,
 	DataType _type
 )
 {
-	return make_pair(assignString(_varRef, _assignValue), checkString(_checkRef, _checkValue, _type));
+	return std::make_pair(assignString(_varRef, _assignValue), checkString(_checkRef, _checkValue, _type));
 }
 
-string AssignCheckVisitor::assignString(string const& _ref, string const& _value)
+std::string AssignCheckVisitor::assignString(std::string const& _ref, std::string const& _value)
 {
-	string assignStmt = Whiskers(R"(<ref> = <value>;)")
+	std::string assignStmt = Whiskers(R"(<ref> = <value>;)")
 		("ref", _ref)
 		("value", _value)
 		.render();
 	return indentation() + assignStmt + "\n";
 }
 
-string AssignCheckVisitor::checkString(string const& _ref, string const& _value, DataType _type)
+std::string AssignCheckVisitor::checkString(std::string const& _ref, std::string const& _value, DataType _type)
 {
-	string checkPred;
+	std::string checkPred;
 	switch (_type)
 	{
 	case DataType::BYTES:
@@ -1184,25 +1183,25 @@ string AssignCheckVisitor::checkString(string const& _ref, string const& _value,
 	case DataType::ARRAY:
 		solUnimplemented("Proto ABIv2 fuzzer: Invalid data type.");
 	}
-	string checkStmt = Whiskers(R"(if (<checkPred>) return <errCode>;)")
+	std::string checkStmt = Whiskers(R"(if (<checkPred>) return <errCode>;)")
 		("checkPred", checkPred)
-		("errCode", to_string(m_errorCode++))
+		("errCode", std::to_string(m_errorCode++))
 		.render();
 	return indentation() + checkStmt + "\n";
 }
 
 /// ValueGetterVisitor
-string ValueGetterVisitor::visit(BoolType const&)
+std::string ValueGetterVisitor::visit(BoolType const&)
 {
 	return counter() % 2 ? "true" : "false";
 }
 
-string ValueGetterVisitor::visit(IntegerType const& _type)
+std::string ValueGetterVisitor::visit(IntegerType const& _type)
 {
 	return integerValue(counter(), getIntWidth(_type), _type.is_signed());
 }
 
-string ValueGetterVisitor::visit(FixedByteType const& _type)
+std::string ValueGetterVisitor::visit(FixedByteType const& _type)
 {
 	return fixedByteValueAsString(
 		getFixedByteWidth(_type),
@@ -1210,12 +1209,12 @@ string ValueGetterVisitor::visit(FixedByteType const& _type)
 	);
 }
 
-string ValueGetterVisitor::visit(AddressType const&)
+std::string ValueGetterVisitor::visit(AddressType const&)
 {
 	return addressValueAsString(counter());
 }
 
-string ValueGetterVisitor::visit(DynamicByteArrayType const&)
+std::string ValueGetterVisitor::visit(DynamicByteArrayType const&)
 {
 	return bytesArrayValueAsString(
 		counter(),
@@ -1331,7 +1330,7 @@ std::string ValueGetterVisitor::variableLengthValueAsString(
 
 	unsigned numBytesRemaining = _numBytes;
 	// Stores the literal
-	string output{};
+	std::string output{};
 	// If requested value is shorter than or exactly 32 bytes,
 	// the literal is the return value of hexValueAsString.
 	if (numBytesRemaining <= 32)
@@ -1350,7 +1349,7 @@ std::string ValueGetterVisitor::variableLengthValueAsString(
 		// update number of bytes to be appended.
 		// Stores the cached literal that saves us
 		// (expensive) calls to keccak256.
-		string cachedString = hexValueAsString(
+		std::string cachedString = hexValueAsString(
 			/*numBytes=*/32,
 			             _counter,
 			             _isHexLiteral,
@@ -1398,7 +1397,7 @@ std::string ValueGetterVisitor::variableLengthValueAsString(
 		.render();
 }
 
-string ValueGetterVisitor::bytesArrayValueAsString(unsigned _counter, bool _isHexLiteral)
+std::string ValueGetterVisitor::bytesArrayValueAsString(unsigned _counter, bool _isHexLiteral)
 {
 	return variableLengthValueAsString(
 		getVarLength(_counter),

--- a/test/tools/ossfuzz/protoToSol.cpp
+++ b/test/tools/ossfuzz/protoToSol.cpp
@@ -26,30 +26,29 @@
 
 using namespace solidity::test::solprotofuzzer;
 using namespace solidity::util;
-using namespace std;
 
-string ProtoConverter::protoToSolidity(Program const& _p)
+std::string ProtoConverter::protoToSolidity(Program const& _p)
 {
 	// Create random number generator with fuzzer supplied
 	// seed.
-	m_randomGen = make_shared<SolRandomNumGenerator>(_p.seed());
+	m_randomGen = std::make_shared<SolRandomNumGenerator>(_p.seed());
 	return visit(_p);
 }
 
-pair<string, string> ProtoConverter::generateTestCase(TestContract const& _testContract)
+std::pair<std::string, std::string> ProtoConverter::generateTestCase(TestContract const& _testContract)
 {
-	ostringstream testCode;
-	string usingLibDecl;
+	std::ostringstream testCode;
+	std::string usingLibDecl;
 	switch (_testContract.type())
 	{
 	case TestContract::LIBRARY:
 	{
 		m_libraryTest = true;
 		auto testTuple = pseudoRandomLibraryTest();
-		m_libraryName = get<0>(testTuple);
+		m_libraryName = std::get<0>(testTuple);
 		Whiskers u(R"(<ind>using <libraryName> for uint;)");
 		u("ind", "\t");
-		u("libraryName", get<0>(testTuple));
+		u("libraryName", std::get<0>(testTuple));
 		usingLibDecl = u.render();
 		Whiskers test(R"(<endl><ind><varDecl><endl><ind><ifStmt>)");
 		test("endl", "\n");
@@ -57,8 +56,8 @@ pair<string, string> ProtoConverter::generateTestCase(TestContract const& _testC
 		test("varDecl", "uint x;");
 		Whiskers ifStmt(R"(if (<cond>)<endl><ind>return 1;)");
 		Whiskers ifCond(R"(x.<testFunction>() != <expectedOutput>)");
-		ifCond("testFunction", get<1>(testTuple));
-		ifCond("expectedOutput", get<2>(testTuple));
+		ifCond("testFunction", std::get<1>(testTuple));
+		ifCond("expectedOutput", std::get<2>(testTuple));
 		ifStmt("cond", ifCond.render());
 		ifStmt("endl", "\n");
 		ifStmt("ind", "\t\t\t");
@@ -77,8 +76,8 @@ pair<string, string> ProtoConverter::generateTestCase(TestContract const& _testC
 			// running into stack too deep errors
 			if (contractVarIndex >= s_maxVars)
 				break;
-			string contractName = testTuple.first;
-			string contractVarName = "tc" + to_string(contractVarIndex);
+			std::string contractName = testTuple.first;
+			std::string contractVarName = "tc" + std::to_string(contractVarIndex);
 			Whiskers init(R"(<endl><ind><contractName> <contractVarName> = new <contractName>();)");
 			init("endl", "\n");
 			init("ind", "\t\t");
@@ -98,7 +97,7 @@ pair<string, string> ProtoConverter::generateTestCase(TestContract const& _testC
 				ifStmt("endl", "\n");
 				ifStmt("cond", ifCond.render());
 				ifStmt("ind", "\t\t\t");
-				ifStmt("errorCode", to_string(errorCode));
+				ifStmt("errorCode", std::to_string(errorCode));
 				tc("ifStmt", ifStmt.render());
 				testCode << tc.render();
 				errorCode++;
@@ -113,10 +112,10 @@ pair<string, string> ProtoConverter::generateTestCase(TestContract const& _testC
 	return {usingLibDecl, testCode.str()};
 }
 
-string ProtoConverter::visit(TestContract const& _testContract)
+std::string ProtoConverter::visit(TestContract const& _testContract)
 {
-	string testCode;
-	string usingLibDecl;
+	std::string testCode;
+	std::string usingLibDecl;
 	m_libraryTest = false;
 
 	// Simply return valid uint (zero) if there are
@@ -143,15 +142,15 @@ bool ProtoConverter::libraryTest() const
 	return m_libraryTest;
 }
 
-string ProtoConverter::libraryName() const
+std::string ProtoConverter::libraryName() const
 {
 	return m_libraryName;
 }
 
-string ProtoConverter::visit(Program const& _p)
+std::string ProtoConverter::visit(Program const& _p)
 {
-	ostringstream program;
-	ostringstream contracts;
+	std::ostringstream program;
+	std::ostringstream contracts;
 
 	for (auto &contract: _p.contracts())
 		contracts << visit(contract);
@@ -163,7 +162,7 @@ string ProtoConverter::visit(Program const& _p)
 	return p.render();
 }
 
-string ProtoConverter::visit(ContractType const& _contractType)
+std::string ProtoConverter::visit(ContractType const& _contractType)
 {
 	switch (_contractType.contract_type_oneof_case())
 	{
@@ -178,25 +177,25 @@ string ProtoConverter::visit(ContractType const& _contractType)
 	}
 }
 
-string ProtoConverter::visit(Contract const& _contract)
+std::string ProtoConverter::visit(Contract const& _contract)
 {
 	openProgramScope(&_contract);
 	return "";
 }
 
-string ProtoConverter::visit(Interface const& _interface)
+std::string ProtoConverter::visit(Interface const& _interface)
 {
 	openProgramScope(&_interface);
 	return "";
 }
 
-string ProtoConverter::visit(Library const& _library)
+std::string ProtoConverter::visit(Library const& _library)
 {
 	openProgramScope(&_library);
 	return "";
 }
 
-tuple<string, string, string> ProtoConverter::pseudoRandomLibraryTest()
+std::tuple<std::string, std::string, std::string> ProtoConverter::pseudoRandomLibraryTest()
 {
 	solAssert(m_libraryTests.size() > 0, "Sol proto fuzzer: No library tests found");
 	unsigned index = randomNumber() % m_libraryTests.size();
@@ -205,18 +204,18 @@ tuple<string, string, string> ProtoConverter::pseudoRandomLibraryTest()
 
 void ProtoConverter::openProgramScope(CIL _program)
 {
-	string programNamePrefix;
-	if (holds_alternative<Contract const*>(_program))
+	std::string programNamePrefix;
+	if (std::holds_alternative<Contract const*>(_program))
 		programNamePrefix = "C";
-	else if (holds_alternative<Interface const*>(_program))
+	else if (std::holds_alternative<Interface const*>(_program))
 		programNamePrefix = "I";
 	else
 		programNamePrefix = "L";
-	string programName = programNamePrefix + to_string(m_programNumericSuffix++);
+	std::string programName = programNamePrefix + std::to_string(m_programNumericSuffix++);
 	m_programNameMap.emplace(_program, programName);
 }
 
-string ProtoConverter::programName(CIL _program)
+std::string ProtoConverter::programName(CIL _program)
 {
 	solAssert(m_programNameMap.count(_program), "Sol proto fuzzer: Unregistered program");
 	return m_programNameMap[_program];

--- a/test/tools/ossfuzz/protoToYul.cpp
+++ b/test/tools/ossfuzz/protoToYul.cpp
@@ -32,14 +32,13 @@
 
 #include <algorithm>
 
-using namespace std;
 using namespace solidity::yul::test::yul_fuzzer;
 using namespace solidity::yul::test;
 using namespace solidity::langutil;
 using namespace solidity::util;
 using namespace solidity;
 
-string ProtoConverter::dictionaryToken(HexPrefix _p)
+std::string ProtoConverter::dictionaryToken(HexPrefix _p)
 {
 	std::string token;
 	// If dictionary constant is requested while converting
@@ -57,9 +56,9 @@ string ProtoConverter::dictionaryToken(HexPrefix _p)
 	return _p == HexPrefix::Add ? "0x" + token : token;
 }
 
-string ProtoConverter::createHex(string const& _hexBytes)
+std::string ProtoConverter::createHex(std::string const& _hexBytes)
 {
-	string tmp{_hexBytes};
+	std::string tmp{_hexBytes};
 	if (!tmp.empty())
 	{
 		ranges::actions::remove_if(tmp, [=](char c) -> bool {
@@ -79,9 +78,9 @@ string ProtoConverter::createHex(string const& _hexBytes)
 	return tmp;
 }
 
-string ProtoConverter::createAlphaNum(string const& _strBytes)
+std::string ProtoConverter::createAlphaNum(std::string const& _strBytes)
 {
-	string tmp{_strBytes};
+	std::string tmp{_strBytes};
 	if (!tmp.empty())
 	{
 		ranges::actions::remove_if(tmp, [=](char c) -> bool {
@@ -123,12 +122,12 @@ EVMVersion ProtoConverter::evmVersionMapping(Program_Version const& _ver)
 	}
 }
 
-string ProtoConverter::visit(Literal const& _x)
+std::string ProtoConverter::visit(Literal const& _x)
 {
 	switch (_x.literal_oneof_case())
 	{
 	case Literal::kIntval:
-		return to_string(_x.intval());
+		return std::to_string(_x.intval());
 	case Literal::kHexval:
 		return "0x" + createHex(_x.hexval());
 	case Literal::kStrval:
@@ -238,7 +237,7 @@ void ProtoConverter::visit(Expression const& _x)
 	case Expression::kFuncExpr:
 		if (auto v = functionExists(NumFunctionReturns::Single); v.has_value())
 		{
-			string functionName = v.value();
+			std::string functionName = v.value();
 			visit(_x.func_expr(), functionName, true);
 		}
 		else
@@ -359,11 +358,11 @@ void ProtoConverter::visit(BinaryOp const& _x)
 	{
 		m_output << "mod(";
 		visit(_x.left());
-		m_output << ", " << to_string(s_maxMemory - s_maxSize) << ")";
+		m_output << ", " << std::to_string(s_maxMemory - s_maxSize) << ")";
 		m_output << ",";
 		m_output << "mod(";
 		visit(_x.right());
-		m_output << ", " << to_string(s_maxSize) << ")";
+		m_output << ", " << std::to_string(s_maxSize) << ")";
 	}
 	else
 	{
@@ -374,7 +373,7 @@ void ProtoConverter::visit(BinaryOp const& _x)
 	m_output << ")";
 }
 
-void ProtoConverter::scopeVariables(vector<string> const& _varNames)
+void ProtoConverter::scopeVariables(std::vector<std::string> const& _varNames)
 {
 	// If we are inside a for-init block, there are two places
 	// where the visited vardecl may have been defined:
@@ -443,7 +442,7 @@ void ProtoConverter::scopeVariables(vector<string> const& _varNames)
 
 void ProtoConverter::visit(VarDecl const& _x)
 {
-	string varName = newVarName();
+	std::string varName = newVarName();
 	m_output << "let " << varName << " := ";
 	visit(_x.expr());
 	m_output << "\n";
@@ -453,14 +452,14 @@ void ProtoConverter::visit(VarDecl const& _x)
 void ProtoConverter::visit(MultiVarDecl const& _x)
 {
 	m_output << "let ";
-	vector<string> varNames;
+	std::vector<std::string> varNames;
 	// We support up to 4 variables in a single
 	// declaration statement.
 	unsigned numVars = _x.num_vars() % 3 + 2;
-	string delimiter;
+	std::string delimiter;
 	for (unsigned i = 0; i < numVars; i++)
 	{
-		string varName = newVarName();
+		std::string varName = newVarName();
 		varNames.push_back(varName);
 		m_output << delimiter << varName;
 		if (i == 0)
@@ -472,7 +471,7 @@ void ProtoConverter::visit(MultiVarDecl const& _x)
 
 void ProtoConverter::visit(TypedVarDecl const& _x)
 {
-	string varName = newVarName();
+	std::string varName = newVarName();
 	m_output << "let " << varName;
 	switch (_x.type())
 	{
@@ -662,7 +661,7 @@ void ProtoConverter::visit(UnaryOp const& _x)
 	{
 		m_output << "mod(";
 		visit(_x.operand());
-		m_output << ", " << to_string(s_maxMemory - 32) << ")";
+		m_output << ", " << std::to_string(s_maxMemory - 32) << ")";
 	}
 	else
 		visit(_x.operand());
@@ -844,20 +843,20 @@ void ProtoConverter::visit(CopyFunc const& _x)
 	m_output << "(";
 	m_output << "mod(";
 	visit(_x.target());
-	m_output << ", " << to_string(s_maxMemory - s_maxSize) << ")";
+	m_output << ", " << std::to_string(s_maxMemory - s_maxSize) << ")";
 	m_output << ", ";
 	if (type == CopyFunc::MEMORY)
 	{
 		m_output << "mod(";
 		visit(_x.source());
-		m_output << ", " << to_string(s_maxMemory - s_maxSize) << ")";
+		m_output << ", " << std::to_string(s_maxMemory - s_maxSize) << ")";
 	}
 	else
 		visit(_x.source());
 	m_output << ", ";
 	m_output << "mod(";
 	visit(_x.size());
-	m_output << ", " << to_string(s_maxSize) << ")";
+	m_output << ", " << std::to_string(s_maxSize) << ")";
 	m_output << ")\n";
 }
 
@@ -869,13 +868,13 @@ void ProtoConverter::visit(ExtCodeCopy const& _x)
 	m_output << ", ";
 	m_output << "mod(";
 	visit(_x.target());
-	m_output << ", " << to_string(s_maxMemory - s_maxSize) << ")";
+	m_output << ", " << std::to_string(s_maxMemory - s_maxSize) << ")";
 	m_output << ", ";
 	visit(_x.source());
 	m_output << ", ";
 	m_output << "mod(";
 	visit(_x.size());
-	m_output << ", " << to_string(s_maxSize) << ")";
+	m_output << ", " << std::to_string(s_maxSize) << ")";
 	m_output << ")\n";
 }
 
@@ -884,11 +883,11 @@ void ProtoConverter::visit(LogFunc const& _x)
 	auto visitPosAndSize = [&](LogFunc const& _y) {
 		m_output << "mod(";
 		visit(_y.pos());
-		m_output << ", " << to_string(s_maxMemory - s_maxSize) << ")";
+		m_output << ", " << std::to_string(s_maxMemory - s_maxSize) << ")";
 		m_output << ", ";
 		m_output << "mod(";
 		visit(_y.size());
-		m_output << ", " << to_string(s_maxSize) << ")";
+		m_output << ", " << std::to_string(s_maxSize) << ")";
 	};
 
 	switch (_x.num_topics())
@@ -984,7 +983,7 @@ void ProtoConverter::visitFunctionInputParams(FunctionCall const& _x, unsigned _
 
 void ProtoConverter::convertFunctionCall(
 	FunctionCall const& _x,
-	string const& _name,
+	std::string const& _name,
 	unsigned _numInParams,
 	bool _newLine
 )
@@ -996,10 +995,10 @@ void ProtoConverter::convertFunctionCall(
 		m_output << "\n";
 }
 
-vector<string> ProtoConverter::createVarDecls(unsigned _start, unsigned _end, bool _isAssignment)
+std::vector<std::string> ProtoConverter::createVarDecls(unsigned _start, unsigned _end, bool _isAssignment)
 {
 	m_output << "let ";
-	vector<string> varsVec = createVars(_start, _end);
+	std::vector<std::string> varsVec = createVars(_start, _end);
 	if (_isAssignment)
 		m_output << " := ";
 	else
@@ -1007,7 +1006,7 @@ vector<string> ProtoConverter::createVarDecls(unsigned _start, unsigned _end, bo
 	return varsVec;
 }
 
-optional<string> ProtoConverter::functionExists(NumFunctionReturns _numReturns)
+std::optional<std::string> ProtoConverter::functionExists(NumFunctionReturns _numReturns)
 {
 	for (auto const& item: m_functionSigMap)
 		if (_numReturns == NumFunctionReturns::None || _numReturns == NumFunctionReturns::Single)
@@ -1020,10 +1019,10 @@ optional<string> ProtoConverter::functionExists(NumFunctionReturns _numReturns)
 			if (item.second.second >= static_cast<unsigned>(_numReturns))
 				return item.first;
 		}
-	return nullopt;
+	return std::nullopt;
 }
 
-void ProtoConverter::visit(FunctionCall const& _x, string const& _functionName, bool _expression)
+void ProtoConverter::visit(FunctionCall const& _x, std::string const& _functionName, bool _expression)
 {
 	yulAssert(m_functionSigMap.count(_functionName), "Proto fuzzer: Invalid function.");
 	auto ret = m_functionSigMap.at(_functionName);
@@ -1038,7 +1037,7 @@ void ProtoConverter::visit(FunctionCall const& _x, string const& _functionName, 
 	else
 	{
 		yulAssert(numOutParams > 0, "");
-		vector<string> varsVec;
+		std::vector<std::string> varsVec;
 		if (!_expression)
 		{
 			// Obtain variable name suffix
@@ -1096,19 +1095,19 @@ void ProtoConverter::visit(LowLevelCall const& _x)
 	}
 	m_output << "mod(";
 	visit(_x.in());
-	m_output << ", " << to_string(s_maxMemory - s_maxSize) << ")";
+	m_output << ", " << std::to_string(s_maxMemory - s_maxSize) << ")";
 	m_output << ", ";
 	m_output << "mod(";
 	visit(_x.insize());
-	m_output << ", " << to_string(s_maxSize) << ")";
+	m_output << ", " << std::to_string(s_maxSize) << ")";
 	m_output << ", ";
 	m_output << "mod(";
 	visit(_x.out());
-	m_output << ", " << to_string(s_maxMemory - s_maxSize) << ")";
+	m_output << ", " << std::to_string(s_maxMemory - s_maxSize) << ")";
 	m_output << ", ";
 	m_output << "mod(";
 	visit(_x.outsize());
-	m_output << ", " << to_string(s_maxSize) << ")";
+	m_output << ", " << std::to_string(s_maxSize) << ")";
 	m_output << ")";
 }
 
@@ -1137,11 +1136,11 @@ void ProtoConverter::visit(Create const& _x)
 	m_output << ", ";
 	m_output << "mod(";
 	visit(_x.position());
-	m_output << ", " << to_string(s_maxMemory - s_maxSize) << ")";
+	m_output << ", " << std::to_string(s_maxMemory - s_maxSize) << ")";
 	m_output << ", ";
 	m_output << "mod(";
 	visit(_x.size());
-	m_output << ", " << to_string(s_maxSize) << ")";
+	m_output << ", " << std::to_string(s_maxSize) << ")";
 	if (type == Create::CREATE2)
 	{
 		m_output << ", ";
@@ -1183,7 +1182,7 @@ void ProtoConverter::visit(StoreFunc const& _x)
 	{
 		m_output << "mod(";
 		visit(_x.loc());
-		m_output << ", " << to_string(s_maxMemory) << ")";
+		m_output << ", " << std::to_string(s_maxMemory) << ")";
 	}
 	else if (storeType == StoreFunc::MSTORE)
 	{
@@ -1191,7 +1190,7 @@ void ProtoConverter::visit(StoreFunc const& _x)
 		// upper bound on memory.
 		m_output << "mod(";
 		visit(_x.loc());
-		m_output << ", " << to_string(s_maxMemory - 32) << ")";
+		m_output << ", " << std::to_string(s_maxMemory - 32) << ")";
 
 	}
 	m_output << ", ";
@@ -1261,7 +1260,7 @@ void ProtoConverter::visit(BoundedForStmt const& _x)
 
 void ProtoConverter::visit(CaseStmt const& _x)
 {
-	string literal = visit(_x.case_lit());
+	std::string literal = visit(_x.case_lit());
 	// u256 value of literal
 	u256 literalVal;
 
@@ -1278,7 +1277,7 @@ void ProtoConverter::visit(CaseStmt const& _x)
 		// a case statement containing a case literal that has already been used in a
 		// previous case statement. If the hash (u256 value) matches a previous hash,
 		// then we simply don't create a new case statement.
-		string noDoubleQuoteStr;
+		std::string noDoubleQuoteStr;
 		if (literal.size() > 2)
 		{
 			// Ensure that all characters in the string literal except the first
@@ -1376,11 +1375,11 @@ void ProtoConverter::visit(RetRevStmt const& _x)
 	m_output << "(";
 	m_output << "mod(";
 	visit(_x.pos());
-	m_output << ", " << to_string(s_maxMemory - s_maxSize) << ")";
+	m_output << ", " << std::to_string(s_maxMemory - s_maxSize) << ")";
 	m_output << ", ";
 	m_output << "mod(";
 	visit(_x.size());
-	m_output << ", " << to_string(s_maxSize) << ")";
+	m_output << ", " << std::to_string(s_maxSize) << ")";
 	m_output << ")\n";
 }
 
@@ -1527,14 +1526,14 @@ void ProtoConverter::openBlockScope()
 			!m_funcVars.empty(),
 			"Proto fuzzer: Invalid data structure"
 		);
-		m_funcVars.back().push_back(vector<string>{});
+		m_funcVars.back().push_back(std::vector<std::string>{});
 		if (m_inForInitScope && m_forInitScopeExtEnabled)
 		{
 			yulAssert(
 				!m_funcForLoopInitVars.empty(),
 				"Proto fuzzer: Invalid data structure"
 			);
-			m_funcForLoopInitVars.back().push_back(vector<string>{});
+			m_funcForLoopInitVars.back().push_back(std::vector<std::string>{});
 		}
 	}
 	else
@@ -1545,13 +1544,13 @@ void ProtoConverter::openBlockScope()
 	}
 }
 
-void ProtoConverter::openFunctionScope(vector<string> const& _funcParams)
+void ProtoConverter::openFunctionScope(std::vector<std::string> const& _funcParams)
 {
-	m_funcVars.push_back(vector<vector<string>>({_funcParams}));
-	m_funcForLoopInitVars.push_back(vector<vector<string>>({}));
+	m_funcVars.push_back(std::vector<std::vector<std::string>>({_funcParams}));
+	m_funcForLoopInitVars.push_back(std::vector<std::vector<std::string>>({}));
 }
 
-void ProtoConverter::updateFunctionMaps(string const& _var)
+void ProtoConverter::updateFunctionMaps(std::string const& _var)
 {
 	size_t erased = m_functionSigMap.erase(_var);
 
@@ -1609,7 +1608,7 @@ void ProtoConverter::closeFunctionScope()
 	m_funcForLoopInitVars.pop_back();
 }
 
-void ProtoConverter::addVarsToScope(vector<string> const& _vars)
+void ProtoConverter::addVarsToScope(std::vector<std::string> const& _vars)
 {
 	// If we are in function definition, add the new vars to current function scope
 	if (m_inFunctionDef)
@@ -1706,12 +1705,12 @@ void ProtoConverter::visit(Block const& _x)
 	closeBlockScope();
 }
 
-vector<string> ProtoConverter::createVars(unsigned _startIdx, unsigned _endIdx)
+std::vector<std::string> ProtoConverter::createVars(unsigned _startIdx, unsigned _endIdx)
 {
 	yulAssert(_endIdx > _startIdx, "Proto fuzzer: Variable indices not in range");
-	string varsStr = suffixedVariableNameList("x_", _startIdx, _endIdx);
+	std::string varsStr = suffixedVariableNameList("x_", _startIdx, _endIdx);
 	m_output << varsStr;
-	vector<string> varsVec;
+	std::vector<std::string> varsVec;
 	boost::split(
 		varsVec,
 		varsStr,
@@ -1740,14 +1739,14 @@ void ProtoConverter::registerFunction(FunctionDef const* _x)
 		numReturns = NumFunctionReturns::Multiple;
 
 	// Generate function name
-	string funcName = functionName(numReturns);
+	std::string funcName = functionName(numReturns);
 
 	// Register function
-	auto ret = m_functionSigMap.emplace(make_pair(funcName, make_pair(numInParams, numOutParams)));
+	auto ret = m_functionSigMap.emplace(std::make_pair(funcName, std::make_pair(numInParams, numOutParams)));
 	yulAssert(ret.second, "Proto fuzzer: Function already exists.");
 	m_functions.push_back(funcName);
 	m_scopeFuncs.back().push_back(funcName);
-	m_functionDefMap.emplace(make_pair(_x, funcName));
+	m_functionDefMap.emplace(std::make_pair(_x, funcName));
 }
 
 void ProtoConverter::fillFunctionCallInput(unsigned _numInParams)
@@ -1760,7 +1759,7 @@ void ProtoConverter::fillFunctionCallInput(unsigned _numInParams)
 		unsigned diceValue = counter() % 4;
 		// Pseudo-randomly choose one of the first ten 32-byte
 		// aligned slots.
-		string slot = to_string((counter() % 10) * 32);
+		std::string slot = std::to_string((counter() % 10) * 32);
 		switch (diceValue)
 		{
 		case 0:
@@ -1769,7 +1768,7 @@ void ProtoConverter::fillFunctionCallInput(unsigned _numInParams)
 		case 1:
 		{
 			// Access memory within stipulated bounds
-			slot = "mod(" + dictionaryToken() + ", " + to_string(s_maxMemory - 32) + ")";
+			slot = "mod(" + dictionaryToken() + ", " + std::to_string(s_maxMemory - 32) + ")";
 			m_output << "mload(" << slot << ")";
 			break;
 		}
@@ -1787,19 +1786,19 @@ void ProtoConverter::fillFunctionCallInput(unsigned _numInParams)
 	}
 }
 
-void ProtoConverter::saveFunctionCallOutput(vector<string> const& _varsVec)
+void ProtoConverter::saveFunctionCallOutput(std::vector<std::string> const& _varsVec)
 {
 	constexpr auto numSlots = 10;
 	constexpr auto slotSize = 32;
 
-	for (string const& var: _varsVec)
+	for (std::string const& var: _varsVec)
 	{
 		// Flip a dice to choose whether to save output values
 		// in storage or memory.
 		unsigned diceThrow = counter() % (m_evmVersion.supportsTransientStorage() ? 3 : 2);
 		// Pseudo-randomly choose one of the first ten 32-byte
 		// aligned slots.
-		string slot = std::to_string((counter() % numSlots) * slotSize);
+		std::string slot = std::to_string((counter() % numSlots) * slotSize);
 		if (diceThrow == 0)
 			m_output << "sstore(" << slot << ", " << var << ")\n";
 		else if (diceThrow == 1)
@@ -1816,12 +1815,12 @@ void ProtoConverter::saveFunctionCallOutput(vector<string> const& _varsVec)
 }
 
 void ProtoConverter::createFunctionCall(
-	string const& _funcName,
+	std::string const& _funcName,
 	unsigned _numInParams,
 	unsigned _numOutParams
 )
 {
-	vector<string> varsVec{};
+	std::vector<std::string> varsVec{};
 	if (_numOutParams > 0)
 	{
 		unsigned startIdx = counter();
@@ -1864,16 +1863,16 @@ void ProtoConverter::createFunctionDefAndCall(
 
 	// Obtain function name
 	yulAssert(m_functionDefMap.count(&_x), "Proto fuzzer: Unregistered function");
-	string funcName = m_functionDefMap.at(&_x);
+	std::string funcName = m_functionDefMap.at(&_x);
 
-	vector<string> varsVec = {};
+	std::vector<std::string> varsVec = {};
 	m_output << "function " << funcName << "(";
 	unsigned startIdx = counter();
 	if (_numInParams > 0)
 		varsVec = createVars(startIdx, startIdx + _numInParams);
 	m_output << ")";
 
-	vector<string> outVarsVec = {};
+	std::vector<std::string> outVarsVec = {};
 	// This creates -> x_n+1,...,x_r
 	if (_numOutParams > 0)
 	{
@@ -1937,15 +1936,15 @@ void ProtoConverter::visit(LeaveStmt const&)
 	m_output << "leave\n";
 }
 
-string ProtoConverter::getObjectIdentifier(unsigned _x)
+std::string ProtoConverter::getObjectIdentifier(unsigned _x)
 {
 	unsigned currentId = currentObjectId();
-	string currentObjName = "object" + to_string(currentId);
+	std::string currentObjName = "object" + std::to_string(currentId);
 	yulAssert(
 		m_objectScope.count(currentObjName) && !m_objectScope.at(currentObjName).empty(),
 		"Yul proto fuzzer: Error referencing object"
 	);
-	vector<string> objectIdsInScope = m_objectScope.at(currentObjName);
+	std::vector<std::string> objectIdsInScope = m_objectScope.at(currentObjName);
 	return objectIdsInScope[_x % objectIdsInScope.size()];
 }
 
@@ -1979,8 +1978,8 @@ void ProtoConverter::visit(Object const& _x)
 void ProtoConverter::buildObjectScopeTree(Object const& _x)
 {
 	// Identifies object being visited
-	string objectName = newObjectId(false);
-	vector<string> node{objectName};
+	std::string objectName = newObjectId(false);
+	std::vector<std::string> node{objectName};
 	if (_x.has_data())
 		node.emplace_back(s_dataIdentifier);
 	for (auto const& subObj: _x.sub_obj())
@@ -1988,12 +1987,12 @@ void ProtoConverter::buildObjectScopeTree(Object const& _x)
 		// Identifies sub object whose numeric suffix is
 		// m_objectId
 		unsigned subObjectId = m_objectId;
-		string subObjectName = "object" + to_string(subObjectId);
+		std::string subObjectName = "object" + std::to_string(subObjectId);
 		node.push_back(subObjectName);
 		buildObjectScopeTree(subObj);
 		// Add sub-object to object's ancestors
 		yulAssert(m_objectScope.count(subObjectName), "Yul proto fuzzer: Invalid object hierarchy");
-		for (string const& item: m_objectScope.at(subObjectName))
+		for (std::string const& item: m_objectScope.at(subObjectName))
 			if (item != subObjectName)
 				node.emplace_back(subObjectName + "." + item);
 	}
@@ -2033,13 +2032,13 @@ void ProtoConverter::visit(Program const& _x)
 	}
 }
 
-string ProtoConverter::programToString(Program const& _input)
+std::string ProtoConverter::programToString(Program const& _input)
 {
 	visit(_input);
 	return m_output.str();
 }
 
-string ProtoConverter::functionTypeToString(NumFunctionReturns _type)
+std::string ProtoConverter::functionTypeToString(NumFunctionReturns _type)
 {
 	switch (_type)
 	{

--- a/test/tools/ossfuzz/protomutators/YulProtoMutator.cpp
+++ b/test/tools/ossfuzz/protomutators/YulProtoMutator.cpp
@@ -6,11 +6,10 @@
 
 using namespace solidity::yul::test::yul_fuzzer;
 using namespace protobuf_mutator;
-using namespace std;
 
 using YPM = YulProtoMutator;
 
-MutationInfo::MutationInfo(ProtobufMessage const* _message, string const& _info):
+MutationInfo::MutationInfo(ProtobufMessage const* _message, std::string const& _info):
 	ScopeGuard([&]{ exitInfo(); }),
 	m_protobufMsg(_message)
 {
@@ -60,7 +59,7 @@ struct addControlFlow
 		/// Unused variable registers callback.
 		LPMPostProcessor<T> callback(function);
 	}
-	function<void(T*, unsigned)> function;
+	std::function<void(T*, unsigned)> function;
 };
 }
 
@@ -182,7 +181,7 @@ void YPM::addControlFlow(T* _msg, unsigned _seed)
 		Leave,
 		Termination
 	};
-	uniform_int_distribution<unsigned> d(
+	std::uniform_int_distribution<unsigned> d(
 		static_cast<unsigned>(ControlFlowStmt::For),
 		static_cast<unsigned>(ControlFlowStmt::Termination)
 	);
@@ -229,7 +228,7 @@ Block* YPM::randomBlock(ForStmt* _stmt, unsigned _seed)
 		Post = 1,
 		Body = 2
 	};
-	uniform_int_distribution<unsigned> d(
+	std::uniform_int_distribution<unsigned> d(
 		static_cast<unsigned>(ForBlocks::Init),
 		static_cast<unsigned>(ForBlocks::Body)
 	);

--- a/test/tools/ossfuzz/solProtoFuzzer.cpp
+++ b/test/tools/ossfuzz/solProtoFuzzer.cpp
@@ -35,19 +35,18 @@ using namespace solidity;
 using namespace solidity::frontend;
 using namespace solidity::test;
 using namespace solidity::util;
-using namespace std;
 
 DEFINE_PROTO_FUZZER(Program const& _input)
 {
 	ProtoConverter converter;
-	string sol_source = converter.protoToSolidity(_input);
+	std::string sol_source = converter.protoToSolidity(_input);
 
 	if (char const* dump_path = getenv("PROTO_FUZZER_DUMP_PATH"))
 	{
 		// With libFuzzer binary run this to generate a YUL source file x.yul:
 		// PROTO_FUZZER_DUMP_PATH=x.yul ./a.out proto-input
-		ofstream of(dump_path);
-		of.write(sol_source.data(), static_cast<streamsize>(sol_source.size()));
+		std::ofstream of(dump_path);
+		of.write(sol_source.data(), static_cast<std::streamsize>(sol_source.size()));
 	}
 
 	if (char const* dump_path = getenv("SOL_DEBUG_FILE"))
@@ -55,7 +54,7 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 		sol_source.clear();
 		// With libFuzzer binary run this to generate a YUL source file x.yul:
 		// PROTO_FUZZER_LOAD_PATH=x.yul ./a.out proto-input
-		ifstream ifstr(dump_path);
+		std::ifstream ifstr(dump_path);
 		sol_source = {
 			std::istreambuf_iterator<char>(ifstr),
 			std::istreambuf_iterator<char>()
@@ -66,9 +65,9 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 	// We target the default EVM which is the latest
 	langutil::EVMVersion version;
 	EVMHost hostContext(version, evmone);
-	string contractName = "C";
-	string libraryName = converter.libraryTest() ? converter.libraryName() : "";
-	string methodName = "test()";
+	std::string contractName = "C";
+	std::string libraryName = converter.libraryTest() ? converter.libraryName() : "";
+	std::string methodName = "test()";
 	StringMap source({{"test.sol", sol_source}});
 	CompilerInput cInput(version, source, contractName, OptimiserSettings::minimal(), {});
 	EvmoneUtility evmoneUtil(

--- a/test/tools/ossfuzz/solc_ossfuzz.cpp
+++ b/test/tools/ossfuzz/solc_ossfuzz.cpp
@@ -23,7 +23,6 @@
 #include <sstream>
 
 using namespace solidity::frontend::test;
-using namespace std;
 
 // Prototype as we can't use the FuzzerInterface.h header.
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size);
@@ -32,13 +31,13 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 {
 	if (_size <= 600)
 	{
-		string input(reinterpret_cast<char const*>(_data), _size);
-		map<string, string> sourceCode;
+		std::string input(reinterpret_cast<char const*>(_data), _size);
+		std::map<std::string, std::string> sourceCode;
 		try
 		{
 			TestCaseReader t = TestCaseReader(std::istringstream(input));
 			sourceCode = t.sources().sources;
-			map<string, string> settings = t.settings();
+			std::map<std::string, std::string> settings = t.settings();
 			bool compileViaYul =
 				settings.count("compileViaYul") &&
 				(settings.at("compileViaYul") == "also" || settings.at("compileViaYul") == "true");
@@ -51,7 +50,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 				compileViaYul
 			);
 		}
-		catch (runtime_error const&)
+		catch (std::runtime_error const&)
 		{
 			return 0;
 		}

--- a/test/tools/ossfuzz/strictasm_assembly_ossfuzz.cpp
+++ b/test/tools/ossfuzz/strictasm_assembly_ossfuzz.cpp
@@ -24,7 +24,6 @@
 
 using namespace solidity;
 using namespace solidity::yul;
-using namespace std;
 
 // Prototype as we can't use the FuzzerInterface.h header.
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size);
@@ -36,10 +35,10 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 
 	YulStringRepository::reset();
 
-	string input(reinterpret_cast<char const*>(_data), _size);
+	std::string input(reinterpret_cast<char const*>(_data), _size);
 	YulStack stack(
 		langutil::EVMVersion(),
-		nullopt,
+		std::nullopt,
 		YulStack::Language::StrictAssembly,
 		solidity::frontend::OptimiserSettings::minimal(),
 		langutil::DebugInfoSelection::All()

--- a/test/tools/ossfuzz/strictasm_diff_ossfuzz.cpp
+++ b/test/tools/ossfuzz/strictasm_diff_ossfuzz.cpp
@@ -36,7 +36,6 @@
 #include <memory>
 #include <iostream>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::yul;
 using namespace solidity::util;
@@ -51,7 +50,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 	if (_size > 600)
 		return 0;
 
-	string input(reinterpret_cast<char const*>(_data), _size);
+	std::string input(reinterpret_cast<char const*>(_data), _size);
 
 	if (std::any_of(input.begin(), input.end(), [](char c) {
 		return ((static_cast<unsigned char>(c) > 127) || !(isPrint(c) || (c == '\n') || (c == '\t')));
@@ -62,7 +61,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 
 	YulStack stack(
 		langutil::EVMVersion(),
-		nullopt,
+		std::nullopt,
 		YulStack::Language::StrictAssembly,
 		solidity::frontend::OptimiserSettings::full(),
 		DebugInfoSelection::All()
@@ -81,8 +80,8 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 		return 0;
 	}
 
-	ostringstream os1;
-	ostringstream os2;
+	std::ostringstream os1;
+	std::ostringstream os2;
 	// Disable memory tracing to avoid false positive reports
 	// such as unused write to memory e.g.,
 	// { mstore(0, 1) }

--- a/test/tools/ossfuzz/strictasm_opt_ossfuzz.cpp
+++ b/test/tools/ossfuzz/strictasm_opt_ossfuzz.cpp
@@ -25,7 +25,6 @@ using namespace solidity;
 using namespace solidity::langutil;
 using namespace solidity::util;
 using namespace solidity::yul;
-using namespace std;
 
 // Prototype as we can't use the FuzzerInterface.h header.
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size);
@@ -37,10 +36,10 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 
 	YulStringRepository::reset();
 
-	string input(reinterpret_cast<char const*>(_data), _size);
+	std::string input(reinterpret_cast<char const*>(_data), _size);
 	YulStack stack(
 		langutil::EVMVersion(),
-		nullopt,
+		std::nullopt,
 		YulStack::Language::StrictAssembly,
 		solidity::frontend::OptimiserSettings::full(),
 		DebugInfoSelection::All()

--- a/test/tools/ossfuzz/yulFuzzerCommon.cpp
+++ b/test/tools/ossfuzz/yulFuzzerCommon.cpp
@@ -17,14 +17,13 @@
 // SPDX-License-Identifier: GPL-3.0
 #include <test/tools/ossfuzz/yulFuzzerCommon.h>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::yul;
 using namespace solidity::yul::test::yul_fuzzer;
 
 yulFuzzerUtil::TerminationReason yulFuzzerUtil::interpret(
-	ostream& _os,
-	shared_ptr<yul::Block> _ast,
+	std::ostream& _os,
+	std::shared_ptr<yul::Block> _ast,
 	Dialect const& _dialect,
 	bool _disableMemoryTracing,
 	bool _outputStorageOnly,

--- a/test/tools/ossfuzz/yulProtoFuzzer.cpp
+++ b/test/tools/ossfuzz/yulProtoFuzzer.cpp
@@ -40,20 +40,19 @@ using namespace solidity::langutil;
 using namespace solidity::yul;
 using namespace solidity::yul::test;
 using namespace solidity::yul::test::yul_fuzzer;
-using namespace std;
 
 DEFINE_PROTO_FUZZER(Program const& _input)
 {
 	ProtoConverter converter;
-	string yul_source = converter.programToString(_input);
+	std::string yul_source = converter.programToString(_input);
 	EVMVersion version = converter.version();
 
 	if (const char* dump_path = getenv("PROTO_FUZZER_DUMP_PATH"))
 	{
 		// With libFuzzer binary run this to generate a YUL source file x.yul:
 		// PROTO_FUZZER_DUMP_PATH=x.yul ./a.out proto-input
-		ofstream of(dump_path);
-		of.write(yul_source.data(), static_cast<streamsize>(yul_source.size()));
+		std::ofstream of(dump_path);
+		of.write(yul_source.data(), static_cast<std::streamsize>(yul_source.size()));
 	}
 
 	if (yul_source.size() > 1200)
@@ -64,7 +63,7 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 	// YulStack entry point
 	YulStack stack(
 		version,
-		nullopt,
+		std::nullopt,
 		YulStack::Language::StrictAssembly,
 		solidity::frontend::OptimiserSettings::full(),
 		DebugInfoSelection::All()
@@ -85,6 +84,6 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 		EVMDialect::strictAssemblyForEVMObjects(version)
 	);
 	optimizerTest.setStep(optimizerTest.randomOptimiserStep(_input.step()));
-	shared_ptr<solidity::yul::Block> astBlock = optimizerTest.run();
+	std::shared_ptr<solidity::yul::Block> astBlock = optimizerTest.run();
 	yulAssert(astBlock != nullptr, "Optimiser error.");
 }

--- a/test/tools/ossfuzz/yulProto_diff_ossfuzz.cpp
+++ b/test/tools/ossfuzz/yulProto_diff_ossfuzz.cpp
@@ -36,7 +36,6 @@
 
 #include <test/tools/ossfuzz/yulFuzzerCommon.h>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::util;
 using namespace solidity::langutil;
@@ -47,15 +46,15 @@ using namespace solidity::yul::test::yul_fuzzer;
 DEFINE_PROTO_FUZZER(Program const& _input)
 {
 	ProtoConverter converter;
-	string yul_source = converter.programToString(_input);
+	std::string yul_source = converter.programToString(_input);
 	EVMVersion version = converter.version();
 
 	if (const char* dump_path = getenv("PROTO_FUZZER_DUMP_PATH"))
 	{
 		// With libFuzzer binary run this to generate a YUL source file x.yul:
 		// PROTO_FUZZER_DUMP_PATH=x.yul ./a.out proto-input
-		ofstream of(dump_path);
-		of.write(yul_source.data(), static_cast<streamsize>(yul_source.size()));
+		std::ofstream of(dump_path);
+		of.write(yul_source.data(), static_cast<std::streamsize>(yul_source.size()));
 	}
 
 	YulStringRepository::reset();
@@ -63,7 +62,7 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 	// YulStack entry point
 	YulStack stack(
 		version,
-		nullopt,
+		std::nullopt,
 		YulStack::Language::StrictAssembly,
 		solidity::frontend::OptimiserSettings::full(),
 		DebugInfoSelection::All()
@@ -81,8 +80,8 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 		yulAssert(false, "Proto fuzzer generated malformed program");
 	}
 
-	ostringstream os1;
-	ostringstream os2;
+	std::ostringstream os1;
+	std::ostringstream os2;
 	// Disable memory tracing to avoid false positive reports
 	// such as unused write to memory e.g.,
 	// { mstore(0, 1) }
@@ -102,7 +101,7 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 		EVMDialect::strictAssemblyForEVMObjects(version)
 	);
 	optimizerTest.setStep(optimizerTest.randomOptimiserStep(_input.step()));
-	shared_ptr<solidity::yul::Block> astBlock = optimizerTest.run();
+	std::shared_ptr<solidity::yul::Block> astBlock = optimizerTest.run();
 	yulAssert(astBlock != nullptr, "Optimiser error.");
 	termReason = yulFuzzerUtil::interpret(
 		os2,
@@ -116,8 +115,8 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 	bool isTraceEq = (os1.str() == os2.str());
 	if (!isTraceEq)
 	{
-		cout << os1.str() << endl;
-		cout << os2.str() << endl;
+		std::cout << os1.str() << std::endl;
+		std::cout << os2.str() << std::endl;
 		yulAssert(false, "Interpreted traces for optimized and unoptimized code differ.");
 	}
 	return;

--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -64,7 +64,6 @@
 #include <iostream>
 #include <variant>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::util;
 using namespace solidity::langutil;
@@ -79,14 +78,14 @@ public:
 	static void printErrors(CharStream const& _charStream, ErrorList const& _errors)
 	{
 		SourceReferenceFormatter{
-			cerr,
+			std::cerr,
 			SingletonCharStreamProvider(_charStream),
 			true,
 			false
 		}.printErrorInformation(_errors);
 	}
 
-	void parse(string const& _input)
+	void parse(std::string const& _input)
 	{
 		ErrorList errors;
 		ErrorReporter errorReporter(errors);
@@ -96,11 +95,11 @@ public:
 			m_ast = yul::Parser(errorReporter, m_dialect).parse(_charStream);
 			if (!m_ast || !errorReporter.errors().empty())
 			{
-				cerr << "Error parsing source." << endl;
+				std::cerr << "Error parsing source." << std::endl;
 				printErrors(_charStream, errors);
 				throw std::runtime_error("Could not parse source.");
 			}
-			m_analysisInfo = make_unique<yul::AsmAnalysisInfo>();
+			m_analysisInfo = std::make_unique<yul::AsmAnalysisInfo>();
 			AsmAnalyzer analyzer(
 				*m_analysisInfo,
 				errorReporter,
@@ -108,21 +107,21 @@ public:
 			);
 			if (!analyzer.analyze(*m_ast) || !errorReporter.errors().empty())
 			{
-				cerr << "Error analyzing source." << endl;
+				std::cerr << "Error analyzing source." << std::endl;
 				printErrors(_charStream, errors);
 				throw std::runtime_error("Could not analyze source.");
 			}
 		}
 		catch(...)
 		{
-			cerr << "Fatal error during parsing: " << endl;
+			std::cerr << "Fatal error during parsing: " << std::endl;
 			printErrors(_charStream, errors);
 			throw;
 		}
 	}
 
 	void printUsageBanner(
-		map<char, string> const& _extraOptions,
+		std::map<char, std::string> const& _extraOptions,
 		size_t _columns
 	)
 	{
@@ -134,10 +133,10 @@ public:
 			max_element(_extraOptions.begin(), _extraOptions.end(), hasShorterString)->second.size()
 		);
 
-		vector<string> overlappingAbbreviations =
+		std::vector<std::string> overlappingAbbreviations =
 			ranges::views::set_intersection(_extraOptions | ranges::views::keys, optimiserSteps | ranges::views::keys) |
-			ranges::views::transform([](char _abbreviation){ return string(1, _abbreviation); }) |
-			ranges::to<vector>();
+			ranges::views::transform([](char _abbreviation){ return std::string(1, _abbreviation); }) |
+			ranges::to<std::vector>();
 
 		yulAssert(
 			overlappingAbbreviations.empty(),
@@ -148,10 +147,10 @@ public:
 			"Please update the code to use a different character and recompile yulopti."
 		);
 
-		vector<tuple<char, string>> sortedOptions =
+		std::vector<std::tuple<char, std::string>> sortedOptions =
 			ranges::views::concat(optimiserSteps, _extraOptions) |
-			ranges::to<vector<tuple<char, string>>>() |
-			ranges::actions::sort([](tuple<char, string> const& _a, tuple<char, string> const& _b) {
+			ranges::to<std::vector<std::tuple<char, std::string>>>() |
+			ranges::actions::sort([](std::tuple<char, std::string> const& _a, std::tuple<char, std::string> const& _b) {
 				return (
 					!boost::algorithm::iequals(get<1>(_a), get<1>(_b)) ?
 					boost::algorithm::lexicographical_compare(get<1>(_a), get<1>(_b), boost::algorithm::is_iless()) :
@@ -164,9 +163,9 @@ public:
 		for (size_t row = 0; row < rows; ++row)
 		{
 			for (auto const& [key, name]: sortedOptions | ranges::views::drop(row) | ranges::views::stride(rows))
-				cout << key << ": " << setw(static_cast<int>(longestDescriptionLength)) << setiosflags(ios::left) << name << " ";
+				std::cout << key << ": " << std::setw(static_cast<int>(longestDescriptionLength)) << std::setiosflags(std::ios::left) << name << " ";
 
-			cout << endl;
+			std::cout << std::endl;
 		}
 	}
 
@@ -177,22 +176,22 @@ public:
 		m_nameDispenser.reset(*m_ast);
 	}
 
-	void runSteps(string _source, string _steps)
+	void runSteps(std::string _source, std::string _steps)
 	{
 		parse(_source);
 		disambiguate();
 		OptimiserSuite{m_context}.runSequence(_steps, *m_ast);
-		cout << AsmPrinter{m_dialect}(*m_ast) << endl;
+		std::cout << AsmPrinter{m_dialect}(*m_ast) << std::endl;
 	}
 
-	void runInteractive(string _source, bool _disambiguated = false)
+	void runInteractive(std::string _source, bool _disambiguated = false)
 	{
 		bool disambiguated = _disambiguated;
 		while (true)
 		{
 			parse(_source);
 			disambiguated = disambiguated || (disambiguate(), true);
-			map<char, string> const& extraOptions = {
+			std::map<char, std::string> const& extraOptions = {
 				// QUIT starts with a non-letter character on purpose to get it to show up on top of the list
 				{'#', ">>> QUIT <<<"},
 				{',', "VarNameCleaner"},
@@ -200,10 +199,10 @@ public:
 			};
 
 			printUsageBanner(extraOptions, 4);
-			cout << "? ";
-			cout.flush();
+			std::cout << "? ";
+			std::cout.flush();
 			char option = static_cast<char>(readStandardInputChar());
-			cout << ' ' << option << endl;
+			std::cout << ' ' << option << std::endl;
 
 			try
 			{
@@ -234,19 +233,19 @@ public:
 			}
 			catch (...)
 			{
-				cerr << endl << "Exception during optimiser step:" << endl;
-				cerr << boost::current_exception_diagnostic_information() << endl;
+				std::cerr << std::endl << "Exception during optimiser step:" << std::endl;
+				std::cerr << boost::current_exception_diagnostic_information() << std::endl;
 			}
-			cout << "----------------------" << endl;
-			cout << _source << endl;
+			std::cout << "----------------------" << std::endl;
+			std::cout << _source << std::endl;
 		}
 	}
 
 private:
-	shared_ptr<yul::Block> m_ast;
+	std::shared_ptr<yul::Block> m_ast;
 	Dialect const& m_dialect{EVMDialect::strictAssemblyForEVMObjects(EVMVersion{})};
-	unique_ptr<AsmAnalysisInfo> m_analysisInfo;
-	set<YulString> const m_reservedIdentifiers = {};
+	std::unique_ptr<AsmAnalysisInfo> m_analysisInfo;
+	std::set<YulString> const m_reservedIdentifiers = {};
 	NameDispenser m_nameDispenser{m_dialect, m_reservedIdentifiers};
 	OptimiserStepContext m_context{
 		m_dialect,
@@ -275,12 +274,12 @@ int main(int argc, char** argv)
 		options.add_options()
 			(
 				"input-file",
-				po::value<string>(),
+				po::value<std::string>(),
 				"input file"
 			)
 			(
 				"steps",
-				po::value<string>(),
+				po::value<std::string>(),
 				"steps to execute non-interactively"
 			)
 			(
@@ -302,43 +301,43 @@ int main(int argc, char** argv)
 
 		if (arguments.count("help"))
 		{
-			cout << options;
+			std::cout << options;
 			return 0;
 		}
 
-		string input;
+		std::string input;
 		if (arguments.count("input-file"))
 		{
-			string filename = arguments["input-file"].as<string>();
+			std::string filename = arguments["input-file"].as<std::string>();
 			if (filename == "-")
 			{
 				nonInteractive = true;
-				input = readUntilEnd(cin);
+				input = readUntilEnd(std::cin);
 			}
 			else
-				input = readFileAsString(arguments["input-file"].as<string>());
+				input = readFileAsString(arguments["input-file"].as<std::string>());
 		}
 		else
 		{
-			cout << options;
+			std::cout << options;
 			return 1;
 		}
 
 		if (nonInteractive && !arguments.count("steps"))
 		{
-			cout << options;
+			std::cout << options;
 			return 1;
 		}
 
 		YulOpti yulOpti;
 		bool disambiguated = false;
 		if (!nonInteractive)
-			cout << input << endl;
+			std::cout << input << std::endl;
 		if (arguments.count("steps"))
 		{
-			string sequence = arguments["steps"].as<string>();
+			std::string sequence = arguments["steps"].as<std::string>();
 			if (!nonInteractive)
-				cout << "----------------------" << endl;
+				std::cout << "----------------------" << std::endl;
 			yulOpti.runSteps(input, sequence);
 			disambiguated = true;
 		}
@@ -349,23 +348,23 @@ int main(int argc, char** argv)
 	}
 	catch (po::error const& _exception)
 	{
-		cerr << _exception.what() << endl;
+		std::cerr << _exception.what() << std::endl;
 		return 1;
 	}
 	catch (FileNotFound const& _exception)
 	{
-		cerr << "File not found:" << _exception.comment() << endl;
+		std::cerr << "File not found:" << _exception.comment() << std::endl;
 		return 1;
 	}
 	catch (NotAFile const& _exception)
 	{
-		cerr << "Not a regular file:" << _exception.comment() << endl;
+		std::cerr << "Not a regular file:" << _exception.comment() << std::endl;
 		return 1;
 	}
 	catch(...)
 	{
-		cerr << endl << "Exception:" << endl;
-		cerr << boost::current_exception_diagnostic_information() << endl;
+		std::cerr << std::endl << "Exception:" << std::endl;
+		std::cerr << boost::current_exception_diagnostic_information() << std::endl;
 		return 1;
 	}
 }

--- a/test/tools/yulrun.cpp
+++ b/test/tools/yulrun.cpp
@@ -43,7 +43,6 @@
 #include <memory>
 #include <iostream>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::util;
 using namespace solidity::langutil;
@@ -55,11 +54,11 @@ namespace po = boost::program_options;
 namespace
 {
 
-pair<shared_ptr<Block>, shared_ptr<AsmAnalysisInfo>> parse(string const& _source)
+std::pair<std::shared_ptr<Block>, std::shared_ptr<AsmAnalysisInfo>> parse(std::string const& _source)
 {
 	YulStack stack(
 		langutil::EVMVersion(),
-		nullopt,
+		std::nullopt,
 		YulStack::Language::StrictAssembly,
 		solidity::frontend::OptimiserSettings::none(),
 		DebugInfoSelection::Default()
@@ -71,15 +70,15 @@ pair<shared_ptr<Block>, shared_ptr<AsmAnalysisInfo>> parse(string const& _source
 	}
 	else
 	{
-		SourceReferenceFormatter(cout, stack, true, false).printErrorInformation(stack.errors());
+		SourceReferenceFormatter(std::cout, stack, true, false).printErrorInformation(stack.errors());
 		return {};
 	}
 }
 
-void interpret(string const& _source, bool _inspect, bool _disableExternalCalls)
+void interpret(std::string const& _source, bool _inspect, bool _disableExternalCalls)
 {
-	shared_ptr<Block> ast;
-	shared_ptr<AsmAnalysisInfo> analysisInfo;
+	std::shared_ptr<Block> ast;
+	std::shared_ptr<AsmAnalysisInfo> analysisInfo;
 	tie(ast, analysisInfo) = parse(_source);
 	if (!ast || !analysisInfo)
 		return;
@@ -100,7 +99,7 @@ void interpret(string const& _source, bool _inspect, bool _disableExternalCalls)
 	{
 	}
 
-	state.dumpTraceAndState(cout, /*disableMemoryTracing=*/false);
+	state.dumpTraceAndState(std::cout, /*disableMemoryTracing=*/false);
 }
 
 }
@@ -119,7 +118,7 @@ Allowed options)",
 		("help", "Show this help screen.")
 		("enable-external-calls", "Enable external calls")
 		("interactive", "Run interactive")
-		("input-file", po::value<vector<string>>(), "input file");
+		("input-file", po::value<std::vector<std::string>>(), "input file");
 	po::positional_options_description filesPositions;
 	filesPositions.add("input-file", -1);
 
@@ -132,17 +131,17 @@ Allowed options)",
 	}
 	catch (po::error const& _exception)
 	{
-		cerr << _exception.what() << endl;
+		std::cerr << _exception.what() << std::endl;
 		return 1;
 	}
 
 	if (arguments.count("help"))
-		cout << options;
+		std::cout << options;
 	else
 	{
-		string input;
+		std::string input;
 		if (arguments.count("input-file"))
-			for (string path: arguments["input-file"].as<vector<string>>())
+			for (std::string path: arguments["input-file"].as<std::vector<std::string>>())
 			{
 				try
 				{
@@ -150,17 +149,17 @@ Allowed options)",
 				}
 				catch (FileNotFound const&)
 				{
-					cerr << "File not found: " << path << endl;
+					std::cerr << "File not found: " << path << std::endl;
 					return 1;
 				}
 				catch (NotAFile const&)
 				{
-					cerr << "Not a regular file: " << path << endl;
+					std::cerr << "Not a regular file: " << path << std::endl;
 					return 1;
 				}
 			}
 		else
-			input = readUntilEnd(cin);
+			input = readUntilEnd(std::cin);
 
 		interpret(input, arguments.count("interactive"), !arguments.count("enable-external-calls"));
 	}

--- a/tools/yulPhaser/AlgorithmRunner.cpp
+++ b/tools/yulPhaser/AlgorithmRunner.cpp
@@ -26,7 +26,6 @@
 #include <cstring>
 #include <fstream>
 
-using namespace std;
 using namespace solidity::phaser;
 
 void AlgorithmRunner::run(GeneticAlgorithm& _algorithm)
@@ -65,12 +64,12 @@ void AlgorithmRunner::printRoundSummary(
 		if (m_options.showRoundInfo)
 		{
 			m_outputStream << "---------- ROUND " << _round + 1;
-			m_outputStream << " [round: " << fixed << setprecision(1) << roundTime << " s,";
-			m_outputStream << " total: " << fixed << setprecision(1) << totalTime << " s]";
-			m_outputStream << " ----------" << endl;
+			m_outputStream << " [round: " << std::fixed << std::setprecision(1) << roundTime << " s,";
+			m_outputStream << " total: " << std::fixed << std::setprecision(1) << totalTime << " s]";
+			m_outputStream << " ----------" << std::endl;
 		}
 		else if (m_population.individuals().size() > 0)
-			m_outputStream << endl;
+			m_outputStream << std::endl;
 
 		m_outputStream << m_population;
 	}
@@ -78,11 +77,11 @@ void AlgorithmRunner::printRoundSummary(
 	{
 		if (m_options.showRoundInfo)
 		{
-			m_outputStream << setw(5) << _round + 1 << " | ";
-			m_outputStream << setw(5) << fixed << setprecision(1) << totalTime << " | ";
+			m_outputStream << std::setw(5) << _round + 1 << " | ";
+			m_outputStream << std::setw(5) << std::fixed << std::setprecision(1) << totalTime << " | ";
 		}
 
-		m_outputStream << m_population.individuals()[0] << endl;
+		m_outputStream << m_population.individuals()[0] << std::endl;
 	}
 }
 
@@ -91,7 +90,7 @@ void AlgorithmRunner::printInitialPopulation() const
 	if (!m_options.showInitialPopulation)
 		return;
 
-	m_outputStream << "---------- INITIAL POPULATION ----------" << endl;
+	m_outputStream << "---------- INITIAL POPULATION ----------" << std::endl;
 	m_outputStream << m_population;
 }
 
@@ -108,23 +107,23 @@ void AlgorithmRunner::printCacheStats() const
 		else
 			++disabledCacheCount;
 
-	m_outputStream << "---------- CACHE STATS ----------" << endl;
+	m_outputStream << "---------- CACHE STATS ----------" << std::endl;
 
 	if (disabledCacheCount < m_programCaches.size())
 	{
 		for (auto& [round, count]: totalStats.roundEntryCounts)
-			m_outputStream << "Round " << round << ": " << count << " entries" << endl;
-		m_outputStream << "Total hits: " << totalStats.hits << endl;
-		m_outputStream << "Total misses: " << totalStats.misses << endl;
-		m_outputStream << "Size of cached code: " << totalStats.totalCodeSize << endl;
+			m_outputStream << "Round " << round << ": " << count << " entries" << std::endl;
+		m_outputStream << "Total hits: " << totalStats.hits << std::endl;
+		m_outputStream << "Total misses: " << totalStats.misses << std::endl;
+		m_outputStream << "Size of cached code: " << totalStats.totalCodeSize << std::endl;
 	}
 
 	if (disabledCacheCount == m_programCaches.size())
-		m_outputStream << "Program cache disabled" << endl;
+		m_outputStream << "Program cache disabled" << std::endl;
 	else if (disabledCacheCount > 0)
 	{
 		m_outputStream << "Program cache disabled for " << disabledCacheCount << " out of ";
-		m_outputStream << m_programCaches.size() << " programs" << endl;
+		m_outputStream << m_programCaches.size() << " programs" << std::endl;
 	}
 }
 
@@ -133,20 +132,20 @@ void AlgorithmRunner::populationAutosave() const
 	if (!m_options.populationAutosaveFile.has_value())
 		return;
 
-	ofstream outputStream(m_options.populationAutosaveFile.value(), ios::out | ios::trunc);
+	std::ofstream outputStream(m_options.populationAutosaveFile.value(), std::ios::out | std::ios::trunc);
 	assertThrow(
 		outputStream.is_open(),
 		FileOpenError,
-		"Could not open file '" + m_options.populationAutosaveFile.value() + "': " + strerror(errno)
+		"Could not open file '" + m_options.populationAutosaveFile.value() + "': " + std::strerror(errno)
 	);
 
 	for (auto& individual: m_population.individuals())
-		outputStream << individual.chromosome << endl;
+		outputStream << individual.chromosome << std::endl;
 
 	assertThrow(
 		!outputStream.bad(),
 		FileWriteError,
-		"Error while writing to file '" + m_options.populationAutosaveFile.value() + "': " + strerror(errno)
+		"Error while writing to file '" + m_options.populationAutosaveFile.value() + "': " + std::strerror(errno)
 	);
 }
 
@@ -188,7 +187,7 @@ Population AlgorithmRunner::randomiseDuplicates(
 	if (_population.individuals().size() == 0)
 		return _population;
 
-	vector<Individual> individuals{_population.individuals()[0]};
+	std::vector<Individual> individuals{_population.individuals()[0]};
 	size_t duplicateCount = 0;
 	for (size_t i = 1; i < _population.individuals().size(); ++i)
 		if (_population.individuals()[i].chromosome == _population.individuals()[i - 1].chromosome)

--- a/tools/yulPhaser/Chromosome.cpp
+++ b/tools/yulPhaser/Chromosome.cpp
@@ -25,7 +25,6 @@
 
 #include <sstream>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::yul;
 using namespace solidity::phaser;
@@ -33,36 +32,36 @@ using namespace solidity::phaser;
 namespace solidity::phaser
 {
 
-ostream& operator<<(ostream& _stream, Chromosome const& _chromosome);
+std::ostream& operator<<(std::ostream& _stream, Chromosome const& _chromosome);
 
 }
 
 Chromosome Chromosome::makeRandom(size_t _length)
 {
-	vector<string> steps;
+	std::vector<std::string> steps;
 	for (size_t i = 0; i < _length; ++i)
 		steps.push_back(randomOptimisationStep());
 
 	return Chromosome(std::move(steps));
 }
 
-ostream& phaser::operator<<(ostream& _stream, Chromosome const& _chromosome)
+std::ostream& phaser::operator<<(std::ostream& _stream, Chromosome const& _chromosome)
 {
 	return _stream << _chromosome.m_genes;
 }
 
-vector<string> Chromosome::allStepNames()
+std::vector<std::string> Chromosome::allStepNames()
 {
-	vector<string> stepNames;
+	std::vector<std::string> stepNames;
 	for (auto const& step: OptimiserSuite::allSteps())
 		stepNames.push_back(step.first);
 
 	return stepNames;
 }
 
-string const& Chromosome::randomOptimisationStep()
+std::string const& Chromosome::randomOptimisationStep()
 {
-	static vector<string> stepNames = allStepNames();
+	static std::vector<std::string> stepNames = allStepNames();
 
 	return stepNames[SimulationRNG::uniformInt(0, stepNames.size() - 1)];
 }
@@ -72,18 +71,18 @@ char Chromosome::randomGene()
 	return OptimiserSuite::stepNameToAbbreviationMap().at(randomOptimisationStep());
 }
 
-string Chromosome::stepsToGenes(vector<string> const& _optimisationSteps)
+std::string Chromosome::stepsToGenes(std::vector<std::string> const& _optimisationSteps)
 {
-	string genes;
-	for (string const& stepName: _optimisationSteps)
+	std::string genes;
+	for (std::string const& stepName: _optimisationSteps)
 		genes.push_back(OptimiserSuite::stepNameToAbbreviationMap().at(stepName));
 
 	return genes;
 }
 
-vector<string> Chromosome::genesToSteps(string const& _genes)
+std::vector<std::string> Chromosome::genesToSteps(std::string const& _genes)
 {
-	vector<string> steps;
+	std::vector<std::string> steps;
 	for (char abbreviation: _genes)
 		steps.push_back(OptimiserSuite::stepAbbreviationToNameMap().at(abbreviation));
 

--- a/tools/yulPhaser/Common.cpp
+++ b/tools/yulPhaser/Common.cpp
@@ -26,21 +26,20 @@
 #include <cstring>
 #include <fstream>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::phaser;
 
-vector<string> phaser::readLinesFromFile(string const& _path)
+std::vector<std::string> phaser::readLinesFromFile(std::string const& _path)
 {
-	ifstream inputStream(_path);
-	assertThrow(inputStream.is_open(), FileOpenError, "Could not open file '" + _path + "': " + strerror(errno));
+	std::ifstream inputStream(_path);
+	assertThrow(inputStream.is_open(), FileOpenError, "Could not open file '" + _path + "': " + std::strerror(errno));
 
-	string line;
-	vector<string> lines;
-	while (!getline(inputStream, line).fail())
+	std::string line;
+	std::vector<std::string> lines;
+	while (!std::getline(inputStream, line).fail())
 		lines.push_back(line);
 
-	assertThrow(!inputStream.bad(), FileReadError, "Error while reading from file '" + _path + "': " + strerror(errno));
+	assertThrow(!inputStream.bad(), FileReadError, "Error while reading from file '" + _path + "': " + std::strerror(errno));
 
 	return lines;
 }

--- a/tools/yulPhaser/FitnessMetrics.cpp
+++ b/tools/yulPhaser/FitnessMetrics.cpp
@@ -22,7 +22,6 @@
 
 #include <cmath>
 
-using namespace std;
 using namespace solidity::util;
 using namespace solidity::yul;
 using namespace solidity::phaser;
@@ -62,7 +61,7 @@ size_t ProgramSize::evaluate(Chromosome const& _chromosome)
 
 size_t RelativeProgramSize::evaluate(Chromosome const& _chromosome)
 {
-	double const scalingFactor = pow(10, m_fixedPointPrecision);
+	double const scalingFactor = std::pow(10, m_fixedPointPrecision);
 
 	size_t unoptimisedSize = optimisedProgram(Chromosome("")).codeSize(codeWeights());
 	if (unoptimisedSize == 0)
@@ -70,7 +69,7 @@ size_t RelativeProgramSize::evaluate(Chromosome const& _chromosome)
 
 	size_t optimisedSize = optimisedProgram(_chromosome).codeSize(codeWeights());
 
-	return static_cast<size_t>(round(
+	return static_cast<size_t>(std::round(
 		double(optimisedSize) / double(unoptimisedSize) * scalingFactor
 	));
 }
@@ -103,7 +102,7 @@ size_t FitnessMetricMaximum::evaluate(Chromosome const& _chromosome)
 
 	size_t maximum = m_metrics[0]->evaluate(_chromosome);
 	for (size_t i = 1; i < m_metrics.size(); ++i)
-		maximum = max(maximum, m_metrics[i]->evaluate(_chromosome));
+		maximum = std::max(maximum, m_metrics[i]->evaluate(_chromosome));
 
 	return maximum;
 }
@@ -114,7 +113,7 @@ size_t FitnessMetricMinimum::evaluate(Chromosome const& _chromosome)
 
 	size_t minimum = m_metrics[0]->evaluate(_chromosome);
 	for (size_t i = 1; i < m_metrics.size(); ++i)
-		minimum = min(minimum, m_metrics[i]->evaluate(_chromosome));
+		minimum = std::min(minimum, m_metrics[i]->evaluate(_chromosome));
 
 	return minimum;
 }

--- a/tools/yulPhaser/GeneticAlgorithms.cpp
+++ b/tools/yulPhaser/GeneticAlgorithms.cpp
@@ -21,13 +21,12 @@
 #include <tools/yulPhaser/Selections.h>
 #include <tools/yulPhaser/PairSelections.h>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::phaser;
 
-function<Crossover> phaser::buildCrossoverOperator(
+std::function<Crossover> phaser::buildCrossoverOperator(
 	CrossoverChoice _choice,
-	optional<double> _uniformCrossoverSwapChance
+	std::optional<double> _uniformCrossoverSwapChance
 )
 {
 	switch (_choice)
@@ -44,9 +43,9 @@ function<Crossover> phaser::buildCrossoverOperator(
 	};
 }
 
-function<SymmetricCrossover> phaser::buildSymmetricCrossoverOperator(
+std::function<SymmetricCrossover> phaser::buildSymmetricCrossoverOperator(
 	CrossoverChoice _choice,
-	optional<double> _uniformCrossoverSwapChance
+	std::optional<double> _uniformCrossoverSwapChance
 )
 {
 	switch (_choice)
@@ -146,14 +145,14 @@ Population ClassicGeneticAlgorithm::select(Population _population, size_t _selec
 
 	size_t maxFitness = 0;
 	for (auto const& individual: _population.individuals())
-		maxFitness = max(maxFitness, individual.fitness);
+		maxFitness = std::max(maxFitness, individual.fitness);
 
 	size_t rouletteRange = 0;
 	for (auto const& individual: _population.individuals())
 		// Add 1 to make sure that every chromosome has non-zero probability of being chosen
 		rouletteRange += maxFitness + 1 - individual.fitness;
 
-	vector<Individual> selectedIndividuals;
+	std::vector<Individual> selectedIndividuals;
 	for (size_t i = 0; i < _selectionSize; ++i)
 	{
 		size_t ball = SimulationRNG::uniformInt(0, rouletteRange - 1);

--- a/tools/yulPhaser/Mutations.cpp
+++ b/tools/yulPhaser/Mutations.cpp
@@ -28,15 +28,14 @@
 #include <string>
 #include <vector>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::phaser;
 
-function<Mutation> phaser::geneRandomisation(double _chance)
+std::function<Mutation> phaser::geneRandomisation(double _chance)
 {
 	return [=](Chromosome const& _chromosome)
 	{
-		string genes;
+		std::string genes;
 		for (char gene: _chromosome.genes())
 			genes.push_back(
 				SimulationRNG::bernoulliTrial(_chance) ?
@@ -48,11 +47,11 @@ function<Mutation> phaser::geneRandomisation(double _chance)
 	};
 }
 
-function<Mutation> phaser::geneDeletion(double _chance)
+std::function<Mutation> phaser::geneDeletion(double _chance)
 {
 	return [=](Chromosome const& _chromosome)
 	{
-		string genes;
+		std::string genes;
 		for (char gene: _chromosome.genes())
 			if (!SimulationRNG::bernoulliTrial(_chance))
 				genes.push_back(gene);
@@ -61,11 +60,11 @@ function<Mutation> phaser::geneDeletion(double _chance)
 	};
 }
 
-function<Mutation> phaser::geneAddition(double _chance)
+std::function<Mutation> phaser::geneAddition(double _chance)
 {
 	return [=](Chromosome const& _chromosome)
 	{
-		string genes;
+		std::string genes;
 
 		if (SimulationRNG::bernoulliTrial(_chance))
 			genes.push_back(Chromosome::randomGene());
@@ -81,10 +80,10 @@ function<Mutation> phaser::geneAddition(double _chance)
 	};
 }
 
-function<Mutation> phaser::alternativeMutations(
+std::function<Mutation> phaser::alternativeMutations(
 	double _firstMutationChance,
-	function<Mutation> _mutation1,
-	function<Mutation> _mutation2
+	std::function<Mutation> _mutation1,
+	std::function<Mutation> _mutation2
 )
 {
 	return [=](Chromosome const& _chromosome)
@@ -96,7 +95,7 @@ function<Mutation> phaser::alternativeMutations(
 	};
 }
 
-function<Mutation> phaser::mutationSequence(vector<function<Mutation>> _mutations)
+std::function<Mutation> phaser::mutationSequence(std::vector<std::function<Mutation>> _mutations)
 {
 	return [=](Chromosome const& _chromosome)
 	{
@@ -134,26 +133,26 @@ ChromosomePair fixedPointSwap(
 
 }
 
-function<Crossover> phaser::randomPointCrossover()
+std::function<Crossover> phaser::randomPointCrossover()
 {
 	return [=](Chromosome const& _chromosome1, Chromosome const& _chromosome2)
 	{
-		size_t minLength = min(_chromosome1.length(), _chromosome2.length());
+		size_t minLength = std::min(_chromosome1.length(), _chromosome2.length());
 
 		// Don't use position 0 (because this just swaps the values) unless it's the only choice.
 		size_t minPoint = (minLength > 0 ? 1 : 0);
 		assert(minPoint <= minLength);
 
 		size_t randomPoint = SimulationRNG::uniformInt(minPoint, minLength);
-		return get<0>(fixedPointSwap(_chromosome1, _chromosome2, randomPoint));
+		return std::get<0>(fixedPointSwap(_chromosome1, _chromosome2, randomPoint));
 	};
 }
 
-function<SymmetricCrossover> phaser::symmetricRandomPointCrossover()
+std::function<SymmetricCrossover> phaser::symmetricRandomPointCrossover()
 {
 	return [=](Chromosome const& _chromosome1, Chromosome const& _chromosome2)
 	{
-		size_t minLength = min(_chromosome1.length(), _chromosome2.length());
+		size_t minLength = std::min(_chromosome1.length(), _chromosome2.length());
 
 		// Don't use position 0 (because this just swaps the values) unless it's the only choice.
 		size_t minPoint = (minLength > 0 ? 1 : 0);
@@ -164,16 +163,16 @@ function<SymmetricCrossover> phaser::symmetricRandomPointCrossover()
 	};
 }
 
-function<Crossover> phaser::fixedPointCrossover(double _crossoverPoint)
+std::function<Crossover> phaser::fixedPointCrossover(double _crossoverPoint)
 {
 	assert(0.0 <= _crossoverPoint && _crossoverPoint <= 1.0);
 
 	return [=](Chromosome const& _chromosome1, Chromosome const& _chromosome2)
 	{
-		size_t minLength = min(_chromosome1.length(), _chromosome2.length());
-		size_t concretePoint = static_cast<size_t>(round(double(minLength) * _crossoverPoint));
+		size_t minLength = std::min(_chromosome1.length(), _chromosome2.length());
+		size_t concretePoint = static_cast<size_t>(std::round(double(minLength) * _crossoverPoint));
 
-		return get<0>(fixedPointSwap(_chromosome1, _chromosome2, concretePoint));
+		return std::get<0>(fixedPointSwap(_chromosome1, _chromosome2, concretePoint));
 	};
 }
 
@@ -192,8 +191,8 @@ ChromosomePair fixedTwoPointSwap(
 	assert(_crossoverPoint2 <= _chromosome1.length());
 	assert(_crossoverPoint2 <= _chromosome2.length());
 
-	size_t lowPoint = min(_crossoverPoint1, _crossoverPoint2);
-	size_t highPoint = max(_crossoverPoint1, _crossoverPoint2);
+	size_t lowPoint = std::min(_crossoverPoint1, _crossoverPoint2);
+	size_t highPoint = std::max(_crossoverPoint1, _crossoverPoint2);
 
 	return {
 		Chromosome(
@@ -211,11 +210,11 @@ ChromosomePair fixedTwoPointSwap(
 
 }
 
-function<Crossover> phaser::randomTwoPointCrossover()
+std::function<Crossover> phaser::randomTwoPointCrossover()
 {
 	return [=](Chromosome const& _chromosome1, Chromosome const& _chromosome2)
 	{
-		size_t minLength = min(_chromosome1.length(), _chromosome2.length());
+		size_t minLength = std::min(_chromosome1.length(), _chromosome2.length());
 
 		// Don't use position 0 (because this just swaps the values) unless it's the only choice.
 		size_t minPoint = (minLength > 0 ? 1 : 0);
@@ -223,15 +222,15 @@ function<Crossover> phaser::randomTwoPointCrossover()
 
 		size_t randomPoint1 = SimulationRNG::uniformInt(minPoint, minLength);
 		size_t randomPoint2 = SimulationRNG::uniformInt(randomPoint1, minLength);
-		return get<0>(fixedTwoPointSwap(_chromosome1, _chromosome2, randomPoint1, randomPoint2));
+		return std::get<0>(fixedTwoPointSwap(_chromosome1, _chromosome2, randomPoint1, randomPoint2));
 	};
 }
 
-function<SymmetricCrossover> phaser::symmetricRandomTwoPointCrossover()
+std::function<SymmetricCrossover> phaser::symmetricRandomTwoPointCrossover()
 {
 	return [=](Chromosome const& _chromosome1, Chromosome const& _chromosome2)
 	{
-		size_t minLength = min(_chromosome1.length(), _chromosome2.length());
+		size_t minLength = std::min(_chromosome1.length(), _chromosome2.length());
 
 		// Don't use position 0 (because this just swaps the values) unless it's the only choice.
 		size_t minPoint = (minLength > 0 ? 1 : 0);
@@ -248,10 +247,10 @@ namespace
 
 ChromosomePair uniformSwap(Chromosome const& _chromosome1, Chromosome const& _chromosome2, double _swapChance)
 {
-	string steps1;
-	string steps2;
+	std::string steps1;
+	std::string steps2;
 
-	size_t minLength = min(_chromosome1.length(), _chromosome2.length());
+	size_t minLength = std::min(_chromosome1.length(), _chromosome2.length());
 	for (size_t i = 0; i < minLength; ++i)
 		if (SimulationRNG::bernoulliTrial(_swapChance))
 		{
@@ -286,15 +285,15 @@ ChromosomePair uniformSwap(Chromosome const& _chromosome1, Chromosome const& _ch
 
 }
 
-function<Crossover> phaser::uniformCrossover(double _swapChance)
+std::function<Crossover> phaser::uniformCrossover(double _swapChance)
 {
 	return [=](Chromosome const& _chromosome1, Chromosome const& _chromosome2)
 	{
-		return get<0>(uniformSwap(_chromosome1, _chromosome2, _swapChance));
+		return std::get<0>(uniformSwap(_chromosome1, _chromosome2, _swapChance));
 	};
 }
 
-function<SymmetricCrossover> phaser::symmetricUniformCrossover(double _swapChance)
+std::function<SymmetricCrossover> phaser::symmetricUniformCrossover(double _swapChance)
 {
 	return [=](Chromosome const& _chromosome1, Chromosome const& _chromosome2)
 	{

--- a/tools/yulPhaser/PairSelections.cpp
+++ b/tools/yulPhaser/PairSelections.cpp
@@ -23,17 +23,16 @@
 
 #include <cmath>
 
-using namespace std;
 using namespace solidity::phaser;
 
-vector<tuple<size_t, size_t>> RandomPairSelection::materialise(size_t _poolSize) const
+std::vector<std::tuple<size_t, size_t>> RandomPairSelection::materialise(size_t _poolSize) const
 {
 	if (_poolSize < 2)
 		return {};
 
-	auto count = static_cast<size_t>(round(double(_poolSize) * m_selectionSize));
+	auto count = static_cast<size_t>(std::round(double(_poolSize) * m_selectionSize));
 
-	vector<tuple<size_t, size_t>> selection;
+	std::vector<std::tuple<size_t, size_t>> selection;
 	for (size_t i = 0; i < count; ++i)
 	{
 		size_t index1 = SimulationRNG::uniformInt(0, _poolSize - 1);
@@ -49,9 +48,9 @@ vector<tuple<size_t, size_t>> RandomPairSelection::materialise(size_t _poolSize)
 	return selection;
 }
 
-vector<tuple<size_t, size_t>> PairsFromRandomSubset::materialise(size_t _poolSize) const
+std::vector<std::tuple<size_t, size_t>> PairsFromRandomSubset::materialise(size_t _poolSize) const
 {
-	vector<size_t> selectedIndices = RandomSubset(m_selectionChance).materialise(_poolSize);
+	std::vector<size_t> selectedIndices = RandomSubset(m_selectionChance).materialise(_poolSize);
 
 	if (selectedIndices.size() % 2 != 0)
 	{
@@ -72,7 +71,7 @@ vector<tuple<size_t, size_t>> PairsFromRandomSubset::materialise(size_t _poolSiz
 	}
 	assert(selectedIndices.size() % 2 == 0);
 
-	vector<tuple<size_t, size_t>> selectedPairs;
+	std::vector<std::tuple<size_t, size_t>> selectedPairs;
 	for (size_t i = selectedIndices.size() / 2; i > 0; --i)
 	{
 		size_t position1 = SimulationRNG::uniformInt(0, selectedIndices.size() - 1);
@@ -89,18 +88,18 @@ vector<tuple<size_t, size_t>> PairsFromRandomSubset::materialise(size_t _poolSiz
 	return selectedPairs;
 }
 
-vector<tuple<size_t, size_t>> PairMosaicSelection::materialise(size_t _poolSize) const
+std::vector<std::tuple<size_t, size_t>> PairMosaicSelection::materialise(size_t _poolSize) const
 {
 	if (_poolSize < 2)
 		return {};
 
-	size_t count = static_cast<size_t>(round(double(_poolSize) * m_selectionSize));
+	size_t count = static_cast<size_t>(std::round(double(_poolSize) * m_selectionSize));
 
-	vector<tuple<size_t, size_t>> selection;
+	std::vector<std::tuple<size_t, size_t>> selection;
 	for (size_t i = 0; i < count; ++i)
 	{
-		tuple<size_t, size_t> pair = m_pattern[i % m_pattern.size()];
-		selection.emplace_back(min(get<0>(pair), _poolSize - 1), min(get<1>(pair), _poolSize - 1));
+		std::tuple<size_t, size_t> pair = m_pattern[i % m_pattern.size()];
+		selection.emplace_back(std::min(std::get<0>(pair), _poolSize - 1), std::min(std::get<1>(pair), _poolSize - 1));
 	}
 
 	return selection;

--- a/tools/yulPhaser/Phaser.cpp
+++ b/tools/yulPhaser/Phaser.cpp
@@ -37,7 +37,6 @@
 
 #include <iostream>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::langutil;
 using namespace solidity::util;
@@ -49,58 +48,58 @@ namespace po = boost::program_options;
 namespace
 {
 
-map<PhaserMode, string> const PhaserModeToStringMap =
+std::map<PhaserMode, std::string> const PhaserModeToStringMap =
 {
 	{PhaserMode::RunAlgorithm, "run-algorithm"},
 	{PhaserMode::PrintOptimisedPrograms, "print-optimised-programs"},
 	{PhaserMode::PrintOptimisedASTs, "print-optimised-asts"},
 };
-map<string, PhaserMode> const StringToPhaserModeMap = invertMap(PhaserModeToStringMap);
+std::map<std::string, PhaserMode> const StringToPhaserModeMap = invertMap(PhaserModeToStringMap);
 
-map<Algorithm, string> const AlgorithmToStringMap =
+std::map<Algorithm, std::string> const AlgorithmToStringMap =
 {
 	{Algorithm::Random, "random"},
 	{Algorithm::GEWEP, "GEWEP"},
 	{Algorithm::Classic, "classic"},
 };
-map<string, Algorithm> const StringToAlgorithmMap = invertMap(AlgorithmToStringMap);
+std::map<std::string, Algorithm> const StringToAlgorithmMap = invertMap(AlgorithmToStringMap);
 
-map<MetricChoice, string> MetricChoiceToStringMap =
+std::map<MetricChoice, std::string> MetricChoiceToStringMap =
 {
 	{MetricChoice::CodeSize, "code-size"},
 	{MetricChoice::RelativeCodeSize, "relative-code-size"},
 };
-map<string, MetricChoice> const StringToMetricChoiceMap = invertMap(MetricChoiceToStringMap);
+std::map<std::string, MetricChoice> const StringToMetricChoiceMap = invertMap(MetricChoiceToStringMap);
 
-map<MetricAggregatorChoice, string> const MetricAggregatorChoiceToStringMap =
+std::map<MetricAggregatorChoice, std::string> const MetricAggregatorChoiceToStringMap =
 {
 	{MetricAggregatorChoice::Average, "average"},
 	{MetricAggregatorChoice::Sum, "sum"},
 	{MetricAggregatorChoice::Maximum, "maximum"},
 	{MetricAggregatorChoice::Minimum, "minimum"},
 };
-map<string, MetricAggregatorChoice> const StringToMetricAggregatorChoiceMap = invertMap(MetricAggregatorChoiceToStringMap);
+std::map<std::string, MetricAggregatorChoice> const StringToMetricAggregatorChoiceMap = invertMap(MetricAggregatorChoiceToStringMap);
 
-map<CrossoverChoice, string> const CrossoverChoiceToStringMap =
+std::map<CrossoverChoice, std::string> const CrossoverChoiceToStringMap =
 {
 	{CrossoverChoice::SinglePoint, "single-point"},
 	{CrossoverChoice::TwoPoint, "two-point"},
 	{CrossoverChoice::Uniform, "uniform"},
 };
-map<string, CrossoverChoice> const StringToCrossoverChoiceMap = invertMap(CrossoverChoiceToStringMap);
+std::map<std::string, CrossoverChoice> const StringToCrossoverChoiceMap = invertMap(CrossoverChoiceToStringMap);
 
 }
 
-istream& phaser::operator>>(istream& _inputStream, PhaserMode& _phaserMode) { return deserializeChoice(_inputStream, _phaserMode, StringToPhaserModeMap); }
-ostream& phaser::operator<<(ostream& _outputStream, PhaserMode _phaserMode) { return serializeChoice(_outputStream, _phaserMode, PhaserModeToStringMap); }
-istream& phaser::operator>>(istream& _inputStream, Algorithm& _algorithm) { return deserializeChoice(_inputStream, _algorithm, StringToAlgorithmMap); }
-ostream& phaser::operator<<(ostream& _outputStream, Algorithm _algorithm) { return serializeChoice(_outputStream, _algorithm, AlgorithmToStringMap); }
-istream& phaser::operator>>(istream& _inputStream, MetricChoice& _metric) { return deserializeChoice(_inputStream, _metric, StringToMetricChoiceMap); }
-ostream& phaser::operator<<(ostream& _outputStream, MetricChoice _metric) { return serializeChoice(_outputStream, _metric, MetricChoiceToStringMap); }
-istream& phaser::operator>>(istream& _inputStream, MetricAggregatorChoice& _aggregator) { return deserializeChoice(_inputStream, _aggregator, StringToMetricAggregatorChoiceMap); }
-ostream& phaser::operator<<(ostream& _outputStream, MetricAggregatorChoice _aggregator) { return serializeChoice(_outputStream, _aggregator, MetricAggregatorChoiceToStringMap); }
-istream& phaser::operator>>(istream& _inputStream, CrossoverChoice& _crossover) { return deserializeChoice(_inputStream, _crossover, StringToCrossoverChoiceMap); }
-ostream& phaser::operator<<(ostream& _outputStream, CrossoverChoice _crossover) { return serializeChoice(_outputStream, _crossover, CrossoverChoiceToStringMap); }
+std::istream& phaser::operator>>(std::istream& _inputStream, PhaserMode& _phaserMode) { return deserializeChoice(_inputStream, _phaserMode, StringToPhaserModeMap); }
+std::ostream& phaser::operator<<(std::ostream& _outputStream, PhaserMode _phaserMode) { return serializeChoice(_outputStream, _phaserMode, PhaserModeToStringMap); }
+std::istream& phaser::operator>>(std::istream& _inputStream, Algorithm& _algorithm) { return deserializeChoice(_inputStream, _algorithm, StringToAlgorithmMap); }
+std::ostream& phaser::operator<<(std::ostream& _outputStream, Algorithm _algorithm) { return serializeChoice(_outputStream, _algorithm, AlgorithmToStringMap); }
+std::istream& phaser::operator>>(std::istream& _inputStream, MetricChoice& _metric) { return deserializeChoice(_inputStream, _metric, StringToMetricChoiceMap); }
+std::ostream& phaser::operator<<(std::ostream& _outputStream, MetricChoice _metric) { return serializeChoice(_outputStream, _metric, MetricChoiceToStringMap); }
+std::istream& phaser::operator>>(std::istream& _inputStream, MetricAggregatorChoice& _aggregator) { return deserializeChoice(_inputStream, _aggregator, StringToMetricAggregatorChoiceMap); }
+std::ostream& phaser::operator<<(std::ostream& _outputStream, MetricAggregatorChoice _aggregator) { return serializeChoice(_outputStream, _aggregator, MetricAggregatorChoiceToStringMap); }
+std::istream& phaser::operator>>(std::istream& _inputStream, CrossoverChoice& _crossover) { return deserializeChoice(_inputStream, _crossover, StringToCrossoverChoiceMap); }
+std::ostream& phaser::operator<<(std::ostream& _outputStream, CrossoverChoice _crossover) { return serializeChoice(_outputStream, _crossover, CrossoverChoiceToStringMap); }
 
 GeneticAlgorithmFactory::Options GeneticAlgorithmFactory::Options::fromCommandLine(po::variables_map const& _arguments)
 {
@@ -112,17 +111,17 @@ GeneticAlgorithmFactory::Options GeneticAlgorithmFactory::Options::fromCommandLi
 		_arguments["uniform-crossover-swap-chance"].as<double>(),
 		_arguments.count("random-elite-pool-size") > 0 ?
 			_arguments["random-elite-pool-size"].as<double>() :
-			optional<double>{},
+			std::optional<double>{},
 		_arguments["gewep-mutation-pool-size"].as<double>(),
 		_arguments["gewep-crossover-pool-size"].as<double>(),
 		_arguments["gewep-randomisation-chance"].as<double>(),
 		_arguments["gewep-deletion-vs-addition-chance"].as<double>(),
 		_arguments.count("gewep-genes-to-randomise") > 0 ?
 			_arguments["gewep-genes-to-randomise"].as<double>() :
-			optional<double>{},
+			std::optional<double>{},
 		_arguments.count("gewep-genes-to-add-or-delete") > 0 ?
 			_arguments["gewep-genes-to-add-or-delete"].as<double>() :
-			optional<double>{},
+			std::optional<double>{},
 		_arguments["classic-elite-pool-size"].as<double>(),
 		_arguments["classic-crossover-chance"].as<double>(),
 		_arguments["classic-mutation-chance"].as<double>(),
@@ -131,7 +130,7 @@ GeneticAlgorithmFactory::Options GeneticAlgorithmFactory::Options::fromCommandLi
 	};
 }
 
-unique_ptr<GeneticAlgorithm> GeneticAlgorithmFactory::build(
+std::unique_ptr<GeneticAlgorithm> GeneticAlgorithmFactory::build(
 	Options const& _options,
 	size_t _populationSize
 )
@@ -147,7 +146,7 @@ unique_ptr<GeneticAlgorithm> GeneticAlgorithmFactory::build(
 			if (_options.randomElitePoolSize.has_value())
 				elitePoolSize = _options.randomElitePoolSize.value();
 
-			return make_unique<RandomAlgorithm>(RandomAlgorithm::Options{
+			return std::make_unique<RandomAlgorithm>(RandomAlgorithm::Options{
 				/* elitePoolSize = */ elitePoolSize,
 				/* minChromosomeLength = */ _options.minChromosomeLength,
 				/* maxChromosomeLength = */ _options.maxChromosomeLength,
@@ -163,7 +162,7 @@ unique_ptr<GeneticAlgorithm> GeneticAlgorithmFactory::build(
 			if (_options.gewepGenesToAddOrDelete.has_value())
 				percentGenesToAddOrDelete = _options.gewepGenesToAddOrDelete.value();
 
-			return make_unique<GenerationalElitistWithExclusivePools>(GenerationalElitistWithExclusivePools::Options{
+			return std::make_unique<GenerationalElitistWithExclusivePools>(GenerationalElitistWithExclusivePools::Options{
 				/* mutationPoolSize = */ _options.gewepMutationPoolSize,
 				/* crossoverPoolSize = */ _options.gewepCrossoverPoolSize,
 				/* randomisationChance = */ _options.gewepRandomisationChance,
@@ -176,7 +175,7 @@ unique_ptr<GeneticAlgorithm> GeneticAlgorithmFactory::build(
 		}
 		case Algorithm::Classic:
 		{
-			return make_unique<ClassicGeneticAlgorithm>(ClassicGeneticAlgorithm::Options{
+			return std::make_unique<ClassicGeneticAlgorithm>(ClassicGeneticAlgorithm::Options{
 				/* elitePoolSize = */ _options.classicElitePoolSize,
 				/* crossoverChance = */ _options.classicCrossoverChance,
 				/* mutationChance = */ _options.classicMutationChance,
@@ -222,24 +221,24 @@ FitnessMetricFactory::Options FitnessMetricFactory::Options::fromCommandLine(po:
 	};
 }
 
-unique_ptr<FitnessMetric> FitnessMetricFactory::build(
+std::unique_ptr<FitnessMetric> FitnessMetricFactory::build(
 	Options const& _options,
-	vector<Program> _programs,
-	vector<shared_ptr<ProgramCache>> _programCaches,
+	std::vector<Program> _programs,
+	std::vector<std::shared_ptr<ProgramCache>> _programCaches,
 	CodeWeights const& _weights
 )
 {
 	assert(_programCaches.size() == _programs.size());
 	assert(_programs.size() > 0 && "Validations should prevent this from being executed with zero files.");
 
-	vector<shared_ptr<FitnessMetric>> metrics;
+	std::vector<std::shared_ptr<FitnessMetric>> metrics;
 	switch (_options.metric)
 	{
 		case MetricChoice::CodeSize:
 		{
 			for (size_t i = 0; i < _programs.size(); ++i)
-				metrics.push_back(make_unique<ProgramSize>(
-					_programCaches[i] != nullptr ? optional<Program>{} : std::move(_programs[i]),
+				metrics.push_back(std::make_unique<ProgramSize>(
+					_programCaches[i] != nullptr ? std::optional<Program>{} : std::move(_programs[i]),
 					std::move(_programCaches[i]),
 					_weights,
 					_options.chromosomeRepetitions
@@ -250,8 +249,8 @@ unique_ptr<FitnessMetric> FitnessMetricFactory::build(
 		case MetricChoice::RelativeCodeSize:
 		{
 			for (size_t i = 0; i < _programs.size(); ++i)
-				metrics.push_back(make_unique<RelativeProgramSize>(
-					_programCaches[i] != nullptr ? optional<Program>{} : std::move(_programs[i]),
+				metrics.push_back(std::make_unique<RelativeProgramSize>(
+					_programCaches[i] != nullptr ? std::optional<Program>{} : std::move(_programs[i]),
 					std::move(_programCaches[i]),
 					_options.relativeMetricScale,
 					_weights,
@@ -266,13 +265,13 @@ unique_ptr<FitnessMetric> FitnessMetricFactory::build(
 	switch (_options.metricAggregator)
 	{
 		case MetricAggregatorChoice::Average:
-			return make_unique<FitnessMetricAverage>(std::move(metrics));
+			return std::make_unique<FitnessMetricAverage>(std::move(metrics));
 		case MetricAggregatorChoice::Sum:
-			return make_unique<FitnessMetricSum>(std::move(metrics));
+			return std::make_unique<FitnessMetricSum>(std::move(metrics));
 		case MetricAggregatorChoice::Maximum:
-			return make_unique<FitnessMetricMaximum>(std::move(metrics));
+			return std::make_unique<FitnessMetricMaximum>(std::move(metrics));
 		case MetricAggregatorChoice::Minimum:
-			return make_unique<FitnessMetricMinimum>(std::move(metrics));
+			return std::make_unique<FitnessMetricMinimum>(std::move(metrics));
 		default:
 			assertThrow(false, solidity::util::Exception, "Invalid MetricAggregatorChoice value.");
 	}
@@ -287,20 +286,20 @@ PopulationFactory::Options PopulationFactory::Options::fromCommandLine(po::varia
 		_arguments["min-chromosome-length"].as<size_t>(),
 		_arguments["max-chromosome-length"].as<size_t>(),
 		_arguments.count("population") > 0 ?
-			_arguments["population"].as<vector<string>>() :
-			vector<string>{},
+			_arguments["population"].as<std::vector<std::string>>() :
+			std::vector<std::string>{},
 		_arguments.count("random-population") > 0 ?
-			_arguments["random-population"].as<vector<size_t>>() :
-			vector<size_t>{},
+			_arguments["random-population"].as<std::vector<size_t>>() :
+			std::vector<size_t>{},
 		_arguments.count("population-from-file") > 0 ?
-			_arguments["population-from-file"].as<vector<string>>() :
-			vector<string>{},
+			_arguments["population-from-file"].as<std::vector<std::string>>() :
+			std::vector<std::string>{},
 	};
 }
 
 Population PopulationFactory::build(
 	Options const& _options,
-	shared_ptr<FitnessMetric> _fitnessMetric
+	std::shared_ptr<FitnessMetric> _fitnessMetric
 )
 {
 	Population population = buildFromStrings(_options.population, _fitnessMetric);
@@ -316,19 +315,19 @@ Population PopulationFactory::build(
 		_fitnessMetric
 	);
 
-	for (string const& populationFilePath: _options.populationFromFile)
+	for (std::string const& populationFilePath: _options.populationFromFile)
 		population = std::move(population) + buildFromFile(populationFilePath, _fitnessMetric);
 
 	return population;
 }
 
 Population PopulationFactory::buildFromStrings(
-	vector<string> const& _geneSequences,
-	shared_ptr<FitnessMetric> _fitnessMetric
+	std::vector<std::string> const& _geneSequences,
+	std::shared_ptr<FitnessMetric> _fitnessMetric
 )
 {
-	vector<Chromosome> chromosomes;
-	for (string const& geneSequence: _geneSequences)
+	std::vector<Chromosome> chromosomes;
+	for (std::string const& geneSequence: _geneSequences)
 		chromosomes.emplace_back(geneSequence);
 
 	return Population(std::move(_fitnessMetric), std::move(chromosomes));
@@ -338,7 +337,7 @@ Population PopulationFactory::buildRandom(
 	size_t _populationSize,
 	size_t _minChromosomeLength,
 	size_t _maxChromosomeLength,
-	shared_ptr<FitnessMetric> _fitnessMetric
+	std::shared_ptr<FitnessMetric> _fitnessMetric
 )
 {
 	return Population::makeRandom(
@@ -350,8 +349,8 @@ Population PopulationFactory::buildRandom(
 }
 
 Population PopulationFactory::buildFromFile(
-	string const& _filePath,
-	shared_ptr<FitnessMetric> _fitnessMetric
+	std::string const& _filePath,
+	std::shared_ptr<FitnessMetric> _fitnessMetric
 )
 {
 	return buildFromStrings(readLinesFromFile(_filePath), std::move(_fitnessMetric));
@@ -364,14 +363,14 @@ ProgramCacheFactory::Options ProgramCacheFactory::Options::fromCommandLine(po::v
 	};
 }
 
-vector<shared_ptr<ProgramCache>> ProgramCacheFactory::build(
+std::vector<std::shared_ptr<ProgramCache>> ProgramCacheFactory::build(
 	Options const& _options,
-	vector<Program> _programs
+	std::vector<Program> _programs
 )
 {
-	vector<shared_ptr<ProgramCache>> programCaches;
+	std::vector<std::shared_ptr<ProgramCache>> programCaches;
 	for (Program& program: _programs)
-		programCaches.push_back(_options.programCacheEnabled ? make_shared<ProgramCache>(std::move(program)) : nullptr);
+		programCaches.push_back(_options.programCacheEnabled ? std::make_shared<ProgramCache>(std::move(program)) : nullptr);
 
 	return programCaches;
 }
@@ -379,28 +378,28 @@ vector<shared_ptr<ProgramCache>> ProgramCacheFactory::build(
 ProgramFactory::Options ProgramFactory::Options::fromCommandLine(po::variables_map const& _arguments)
 {
 	return {
-		_arguments["input-files"].as<vector<string>>(),
-		_arguments["prefix"].as<string>(),
+		_arguments["input-files"].as<std::vector<std::string>>(),
+		_arguments["prefix"].as<std::string>(),
 	};
 }
 
-vector<Program> ProgramFactory::build(Options const& _options)
+std::vector<Program> ProgramFactory::build(Options const& _options)
 {
-	vector<Program> inputPrograms;
+	std::vector<Program> inputPrograms;
 	for (auto& path: _options.inputFiles)
 	{
 		CharStream sourceCode = loadSource(path);
-		variant<Program, ErrorList> programOrErrors = Program::load(sourceCode);
-		if (holds_alternative<ErrorList>(programOrErrors))
+		std::variant<Program, ErrorList> programOrErrors = Program::load(sourceCode);
+		if (std::holds_alternative<ErrorList>(programOrErrors))
 		{
-			SourceReferenceFormatter{cerr, SingletonCharStreamProvider(sourceCode), true, false}
-				.printErrorInformation(get<ErrorList>(programOrErrors));
-			cerr << endl;
+			SourceReferenceFormatter{std::cerr, SingletonCharStreamProvider(sourceCode), true, false}
+				.printErrorInformation(std::get<ErrorList>(programOrErrors));
+			std::cerr << std::endl;
 			assertThrow(false, InvalidProgram, "Failed to load program " + path);
 		}
 
-		get<Program>(programOrErrors).optimise(Chromosome(_options.prefix).optimisationSteps());
-		inputPrograms.push_back(std::move(get<Program>(programOrErrors)));
+		std::get<Program>(programOrErrors).optimise(Chromosome(_options.prefix).optimisationSteps());
+		inputPrograms.push_back(std::move(std::get<Program>(programOrErrors)));
 	}
 
 	return inputPrograms;
@@ -410,13 +409,13 @@ CharStream ProgramFactory::loadSource(boost::filesystem::path const& _sourcePath
 {
 	assertThrow(boost::filesystem::exists(_sourcePath), MissingFile, "Source file does not exist: " + _sourcePath.string());
 
-	string sourceCode = readFileAsString(_sourcePath);
+	std::string sourceCode = readFileAsString(_sourcePath);
 	return CharStream(sourceCode, _sourcePath.string());
 }
 
 void Phaser::main(int _argc, char** _argv)
 {
-	optional<po::variables_map> arguments = parseCommandLine(_argc, _argv);
+	std::optional<po::variables_map> arguments = parseCommandLine(_argc, _argv);
 	if (!arguments.has_value())
 		return;
 
@@ -447,10 +446,10 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 	po::options_description generalDescription("GENERAL", lineLength, minDescriptionLength);
 	generalDescription.add_options()
 		("help", "Show help message and exit.")
-		("input-files", po::value<vector<string>>()->required()->value_name("<PATH>"), "Input files.")
+		("input-files", po::value<std::vector<std::string>>()->required()->value_name("<PATH>"), "Input files.")
 		(
 			"prefix",
-			po::value<string>()->value_name("<CHROMOSOME>")->default_value(""),
+			po::value<std::string>()->value_name("<CHROMOSOME>")->default_value(""),
 			"Initial optimisation steps automatically applied to every input program.\n"
 			"The result is treated as if it was the actual input, i.e. the steps are not considered "
 			"a part of the chromosomes and cannot be mutated. The values of relative metric values "
@@ -615,24 +614,24 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 	populationDescription.add_options()
 		(
 			"population",
-			po::value<vector<string>>()->multitoken()->value_name("<CHROMOSOMES>"),
+			po::value<std::vector<std::string>>()->multitoken()->value_name("<CHROMOSOMES>"),
 			"List of chromosomes to be included in the initial population. "
 			"You can specify multiple values separated with spaces or invoke the option multiple times "
 			"and all the values will be included."
 		)
 		(
 			"random-population",
-			po::value<vector<size_t>>()->value_name("<SIZE>"),
+			po::value<std::vector<size_t>>()->value_name("<SIZE>"),
 			"The number of randomly generated chromosomes to be included in the initial population."
 		)
 		(
 			"population-from-file",
-			po::value<vector<string>>()->value_name("<FILE>"),
+			po::value<std::vector<std::string>>()->value_name("<FILE>"),
 			"A text file with a list of chromosomes (one per line) to be included in the initial population."
 		)
 		(
 			"population-autosave",
-			po::value<string>()->value_name("<FILE>"),
+			po::value<std::string>()->value_name("<FILE>"),
 			"If specified, the population is saved in the specified file after each round. (default=autosave disabled)"
 		)
 	;
@@ -756,7 +755,7 @@ Phaser::CommandLineDescription Phaser::buildCommandLineDescription()
 	return {keywordDescription, positionalDescription};
 }
 
-optional<po::variables_map> Phaser::parseCommandLine(int _argc, char** _argv)
+std::optional<po::variables_map> Phaser::parseCommandLine(int _argc, char** _argv)
 {
 	auto [keywordDescription, positionalDescription] = buildCommandLineDescription();
 
@@ -769,8 +768,8 @@ optional<po::variables_map> Phaser::parseCommandLine(int _argc, char** _argv)
 
 	if (arguments.count("help") > 0)
 	{
-		cout << keywordDescription << endl;
-		return nullopt;
+		std::cout << keywordDescription << std::endl;
+		return std::nullopt;
 	}
 
 	if (arguments.count("input-files") == 0)
@@ -789,14 +788,14 @@ void Phaser::initialiseRNG(po::variables_map const& _arguments)
 
 	SimulationRNG::reset(seed);
 	if (_arguments["show-seed"].as<bool>())
-		cout << "Random seed: " << seed << endl;
+		std::cout << "Random seed: " << seed << std::endl;
 }
 
 AlgorithmRunner::Options Phaser::buildAlgorithmRunnerOptions(po::variables_map const& _arguments)
 {
 	return {
-		_arguments.count("rounds") > 0 ? static_cast<optional<size_t>>(_arguments["rounds"].as<size_t>()) : nullopt,
-		_arguments.count("population-autosave") > 0 ? static_cast<optional<string>>(_arguments["population-autosave"].as<string>()) : nullopt,
+		_arguments.count("rounds") > 0 ? static_cast<std::optional<size_t>>(_arguments["rounds"].as<size_t>()) : std::nullopt,
+		_arguments.count("population-autosave") > 0 ? static_cast<std::optional<std::string>>(_arguments["population-autosave"].as<std::string>()) : std::nullopt,
 		!_arguments["no-randomise-duplicates"].as<bool>(),
 		_arguments["min-chromosome-length"].as<size_t>(),
 		_arguments["max-chromosome-length"].as<size_t>(),
@@ -814,10 +813,10 @@ void Phaser::runPhaser(po::variables_map const& _arguments)
 	auto metricOptions = FitnessMetricFactory::Options::fromCommandLine(_arguments);
 	auto populationOptions = PopulationFactory::Options::fromCommandLine(_arguments);
 
-	vector<Program> programs = ProgramFactory::build(programOptions);
-	vector<shared_ptr<ProgramCache>> programCaches = ProgramCacheFactory::build(cacheOptions, programs);
+	std::vector<Program> programs = ProgramFactory::build(programOptions);
+	std::vector<std::shared_ptr<ProgramCache>> programCaches = ProgramCacheFactory::build(cacheOptions, programs);
 	CodeWeights codeWeights = CodeWeightFactory::buildFromCommandLine(_arguments);
-	unique_ptr<FitnessMetric> fitnessMetric = FitnessMetricFactory::build(
+	std::unique_ptr<FitnessMetric> fitnessMetric = FitnessMetricFactory::build(
 		metricOptions,
 		programs,
 		programCaches,
@@ -834,51 +833,51 @@ void Phaser::runPhaser(po::variables_map const& _arguments)
 void Phaser::runAlgorithm(
 	po::variables_map const& _arguments,
 	Population _population,
-	vector<shared_ptr<ProgramCache>> _programCaches
+	std::vector<std::shared_ptr<ProgramCache>> _programCaches
 )
 {
 	auto algorithmOptions = GeneticAlgorithmFactory::Options::fromCommandLine(_arguments);
 
-	unique_ptr<GeneticAlgorithm> geneticAlgorithm = GeneticAlgorithmFactory::build(
+	std::unique_ptr<GeneticAlgorithm> geneticAlgorithm = GeneticAlgorithmFactory::build(
 		algorithmOptions,
 		_population.individuals().size()
 	);
 
-	AlgorithmRunner algorithmRunner(std::move(_population), std::move(_programCaches), buildAlgorithmRunnerOptions(_arguments), cout);
+	AlgorithmRunner algorithmRunner(std::move(_population), std::move(_programCaches), buildAlgorithmRunnerOptions(_arguments), std::cout);
 	algorithmRunner.run(*geneticAlgorithm);
 }
 
 void Phaser::printOptimisedProgramsOrASTs(
 	po::variables_map const& _arguments,
 	Population const& _population,
-	vector<Program> _programs,
+	std::vector<Program> _programs,
 	PhaserMode phaserMode
 )
 {
 	assert(phaserMode == PhaserMode::PrintOptimisedPrograms || phaserMode == PhaserMode::PrintOptimisedASTs);
-	assert(_programs.size() == _arguments["input-files"].as<vector<string>>().size());
+	assert(_programs.size() == _arguments["input-files"].as<std::vector<std::string>>().size());
 
 	if (_population.individuals().size() == 0)
 	{
-		cout << "<EMPTY POPULATION>" << endl;
+		std::cout << "<EMPTY POPULATION>" << std::endl;
 		return;
 	}
 
-	vector<string> const& paths = _arguments["input-files"].as<vector<string>>();
+	std::vector<std::string> const& paths = _arguments["input-files"].as<std::vector<std::string>>();
 	for (auto& individual: _population.individuals())
 	{
-		cout << "Chromosome: " << individual.chromosome << endl;
+		std::cout << "Chromosome: " << individual.chromosome << std::endl;
 
 		for (size_t i = 0; i < _programs.size(); ++i)
 		{
 			for (size_t j = 0; j < _arguments["chromosome-repetitions"].as<size_t>(); ++j)
 				_programs[i].optimise(individual.chromosome.optimisationSteps());
 
-			cout << "Program: " << paths[i] << endl;
+			std::cout << "Program: " << paths[i] << std::endl;
 			if (phaserMode == PhaserMode::PrintOptimisedPrograms)
-				cout << _programs[i] << endl;
+				std::cout << _programs[i] << std::endl;
 			else
-				cout << _programs[i].toJson() << endl;
+				std::cout << _programs[i].toJson() << std::endl;
 		}
 	}
 }

--- a/tools/yulPhaser/Population.cpp
+++ b/tools/yulPhaser/Population.cpp
@@ -28,7 +28,6 @@
 #include <cassert>
 #include <numeric>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::langutil;
 using namespace solidity::util;
@@ -37,12 +36,12 @@ using namespace solidity::phaser;
 namespace solidity::phaser
 {
 
-ostream& operator<<(ostream& _stream, Individual const& _individual);
-ostream& operator<<(ostream& _stream, Population const& _population);
+std::ostream& operator<<(std::ostream& _stream, Individual const& _individual);
+std::ostream& operator<<(std::ostream& _stream, Population const& _population);
 
 }
 
-ostream& phaser::operator<<(ostream& _stream, Individual const& _individual)
+std::ostream& phaser::operator<<(std::ostream& _stream, Individual const& _individual)
 {
 	_stream << _individual.fitness << " " << _individual.chromosome;
 
@@ -59,12 +58,12 @@ bool phaser::isFitter(Individual const& a, Individual const& b)
 }
 
 Population Population::makeRandom(
-	shared_ptr<FitnessMetric> _fitnessMetric,
+	std::shared_ptr<FitnessMetric> _fitnessMetric,
 	size_t _size,
-	function<size_t()> _chromosomeLengthGenerator
+	std::function<size_t()> _chromosomeLengthGenerator
 )
 {
-	vector<Chromosome> chromosomes;
+	std::vector<Chromosome> chromosomes;
 	for (size_t i = 0; i < _size; ++i)
 		chromosomes.push_back(Chromosome::makeRandom(_chromosomeLengthGenerator()));
 
@@ -72,7 +71,7 @@ Population Population::makeRandom(
 }
 
 Population Population::makeRandom(
-	shared_ptr<FitnessMetric> _fitnessMetric,
+	std::shared_ptr<FitnessMetric> _fitnessMetric,
 	size_t _size,
 	size_t _minChromosomeLength,
 	size_t _maxChromosomeLength
@@ -87,25 +86,25 @@ Population Population::makeRandom(
 
 Population Population::select(Selection const& _selection) const
 {
-	vector<Individual> selectedIndividuals;
+	std::vector<Individual> selectedIndividuals;
 	for (size_t i: _selection.materialise(m_individuals.size()))
 		selectedIndividuals.emplace_back(m_individuals[i]);
 
 	return Population(m_fitnessMetric, selectedIndividuals);
 }
 
-Population Population::mutate(Selection const& _selection, function<Mutation> _mutation) const
+Population Population::mutate(Selection const& _selection, std::function<Mutation> _mutation) const
 {
-	vector<Individual> mutatedIndividuals;
+	std::vector<Individual> mutatedIndividuals;
 	for (size_t i: _selection.materialise(m_individuals.size()))
 		mutatedIndividuals.emplace_back(_mutation(m_individuals[i].chromosome), *m_fitnessMetric);
 
 	return Population(m_fitnessMetric, mutatedIndividuals);
 }
 
-Population Population::crossover(PairSelection const& _selection, function<Crossover> _crossover) const
+Population Population::crossover(PairSelection const& _selection, std::function<Crossover> _crossover) const
 {
-	vector<Individual> crossedIndividuals;
+	std::vector<Individual> crossedIndividuals;
 	for (auto const& [i, j]: _selection.materialise(m_individuals.size()))
 	{
 		auto childChromosome = _crossover(
@@ -118,27 +117,27 @@ Population Population::crossover(PairSelection const& _selection, function<Cross
 	return Population(m_fitnessMetric, crossedIndividuals);
 }
 
-tuple<Population, Population> Population::symmetricCrossoverWithRemainder(
+std::tuple<Population, Population> Population::symmetricCrossoverWithRemainder(
 	PairSelection const& _selection,
-	function<SymmetricCrossover> _symmetricCrossover
+	std::function<SymmetricCrossover> _symmetricCrossover
 ) const
 {
-	vector<int> indexSelected(m_individuals.size(), false);
+	std::vector<int> indexSelected(m_individuals.size(), false);
 
-	vector<Individual> crossedIndividuals;
+	std::vector<Individual> crossedIndividuals;
 	for (auto const& [i, j]: _selection.materialise(m_individuals.size()))
 	{
 		auto children = _symmetricCrossover(
 			m_individuals[i].chromosome,
 			m_individuals[j].chromosome
 		);
-		crossedIndividuals.emplace_back(std::move(get<0>(children)), *m_fitnessMetric);
-		crossedIndividuals.emplace_back(std::move(get<1>(children)), *m_fitnessMetric);
+		crossedIndividuals.emplace_back(std::move(std::get<0>(children)), *m_fitnessMetric);
+		crossedIndividuals.emplace_back(std::move(std::get<1>(children)), *m_fitnessMetric);
 		indexSelected[i] = true;
 		indexSelected[j] = true;
 	}
 
-	vector<Individual> remainder;
+	std::vector<Individual> remainder;
 	for (size_t i = 0; i < indexSelected.size(); ++i)
 		if (!indexSelected[i])
 			remainder.emplace_back(m_individuals[i]);
@@ -166,7 +165,7 @@ Population operator+(Population _a, Population _b)
 
 Population Population::combine(std::tuple<Population, Population> _populationPair)
 {
-	return get<0>(_populationPair) + get<1>(_populationPair);
+	return std::get<0>(_populationPair) + std::get<1>(_populationPair);
 }
 
 bool Population::operator==(Population const& _other) const
@@ -177,28 +176,28 @@ bool Population::operator==(Population const& _other) const
 	return m_individuals == _other.m_individuals && m_fitnessMetric == _other.m_fitnessMetric;
 }
 
-ostream& phaser::operator<<(ostream& _stream, Population const& _population)
+std::ostream& phaser::operator<<(std::ostream& _stream, Population const& _population)
 {
 	auto individual = _population.m_individuals.begin();
 	for (; individual != _population.m_individuals.end(); ++individual)
-		_stream << *individual << endl;
+		_stream << *individual << std::endl;
 
 	return _stream;
 }
 
-vector<Individual> Population::chromosomesToIndividuals(
+std::vector<Individual> Population::chromosomesToIndividuals(
 	FitnessMetric& _fitnessMetric,
-	vector<Chromosome> _chromosomes
+	std::vector<Chromosome> _chromosomes
 )
 {
-	vector<Individual> individuals;
+	std::vector<Individual> individuals;
 	for (auto& chromosome: _chromosomes)
 		individuals.emplace_back(std::move(chromosome), _fitnessMetric);
 
 	return individuals;
 }
 
-vector<Individual> Population::sortedIndividuals(vector<Individual> _individuals)
+std::vector<Individual> Population::sortedIndividuals(std::vector<Individual> _individuals)
 {
 	sort(_individuals.begin(), _individuals.end(), isFitter);
 	return _individuals;

--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -45,7 +45,6 @@
 #include <cassert>
 #include <memory>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::langutil;
 using namespace solidity::yul;
@@ -55,39 +54,39 @@ using namespace solidity::phaser;
 namespace solidity::phaser
 {
 
-ostream& operator<<(ostream& _stream, Program const& _program);
+std::ostream& operator<<(std::ostream& _stream, Program const& _program);
 
 }
 
 Program::Program(Program const& program):
-	m_ast(make_unique<Block>(get<Block>(ASTCopier{}(*program.m_ast)))),
+	m_ast(std::make_unique<Block>(std::get<Block>(ASTCopier{}(*program.m_ast)))),
 	m_dialect{program.m_dialect},
 	m_nameDispenser(program.m_nameDispenser)
 {
 }
 
-variant<Program, ErrorList> Program::load(CharStream& _sourceCode)
+std::variant<Program, ErrorList> Program::load(CharStream& _sourceCode)
 {
 	// ASSUMPTION: parseSource() rewinds the stream on its own
 	Dialect const& dialect = EVMDialect::strictAssemblyForEVMObjects(EVMVersion{});
 
-	variant<unique_ptr<Block>, ErrorList> astOrErrors = parseObject(dialect, _sourceCode);
-	if (holds_alternative<ErrorList>(astOrErrors))
-		return get<ErrorList>(astOrErrors);
+	std::variant<std::unique_ptr<Block>, ErrorList> astOrErrors = parseObject(dialect, _sourceCode);
+	if (std::holds_alternative<ErrorList>(astOrErrors))
+		return std::get<ErrorList>(astOrErrors);
 
-	variant<unique_ptr<AsmAnalysisInfo>, ErrorList> analysisInfoOrErrors = analyzeAST(
+	std::variant<std::unique_ptr<AsmAnalysisInfo>, ErrorList> analysisInfoOrErrors = analyzeAST(
 		dialect,
-		*get<unique_ptr<Block>>(astOrErrors)
+		*std::get<std::unique_ptr<Block>>(astOrErrors)
 	);
-	if (holds_alternative<ErrorList>(analysisInfoOrErrors))
-		return get<ErrorList>(analysisInfoOrErrors);
+	if (std::holds_alternative<ErrorList>(analysisInfoOrErrors))
+		return std::get<ErrorList>(analysisInfoOrErrors);
 
 	Program program(
 		dialect,
 		disambiguateAST(
 			dialect,
-			*get<unique_ptr<Block>>(astOrErrors),
-			*get<unique_ptr<AsmAnalysisInfo>>(analysisInfoOrErrors)
+			*std::get<std::unique_ptr<Block>>(astOrErrors),
+			*std::get<std::unique_ptr<AsmAnalysisInfo>>(analysisInfoOrErrors)
 		)
 	);
 	program.optimise({
@@ -99,30 +98,30 @@ variant<Program, ErrorList> Program::load(CharStream& _sourceCode)
 	return program;
 }
 
-void Program::optimise(vector<string> const& _optimisationSteps)
+void Program::optimise(std::vector<std::string> const& _optimisationSteps)
 {
 	m_ast = applyOptimisationSteps(m_dialect, m_nameDispenser, std::move(m_ast), _optimisationSteps);
 }
 
-ostream& phaser::operator<<(ostream& _stream, Program const& _program)
+std::ostream& phaser::operator<<(std::ostream& _stream, Program const& _program)
 {
 	return _stream << AsmPrinter()(*_program.m_ast);
 }
 
-string Program::toJson() const
+std::string Program::toJson() const
 {
 	Json serializedAst = AsmJsonConverter(0)(*m_ast);
 	return jsonPrettyPrint(removeNullMembers(std::move(serializedAst)));
 }
 
-variant<unique_ptr<Block>, ErrorList> Program::parseObject(Dialect const& _dialect, CharStream _source)
+std::variant<std::unique_ptr<Block>, ErrorList> Program::parseObject(Dialect const& _dialect, CharStream _source)
 {
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);
-	auto scanner = make_shared<Scanner>(_source);
+	auto scanner = std::make_shared<Scanner>(_source);
 
 	ObjectParser parser(errorReporter, _dialect);
-	shared_ptr<Object> object = parser.parse(scanner, false);
+	std::shared_ptr<Object> object = parser.parse(scanner, false);
 	if (object == nullptr || !errorReporter.errors().empty())
 		// NOTE: It's possible to get errors even if the returned object is non-null.
 		// For example when there are errors in a nested object.
@@ -150,16 +149,16 @@ variant<unique_ptr<Block>, ErrorList> Program::parseObject(Dialect const& _diale
 	// The public API of the class does not provide access to the smart pointer so it won't be hard
 	// to switch to shared_ptr if the copying turns out to be an issue (though it would be better
 	// to refactor ObjectParser and Object to use unique_ptr instead).
-	auto astCopy = make_unique<Block>(get<Block>(ASTCopier{}(*selectedObject->code)));
+	auto astCopy = std::make_unique<Block>(std::get<Block>(ASTCopier{}(*selectedObject->code)));
 
-	return variant<unique_ptr<Block>, ErrorList>(std::move(astCopy));
+	return std::variant<std::unique_ptr<Block>, ErrorList>(std::move(astCopy));
 }
 
-variant<unique_ptr<AsmAnalysisInfo>, ErrorList> Program::analyzeAST(Dialect const& _dialect, Block const& _ast)
+std::variant<std::unique_ptr<AsmAnalysisInfo>, ErrorList> Program::analyzeAST(Dialect const& _dialect, Block const& _ast)
 {
 	ErrorList errors;
 	ErrorReporter errorReporter(errors);
-	auto analysisInfo = make_unique<AsmAnalysisInfo>();
+	auto analysisInfo = std::make_unique<AsmAnalysisInfo>();
 	AsmAnalyzer analyzer(*analysisInfo, errorReporter, _dialect);
 
 	bool analysisSuccessful = analyzer.analyze(_ast);
@@ -167,31 +166,31 @@ variant<unique_ptr<AsmAnalysisInfo>, ErrorList> Program::analyzeAST(Dialect cons
 		return errors;
 
 	assert(errorReporter.errors().empty());
-	return variant<unique_ptr<AsmAnalysisInfo>, ErrorList>(std::move(analysisInfo));
+	return std::variant<std::unique_ptr<AsmAnalysisInfo>, ErrorList>(std::move(analysisInfo));
 }
 
-unique_ptr<Block> Program::disambiguateAST(
+std::unique_ptr<Block> Program::disambiguateAST(
 	Dialect const& _dialect,
 	Block const& _ast,
 	AsmAnalysisInfo const& _analysisInfo
 )
 {
-	set<YulString> const externallyUsedIdentifiers = {};
+	std::set<YulString> const externallyUsedIdentifiers = {};
 	Disambiguator disambiguator(_dialect, _analysisInfo, externallyUsedIdentifiers);
 
-	return make_unique<Block>(get<Block>(disambiguator(_ast)));
+	return std::make_unique<Block>(std::get<Block>(disambiguator(_ast)));
 }
 
-unique_ptr<Block> Program::applyOptimisationSteps(
+std::unique_ptr<Block> Program::applyOptimisationSteps(
 	Dialect const& _dialect,
 	NameDispenser& _nameDispenser,
-	unique_ptr<Block> _ast,
-	vector<string> const& _optimisationSteps
+	std::unique_ptr<Block> _ast,
+	std::vector<std::string> const& _optimisationSteps
 )
 {
 	// An empty set of reserved identifiers. It could be a constructor parameter but I don't
 	// think it would be useful in this tool. Other tools (like yulopti) have it empty too.
-	set<YulString> const externallyUsedIdentifiers = {};
+	std::set<YulString> const externallyUsedIdentifiers = {};
 	OptimiserStepContext context{
 		_dialect,
 		_nameDispenser,
@@ -199,7 +198,7 @@ unique_ptr<Block> Program::applyOptimisationSteps(
 		frontend::OptimiserSettings::standard().expectedExecutionsPerDeployment
 	};
 
-	for (string const& step: _optimisationSteps)
+	for (std::string const& step: _optimisationSteps)
 		OptimiserSuite::allSteps().at(step)->run(context, *_ast);
 
 	return _ast;

--- a/tools/yulPhaser/ProgramCache.cpp
+++ b/tools/yulPhaser/ProgramCache.cpp
@@ -22,7 +22,6 @@
 
 #include <libyul/optimiser/Suite.h>
 
-using namespace std;
 using namespace solidity::yul;
 using namespace solidity::phaser;
 
@@ -51,16 +50,16 @@ bool CacheStats::operator==(CacheStats const& _other) const
 }
 
 Program ProgramCache::optimiseProgram(
-	string const& _abbreviatedOptimisationSteps,
-	size_t _repetitionCount
+	std::string const& _abbreviatedOptimisationSteps,
+	std::size_t _repetitionCount
 )
 {
-	string targetOptimisations = _abbreviatedOptimisationSteps;
-	for (size_t i = 1; i < _repetitionCount; ++i)
+	std::string targetOptimisations = _abbreviatedOptimisationSteps;
+	for (std::size_t i = 1; i < _repetitionCount; ++i)
 		targetOptimisations += _abbreviatedOptimisationSteps;
 
-	size_t prefixSize = 0;
-	for (size_t i = 1; i <= targetOptimisations.size(); ++i)
+	std::size_t prefixSize = 0;
+	for (std::size_t i = 1; i <= targetOptimisations.size(); ++i)
 	{
 		auto const& pair = m_entries.find(targetOptimisations.substr(0, i));
 		if (pair != m_entries.end())
@@ -79,9 +78,9 @@ Program ProgramCache::optimiseProgram(
 		m_entries.at(targetOptimisations.substr(0, prefixSize)).program
 	);
 
-	for (size_t i = prefixSize + 1; i <= targetOptimisations.size(); ++i)
+	for (std::size_t i = prefixSize + 1; i <= targetOptimisations.size(); ++i)
 	{
-		string stepName = OptimiserSuite::stepAbbreviationToNameMap().at(targetOptimisations[i - 1]);
+		std::string stepName = OptimiserSuite::stepAbbreviationToNameMap().at(targetOptimisations[i - 1]);
 		intermediateProgram.optimise({stepName});
 
 		m_entries.insert({targetOptimisations.substr(0, i), {intermediateProgram, m_currentRound}});
@@ -91,7 +90,7 @@ Program ProgramCache::optimiseProgram(
 	return intermediateProgram;
 }
 
-void ProgramCache::startRound(size_t _roundNumber)
+void ProgramCache::startRound(std::size_t _roundNumber)
 {
 	assert(_roundNumber > m_currentRound);
 	m_currentRound = _roundNumber;
@@ -113,7 +112,7 @@ void ProgramCache::clear()
 	m_currentRound = 0;
 }
 
-Program const* ProgramCache::find(string const& _abbreviatedOptimisationSteps) const
+Program const* ProgramCache::find(std::string const& _abbreviatedOptimisationSteps) const
 {
 	auto const& pair = m_entries.find(_abbreviatedOptimisationSteps);
 	if (pair == m_entries.end())
@@ -132,18 +131,18 @@ CacheStats ProgramCache::gatherStats() const
 	};
 }
 
-size_t ProgramCache::calculateTotalCachedCodeSize() const
+std::size_t ProgramCache::calculateTotalCachedCodeSize() const
 {
-	size_t size = 0;
+	std::size_t size = 0;
 	for (auto const& pair: m_entries)
 		size += pair.second.program.codeSize(CacheStats::StorageWeights);
 
 	return size;
 }
 
-map<size_t, size_t> ProgramCache::countRoundEntries() const
+std::map<std::size_t, std::size_t> ProgramCache::countRoundEntries() const
 {
-	map<size_t, size_t> counts;
+	std::map<std::size_t, std::size_t> counts;
 	for (auto& pair: m_entries)
 		if (counts.find(pair.second.roundNumber) != counts.end())
 			++counts.at(pair.second.roundNumber);

--- a/tools/yulPhaser/Selections.cpp
+++ b/tools/yulPhaser/Selections.cpp
@@ -23,14 +23,13 @@
 #include <cmath>
 #include <numeric>
 
-using namespace std;
 using namespace solidity::phaser;
 
-vector<size_t> RangeSelection::materialise(size_t _poolSize) const
+std::vector<size_t> RangeSelection::materialise(size_t _poolSize) const
 {
-	size_t beginIndex = static_cast<size_t>(round(double(_poolSize) * m_startPercent));
-	size_t endIndex = static_cast<size_t>(round(double(_poolSize) * m_endPercent));
-	vector<size_t> selection;
+	size_t beginIndex = static_cast<size_t>(std::round(double(_poolSize) * m_startPercent));
+	size_t endIndex = static_cast<size_t>(std::round(double(_poolSize) * m_endPercent));
+	std::vector<size_t> selection;
 
 	for (size_t i = beginIndex; i < endIndex; ++i)
 		selection.push_back(i);
@@ -38,31 +37,31 @@ vector<size_t> RangeSelection::materialise(size_t _poolSize) const
 	return selection;
 }
 
-vector<size_t> MosaicSelection::materialise(size_t _poolSize) const
+std::vector<size_t> MosaicSelection::materialise(size_t _poolSize) const
 {
-	size_t count = static_cast<size_t>(round(double(_poolSize) * m_selectionSize));
+	size_t count = static_cast<size_t>(std::round(double(_poolSize) * m_selectionSize));
 
-	vector<size_t> selection;
+	std::vector<size_t> selection;
 	for (size_t i = 0; i < count; ++i)
-		selection.push_back(min(m_pattern[i % m_pattern.size()], _poolSize - 1));
+		selection.push_back(std::min(m_pattern[i % m_pattern.size()], _poolSize - 1));
 
 	return selection;
 }
 
-vector<size_t> RandomSelection::materialise(size_t _poolSize) const
+std::vector<size_t> RandomSelection::materialise(size_t _poolSize) const
 {
-	size_t count = static_cast<size_t>(round(double(_poolSize) * m_selectionSize));
+	size_t count = static_cast<size_t>(std::round(double(_poolSize) * m_selectionSize));
 
-	vector<size_t> selection;
+	std::vector<size_t> selection;
 	for (size_t i = 0; i < count; ++i)
 		selection.push_back(SimulationRNG::uniformInt(0, _poolSize - 1));
 
 	return selection;
 }
 
-vector<size_t> RandomSubset::materialise(size_t _poolSize) const
+std::vector<size_t> RandomSubset::materialise(size_t _poolSize) const
 {
-	vector<size_t> selection;
+	std::vector<size_t> selection;
 	for (size_t index = 0; index < _poolSize; ++index)
 		if (SimulationRNG::bernoulliTrial(m_selectionChance))
 			selection.push_back(index);

--- a/tools/yulPhaser/SimulationRNG.cpp
+++ b/tools/yulPhaser/SimulationRNG.cpp
@@ -28,7 +28,6 @@
 #include <ctime>
 #include <limits>
 
-using namespace std;
 using namespace solidity;
 using namespace solidity::phaser;
 
@@ -51,7 +50,7 @@ size_t SimulationRNG::binomialInt(size_t _numTrials, double _successProbability)
 {
 	// NOTE: binomial_distribution<size_t> would not work because it internally tries to use abs()
 	// and fails to compile due to ambiguous conversion.
-	assert(_numTrials <= static_cast<size_t>(numeric_limits<long>::max()));
+	assert(_numTrials <= static_cast<size_t>(std::numeric_limits<long>::max()));
 
 	boost::random::binomial_distribution<long> distribution(static_cast<long>(_numTrials), _successProbability);
 	return static_cast<size_t>(distribution(s_generator));
@@ -62,5 +61,5 @@ uint32_t SimulationRNG::generateSeed()
 	// This is not a secure way to seed the generator but it's good enough for simulation purposes.
 	// The only thing that matters for us is that the sequence is different on each run and that
 	// it fits the expected distribution. It does not have to be 100% unpredictable.
-	return static_cast<uint32_t>(time(nullptr));
+	return static_cast<uint32_t>(std::time(nullptr));
 }


### PR DESCRIPTION
In this PR, I removed some of the `using namespace std` statements mentioned in #14403 

* test/tools
* test/tools/ossfuzz
* tools/yulPhaser