### PR TITLE
SMTChecker: Add CHC engine check for underflow and overflow in unary minus operation 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Language Features:
 
 
 Compiler Features:
+ * SMTChecker: Add CHC engine check for underflow and overflow in unary minus operation.
 
 
 Bugfixes:

--- a/test/libsolidity/smtCheckerTests/control_flow/branches_with_return/constructor_state_variable_init.sol
+++ b/test/libsolidity/smtCheckerTests/control_flow/branches_with_return/constructor_state_variable_init.sol
@@ -39,5 +39,4 @@ contract C is B {
 // Warning 6328: (389-412): CHC: Assertion violation happens here.
 // Warning 6328: (489-513): CHC: Assertion violation happens here.
 // Warning 6328: (533-546): CHC: Assertion violation happens here.
-// Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
-// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 1391: CHC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/inheritance/constructor_state_variable_init_asserts.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/constructor_state_variable_init_asserts.sol
@@ -37,5 +37,4 @@ contract C is B {
 // Warning 6328: (339-362): CHC: Assertion violation happens here.
 // Warning 6328: (439-463): CHC: Assertion violation happens here.
 // Warning 6328: (483-496): CHC: Assertion violation happens here.
-// Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
-// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 1391: CHC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/inheritance/constructor_state_variable_init_chain_tree.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/constructor_state_variable_init_chain_tree.sol
@@ -41,5 +41,4 @@ contract C is B {
 // ----
 // Warning 6328: (403-417): CHC: Assertion violation happens here.
 // Warning 6328: (450-463): CHC: Assertion violation happens here.
-// Info 1391: CHC: 6 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
-// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 1391: CHC: 7 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/operators/mod.sol
+++ b/test/libsolidity/smtCheckerTests/operators/mod.sol
@@ -10,5 +10,4 @@ contract C {
 // ====
 // SMTEngine: all
 // ----
-// Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
-// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 1391: CHC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/operators/mod_signed.sol
+++ b/test/libsolidity/smtCheckerTests/operators/mod_signed.sol
@@ -12,5 +12,5 @@ contract C {
 // SMTEngine: all
 // ----
 // Warning 6328: (131-148): CHC: Assertion violation might happen here.
-// Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
-// Info 6002: BMC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 1391: CHC: 5 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/operators/unary_minus_bmc.sol
+++ b/test/libsolidity/smtCheckerTests/operators/unary_minus_bmc.sol
@@ -1,0 +1,11 @@
+contract C
+{
+	function f(int x) public pure {
+		assert(x == -x);
+	}
+}
+// ====
+// SMTEngine: bmc
+// ----
+// Warning 4661: (48-63): BMC: Assertion violation happens here.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/operators/unary_minus_chc.sol
+++ b/test/libsolidity/smtCheckerTests/operators/unary_minus_chc.sol
@@ -1,0 +1,11 @@
+contract C
+{
+	function f(int x) public pure {
+		assert(x == -x);
+	}
+}
+// ====
+// SMTEngine: chc
+// ----
+//  Warning 6328: (48-63): CHC: Assertion violation happens here.
+//  Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/operators/userDefined/user_defined_operations_on_constants.sol
+++ b/test/libsolidity/smtCheckerTests/operators/userDefined/user_defined_operations_on_constants.sol
@@ -60,5 +60,4 @@ contract C {
 // ====
 // SMTEngine: all
 // ----
-// Info 1391: CHC: 21 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
-// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 1391: CHC: 22 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/operators/userDefined/user_defined_operations_on_constants_fail.sol
+++ b/test/libsolidity/smtCheckerTests/operators/userDefined/user_defined_operations_on_constants_fail.sol
@@ -76,5 +76,4 @@ contract C {
 // Warning 6328: (2741-2758): CHC: Assertion violation happens here.
 // Warning 6328: (2783-2804): CHC: Assertion violation happens here.
 // Warning 6328: (2829-2850): CHC: Assertion violation happens here.
-// Info 1391: CHC: 5 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
-// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 1391: CHC: 6 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/operators/userDefined/user_defined_operator_matches_equivalent_function_call.sol
+++ b/test/libsolidity/smtCheckerTests/operators/userDefined/user_defined_operator_matches_equivalent_function_call.sol
@@ -56,27 +56,25 @@ contract C {
 // SMTIgnoreOS: macos
 // ----
 // Warning 3944: (679-708): CHC: Underflow (resulting value less than -32768) might happen here.
-// Warning 4984: (679-708): CHC: Overflow (resulting value larger than 32767) might happen here.
-// Warning 3944: (777-806): CHC: Underflow (resulting value less than -32768) happens here.
+// Warning 4984: (679-708): CHC: Overflow (resulting value larger than 32767) happens here.
+// Warning 3944: (777-806): CHC: Underflow (resulting value less than -32768) might happen here.
 // Warning 4984: (777-806): CHC: Overflow (resulting value larger than 32767) might happen here.
+// Warning 4984: (870-884): CHC: Overflow (resulting value larger than 32767) might happen here.
 // Warning 3944: (953-982): CHC: Underflow (resulting value less than -32768) might happen here.
 // Warning 4984: (953-982): CHC: Overflow (resulting value larger than 32767) might happen here.
 // Warning 4984: (1051-1080): CHC: Overflow (resulting value larger than 32767) might happen here.
-// Warning 4281: (1051-1080): CHC: Division by zero might happen here.
+// Warning 4281: (1051-1080): CHC: Division by zero happens here.
 // Warning 4281: (1149-1178): CHC: Division by zero might happen here.
 // Warning 6328: (2069-2095): CHC: Assertion violation might happen here.
-// Warning 6328: (2105-2131): CHC: Assertion violation might happen here.
 // Warning 6328: (2141-2163): CHC: Assertion violation might happen here.
-// Warning 6328: (2173-2199): CHC: Assertion violation might happen here.
 // Warning 6328: (2209-2235): CHC: Assertion violation might happen here.
 // Warning 6328: (2245-2271): CHC: Assertion violation might happen here.
-// Info 1391: CHC: 10 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
-// Warning 2661: (679-708): BMC: Overflow (resulting value larger than 32767) happens here.
+// Info 1391: CHC: 13 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
 // Warning 4144: (679-708): BMC: Underflow (resulting value less than -32768) happens here.
 // Warning 2661: (777-806): BMC: Overflow (resulting value larger than 32767) happens here.
+// Warning 4144: (777-806): BMC: Underflow (resulting value less than -32768) happens here.
 // Warning 2661: (953-982): BMC: Overflow (resulting value larger than 32767) happens here.
 // Warning 4144: (953-982): BMC: Underflow (resulting value less than -32768) happens here.
-// Warning 3046: (1051-1080): BMC: Division by zero happens here.
 // Warning 3046: (1149-1178): BMC: Division by zero happens here.
 // Warning 7812: (2245-2271): BMC: Assertion violation might happen here.
-// Info 6002: BMC: 10 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 8 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/unchecked/flipping_sign_tests.sol
+++ b/test/libsolidity/smtCheckerTests/unchecked/flipping_sign_tests.sol
@@ -2,14 +2,13 @@ contract test {
     function f() public pure returns (bool) {
         int256 x = -2**255;
         unchecked { assert(-x == x); }
-        assert(-x == x); // CHC apparently does not create an underflow target for unary minus
+        assert(-x == x);
         return true;
     }
 }
 // ====
 // SMTEngine: all
 // ----
+// Warning 4984: (117-119): CHC: Overflow (resulting value larger than 2**255 - 1) happens here.
 // Warning 6328: (110-125): CHC: Assertion violation happens here.
-// Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
-// Warning 2661: (117-119): BMC: Overflow (resulting value larger than 2**255 - 1) happens here.
-// Info 6002: BMC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.


### PR DESCRIPTION
We already have it for BMC. Now we'll have it in CHC too.