### PR TITLE
SMTChecker: Increase Z3 resource limit

### DIFF
--- a/libsmtutil/Z3Interface.h
+++ b/libsmtutil/Z3Interface.h
@@ -55,7 +55,7 @@ public:
 
 	// Z3 "basic resources" limit.
 	// This is used to make the runs more deterministic and platform/machine independent.
-	static int const resourceLimit = 1000000;
+	static int const resourceLimit = 2000000;
 
 private:
 	void declareFunction(std::string const& _name, Sort const& _sort);

--- a/test/libsolidity/smtCheckerTests/abi/abi_encode_with_selector_array_slice.sol
+++ b/test/libsolidity/smtCheckerTests/abi/abi_encode_with_selector_array_slice.sol
@@ -28,6 +28,4 @@ contract C {
 // ----
 // Warning 6328: (325-355): CHC: Assertion violation happens here.
 // Warning 6328: (578-608): CHC: Assertion violation happens here.
-// Warning 6328: (1079-1109): CHC: Assertion violation might happen here.
-// Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
-// Warning 4661: (1079-1109): BMC: Assertion violation happens here.
+// Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/abi/abi_encode_with_selector_array_slice_2.sol
+++ b/test/libsolidity/smtCheckerTests/abi/abi_encode_with_selector_array_slice_2.sol
@@ -28,6 +28,4 @@ contract C {
 // ----
 // Warning 6328: (326-356): CHC: Assertion violation happens here.
 // Warning 6328: (579-609): CHC: Assertion violation happens here.
-// Warning 6328: (1080-1110): CHC: Assertion violation might happen here.
-// Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
-// Warning 4661: (1080-1110): BMC: Assertion violation happens here.
+// Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/deployment/deploy_trusted_flow.sol
+++ b/test/libsolidity/smtCheckerTests/deployment/deploy_trusted_flow.sol
@@ -18,13 +18,9 @@ contract C {
 // ====
 // SMTEngine: all
 // SMTExtCalls: trusted
-// SMTIgnoreOS: macos
 // ----
 // Warning 4984: (47-50): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
-// Warning 6328: (215-233): CHC: Assertion violation might happen here.
-// Warning 6328: (267-285): CHC: Assertion violation might happen here.
-// Warning 6328: (304-322): CHC: Assertion violation happens here.
-// Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 6328: (304-322): CHC: Assertion violation might happen here.
+// Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
 // Warning 2661: (47-50): BMC: Overflow (resulting value larger than 2**256 - 1) happens here.
-// Warning 4661: (215-233): BMC: Assertion violation happens here.
-// Warning 4661: (267-285): BMC: Assertion violation happens here.
+// Warning 4661: (304-322): BMC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/external_calls/external_call_indirect_1.sol
+++ b/test/libsolidity/smtCheckerTests/external_calls/external_call_indirect_1.sol
@@ -38,5 +38,5 @@ contract C {
 // SMTIgnoreOS: macos
 // ----
 // Warning 6328: (256-277): CHC: Assertion violation happens here.
-// Warning 6328: (533-554): CHC: Assertion violation might happen here.
+// Warning 6328: (533-554): CHC: Assertion violation happens here.
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/external_calls/external_call_indirect_3.sol
+++ b/test/libsolidity/smtCheckerTests/external_calls/external_call_indirect_3.sol
@@ -40,7 +40,6 @@ contract C {
 // ====
 // SMTEngine: chc
 // SMTExtCalls: trusted
-// SMTIgnoreOS: macos
 // ----
-// Warning 6328: (561-582): CHC: Assertion violation might happen here.
+// Warning 6328: (561-582): CHC: Assertion violation happens here.
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/external_calls/external_call_indirect_4.sol
+++ b/test/libsolidity/smtCheckerTests/external_calls/external_call_indirect_4.sol
@@ -43,7 +43,6 @@ contract C {
 // ====
 // SMTEngine: chc
 // SMTExtCalls: trusted
-// SMTIgnoreOS: macos
 // ----
-// Warning 6328: (641-662): CHC: Assertion violation might happen here.
+// Warning 6328: (641-662): CHC: Assertion violation happens here.
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/external_calls/external_call_indirect_5.sol
+++ b/test/libsolidity/smtCheckerTests/external_calls/external_call_indirect_5.sol
@@ -47,5 +47,5 @@ contract C {
 // SMTEngine: chc
 // SMTExtCalls: trusted
 // ----
-// Warning 6328: (601-622): CHC: Assertion violation might happen here.
+// Warning 6328: (601-622): CHC: Assertion violation happens here.
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_storage_storage.sol
+++ b/test/libsolidity/smtCheckerTests/loops/while_loop_array_assignment_storage_storage.sol
@@ -23,10 +23,8 @@ contract LoopFor2 {
 	}
 }
 // ====
-// SMTEngine: all
+// SMTEngine: chc
+// SMTTargets: assert
 // ----
-// Warning 6368: (288-292): CHC: Out of bounds access might happen here.
-// Warning 6368: (459-463): CHC: Out of bounds access happens here.
-// Warning 6328: (452-471): CHC: Assertion violation happens here.
-// Warning 6328: (475-494): CHC: Assertion violation happens here.
-// Info 1391: CHC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 6328: (452-471): CHC: Assertion violation happens here.\nCounterexample:\nb = [1, 0], c = [0, 0]\nn = 1\ni = 1\n\nTransaction trace:\nLoopFor2.constructor()\nState: b = [], c = []\nLoopFor2.p()\nState: b = [0], c = [0]\nLoopFor2.p()\nState: b = [0, 0], c = [0, 0]\nLoopFor2.testUnboundedForLoop(1)
+// Warning 6328: (475-494): CHC: Assertion violation happens here.\nCounterexample:\nb = [1, 0], c = [0, 0]\nn = 1\ni = 1\n\nTransaction trace:\nLoopFor2.constructor()\nState: b = [], c = []\nLoopFor2.p()\nState: b = [0], c = [0]\nLoopFor2.p()\nState: b = [0, 0], c = [0, 0]\nLoopFor2.testUnboundedForLoop(1)

--- a/test/libsolidity/smtCheckerTests/operators/index_access_side_effect.sol
+++ b/test/libsolidity/smtCheckerTests/operators/index_access_side_effect.sol
@@ -22,6 +22,4 @@ contract C {
 // SMTEngine: all
 // SMTIgnoreCex: yes
 // ----
-// Warning 6328: (335-354): CHC: Assertion violation might happen here.
-// Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
-// Warning 4661: (335-354): BMC: Assertion violation happens here.
+// Info 1391: CHC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/operators/slice_default_start.sol
+++ b/test/libsolidity/smtCheckerTests/operators/slice_default_start.sol
@@ -10,8 +10,5 @@ contract C {
 // ====
 // SMTEngine: all
 // ----
-// Warning 6328: (150-182): CHC: Assertion violation might happen here.
-// Warning 6328: (186-218): CHC: Assertion violation might happen here.
-// Info 1391: CHC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
-// Warning 4661: (150-182): BMC: Assertion violation happens here.
-// Warning 4661: (186-218): BMC: Assertion violation happens here.
+// Warning 6328: (186-218): CHC: Assertion violation happens here.
+// Info 1391: CHC: 5 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/operators/userDefined/user_defined_operator_matches_equivalent_function_call.sol
+++ b/test/libsolidity/smtCheckerTests/operators/userDefined/user_defined_operator_matches_equivalent_function_call.sol
@@ -53,32 +53,10 @@ contract C {
 }
 // ====
 // SMTEngine: all
+// SMTTargets: assert
 // ----
-// Warning 3944: (679-708): CHC: Underflow (resulting value less than -32768) might happen here.
-// Warning 4984: (679-708): CHC: Overflow (resulting value larger than 32767) might happen here.
-// Warning 3944: (777-806): CHC: Underflow (resulting value less than -32768) might happen here.
-// Warning 4984: (777-806): CHC: Overflow (resulting value larger than 32767) might happen here.
-// Warning 3944: (870-884): CHC: Underflow (resulting value less than -32768) might happen here.
-// Warning 4984: (870-884): CHC: Overflow (resulting value larger than 32767) might happen here.
-// Warning 3944: (953-982): CHC: Underflow (resulting value less than -32768) might happen here.
-// Warning 4984: (953-982): CHC: Overflow (resulting value larger than 32767) might happen here.
-// Warning 4984: (1051-1080): CHC: Overflow (resulting value larger than 32767) might happen here.
-// Warning 4281: (1051-1080): CHC: Division by zero might happen here.
-// Warning 4281: (1149-1178): CHC: Division by zero might happen here.
-// Warning 6328: (2069-2095): CHC: Assertion violation might happen here.
-// Warning 6328: (2105-2131): CHC: Assertion violation might happen here.
-// Warning 6328: (2141-2163): CHC: Assertion violation might happen here.
-// Warning 6328: (2173-2199): CHC: Assertion violation might happen here.
 // Warning 6328: (2209-2235): CHC: Assertion violation might happen here.
 // Warning 6328: (2245-2271): CHC: Assertion violation might happen here.
-// Info 1391: CHC: 10 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
-// Warning 2661: (679-708): BMC: Overflow (resulting value larger than 32767) happens here.
-// Warning 4144: (679-708): BMC: Underflow (resulting value less than -32768) happens here.
-// Warning 2661: (777-806): BMC: Overflow (resulting value larger than 32767) happens here.
-// Warning 4144: (777-806): BMC: Underflow (resulting value less than -32768) happens here.
-// Warning 2661: (953-982): BMC: Overflow (resulting value larger than 32767) happens here.
-// Warning 4144: (953-982): BMC: Underflow (resulting value less than -32768) happens here.
-// Warning 3046: (1051-1080): BMC: Division by zero happens here.
-// Warning 3046: (1149-1178): BMC: Division by zero happens here.
+// Info 1391: CHC: 14 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
 // Warning 7812: (2245-2271): BMC: Assertion violation might happen here.
-// Info 6002: BMC: 14 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 6002: BMC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/out_of_bounds/array_1.sol
+++ b/test/libsolidity/smtCheckerTests/out_of_bounds/array_1.sol
@@ -18,9 +18,6 @@ contract C {
 }
 // ====
 // SMTEngine: all
-// SMTIgnoreOS: macos
+// SMTTargets: outOfBounds
 // ----
-// Warning 4984: (112-115): CHC: Overflow (resulting value larger than 2**256 - 1) might happen here.
-// Warning 6368: (259-263): CHC: Out of bounds access happens here.
-// Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
-// Warning 2661: (112-115): BMC: Overflow (resulting value larger than 2**256 - 1) happens here.
+// Warning 6368: (259-263): CHC: Out of bounds access happens here.\nCounterexample:\na = [0], l = 1\n = 0\n\nTransaction trace:\nC.constructor()\nState: a = [], l = 0\nC.p()\nState: a = [0], l = 1\nC.r()


### PR DESCRIPTION
Increasing resource limit of z3 results in more SMTChecker tests correctly solved, without increasing the running time significantly.

This is in preparation for switching z3 to SMT-LIB interface, so as to not have significant changes in tests for that switch.