### PR TITLE
yul literal value as struct of u256 + optional formatting hint

### DIFF
--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -37,6 +37,7 @@
 #include <libyul/AsmPrinter.h>
 #include <libyul/AST.h>
 #include <libyul/Dialect.h>
+#include <libyul/Utilities.h>
 #include <libyul/optimiser/ASTCopier.h>
 
 #include <liblangutil/Exceptions.h>
@@ -203,7 +204,7 @@ private:
 			solAssert(false);
 
 		if (isDigit(value.front()))
-			return yul::Literal{_identifier.debugData, yul::LiteralKind::Number, yul::YulString{value}, {}};
+			return yul::Literal{_identifier.debugData, yul::LiteralKind::Number, yul::valueOfNumberLiteral(value), {}};
 		else
 			return yul::Identifier{_identifier.debugData, yul::YulString{value}};
 	}

--- a/libsolutil/CommonData.cpp
+++ b/libsolutil/CommonData.cpp
@@ -161,7 +161,7 @@ std::string solidity::util::getChecksummedAddress(std::string const& _addr)
 	return ret;
 }
 
-bool solidity::util::isValidHex(std::string const& _string)
+bool solidity::util::isValidHex(std::string_view const _string)
 {
 	if (_string.substr(0, 2) != "0x")
 		return false;
@@ -170,7 +170,7 @@ bool solidity::util::isValidHex(std::string const& _string)
 	return true;
 }
 
-bool solidity::util::isValidDecimal(std::string const& _string)
+bool solidity::util::isValidDecimal(std::string_view const _string)
 {
 	if (_string.empty())
 		return false;

--- a/libsolutil/CommonData.h
+++ b/libsolutil/CommonData.h
@@ -584,8 +584,8 @@ bool passesAddressChecksum(std::string const& _str, bool _strict);
 /// @param hex strings that look like an address
 std::string getChecksummedAddress(std::string const& _addr);
 
-bool isValidHex(std::string const& _string);
-bool isValidDecimal(std::string const& _string);
+bool isValidHex(std::string_view _string);
+bool isValidDecimal(std::string_view _string);
 
 /// @returns a quoted string if all characters are printable ASCII chars,
 /// or its hex representation otherwise.

--- a/libyul/AST.cpp
+++ b/libyul/AST.cpp
@@ -1,0 +1,80 @@
+/*
+This file is part of solidity.
+
+solidity is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+solidity is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libyul/AST.h>
+#include <libyul/Exceptions.h>
+
+namespace solidity::yul
+{
+
+LiteralValue::LiteralValue(std::string _builtinStringLiteralValue):
+	m_numericValue(std::nullopt),
+	m_stringValue(std::make_shared<std::string>(std::move(_builtinStringLiteralValue)))
+{ }
+
+LiteralValue::LiteralValue(solidity::yul::LiteralValue::Data const& _data, std::optional<std::string> const& _hint):
+	m_numericValue(_data),
+	m_stringValue(_hint ? std::make_shared<std::string>(*_hint) : nullptr)
+{ }
+
+LiteralValue::Data const& LiteralValue::value() const
+{
+	yulAssert(!unlimited());
+	return *m_numericValue;
+}
+
+LiteralValue::BuiltinStringLiteralData const& LiteralValue::builtinStringLiteralValue() const
+{
+	yulAssert(unlimited());
+	return *m_stringValue;
+}
+
+bool LiteralValue::unlimited() const
+{
+	return !m_numericValue.has_value();
+}
+
+LiteralValue::RepresentationHint const& LiteralValue::hint() const
+{
+	yulAssert(!unlimited());
+	return m_stringValue;
+}
+
+bool LiteralValue::operator==(LiteralValue const& _rhs) const
+{
+	if (unlimited() != _rhs.unlimited())
+		return false;
+
+	if (unlimited())
+		return builtinStringLiteralValue() == _rhs.builtinStringLiteralValue();
+
+	return value() == _rhs.value();
+}
+
+bool LiteralValue::operator<(solidity::yul::LiteralValue const& _rhs) const
+{
+	if (unlimited() != _rhs.unlimited())
+		return unlimited() < _rhs.unlimited();
+
+	if (unlimited())
+		return builtinStringLiteralValue() < _rhs.builtinStringLiteralValue();
+
+	return value() < _rhs.value();
+}
+
+}

--- a/libyul/ASTForward.h
+++ b/libyul/ASTForward.h
@@ -29,6 +29,7 @@ namespace solidity::yul
 {
 
 enum class LiteralKind;
+class LiteralValue;
 struct Literal;
 struct Label;
 struct Identifier;

--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -41,7 +41,6 @@
 
 #include <fmt/format.h>
 
-#include <memory>
 #include <functional>
 
 using namespace std::string_literals;
@@ -104,24 +103,32 @@ AsmAnalysisInfo AsmAnalyzer::analyzeStrictAssertCorrect(Dialect const& _dialect,
 std::vector<YulString> AsmAnalyzer::operator()(Literal const& _literal)
 {
 	expectValidType(_literal.type, nativeLocationOf(_literal));
-	if (_literal.kind == LiteralKind::String && _literal.value.str().size() > 32)
+	bool erroneousLiteralValue = false;
+	if (_literal.kind == LiteralKind::String && !_literal.value.unlimited() && _literal.value.hint() && _literal.value.hint()->size() > 32)
+	{
+		erroneousLiteralValue = true;
 		m_errorReporter.typeError(
 			3069_error,
 			nativeLocationOf(_literal),
-			"String literal too long (" + std::to_string(_literal.value.str().size()) + " > 32)"
+			"String literal too long (" + std::to_string(formatLiteral(_literal, false /* _validated */ ).size()) + " > 32)"
 		);
-	else if (_literal.kind == LiteralKind::Number && bigint(_literal.value.str()) > u256(-1))
+	}
+	else if (_literal.kind == LiteralKind::Number && _literal.value.hint() && bigint(*_literal.value.hint()) > u256(-1))
+	{
+		erroneousLiteralValue = true;
 		m_errorReporter.typeError(6708_error, nativeLocationOf(_literal), "Number literal too large (> 256 bits)");
-	else if (_literal.kind == LiteralKind::Boolean)
-		yulAssert(_literal.value == "true"_yulstring || _literal.value == "false"_yulstring, "");
+	}
 
 	if (!m_dialect.validTypeForLiteral(_literal.kind, _literal.value, _literal.type))
+	{
 		m_errorReporter.typeError(
 			5170_error,
 			nativeLocationOf(_literal),
-			"Invalid type \"" + _literal.type.str() + "\" for literal \"" + _literal.value.str() + "\"."
+			"Invalid type \"" + _literal.type.str() + "\" for literal \"" + formatLiteral(_literal) + "\"."
 		);
+	}
 
+	yulAssert(erroneousLiteralValue ^ validLiteral(_literal), "Invalid literal after validating it through AsmAnalyzer.");
 	return {_literal.type};
 }
 
