### PR TITLE
Restrict the initialization of transient storage state variables

### DIFF
--- a/libsolidity/analysis/DeclarationTypeChecker.cpp
+++ b/libsolidity/analysis/DeclarationTypeChecker.cpp
@@ -469,6 +469,14 @@ void DeclarationTypeChecker::endVisit(VariableDeclaration const& _variable)
 						_variable.location(),
 						"Transient cannot be used as data location for constant or immutable variables."
 					);
+
+				if (_variable.value())
+					m_errorReporter.declarationError(
+						9825_error,
+						_variable.location(),
+						"Initialization of transient storage state variables is not supported."
+					);
+
 				typeLoc = DataLocation::Transient;
 				break;
 			default:

--- a/test/libsolidity/smtCheckerTests/unsupported/transient_storage_state_variable.sol
+++ b/test/libsolidity/smtCheckerTests/unsupported/transient_storage_state_variable.sol
@@ -1,6 +1,6 @@
 contract C {
-    uint transient x = 42;
-    function test() public view { assert(x == 42); }
+    uint transient x;
+    function test() public view { assert(x == 0); }
 }
 // ====
 // SMTEngine: all

--- a/test/libsolidity/syntaxTests/constants/constant_transient_state_variable.sol
+++ b/test/libsolidity/syntaxTests/constants/constant_transient_state_variable.sol
@@ -3,3 +3,4 @@ contract C {
 }
 // ----
 // DeclarationError 2197: (17-52): Transient cannot be used as data location for constant or immutable variables.
+// DeclarationError 9825: (17-52): Initialization of transient storage state variables is not supported.

--- a/test/libsolidity/syntaxTests/dataLocations/transient_value_type_state_variables_assignment.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_value_type_state_variables_assignment.sol
@@ -1,9 +1,0 @@
-contract D { }
-
-contract C {
-	int transient x = -99;
-	address transient a = address(0xABC);
-	bool transient b = x > 0 ? false : true;
-}
-// ----
-// UnimplementedFeatureError 1834: Transient storage variables are not supported.

--- a/test/libsolidity/syntaxTests/dataLocations/transient_value_type_state_variables_initialization.sol
+++ b/test/libsolidity/syntaxTests/dataLocations/transient_value_type_state_variables_initialization.sol
@@ -1,0 +1,11 @@
+contract D { }
+
+contract C {
+	int transient x = -99;
+	address transient a = address(0xABC);
+	bool transient b = x > 0 ? false : true;
+}
+// ----
+// DeclarationError 9825: (30-51): Initialization of transient storage state variables is not supported.
+// DeclarationError 9825: (54-90): Initialization of transient storage state variables is not supported.
+// DeclarationError 9825: (93-132): Initialization of transient storage state variables is not supported.


### PR DESCRIPTION
This was decided during internal review of #15257.