### PR TITLE
Add notes about the library ABI differences in the ABI page

### DIFF
--- a/docs/abi-spec.rst
+++ b/docs/abi-spec.rst
@@ -16,7 +16,7 @@ as described in this specification. The encoding is not self describing and thus
 We assume that the interface functions of a contract are strongly typed, known at compilation time and static.
 We assume that all contracts will have the interface definitions of any contracts they call available at compile-time.
 
-This specification does not address contracts whose interface is dynamic or otherwise known only at run-time.
+This specification does not address contracts whose interface is dynamic or otherwise known only at run-time. Also, the ABI specification for libraries is :ref:`slightly different <library-selectors>`.
 
 .. _abi_function_selector:
 .. index:: ! selector; of a function
@@ -46,6 +46,8 @@ without the four bytes specifying the function.
 
 Types
 =====
+
+Note that the library ABIs can take types different than below e.g. for non-storage structs. See :ref:`library selectors <library-selectors>` for details.
 
 The following elementary types exist:
 

--- a/docs/contracts/libraries.rst
+++ b/docs/contracts/libraries.rst
@@ -196,7 +196,7 @@ It is possible to obtain the address of a library by converting
 the library type to the ``address`` type, i.e. using ``address(LibraryName)``.
 
 As the compiler does not know the address where the library will be deployed, the compiled hex code
-will contain placeholders of the form ``__$30bbc0abd4d6364515865950d3e0d10953$__`` `(format was different <v0.5.0) <https://docs.soliditylang.org/en/v0.4.26/using-the-compiler.html>`_. The placeholder
+will contain placeholders of the form ``__$30bbc0abd4d6364515865950d3e0d10953$__`` `(format was different <v0.5.0) <https://docs.soliditylang.org/en/v0.4.26/contracts.html#libraries>`_. The placeholder
 is a 34 character prefix of the hex encoding of the keccak256 hash of the fully qualified library
 name, which would be for example ``libraries/bigint.sol:BigInt`` if the library was stored in a file
 called ``bigint.sol`` in a ``libraries/`` directory. Such bytecode is incomplete and should not be

--- a/docs/contracts/libraries.rst
+++ b/docs/contracts/libraries.rst
@@ -196,7 +196,7 @@ It is possible to obtain the address of a library by converting
 the library type to the ``address`` type, i.e. using ``address(LibraryName)``.
 
 As the compiler does not know the address where the library will be deployed, the compiled hex code
-will contain placeholders of the form ``__$30bbc0abd4d6364515865950d3e0d10953$__``. The placeholder
+will contain placeholders of the form ``__$30bbc0abd4d6364515865950d3e0d10953$__`` `(format was different <v0.5.0) <https://docs.soliditylang.org/en/v0.4.26/using-the-compiler.html>`_. The placeholder
 is a 34 character prefix of the hex encoding of the keccak256 hash of the fully qualified library
 name, which would be for example ``libraries/bigint.sol:BigInt`` if the library was stored in a file
 called ``bigint.sol`` in a ``libraries/`` directory. Such bytecode is incomplete and should not be

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -71,7 +71,7 @@ For a detailed explanation with examples and discussion of corner cases please r
 Library Linking
 ---------------
 
-If your contracts use :ref:`libraries <libraries>`, you will notice that the bytecode contains substrings of the form ``__$53aea86b7d70b31448b230b20ae141a537$__``. These are placeholders for the actual library addresses.
+If your contracts use :ref:`libraries <libraries>`, you will notice that the bytecode contains substrings of the form ``__$53aea86b7d70b31448b230b20ae141a537$__`` `(format was different <v0.5.0) <https://docs.soliditylang.org/en/v0.4.26/using-the-compiler.html>`_. These are placeholders for the actual library addresses.
 The placeholder is a 34 character prefix of the hex encoding of the keccak256 hash of the fully qualified library name.
 The bytecode file will also contain lines of the form ``// <placeholder> -> <fq library name>`` at the end to help
 identify which libraries the placeholders represent. Note that the fully qualified library name

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -71,7 +71,7 @@ For a detailed explanation with examples and discussion of corner cases please r
 Library Linking
 ---------------
 
-If your contracts use :ref:`libraries <libraries>`, you will notice that the bytecode contains substrings of the form ``__$53aea86b7d70b31448b230b20ae141a537$__`` `(format was different <v0.5.0) <https://docs.soliditylang.org/en/v0.4.26/using-the-compiler.html>`_. These are placeholders for the actual library addresses.
+If your contracts use :ref:`libraries <libraries>`, you will notice that the bytecode contains substrings of the form ``__$53aea86b7d70b31448b230b20ae141a537$__`` `(format was different <v0.5.0) <https://docs.soliditylang.org/en/v0.4.26/contracts.html#libraries>`_. These are placeholders for the actual library addresses.
 The placeholder is a 34 character prefix of the hex encoding of the keccak256 hash of the fully qualified library name.
 The bytecode file will also contain lines of the form ``// <placeholder> -> <fq library name>`` at the end to help
 identify which libraries the placeholders represent. Note that the fully qualified library name


### PR DESCRIPTION
It is not immediately clear that the library ABI JSON can be slightly different than the contract ABIs. By looking at the ABI page one can easily assume contract and library abis are the same. Therefore IMO it makes sense to add notes in the ABI page.

This is apparent with the number of issues opened on this: 
https://github.com/verifier-alliance/parquet-export/issues/2
https://github.com/ethereum/solidity/issues/9278#issuecomment-718168636
https://github.com/ethereum/solidity/issues/14553
https://github.com/ethereum/solidity/issues/12867