@@ -420,23 +427,25 @@ std::vector<YulString> AsmAnalyzer::operator()(FunctionCall const& _funCall)
 				std::string functionName = _funCall.functionName.name.str();
 				if (functionName == "datasize" || functionName == "dataoffset")
 				{
-					if (!m_dataNames.count(std::get<Literal>(arg).value))
+					auto const& argumentAsLiteral = std::get<Literal>(arg);
+					if (!m_dataNames.count(YulString(formatLiteral(argumentAsLiteral))))
 						m_errorReporter.typeError(
 							3517_error,
 							nativeLocationOf(arg),
-							"Unknown data object \"" + std::get<Literal>(arg).value.str() + "\"."
+							"Unknown data object \"" + formatLiteral(argumentAsLiteral) + "\"."
 						);
 				}
 				else if (functionName.substr(0, "verbatim_"s.size()) == "verbatim_")
 				{
-					if (std::get<Literal>(arg).value.empty())
+					auto const& literalValue = std::get<Literal>(arg).value;
+					yulAssert(literalValue.unlimited());  // verbatim literals are always unlimited
+					if (literalValue.builtinStringLiteralValue().empty())
 						m_errorReporter.typeError(
 							1844_error,
 							nativeLocationOf(arg),
 							"The \"verbatim_*\" builtins cannot be used with empty bytecode."
 						);
 				}
-
 				argTypes.emplace_back(expectUnlimitedStringLiteral(std::get<Literal>(arg)));
 				continue;
 			}
@@ -495,12 +504,12 @@ void AsmAnalyzer::operator()(Switch const& _switch)
 			(*this)(*_case.value);
 
 			/// Note: the parser ensures there is only one default case
-			if (watcher.ok() && !cases.insert(valueOfLiteral(*_case.value)).second)
+			if (watcher.ok() && !cases.insert(_case.value->value.value()).second)
 				m_errorReporter.declarationError(
 					6792_error,
 					nativeLocationOf(_case),
 					"Duplicate case \"" +
-					valueOfLiteral(*_case.value).str() +
+					formatLiteral(*_case.value) +
 					"\" defined."
 				);
 		}
@@ -560,8 +569,9 @@ YulString AsmAnalyzer::expectExpression(Expression const& _expr)
 
 YulString AsmAnalyzer::expectUnlimitedStringLiteral(Literal const& _literal)
 {
-	yulAssert(_literal.kind == LiteralKind::String, "");
-	yulAssert(m_dialect.validTypeForLiteral(LiteralKind::String, _literal.value, _literal.type), "");
+	yulAssert(_literal.kind == LiteralKind::String);
+	yulAssert(m_dialect.validTypeForLiteral(LiteralKind::String, _literal.value, _literal.type));
+	yulAssert(_literal.value.unlimited());
 
 	return {_literal.type};
 }

--- a/libyul/AsmJsonConverter.cpp
+++ b/libyul/AsmJsonConverter.cpp
@@ -20,9 +20,10 @@
  * Converts inline assembly AST to JSON format
  */
 
-#include <libyul/AsmJsonConverter.h>
 #include <libyul/AST.h>
+#include <libyul/AsmJsonConverter.h>
 #include <libyul/Exceptions.h>
+#include <libyul/Utilities.h>
 #include <libsolutil/CommonData.h>
 #include <libsolutil/UTF8.h>
 
@@ -47,14 +48,11 @@ Json AsmJsonConverter::operator()(TypedName const& _node) const
 
 Json AsmJsonConverter::operator()(Literal const& _node) const
 {
+	yulAssert(validLiteral(_node));
 	Json ret = createAstNode(originLocationOf(_node), nativeLocationOf(_node), "YulLiteral");
 	switch (_node.kind)
 	{
 	case LiteralKind::Number:
-		yulAssert(
-			util::isValidDecimal(_node.value.str()) || util::isValidHex(_node.value.str()),
-			"Invalid number literal"
-		);
 		ret["kind"] = "number";
 		break;
 	case LiteralKind::Boolean:
@@ -62,12 +60,15 @@ Json AsmJsonConverter::operator()(Literal const& _node) const
 		break;
 	case LiteralKind::String:
 		ret["kind"] = "string";
-		ret["hexValue"] = util::toHex(util::asBytes(_node.value.str()));
+		ret["hexValue"] = util::toHex(util::asBytes(formatLiteral(_node)));
 		break;
 	}
 	ret["type"] = _node.type.str();
-	if (util::validateUTF8(_node.value.str()))
-		ret["value"] = _node.value.str();
+	{
+		auto const formattedLiteral = formatLiteral(_node);
+		if (util::validateUTF8(formattedLiteral))
+			ret["value"] = formattedLiteral;
+	}
 	return ret;
 }
 

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -24,6 +24,7 @@
 #include <libyul/AST.h>
 #include <libyul/AsmParser.h>
 #include <libyul/Exceptions.h>
+#include <libyul/Utilities.h>
 #include <liblangutil/ErrorReporter.h>
 #include <liblangutil/Exceptions.h>
 #include <liblangutil/Scanner.h>
@@ -470,11 +471,11 @@ ForLoop Parser::parseForLoop()
 	return forLoop;
 }
 
