### PR TITLE
Explicit treatment of printing mode in Yul AsmPrinter

### DIFF
--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -491,8 +491,8 @@ void CompilerContext::appendInlineAssembly(
 		{
 			// Store as generated sources, but first re-parse to update the source references.
 			solAssert(m_generatedYulUtilityCode.empty(), "");
-			m_generatedYulUtilityCode = yul::AsmPrinter(dialect)(*obj.code);
-			std::string code = yul::AsmPrinter{dialect}(*obj.code);
+			m_generatedYulUtilityCode = yul::AsmPrinter(yul::AsmPrinter::TypePrinting::OmitDefault, dialect)(*obj.code);
+			std::string code = yul::AsmPrinter{yul::AsmPrinter::TypePrinting::OmitDefault, dialect}(*obj.code);
 			langutil::CharStream charStream(m_generatedYulUtilityCode, _sourceName);
 			obj.code = yul::Parser(errorReporter, dialect).parse(charStream);
 			*obj.analysisInfo = yul::AsmAnalyzer::analyzeStrictAssertCorrect(dialect, obj);

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -2256,8 +2256,7 @@ bool IRGeneratorForStatements::visit(InlineAssembly const& _inlineAsm)
 
 	solAssert(std::holds_alternative<yul::Block>(modified));
 
-	// Do not provide dialect so that we get the full type information.
-	appendCode() << yul::AsmPrinter()(std::get<yul::Block>(modified)) << "\n";
+	appendCode() << yul::AsmPrinter(yul::AsmPrinter::TypePrinting::Full, _inlineAsm.dialect())(std::get<yul::Block>(modified)) << "\n";
 	return false;
 }
 

--- a/libsolidity/experimental/codegen/IRGeneratorForStatements.cpp
+++ b/libsolidity/experimental/codegen/IRGeneratorForStatements.cpp
@@ -132,7 +132,7 @@ bool IRGeneratorForStatements::visit(InlineAssembly const& _assembly)
 	CopyTranslate bodyCopier{m_context, _assembly.dialect(), _assembly.annotation().externalReferences};
 	yul::Statement modified = bodyCopier(_assembly.operations());
 	solAssert(std::holds_alternative<yul::Block>(modified));
-	m_code << yul::AsmPrinter()(std::get<yul::Block>(modified)) << "\n";
+	m_code << yul::AsmPrinter(yul::AsmPrinter::TypePrinting::Full, _assembly.dialect())(std::get<yul::Block>(modified)) << "\n";
 	return false;
 }
 

--- a/libyul/AsmPrinter.cpp
+++ b/libyul/AsmPrinter.cpp
@@ -245,11 +245,15 @@ std::string AsmPrinter::formatTypedName(TypedName _variable)
 
 std::string AsmPrinter::appendTypeName(YulName _type, bool _isBoolLiteral) const
 {
-	if (m_dialect && !_type.empty())
+	yulAssert(
+		m_typePrintingMode == TypePrinting::OmitDefault || m_typePrintingMode == TypePrinting::Full,
+		"unhandled printing mode"
+	);
+	if (m_typePrintingMode == TypePrinting::OmitDefault && !_type.empty())
 	{
-		if (!_isBoolLiteral && _type == m_dialect->defaultType)
+		if (!_isBoolLiteral && _type == m_dialect.defaultType)
 			_type = {};
-		else if (_isBoolLiteral && _type == m_dialect->boolType && !m_dialect->defaultType.empty())
+		else if (_isBoolLiteral && _type == m_dialect.boolType && !m_dialect.defaultType.empty())
 			// Special case: If we have a bool type but empty default type, do not remove the type.
 			_type = {};
 	}

--- a/libyul/AsmPrinter.h
+++ b/libyul/AsmPrinter.h
@@ -46,12 +46,20 @@ struct Dialect;
 class AsmPrinter
 {
 public:
+	enum class TypePrinting
+	{
+		OmitDefault,
+		Full
+	};
+
 	explicit AsmPrinter(
-		Dialect const* _dialect = nullptr,
+		TypePrinting const _typePrintingMode,
+		Dialect const& _dialect,
 		std::optional<std::map<unsigned, std::shared_ptr<std::string const>>> _sourceIndexToName = {},
 		langutil::DebugInfoSelection const& _debugInfoSelection = langutil::DebugInfoSelection::Default(),
 		langutil::CharStreamProvider const* _soliditySourceProvider = nullptr
 	):
+		m_typePrintingMode(_typePrintingMode),
 		m_dialect(_dialect),
 		m_debugInfoSelection(_debugInfoSelection),
 		m_soliditySourceProvider(_soliditySourceProvider)
@@ -60,13 +68,6 @@ public:
 			for (auto&& [index, name]: *_sourceIndexToName)
 				m_nameToSourceIndex[*name] = index;
 	}
-
-	explicit AsmPrinter(
-		Dialect const& _dialect,
-		std::optional<std::map<unsigned, std::shared_ptr<std::string const>>> _sourceIndexToName = {},
-		langutil::DebugInfoSelection const& _debugInfoSelection = langutil::DebugInfoSelection::Default(),
-		langutil::CharStreamProvider const* _soliditySourceProvider = nullptr
-	): AsmPrinter(&_dialect, _sourceIndexToName, _debugInfoSelection, _soliditySourceProvider) {}
 
 	std::string operator()(Literal const& _literal);
 	std::string operator()(Identifier const& _identifier);
@@ -101,7 +102,8 @@ private:
 		return formatDebugData(_node.debugData, !isExpression);
 	}
 
