### PR TITLE
AsmParser: parse source comment using scanner instead of regex

### DIFF
--- a/.circleci/parallel_bytecode_report.sh
+++ b/.circleci/parallel_bytecode_report.sh
@@ -44,9 +44,6 @@ cd test-cases/
 echo "Preparing input files"
 python3 ../scripts/isolate_tests.py ../test/
 
-# FIXME: These cases crash because of https://github.com/ethereum/solidity/issues/13583
-rm ./*_bytecode_too_large_*.sol ./*_combined_too_large_*.sol
-
 if [[ $binary_type == native || $binary_type == "osx_intel" ]]; then
     interface=$(echo -e "standard-json\ncli" | circleci tests split)
     echo "Selected interface: ${interface}"

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Language Features:
  * Accept declarations of state variables with ``transient`` data location (parser support only, no code generation yet).
  * Make ``require(bool, Error)`` available when using the legacy pipeline.
+ * Yul: Parsing rules for source location comments have been relaxed: Whitespace between the location components as well as single-quoted code snippets are now allowed.
 
 
 Compiler Features:
@@ -18,6 +19,7 @@ Bugfixes:
  * SMTChecker: Fix internal compiler error when reporting proved targets for BMC engine.
  * TypeChecker: Fix segfault when assigning nested tuple to tuple.
  * Yul Optimizer: Name simplification could lead to forbidden identifiers with a leading and/or trailing dot, e.g., ``x._`` would get simplified into ``x.``.
+ * Yul Parser: Fix segfault when parsing very long location comments.
 
 
 ### 0.8.26 (2024-05-21)

--- a/liblangutil/Scanner.h
+++ b/liblangutil/Scanner.h
@@ -62,15 +62,12 @@
 namespace solidity::langutil
 {
 
-class AstRawString;
-class AstValueFactory;
-class ParserRecorder;
-
 enum class ScannerKind
 {
 	Solidity,
 	Yul,
-	ExperimentalSolidity
+	ExperimentalSolidity,
+	SpecialComment
 };
 
 enum class ScannerError
@@ -102,11 +99,13 @@ class Scanner
 {
 	friend class LiteralScope;
 public:
-	explicit Scanner(CharStream& _source):
+	explicit Scanner(CharStream& _source, ScannerKind _kind = ScannerKind::Solidity):
 		m_source(_source),
 		m_sourceName{std::make_shared<std::string>(_source.name())}
 	{
 		reset();
+		if (_kind != ScannerKind::Solidity)
+			setScannerMode(_kind);
 	}
 
 	/// Resets scanner to the start of input.


### PR DESCRIPTION
Fixes #15207
Fixes #13496