-Expression Parser::parseExpression()
+Expression Parser::parseExpression(bool _unlimitedLiteralArgument)
 {
 	RecursionGuard recursionGuard(*this);
 
-	std::variant<Literal, Identifier> operation = parseLiteralOrIdentifier();
+	std::variant<Literal, Identifier> operation = parseLiteralOrIdentifier(_unlimitedLiteralArgument);
 	return visit(GenericVisitor{
 		[&](Identifier& _identifier) -> Expression
 		{
@@ -495,7 +496,7 @@ Expression Parser::parseExpression()
 	}, operation);
 }
 
-std::variant<Literal, Identifier> Parser::parseLiteralOrIdentifier()
+std::variant<Literal, Identifier> Parser::parseLiteralOrIdentifier(bool _unlimitedLiteralArgument)
 {
 	RecursionGuard recursionGuard(*this);
 	switch (currentToken())
@@ -535,7 +536,7 @@ std::variant<Literal, Identifier> Parser::parseLiteralOrIdentifier()
 		Literal literal{
 			createDebugData(),
 			kind,
-			YulString{currentLiteral()},
+			valueOfLiteral(currentLiteral(), kind, _unlimitedLiteralArgument && kind == LiteralKind::String),
 			kind == LiteralKind::Boolean ? m_dialect.boolType : m_dialect.defaultType
 		};
 		advance();
@@ -639,15 +640,20 @@ FunctionCall Parser::parseCall(std::variant<Literal, Identifier>&& _initialOp)
 	FunctionCall ret;
 	ret.functionName = std::move(std::get<Identifier>(_initialOp));
 	ret.debugData = ret.functionName.debugData;
-
+	auto const isUnlimitedLiteralArgument = [f=m_dialect.builtin(ret.functionName.name)](size_t const index) {
+		if (f && index < f->literalArguments.size())
+			return f->literalArgument(index).has_value();
+		return false;
+	};
+	size_t argumentIndex {0};
 	expectToken(Token::LParen);
 	if (currentToken() != Token::RParen)
 	{
-		ret.arguments.emplace_back(parseExpression());
+		ret.arguments.emplace_back(parseExpression(isUnlimitedLiteralArgument(argumentIndex++)));
 		while (currentToken() != Token::RParen)
 		{
 			expectToken(Token::Comma);
-			ret.arguments.emplace_back(parseExpression());
+			ret.arguments.emplace_back(parseExpression(isUnlimitedLiteralArgument(argumentIndex++)));
 		}
 	}
 	updateLocationEndFrom(ret.debugData, currentLocation());

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -138,10 +138,10 @@ protected:
 	Case parseCase();
 	ForLoop parseForLoop();
 	/// Parses a functional expression that has to push exactly one stack element
-	Expression parseExpression();
+	Expression parseExpression(bool _unlimitedLiteralArgument = false);
 	/// Parses an elementary operation, i.e. a literal, identifier, instruction or
 	/// builtin function call (only the name).
-	std::variant<Literal, Identifier> parseLiteralOrIdentifier();
+	std::variant<Literal, Identifier> parseLiteralOrIdentifier(bool _unlimitedLiteralArgument = false);
 	VariableDeclaration parseVariableDeclaration();
 	FunctionDefinition parseFunctionDefinition();
 	FunctionCall parseCall(std::variant<Literal, Identifier>&& _initialOp);

--- a/libyul/AsmPrinter.cpp
+++ b/libyul/AsmPrinter.cpp
@@ -25,6 +25,7 @@
 #include <libyul/AST.h>
 #include <libyul/Exceptions.h>
 #include <libyul/Dialect.h>
+#include <libyul/Utilities.h>
 
 #include <libsolutil/CommonData.h>
 #include <libsolutil/StringUtils.h>
@@ -34,8 +35,8 @@
 
 #include <range/v3/view/transform.hpp>
 
-#include <memory>
 #include <functional>
+#include <memory>
 
 using namespace solidity;
 using namespace solidity::langutil;
@@ -44,21 +45,22 @@ using namespace solidity::yul;
 
 std::string AsmPrinter::operator()(Literal const& _literal)
 {
+	yulAssert(validLiteral(_literal));
+
 	std::string const locationComment = formatDebugData(_literal);
+	std::string const formattedValue = formatLiteral(_literal);
 
 	switch (_literal.kind)
 	{
 	case LiteralKind::Number:
-		yulAssert(isValidDecimal(_literal.value.str()) || isValidHex(_literal.value.str()), "Invalid number literal");
-		return locationComment + _literal.value.str() + appendTypeName(_literal.type);
+		return locationComment + formattedValue + appendTypeName(_literal.type);
 	case LiteralKind::Boolean:
-		yulAssert(_literal.value == "true"_yulstring || _literal.value == "false"_yulstring, "Invalid bool literal.");
-		return locationComment + ((_literal.value == "true"_yulstring) ? "true" : "false") + appendTypeName(_literal.type, true);
+		return locationComment + formattedValue + appendTypeName(_literal.type, true);
 	case LiteralKind::String:
 		break;
 	}
 
-	return locationComment + escapeAndQuoteString(_literal.value.str()) + appendTypeName(_literal.type);
+	return locationComment + escapeAndQuoteString(formattedValue) + appendTypeName(_literal.type);
 }
 
 std::string AsmPrinter::operator()(Identifier const& _identifier)

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(yul
 	AsmAnalysis.h
 	AsmAnalysisInfo.h
 	AST.h
+	AST.cpp
 	ASTForward.h
 	AsmJsonConverter.h
 	AsmJsonConverter.cpp

--- a/libyul/Dialect.cpp
+++ b/libyul/Dialect.cpp
@@ -28,20 +28,20 @@ using namespace solidity::langutil;
 Literal Dialect::zeroLiteralForType(solidity::yul::YulString _type) const
 {
 	if (_type == boolType && _type != defaultType)
-		return {DebugData::create(), LiteralKind::Boolean, "false"_yulstring, _type};
-	return {DebugData::create(), LiteralKind::Number, "0"_yulstring, _type};
+		return {DebugData::create(), LiteralKind::Boolean, LiteralValue(false), _type};
+	return {DebugData::create(), LiteralKind::Number, LiteralValue(0, std::nullopt), _type};
 }
 
 
 Literal Dialect::trueLiteral() const
 {
 	if (boolType != defaultType)
-		return {DebugData::create(), LiteralKind::Boolean, "true"_yulstring, boolType};
+		return {DebugData::create(), LiteralKind::Boolean, LiteralValue(true), boolType};
 	else
-		return {DebugData::create(), LiteralKind::Number, "1"_yulstring, defaultType};
+		return {DebugData::create(), LiteralKind::Number, LiteralValue(1), defaultType};
 }
 
-bool Dialect::validTypeForLiteral(LiteralKind _kind, YulString, YulString _type) const
+bool Dialect::validTypeForLiteral(LiteralKind _kind, LiteralValue const&, YulString _type) const
 {
 	if (_kind == LiteralKind::Boolean)
 		return _type == boolType;

--- a/libyul/Dialect.h
+++ b/libyul/Dialect.h
@@ -35,6 +35,7 @@ namespace solidity::yul
 class YulString;
 using Type = YulString;
 enum class LiteralKind;
+class LiteralValue;
 struct Literal;
 
 struct BuiltinFunction
@@ -85,7 +86,7 @@ struct Dialect
 
 	/// Check whether the given type is legal for the given literal value.
 	/// Should only be called if the type exists in the dialect at all.
-	virtual bool validTypeForLiteral(LiteralKind _kind, YulString _value, YulString _type) const;
+	virtual bool validTypeForLiteral(LiteralKind _kind, LiteralValue const& _value, YulString _type) const;
 
 	virtual Literal zeroLiteralForType(YulString _type) const;
 	virtual Literal trueLiteral() const;

--- a/libyul/Utilities.h
+++ b/libyul/Utilities.h
@@ -25,15 +25,28 @@
 #include <libsolutil/Numeric.h>
 #include <libyul/ASTForward.h>
 
+#include <string_view>
+
 namespace solidity::yul
 {
 
 std::string reindent(std::string const& _code);
 
-u256 valueOfNumberLiteral(Literal const& _literal);
-u256 valueOfStringLiteral(Literal const& _literal);
-u256 valueOfBoolLiteral(Literal const& _literal);
-u256 valueOfLiteral(Literal const& _literal);
+LiteralValue valueOfNumberLiteral(std::string_view _literal);
+LiteralValue valueOfStringLiteral(std::string_view _literal);
+LiteralValue valueOfBuiltinStringLiteralArgument(std::string_view _literal);
+LiteralValue valueOfBoolLiteral(std::string_view _literal);
+LiteralValue valueOfLiteral(std::string_view _literal, LiteralKind const& _kind, bool _unlimitedLiteralArgument = false);
+bool validLiteral(Literal const& _literal);
+bool validStringLiteral(Literal const& _literal);
+bool validNumberLiteral(Literal const& _literal);
+bool validBoolLiteral(Literal const& _literal);
+
+/// Produces a string representation of a Literal instance.
+/// @param _literal the Literal to be formatted
+/// @param _validated whether the Literal was already validated, i.e., assumptions are asserted in the method
+/// @returns the literal's string representation
+std::string formatLiteral(Literal const& _literal, bool _validated = true);
 
 /**
  * Linear order on Yul AST nodes.

--- a/libyul/backends/evm/ConstantOptimiser.cpp
+++ b/libyul/backends/evm/ConstantOptimiser.cpp
@@ -81,7 +81,7 @@ struct MiniEVMInterpreter
 	}
 	u256 operator()(Literal const& _literal)
 	{
-		return valueOfLiteral(_literal);
+		return _literal.value.value();
 	}
 	u256 operator()(Identifier const&) { yulAssert(false, ""); }
 
@@ -100,7 +100,7 @@ void ConstantOptimiser::visit(Expression& _e)
 		if (
 			Expression const* repr =
 				RepresentationFinder(m_dialect, m_meter, debugDataOf(_e), m_cache)
-				.tryFindRepresentation(valueOfLiteral(literal))
+				.tryFindRepresentation(literal.value.value())
 		)
 			_e = ASTCopier{}.translate(*repr);
 	}
@@ -179,7 +179,7 @@ Representation const& RepresentationFinder::findRepresentation(u256 const& _valu
 Representation RepresentationFinder::represent(u256 const& _value) const
 {
 	Representation repr;
-	repr.expression = std::make_unique<Expression>(Literal{m_debugData, LiteralKind::Number, YulString{formatNumber(_value)}, {}});
+	repr.expression = std::make_unique<Expression>(Literal{m_debugData, LiteralKind::Number, LiteralValue{_value, formatNumber(_value)}, {}});
 	repr.cost = m_meter.costs(*repr.expression);
 	return repr;
 }

--- a/libyul/backends/evm/ControlFlowGraphBuilder.cpp
+++ b/libyul/backends/evm/ControlFlowGraphBuilder.cpp
@@ -245,7 +245,7 @@ ControlFlowGraphBuilder::ControlFlowGraphBuilder(
 
 StackSlot ControlFlowGraphBuilder::operator()(Literal const& _literal)
 {
-	return LiteralSlot{valueOfLiteral(_literal), _literal.debugData};
+	return LiteralSlot{_literal.value.value(), _literal.debugData};
 }
 
 StackSlot ControlFlowGraphBuilder::operator()(Identifier const& _identifier)
@@ -361,7 +361,7 @@ void ControlFlowGraphBuilder::operator()(Switch const& _switch)
 			{*_case.value, Identifier{{}, ghostVariableName}}
 		});
 		CFG::Operation& operation = m_currentBlock->operations.emplace_back(CFG::Operation{
-			Stack{ghostVarSlot, LiteralSlot{valueOfLiteral(*_case.value), debugDataOf(*_case.value)}},
+			Stack{ghostVarSlot, LiteralSlot{_case.value->value.value(), debugDataOf(*_case.value)}},
 			Stack{TemporarySlot{ghostCall, 0}},
 			CFG::BuiltinCall{debugDataOf(_case), *equalityBuiltin, ghostCall, 2},
 		});
@@ -399,7 +399,7 @@ void ControlFlowGraphBuilder::operator()(ForLoop const& _loop)
 
 	std::optional<bool> constantCondition;
 	if (auto const* literalCondition = std::get_if<yul::Literal>(_loop.condition.get()))
-		constantCondition = valueOfLiteral(*literalCondition) != 0;
+		constantCondition = literalCondition->value.value() != 0;
 
 	CFG::BasicBlock& loopCondition = m_graph.makeBlock(debugDataOf(*_loop.condition));
 	CFG::BasicBlock& loopBody = m_graph.makeBlock(debugDataOf(_loop.body));

--- a/libyul/backends/evm/EVMCodeTransform.cpp
+++ b/libyul/backends/evm/EVMCodeTransform.cpp
@@ -297,7 +297,7 @@ void CodeTransform::operator()(Identifier const& _identifier)
 void CodeTransform::operator()(Literal const& _literal)
 {
 	m_assembly.setSourceLocation(originLocationOf(_literal));
-	m_assembly.appendConstant(valueOfLiteral(_literal));
+	m_assembly.appendConstant(_literal.value.value());
 }
 
 void CodeTransform::operator()(If const& _if)

--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -219,7 +219,7 @@ std::map<YulString, BuiltinFunctionForEVM> createBuiltins(langutil::EVMVersion _
 		) {
 			yulAssert(_call.arguments.size() == 1, "");
 			Expression const& arg = _call.arguments.front();
-			_assembly.appendLinkerSymbol(std::get<Literal>(arg).value.str());
+			_assembly.appendLinkerSymbol(formatLiteral(std::get<Literal>(arg)));
 		}));
 
 		builtins.emplace(createFunction(
@@ -236,7 +236,7 @@ std::map<YulString, BuiltinFunctionForEVM> createBuiltins(langutil::EVMVersion _
 				yulAssert(_call.arguments.size() == 1, "");
 				Literal const* literal = std::get_if<Literal>(&_call.arguments.front());
 				yulAssert(literal, "");
-				_assembly.appendConstant(valueOfLiteral(*literal));
+				_assembly.appendConstant(literal->value.value());
 			})
 		);
 
@@ -248,7 +248,7 @@ std::map<YulString, BuiltinFunctionForEVM> createBuiltins(langutil::EVMVersion _
 			yulAssert(_context.currentObject, "No object available.");
 			yulAssert(_call.arguments.size() == 1, "");
 			Expression const& arg = _call.arguments.front();
-			YulString dataName = std::get<Literal>(arg).value;
+			YulString const dataName (formatLiteral(std::get<Literal>(arg)));
 			if (_context.currentObject->name == dataName)
 				_assembly.appendAssemblySize();
 			else
@@ -269,7 +269,7 @@ std::map<YulString, BuiltinFunctionForEVM> createBuiltins(langutil::EVMVersion _
 			yulAssert(_context.currentObject, "No object available.");
 			yulAssert(_call.arguments.size() == 1, "");
 			Expression const& arg = _call.arguments.front();
-			YulString dataName = std::get<Literal>(arg).value;
+			YulString const dataName (formatLiteral(std::get<Literal>(arg)));
 			if (_context.currentObject->name == dataName)
 				_assembly.appendConstant(0);
 			else
@@ -328,8 +328,8 @@ std::map<YulString, BuiltinFunctionForEVM> createBuiltins(langutil::EVMVersion _
 				BuiltinContext&
 			) {
 				yulAssert(_call.arguments.size() == 3, "");
-				YulString identifier = std::get<Literal>(_call.arguments[1]).value;
-				_assembly.appendImmutableAssignment(identifier.str());
+				auto const identifier = (formatLiteral(std::get<Literal>(_call.arguments[1])));
+				_assembly.appendImmutableAssignment(identifier);
 			}
 		));
 		builtins.emplace(createFunction(
@@ -344,7 +344,7 @@ std::map<YulString, BuiltinFunctionForEVM> createBuiltins(langutil::EVMVersion _
 				BuiltinContext&
 			) {
 				yulAssert(_call.arguments.size() == 1, "");
-				_assembly.appendImmutable(std::get<Literal>(_call.arguments.front()).value.str());
+				_assembly.appendImmutable(formatLiteral(std::get<Literal>(_call.arguments.front())));
 			}
 		));
 	}
@@ -450,7 +450,7 @@ BuiltinFunctionForEVM const* EVMDialect::verbatimFunction(size_t _arguments, siz
 				Expression const& bytecode = _call.arguments.front();
 
 				_assembly.appendVerbatim(
-					asBytes(std::get<Literal>(bytecode).value.str()),
+					asBytes(formatLiteral(std::get<Literal>(bytecode))),
 					_arguments,
 					_returnVariables
 				);

--- a/libyul/backends/evm/EVMMetrics.cpp
+++ b/libyul/backends/evm/EVMMetrics.cpp
@@ -91,7 +91,7 @@ void GasMeterVisitor::operator()(Literal const& _lit)
 	m_dataGas +=
 		singleByteDataGas() +
 		evmasm::GasMeter::dataGas(
-			toCompactBigEndian(valueOfLiteral(_lit), 1),
+			toCompactBigEndian(_lit.value.value(), 1),
 			m_isCreation,
 			m_dialect.evmVersion()
 		);

--- a/libyul/backends/evm/OptimizedEVMCodeTransform.cpp
+++ b/libyul/backends/evm/OptimizedEVMCodeTransform.cpp
@@ -224,7 +224,7 @@ void OptimizedEVMCodeTransform::validateSlot(StackSlot const& _slot, Expression 
 	std::visit(util::GenericVisitor{
 		[&](yul::Literal const& _literal) {
 			auto* literalSlot = std::get_if<LiteralSlot>(&_slot);
-			yulAssert(literalSlot && valueOfLiteral(_literal) == literalSlot->value, "");
+			yulAssert(literalSlot && _literal.value.value() == literalSlot->value, "");
 		},
 		[&](yul::Identifier const& _identifier) {
 			auto* variableSlot = std::get_if<VariableSlot>(&_slot);

--- a/libyul/optimiser/BlockHasher.cpp
+++ b/libyul/optimiser/BlockHasher.cpp
@@ -41,6 +41,18 @@ static constexpr uint64_t compileTimeLiteralHash(char const (&_literal)[N])
 }
 }
 
+void ASTHasherBase::hashLiteral(solidity::yul::Literal const& _literal)
+{
+	hash64(compileTimeLiteralHash("Literal"));
+	if (!_literal.value.unlimited())
+		hash64(std::hash<u256>{}(_literal.value.value()));
+	else
+		hash64(std::hash<std::string>{}(_literal.value.builtinStringLiteralValue()));
+	hash64(_literal.type.hash());
+	hash8(static_cast<uint8_t>(_literal.kind));
+	hash8(_literal.value.unlimited());
+}
+
 std::map<Block const*, uint64_t> BlockHasher::run(Block const& _block)
 {
 	std::map<Block const*, uint64_t> result;
@@ -51,13 +63,7 @@ std::map<Block const*, uint64_t> BlockHasher::run(Block const& _block)
 
 void BlockHasher::operator()(Literal const& _literal)
 {
-	hash64(compileTimeLiteralHash("Literal"));
-	if (_literal.kind == LiteralKind::Number)
-		hash64(std::hash<u256>{}(valueOfNumberLiteral(_literal)));
-	else
-		hash64(_literal.value.hash());
-	hash64(_literal.type.hash());
-	hash8(static_cast<uint8_t>(_literal.kind));
+	hashLiteral(_literal);
 }
 
 void BlockHasher::operator()(Identifier const& _identifier)
@@ -203,13 +209,7 @@ uint64_t ExpressionHasher::run(Expression const& _e)
 
 void ExpressionHasher::operator()(Literal const& _literal)
 {
-	hash64(compileTimeLiteralHash("Literal"));
-	if (_literal.kind == LiteralKind::Number)
-		hash64(std::hash<u256>{}(valueOfNumberLiteral(_literal)));
-	else
-		hash64(_literal.value.hash());
-	hash64(_literal.type.hash());
-	hash8(static_cast<uint8_t>(_literal.kind));
+	hashLiteral(_literal);
 }
 
 void ExpressionHasher::operator()(Identifier const& _identifier)

--- a/libyul/optimiser/BlockHasher.h
+++ b/libyul/optimiser/BlockHasher.h
@@ -55,8 +55,13 @@ protected:
 		hash32(static_cast<uint32_t>(_value >> 32));
 	}
 
-
 	uint64_t m_hash = fnvEmptyHash;
+};
+
+class ASTHasherBase: public HasherBase
+{
+protected:
+	void hashLiteral(solidity::yul::Literal const& _literal);
 };
 
 /**
@@ -73,7 +78,7 @@ protected:
  *
  * Prerequisite: Disambiguator, ForLoopInitRewriter
  */
-class BlockHasher: public ASTWalker, public HasherBase
+class BlockHasher: public ASTWalker, public ASTHasherBase
 {
 public:
 
@@ -120,7 +125,7 @@ private:
  * have a different name and the same if the name matches.
  * This means this hasher should only be used on disambiguated sources.
  */
-class ExpressionHasher: public ASTWalker, public HasherBase
+class ExpressionHasher: public ASTWalker, public ASTHasherBase
 {
 public:
 	/// Computes a hash of an expression that (in contrast to the behaviour of the class)

--- a/libyul/optimiser/CommonSubexpressionEliminator.cpp
+++ b/libyul/optimiser/CommonSubexpressionEliminator.cpp
@@ -114,7 +114,7 @@ void CommonSubexpressionEliminator::visit(Expression& _e)
 				if (
 					m_returnVariables.count(variable) &&
 					std::holds_alternative<Literal>(*value->value) &&
-					valueOfLiteral(std::get<Literal>(*value->value)) == 0
+					std::get<Literal>(*value->value).value.value() == 0
 				)
 					continue;
 				// We check for syntactic equality again because the value might have changed.

--- a/libyul/optimiser/ConditionalUnsimplifier.cpp
+++ b/libyul/optimiser/ConditionalUnsimplifier.cpp
@@ -59,7 +59,7 @@ void ConditionalUnsimplifier::operator()(Switch& _switch)
 					assignment.variableNames.size() == 1 &&
 					assignment.variableNames.front().name == expr &&
 					std::holds_alternative<Literal>(*assignment.value) &&
-					valueOfLiteral(std::get<Literal>(*assignment.value)) == valueOfLiteral(*_case.value)
+					std::get<Literal>(*assignment.value).value == _case.value->value
 				)
 					_case.body.statements.erase(_case.body.statements.begin());
 			}
@@ -95,7 +95,7 @@ void ConditionalUnsimplifier::operator()(Block& _block)
 							assignment.variableNames.size() == 1 &&
 							assignment.variableNames.front().name == condition &&
 							std::holds_alternative<Literal>(*assignment.value) &&
-							valueOfLiteral(std::get<Literal>(*assignment.value)) == 0
+							std::get<Literal>(*assignment.value).value.value() == 0
 						)
 							return {make_vector<Statement>(std::move(_stmt1))};
 					}

--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -414,7 +414,7 @@ std::optional<u256> DataFlowAnalyzer::valueOfIdentifier(YulString const& _name) 
 {
 	if (AssignedValue const* value = variableValue(_name))
 		if (Literal const* literal = std::get_if<Literal>(value->value))
-			return valueOfLiteral(*literal);
+			return literal->value.value();
 	return std::nullopt;
 }
 

--- a/libyul/optimiser/DataFlowAnalyzer.h
+++ b/libyul/optimiser/DataFlowAnalyzer.h
@@ -217,7 +217,7 @@ protected:
 	};
 	/// Special expression whose address will be used in m_value.
 	/// YulString does not need to be reset because DataFlowAnalyzer is short-lived.
-	Expression const m_zero{Literal{{}, LiteralKind::Number, YulString{"0"}, {}}};
+	Expression const m_zero{Literal{{}, LiteralKind::Number, LiteralValue{0, "0"}, {}}};
 	/// List of scopes.
 	std::vector<Scope> m_variableScopes;
 };

--- a/libyul/optimiser/ExpressionSimplifier.cpp
+++ b/libyul/optimiser/ExpressionSimplifier.cpp
@@ -60,14 +60,14 @@ void ExpressionSimplifier::visit(Expression& _expression)
 						!knownToBeZero(startArgument) &&
 						!std::holds_alternative<FunctionCall>(startArgument)
 					)
