### PR TITLE
ossfuzz: add fstream std header to not break build after compiler upgrade.

### DIFF
--- a/test/tools/ossfuzz/AbiV2IsabelleFuzzer.cpp
+++ b/test/tools/ossfuzz/AbiV2IsabelleFuzzer.cpp
@@ -22,6 +22,7 @@
 
 #include <src/libfuzzer/libfuzzer_macro.h>
 #include <abicoder.hpp>
+#include <fstream>
 
 using namespace solidity::frontend;
 using namespace solidity::test::fuzzer;


### PR DESCRIPTION
Required by https://github.com/google/oss-fuzz/pull/12172

tl;dr ossfuzz upgraded compiler to clang v18.1.8 and ever since, one of the fuzzers breaks build because the fstream header was not explicitly included.