### PR TITLE
SMTChecker: Introduce helper struct for query result

### DIFF
--- a/libsmtutil/CHCSmtLib2Interface.cpp
+++ b/libsmtutil/CHCSmtLib2Interface.cpp
@@ -90,7 +90,7 @@ void CHCSmtLib2Interface::addRule(Expression const& _expr, std::string const& /*
 	m_commands.assertion("(forall" + forall(_expr) + '\n' + m_context.toSExpr(_expr) + ")\n");
 }
 
-std::tuple<CheckResult, Expression, CHCSolverInterface::CexGraph> CHCSmtLib2Interface::query(Expression const& _block)
+CHCSolverInterface::QueryResult CHCSmtLib2Interface::query(Expression const& _block)
 {
 	std::string query = dumpQuery(_block);
 	std::string response = querySolver(query);

--- a/libsmtutil/CHCSmtLib2Interface.h
+++ b/libsmtutil/CHCSmtLib2Interface.h
@@ -47,7 +47,7 @@ public:
 
 	/// Takes a function application _expr and checks for reachability.
 	/// @returns solving result, an invariant, and counterexample graph, if possible.
-	std::tuple<CheckResult, Expression, CexGraph> query(Expression const& _expr) override;
+	QueryResult query(Expression const& _expr) override;
 
 	void declareVariable(std::string const& _name, SortPointer const& _sort) override;
 

--- a/libsmtutil/CHCSolverInterface.h
+++ b/libsmtutil/CHCSolverInterface.h
@@ -49,11 +49,15 @@ public:
 		std::map<unsigned, std::vector<unsigned>> edges;
 	};
 
+	struct QueryResult
+	{
+		CheckResult answer;
+		Expression invariant;
+		CexGraph cex;
+	};
 	/// Takes a function application _expr and checks for reachability.
 	/// @returns solving result, an invariant, and counterexample graph, if possible.
-	virtual std::tuple<CheckResult, Expression, CexGraph> query(
-		Expression const& _expr
-	) = 0;
+	virtual QueryResult query(Expression const& _expr) = 0;
 
 protected:
 	std::optional<unsigned> m_queryTimeout;

--- a/libsmtutil/Z3CHCInterface.cpp
+++ b/libsmtutil/Z3CHCInterface.cpp
@@ -78,7 +78,7 @@ void Z3CHCInterface::addRule(Expression const& _expr, std::string const& _name)
 	}
 }
 
-std::tuple<CheckResult, Expression, CHCSolverInterface::CexGraph> Z3CHCInterface::query(Expression const& _expr)
+CHCSolverInterface::QueryResult Z3CHCInterface::query(Expression const& _expr)
 {
 	CheckResult result;
 	try

--- a/libsmtutil/Z3CHCInterface.h
+++ b/libsmtutil/Z3CHCInterface.h
@@ -43,7 +43,7 @@ public:
 
 	void addRule(Expression const& _expr, std::string const& _name) override;
 
-	std::tuple<CheckResult, Expression, CexGraph> query(Expression const& _expr) override;
+	QueryResult query(Expression const& _expr) override;
 
 	Z3Interface* z3Interface() const { return m_z3Interface.get(); }
 

--- a/libsolidity/formal/CHC.cpp
+++ b/libsolidity/formal/CHC.cpp
@@ -1916,11 +1916,8 @@ void CHC::addRule(smtutil::Expression const& _rule, std::string const& _ruleName
 	m_interface->addRule(_rule, _ruleName);
 }
 
-std::tuple<CheckResult, smtutil::Expression, CHCSolverInterface::CexGraph> CHC::query(smtutil::Expression const& _query, langutil::SourceLocation const& _location)
+CHCSolverInterface::QueryResult CHC::query(smtutil::Expression const& _query, langutil::SourceLocation const& _location)
 {
-	CheckResult result;
-	smtutil::Expression invariant(true);
-	CHCSolverInterface::CexGraph cex;
 	if (m_settings.printQuery)
 	{
 		auto smtLibInterface = dynamic_cast<CHCSmtLib2Interface*>(m_interface.get());
@@ -1931,8 +1928,8 @@ std::tuple<CheckResult, smtutil::Expression, CHCSolverInterface::CexGraph> CHC::
 			"CHC: Requested query:\n" + smtLibCode
 		);
 	}
-	std::tie(result, invariant, cex) = m_interface->query(_query);
-	switch (result)
+	auto result = m_interface->query(_query);
+	switch (result.answer)
 	{
 	case CheckResult::SATISFIABLE:
 	{
@@ -1946,13 +1943,10 @@ std::tuple<CheckResult, smtutil::Expression, CHCSolverInterface::CexGraph> CHC::
 			solAssert(spacer, "");
 			spacer->setSpacerOptions(false);
 
-			CheckResult resultNoOpt;
-			smtutil::Expression invariantNoOpt(true);
-			CHCSolverInterface::CexGraph cexNoOpt;
-			std::tie(resultNoOpt, invariantNoOpt, cexNoOpt) = m_interface->query(_query);
+			auto resultNoOpt = m_interface->query(_query);
 
-			if (resultNoOpt == CheckResult::SATISFIABLE)
-				cex = std::move(cexNoOpt);
+			if (resultNoOpt.answer == CheckResult::SATISFIABLE)
+				result.cex = std::move(resultNoOpt.cex);
 
 			spacer->setSpacerOptions(true);
 #else
@@ -1962,7 +1956,6 @@ std::tuple<CheckResult, smtutil::Expression, CHCSolverInterface::CexGraph> CHC::
 		break;
 	}
 	case CheckResult::UNSATISFIABLE:
-		break;
 	case CheckResult::UNKNOWN:
 		break;
 	case CheckResult::CONFLICTING:
@@ -1972,7 +1965,7 @@ std::tuple<CheckResult, smtutil::Expression, CHCSolverInterface::CexGraph> CHC::
 		m_errorReporter.warning(1218_error, _location, "CHC: Error trying to invoke SMT solver.");
 		break;
 	}
-	return {result, invariant, cex};
+	return result;
 }
 
 void CHC::verificationTargetEncountered(

--- a/libsolidity/formal/CHC.h
+++ b/libsolidity/formal/CHC.h
@@ -296,7 +296,7 @@ private:
 	void addRule(smtutil::Expression const& _rule, std::string const& _ruleName);
 	/// @returns <true, invariant, empty> if query is unsatisfiable (safe).
 	/// @returns <false, Expression(true), model> otherwise.
-	std::tuple<smtutil::CheckResult, smtutil::Expression, smtutil::CHCSolverInterface::CexGraph> query(smtutil::Expression const& _query, langutil::SourceLocation const& _location);
+	smtutil::CHCSolverInterface::QueryResult query(smtutil::Expression const& _query, langutil::SourceLocation const& _location);
 
 	void verificationTargetEncountered(ASTNode const* const _errorNode, VerificationTargetType _type, smtutil::Expression const& _errorCondition);
 

--- a/libsolidity/formal/Z3CHCSmtLib2Interface.cpp
+++ b/libsolidity/formal/Z3CHCSmtLib2Interface.cpp
@@ -43,7 +43,7 @@ void Z3CHCSmtLib2Interface::setupSmtCallback(bool _enablePreprocessing)
 		universalCallback->smtCommand().setZ3(m_queryTimeout, _enablePreprocessing, m_computeInvariants);
 }
 
-std::tuple<CheckResult, Expression, CHCSolverInterface::CexGraph> Z3CHCSmtLib2Interface::query(smtutil::Expression const& _block)
+CHCSolverInterface::QueryResult Z3CHCSmtLib2Interface::query(smtutil::Expression const& _block)
 {
 	setupSmtCallback(true);
 	std::string query = dumpQuery(_block);

--- a/libsolidity/formal/Z3CHCSmtLib2Interface.h
+++ b/libsolidity/formal/Z3CHCSmtLib2Interface.h
@@ -35,7 +35,7 @@ public:
 private:
 	void setupSmtCallback(bool _disablePreprocessing);
 
-	std::tuple<smtutil::CheckResult, smtutil::Expression, CexGraph> query(smtutil::Expression const& _expr) override;
+	CHCSolverInterface::QueryResult query(smtutil::Expression const& _expr) override;
 
 	CHCSolverInterface::CexGraph graphFromZ3Answer(std::string const& _proof) const;
 


### PR DESCRIPTION
Instead of working with tuple, we give the query result its own struct, to properly name it and its components.