-						startArgument = Literal{debugDataOf(startArgument), LiteralKind::Number, "0"_yulstring, {}};
+						startArgument = Literal{debugDataOf(startArgument), LiteralKind::Number, LiteralValue{0, "0"}, {}};
 				}
 }
 
 bool ExpressionSimplifier::knownToBeZero(Expression const& _expression) const
 {
 	if (auto const* literal = std::get_if<Literal>(&_expression))
-		return valueOfLiteral(*literal) == 0;
+		return literal->value.value() == 0;
 	else if (auto const* identifier = std::get_if<Identifier>(&_expression))
 		return valueOfIdentifier(identifier->name) == 0;
 	else

--- a/libyul/optimiser/ForLoopConditionIntoBody.cpp
+++ b/libyul/optimiser/ForLoopConditionIntoBody.cpp
@@ -58,7 +58,7 @@ void ForLoopConditionIntoBody::operator()(ForLoop& _forLoop)
 			Literal {
 				debugData,
 				LiteralKind::Boolean,
-				"true"_yulstring,
+				LiteralValue{true},
 				m_dialect.boolType
 			}
 		);

--- a/libyul/optimiser/ForLoopConditionOutOfBody.cpp
+++ b/libyul/optimiser/ForLoopConditionOutOfBody.cpp
@@ -38,7 +38,7 @@ void ForLoopConditionOutOfBody::operator()(ForLoop& _forLoop)
 	if (
 		!m_dialect.booleanNegationFunction() ||
 		!std::holds_alternative<Literal>(*_forLoop.condition) ||
-		valueOfLiteral(std::get<Literal>(*_forLoop.condition)) == u256(0) ||
+		std::get<Literal>(*_forLoop.condition).value.value() == 0 ||
 		_forLoop.body.statements.empty() ||
 		!std::holds_alternative<If>(_forLoop.body.statements.front())
 	)

