### PR TITLE
Fix spuriously emitted parser error for unary plus operations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,6 +20,7 @@ Compiler Features:
 
 
 Bugfixes:
+ * Parser: Fix spuriously emitted parser error for unary plus operations when used as binary operator in some cases.
  * SMTChecker: Fix error that reports invalid number of verified checks for BMC and CHC engines.
  * SMTChecker: Fix formatting of unary minus expressions in invariants.
  * SMTChecker: Fix internal compiler error when reporting proved targets for BMC engine.

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -2152,7 +2152,7 @@ ASTPointer<Expression> Parser::parseUnaryExpression(
 		ASTNodeFactory(*this, _partiallyParsedExpression) : ASTNodeFactory(*this);
 	Token token = m_scanner->currentToken();
 
-	if (token == Token::Add)
+	if (!_partiallyParsedExpression && token == Token::Add)
 		fatalParserError(9636_error, "Use of unary + is disallowed.");
 
 	if (!_partiallyParsedExpression && (TokenTraits::isUnaryOp(token) || TokenTraits::isCountOp(token)))

--- a/test/libsolidity/syntaxTests/iceRegressionTests/declarationUnaryTuple/declaration_unary_plus_tuple_compound_assign.sol
+++ b/test/libsolidity/syntaxTests/iceRegressionTests/declarationUnaryTuple/declaration_unary_plus_tuple_compound_assign.sol
@@ -1,0 +1,9 @@
+contract C
+{
+    function f(int x) public
+    {
+        (x /= 1) + +(1,1);
+    }
+}
+// ----
+// ParserError 9636: (67-68): Use of unary + is disallowed.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/591_access_to_internal_variable.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/591_access_to_internal_variable.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f(int32 x) external pure returns (int32)
+    {
+        this.x + 1;
+        return x;
+    }
+}
+// ----
+// TypeError 9582: (81-87): Member "x" not found or not visible after argument-dependent lookup in contract C.

--- a/test/libsolidity/syntaxTests/types/binary_add_op.sol
+++ b/test/libsolidity/syntaxTests/types/binary_add_op.sol
@@ -1,0 +1,12 @@
+contract C {
+    function f(int32 x) external pure returns (int32)
+    {
+        x = 1 + 1;
+        (x /= 1) + 1;
+        (x = ++x) + 1;
+        (0) + 1;
+        return x;
+    }
+}
+// ----
+// Warning 6133: (145-152): Statement has no effect.


### PR DESCRIPTION
... when used as binary operator in some cases

Fixes #14624
Fixes #15236