### PR TITLE
SMTChecker: Add setup of z3 to SMTSolverCommand

### DIFF
--- a/libsolidity/interface/SMTSolverCommand.h
+++ b/libsolidity/interface/SMTSolverCommand.h
@@ -38,6 +38,7 @@ public:
 
 	void setEldarica(std::optional<unsigned int> timeoutInMilliseconds, bool computeInvariants);
 	void setCvc5(std::optional<unsigned int> timeoutInMilliseconds);
+	void setZ3(std::optional<unsigned int> timeoutInMilliseconds, bool _preprocessing, bool _computeInvariants);
 
 private:
 	/// The name of the solver's binary.


### PR DESCRIPTION
This prepares SMTSolverCommand for invocation of Z3 as an external solver.
Command line arguments enusure we match the way we set Z3 in our current code.

This was separated from #15252.