--- a/libyul/optimiser/KnowledgeBase.cpp
+++ b/libyul/optimiser/KnowledgeBase.cpp
@@ -78,7 +78,7 @@ std::optional<u256> KnowledgeBase::valueIfKnownConstant(Expression const& _expre
 	if (Identifier const* ident = std::get_if<Identifier>(&_expression))
 		return valueIfKnownConstant(ident->name);
 	else if (Literal const* lit = std::get_if<Literal>(&_expression))
-		return valueOfLiteral(*lit);
+		return lit->value.value();
 	else
 		return std::nullopt;
 }
@@ -113,7 +113,7 @@ KnowledgeBase::VariableOffset KnowledgeBase::explore(YulString _var)
 std::optional<KnowledgeBase::VariableOffset> KnowledgeBase::explore(Expression const& _value)
 {
 	if (Literal const* literal = std::get_if<Literal>(&_value))
-		return VariableOffset{YulString{}, valueOfLiteral(*literal)};
+		return VariableOffset{YulString{}, literal->value.value()};
 	else if (Identifier const* identifier = std::get_if<Identifier>(&_value))
 		return explore(identifier->name);
 	else if (FunctionCall const* f = std::get_if<FunctionCall>(&_value))

--- a/libyul/optimiser/LoadResolver.cpp
+++ b/libyul/optimiser/LoadResolver.cpp
@@ -125,7 +125,7 @@ void LoadResolver::tryEvaluateKeccak(
 			{},
 			LiteralKind::Number,
 			// a dummy 256-bit number to represent the Keccak256 hash.
-			YulString{std::numeric_limits<u256>::max().str()},
+			LiteralValue{std::numeric_limits<u256>::max()},
 			{}
 		}
 	);
