### PR TITLE
`b_alpine_docker` CI run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1830,6 +1830,22 @@ jobs:
       - matrix_notify_failure_unless_pr
       - matrix_notify_release_unless_pr
 
+  b_alpine_docker:
+    <<: *base_cimg_small
+    steps:
+      - setup_remote_docker:
+          # Always build from scratch to use current packages.
+          # This job is only meant to run nightly so build time is not an issue.
+          docker_layer_caching: false
+      - checkout
+      - run:
+          name: Build and tag the container
+          command: scripts/docker_deploy_manual.sh develop "file://$PWD" --no-push
+      - run:
+          name: Smoke test
+          command: docker run --pull=never ethereum/solc:build-alpine --version
+      - matrix_notify_failure_unless_pr
+
 workflows:
   version: 2
 
@@ -2008,6 +2024,9 @@ workflows:
       # Deprecated EVM versions tests
       - b_ubu: *requires_nothing
       - t_ubu_soltest_deprecated_evm_versions: *requires_b_ubu
+
+      # Build in a Docker container (on Alpine Linux)
+      - b_alpine_docker: *requires_nothing
 
   nightly-ossfuzz:
 

--- a/scripts/docker_deploy_manual.sh
+++ b/scripts/docker_deploy_manual.sh
@@ -21,7 +21,7 @@ cd solidity
 commithash=$(git rev-parse --short=8 HEAD)
 echo -n "$commithash" > commit_hash.txt
 version=$("$(dirname "$0")/get_version.sh")
-if [ "$branch" = "release" ] || [ "$branch" = v"$version" ]
+if [ "$branch" = v"$version" ]
 then
     echo -n > prerelease.txt
 else

--- a/scripts/docker_deploy_manual.sh
+++ b/scripts/docker_deploy_manual.sh
@@ -28,7 +28,7 @@ DIR=$(mktemp -d)
 (
 cd "$DIR"
 
-git clone --recursive --depth 2 "$repo_url" -b "$branch"
+git clone --recursive --depth 2 "$repo_url" -b "$branch" solidity
 cd solidity
 commithash=$(git rev-parse --short=8 HEAD)
 echo -n "$commithash" > commit_hash.txt

--- a/scripts/docker_deploy_manual.sh
+++ b/scripts/docker_deploy_manual.sh
@@ -47,13 +47,13 @@ function tag_and_push
 }
 
 rm -rf .git
-docker build -t "$image":build -f scripts/Dockerfile .
+docker build -t "$image":build -f scripts/Dockerfile . --progress plain
 tmp_container=$(docker create "$image":build sh)
 
 # Alpine image
 mkdir -p upload
 docker cp "${tmp_container}":/usr/bin/solc upload/solc-static-linux
-docker build -t "$image":build-alpine -f scripts/Dockerfile_alpine .
+docker build -t "$image":build-alpine -f scripts/Dockerfile_alpine . --progress plain
 
 if [ "$branch" = "develop" ]
 then

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -6,7 +6,7 @@
 ## You can pass a branch name as argument to this script (which, if no argument is given,
 ## will default to "develop").
 ##
-## If the given branch is "release", the resulting package will be uploaded to
+## If the given branch matches a release version tag, the resulting package will be uploaded to
 ## ethereum/ethereum PPA, or ethereum/ethereum-dev PPA otherwise.
 ##
 ## It will clone the Solidity git from github, determine the version,


### PR DESCRIPTION
Fixes #14816.

The PR makes it possible to run `docker_deploy_manual.sh` without getting a new checkout of the repo or pushing the resulting image. With that we can run the build in CI and avoid breakage suddenly appearing during releases.

I'm also removing support for the `release` branch, which we no longer use.

Still a draft, because I made it run in PRs to test it. When it succeeds, I'm going to remove the commit that enables it and make it reviewable.