### PR TITLE
SMTChecker: Fix SMT logic error when assigning to an array of addresses

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@ Compiler Features:
 
 
 Bugfixes:
-
+ * SMTChecker: Fix SMT logic error when assigning to an array of addresses.
 
 ### 0.8.27 (2024-09-04)
 

--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -118,6 +118,10 @@ SortPointer smtSort(frontend::Type const& _type)
 				// use a common sort for functions so pure and view modifier do not cause conflicting SMT types
 				// solc handles types mismtach
 				tupleName = "function";
+			else if (isAddress(*baseType))
+				// use a common sort for address and address payable so it does not cause conflicting SMT types
+				// solc handles types mismtach
+				tupleName = "address";
 			else if (
 				baseType->category() == frontend::Type::Category::Integer ||
 				baseType->category() == frontend::Type::Category::FixedPoint

--- a/test/libsolidity/smtCheckerTests/types/array_of_addresses.sol
+++ b/test/libsolidity/smtCheckerTests/types/array_of_addresses.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity >=0.0.0;
+contract C {
+	address[10] a;
+	address payable[10] b;
+
+	function f() public {
+		a = b;
+		assert(a[0] == b[0]);
+	}
+}
+// ====
+// SMTEngine: all
+// ----
+// Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.


### PR DESCRIPTION
There was a SMT logic error when assigning a value of  `address payable[]` type to a variable of type `address[]`.

Closes https://github.com/ethereum/solidity/issues/15308
look at this comment: https://github.com/ethereum/solidity/issues/15308#issuecomment-2332905155