@@ -146,10 +146,11 @@ void LoadResolver::tryEvaluateKeccak(
 		{
 			bytes contentAsBytes = toBigEndian(*memoryContent);
 			contentAsBytes.resize(static_cast<size_t>(*byteLength));
+			u256 const contentHash (keccak256(contentAsBytes));
 			_e = Literal{
 				debugDataOf(_e),
 				LiteralKind::Number,
-				YulString{u256(keccak256(contentAsBytes)).str()},
+				LiteralValue{contentHash},
 				m_dialect.defaultType
 			};
 		}

--- a/libyul/optimiser/Metrics.cpp
+++ b/libyul/optimiser/Metrics.cpp
@@ -71,7 +71,7 @@ size_t CodeWeights::costOf(Expression const& _expression) const
 	else if (Literal const* literal = std::get_if<Literal>(&_expression))
 	{
 		// Avoid strings because they could be longer than 32 bytes.
-		if (literal->kind != LiteralKind::String && valueOfLiteral(*literal) == 0)
+		if (literal->kind != LiteralKind::String && literal->value.value() == 0)
 			return literalZeroCost;
 		else
 			return literalCost;
@@ -155,15 +155,15 @@ void CodeCost::operator()(Literal const& _literal)
 	case LiteralKind::Boolean:
 		break;
 	case LiteralKind::Number:
-		for (u256 n = u256(_literal.value.str()); n >= 0x100; n >>= 8)
+		for (u256 n = _literal.value.value(); n >= 0x100; n >>= 8)
 			cost++;
-		if (valueOfLiteral(_literal) == 0)
+		if (_literal.value.value() == 0)
 			if (auto evmDialect = dynamic_cast<EVMDialect const*>(&m_dialect))
 				if (evmDialect->evmVersion().hasPush0())
 					--m_cost;
 		break;
 	case LiteralKind::String:
-		cost = _literal.value.str().size();
+		cost = formatLiteral(_literal).size();
 		break;
 	}
 

--- a/libyul/optimiser/SSAValueTracker.h
+++ b/libyul/optimiser/SSAValueTracker.h
@@ -57,7 +57,7 @@ private:
 
 	/// Special expression whose address will be used in m_values.
 	/// YulString does not need to be reset because SSAValueTracker is short-lived.
-	Expression const m_zero{Literal{{}, LiteralKind::Number, YulString{"0"}, {}}};
+	Expression const m_zero{Literal{{}, LiteralKind::Number, LiteralValue(u256{0}), {}}};
 	std::map<YulString, Expression const*> m_values;
 };
 

--- a/libyul/optimiser/SimplificationRules.cpp
+++ b/libyul/optimiser/SimplificationRules.cpp
@@ -160,7 +160,7 @@ bool Pattern::matches(
 		Literal const& literal = std::get<Literal>(*expr);
 		if (literal.kind != LiteralKind::Number)
 			return false;
-		if (m_data && *m_data != u256(literal.value.str()))
+		if (m_data && *m_data != literal.value.value())
 			return false;
 		assertThrow(m_arguments.empty(), OptimizerException, "");
 	}