-	Dialect const* const m_dialect = nullptr;
+	TypePrinting const m_typePrintingMode{};
+	Dialect const& m_dialect;
 	std::map<std::string, unsigned> m_nameToSourceIndex;
 	langutil::SourceLocation m_lastLocation = {};
 	langutil::DebugInfoSelection m_debugInfoSelection = {};

--- a/libyul/Object.cpp
+++ b/libyul/Object.cpp
@@ -38,13 +38,14 @@ using namespace solidity::langutil;
 using namespace solidity::util;
 using namespace solidity::yul;
 
-std::string Data::toString(Dialect const*, DebugInfoSelection const&, CharStreamProvider const*) const
+std::string Data::toString(Dialect const&, AsmPrinter::TypePrinting, DebugInfoSelection const&, CharStreamProvider const*) const
 {
 	return "data \"" + name + "\" hex\"" + util::toHex(data) + "\"";
 }
 
 std::string Object::toString(
-	Dialect const* _dialect,
+	Dialect const& _dialect,
+	AsmPrinter::TypePrinting const _printingMode,
 	DebugInfoSelection const& _debugInfoSelection,
 	CharStreamProvider const* _soliditySourceProvider
 ) const
@@ -63,6 +64,7 @@ std::string Object::toString(
 			"\n";
 
 	std::string inner = "code " + AsmPrinter(
+		_printingMode,
 		_dialect,
 		debugData->sourceNames,
 		_debugInfoSelection,
@@ -70,7 +72,7 @@ std::string Object::toString(
 	)(*code);
 
 	for (auto const& obj: subObjects)
-		inner += "\n" + obj->toString(_dialect, _debugInfoSelection, _soliditySourceProvider);
+		inner += "\n" + obj->toString(_dialect, _printingMode, _debugInfoSelection, _soliditySourceProvider);
 
 	return useSrcComment + "object \"" + name + "\" {\n" + indent(inner) + "\n}";
 }

--- a/libyul/Object.h
+++ b/libyul/Object.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <libyul/AsmPrinter.h>
 #include <libyul/ASTForward.h>
 
 #include <liblangutil/CharStreamProvider.h>
@@ -53,7 +54,8 @@ struct ObjectNode
 	/// Can be empty since .yul files can also just contain code, without explicitly placing it in an object.
 	std::string name;
 	virtual std::string toString(
-		Dialect const* _dialect,
+		Dialect const& _dialect,
+		AsmPrinter::TypePrinting printingMode,
 		langutil::DebugInfoSelection const& _debugInfoSelection,
 		langutil::CharStreamProvider const* _soliditySourceProvider
 	) const = 0;
@@ -70,7 +72,8 @@ struct Data: public ObjectNode
 	bytes data;
 
 	std::string toString(
-		Dialect const* _dialect,
+		Dialect const& _dialect,
+		AsmPrinter::TypePrinting printingMode,
 		langutil::DebugInfoSelection const& _debugInfoSelection,
 		langutil::CharStreamProvider const* _soliditySourceProvider
 	) const override;
@@ -92,7 +95,8 @@ struct Object: public ObjectNode
 public:
 	/// @returns a (parseable) string representation.
 	std::string toString(
-		Dialect const* _dialect,
+		Dialect const& _dialect,
+		AsmPrinter::TypePrinting printingMode = AsmPrinter::TypePrinting::Full,
 		langutil::DebugInfoSelection const& _debugInfoSelection = langutil::DebugInfoSelection::Default(),
 		langutil::CharStreamProvider const* _soliditySourceProvider = nullptr
 	) const;

--- a/libyul/YulStack.cpp
+++ b/libyul/YulStack.cpp
@@ -365,7 +365,12 @@ std::string YulStack::print(
 	yulAssert(m_stackState >= Parsed);
 	yulAssert(m_parserResult, "");
 	yulAssert(m_parserResult->code, "");
-	return m_parserResult->toString(&languageToDialect(m_language, m_evmVersion), m_debugInfoSelection, _soliditySourceProvider) + "\n";
+	return m_parserResult->toString(
+		languageToDialect(m_language, m_evmVersion),
+		AsmPrinter::TypePrinting::OmitDefault,
+		m_debugInfoSelection,
+		_soliditySourceProvider
+	) + "\n";
 }
 
 Json YulStack::astJson() const

--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -510,7 +510,7 @@ void OptimiserSuite::runSequence(std::vector<std::string> const& _steps, Block& 
 			else
 			{
 				std::cout << "== Running " << step << " changed the AST." << std::endl;
-				std::cout << AsmPrinter{}(_ast) << std::endl;
+				std::cout << AsmPrinter{AsmPrinter::TypePrinting::Full, m_context.dialect}(_ast) << std::endl;
 				copy = std::make_unique<Block>(std::get<Block>(ASTCopier{}(_ast)));
 			}
 		}

--- a/test/libyul/Common.cpp
+++ b/test/libyul/Common.cpp
@@ -96,7 +96,9 @@ yul::Block yul::test::disambiguate(std::string const& _source, bool _yul)
 
 std::string yul::test::format(std::string const& _source, bool _yul)
 {
-	return yul::AsmPrinter()(*parse(_source, _yul).first);
+	auto const version = solidity::test::CommonOptions::get().evmVersion();
+	Dialect const& dialect = _yul ? EVMDialectTyped::instance(version) : EVMDialect::strictAssemblyForEVMObjects(version);
+	return yul::AsmPrinter(yul::AsmPrinter::TypePrinting::Full, dialect)(*parse(_source, _yul).first);
 }
 
 namespace

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -164,9 +164,8 @@ BOOST_AUTO_TEST_CASE(default_types_set)
 	);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 
