### PR TITLE
Add back CLion build directories to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ __pycache__/
 *.app
 
 # Build directory
+/cmake-build-*/
 /build*/
 emscripten_build/
 /docs/_build/


### PR DESCRIPTION
Not sure how they were removed just like that in https://github.com/ethereum/solidity/pull/13355, but it's been annoying me ever since :-).