### PR TITLE
Do not store JSON Yul ASTs and Yul CFG in `CompilerStack`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Language Features:
 
 Compiler Features:
  * Code Generator: Transient storage value type state variables are now supported by the legacy pipeline.
+ * General: Generate JSON representations of Yul ASTs only on demand to reduce memory usage.
 
 
 Bugfixes:

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -71,6 +71,11 @@ class AssemblyItem;
 using AssemblyItems = std::vector<AssemblyItem>;
 }
 
+namespace solidity::yul
+{
+class YulStack;
+}
+
 namespace solidity::frontend
 {
 
@@ -489,6 +494,11 @@ private:
 	/// Links all the known library addresses in the available objects. Any unknown
 	/// library will still be kept as an unlinked placeholder in the objects.
 	void link();
+
+	/// Parses and analyzes specified Yul source and returns the YulStack that can be used to manipulate it.
+	/// Assumes that the IR was generated from sources loaded currently into CompilerStack, which
+	/// means that it is error-free and uses the same settings.
+	yul::YulStack loadGeneratedIR(std::string const& _ir) const;
 
 	/// @returns the contract object for the given @a _contractName.
 	/// Can only be called after state is CompilationSuccessful.

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -295,15 +295,15 @@ public:
 	std::string const& yulIR(std::string const& _contractName) const;
 
 	/// @returns the IR representation of a contract AST in format.
-	Json const& yulIRAst(std::string const& _contractName) const;
+	Json yulIRAst(std::string const& _contractName) const;
 
 	/// @returns the optimized IR representation of a contract.
 	std::string const& yulIROptimized(std::string const& _contractName) const;
 
 	/// @returns the optimized IR representation of a contract AST in JSON format.
-	Json const& yulIROptimizedAst(std::string const& _contractName) const;
+	Json yulIROptimizedAst(std::string const& _contractName) const;
 
-	Json const& yulCFGJson(std::string const& _contractName) const;
+	Json yulCFGJson(std::string const& _contractName) const;
 
 	/// @returns the assembled object for a contract.
 	virtual evmasm::LinkerObject const& object(std::string const& _contractName) const override;
@@ -416,9 +416,6 @@ private:
 		evmasm::LinkerObject runtimeObject; ///< Runtime object.
 		std::string yulIR; ///< Yul IR code straight from the code generator.
 		std::string yulIROptimized; ///< Reparsed and possibly optimized Yul IR code.
-		Json yulIRAst; ///< JSON AST of Yul IR code.
-		Json yulIROptimizedAst; ///< JSON AST of optimized Yul IR code.
-		Json yulCFGJson; ///< JSON CFG of Yul IR code.
 		util::LazyInit<std::string const> metadata; ///< The metadata json that will be hashed into the chain.
 		util::LazyInit<Json const> abi;
 		util::LazyInit<Json const> storageLayout;


### PR DESCRIPTION
~Depends on #15457.~ Merged.

This fixes excessive memory usage due to JSON representation of Yul ASTs and Yul CFG being always calculated from IR, even if not requested as an output.

The PR fixes the problem by changing `CompilerStack` so that these artifacts are only prepared when requested by CLI or `StandardCompiler`. This requires reparsing the IR from scratch each time (and the PR *does not* go out of its way to ensure it's parsed only once if multiple ASTs are requested), but Yul parsing is generally fast and these artifacts are not needed in the typical Solidity development workflow anyway.

### Effects
This has a huge impact on memory usage and also non-negligible impact on running time.

For example when compiling Uniswap using our [external benchmarks](https://github.com/ethereum/solidity/blob/develop/test/benchmarks/external.sh), disabling generation of this data makes it go from 143 s and 5 GB RAM down to 115 s and 1.5 GB RAM.

I've been noticing the aggressive RAM usage for a while now, to the point that I had to be careful when running the external benchmarks - compiling Eigenlayer or Sablier sometimes required more than 30 GB RAM and would crash on my machine.