### PR TITLE
Generating IR without dependencies included

### DIFF
--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -39,6 +39,8 @@
 #include <libsolutil/Whiskers.h>
 #include <libsolutil/JSON.h>
 
+#include <boost/algorithm/string/trim.hpp>
+
 #include <sstream>
 #include <variant>
 
@@ -86,68 +88,41 @@ std::set<CallableDeclaration const*, ASTNode::CompareByID> collectReachableCalla
 
 }
 
-std::string IRGenerator::run(
+std::shared_ptr<yul::ObjectSource> IRGenerator::run(
 	ContractDefinition const& _contract,
-	bytes const& _cborMetadata,
-	std::map<ContractDefinition const*, std::string_view const> const& _otherYulSources
+	bytes const& _cborMetadata
 )
 {
-	return yul::reindent(generate(_contract, _cborMetadata, _otherYulSources));
+	std::shared_ptr<yul::ObjectSource> creationObjectSource;
+	InternalDispatchMap creationDispatch;
+	std::tie(creationObjectSource, creationDispatch) = generateCreation(_contract);
+	std::shared_ptr<yul::ObjectSource> deployedObjectSource = generateDeployed(
+		_contract,
+		_cborMetadata,
+		std::move(creationDispatch)
+	);
+
+	yul::YulString deplyedObjectName(IRNames::deployedObject(_contract));
+	solAssert(creationObjectSource->subIndexByName.count(deplyedObjectName) != 0);
+	creationObjectSource->subObjects[creationObjectSource->subIndexByName[deplyedObjectName]] = deployedObjectSource;
+
+	return creationObjectSource;
 }
 
-std::string IRGenerator::generate(
-	ContractDefinition const& _contract,
-	bytes const& _cborMetadata,
-	std::map<ContractDefinition const*, std::string_view const> const& _otherYulSources
-)
+std::pair<std::shared_ptr<yul::ObjectSource>, InternalDispatchMap> IRGenerator::generateCreation(ContractDefinition const& _contract)
 {
-	auto subObjectSources = [&_otherYulSources](std::set<ContractDefinition const*, ASTNode::CompareByID> const& subObjects) -> std::string
-	{
-		std::string subObjectsSources;
-		for (ContractDefinition const* subObject: subObjects)
-			subObjectsSources += _otherYulSources.at(subObject);
-		return subObjectsSources;
-	};
-	auto formatUseSrcMap = [](IRGenerationContext const& _context) -> std::string
-	{
-		return joinHumanReadable(
-			ranges::views::transform(_context.usedSourceNames(), [_context](std::string const& _sourceName) {
-				return std::to_string(_context.sourceIndices().at(_sourceName)) + ":" + escapeAndQuoteString(_sourceName);
-			}),
-			", "
-		);
-	};
-
 	Whiskers t(R"(
-		/// @use-src <useSrcMapCreation>
-		object "<CreationObject>" {
-			code {
-				<sourceLocationCommentCreation>
-				<memoryInitCreation>
-				<callValueCheck>
-				<?library>
-				<!library>
-				<?constructorHasParams> let <constructorParams> := <copyConstructorArguments>() </constructorHasParams>
-				<constructor>(<constructorParams>)
-				</library>
-				<deploy>
-				<functions>
-			}
-			/// @use-src <useSrcMapDeployed>
-			object "<DeployedObject>" {
-				code {
-					<sourceLocationCommentDeployed>
-					<memoryInitDeployed>
-					<?library>
-					let called_via_delegatecall := iszero(eq(loadimmutable("<library_address>"), address()))
-					</library>
-					<dispatch>
-					<deployedFunctions>
-				}
-				<deployedSubObjects>
-				data "<metadataName>" hex"<cborMetadata>"
-			}
-			<subObjects>
+		{
+			<sourceLocationCommentCreation>
+			<memoryInitCreation>
+			<callValueCheck>
+			<?library>
+			<!library>
+			<?constructorHasParams> let <constructorParams> := <copyConstructorArguments>() </constructorHasParams>
+			<constructor>(<constructorParams>)
+			</library>
+			<deploy>
+			<functions>
 		}
 	)");
 
@@ -155,7 +130,6 @@ std::string IRGenerator::generate(
 	for (VariableDeclaration const* var: ContractType(_contract).immutableVariables())
 		m_context.registerImmutableVariable(*var);
 
-	t("CreationObject", IRNames::creationObject(_contract));
 	t("sourceLocationCommentCreation", dispenseLocationComment(_contract));
 	t("library", _contract.isLibrary());
 
@@ -181,44 +155,75 @@ std::string IRGenerator::generate(
 	InternalDispatchMap internalDispatchMap = generateInternalDispatchFunctions(_contract);
 
 	t("functions", m_context.functionCollector().requestedFunctions());
-	t("subObjects", subObjectSources(m_context.subObjectsCreated()));
 
 	// This has to be called only after all other code generation for the creation object is complete.
 	bool creationInvolvesMemoryUnsafeAssembly = m_context.memoryUnsafeInlineAssemblySeen();
 	t("memoryInitCreation", memoryInit(!creationInvolvesMemoryUnsafeAssembly));
-	t("useSrcMapCreation", formatUseSrcMap(m_context));
+
+	solAssert(_contract.annotation().creationCallGraph->get() != nullptr, "");
+	verifyCallGraph(collectReachableCallables(**_contract.annotation().creationCallGraph), std::move(creationFunctionList));
+
+	auto objectSource = std::make_shared<yul::ObjectSource>();
+	objectSource->name = yul::YulString(IRNames::creationObject(_contract));
+	objectSource->code = boost::trim_copy(yul::reindent(t.render()));
+	objectSource->debugData = buildObjectDebugData();
+	objectSource->addSubObjectPlaceholder(yul::YulString(IRNames::deployedObject(_contract)));
+	for (ContractDefinition const* dependency: m_context.subObjectsCreated())
+		objectSource->addSubObjectPlaceholder(yul::YulString(IRNames::creationObject(*dependency)));
+
+	return {objectSource, std::move(internalDispatchMap)};
+}
+
+std::shared_ptr<yul::ObjectSource> IRGenerator::generateDeployed(
+	ContractDefinition const& _contract,
+	bytes const& _cborMetadata,
+	InternalDispatchMap _creationDispatch
+)
+{
+	Whiskers t(R"(
+		{
+			<sourceLocationCommentDeployed>
+			<memoryInitDeployed>
+			<?library>
+			let called_via_delegatecall := iszero(eq(loadimmutable("<library_address>"), address()))
+			</library>
+			<dispatch>
+			<deployedFunctions>
+		}
+	)");
 
 	resetContext(_contract, ExecutionContext::Deployed);
 
 	// NOTE: Function pointers can be passed from creation code via storage variables. We need to
 	// get all the functions they could point to into the dispatch functions even if they're never
 	// referenced by name in the deployed code.
-	m_context.initializeInternalDispatch(std::move(internalDispatchMap));
+	m_context.initializeInternalDispatch(std::move(_creationDispatch));
 
 	// Do not register immutables to avoid assignment.
-	t("DeployedObject", IRNames::deployedObject(_contract));
 	t("sourceLocationCommentDeployed", dispenseLocationComment(_contract));
+	t("library", _contract.isLibrary());
 	t("library_address", IRNames::libraryAddressImmutable());
 	t("dispatch", dispatchRoutine(_contract));
 	std::set<FunctionDefinition const*> deployedFunctionList = generateQueuedFunctions();
 	generateInternalDispatchFunctions(_contract);
 	t("deployedFunctions", m_context.functionCollector().requestedFunctions());
-	t("deployedSubObjects", subObjectSources(m_context.subObjectsCreated()));
-	t("metadataName", yul::Object::metadataName());
-	t("cborMetadata", util::toHex(_cborMetadata));
-
-	t("useSrcMapDeployed", formatUseSrcMap(m_context));
 
 	// This has to be called only after all other code generation for the deployed object is complete.
 	bool deployedInvolvesMemoryUnsafeAssembly = m_context.memoryUnsafeInlineAssemblySeen();
 	t("memoryInitDeployed", memoryInit(!deployedInvolvesMemoryUnsafeAssembly));
 
-	solAssert(_contract.annotation().creationCallGraph->get() != nullptr, "");
 	solAssert(_contract.annotation().deployedCallGraph->get() != nullptr, "");
-	verifyCallGraph(collectReachableCallables(**_contract.annotation().creationCallGraph), std::move(creationFunctionList));
 	verifyCallGraph(collectReachableCallables(**_contract.annotation().deployedCallGraph), std::move(deployedFunctionList));
 
-	return t.render();
+	auto objectSource = std::make_shared<yul::ObjectSource>();
+	objectSource->name = yul::YulString(IRNames::deployedObject(_contract));
+	objectSource->code = boost::trim_copy(yul::reindent(t.render()));
+	objectSource->debugData = buildObjectDebugData();
+	for (ContractDefinition const* dependency: m_context.subObjectsCreated())
+		objectSource->addSubObjectPlaceholder(yul::YulString(IRNames::creationObject(*dependency)));
+	objectSource->addMetadata(_cborMetadata);
+
+	return objectSource;
 }
 
 std::string IRGenerator::generate(Block const& _block)
@@ -1110,4 +1115,20 @@ void IRGenerator::resetContext(ContractDefinition const& _contract, ExecutionCon
 std::string IRGenerator::dispenseLocationComment(ASTNode const& _node)
 {
 	return ::dispenseLocationComment(_node, m_context);
+}
+
+std::shared_ptr<yul::ObjectDebugData> IRGenerator::buildObjectDebugData() const
+{
+	auto makeIndexSourcePair = [this](std::string const& _sourceName) {
+		return std::pair<unsigned, std::shared_ptr<std::string>>{
+			m_context.sourceIndices().at(_sourceName),
+			std::make_shared<std::string>(_sourceName),
+		};
+	};
+
+	return std::make_shared<yul::ObjectDebugData>(yul::ObjectDebugData{
+		m_context.usedSourceNames() |
+		ranges::views::transform(makeIndexSourcePair) |
+		ranges::to<yul::SourceNameMap>()
+	});
 }

--- a/libsolidity/experimental/codegen/IRGenerator.h
+++ b/libsolidity/experimental/codegen/IRGenerator.h
@@ -25,6 +25,10 @@
 #include <libsolidity/ast/CallGraph.h>
 #include <libsolidity/experimental/ast/TypeSystem.h>
 
+// TMP: Is it really a good idea to introduce a dependency on libyul here?
+// Should I put ObjectSource in libsolidity instead and make it independent of Object hierarchy?
+#include <libyul/Object.h>
+
 #include <liblangutil/CharStreamProvider.h>
 #include <liblangutil/DebugInfoSelection.h>
 #include <liblangutil/EVMVersion.h>
@@ -51,15 +55,18 @@ public:
 		Analysis const& _analysis
 	);
 
-	std::string run(
+	std::shared_ptr<yul::ObjectSource> run(
 		ContractDefinition const& _contract,
-		bytes const& _cborMetadata,
-		std::map<ContractDefinition const*, std::string_view const> const& _otherYulSources
+		bytes const& _cborMetadata
 	);
 
 	std::string generate(ContractDefinition const& _contract);
 	std::string generate(FunctionDefinition const& _function, Type _type);
+
 private:
+	std::shared_ptr<yul::ObjectSource> generateCreation(ContractDefinition const& _contract);
+	std::shared_ptr<yul::ObjectSource> generateDeployed( ContractDefinition const& _contract);
+
 	langutil::EVMVersion const m_evmVersion;
 	std::optional<uint8_t> const m_eofVersion;
 	OptimiserSettings const m_optimiserSettings;

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -35,6 +35,8 @@
 
 #include <libsmtutil/SolverInterface.h>
 
+#include <libyul/Object.h>
+
 #include <liblangutil/CharStreamProvider.h>
 #include <liblangutil/DebugInfoSelection.h>
 #include <liblangutil/ErrorReporter.h>
@@ -387,6 +389,8 @@ private:
 		std::shared_ptr<evmasm::Assembly> evmRuntimeAssembly;
 		evmasm::LinkerObject object; ///< Deployment object (includes the runtime sub-object).
 		evmasm::LinkerObject runtimeObject; ///< Runtime object.
+		// TMP: docstring
+		std::shared_ptr<yul::ObjectSource> yulIRObjectSource;
 		std::string yulIR; ///< Yul IR code.
 		std::string yulIROptimized; ///< Optimized Yul IR code.
 		Json yulIRAst; ///< JSON AST of Yul IR code.
@@ -467,6 +471,9 @@ private:
 	/// @returns the source object for the given @a _sourceName.
 	/// Can only be called after state is SourcesSet.
 	Source const& source(std::string const& _sourceName) const;
+
+	// TMP: docstring
+	std::string linkIR(Contract const& _contract) const;
 
 	/// @param _forIR If true, include a flag that indicates that the bytecode comes from IR codegen.
 	/// @returns the metadata JSON as a compact string for the given contract.

--- a/libyul/Object.h
+++ b/libyul/Object.h
@@ -96,9 +96,9 @@ public:
 		Dialect const* _dialect,
 		langutil::DebugInfoSelection const& _debugInfoSelection = langutil::DebugInfoSelection::Default(),
 		langutil::CharStreamProvider const* _soliditySourceProvider = nullptr
-	) const;
+	) const override;
 	/// @returns a compact JSON representation of the AST.
-	Json toJson() const;
+	Json toJson() const override;
 	/// @returns the set of names of data objects accessible from within the code of
 	/// this object, including the name of object itself
 	/// Handles all names containing dots as reserved identifiers, not accessible as data.

--- a/libyul/Object.h
+++ b/libyul/Object.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <libyul/ASTForward.h>
+#include <libyul/Exceptions.h>
 #include <libyul/YulString.h>
 
 #include <liblangutil/CharStreamProvider.h>
@@ -128,6 +129,41 @@ public:
 
 	/// @returns the name of the special metadata data object.
 	static std::string metadataName() { return ".metadata"; }
+};
+
+// TMP: docstrings
+struct ObjectSource: public ObjectNode
+{
+public:
+	/// @returns a (parseable) string representation.
+	std::string toString() const;
+	std::string toString(
+		Dialect const* _dialect,
+		langutil::DebugInfoSelection const& _debugInfoSelection = langutil::DebugInfoSelection::Default(),
+		langutil::CharStreamProvider const* _soliditySourceProvider = nullptr
+	) const override;
+	// TMP: toJson() makes no sense in ObjectNode and should be moved out.
+	Json toJson() const override { yulAssert(false); }
+
+	void addSubObject(std::shared_ptr<ObjectNode> _subObject);
+	void addSubObjectPlaceholder(YulString _name);
+	void addMetadata(bytes const& _cborMetadata);
+
+	// TMP: docstring
+	std::shared_ptr<ObjectSource> clone() const;
+	// TMP: docstring
+	// Note: same object may be inserted multiple times, at multiple levels
+	// Note: no cycles
+	// Note: works best if _availableSources are all unlinked
+	// Note: _availableSources must not contain current object
+	bool fillPlaceholders(std::map<std::string, std::shared_ptr<ObjectSource>> const& _availableSources);
+
+	// TMP: Should the outer braces be a part of the value or added automatically when the object is printed?
+	std::string code;
+	std::vector<std::shared_ptr<ObjectNode>> subObjects;
+	std::map<YulString, size_t> subIndexByName;
+
+	std::shared_ptr<ObjectDebugData const> debugData;
 };
 
 }

--- a/test/libsolidity/semanticTests/various/subassemblies_for_identically_named_contracts.sol
+++ b/test/libsolidity/semanticTests/various/subassemblies_for_identically_named_contracts.sol
@@ -1,0 +1,28 @@
+==== Source: D1.sol ====
+contract D {
+    function f() public pure returns (uint) {
+        return 42;
+    }
+}
+==== Source: D2.sol ====
+contract D {
+    function f() public pure returns (uint) {
+        return 66;
+    }
+}
+==== Source: C.sol ====
+import {D as D1} from "D1.sol";
+import {D as D2} from "D2.sol";
+
+contract C {
+    // The purpose of the test is to ensure that there is no naming conflict between subobjects
+    // that the codegen will produce from contracts with identical names and that both get included.
+    D1 d1 = new D1();
+    D2 d2 = new D2();
+
+    function test() public returns (uint, uint) {
+        return (d1.f(), d2.f());
+    }
+}
+// ----
+// test() -> 42, 66


### PR DESCRIPTION
The first part of refactor for #15179.

Introduces `ObjectSource` object that can store partial IR output (without the sources of dependent contracts). Then makes `IRGenerator` output it. Finally `CompilerStack` puts it together into a complete IR source file.

### Status
Works but still needs some tweaks.

It compiles and gives the same results as the original codegen, but I want to do some final changes to the structure and also fill in small things that I skipped on the first pass (constructors, docstrings, etc.). The remaining stuff is marked with `TMP` notes.

The next step will be passing `ObjectSource` directly to `YulStack` and making it handle incomplete `Object`s. This will make the compiler reuse optimized IR