### PR TITLE
Remove overly specific handlers for unexpected exceptions

### DIFF
--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -744,8 +744,10 @@ bool CompilerStack::compile(State _stopAfter)
 					}
 					catch (Error const& _error)
 					{
-						if (_error.type() != Error::Type::CodeGenerationError)
-							throw;
+						// Since codegen has no access to the error reporter, the only way for it to
+						// report an error is to throw. In most cases it uses dedicated exceptions,
+						// but CodeGenerationError is one case where someone decided to just throw Error.
+						solAssert(_error.type() == Error::Type::CodeGenerationError);
 						m_errorReporter.error(_error.errorId(), _error.type(), SourceLocation(), _error.what());
 						return false;
 					}

--- a/libsolidity/interface/FileReader.cpp
+++ b/libsolidity/interface/FileReader.cpp
@@ -164,17 +164,9 @@ ReadCallback::Result FileReader::readFile(std::string const& _kind, std::string 
 		m_sourceCodes[_sourceUnitName] = contents;
 		return ReadCallback::Result{true, contents};
 	}
-	catch (util::Exception const& _exception)
-	{
-		return ReadCallback::Result{false, "Exception in read callback: " + boost::diagnostic_information(_exception)};
-	}
-	catch (std::exception const& _exception)
-	{
-		return ReadCallback::Result{false, "Exception in read callback: " + boost::diagnostic_information(_exception)};
-	}
 	catch (...)
 	{
-		return ReadCallback::Result{false, "Unknown exception in read callback: " + boost::current_exception_diagnostic_information()};
+		return ReadCallback::Result{false, "Exception in read callback: " + boost::current_exception_diagnostic_information()};
 	}
 }
 

--- a/libsolidity/interface/SMTSolverCommand.cpp
+++ b/libsolidity/interface/SMTSolverCommand.cpp
@@ -108,7 +108,7 @@ ReadCallback::Result SMTSolverCommand::solve(std::string const& _kind, std::stri
 	}
 	catch (...)
 	{
-		return ReadCallback::Result{false, "Unknown exception in SMTQuery callback: " + boost::current_exception_diagnostic_information()};
+		return ReadCallback::Result{false, "Exception in SMTQuery callback: " + boost::current_exception_diagnostic_information()};
 	}
 }
 

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -1361,17 +1361,6 @@ Json StandardCompiler::compileSolidity(StandardCompiler::InputsAndSettings _inpu
 				));
 		}
 	}
