### PR TITLE
Tweak advanced CMake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ option(PROFILE_OPTIMIZER_STEPS "Output performance metrics for the optimiser ste
 option(USE_SYSTEM_LIBRARIES "Use system libraries" OFF)
 option(ONLY_BUILD_SOLIDITY_LIBRARIES "Only build solidity libraries" OFF)
 option(STRICT_NLOHMANN_JSON_VERSION "Strictly check installed nlohmann json version" ON)
+mark_as_advanced(PROFILE_OPTIMIZER_STEPS)
 mark_as_advanced(USE_SYSTEM_LIBRARIES)
 mark_as_advanced(ONLY_BUILD_SOLIDITY_LIBRARIES)
 mark_as_advanced(STRICT_NLOHMANN_JSON_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,11 +39,9 @@ option(PEDANTIC "Enable extra warnings and pedantic build flags. Treat all warni
 option(PROFILE_OPTIMIZER_STEPS "Output performance metrics for the optimiser steps." OFF)
 option(USE_SYSTEM_LIBRARIES "Use system libraries" OFF)
 option(ONLY_BUILD_SOLIDITY_LIBRARIES "Only build solidity libraries" OFF)
-option(STRICT_NLOHMANN_JSON_VERSION "Strictly check installed nlohmann json version" ON)
 mark_as_advanced(PROFILE_OPTIMIZER_STEPS)
 mark_as_advanced(USE_SYSTEM_LIBRARIES)
 mark_as_advanced(ONLY_BUILD_SOLIDITY_LIBRARIES)
-mark_as_advanced(STRICT_NLOHMANN_JSON_VERSION)
 
 # Setup cccache.
 include(EthCcache)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,10 +37,19 @@ option(SOLC_STATIC_STDLIBS "Link solc against static versions of libgcc and libs
 option(STRICT_Z3_VERSION "Use the latest version of Z3" ON)
 option(PEDANTIC "Enable extra warnings and pedantic build flags. Treat all warnings as errors." ON)
 option(PROFILE_OPTIMIZER_STEPS "Output performance metrics for the optimiser steps." OFF)
-option(USE_SYSTEM_LIBRARIES "Use system libraries" OFF)
-option(ONLY_BUILD_SOLIDITY_LIBRARIES "Only build solidity libraries" OFF)
+option(
+	IGNORE_VENDORED_DEPENDENCIES
+	"Ignore libraries provided as submodules of the repository and allow CMake to look for \
+them in the typical locations, including system-wide dirs."
+	OFF
+)
+option(
+	ONLY_BUILD_SOLIDITY_LIBRARIES
+	"Only build library targets that can be statically linked against. Do not build executables or tests."
+	OFF
+)
 mark_as_advanced(PROFILE_OPTIMIZER_STEPS)
-mark_as_advanced(USE_SYSTEM_LIBRARIES)
+mark_as_advanced(IGNORE_VENDORED_DEPENDENCIES)
 mark_as_advanced(ONLY_BUILD_SOLIDITY_LIBRARIES)
 
 # Setup cccache.
@@ -48,7 +57,7 @@ include(EthCcache)
 
 # Let's find our dependencies
 include(EthDependencies)
-if (NOT USE_SYSTEM_LIBRARIES)
+if (NOT IGNORE_VENDORED_DEPENDENCIES)
   include(fmtlib)
   include(nlohmann-json)
   include(range-v3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 option(SOLC_LINK_STATIC "Link solc executable statically on supported platforms" OFF)
 option(SOLC_STATIC_STDLIBS "Link solc against static versions of libgcc and libstdc++ on supported platforms" OFF)
-option(STRICT_Z3_VERSION "Use the latest version of Z3" ON)
+option(STRICT_Z3_VERSION "Require the exact version of Z3 solver expected by our test suite." ON)
 option(PEDANTIC "Enable extra warnings and pedantic build flags. Treat all warnings as errors." ON)
 option(PROFILE_OPTIMIZER_STEPS "Output performance metrics for the optimiser steps." OFF)
 option(
@@ -94,15 +94,15 @@ configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/license.h.in" include/lice
 
 include(EthOptions)
 configure_project(TESTS)
-set(LATEST_Z3_VERSION "4.12.1")
+set(TESTED_Z3_VERSION "4.12.1")
 set(MINIMUM_Z3_VERSION "4.8.16")
 find_package(Z3)
 if (${Z3_FOUND})
   if (${STRICT_Z3_VERSION})
-    if (NOT ("${Z3_VERSION_STRING}" VERSION_EQUAL ${LATEST_Z3_VERSION}))
+    if (NOT ("${Z3_VERSION_STRING}" VERSION_EQUAL ${TESTED_Z3_VERSION}))
       message(
         FATAL_ERROR
-        "SMTChecker tests require Z3 ${LATEST_Z3_VERSION} for all tests to pass.\n\
+        "SMTChecker tests require Z3 ${TESTED_Z3_VERSION} for all tests to pass.\n\
 Build with -DSTRICT_Z3_VERSION=OFF if you want to use a different version. \
 You can also use -DUSE_Z3=OFF to build without Z3. In both cases use --no-smt when running tests."
       )

--- a/cmake/submodules.cmake
+++ b/cmake/submodules.cmake
@@ -1,5 +1,5 @@
 macro(initialize_submodule SUBMODULE_PATH)
-	if(NOT USE_SYSTEM_LIBRARIES)
+	if(NOT IGNORE_VENDORED_DEPENDENCIES)
 		file(GLOB submodule_contents "${CMAKE_SOURCE_DIR}/deps/${SUBMODULE_PATH}/*")
 
 		if(submodule_contents)

--- a/libsolutil/JSON.cpp
+++ b/libsolutil/JSON.cpp
@@ -28,12 +28,6 @@
 
 #include <sstream>
 
-#ifdef STRICT_NLOHMANN_JSON_VERSION_CHECK
-static_assert(
-	(NLOHMANN_JSON_VERSION_MAJOR == 3) && (NLOHMANN_JSON_VERSION_MINOR == 11) && (NLOHMANN_JSON_VERSION_PATCH == 3),
-	"Unexpected nlohmann-json version. Expecting 3.11.3.");
-#endif
-
 namespace solidity::util
 {
 


### PR DESCRIPTION
Some tweaks to names and descriptions of options added in #15195. See https://github.com/ethereum/solidity/pull/15081#issuecomment-2100797921 for context.

I'd like to get that in before the release, while the options are still relatively fresh so that we're not stuck with them as is forever.