### PR TITLE
Error out on transient usage in TypeChecker

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -478,6 +478,13 @@ bool TypeChecker::visit(VariableDeclaration const& _variable)
 	Type const* varType = _variable.annotation().type;
 	solAssert(!!varType, "Variable type not provided.");
 
+	if (_variable.referenceLocation() == VariableDeclaration::Location::Transient)
+		m_errorReporter.unimplementedFeatureError(
+			6715_error,
+			_variable.location(),
+			"Transient storage is not yet implemented."
+		);
+
 	if (_variable.value())
 	{
 		if (_variable.isStateVariable() && varType->containsNestedMapping())

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -585,8 +585,11 @@ void ContractCompiler::initializeStateVariables(ContractDefinition const& _contr
 {
 	solAssert(!_contract.isLibrary(), "Tried to initialize state variables of library.");
 	for (VariableDeclaration const* variable: _contract.stateVariables())
+	{
+		solUnimplementedAssert(variable->referenceLocation() != VariableDeclaration::Location::Transient, "Transient storage variables not supported.");
 		if (variable->value() && !variable->isConstant())
 			ExpressionCompiler(m_context, m_optimiserSettings.runOrderLiterals).appendStateVariableInitialization(*variable);
+	}
 }
 
 bool ContractCompiler::visit(VariableDeclaration const& _variableDeclaration)

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -821,8 +821,11 @@ std::string IRGenerator::initStateVariables(ContractDefinition const& _contract)
 {
 	IRGeneratorForStatements generator{m_context, m_utils, m_optimiserSettings};
 	for (VariableDeclaration const* variable: _contract.stateVariables())
+	{
+		solUnimplementedAssert(variable->referenceLocation() != VariableDeclaration::Location::Transient, "Transient storage variables not supported.");
 		if (!variable->isConstant())
 			generator.initializeStateVar(*variable);
+	}
 
 	return generator.code();
 }

--- a/test/cmdlineTests/storage_layout_transient_value_types/output.json
+++ b/test/cmdlineTests/storage_layout_transient_value_types/output.json
@@ -2,10 +2,61 @@
     "errors": [
         {
             "component": "general",
-            "formattedMessage": "Transient storage layout is not supported yet.",
-            "message": "Transient storage layout is not supported yet.",
+            "errorCode": "6715",
+            "formattedMessage": "UnimplementedFeatureError: Transient storage is not yet implemented.
+ --> fileA:4:5:
+  |
+4 |     uint transient x;
+  |     ^^^^^^^^^^^^^^^^
+
+",
+            "message": "Transient storage is not yet implemented.",
             "severity": "error",
+            "sourceLocation": {
+                "end": 91,
+                "file": "fileA",
+                "start": 75
+            },
+            "type": "UnimplementedFeatureError"
+        },
+        {
+            "component": "general",
+            "errorCode": "6715",
+            "formattedMessage": "UnimplementedFeatureError: Transient storage is not yet implemented.
+ --> fileA:6:5:
+  |
+6 |     bytes32 transient b;
+  |     ^^^^^^^^^^^^^^^^^^^
+
+",
+            "message": "Transient storage is not yet implemented.",
+            "severity": "error",
+            "sourceLocation": {
+                "end": 128,
+                "file": "fileA",
+                "start": 109
+            },
+            "type": "UnimplementedFeatureError"
+        },
+        {
+            "component": "general",
+            "errorCode": "6715",
+            "formattedMessage": "UnimplementedFeatureError: Transient storage is not yet implemented.
+ --> fileA:8:5:
+  |
+8 |     address transient a;
+  |     ^^^^^^^^^^^^^^^^^^^
+
+",
+            "message": "Transient storage is not yet implemented.",
+            "severity": "error",
+            "sourceLocation": {
+                "end": 168,
+                "file": "fileA",
+                "start": 149
+            },
             "type": "UnimplementedFeatureError"
         }
-    ]
+    ],
+    "sources": {}
 }

--- a/test/libsolidity/astPropertyTests/transient_data_location.sol
+++ b/test/libsolidity/astPropertyTests/transient_data_location.sol
@@ -1,8 +1,0 @@
-contract C {
-    /// TestVarDataLocation: storageLocation
-    /// TestVarName: name
-    uint transient transient;
-}
-// ----
-// TestVarDataLocation: transient
-// TestVarName: transient

