### PR TITLE
OptimizedEVMCodeTransform: tag source location in stack too deep errors in yul

### DIFF
--- a/libyul/backends/evm/OptimizedEVMCodeTransform.cpp
+++ b/libyul/backends/evm/OptimizedEVMCodeTransform.cpp
@@ -275,7 +275,7 @@ void OptimizedEVMCodeTransform::createStackLayout(langutil::DebugData::ConstPtr 
 					varNameDeep.empty() ? varNameTop : varNameDeep,
 					deficit,
 					msg
-				));
+				) << langutil::errinfo_sourceLocation(sourceLocation));
 				m_assembly.markAsInvalid();
 			}
 		},


### PR DESCRIPTION
Right now the compiler prints the variable names and the stack representation, but it is not very helpful when you run into this error in a big codebase. This PR tries to tag the available source location as additional information to the exception.

Before:
```
$ ~/.svm/0.8.25/solc-0.8.25 src/test.sol --bin  --via-ir
Uncaught exception:
/solidity/libyul/backends/evm/EVMObjectCompiler.cpp(106): Throw in function run
Dynamic exception type: boost::wrapexcept<solidity::yul::StackTooDeepError>
std::exception::what: Cannot swap Slot RET with Variable value1: too deep in the stack by 1 slots in [ RET headStart value14 value13 value12 value11 value10 value9 value8 value7 value6 value5 value4 value3 value2 value15 value0 value1 ]
memoryguard was present.
[solidity::util::tag_comment*] = Cannot swap Slot RET with Variable value1: too deep in the stack by 1 slots in [ RET headStart value14 value13 value12 value11 value10 value9 value8 value7 value6 value5 value4 value3 value2 value15 value0 value1 ]
memoryguard was present.
```

After:
```
$ ~/dev/ethereum/solidity/build/solc/solc src/test.sol --bin --via-ir
Uncaught exception:
/solidity/libyul/backends/evm/EVMObjectCompiler.cpp(106): Throw in function run
Dynamic exception type: boost::wrapexcept<solidity::yul::StackTooDeepError>
std::exception::what: Cannot swap Slot RET with Variable value1: too deep in the stack by 1 slots in [ RET headStart value14 value13 value12 value11 value10 value9 value8 value7 value6 value5 value4 value3 value2 value15 value0 value1 ]
memoryguard was present.
[solidity::util::tag_comment*] = Cannot swap Slot RET with Variable value1: too deep in the stack by 1 slots in [ RET headStart value14 value13 value12 value11 value10 value9 value8 value7 value6 value5 value4 value3 value2 value15 value0 value1 ]
memoryguard was present.
[solidity::langutil::tag_sourceLocation*] = src/test.sol[0,1145]
```

<details>
<summary> src/test.sol: </summary>

```solidity
contract SomeContarct {
    function someFunction()
        external
        payable
        returns (
            uint256,
            uint256,
            uint256,
            uint256,
            uint256,
            uint256,
            uint256,
            uint256,
            uint256,
            uint256,
            uint256,
            uint256,
            uint256,
            uint256,
            uint256,
            uint256
        )
    {
        uint256 a = 1;
        uint256 a0 = a + 1;
        uint256 a1 = a0 + 1;
        uint256 a2 = a1 + 1;
        uint256 a3 = a2 + 1;
        uint256 a4 = a3 + 1;
        uint256 a5 = a4 + 1;
        uint256 a6 = a5 + 1;
        uint256 a7 = a6 + 1;
        uint256 a8 = a7 + 1;
        uint256 a9 = a8 + 1;
        uint256 a01 = a9 + 1;
        uint256 a11 = a01 + a4 + 1;
        uint256 a21 = a11 + a5 + 1;
        uint256 a31 = a21 + a6 + 1;
        uint256 a41 = a31 + a7 + 1;
        uint256 a51 = a41 + a8 + 1;
        uint256 a61 = a51 + a9 + 1;
        uint256 a71 = a61 + a + 60 + 1;

        return (a71, a, a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a01, a11, a21, a31);
    }
}
```
</details>