### PR TITLE
Add authentication header to circleci api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1522,6 +1522,13 @@ jobs:
   c_ext_benchmarks:
     <<: *base_node_small
     steps:
+      - run:
+          name: Check CircleCI token presence; Skip job if not set.
+          command: |
+            if [[ -z "$CIRCLECI_TOKEN" ]]; then
+              echo "Skipping benchmarks..."
+              circleci-agent step halt
+            fi
       - install_python3:
           packages: requests
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1522,13 +1522,6 @@ jobs:
   c_ext_benchmarks:
     <<: *base_node_small
     steps:
-      - run:
-          name: Check CircleCI token presence; Skip job if not set.
-          command: |
-            if [[ -z "$CIRCLECI_TOKEN" ]]; then
-              echo "Skipping benchmarks..."
-              circleci-agent step halt
-            fi
       - install_python3:
           packages: requests
       - checkout
@@ -1540,6 +1533,19 @@ jobs:
       - run:
           name: Summarize reports
           command: cat reports/externalTests/all-benchmarks.json | scripts/externalTests/summarize_benchmarks.sh > reports/externalTests/summarized-benchmarks.json
+      - store_artifacts:
+          path: reports/externalTests/all-benchmarks.json
+      - store_artifacts:
+          path: reports/externalTests/summarized-benchmarks.json
+      - run:
+          name: Check CircleCI token presence; Skip remaining steps if the token is not present.
+          command: |
+            # NOTE: download_benchmarks.py requires CIRCLECI_TOKEN environment variable to be set to
+            # a valid CircleCI API token to download the benchmark artifacts.
+            if [[ -z "$CIRCLECI_TOKEN" ]]; then
+              echo "Skipping download benchmarks..."
+              circleci-agent step halt
+            fi
       - run:
           name: Download reports from base branch
           command: |
@@ -1584,10 +1590,6 @@ jobs:
                 base-branch/all-benchmarks-*.json \
                 all-benchmarks.json > diff/benchmark-diff-all-table-inplace-absolute.md
             fi
-      - store_artifacts:
-          path: reports/externalTests/all-benchmarks.json
-      - store_artifacts:
-          path: reports/externalTests/summarized-benchmarks.json
       - store_artifacts:
           path: reports/externalTests/diff/
       - store_artifacts:

--- a/scripts/externalTests/download_benchmarks.py
+++ b/scripts/externalTests/download_benchmarks.py
@@ -34,8 +34,8 @@ def process_commandline() -> Namespace:
         Downloads benchmark results attached as artifacts to the c_ext_benchmarks job on CircleCI.
         If no options are specified, downloads results for the currently checked out git branch.
 
-        The script requires the CIRCLECI_TOKEN environment variable to be set with a valid CircleCI API token.
-        You can generate a new token at https://app.circleci.com/settings/user/tokens.
+        The script will use the CIRCLECI_TOKEN environment as a CircleCI API token if set.
+        You can generate a new personal token at https://app.circleci.com/settings/user/tokens.
         """
     )
 

--- a/scripts/externalTests/download_benchmarks.py
+++ b/scripts/externalTests/download_benchmarks.py
@@ -34,8 +34,8 @@ def process_commandline() -> Namespace:
         Downloads benchmark results attached as artifacts to the c_ext_benchmarks job on CircleCI.
         If no options are specified, downloads results for the currently checked out git branch.
 
-        The script will use the CIRCLECI_TOKEN environment as a CircleCI API token if set.
-        You can generate a new personal token at https://app.circleci.com/settings/user/tokens.
+        The script requires the CIRCLECI_TOKEN environment variable to be set with a valid CircleCI API token.
+        You can generate a new token at https://app.circleci.com/settings/user/tokens.
         """
     )
 


### PR DESCRIPTION
Attempt to fix `c_ext_benchmarks` job when downloading artifacts from CircleCI API: https://app.circleci.com/pipelines/github/ethereum/solidity/34295/workflows/0cf0489b-11bd-4eae-8a23-6951de527304/jobs/1552691

The problem is only with CircleCI API that apparently started to require authenticated requests. Maybe this changed recently in the v2 API, I honestly don't know. I couldn't find any information about it.

Also, note that CircleCI v2 API does not support project API tokens and, currently, recommends the use of personal API tokens (see: https://circleci.com/docs/api/v2/index.html#section/Authentication).

Furthermore, the way it is currently done in this PR, reads a personal token from the environment variable that is set in the project settings to build the http header, this method has some risks of exposing the token, but we already do similar thing in our CI: https://github.com/ethereum/solidity/blob/develop/.circleci/config.yml#L146