### PR TITLE
Docs: Add note about the library placeholder format change in v0.5.0

### DIFF
--- a/docs/contracts/libraries.rst
+++ b/docs/contracts/libraries.rst
@@ -196,7 +196,7 @@ It is possible to obtain the address of a library by converting
 the library type to the ``address`` type, i.e. using ``address(LibraryName)``.
 
 As the compiler does not know the address where the library will be deployed, the compiled hex code
-will contain placeholders of the form ``__$30bbc0abd4d6364515865950d3e0d10953$__`` `(format was different <v0.5.0) <https://docs.soliditylang.org/en/v0.4.26/using-the-compiler.html>`_. The placeholder
+will contain placeholders of the form ``__$30bbc0abd4d6364515865950d3e0d10953$__`` `(format was different <v0.5.0) <https://docs.soliditylang.org/en/v0.4.26/contracts.html#libraries>`_. The placeholder
 is a 34 character prefix of the hex encoding of the keccak256 hash of the fully qualified library
 name, which would be for example ``libraries/bigint.sol:BigInt`` if the library was stored in a file
 called ``bigint.sol`` in a ``libraries/`` directory. Such bytecode is incomplete and should not be

--- a/docs/contracts/libraries.rst
+++ b/docs/contracts/libraries.rst
@@ -196,7 +196,7 @@ It is possible to obtain the address of a library by converting
 the library type to the ``address`` type, i.e. using ``address(LibraryName)``.
 
 As the compiler does not know the address where the library will be deployed, the compiled hex code
-will contain placeholders of the form ``__$30bbc0abd4d6364515865950d3e0d10953$__``. The placeholder
+will contain placeholders of the form ``__$30bbc0abd4d6364515865950d3e0d10953$__`` `(format was different <v0.5.0) <https://docs.soliditylang.org/en/v0.4.26/using-the-compiler.html>`_. The placeholder
 is a 34 character prefix of the hex encoding of the keccak256 hash of the fully qualified library
 name, which would be for example ``libraries/bigint.sol:BigInt`` if the library was stored in a file
 called ``bigint.sol`` in a ``libraries/`` directory. Such bytecode is incomplete and should not be

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -71,7 +71,7 @@ For a detailed explanation with examples and discussion of corner cases please r
 Library Linking
 ---------------
 
-If your contracts use :ref:`libraries <libraries>`, you will notice that the bytecode contains substrings of the form ``__$53aea86b7d70b31448b230b20ae141a537$__``. These are placeholders for the actual library addresses.
+If your contracts use :ref:`libraries <libraries>`, you will notice that the bytecode contains substrings of the form ``__$53aea86b7d70b31448b230b20ae141a537$__`` `(format was different <v0.5.0) <https://docs.soliditylang.org/en/v0.4.26/using-the-compiler.html>`_. These are placeholders for the actual library addresses.
 The placeholder is a 34 character prefix of the hex encoding of the keccak256 hash of the fully qualified library name.
 The bytecode file will also contain lines of the form ``// <placeholder> -> <fq library name>`` at the end to help
 identify which libraries the placeholders represent. Note that the fully qualified library name

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -71,7 +71,7 @@ For a detailed explanation with examples and discussion of corner cases please r
 Library Linking
 ---------------
 
-If your contracts use :ref:`libraries <libraries>`, you will notice that the bytecode contains substrings of the form ``__$53aea86b7d70b31448b230b20ae141a537$__`` `(format was different <v0.5.0) <https://docs.soliditylang.org/en/v0.4.26/using-the-compiler.html>`_. These are placeholders for the actual library addresses.
+If your contracts use :ref:`libraries <libraries>`, you will notice that the bytecode contains substrings of the form ``__$53aea86b7d70b31448b230b20ae141a537$__`` `(format was different <v0.5.0) <https://docs.soliditylang.org/en/v0.4.26/contracts.html#libraries>`_. These are placeholders for the actual library addresses.
 The placeholder is a 34 character prefix of the hex encoding of the keccak256 hash of the fully qualified library name.
 The bytecode file will also contain lines of the form ``// <placeholder> -> <fq library name>`` at the end to help
 identify which libraries the placeholders represent. Note that the fully qualified library name


### PR DESCRIPTION
The library placeholder string format has changed on v0.5.0. Someone reading the docs would be unaware of this and can assume the format remained the same.

This can be important e.g. verifying contracts pre 0.5.0 or working on the bytecode