-	/// This is only thrown in a very few locations.
-	catch (Error const& _error)
-	{
-		errors.emplace_back(formatErrorWithException(
-			compilerStack,
-			_error,
-			_error.type(),
-			"general",
-			"Uncaught error: "
-		));
-	}
 	catch (CompilerError const& _exception)
 	{
 		errors.emplace_back(formatErrorWithException(

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -1372,15 +1372,6 @@ Json StandardCompiler::compileSolidity(StandardCompiler::InputsAndSettings _inpu
 			"Uncaught error: "
 		));
 	}
-	/// This should not be leaked from compile().
-	catch (FatalError const& _exception)
-	{
-		errors.emplace_back(formatError(
-			Error::Type::FatalError,
-			"general",
-			"Uncaught fatal error: " + boost::diagnostic_information(_exception)
-		));
-	}
 	catch (CompilerError const& _exception)
 	{
 		errors.emplace_back(formatErrorWithException(
@@ -1424,22 +1415,6 @@ Json StandardCompiler::compileSolidity(StandardCompiler::InputsAndSettings _inpu
 			Error::Type::SMTLogicException,
 			"general",
 			"SMT logic exception"
-		));
-	}
-	catch (util::Exception const& _exception)
-	{
-		errors.emplace_back(formatError(
-			Error::Type::Exception,
-			"general",
-			"Exception during compilation: " + boost::diagnostic_information(_exception)
-		));
-	}
-	catch (std::exception const& _exception)
-	{
-		errors.emplace_back(formatError(
-			Error::Type::Exception,
-			"general",
-			"Unknown exception during compilation: " + boost::diagnostic_information(_exception)
 		));
 	}
 	catch (...)
@@ -1755,38 +1730,10 @@ Json StandardCompiler::compile(Json const& _input) noexcept
 		else
 			return formatFatalError(Error::Type::JSONError, "Only \"Solidity\", \"Yul\", \"SolidityAST\" or \"EVMAssembly\" is supported as a language.");
 	}
-	catch (Json::parse_error const& _exception)
-	{
-		return formatFatalError(Error::Type::InternalCompilerError, std::string("JSON parse_error exception: ") + util::removeNlohmannInternalErrorIdentifier(_exception.what()));
-	}
-	catch (Json::invalid_iterator const& _exception)
-	{
-		return formatFatalError(Error::Type::InternalCompilerError, std::string("JSON invalid_iterator exception: ") + util::removeNlohmannInternalErrorIdentifier(_exception.what()));
-	}
-	catch (Json::type_error const& _exception)
-	{
-		return formatFatalError(Error::Type::InternalCompilerError, std::string("JSON type_error exception: ") + util::removeNlohmannInternalErrorIdentifier(_exception.what()));
-	}
-	catch (Json::out_of_range const& _exception)
-	{
-		return formatFatalError(Error::Type::InternalCompilerError, std::string("JSON out_of_range exception: ") + util::removeNlohmannInternalErrorIdentifier(_exception.what()));
-	}
-	catch (Json::other_error const& _exception)
-	{
-		return formatFatalError(Error::Type::InternalCompilerError, std::string("JSON other_error exception: ") + util::removeNlohmannInternalErrorIdentifier(_exception.what()));
-	}
-	catch (Json::exception const& _exception)
-	{
-		return formatFatalError(Error::Type::InternalCompilerError, std::string("JSON runtime exception: ") + util::removeNlohmannInternalErrorIdentifier(_exception.what()));
-	}
 	catch (UnimplementedFeatureError const& _exception)
 	{
 		solAssert(_exception.comment(), "Unimplemented feature errors must include a message for the user");
 		return formatFatalError(Error::Type::UnimplementedFeatureError, stringOrDefault(_exception.comment()));
-	}
-	catch (util::Exception const& _exception)
-	{
-		return formatFatalError(Error::Type::InternalCompilerError, "Internal exception in StandardCompiler::compile: " + boost::diagnostic_information(_exception));
 	}
 	catch (...)
 	{

--- a/libsolidity/lsp/FileRepository.cpp
+++ b/libsolidity/lsp/FileRepository.cpp
@@ -170,13 +170,9 @@ frontend::ReadCallback::Result FileRepository::readFile(std::string const& _kind
 		m_sourceCodes[_sourceUnitName] = contents;
 		return ReadCallback::Result{true, std::move(contents)};
 	}
-	catch (std::exception const& _exception)
-	{
-		return ReadCallback::Result{false, "Exception in read callback: " + boost::diagnostic_information(_exception)};
-	}
 	catch (...)
 	{
-		return ReadCallback::Result{false, "Unknown exception in read callback: " + boost::current_exception_diagnostic_information()};
+		return ReadCallback::Result{false, "Exception in read callback: " + boost::current_exception_diagnostic_information()};
 	}
 }
 

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -923,17 +923,9 @@ void CommandLineInterface::compile()
 	}
 	catch (Error const& _error)
 	{
-		if (_error.type() == Error::Type::DocstringParsingError)
-		{
-			report(Error::Severity::Error, *boost::get_error_info<errinfo_comment>(_error));
-			solThrow(CommandLineExecutionError, "Documentation parsing failed.");
-		}
-		else
-		{
-			m_hasOutput = true;
-			formatter.printErrorInformation(_error);
-			solThrow(CommandLineExecutionError, "");
-		}
+		m_hasOutput = true;
+		formatter.printErrorInformation(_error);
+		solThrow(CommandLineExecutionError, "");
 	}
 }
 

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -921,12 +921,6 @@ void CommandLineInterface::compile()
 		);
 		solThrow(CommandLineExecutionError, "");
 	}
