### PR TITLE
Yul: Fix removal of trivial phi functions in SSA CFG Builder

### DIFF
--- a/libyul/backends/evm/SSAControlFlowGraphBuilder.h
+++ b/libyul/backends/evm/SSAControlFlowGraphBuilder.h
@@ -73,6 +73,8 @@ public:
 	SSACFG::ValueId operator()(Literal const& _literal);
 
 private:
+	void cleanUnreachable();
+	SSACFG::ValueId tryRemoveTrivialPhi(SSACFG::ValueId _phi);
 	void assign(std::vector<std::reference_wrapper<Scope::Variable const>> _variables, Expression const* _expression);
 	std::vector<SSACFG::ValueId> visitFunctionCall(FunctionCall const& _call);
 
@@ -80,7 +82,6 @@ private:
 	SSACFG::ValueId readVariable(Scope::Variable const& _variable, SSACFG::BlockId _block);
 	SSACFG::ValueId readVariableRecursive(Scope::Variable const& _variable, SSACFG::BlockId _block);
 	SSACFG::ValueId addPhiOperands(Scope::Variable const& _variable, SSACFG::ValueId _phi);
-	SSACFG::ValueId tryRemoveTrivialPhi(SSACFG::ValueId _phi);
 	void writeVariable(Scope::Variable const& _variable, SSACFG::BlockId _block, SSACFG::ValueId _value);
 
 	SSACFG& m_graph;

--- a/libyul/backends/evm/SSAControlFlowGraphBuilder.h
+++ b/libyul/backends/evm/SSAControlFlowGraphBuilder.h
@@ -17,6 +17,15 @@
 // SPDX-License-Identifier: GPL-3.0
 /**
 * Transformation of a Yul AST into a control flow graph.
+*
+* Based on https://doi.org/10.1007/978-3-642-37051-9_6
+* Braun, Matthias, et al. "Simple and efficient construction of static single assignment form."
+* Compiler Construction: 22nd International Conference, CC 2013,
+* ETAPS 2013, Rome, Italy, March 16-24, 2013. Proceedings 22. Springer Berlin Heidelberg, 2013.
+*
+* We have small deviations in Algorithms 2 and 4, as the paper's presentation leads to trivial phis being spuriously
+* removed from not yet sealed blocks via a call to addPhiOperands in Algorithm 4. Instead, we perform the deletion
+* of trivial phis only after a block has been sealed, i.e., all block's predecessors are present.
 */
 #pragma once
 

--- a/test/libyul/yulSSAControlFlowGraph/complex.yul
+++ b/test/libyul/yulSSAControlFlowGraph/complex.yul
@@ -87,7 +87,7 @@
 // Block1_4 [label="\
 // Block 4\nsstore(3084, 12)\l\
 // "];
-// Block1_4Exit [label="FunctionReturn[v17]"];
+// Block1_4Exit [label="FunctionReturn[0]"];
 // Block1_4 -> Block1_4Exit;
 // Block1_6 [label="\
 // Block 6\nsstore(514, 2)\l\
@@ -105,7 +105,7 @@
 // Block1_9 [label="\
 // Block 9\nsstore(1028, 4)\l\
 // "];
-// Block1_9Exit [label="FunctionReturn[v17]"];
+// Block1_9Exit [label="FunctionReturn[0]"];
 // Block1_9 -> Block1_9Exit;
 // Block1_10 [label="\
 // Block 10\nv20 := eq(2, v6)\l\
@@ -168,7 +168,7 @@
 // Block1_20 [label="\
 // Block 20\nsstore(v43, 0)\l\
 // "];
-// Block1_20Exit [label="FunctionReturn[v45]"];
+// Block1_20Exit [label="FunctionReturn[0]"];
 // Block1_20 -> Block1_20Exit;
 // Block1_21 [label="\
 // Block 21\nsstore(65535, 255)\l\

--- a/test/libyul/yulSSAControlFlowGraph/complex.yul
+++ b/test/libyul/yulSSAControlFlowGraph/complex.yul
@@ -66,22 +66,22 @@
 // Block1_0Exit [label="Jump" shape=oval];
 // Block1_0Exit -> Block1_1;
 // Block1_1 [label="\
