### PR TITLE
Remove mantic from release PPA script (obsolete).

### DIFF
--- a/scripts/deps-ppa/static_z3.sh
+++ b/scripts/deps-ppa/static_z3.sh
@@ -41,7 +41,7 @@ sourcePPAConfig
 # Sanity check
 checkDputEntries "\[cpp-build-deps\]"
 
-DISTRIBUTIONS="focal jammy mantic noble"
+DISTRIBUTIONS="focal jammy noble oracular"
 
 for distribution in $DISTRIBUTIONS
 do

--- a/scripts/release_ppa.sh
+++ b/scripts/release_ppa.sh
@@ -68,7 +68,7 @@ packagename=solc
 # This needs to be a still active release
 static_build_distribution=focal
 
-DISTRIBUTIONS="focal jammy mantic noble"
+DISTRIBUTIONS="focal jammy noble oracular"
 
 if is_release
 then


### PR DESCRIPTION
New mantic packages are rejected since mantic is EOL.
Adding oracular (24.10) even though it's unreleased as of yet (we should watch the build in https://launchpad.net/~ethereum/+archive/ubuntu/ethereum-dev/+packages - but since it's unreleased oracular is not live yet, it failing wouldn't be a blocker)