### PR TITLE
SMTChecker: Prepare BMC engine for switching Z3 to SMT-LIB Interface.

### DIFF
--- a/libsmtutil/SMTLib2Interface.h
+++ b/libsmtutil/SMTLib2Interface.h
@@ -103,7 +103,6 @@ protected:
 	void declareFunction(std::string const& _name, SortPointer const& _sort);
 
 	std::string checkSatAndGetValuesCommand(std::vector<Expression> const& _expressionsToEvaluate);
-	std::vector<std::string> parseValues(std::string::const_iterator _start, std::string::const_iterator _end);
 
 	/// Communicates with the solver via the callback. Throws SMTSolverError on error.
 	std::string querySolver(std::string const& _input);

--- a/libsolidity/formal/Z3SMTLib2Interface.cpp
+++ b/libsolidity/formal/Z3SMTLib2Interface.cpp
@@ -1,0 +1,35 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libsolidity/formal/Z3SMTLib2Interface.h>
+
+#include <libsolidity/interface/UniversalCallback.h>
+
+using namespace solidity::frontend::smt;
+
+Z3SMTLib2Interface::Z3SMTLib2Interface(
+	frontend::ReadCallback::Callback _smtCallback,
+	std::optional<unsigned int> _queryTimeout
+): SMTLib2Interface({}, std::move(_smtCallback), _queryTimeout)
+{
+}
+
+void Z3SMTLib2Interface::setupSmtCallback() {
+	if (auto* universalCallback = m_smtCallback.target<frontend::UniversalCallback>())
+		universalCallback->smtCommand().setZ3(m_queryTimeout, true, false);
+}

--- a/libsolidity/formal/Z3SMTLib2Interface.h
+++ b/libsolidity/formal/Z3SMTLib2Interface.h
@@ -1,0 +1,37 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libsmtutil/SMTLib2Interface.h>
+
+namespace solidity::frontend::smt
+{
+
+class Z3SMTLib2Interface: public smtutil::SMTLib2Interface
+{
+public:
+	explicit Z3SMTLib2Interface(
+		frontend::ReadCallback::Callback _smtCallback = {},
+		std::optional<unsigned> _queryTimeout = {}
+	);
+private:
+	void setupSmtCallback() override;
+};
+
+}


### PR DESCRIPTION
This PR prepares the BMC engine for the switch from Z3 as a library to Z3 using SMT-LIB interface.
Separated from #15252.

The PR consists of two commits.
One adds the new interface class that BMC engine will use instead of `Z3Interface`.

The other one fixes parsing of model values in BMC.
SMT solvers return model values as pairs (enclosed in parentheses) of name and value.
Previous way of parsing model values relied on finding the next closing bracket. However, this does not work for negative numbers, which are themselves wrapped in parentheses, e.g. (- 1).
We can now use our SMT-LIB parser to parse these values properly.

