### PR TITLE
Remove special yul strings from UnusedStoreEliminator

### DIFF
--- a/libyul/optimiser/UnusedAssignEliminator.h
+++ b/libyul/optimiser/UnusedAssignEliminator.h
@@ -113,7 +113,7 @@ struct Dialect;
  *
  * Prerequisite: Disambiguator, ForLoopInitRewriter.
  */
-class UnusedAssignEliminator: public UnusedStoreBase
+class UnusedAssignEliminator: public UnusedStoreBase<YulName>
 {
 public:
 	static constexpr char const* name{"UnusedAssignEliminator"};

--- a/libyul/optimiser/UnusedStoreBase.h
+++ b/libyul/optimiser/UnusedStoreBase.h
@@ -46,6 +46,7 @@ struct Dialect;
  *
  * Prerequisite: Disambiguator, ForLoopInitRewriter.
  */
+template<typename ActiveStoreKeyType>
 class UnusedStoreBase: public ASTWalker
 {
 public:
@@ -60,7 +61,7 @@ public:
 	void operator()(Continue const&) override;
 
 protected:
-	using ActiveStores = std::map<YulName, std::set<Statement const*>>;
+	using ActiveStores = std::map<ActiveStoreKeyType, std::set<Statement const*>>;
 
 	/// This function is called for a loop that is nested too deep to avoid
 	/// horrible runtime and should just resolve the situation in a pragmatic
@@ -98,4 +99,7 @@ protected:
 	size_t m_forLoopNestingDepth = 0;
 };
 
+enum class UnusedStoreEliminatorKey { Memory, Storage };
+extern template class UnusedStoreBase<YulString>;
+extern template class UnusedStoreBase<UnusedStoreEliminatorKey>;
 }

--- a/libyul/optimiser/UnusedStoreEliminator.h
+++ b/libyul/optimiser/UnusedStoreEliminator.h
@@ -50,13 +50,11 @@ struct AssignedValue;
  * to sstore, as we don't know whether the memory location will be read once we leave the function's scope,
  * so the statement will be removed only if all code code paths lead to a memory overwrite.
  *
- * The m_store member of UnusedStoreBase uses the key "m" for memory and "s" for storage stores.
- *
  * Best run in SSA form.
  *
  * Prerequisite: Disambiguator, ForLoopInitRewriter.
  */
-class UnusedStoreEliminator: public UnusedStoreBase
+class UnusedStoreEliminator: public UnusedStoreBase<UnusedStoreEliminatorKey>
 {
 public:
 	static constexpr char const* name{"UnusedStoreEliminator"};
@@ -92,8 +90,8 @@ public:
 	};
 
 private:
-	std::set<Statement const*>& activeMemoryStores() { return m_activeStores["m"_yulname]; }
-	std::set<Statement const*>& activeStorageStores() { return m_activeStores["s"_yulname]; }
+	std::set<Statement const*>& activeMemoryStores() { return m_activeStores[UnusedStoreEliminatorKey::Memory]; }
+	std::set<Statement const*>& activeStorageStores() { return m_activeStores[UnusedStoreEliminatorKey::Storage]; }
 
 	void shortcutNestedLoop(ActiveStores const&) override
 	{


### PR DESCRIPTION
Just quickly written and not urgent - but before @clonker gets back to the actual YulName->ID replacement an FYI that the weird special names in the ``UnusedStoreEliminator`` can easily be removed.