### PR TITLE
Add missing checks to forbid codegen working with transient storage variables

### DIFF
--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -39,6 +39,8 @@
 #include <libsolutil/Whiskers.h>
 #include <libsolutil/JSON.h>
 
+#include <range/v3/algorithm/all_of.hpp>
+
 #include <sstream>
 #include <variant>
 
@@ -101,6 +103,16 @@ std::string IRGenerator::generate(
 	std::map<ContractDefinition const*, std::string_view const> const& _otherYulSources
 )
 {
+	auto static notTransient = [](VariableDeclaration const* _varDeclaration) {
+		solAssert(_varDeclaration);
+		return _varDeclaration->referenceLocation() != VariableDeclaration::Location::Transient;
+	};
+
+	solUnimplementedAssert(
+		ranges::all_of(_contract.stateVariables(), notTransient),
+		"Transient storage variables are not supported."
+	);
+
 	auto subObjectSources = [&_otherYulSources](std::set<ContractDefinition const*, ASTNode::CompareByID> const& subObjects) -> std::string
 	{
 		std::string subObjectsSources;


### PR DESCRIPTION
Unfortunately, this was missed on #15001.
I think this will cover every path leading to codegen.