### PR TITLE
Add missing ASAN runtime libraries

### DIFF
--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2404.clang
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2404.clang
@@ -22,7 +22,7 @@
 # (c) 2016-2024 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:noble AS base
-LABEL version="1"
+LABEL version="2"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -40,13 +40,14 @@ RUN set -ex; \
 		clang \
 		cmake \
 		jq \
-		lsof \
 		libboost-filesystem-dev \
 		libboost-program-options-dev \
 		libboost-system-dev \
 		libboost-test-dev \
+		libclang-rt-dev \
 		libcln-dev \
 		libz3-static-dev \
+		lsof \
 		ninja-build \
 		python3-pip \
 		software-properties-common \


### PR DESCRIPTION
This package [libclang-rt-dev](https://ubuntu.pkgs.org/24.04/ubuntu-universe-amd64/libclang-rt-18-dev_18.1.3-1_amd64.deb.html) which contains the sanitizer runtimes is missing in our ubuntu 24.04 clang image, causing problems like: https://app.circleci.com/pipelines/github/ethereum/solidity/36095/workflows/642d1bc0-2c10-48d8-a8c3-0c6812a177cf/jobs/1644834

After installing the runtime libraries, I was able to successfully build the image locally.