-	catch (Error const& _error)
-	{
-		m_hasOutput = true;
-		formatter.printErrorInformation(_error);
-		solThrow(CommandLineExecutionError, "");
-	}
 }
 
 void CommandLineInterface::handleCombinedJSON()

--- a/test/libsolidity/InlineAssembly.cpp
+++ b/test/libsolidity/InlineAssembly.cpp
@@ -66,18 +66,9 @@ std::optional<Error> parseAndReturnFirstError(
 		solidity::frontend::OptimiserSettings::none(),
 		DebugInfoSelection::None()
 	);
-	bool success = false;
-	try
-	{
-		success = stack.parseAndAnalyze("", _source);
-		if (success && _assemble)
-			stack.assemble(_machine);
-	}
-	catch (FatalError const&)
-	{
-		BOOST_FAIL("Fatal error leaked.");
-		success = false;
-	}
+	bool success = stack.parseAndAnalyze("", _source);
+	if (success && _assemble)
+		stack.assemble(_machine);
 	std::shared_ptr<Error const> error;
 	for (auto const& e: stack.errors())
 	{

--- a/test/libsolidity/SolidityExpressionCompiler.cpp
+++ b/test/libsolidity/SolidityExpressionCompiler.cpp
@@ -112,11 +112,6 @@ bytes compileFirstExpression(
 		if (!sourceUnit)
 			return bytes();
 	}
-	catch (boost::exception const& _e)
-	{
-		std::string msg = "Parsing source code failed with:\n" + boost::diagnostic_information(_e);
-		BOOST_FAIL(msg);
-	}
 	catch (...)
 	{
 		std::string msg = "Parsing source code failed with:\n" + boost::current_exception_diagnostic_information();

--- a/test/libyul/ObjectParser.cpp
+++ b/test/libyul/ObjectParser.cpp
@@ -55,23 +55,15 @@ namespace
 
 std::pair<bool, ErrorList> parse(std::string const& _source)
 {
-	try
-	{
-		YulStack asmStack(
-			solidity::test::CommonOptions::get().evmVersion(),
-			solidity::test::CommonOptions::get().eofVersion(),
-			YulStack::Language::StrictAssembly,
-			solidity::frontend::OptimiserSettings::none(),
-			DebugInfoSelection::All()
-		);
-		bool success = asmStack.parseAndAnalyze("source", _source);
-		return {success, asmStack.errors()};
-	}
-	catch (FatalError const&)
-	{
-		BOOST_FAIL("Fatal error leaked.");
-	}
-	return {false, {}};
+	YulStack asmStack(
+		solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion(),
+		YulStack::Language::StrictAssembly,
+		solidity::frontend::OptimiserSettings::none(),
+		DebugInfoSelection::All()
+	);
+	bool success = asmStack.parseAndAnalyze("source", _source);
+	return {success, asmStack.errors()};
 }
 
 std::optional<Error> parseAndReturnFirstError(std::string const& _source, bool _allowWarningsAndInfos = true)

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -54,32 +54,25 @@ namespace
 
 std::shared_ptr<Block> parse(std::string const& _source, Dialect const& _dialect, ErrorReporter& errorReporter)
 {
-	try
-	{
-		auto stream = CharStream(_source, "");
-		std::map<unsigned, std::shared_ptr<std::string const>> indicesToSourceNames;
-		indicesToSourceNames[0] = std::make_shared<std::string const>("source0");
-		indicesToSourceNames[1] = std::make_shared<std::string const>("source1");
+	auto stream = CharStream(_source, "");
+	std::map<unsigned, std::shared_ptr<std::string const>> indicesToSourceNames;
+	indicesToSourceNames[0] = std::make_shared<std::string const>("source0");
+	indicesToSourceNames[1] = std::make_shared<std::string const>("source1");
 
-		auto parserResult = yul::Parser(
-			errorReporter,
-			_dialect,
-			std::move(indicesToSourceNames)
-		).parse(stream);
-		if (parserResult)
-		{
-			yul::AsmAnalysisInfo analysisInfo;
-			if (yul::AsmAnalyzer(
-				analysisInfo,
-				errorReporter,
-				_dialect
-			).analyze(*parserResult))
-				return parserResult;
-		}
-	}
-	catch (FatalError const&)
+	auto parserResult = yul::Parser(
+		errorReporter,
+		_dialect,
+		std::move(indicesToSourceNames)
+	).parse(stream);
+	if (parserResult)
 	{
-		BOOST_FAIL("Fatal error leaked.");
+		yul::AsmAnalysisInfo analysisInfo;
+		if (yul::AsmAnalyzer(
+			analysisInfo,
+			errorReporter,
+			_dialect
+		).analyze(*parserResult))
+			return parserResult;
 	}
 	return {};
 }

--- a/test/soltest.cpp
+++ b/test/soltest.cpp
@@ -115,17 +115,9 @@ void runTestCase(TestCase::Config const& _config, TestCase::TestCaseCreator cons
 					break;
 			}
 	}
-	catch (boost::exception const& _e)
-	{
-		BOOST_ERROR("Exception during extracted test: " << boost::diagnostic_information(_e));
-	}
-	catch (std::exception const& _e)
-	{
-		BOOST_ERROR("Exception during extracted test: " << boost::diagnostic_information(_e));
-	}
 	catch (...)
 	{
-		BOOST_ERROR("Unknown exception during extracted test: " << boost::current_exception_diagnostic_information());
+		BOOST_ERROR("Exception during extracted test: " << boost::current_exception_diagnostic_information());
 	}
 }
 

