### PR TITLE
Downgrade nodejs in base_node_small image to fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -487,7 +487,8 @@ defaults:
 
   - base_node_small: &base_node_small
       docker:
-        - image: cimg/node:current
+        # TODO: Revert to cimg/node:current once https://github.com/npm/cli/issues/7657 is resolved.
+        - image: cimg/node:22.4
       resource_class: small
       environment: &base_node_small_env
         TERM: xterm
@@ -761,6 +762,7 @@ defaults:
       # which does not support shanghai EVM.
       compile_only: 1
       resource_class: medium
+      image: cimg/node:18.16
 
   - job_native_test_ext_yield_liquidator: &job_native_test_ext_yield_liquidator
       <<: *requires_b_ubu_static


### PR DESCRIPTION
Temporary fix (hopefully) to bring the bytecode_compare jobs back to life. 

`node v22.5.0` throws the following:
```bash
npm error Exit handler never called!
npm error This is an error with npm itself. Please report this error at:
npm error   <https://github.com/npm/cli/issues>
npm error A complete log of this run can be found in: /home/circleci/.npm/_logs/2024-07-19T07_48_08_508Z-debug-0.log
```

Bug here https://github.com/npm/cli/issues/7657. This fix should be revert when `v22.5.1` comes out (hopefully soon).