-// Block 1\nv4 := φ(\l\
+// Block 1\nv5 := φ(\l\
 // 	Block 0 => 42,\l\
 // 	Block 21 => v43\l\
 // )\l\
-// v5 := lt(v0, v4)\l\
+// v6 := lt(v0, v5)\l\
 // "];
 // Block1_1 -> Block1_1Exit;
-// Block1_1Exit [label="{ If v5| { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_1Exit [label="{ If v6| { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_1Exit:0 -> Block1_4;
 // Block1_1Exit:1 -> Block1_2;
 // Block1_2 [label="\
-// Block 2\nv6 := mload(v4)\l\
-// v7 := eq(0, v6)\l\
+// Block 2\nv7 := mload(v5)\l\
+// v8 := eq(0, v7)\l\
 // "];
 // Block1_2 -> Block1_2Exit;
-// Block1_2Exit [label="{ If v7| { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_2Exit [label="{ If v8| { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_2Exit:0 -> Block1_7;
 // Block1_2Exit:1 -> Block1_6;
 // Block1_4 [label="\
@@ -96,7 +96,7 @@
 // Block1_6Exit [label="Jump" shape=oval];
 // Block1_6Exit -> Block1_4;
 // Block1_7 [label="\
-// Block 7\nv13 := eq(1, v6)\l\
+// Block 7\nv13 := eq(1, v7)\l\
 // "];
 // Block1_7 -> Block1_7Exit;
 // Block1_7Exit [label="{ If v13| { <0> Zero | <1> NonZero }}" shape=Mrecord];
@@ -108,7 +108,7 @@
 // Block1_9Exit [label="FunctionReturn[0]"];
 // Block1_9 -> Block1_9Exit;
 // Block1_10 [label="\
-// Block 10\nv20 := eq(2, v6)\l\
+// Block 10\nv20 := eq(2, v7)\l\
 // "];
 // Block1_10 -> Block1_10Exit;
 // Block1_10Exit [label="{ If v20| { <0> Zero | <1> NonZero }}" shape=Mrecord];
@@ -121,7 +121,7 @@
 // Block1_12Exit [label="Terminated"];
 // Block1_12 -> Block1_12Exit;
 // Block1_13 [label="\
-// Block 13\nv25 := eq(3, v6)\l\
+// Block 13\nv25 := eq(3, v7)\l\
 // "];
 // Block1_13 -> Block1_13Exit;
 // Block1_13Exit [label="{ If v25| { <0> Zero | <1> NonZero }}" shape=Mrecord];
@@ -158,7 +158,7 @@
 // Block1_18Exit [label="Jump" shape=oval];
 // Block1_18Exit -> Block1_5;
 // Block1_3 [label="\
-// Block 3\nv43 := add(1, v4)\l\
+// Block 3\nv43 := add(1, v5)\l\
 // v44 := calldataload(v43)\l\
 // "];
 // Block1_3 -> Block1_3Exit;

--- a/test/libyul/yulSSAControlFlowGraph/complex2.yul
+++ b/test/libyul/yulSSAControlFlowGraph/complex2.yul
@@ -121,7 +121,7 @@
 // Block1_9 [label="\
 // Block 9\nsstore(1028, 4)\l\
 // "];
-// Block1_9Exit [label="FunctionReturn[v17]"];
+// Block1_9Exit [label="FunctionReturn[0]"];
 // Block1_9 -> Block1_9Exit;
 // Block1_10 [label="\
 // Block 10\nv20 := eq(2, v6)\l\
@@ -184,7 +184,7 @@
 // Block1_20 [label="\
 // Block 20\nsstore(v43, 0)\l\
 // "];
-// Block1_20Exit [label="FunctionReturn[v45]"];
+// Block1_20Exit [label="FunctionReturn[0]"];
 // Block1_20 -> Block1_20Exit;
 // Block1_21 [label="\
 // Block 21\nsstore(65535, 255)\l\

--- a/test/libyul/yulSSAControlFlowGraph/complex2.yul
+++ b/test/libyul/yulSSAControlFlowGraph/complex2.yul
@@ -82,22 +82,22 @@
 // Block1_0Exit [label="Jump" shape=oval];
 // Block1_0Exit -> Block1_1;
 // Block1_1 [label="\
