### PR TITLE
Propagate `AssemblyException` message

### DIFF
--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -1348,9 +1348,9 @@ void CompilerStack::assembleYul(
 		// Assemble deployment (incl. runtime)  object.
 		compiledContract.object = compiledContract.evmAssembly->assemble();
 	}
-	catch (evmasm::AssemblyException const&)
+	catch (evmasm::AssemblyException const& error)
 	{
-		solAssert(false, "Assembly exception for bytecode");
+		solAssert(false, "Assembly exception for bytecode: "s + error.what());
 	}
 	solAssert(compiledContract.object.immutableReferences.empty(), "Leftover immutables.");
 
@@ -1361,9 +1361,9 @@ void CompilerStack::assembleYul(
 		// Assemble runtime object.
 		compiledContract.runtimeObject = compiledContract.evmRuntimeAssembly->assemble();
 	}
-	catch (evmasm::AssemblyException const&)
+	catch (evmasm::AssemblyException const& error)
 	{
-		solAssert(false, "Assembly exception for deployed bytecode");
+		solAssert(false, "Assembly exception for deployed bytecode"s + error.what());
 	}
 
 	// Throw a warning if EIP-170 limits are exceeded:


### PR DESCRIPTION
Related to https://github.com/ethereum/solidity/issues/15004#issuecomment-2048012406

Fixes the minor annoyance which is that the `AssemblyException`s thrown from `Assembly` have their message discarded and we only see a generic one, which makes locating the problem harder. Especially given that the source line points at the handler which intercepted the error and not at the point where the error occurred.

With this fix the output looks like this:
```
Internal compiler error:
/solidity/libsolidity/interface/CompilerStack.cpp(1353): Throw in function void solidity::frontend::CompilerStack::assembleYul(const solidity::frontend::ContractDefinition&, std::shared_ptr<solidity::evmasm::Assembly>, std::shared_ptr<solidity::evmasm::Assembly>)
Dynamic exception type: boost::wrapexcept<solidity::langutil::InternalCompilerError>
std::exception::what: Assembly exception for bytecode: Tag too large for reserved space.
[solidity::util::tag_comment*] = Assembly exception for bytecode: Tag too large for reserved space.
```

By the way, error reporting in `Assembly` generally sucks. We should get rid of this `assertThrow()` thing (or rename it). Most of the checks there should be just regular asserts and `AssemblyException` should only be thrown for actual errors that can legitimately happen during compilation. I did not attempt to fix that though. The PR is only a quick patch for the immediate problem.