### PR TITLE
SMTChecker: Inline let expressions in solvers' models

### DIFF
--- a/libsmtutil/CHCSmtLib2Interface.h
+++ b/libsmtutil/CHCSmtLib2Interface.h
@@ -80,6 +80,9 @@ protected:
 		std::unordered_map<std::string, SortPointer> m_localVariables;
 	};
 
+	/* Modifies the passed expression by inlining all let subexpressions */
+	static void inlineLetExpressions(SMTLib2Expression& _expr);
+
 	std::string toSmtLibSort(SortPointer const& _sort);
 	std::vector<std::string> toSmtLibSort(std::vector<SortPointer> const& _sort);
 


### PR DESCRIPTION
Models computed by CHC solvers (especially Z3) can contain SMT-LIB's let expressions. These are used to name a subterm and use the name instead of repeating the subterm possibly many times.

The easiest (but not necessary the best) way to deal with let terms is to inline (expand) them. In our current experiments inlining did not pose any problem. If, in the future, this would turn out to cause problems, we can devise a way to process let terms without expanding the term to its full tree-like representation.

This is part of the preparation to use Z3 as an external solver. It allows us to properly process models returned by Z3.
It has been separated from #15252.