-// Block 1\nv4 := φ(\l\
+// Block 1\nv5 := φ(\l\
 // 	Block 0 => 42,\l\
 // 	Block 21 => v43\l\
 // )\l\
-// v5 := lt(v0, v4)\l\
+// v6 := lt(v0, v5)\l\
 // "];
 // Block1_1 -> Block1_1Exit;
-// Block1_1Exit [label="{ If v5| { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_1Exit [label="{ If v6| { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_1Exit:0 -> Block1_4;
 // Block1_1Exit:1 -> Block1_2;
 // Block1_2 [label="\
-// Block 2\nv6 := mload(v4)\l\
-// v7 := eq(0, v6)\l\
+// Block 2\nv7 := mload(v5)\l\
+// v8 := eq(0, v7)\l\
 // "];
 // Block1_2 -> Block1_2Exit;
-// Block1_2Exit [label="{ If v7| { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_2Exit [label="{ If v8| { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_2Exit:0 -> Block1_7;
 // Block1_2Exit:1 -> Block1_6;
 // Block1_4 [label="\
@@ -112,7 +112,7 @@
 // Block1_6Exit [label="Jump" shape=oval];
 // Block1_6Exit -> Block1_4;
 // Block1_7 [label="\
-// Block 7\nv13 := eq(1, v6)\l\
+// Block 7\nv13 := eq(1, v7)\l\
 // "];
 // Block1_7 -> Block1_7Exit;
 // Block1_7Exit [label="{ If v13| { <0> Zero | <1> NonZero }}" shape=Mrecord];
@@ -124,7 +124,7 @@
 // Block1_9Exit [label="FunctionReturn[0]"];
 // Block1_9 -> Block1_9Exit;
 // Block1_10 [label="\
-// Block 10\nv20 := eq(2, v6)\l\
+// Block 10\nv20 := eq(2, v7)\l\
 // "];
 // Block1_10 -> Block1_10Exit;
 // Block1_10Exit [label="{ If v20| { <0> Zero | <1> NonZero }}" shape=Mrecord];
@@ -137,7 +137,7 @@
 // Block1_12Exit [label="Terminated"];
 // Block1_12 -> Block1_12Exit;
 // Block1_13 [label="\
-// Block 13\nv25 := eq(3, v6)\l\
+// Block 13\nv25 := eq(3, v7)\l\
 // "];
 // Block1_13 -> Block1_13Exit;
 // Block1_13Exit [label="{ If v25| { <0> Zero | <1> NonZero }}" shape=Mrecord];
@@ -174,7 +174,7 @@
 // Block1_18Exit [label="Jump" shape=oval];
 // Block1_18Exit -> Block1_5;
 // Block1_3 [label="\
-// Block 3\nv43 := add(1, v4)\l\
+// Block 3\nv43 := add(1, v5)\l\
 // v44 := calldataload(v43)\l\
 // "];
 // Block1_3 -> Block1_3Exit;

--- a/test/libyul/yulSSAControlFlowGraph/function.yul
+++ b/test/libyul/yulSSAControlFlowGraph/function.yul
@@ -37,10 +37,10 @@
 //  r := f(v0, v1)"];
 // FunctionEntry_f_0 -> Block1_0;
 // Block1_0 [label="\
-// Block 0\nv2 := add(v1, v0)\l\
-// v3 := sub(v0, v2)\l\
+// Block 0\nv3 := add(v1, v0)\l\
+// v4 := sub(v0, v3)\l\
 // "];
-// Block1_0Exit [label="FunctionReturn[v3]"];
+// Block1_0Exit [label="FunctionReturn[v4]"];
 // Block1_0 -> Block1_0Exit;
 // FunctionEntry_g_0 [label="function g:
 //  g()"];

--- a/test/libyul/yulSSAControlFlowGraph/nested_for.yul
+++ b/test/libyul/yulSSAControlFlowGraph/nested_for.yul
@@ -55,10 +55,6 @@
 // 	Block 2 => 0,\l\
 // 	Block 7 => v35\l\
 // )\l\
-// v33 := φ(\l\
-// 	Block 2 => v2,\l\
-// 	Block 7 => v18\l\
-// )\l\
 // v5 := lt(3, v4)\l\
 // "];
 // Block0_5 -> Block0_5Exit;