@@ -241,7 +241,7 @@ Expression Pattern::toExpression(langutil::DebugData::ConstPtr const& _debugData
 	if (m_kind == PatternKind::Constant)
 	{
 		assertThrow(m_data, OptimizerException, "No match group and no constant value given.");
-		return Literal{_debugData, LiteralKind::Number, YulString{formatNumber(*m_data)}, {}};
+		return Literal{_debugData, LiteralKind::Number, LiteralValue{*m_data, formatNumber(*m_data)}, {}};
 	}
 	else if (m_kind == PatternKind::Operation)
 	{
@@ -261,7 +261,7 @@ Expression Pattern::toExpression(langutil::DebugData::ConstPtr const& _debugData
 
 u256 Pattern::d() const
 {
-	return valueOfNumberLiteral(std::get<Literal>(matchGroupValue()));
+	return std::get<Literal>(matchGroupValue()).value.value();
 }
 
 Expression const& Pattern::matchGroupValue() const

--- a/libyul/optimiser/StackLimitEvader.cpp
+++ b/libyul/optimiser/StackLimitEvader.cpp
@@ -113,7 +113,7 @@ u256 literalArgumentValue(FunctionCall const& _call)
 	yulAssert(_call.arguments.size() == 1, "");
 	Literal const* literal = std::get_if<Literal>(&_call.arguments.front());
 	yulAssert(literal && literal->kind == LiteralKind::Number, "");
-	return valueOfLiteral(*literal);
+	return literal->value.value();
 }
 }
 
@@ -210,6 +210,6 @@ void StackLimitEvader::run(
 	{
 		Literal* literal = std::get_if<Literal>(&memoryGuardCall->arguments.front());
 		yulAssert(literal && literal->kind == LiteralKind::Number, "");
-		literal->value = YulString{toCompactHexWithPrefix(reservedMemory)};
+		literal->value = LiteralValue{reservedMemory, toCompactHexWithPrefix(reservedMemory)};
 	}
 }

--- a/libyul/optimiser/StackToMemoryMover.h
+++ b/libyul/optimiser/StackToMemoryMover.h
@@ -165,13 +165,13 @@ private:
 
 		/// @returns a YulString containing the memory offset to be assigned to @a _variable as number literal
 		/// or std::nullopt if the variable should not be moved.
-		std::optional<YulString> operator()(YulString _variable) const;
+		std::optional<LiteralValue> operator()(YulString const& _variable) const;
 		/// @returns a YulString containing the memory offset to be assigned to @a _variable as number literal
 		/// or std::nullopt if the variable should not be moved.
-		std::optional<YulString> operator()(TypedName const& _variable) const;
+		std::optional<LiteralValue> operator()(TypedName const& _variable) const;
 		/// @returns a YulString containing the memory offset to be assigned to @a _variable as number literal
 		/// or std::nullopt if the variable should not be moved.
-		std::optional<YulString> operator()(Identifier const& _variable) const;
+		std::optional<LiteralValue> operator()(Identifier const& _variable) const;
 
 	private:
 		u256 m_reservedMemory;

--- a/libyul/optimiser/StructuralSimplifier.cpp
+++ b/libyul/optimiser/StructuralSimplifier.cpp
@@ -36,7 +36,7 @@ OptionalStatements replaceConstArgSwitch(Switch& _switchStmt, u256 const& _const
 
 	for (auto& _case: _switchStmt.cases)
 	{
-		if (_case.value && valueOfLiteral(*_case.value) == _constExprVal)
+		if (_case.value && _case.value->value.value() == _constExprVal)
 		{
 			matchingCaseBlock = &_case.body;
 			break;
@@ -57,9 +57,9 @@ OptionalStatements replaceConstArgSwitch(Switch& _switchStmt, u256 const& _const
 std::optional<u256> hasLiteralValue(Expression const& _expression)
 {
 	if (std::holds_alternative<Literal>(_expression))
-		return valueOfLiteral(std::get<Literal>(_expression));
+		return std::get<Literal>(_expression).value.value();
 	else
-		return std::optional<u256>();
+		return std::nullopt;
 }
 
 bool expressionAlwaysTrue(Expression const& _expression)

--- a/libyul/optimiser/SyntacticalEquality.cpp
+++ b/libyul/optimiser/SyntacticalEquality.cpp
@@ -22,6 +22,7 @@
 
 #include <libyul/AST.h>
 #include <libyul/Utilities.h>
+#include <libyul/Exceptions.h>
 
 #include <libsolutil/CommonData.h>
 
@@ -63,12 +64,13 @@ bool SyntacticallyEqual::expressionEqual(Identifier const& _lhs, Identifier cons
 }
 bool SyntacticallyEqual::expressionEqual(Literal const& _lhs, Literal const& _rhs)
 {
-	if (_lhs.kind != _rhs.kind || _lhs.type != _rhs.type)
+	yulAssert(validLiteral(_lhs), "Invalid lhs literal during syntactical equality check");
+	yulAssert(validLiteral(_rhs), "Invalid rhs literal during syntactical equality check");
+
+	if (_lhs.type != _rhs.type)
 		return false;
-	if (_lhs.kind == LiteralKind::Number)
-		return valueOfNumberLiteral(_lhs) == valueOfNumberLiteral(_rhs);
-	else
-		return _lhs.value == _rhs.value;
+
+	return _lhs.value == _rhs.value;
 }
 
 bool SyntacticallyEqual::statementEqual(ExpressionStatement const& _lhs, ExpressionStatement const& _rhs)

--- a/libyul/optimiser/SyntacticalEquality.h
+++ b/libyul/optimiser/SyntacticalEquality.h
@@ -34,6 +34,9 @@ namespace solidity::yul
 /**
  * Component that can compare ASTs for equality on a syntactic basis.
  * Ignores source locations and allows for different variable names but requires exact matches otherwise.
+ * Literals are compared based on their values, e.g., `0x01`, `1`, `"\x01"` and `true` all evaluate as equal.
+ * Note that this does not apply to unlimited literal strings, which are never considered equal to normal literals,
+ * even when the values would look like identical strings in the source.
  *
  * Prerequisite: Disambiguator (unless only expressions are compared)
  */

--- a/libyul/optimiser/UnusedStoreEliminator.cpp
+++ b/libyul/optimiser/UnusedStoreEliminator.cpp
@@ -61,9 +61,9 @@ void UnusedStoreEliminator::run(OptimiserStepContext& _context, Block& _ast)
 	std::map<YulString, AssignedValue> values;
 	for (auto const& [name, expression]: ssaValues.values())
 		values[name] = AssignedValue{expression, {}};
-	Expression const zeroLiteral{Literal{{}, LiteralKind::Number, YulString{"0"}, {}}};
-	Expression const oneLiteral{Literal{{}, LiteralKind::Number, YulString{"1"}, {}}};
-	Expression const thirtyTwoLiteral{Literal{{}, LiteralKind::Number, YulString{"32"}, {}}};
+	Expression const zeroLiteral{Literal{{}, LiteralKind::Number, LiteralValue(u256{0}), {}}};
+	Expression const oneLiteral{Literal{{}, LiteralKind::Number, LiteralValue(u256{1}), {}}};
+	Expression const thirtyTwoLiteral{Literal{{}, LiteralKind::Number, LiteralValue(u256{32}), {}}};
 	values[YulString{zero}] = AssignedValue{&zeroLiteral, {}};
 	values[YulString{one}] = AssignedValue{&oneLiteral, {}};
 	values[YulString{thirtyTwo}] = AssignedValue{&thirtyTwoLiteral, {}};

--- a/test/libyul/yulOptimizerTests/disambiguator/similar_literals.yul
+++ b/test/libyul/yulOptimizerTests/disambiguator/similar_literals.yul
@@ -1,0 +1,23 @@
+{
+    let a := 1234
+    let a_hex := 0x4d2
+    let b := "1234"
+    let b_hex := "0x4d2"
+    let c := '1234'
+    let c_hex := '0x4d2'
+    let d := hex"1234"
+    let d_hex := hex"04d2"
+}
+// ----
+// step: disambiguator
+//
+// {
+//     let a := 1234
+//     let a_hex := 0x4d2
+//     let b := "1234"
+//     let b_hex := "0x4d2"
+//     let c := "1234"
+//     let c_hex := "0x4d2"
+//     let d := "\x124"
+//     let d_hex := "\x04\xd2"
+// }

--- a/test/libyul/yulOptimizerTests/disambiguator/string_as_hex_and_hex_as_string.yul
+++ b/test/libyul/yulOptimizerTests/disambiguator/string_as_hex_and_hex_as_string.yul
@@ -1,0 +1,13 @@
+object "A" {
+    code {
+        pop(datasize(hex'616263'))
+    }
+    data 'abc' "1234"
+}
+// ----
+// step: disambiguator
+//
+// object "A" {
+//     code { pop(datasize("abc")) }
+//     data "abc" hex"31323334"
+// }

--- a/test/libyul/yulOptimizerTests/equivalentFunctionCombiner/constant_representation.yul
+++ b/test/libyul/yulOptimizerTests/equivalentFunctionCombiner/constant_representation.yul
@@ -1,8 +1,10 @@
 {
   f()
   g()
-  function f() { mstore(0x01, mload(0x00)) }
-  function g() { mstore(1, mload(0)) }
+  h()
+  function f() { mstore(29400335157912315244266070412362164103369332044010299463143527189509193072640, mload(0x00)) }
+  function g() { mstore(0x4100000000000000000000000000000000000000000000000000000000000000, mload(0x00)) }
+  function h() { mstore("A", mload(0)) }
 }
 // ----
 // step: equivalentFunctionCombiner
@@ -10,8 +12,15 @@
 // {
 //     f()
 //     f()
+//     h()
 //     function f()
-//     { mstore(0x01, mload(0x00)) }
+//     {
+//         mstore(29400335157912315244266070412362164103369332044010299463143527189509193072640, mload(0x00))
+//     }
 //     function g()
-//     { mstore(1, mload(0)) }
+//     {
+//         mstore(0x4100000000000000000000000000000000000000000000000000000000000000, mload(0x00))
+//     }
+//     function h()
+//     { mstore("A", mload(0)) }
 // }

--- a/test/libyul/yulOptimizerTests/equivalentFunctionCombiner/constant_representation_datasize.yul
+++ b/test/libyul/yulOptimizerTests/equivalentFunctionCombiner/constant_representation_datasize.yul
@@ -1,0 +1,48 @@
+object "test"
+{
+  code
+  {
+    f()
+    g()
+    h()
+    i()
+    function f()
+    {
+      let x := datasize("A")
+    }
+    function g()
+    {
+      let x := datasize(hex"41")
+    }
+    function h()
+    {
+      let x := datasize("\x41")
+    }
+    function i()
+    {
+      let x := datasize("\u0041")
+    }
+  }
+  data 'A' "A"
+}
+
+// ----
+// step: equivalentFunctionCombiner
+//
+// object "test" {
+//     code {
+//         f()
+//         f()
+//         f()
+//         f()
+//         function f()
+//         { let x := datasize("A") }
+//         function g()
+//         { let x_1 := datasize("A") }
+//         function h()
+//         { let x_2 := datasize("A") }
+//         function i()
+//         { let x_3 := datasize("A") }
+//     }
+//     data "A" hex"41"
+// }

--- a/test/libyul/yulSyntaxTests/switch_duplicate_case.yul
+++ b/test/libyul/yulSyntaxTests/switch_duplicate_case.yul
@@ -6,4 +6,4 @@
 // ====
 // dialect: evmTyped
 // ----
-// DeclarationError 6792: (34-50): Duplicate case "0" defined.
+// DeclarationError 6792: (34-50): Duplicate case "0x0" defined.

--- a/test/libyul/yulSyntaxTests/switch_duplicate_case_different_literal.yul
+++ b/test/libyul/yulSyntaxTests/switch_duplicate_case_different_literal.yul
@@ -6,4 +6,4 @@
 // ====
 // dialect: evmTyped
 // ----
-// DeclarationError 6792: (34-49): Duplicate case "0" defined.
+// DeclarationError 6792: (34-49): Duplicate case "" defined.

--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
@@ -25,6 +25,7 @@
 
 #include <libyul/backends/evm/EVMDialect.h>
 #include <libyul/AST.h>
+#include <libyul/Utilities.h>
 
 #include <libevmasm/Instruction.h>
 #include <libevmasm/SemanticInformation.h>
@@ -508,7 +509,7 @@ u256 EVMInstructionInterpreter::evalBuiltin(
 	// Evaluate datasize/offset/copy instructions
 	if (fun == "datasize" || fun == "dataoffset")
 	{
-		std::string arg = std::get<Literal>(_arguments.at(0)).value.str();
+		std::string arg = formatLiteral(std::get<Literal>(_arguments.at(0)));
 		if (arg.length() < 32)
 			arg.resize(32, 0);
 		if (fun == "datasize")

--- a/test/tools/yulInterpreter/Interpreter.cpp
+++ b/test/tools/yulInterpreter/Interpreter.cpp
@@ -296,10 +296,7 @@ void Interpreter::incrementStep()
 void ExpressionEvaluator::operator()(Literal const& _literal)
 {
 	incrementStep();
-	static YulString const trueString("true");
-	static YulString const falseString("false");
-
-	setValue(valueOfLiteral(_literal));
+	setValue(_literal.value.value());
 }
 
 void ExpressionEvaluator::operator()(Identifier const& _identifier)
@@ -389,16 +386,13 @@ void ExpressionEvaluator::evaluateArgs(
 			visit(expr);
 		else
 		{
-			std::string literal = std::get<Literal>(expr).value.str();
-
-			try
+			if (std::get<Literal>(expr).value.unlimited())
 			{
-				m_values = {u256(literal)};
+				yulAssert(std::get<Literal>(expr).kind == LiteralKind::String);
+				m_values = {0xdeadbeef};
 			}
-			catch (std::exception&)
-			{
-				m_values = {u256(0)};
-			}
+			else
+				m_values = {std::get<Literal>(expr).value.value()};
 		}
 
 		values.push_back(value());


### PR DESCRIPTION
Changed the definition of the `solidity::yul::Literal` to carry its value not  as `YulString` but as `LiteralValue` struct, consisting of a `u256` and an optional string representation hint. Upon converting from its data back to a string representation, it is first checked if the hint is not empty and in that case, whether `value == parseValue(hint)`.