### PR TITLE
Docs: Fix showProvedSafe flag and JSON key name

### DIFF
--- a/docs/smtchecker.rst
+++ b/docs/smtchecker.rst
@@ -488,8 +488,8 @@ Proved Targets
 
 If there are any proved targets, the SMTChecker issues one warning per engine stating
 how many targets were proved. If the user wishes to see all the specific
-proved targets, the CLI option ``--model-checker-show-proved`` and
-the JSON option ``settings.modelChecker.showProved = true`` can be used.
+proved targets, the CLI option ``--model-checker-show-proved-safe`` and
+the JSON option ``settings.modelChecker.showProvedSafe = true`` can be used.
 
 Unproved Targets
 ================

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -481,7 +481,7 @@ Input Description
           // Choose which types of invariants should be reported to the user: contract, reentrancy.
           "invariants": ["contract", "reentrancy"],
           // Choose whether to output all proved targets. The default is `false`.
-          "showProved": true,
+          "showProvedSafe": true,
           // Choose whether to output all unproved targets. The default is `false`.
           "showUnproved": true,
           // Choose whether to output all unsupported language features. The default is `false`.


### PR DESCRIPTION
Currently, the ["SMTChecker and Formal Verification" documentation page says](https://docs.soliditylang.org/en/latest/smtchecker.html#proved-targets):

> # Proved Targets
> If there are any proved targets, the SMTChecker issues one warning per engine stating how many targets were proved. If the user wishes to see all the specific proved targets, the CLI option `--model-checker-show-proved` and the JSON option `settings.modelChecker.showProved = true` can be used.

However, the correct CLI flag is `--model-checker-show-proved-safe` and the correct JSON key is `showProvedSafe`.

This PR updates the documentation to reflect the correct flag and JSON key.

Interestingly, [the commit that introduced this mistake](https://github.com/ethereum/solidity/commit/21c0f7865055c0e276c94332bbb5e1e46d639f84) used the correct flag/key in the changelog but not the docs for some reason.