### PR TITLE
Benchmarking compiler's peak memory use

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -359,6 +359,6 @@ function gnu_time_to_json_file
     "$gnu_time_path" \
         --output "$time_file" \
         --quiet \
-        --format '{"real": %e, "user": %U, "sys": %S, "exit": %x}' \
+        --format '{"real": %e, "user": %U, "sys": %S, "mem": %M, "exit": %x}' \
             "${cmd[@]}"
 }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -327,7 +327,7 @@ function gnu_grep
 
 function time_to_json_file
 {
-    local output_file="$1"
+    local time_file="$1"
     local cmd=("${@:2}")
     (( $# >= 2 )) || assertFail
 
@@ -340,9 +340,25 @@ function time_to_json_file
     {
         {
             time { "${cmd[@]}" 1>&3 2>&4; }
-        } 2> "$output_file"
+        } 2> "$time_file"
     } 3>&1 4>&2
 
     # Restore original format so that it does not spill outside of the function.
     TIMEFORMAT="$original_timeformat"
+}
+
+function gnu_time_to_json_file
+{
+    local time_file="$1"
+    local cmd=("${@:2}")
+    (( $# >= 2 )) || assertFail
+
+    local gnu_time_path
+    gnu_time_path=$(type -P time)
+
+    "$gnu_time_path" \
+        --output "$time_file" \
+        --quiet \
+        --format '{"real": %e, "user": %U, "sys": %S, "exit": %x}' \
+            "${cmd[@]}"
 }

--- a/test/benchmarks/external.sh
+++ b/test/benchmarks/external.sh
@@ -65,10 +65,11 @@ function benchmark_project {
         > /dev/null \
         2> "../stderr-${project}-${pipeline}.log" || true
 
-    printf '| %-20s | %8s | %7d s | %9d |\n' \
+    printf '| %-20s | %8s | %7d s | %9d MiB | %9d |\n' \
         "$project" \
         "$pipeline" \
         "$(jq '(.user + .sys) | round' "$time_file")" \
+        "$(jq '.mem / 1024 | round' "$time_file")" \
         "$(jq '.exit' "$time_file")"
     cd ..
 }
@@ -85,8 +86,8 @@ benchmarks=(
 mkdir -p "$BENCHMARK_DIR"
 cd "$BENCHMARK_DIR"
 
-echo "| Project              | Pipeline | Time      | Exit code |"
-echo "|----------------------|----------|----------:|----------:|"
+echo "| Project              | Pipeline | Time      | Memory (peak) | Exit code |"
+echo "|----------------------|----------|----------:|--------------:|----------:|"
 
 for project in "${benchmarks[@]}"; do
     benchmark_project legacy "$project"

--- a/test/benchmarks/external.sh
+++ b/test/benchmarks/external.sh
@@ -65,7 +65,7 @@ function benchmark_project {
         > /dev/null \
         2> "../stderr-${project}-${pipeline}.log" || true
 
-    printf '| %-20s | %8s | %7d s | %9d MiB | %9d |\n' \
+    printf '| %-20s | %8s | %6d s | %9d MiB | %9d |\n' \
         "$project" \
         "$pipeline" \
         "$(jq '(.user + .sys) | round' "$time_file")" \
@@ -86,8 +86,8 @@ benchmarks=(
 mkdir -p "$BENCHMARK_DIR"
 cd "$BENCHMARK_DIR"
 
-echo "| Project              | Pipeline | Time      | Memory (peak) | Exit code |"
-echo "|----------------------|----------|----------:|--------------:|----------:|"
+echo "|         File         | Pipeline |   Time   | Memory (peak) | Exit code |"
+echo "|----------------------|----------|---------:|--------------:|----------:|"
 
 for project in "${benchmarks[@]}"; do
     benchmark_project legacy "$project"

--- a/test/benchmarks/external.sh
+++ b/test/benchmarks/external.sh
@@ -65,10 +65,10 @@ function benchmark_project {
         > /dev/null \
         2> "../stderr-${project}-${pipeline}.log" || true
 
-    printf '| %-20s | %8s | %7s s | %9d |\n' \
+    printf '| %-20s | %8s | %7d s | %9d |\n' \
         "$project" \
         "$pipeline" \
-        "$(jq '.real' "$time_file")" \
+        "$(jq '(.user + .sys) | round' "$time_file")" \
         "$(jq '.exit' "$time_file")"
     cd ..
 }

--- a/test/benchmarks/local.sh
+++ b/test/benchmarks/local.sh
@@ -60,18 +60,19 @@ function benchmark_contract {
         > "${output_dir}/bytecode-${pipeline}.bin" \
         2>> "${output_dir}/benchmark-warn-err.txt" || [[ $pipeline == legacy ]]
 
-    printf '| %-20s | %s   | %7d bytes | %6.2f s | %9d |\n' \
+    printf '| %-20s | %s   | %7d bytes | %6.2f s | %9d MiB | %9d |\n' \
         '`'"$input_file"'`' \
         "$pipeline" \
         "$(bytecode_size < "${output_dir}/bytecode-${pipeline}.bin")" \
         "$(jq '(.user + .sys) * 100 | round / 100' "$time_file")" \
+        "$(jq '.mem / 1024 | round' "$time_file")" \
         "$(jq '.exit' "$time_file")"
 }
 
 benchmarks=("verifier.sol" "OptimizorClub.sol" "chains.sol")
 
-echo "| File                 | Pipeline | Bytecode size | Time     | Exit code |"
-echo "|----------------------|----------|--------------:|---------:|----------:|"
+echo "| File                 | Pipeline | Bytecode size | Time     | Memory (peak) | Exit code |"
+echo "|----------------------|----------|--------------:|---------:|--------------:|----------:|"
 
 for input_file in "${benchmarks[@]}"
 do

--- a/test/benchmarks/local.sh
+++ b/test/benchmarks/local.sh
@@ -51,7 +51,7 @@ function benchmark_contract {
     local input_path="$2"
 
     local solc_command=("${solc}" --optimize --bin --color "${input_path}")
-    [[ $pipeline == via-ir ]] && solc_command+=(--via-ir)
+    [[ $pipeline == ir ]] && solc_command+=(--via-ir)
     local time_file="${output_dir}/time-and-status-${pipeline}.txt"
 
     # NOTE: Legacy pipeline may fail with "Stack too deep" in some cases. That's fine.
@@ -60,7 +60,7 @@ function benchmark_contract {
         > "${output_dir}/bytecode-${pipeline}.bin" \
         2>> "${output_dir}/benchmark-warn-err.txt" || [[ $pipeline == legacy ]]
 
-    printf '| %-20s | %s   | %7d bytes | %6.2f s | %9d MiB | %9d |\n' \
+    printf '| %-20s | %8s | %7d bytes | %6.2f s | %9d MiB | %9d |\n' \
         '`'"$input_file"'`' \
         "$pipeline" \
         "$(bytecode_size < "${output_dir}/bytecode-${pipeline}.bin")" \
@@ -71,13 +71,13 @@ function benchmark_contract {
 
 benchmarks=("verifier.sol" "OptimizorClub.sol" "chains.sol")
 
-echo "| File                 | Pipeline | Bytecode size | Time     | Memory (peak) | Exit code |"
+echo "|         File         | Pipeline | Bytecode size |   Time   | Memory (peak) | Exit code |"
 echo "|----------------------|----------|--------------:|---------:|--------------:|----------:|"
 
 for input_file in "${benchmarks[@]}"
 do
     benchmark_contract legacy "${REPO_ROOT}/test/benchmarks/${input_file}"
-    benchmark_contract via-ir "${REPO_ROOT}/test/benchmarks/${input_file}"
+    benchmark_contract ir     "${REPO_ROOT}/test/benchmarks/${input_file}"
 done
 
 echo

--- a/test/benchmarks/local.sh
+++ b/test/benchmarks/local.sh
@@ -60,11 +60,11 @@ function benchmark_contract {
         > "${output_dir}/bytecode-${pipeline}.bin" \
         2>> "${output_dir}/benchmark-warn-err.txt" || [[ $pipeline == legacy ]]
 
-    printf '| %-20s | %s   | %7d bytes | %6s s | %9d |\n' \
+    printf '| %-20s | %s   | %7d bytes | %6.2f s | %9d |\n' \
         '`'"$input_file"'`' \
         "$pipeline" \
         "$(bytecode_size < "${output_dir}/bytecode-${pipeline}.bin")" \
-        "$(jq '.real' "$time_file")" \
+        "$(jq '(.user + .sys) * 100 | round / 100' "$time_file")" \
         "$(jq '.exit' "$time_file")"
 }
 


### PR DESCRIPTION
This PR adds an extra column showing maximum resident set size of the process during its lifetime, as reported by `/usr/bin/time`. In local benchmarks this is `solc` alone, while in external ones this is the whole `forge` command.

It also updates the scripts to report the CPU time rather than wall clock time. Since solc is single-threaded they should mostly match but CPU time is what we're really interested in (we could very easily start reporting both if that ever changes).

Also small tweaks, like time rounding in external benchmarks or cosmetic changes to how table looks.