### PR TITLE
EOF: Support strict assembly output and source mapping for EOF

### DIFF
--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -403,12 +403,13 @@ void Assembly::assemblyStream(
 {
 	Functionalizer f(_out, _prefix, _sourceCodes, *this);
 
-	// TODO: support EOF
-	solUnimplementedAssert(!m_eofVersion.has_value(), "Assembly output for EOF is not yet implemented.");
-	solAssert(m_codeSections.size() == 1);
 	for (auto const& i: m_codeSections.front().items)
 		f.feed(i, _debugInfoSelection);
 	f.flush();
+
+	// Implementing this requires introduction of CALLF, RETF and JUMPF
+	if (m_codeSections.size() > 1)
+		solUnimplemented("Add support for more code sections");
 
 	if (!m_data.empty() || !m_subs.empty())
 	{

--- a/libevmasm/AssemblyItem.cpp
+++ b/libevmasm/AssemblyItem.cpp
@@ -450,9 +450,10 @@ std::string AssemblyItem::computeSourceMapping(
 			static_cast<int>(_sourceIndicesMap.at(*location.sourceName)) :
 			-1;
 		char jump = '-';
-		if (item.getJumpType() == evmasm::AssemblyItem::JumpType::IntoFunction)
+		// TODO: Uncomment when EOF functions introduced.
+		if (item.getJumpType() == evmasm::AssemblyItem::JumpType::IntoFunction /*|| item.type() == CallF || item.type() == JumpF*/)
 			jump = 'i';
-		else if (item.getJumpType() == evmasm::AssemblyItem::JumpType::OutOfFunction)
+		else if (item.getJumpType() == evmasm::AssemblyItem::JumpType::OutOfFunction /*|| item.type() == RetF*/)
 			jump = 'o';
 		int modifierDepth = static_cast<int>(item.m_modifierDepth);
 

--- a/libyul/YulStack.cpp
+++ b/libyul/YulStack.cpp
@@ -262,15 +262,14 @@ YulStack::assembleWithDeployed(std::optional<std::string_view> _deployName)
 		creationObject.bytecode = std::make_shared<evmasm::LinkerObject>(creationAssembly->assemble());
 		yulAssert(creationObject.bytecode->immutableReferences.empty(), "Leftover immutables.");
 		creationObject.assembly = creationAssembly;
-		solUnimplementedAssert(!m_eofVersion.has_value(), "EVM assembly output not implemented for EOF yet.");
-		solAssert(creationAssembly->codeSections().size() == 1);
-		creationObject.sourceMappings = std::make_unique<std::string>(
-			// TODO: fix for EOF
-			evmasm::AssemblyItem::computeSourceMapping(
-				creationAssembly->codeSections().front().items,
+		creationObject.sourceMappings = std::make_unique<std::string>();
+		for (auto const& codeSection: creationAssembly->codeSections())
+		{
+			*creationObject.sourceMappings += evmasm::AssemblyItem::computeSourceMapping(
+				codeSection.items,
 				{{m_charStream->name(), 0}}
-			)
-		);
+			);
+		}
 
 		if (deployedAssembly)
 		{

--- a/test/cmdlineTests/strict_asm_eof_container_prague/args
+++ b/test/cmdlineTests/strict_asm_eof_container_prague/args
@@ -1,1 +1,1 @@
- --strict-assembly --experimental-eof-version 1 --evm-version prague --bin
+ --strict-assembly --experimental-eof-version 1 --evm-version prague --asm --ir-optimized --bin --debug-info none

--- a/test/cmdlineTests/strict_asm_eof_container_prague/output
+++ b/test/cmdlineTests/strict_asm_eof_container_prague/output
@@ -1,5 +1,103 @@
 
 ======= strict_asm_eof_container_prague/input.yul (EVM) =======
 
+Pretty printed source:
+object "object" {
+    code { { revert(0, 0) } }
+    object "sub0" {
+        code {
+            {
+                mstore(0, 0)
+                revert(0, 32)
+            }
+        }
+    }
+    object "sub1" {
+        code {
+            {
+                mstore(0, 1)
+                revert(0, 32)
+            }
+        }
+    }
+    object "sub2" {
+        code {
+            {
+                mstore(0, 2)
+                revert(0, 32)
+            }
+        }
+        object "sub20" {
+            code {
+                {
+                    mstore(0, 0x20)
+                    revert(0, 32)
+                }
+            }
+        }
+    }
+    object "sub3" {
+        code {
+            {
+                mstore(0, 3)
+                revert(0, 32)
+            }
+        }
+    }
+}
+
+
 Binary representation:
 ef00010100040200010003030004001a001b003b001b040000000080ffff5f80fdef00010100040200010007040000000080ffff5f805260205ffdef00010100040200010008040000000080ffff60015f5260205ffdef00010100040200010008030001001b040000000080ffff60025f5260205ffdef00010100040200010008040000000080ffff60205f5260205ffdef00010100040200010008040000000080ffff60035f5260205ffd
+
+Text representation:
+  0x00
+  dup1
+  revert
+stop
+
+sub_0: assembly {
+      0x00
+      dup1
+      mstore
+      0x20
+      0x00
+      revert
+}
+
+sub_1: assembly {
+      0x01
+      0x00
+      mstore
+      0x20
+      0x00
+      revert
+}
+
+sub_2: assembly {
+      0x02
+      0x00
+      mstore
+      0x20
+      0x00
+      revert
+    stop
+
+    sub_0: assembly {
+          0x20
+          0x00
+          mstore
+          0x20
+          0x00
+          revert
+    }
+}
+
+sub_3: assembly {
+      0x03
+      0x00
+      mstore
+      0x20
+      0x00
+      revert
+}


### PR DESCRIPTION
- Support `--asm` output for EOF (no code sections yet) Code sections support requires introduction of code section related opcodes `CALLF`, `RETF` and `JUMPF`
- Update test.

~Depends on #15446~. Merged.