### PR TITLE
Yul: Add const version of FunctionCallFinder

### DIFF
--- a/libyul/backends/evm/EVMObjectCompiler.cpp
+++ b/libyul/backends/evm/EVMObjectCompiler.cpp
@@ -90,8 +90,8 @@ void EVMObjectCompiler::run(Object& _object, bool _optimize)
 		);
 		if (!stackErrors.empty())
 		{
-			std::vector<FunctionCall*> memoryGuardCalls = FunctionCallFinder::run(
-				*_object.code,
+			std::vector<FunctionCall const*> memoryGuardCalls = findFunctionCalls(
+				std::as_const(*_object.code),
 				"memoryguard"_yulstring
 			);
 			auto stackError = stackErrors.front();

--- a/libyul/optimiser/FullInliner.cpp
+++ b/libyul/optimiser/FullInliner.cpp
@@ -83,7 +83,7 @@ FullInliner::FullInliner(Block& _ast, NameDispenser& _dispenser, Dialect const& 
 	}
 
 	// Check for memory guard.
-	std::vector<FunctionCall*> memoryGuardCalls = FunctionCallFinder::run(
+	std::vector<FunctionCall*> memoryGuardCalls = findFunctionCalls(
 		_ast,
 		"memoryguard"_yulstring
 	);

--- a/libyul/optimiser/FunctionCallFinder.h
+++ b/libyul/optimiser/FunctionCallFinder.h
@@ -20,7 +20,8 @@
 
 #pragma once
 
-#include <libyul/optimiser/ASTWalker.h>
+#include <libyul/ASTForward.h>
+#include <libyul/YulString.h>
 
 #include <vector>
 
@@ -28,20 +29,17 @@ namespace solidity::yul
 {
 
 /**
- * AST walker that finds all calls to a function of a given name.
+ * Finds all calls to a function of a given name using an ASTModifier.
  *
  * Prerequisite: Disambiguator
  */
-class FunctionCallFinder: ASTModifier
-{
-public:
-	static std::vector<FunctionCall*> run(Block& _block, YulString _functionName);
-private:
-	FunctionCallFinder(YulString _functionName);
-	using ASTModifier::operator();
-	void operator()(FunctionCall& _functionCall) override;
-	YulString m_functionName;
-	std::vector<FunctionCall*> m_calls;
-};
+std::vector<FunctionCall*> findFunctionCalls(Block& _block, YulString _functionName);
+
+/**
+ * Finds all calls to a function of a given name using an ASTWalker.
+ *
+ * Prerequisite: Disambiguator
+ */
+std::vector<FunctionCall const*> findFunctionCalls(Block const& _block, YulString _functionName);
 
 }

--- a/libyul/optimiser/StackLimitEvader.cpp
+++ b/libyul/optimiser/StackLimitEvader.cpp
@@ -174,7 +174,7 @@ void StackLimitEvader::run(
 		"StackLimitEvader can only be run on objects using the EVMDialect with object access."
 	);
 
-	std::vector<FunctionCall*> memoryGuardCalls = FunctionCallFinder::run(
+	std::vector<FunctionCall*> memoryGuardCalls = findFunctionCalls(
 		*_object.code,
 		"memoryguard"_yulstring
 	);
@@ -206,7 +206,7 @@ void StackLimitEvader::run(
 	StackToMemoryMover::run(_context, reservedMemory, memoryOffsetAllocator.slotAllocations, requiredSlots, *_object.code);
 
 	reservedMemory += 32 * requiredSlots;
-	for (FunctionCall* memoryGuardCall: FunctionCallFinder::run(*_object.code, "memoryguard"_yulstring))
+	for (FunctionCall* memoryGuardCall: findFunctionCalls(*_object.code, "memoryguard"_yulstring))
 	{
 		Literal* literal = std::get_if<Literal>(&memoryGuardCall->arguments.front());
 		yulAssert(literal && literal->kind == LiteralKind::Number, "");

--- a/test/libsolidity/MemoryGuardTest.cpp
+++ b/test/libsolidity/MemoryGuardTest.cpp
@@ -73,7 +73,7 @@ TestCase::TestResult MemoryGuardTest::run(std::ostream& _stream, std::string con
 		}
 
 		auto handleObject = [&](std::string const& _kind, Object const& _object) {
-			m_obtainedResult += contractName + "(" + _kind + ") " + (FunctionCallFinder::run(
+			m_obtainedResult += contractName + "(" + _kind + ") " + (findFunctionCalls(
 				*_object.code,
 				"memoryguard"_yulstring
 			).empty() ? "false" : "true") + "\n";


### PR DESCRIPTION
So that functions may be found as pointers to `const FunctionCall` if it is not required to mutate them.