-	// Use no dialect so that all types are printed.
-	// This tests that the default types are properly assigned.
-	BOOST_CHECK_EQUAL(AsmPrinter{}(*result),
+	// All types are printed.
+	BOOST_CHECK_EQUAL(AsmPrinter(AsmPrinter::TypePrinting::Full, EVMDialectTyped::instance(EVMVersion()))(*result),
 		"{\n"
 		"    let x:bool := true:bool\n"
 		"    let z:bool := true:bool\n"
@@ -177,9 +176,8 @@ BOOST_AUTO_TEST_CASE(default_types_set)
 		"}"
 	);
 
-	// Now test again with type dialect. Now the default types
-	// should be omitted.
-	BOOST_CHECK_EQUAL(AsmPrinter{EVMDialectTyped::instance(EVMVersion{})}(*result),
+	// Now the default types should be omitted.
+	BOOST_CHECK_EQUAL(AsmPrinter(AsmPrinter::TypePrinting::OmitDefault, EVMDialectTyped::instance(EVMVersion()))(*result),
 		"{\n"
 		"    let x:bool := true\n"
 		"    let z:bool := true\n"

--- a/test/libyul/YulOptimizerTest.cpp
+++ b/test/libyul/YulOptimizerTest.cpp
@@ -78,7 +78,7 @@ TestCase::TestResult YulOptimizerTest::run(std::ostream& _stream, std::string co
 		return TestResult::FatalError;
 	}
 
-	auto const printed = (m_object->subObjects.empty() ? AsmPrinter{ *m_dialect }(*m_object->code) : m_object->toString(m_dialect));
+	auto const printed = (m_object->subObjects.empty() ? AsmPrinter{AsmPrinter::TypePrinting::OmitDefault, *m_dialect}(*m_object->code) : m_object->toString(*m_dialect));
 
 	// Re-parse new code for compilability
 	if (!std::get<0>(parse(_stream, _linePrefix, _formatted, printed)))

--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -181,7 +181,7 @@ public:
 		parse(_source);
 		disambiguate();
 		OptimiserSuite{m_context}.runSequence(_steps, *m_ast);
-		std::cout << AsmPrinter{m_dialect}(*m_ast) << std::endl;
+		std::cout << AsmPrinter{AsmPrinter::TypePrinting::OmitDefault, m_dialect}(*m_ast) << std::endl;
 	}
 
 	void runInteractive(std::string _source, bool _disambiguated = false)
@@ -229,7 +229,7 @@ public:
 							*m_ast
 						);
 				}
-				_source = AsmPrinter{m_dialect}(*m_ast);
+				_source = AsmPrinter{AsmPrinter::TypePrinting::OmitDefault, m_dialect}(*m_ast);
 			}
 			catch (...)
 			{

--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -105,7 +105,7 @@ void Program::optimise(std::vector<std::string> const& _optimisationSteps)
 
 std::ostream& phaser::operator<<(std::ostream& _stream, Program const& _program)
 {
-	return _stream << AsmPrinter()(*_program.m_ast);
+	return _stream << AsmPrinter(AsmPrinter::TypePrinting::Full, _program.m_dialect)(*_program.m_ast);
 }
 
 std::string Program::toJson() const


### PR DESCRIPTION
When the YulNameRepository is merged, the AsmPrinter will need to have an instance of it anyways (which contains the dialect), so I changed the AsmPrinter s.t. the printing mode is explicitly specified instead of implicitly inferred from whether a dialect pointer is null or not.