--- a/test/libsolidity/smtCheckerTests/unsupported/transient_storage_state_variable.sol
+++ b/test/libsolidity/smtCheckerTests/unsupported/transient_storage_state_variable.sol
@@ -5,4 +5,4 @@ contract C {
 // ====
 // SMTEngine: all
 // ----
-// UnimplementedFeatureError 1834: Transient storage variables are not supported.
+// UnimplementedFeatureError 6715: (17-38): Transient storage is not yet implemented.

--- a/test/libsolidity/syntaxTests/dataLocations/transient_dynamic_array_state_variable.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_dynamic_array_state_variable.sol
@@ -1,7 +1,5 @@
 contract C {
 	uint[] transient x;
 }
-// ====
-// stopAfter: analysis
 // ----
 // UnimplementedFeatureError 1834: Transient data location is only supported for value types.

--- a/test/libsolidity/syntaxTests/dataLocations/transient_fixed_array_state_variable.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_fixed_array_state_variable.sol
@@ -1,7 +1,5 @@
 contract C {
 	uint[3] transient x;
 }
-// ====
-// stopAfter: analysis
 // ----
 // UnimplementedFeatureError 1834: Transient data location is only supported for value types.

--- a/test/libsolidity/syntaxTests/dataLocations/transient_function_type.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_function_type.sol
@@ -6,6 +6,10 @@ contract C {
     function () internal transient internal fiti;
     function () internal internal transient fiit;
 }
-// ====
-// stopAfter: analysis
 // ----
+// UnimplementedFeatureError 6715: (17-40): Transient storage is not yet implemented.
+// UnimplementedFeatureError 6715: (46-82): Transient storage is not yet implemented.
+// UnimplementedFeatureError 6715: (88-122): Transient storage is not yet implemented.
+// UnimplementedFeatureError 6715: (128-162): Transient storage is not yet implemented.
+// UnimplementedFeatureError 6715: (168-212): Transient storage is not yet implemented.
+// UnimplementedFeatureError 6715: (218-262): Transient storage is not yet implemented.

--- a/test/libsolidity/syntaxTests/dataLocations/transient_mapping_state_variable.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_mapping_state_variable.sol
@@ -1,7 +1,6 @@
 contract C {
 	mapping(uint => uint) transient y;
 }
-// ====
-// stopAfter: analysis
+
 // ----
 // UnimplementedFeatureError 1834: Transient data location is only supported for value types.

--- a/test/libsolidity/syntaxTests/dataLocations/transient_state_variable_visibility.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_state_variable_visibility.sol
@@ -7,6 +7,10 @@ contract C {
     uint transient internal ti;
     uint transient private tprv;
 }
-// ====
-// stopAfter: parsing
 // ----
+// UnimplementedFeatureError 6715: (17-43): Transient storage is not yet implemented.
+// UnimplementedFeatureError 6715: (49-75): Transient storage is not yet implemented.
+// UnimplementedFeatureError 6715: (81-108): Transient storage is not yet implemented.
+// UnimplementedFeatureError 6715: (115-141): Transient storage is not yet implemented.
+// UnimplementedFeatureError 6715: (147-173): Transient storage is not yet implemented.
+// UnimplementedFeatureError 6715: (179-206): Transient storage is not yet implemented.

--- a/test/libsolidity/syntaxTests/dataLocations/transient_struct_state_variable.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_struct_state_variable.sol
@@ -6,7 +6,5 @@ struct S {
 contract C {
 	S transient s;
 }
-// ====
-// stopAfter: analysis
 // ----
 // UnimplementedFeatureError 1834: Transient data location is only supported for value types.

--- a/test/libsolidity/syntaxTests/dataLocations/transient_value_type_state_variables.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_value_type_state_variables.sol
@@ -7,6 +7,9 @@ contract C {
 	uint transient x;
 	bytes32 transient y;
 }
-// ====
-// stopAfter: parsing
 // ----
+// UnimplementedFeatureError 6715: (30-49): Transient storage is not yet implemented.
+// UnimplementedFeatureError 6715: (52-68): Transient storage is not yet implemented.
+// UnimplementedFeatureError 6715: (71-84): Transient storage is not yet implemented.
+// UnimplementedFeatureError 6715: (87-103): Transient storage is not yet implemented.
+// UnimplementedFeatureError 6715: (106-125): Transient storage is not yet implemented.

--- a/test/libsolidity/syntaxTests/dataLocations/transient_value_type_state_variables_assignment.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_value_type_state_variables_assignment.sol
@@ -5,6 +5,7 @@ contract C {
 	address transient a = address(0xABC);
 	bool transient b = x > 0 ? false : true;
 }
-// ====
-// stopAfter: parsing
 // ----
+// UnimplementedFeatureError 6715: (30-51): Transient storage is not yet implemented.
+// UnimplementedFeatureError 6715: (54-90): Transient storage is not yet implemented.
+// UnimplementedFeatureError 6715: (93-132): Transient storage is not yet implemented.


### PR DESCRIPTION
In https://github.com/ethereum/solidity/pull/15001 the prototypical case where a transient state variable is declared/defined compiled fine and even generated bytecode by treating the transient variable as a storage variable. This is a fix for that, mainly to keep develop in a releasable state, but will be removed once code generation (for value types) is implemented.