### PR TITLE
test for unlimited string literal in IR via yul

### DIFF
--- a/test/libyul/yulOptimizerTests/commonSubexpressionEliminator/long_literals_as_builtin_args.yul
+++ b/test/libyul/yulOptimizerTests/commonSubexpressionEliminator/long_literals_as_builtin_args.yul
@@ -1,0 +1,28 @@
+object "AccessControlDefaultAdminRules4233_14" {
+    code {
+        let programSize := datasize("AccessControlDefaultAdminRules4233_14")
+        let i := mload(64)
+        // argument of datasize is a literal of length >32 which shares a common substring
+        // of length 32 with programSize, this should not be substituted
+        let j := datasize("AccessControlDefaultAdminRules4233_14_deployed")
+        codecopy(i, dataoffset("AccessControlDefaultAdminRules4233_14_deployed"), j)
+    }
+    object "AccessControlDefaultAdminRules4233_14_deployed" {
+        code {}
+    }
+
+}
+// ----
+// step: commonSubexpressionEliminator
+//
+// object "AccessControlDefaultAdminRules4233_14" {
+//     code {
+//         let programSize := datasize("AccessControlDefaultAdminRules4233_14")
+//         let i := mload(64)
+//         let j := datasize("AccessControlDefaultAdminRules4233_14_deployed")
+//         codecopy(i, dataoffset("AccessControlDefaultAdminRules4233_14_deployed"), j)
+//     }
+//     object "AccessControlDefaultAdminRules4233_14_deployed" {
+//         code { }
+//     }
+// }


### PR DESCRIPTION
- Defines a contract with a name that exceeds 32 characters
- programSize is defined as datasize(contractName)
- if not correct, programSize can be substituted by optimizations into ctor return value
- this is due to u256 words only capturing first 32 chars