### PR TITLE
Prevent NameSimplifier and VarNameCleaner from producing Yul identifiers with leading and trailing dots

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Compiler Features:
 
 
 Bugfixes:
+Yul Optimizer: Name simplification could lead to forbidden identifiers with a leading and/or trailing dot, e.g., ``x._`` would get simplified into ``x.``.
 
 
 ### 0.8.26 (2024-05-21)

--- a/libyul/optimiser/OptimizerUtilities.cpp
+++ b/libyul/optimiser/OptimizerUtilities.cpp
@@ -36,6 +36,17 @@ using namespace solidity::langutil;
 using namespace solidity::util;
 using namespace solidity::yul;
 
+namespace
+{
+
+bool hasLeadingOrTrailingDot(std::string_view const _s)
+{
+	yulAssert(!_s.empty());
+	return _s.front() == '.' || _s.back() == '.';
+}
+
+}
+
 void yul::removeEmptyBlocks(Block& _block)
 {
 	auto isEmptyBlock = [](Statement const& _st) -> bool {
@@ -46,7 +57,7 @@ void yul::removeEmptyBlocks(Block& _block)
 
 bool yul::isRestrictedIdentifier(Dialect const& _dialect, YulString const& _identifier)
 {
-	return _identifier.empty() || TokenTraits::isYulKeyword(_identifier.str()) || _dialect.reservedIdentifier(_identifier);
+	return _identifier.empty() || hasLeadingOrTrailingDot(_identifier.str()) || TokenTraits::isYulKeyword(_identifier.str()) || _dialect.reservedIdentifier(_identifier);
 }
 
 std::optional<evmasm::Instruction> yul::toEVMInstruction(Dialect const& _dialect, YulString const& _name)

--- a/test/libyul/objectCompiler/leading_and_trailing_dots.yul
+++ b/test/libyul/objectCompiler/leading_and_trailing_dots.yul
@@ -1,0 +1,42 @@
+{
+    function e(_._) {
+        e(0)
+    }
+    e(2)
+    function f(n._) {
+        f(0)
+    }
+    f(2)
+    function g(_.n) {
+        g(0)
+    }
+    g(2)
+}
+// ----
+// Assembly:
+//     /* "source":49:50   */
+//   0x02
+//     /* "source":6:42   */
+// tag_1:
+//     /* "source":34:35   */
+//   0x00
+//     /* "source":32:36   */
+//   tag_1
+//   jump	// in
+//     /* "source":56:92   */
+// tag_2:
+//     /* "source":84:85   */
+//   0x00
+//     /* "source":82:86   */
+//   tag_2
+//   jump	// in
+//     /* "source":106:142   */
+// tag_3:
+//     /* "source":134:135   */
+//   0x00
+//     /* "source":132:136   */
+//   tag_3
+//   jump	// in
+// Bytecode: 60025b5f6002565b5f6007565b5f600c56
+// Opcodes: PUSH1 0x2 JUMPDEST PUSH0 PUSH1 0x2 JUMP JUMPDEST PUSH0 PUSH1 0x7 JUMP JUMPDEST PUSH0 PUSH1 0xC JUMP
+// SourceMappings: 49:1:0:-:0;6:36;34:1;32:4;:::i;56:36::-;84:1;82:4;:::i;106:36::-;134:1;132:4;:::i


### PR DESCRIPTION
Fixes #11496