### PR TITLE
Reuse optimized IR for bytecode dependencies

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Language Features:
 Compiler Features:
  * EVM: Support for the EVM version "Prague".
  * SMTChecker: Add CHC engine check for underflow and overflow in unary minus operation.
+ * Yul Optimizer: Reuse optimized Yul IR of contract dependencies instead of optimizing them again along with the dependent contract.
 
 
 Bugfixes:

--- a/libsolidity/codegen/ir/IRGenerator.h
+++ b/libsolidity/codegen/ir/IRGenerator.h
@@ -76,6 +76,8 @@ public:
 		std::map<ContractDefinition const*, std::string_view const> const& _otherYulSources
 	);
 
+	std::map<std::string, ContractDefinition const*> const& dependencySubObjects() const { return m_dependencySubObjects; }
+
 private:
 	std::string generate(
 		ContractDefinition const& _contract,
@@ -145,6 +147,8 @@ private:
 	IRGenerationContext m_context;
 	YulUtilFunctions m_utils;
 	OptimiserSettings m_optimiserSettings;
+
+	std::map<std::string, ContractDefinition const*> m_dependencySubObjects;
 };
 
 }


### PR DESCRIPTION
The quick and easy solution for #15179, which only reuses the IR.