### PR TITLE
fix(codegen-ir): remove `<forwardingRevert>` for precompiled contracts

### DIFF
--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1658,7 +1658,7 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 				mstore(0, 0)
 			</isECRecover>
 			let <success> := <call>(<gas>, <address> <?isCall>, 0</isCall>, <pos>, sub(<end>, <pos>), 0, 32)
-			if iszero(<success>) { <forwardingRevert>() }
+			if iszero(<success>) { revert(0, 0) }
 			let <retVars> := <shl>(mload(0))
 		)");
 		templ("call", m_context.evmVersion().hasStaticCall() ? "staticcall" : "call");
@@ -1676,7 +1676,6 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		templ("address", toString(address));
 		templ("success", m_context.newYulVariable());
 		templ("retVars", IRVariable(_functionCall).commaSeparatedList());
-		templ("forwardingRevert", m_utils.forwardingRevertFunction());
 		if (m_context.evmVersion().canOverchargeGasForCall())
 			// Send all gas (requires tangerine whistle EVM)
 			templ("gas", "gas()");

--- a/test/libsolidity/semanticTests/externalContracts/deposit_contract.sol
+++ b/test/libsolidity/semanticTests/externalContracts/deposit_contract.sol
@@ -176,8 +176,8 @@ contract DepositContract is IDepositContract, ERC165 {
 }
 // ----
 // constructor()
-// gas irOptimized: 809602
-// gas irOptimized code: 558000
+// gas irOptimized: 809020
+// gas irOptimized code: 555800
 // gas legacy: 919945
 // gas legacy code: 1437600
 // gas legacyOptimized: 848699


### PR DESCRIPTION
Resolves https://github.com/ethereum/solidity/issues/15295#issuecomment-2247754746

I checked the EVM implementation in geth and concluded that `<forwardingRevert>` can be safely replaced with `revert(0, 0)` since the pre-compiled contracts `ECRecover`, `RIPEMD160` and `SHA256` never return data as bytes, even in case of error. 
https://github.com/ethereum/go-ethereum/blob/4ad88e9463090a6363be5ed8dca733c890e91b7b/core/vm/contracts.go#L195-L206

`ECRecover`
- https://github.com/ethereum/go-ethereum/blob/4ad88e9463090a6363be5ed8dca733c890e91b7b/core/vm/contracts.go#L215-L244

`RIPEMD160`
- https://github.com/ethereum/go-ethereum/blob/4ad88e9463090a6363be5ed8dca733c890e91b7b/core/vm/contracts.go#L271-L275

`SHA256`
- https://github.com/ethereum/go-ethereum/blob/4ad88e9463090a6363be5ed8dca733c890e91b7b/core/vm/contracts.go#L256-L259