@@ -80,14 +76,6 @@
 // 	Block 6 => 0,\l\
 // 	Block 11 => v31\l\
 // )\l\
-// v17 := φ(\l\
-// 	Block 6 => v4,\l\
-// 	Block 11 => v32\l\
-// )\l\
-// v18 := φ(\l\
-// 	Block 6 => v33,\l\
-// 	Block 11 => v34\l\
-// )\l\
 // v7 := lt(3, v6)\l\
 // "];
 // Block0_9 -> Block0_9Exit;
@@ -95,7 +83,7 @@
 // Block0_9Exit:0 -> Block0_12;
 // Block0_9Exit:1 -> Block0_10;
 // Block0_3 [label="\
-// Block 3\nv36 := add(1, v33)\l\
+// Block 3\nv36 := add(1, v2)\l\
 // "];
 // Block0_3 -> Block0_3Exit [arrowhead=none];
 // Block0_3Exit [label="Jump" shape=oval];
@@ -117,25 +105,13 @@
 // Block0_13Exit [label="Jump" shape=oval];
 // Block0_13Exit -> Block0_15;
 // Block0_14 [label="\
-// Block 14\nv27 := φ(\l\
-// 	Block 10 => v6,\l\
-// 	Block 18 => v10\l\
-// )\l\
-// v28 := φ(\l\
-// 	Block 10 => v17,\l\
-// 	Block 18 => v11\l\
-// )\l\
-// v29 := φ(\l\
-// 	Block 10 => v18,\l\
-// 	Block 18 => v12\l\
-// )\l\
-// "];
+// Block 14\n"];
 // Block0_14 -> Block0_14Exit;
 // Block0_14Exit [label="{ If 1| { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block0_14Exit:0 -> Block0_20;
 // Block0_14Exit:1 -> Block0_19;
 // Block0_7 [label="\
-// Block 7\nv35 := add(1, v17)\l\
+// Block 7\nv35 := add(1, v4)\l\
 // "];
 // Block0_7 -> Block0_7Exit [arrowhead=none];
 // Block0_7Exit [label="Jump" shape=oval];
@@ -157,24 +133,12 @@
 // Block0_19Exit [label="Jump" shape=oval];
 // Block0_19Exit -> Block0_21;
 // Block0_20 [label="\
-// Block 20\nv30 := φ(\l\
-// 	Block 14 => v27,\l\
-// 	Block 24 => v21\l\
-// )\l\
-// v32 := φ(\l\
-// 	Block 14 => v28,\l\
-// 	Block 24 => v22\l\
-// )\l\
-// v34 := φ(\l\
-// 	Block 14 => v29,\l\
-// 	Block 24 => v23\l\
-// )\l\
-// "];
+// Block 20\n"];
 // Block0_20 -> Block0_20Exit [arrowhead=none];
 // Block0_20Exit [label="Jump" shape=oval];
 // Block0_20Exit -> Block0_11;
 // Block0_16 [label="\
-// Block 16\nv13 := add(v17, v18)\l\
+// Block 16\nv13 := add(v4, v2)\l\
 // v14 := add(v6, v13)\l\
 // sstore(v14, v8)\l\
 // "];
@@ -198,7 +162,7 @@
 // Block0_21Exit:0 -> Block0_24;
 // Block0_21Exit:1 -> Block0_22;
 // Block0_11 [label="\
-// Block 11\nv31 := add(1, v30)\l\
+// Block 11\nv31 := add(1, v6)\l\
 // "];
 // Block0_11 -> Block0_11Exit [arrowhead=none];
 // Block0_11Exit [label="Jump" shape=oval];
@@ -210,8 +174,8 @@
 // Block0_17Exit [label="Jump" shape=oval];
 // Block0_17Exit -> Block0_15;
 // Block0_22 [label="\
-// Block 22\nv24 := add(v28, v29)\l\
-// v25 := add(v27, v24)\l\
+// Block 22\nv24 := add(v4, v2)\l\
+// v25 := add(v6, v24)\l\
 // sstore(v25, v19)\l\
 // "];
 // Block0_22 -> Block0_22Exit [arrowhead=none];


### PR DESCRIPTION
previously could lead to dangling (undeclared) variables from removed phi functions