### PR TITLE
Per-contract output selection in `CompilerStack`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Language Features:
 Compiler Features:
  * Code Generator: Transient storage value type state variables are now supported.
  * General: Generate JSON representations of Yul ASTs only on demand to reduce memory usage.
+ * Standard JSON Interface: Bytecode or IR can now be requested for a subset of all contracts without triggering unnecessary code generation for other contracts.
 
 
 Bugfixes:

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -313,7 +313,9 @@ void CompilerStack::reset(bool _keepSettings)
 		m_libraries.clear();
 		m_viaIR = false;
 		m_evmVersion = langutil::EVMVersion();
+		m_eofVersion.reset();
 		m_modelCheckerSettings = ModelCheckerSettings{};
+		m_requestedContractNames.clear();
 		m_irOutputSelection = IROutputSelection::None;
 		m_revertStrings = RevertStrings::Default;
 		m_optimiserSettings = OptimiserSettings::minimal();
@@ -321,6 +323,7 @@ void CompilerStack::reset(bool _keepSettings)
 		m_metadataFormat = defaultMetadataFormat();
 		m_metadataHash = MetadataHash::IPFS;
 		m_stopAfter = State::CompilationSuccessful;
+		m_compilationSourceType = CompilationSourceType::Solidity;
 	}
 	m_experimentalAnalysis.reset();
 	m_globalContext.reset();

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -150,21 +150,6 @@ Json formatErrorWithException(
 	return error;
 }
 
-std::map<std::string, std::set<std::string>> requestedContractNames(Json const& _outputSelection)
-{
-	std::map<std::string, std::set<std::string>> contracts;
-	for (auto const& [sourceName, _]: _outputSelection.items())
-	{
-		std::string key = (sourceName == "*") ? "" : sourceName;
-		for (auto const& [contractName, _]: _outputSelection[sourceName].items())
-		{
-			std::string value = (contractName == "*") ? "" : contractName;
-			contracts[key].insert(value);
-		}
-	}
-	return contracts;
-}
-
 /// Returns true iff @a _hash (hex with 0x prefix) is the Keccak256 hash of the binary data in @a _content.
 bool hashMatchesContent(std::string const& _hash, std::string const& _content)
 {
@@ -298,26 +283,45 @@ bool isEvmBytecodeRequested(Json const& _outputSelection)
 	return false;
 }
 
-/// @returns The IR output selection for CompilerStack, based on outputs requested in the JSON.
+/// @returns The set of selected contracts, along with their compiler pipeline configuration, based
+/// on outputs requested in the JSON. Translates wildcards to the ones understood by CompilerStack.
 /// Note that as an exception, '*' does not yet match "ir", "irAst", "irOptimized" or "irOptimizedAst".
-CompilerStack::IROutputSelection irOutputSelection(Json const& _outputSelection)
+CompilerStack::ContractSelection pipelineConfig(
+	Json const& _jsonOutputSelection
+)
 {
-	if (!_outputSelection.is_object())
-		return CompilerStack::IROutputSelection::None;
+	if (!_jsonOutputSelection.is_object())
+		return {};
 
-	CompilerStack::IROutputSelection selection = CompilerStack::IROutputSelection::None;
-	for (auto const& fileRequests: _outputSelection)
-		for (auto const& requests: fileRequests)
-			for (auto const& request: requests)
+	CompilerStack::ContractSelection contractSelection;
+	for (auto const& [sourceUnitName, jsonOutputSelectionForSource]: _jsonOutputSelection.items())
+	{
+		solAssert(jsonOutputSelectionForSource.is_object());
+		for (auto const& [contractName, jsonOutputSelectionForContract]: jsonOutputSelectionForSource.items())
+		{
+			solAssert(jsonOutputSelectionForContract.is_array());
+			CompilerStack::PipelineConfig pipelineForContract;
+			for (Json const& request: jsonOutputSelectionForContract)
 			{
-				if (request == "irOptimized" || request == "irOptimizedAst" || request == "yulCFGJson")
-					return CompilerStack::IROutputSelection::UnoptimizedAndOptimized;
-
-				if (request == "ir" || request == "irAst")
-					selection = CompilerStack::IROutputSelection::UnoptimizedOnly;
+				solAssert(request.is_string());
+				pipelineForContract.irOptimization =
+					pipelineForContract.irOptimization ||
+					request == "irOptimized" ||
+					request == "irOptimizedAst" ||
+					request == "yulCFGJson";
+				pipelineForContract.irCodegen =
+					pipelineForContract.irCodegen ||
+					pipelineForContract.irOptimization ||
+					request == "ir" ||
+					request == "irAst";
+				pipelineForContract.bytecode = isEvmBytecodeRequested(_jsonOutputSelection);
 			}
-
-	return selection;
+			std::string key = (sourceUnitName == "*") ? "" : sourceUnitName;
+			std::string value = (contractName == "*") ? "" : contractName;
+			contractSelection[key][value] = pipelineForContract;
+		}
+	}
+	return contractSelection;
 }
 
 Json formatLinkReferences(std::map<size_t, std::string> const& linkReferences)
@@ -1321,11 +1325,8 @@ Json StandardCompiler::compileSolidity(StandardCompiler::InputsAndSettings _inpu
 	compilerStack.useMetadataLiteralSources(_inputsAndSettings.metadataLiteralSources);
 	compilerStack.setMetadataFormat(_inputsAndSettings.metadataFormat);
 	compilerStack.setMetadataHash(_inputsAndSettings.metadataHash);
-	compilerStack.setRequestedContractNames(requestedContractNames(_inputsAndSettings.outputSelection));
+	compilerStack.selectContracts(pipelineConfig(_inputsAndSettings.outputSelection));
 	compilerStack.setModelCheckerSettings(_inputsAndSettings.modelCheckerSettings);
-
-	compilerStack.enableEvmBytecodeGeneration(isEvmBytecodeRequested(_inputsAndSettings.outputSelection));
-	compilerStack.requestIROutputs(irOutputSelection(_inputsAndSettings.outputSelection));
 
 	Json errors = std::move(_inputsAndSettings.errors);
 

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -1434,7 +1434,7 @@ Json StandardCompiler::compileSolidity(StandardCompiler::InputsAndSettings _inpu
 	Json output;
 
 	if (errors.size() > 0)
-	output["errors"] = std::move(errors);
+		output["errors"] = std::move(errors);
 
 	if (!compilerStack.unhandledSMTLib2Queries().empty())
 		for (std::string const& query: compilerStack.unhandledSMTLib2Queries())

--- a/test/libsolidity/SolidityExecutionFramework.cpp
+++ b/test/libsolidity/SolidityExecutionFramework.cpp
@@ -60,7 +60,6 @@ bytes SolidityExecutionFramework::multiSourceCompileContract(
 	m_compiler.setEVMVersion(m_evmVersion);
 	m_compiler.setEOFVersion(m_eofVersion);
 	m_compiler.setOptimiserSettings(m_optimiserSettings);
-	m_compiler.enableEvmBytecodeGeneration(true);
 	m_compiler.setViaIR(m_compileViaYul);
 	m_compiler.setRevertStringBehaviour(m_revertStrings);
 	if (!m_appendCBORMetadata) {


### PR DESCRIPTION
Fixes #15373.
Depends on #15447.

Turned out to be less tedious than expected, though TBH contract and output selection feels like something that shouldn't really be a part of `CompilerStack` and should sit in `StandardCompiler` instead.