### PR TITLE
EOF: Refactor `assemble` functions in `evmasm::Assembly`

### DIFF
--- a/libevmasm/Assembly.h
+++ b/libevmasm/Assembly.h
@@ -47,6 +47,12 @@ using AssemblyPointer = std::shared_ptr<Assembly>;
 
 class Assembly
 {
+	using TagRefs = std::map<size_t, std::pair<size_t, size_t>>;
+	using DataRefs = std::multimap<util::h256, unsigned>;
+	using SubAssemblyRefs = std::multimap<size_t, size_t>;
+	using ProgramSizeRefs = std::vector<unsigned>;
+	using LinkRef = std::pair<size_t, std::string>;
+
 public:
 	Assembly(langutil::EVMVersion _evmVersion, bool _creation, std::optional<uint8_t> _eofVersion, std::string _name):
 		m_evmVersion(_evmVersion),
@@ -234,6 +240,14 @@ private:
 
 	/// Returns map from m_subs to an index of subcontainer in the final EOF bytecode
 	std::map<uint16_t, uint16_t> findReferencedContainers() const;
+
+	/// Assemble bytecode for AssemblyItem type.
+	[[nodiscard]] bytes assembleOperation(AssemblyItem const& _item) const;
+	[[nodiscard]] bytes assemblePush(AssemblyItem const& _item) const;
+	[[nodiscard]] std::pair<bytes, Assembly::LinkRef> assemblePushLibraryAddress(AssemblyItem const& _item, size_t _pos) const;
+	[[nodiscard]] bytes assembleVerbatimBytecode(AssemblyItem const& item) const;
+	[[nodiscard]] bytes assemblePushDeployTimeAddress() const;
+	[[nodiscard]] bytes assembleTag(AssemblyItem const& _item, size_t _pos, bool _addJumpDest) const;
 
 protected:
 	/// 0 is reserved for exception

--- a/libevmasm/LinkerObject.h
+++ b/libevmasm/LinkerObject.h
@@ -34,6 +34,7 @@ namespace solidity::evmasm
  */
 struct LinkerObject
 {
+	using ImmutableRefs = std::pair<std::string, std::vector<size_t>>;
 	/// The bytecode.
 	bytes bytecode;
 
@@ -43,7 +44,7 @@ struct LinkerObject
 
 	/// Map from hashes of the identifiers of immutable variables to the full identifier of the immutable and
 	/// to a list of offsets into the bytecode that refer to their values.
-	std::map<u256, std::pair<std::string, std::vector<size_t>>> immutableReferences;
+	std::map<u256, ImmutableRefs> immutableReferences;
 
 	struct FunctionDebugData
 	{

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -349,7 +349,7 @@ Json formatLinkReferences(std::map<size_t, std::string> const& linkReferences)
 	return ret;
 }
 
-Json formatImmutableReferences(std::map<u256, std::pair<std::string, std::vector<size_t>>> const& _immutableReferences)
+Json formatImmutableReferences(std::map<u256, evmasm::LinkerObject::ImmutableRefs> const& _immutableReferences)
 {
 	Json ret = Json::object();
 


### PR DESCRIPTION
- Separate common code from `assembleLegacy` and `assebleEOF` to be reused.
- Separate big and unreadable `switch`s to corresponding functions.