### PR TITLE
Remove STRICT_NLOHMANN_JSON_VERSION_CHECK leftover.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,10 +73,6 @@ if (PROFILE_OPTIMIZER_STEPS)
     add_definitions(-DPROFILE_OPTIMIZER_STEPS)
 endif()
 
-if (STRICT_NLOHMANN_JSON_VERSION)
-	add_definitions(-DSTRICT_NLOHMANN_JSON_VERSION_CHECK)
-endif()
-
 # Figure out what compiler and system are we using
 include(EthCompilerSettings)
 


### PR DESCRIPTION
We forgot to remove the `STRICT_NLOHMANN_JSON_VERSION_CHECK` define in https://github.com/ethereum/solidity/pull/15377.