### PR TITLE
chore(build): prefer system deps for fmt/nlohmann_json/range-v3

### DIFF
--- a/cmake/fmtlib.cmake
+++ b/cmake/fmtlib.cmake
@@ -1,9 +1,14 @@
-include(${CMAKE_SOURCE_DIR}/cmake/submodules.cmake)
-initialize_submodule(fmtlib)
-
+find_package(fmt QUIET)
 set(FMT_SYSTEM_HEADERS ON)
-add_subdirectory(
-	${CMAKE_SOURCE_DIR}/deps/fmtlib
-	EXCLUDE_FROM_ALL
-)
 
+if(fmt_FOUND)
+	message(STATUS "Using system-installed fmt library")
+else()
+	# Fallback to submodule if fmt is not found
+	include(${CMAKE_SOURCE_DIR}/cmake/submodules.cmake)
+	initialize_submodule(fmtlib)
+	add_subdirectory(
+		${CMAKE_SOURCE_DIR}/deps/fmtlib
+		EXCLUDE_FROM_ALL
+	)
+endif()

--- a/cmake/nlohmann-json.cmake
+++ b/cmake/nlohmann-json.cmake
@@ -1,9 +1,14 @@
-include(${CMAKE_SOURCE_DIR}/cmake/submodules.cmake)
-initialize_submodule(nlohmann-json)
+find_package(nlohmann_json QUIET)
 
 set(JSON_Install OFF CACHE INTERNAL "")
-add_subdirectory(
-	${CMAKE_SOURCE_DIR}/deps/nlohmann-json
-	EXCLUDE_FROM_ALL
-)
 
+if(nlohmann_json_FOUND)
+	message(STATUS "Using system-installed nlohmann-json library")
+else()
+	include(${CMAKE_SOURCE_DIR}/cmake/submodules.cmake)
+	initialize_submodule(nlohmann-json)
+	add_subdirectory(
+		${CMAKE_SOURCE_DIR}/deps/nlohmann-json
+		EXCLUDE_FROM_ALL
+	)
+endif()

--- a/cmake/range-v3.cmake
+++ b/cmake/range-v3.cmake
@@ -1,11 +1,16 @@
-include(${CMAKE_SOURCE_DIR}/cmake/submodules.cmake)
-initialize_submodule(range-v3)
+find_package(range-v3 QUIET)
 
-add_library(range-v3 INTERFACE IMPORTED)
-set_target_properties(range-v3 PROPERTIES
-	INTERFACE_COMPILE_OPTIONS "\$<\$<CXX_COMPILER_ID:MSVC>:/permissive->"
-	INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR}/deps/range-v3/include
-	INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR}/deps/range-v3/include
-)
-add_dependencies(range-v3 range-v3-project)
+if(range-v3_FOUND)
+	message(STATUS "Using system-installed range-v3 library")
+else()
+	include(${CMAKE_SOURCE_DIR}/cmake/submodules.cmake)
+	initialize_submodule(range-v3)
 
+	add_library(range-v3 INTERFACE IMPORTED)
+	set_target_properties(range-v3 PROPERTIES
+		INTERFACE_COMPILE_OPTIONS "\$<\$<CXX_COMPILER_ID:MSVC>:/permissive->"
+		INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR}/deps/range-v3/include
+		INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR}/deps/range-v3/include
+	)
+	add_dependencies(range-v3 range-v3-project)
+endif()


### PR DESCRIPTION
While [regression build solidity](https://github.com/Homebrew/homebrew-core/pull/183889), I saw it always pull the deps rather than using the system deps, thus updating the build to prefer system deps