### PR TITLE
SMTChecker: Fix formatting of unary minus expressions in invariants

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ Compiler Features:
 
 Bugfixes:
  * SMTChecker: Fix error that reports invalid number of verified checks for BMC and CHC engines.
+ * SMTChecker: Fix formatting of unary minus expressions in invariants.
  * SMTChecker: Fix internal compiler error when reporting proved targets for BMC engine.
  * TypeChecker: Fix segfault when assigning nested tuple to tuple.
  * Yul Optimizer: Name simplification could lead to forbidden identifiers with a leading and/or trailing dot, e.g., ``x._`` would get simplified into ``x.``.

--- a/libsolidity/formal/ExpressionFormatter.cpp
+++ b/libsolidity/formal/ExpressionFormatter.cpp
@@ -115,6 +115,8 @@ std::string formatUnaryOp(smtutil::Expression const& _expr, std::vector<std::str
 {
 	if (_expr.name == "not")
 		return "!" + _args.at(0);
+	if (_expr.name == "-")
+		return "-" + _args.at(0);
 	// Other operators such as exists may end up here.
 	return formatGenericOp(_expr, _args);
 }
@@ -166,7 +168,7 @@ std::string toSolidityStr(smtutil::Expression const& _expr)
 		{"mod", "%"}
 	};
 	// Some of these (and, or, +, *) may have >= 2 arguments from z3.
-	if (infixOps.count(op))
+	if (infixOps.count(op) && args.size() >= 2)
 		return formatInfixOp(infixOps.at(op), strArgs);
 
 	static std::set<std::string> const arrayOps{"select", "store", "const_array"};

--- a/scripts/error_codes.py
+++ b/scripts/error_codes.py
@@ -203,7 +203,6 @@ def examine_id_coverage(top_dir, source_id_to_file_names, new_ids_only=False):
                 # Due to 3805, the warning lists look different for different compiler builds.
         "1920", # Unimplemented feature error from YulStack (currently there are no UnimplementedFeatureErrors thrown by libyul)
         "7053", # Unimplemented feature error (parsing stage), currently has no tests
-        "1180", # SMTChecker, covered by CL tests
         "2339", # SMTChecker, covered by CL tests
         "6240", # SMTChecker, covered by CL tests
     }

--- a/test/libsolidity/SMTCheckerTest.cpp
+++ b/test/libsolidity/SMTCheckerTest.cpp
@@ -107,8 +107,6 @@ SMTCheckerTest::SMTCheckerTest(std::string const& _filename):
 				filtered.emplace_back(e);
 		return filtered;
 	};
-	if (m_modelCheckerSettings.invariants.invariants.empty())
-		m_expectations = removeInv(std::move(m_expectations));
 
 	auto const& ignoreInv = m_reader.stringSetting("SMTIgnoreInv", "yes");
 	if (ignoreInv == "no")
@@ -117,6 +115,9 @@ SMTCheckerTest::SMTCheckerTest(std::string const& _filename):
 		m_modelCheckerSettings.invariants = ModelCheckerInvariants::None();
 	else
 		BOOST_THROW_EXCEPTION(std::runtime_error("Invalid SMT invariant choice."));
+
+	if (m_modelCheckerSettings.invariants.invariants.empty())
+		m_expectations = removeInv(std::move(m_expectations));
 
 	auto const& ignoreOSSetting = m_reader.stringSetting("SMTIgnoreOS", "none");
 	for (std::string const& os: ignoreOSSetting | ranges::views::split(',') | ranges::to<std::vector<std::string>>())

--- a/test/libsolidity/smtCheckerTests/invariants/unary_minus_formatting.sol
+++ b/test/libsolidity/smtCheckerTests/invariants/unary_minus_formatting.sol
@@ -1,0 +1,13 @@
+contract C {
+        int x = -1;
+	function i() public view {
+		assert(x == -1);
+	}
+}
+// ====
+// SMTEngine: chc
+// SMTIgnoreInv: no
+// SMTSolvers: eld
+// ----
+// Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 1180: Contract invariant(s) for :C:\n(x = -1)\n


### PR DESCRIPTION
Previously, unary minus expressions actually ended up formatted as binary expressions in infix format, which meant that the unary minus operator actually disappeared.

Additionally, SMTCheckerTest was actually always ignoring the invariant message, and we fix that as well.