### PR TITLE
Add `stopAfter` setting to syntax tests

### DIFF
--- a/test/libsolidity/SyntaxTest.h
+++ b/test/libsolidity/SyntaxTest.h
@@ -55,6 +55,7 @@ protected:
 	bool m_optimiseYul{};
 	std::string m_compileViaYul{};
 	langutil::Error::Severity m_minSeverity{};
+	PipelineStage m_stopAfter;
 };
 
 }

--- a/test/libsolidity/syntaxTests/stopAfterAnalysisError.sol
+++ b/test/libsolidity/syntaxTests/stopAfterAnalysisError.sol
@@ -1,0 +1,8 @@
+contract C {
+    function f(uint[] x) public pure {
+    }
+}
+// ====
+// stopAfter: analysis
+// ----
+// TypeError 6651: (28-36): Data location must be "memory" or "calldata" for parameter in function, but none was given.

--- a/test/libsolidity/syntaxTests/stopAfterParsingAnalysisErrorNotShowing.sol
+++ b/test/libsolidity/syntaxTests/stopAfterParsingAnalysisErrorNotShowing.sol
@@ -1,0 +1,6 @@
+contract C {
+    uint x = address(0xabc);
+}
+// ====
+// stopAfter: parsing
+// ----

--- a/test/libsolidity/syntaxTests/stopAfterParsingError.sol
+++ b/test/libsolidity/syntaxTests/stopAfterParsingError.sol
@@ -1,0 +1,7 @@
+contract C {
+    uint storage x;
+}
+// ====
+// stopAfter:parsing
+// ----
+// ParserError 2314: (22-29): Expected identifier but got 'storage'


### PR DESCRIPTION
This adds the `stopAfter` setting to syntax tests, making it possible to test changes that are contained to parsing, analysis or compilation stages.
suggested here: https://github.com/ethereum/solidity/pull/15001#discussion_r1605252106