--- a/test/tools/fuzzer_common.cpp
+++ b/test/tools/fuzzer_common.cpp
@@ -128,9 +128,6 @@ void FuzzerUtil::testCompiler(
 	{
 		compiler.compile();
 	}
-	catch (Error const&)
-	{
-	}
 	catch (UnimplementedFeatureError const&)
 	{
 	}

--- a/test/tools/fuzzer_common.cpp
+++ b/test/tools/fuzzer_common.cpp
@@ -131,9 +131,6 @@ void FuzzerUtil::testCompiler(
 	catch (Error const&)
 	{
 	}
-	catch (FatalError const&)
-	{
-	}
 	catch (UnimplementedFeatureError const&)
 	{
 	}

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -191,22 +191,10 @@ TestTool::Result TestTool::process()
 		else
 			return Result::Skipped;
 	}
-	catch (boost::exception const& _e)
-	{
-		AnsiColorized(std::cout, formatted, {BOLD, RED}) <<
-			"Exception during test: " << boost::diagnostic_information(_e) << std::endl;
-		return Result::Exception;
-	}
-	catch (std::exception const& _e)
-	{
-		AnsiColorized(std::cout, formatted, {BOLD, RED}) <<
-			"Exception during test: " << boost::diagnostic_information(_e) << std::endl;
-		return Result::Exception;
-	}
 	catch (...)
 	{
 		AnsiColorized(std::cout, formatted, {BOLD, RED}) <<
-			"Unknown exception during test: " << boost::current_exception_diagnostic_information() << std::endl;
+			"Unhandled exception during test: " << boost::current_exception_diagnostic_information() << std::endl;
 		return Result::Exception;
 	}
 }


### PR DESCRIPTION
In some places we have handlers for some exceptions that are unexpected and can reach those handlers only as a result of a bug. This is unnecessary and just complicates error handling. We should be explicitly handling expected exceptions and let everything else bubble up as far as possible and deal with it in the most generic handler possible.