### PR TITLE
Fix shift in Yul AST native src locations due to code snippets in debug info

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,8 @@ Compiler Features:
 
 Bugfixes:
  * SMTChecker: Fix SMT logic error when assigning to an array of addresses.
+ * Yul AST: Fix shifted native source locations when debug info selection included code snippets.
+
 
 ### 0.8.27 (2024-09-04)
 

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -30,7 +30,7 @@
 #include <libsolidity/codegen/ABIFunctions.h>
 #include <libsolidity/codegen/CompilerUtils.h>
 
-#include <libyul/YulStack.h>
+#include <libyul/Object.h>
 #include <libyul/Utilities.h>
 
 #include <libsolutil/Algorithms.h>

--- a/libsolidity/experimental/codegen/IRGenerator.cpp
+++ b/libsolidity/experimental/codegen/IRGenerator.cpp
@@ -27,7 +27,6 @@
 
 #include <libsolidity/experimental/ast/TypeSystemHelper.h>
 
-#include <libyul/YulStack.h>
 #include <libyul/AsmPrinter.h>
 #include <libyul/AST.h>
 #include <libyul/optimiser/ASTCopier.h>

--- a/libsolidity/experimental/codegen/IRGeneratorForStatements.cpp
+++ b/libsolidity/experimental/codegen/IRGeneratorForStatements.cpp
@@ -25,9 +25,9 @@
 
 #include <libsolidity/experimental/ast/TypeSystemHelper.h>
 
-#include <libyul/YulStack.h>
 #include <libyul/AsmPrinter.h>
 #include <libyul/AST.h>
+#include <libyul/backends/evm/EVMDialect.h>
 #include <libyul/optimiser/ASTCopier.h>
 
 #include <libsolidity/experimental/codegen/Common.h>

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -1522,6 +1522,7 @@ void CompilerStack::generateIR(ContractDefinition const& _contract, bool _unopti
 		YulStack::Language::StrictAssembly,
 		m_optimiserSettings,
 		m_debugInfoSelection,
+		this, // _soliditySourceProvider
 		m_objectOptimizer
 	);
 	bool yulAnalysisSuccessful = stack.parseAndAnalyze("", compiledContract.yulIR);
@@ -1537,7 +1538,7 @@ void CompilerStack::generateIR(ContractDefinition const& _contract, bool _unopti
 	if (!_unoptimizedOnly)
 	{
 		stack.optimize();
-		compiledContract.yulIROptimized = stack.print(this);
+		compiledContract.yulIROptimized = stack.print();
 		compiledContract.yulIROptimizedAst = stack.astJson();
 	}
 }
@@ -1561,6 +1562,7 @@ void CompilerStack::generateEVMFromIR(ContractDefinition const& _contract)
 		yul::YulStack::Language::StrictAssembly,
 		m_optimiserSettings,
 		m_debugInfoSelection,
+		this, // _soliditySourceProvider
 		m_objectOptimizer
 	);
 	bool analysisSuccessful = stack.parseAndAnalyze("", compiledContract.yulIROptimized);

--- a/libyul/YulStack.cpp
+++ b/libyul/YulStack.cpp
@@ -211,10 +211,10 @@ void YulStack::reparse()
 	yulAssert(m_parserResult);
 	yulAssert(m_charStream);
 
-	// NOTE: Without passing in _soliditySourceProvider, printed debug info will not include code
-	// snippets, but it does not matter - we'll still get the same AST after we parse it. Snippets
-	// are not stored in the AST and the other info that is (location, AST ID, etc) will still be present.
-	std::string source = print(nullptr /* _soliditySourceProvider */);
+	// NOTE: it is important for the source printed here to exactly match what the compiler will
+	// eventually output to the user. In particular, debug info must be exactly the same.
+	// Otherwise source locations will be off.
+	std::string source = print();
 
 	YulStack cleanStack(
 		m_evmVersion,

--- a/libyul/YulStack.cpp
+++ b/libyul/YulStack.cpp
@@ -216,7 +216,15 @@ void YulStack::reparse()
 	// are not stored in the AST and the other info that is (location, AST ID, etc) will still be present.
 	std::string source = print(nullptr /* _soliditySourceProvider */);
 
-	YulStack cleanStack(m_evmVersion, m_eofVersion, m_language, m_optimiserSettings, m_debugInfoSelection, m_objectOptimizer);
+	YulStack cleanStack(
+		m_evmVersion,
+		m_eofVersion,
+		m_language,
+		m_optimiserSettings,
+		m_debugInfoSelection,
+		m_soliditySourceProvider,
+		m_objectOptimizer
+	);
 	bool reanalysisSuccessful = cleanStack.parseAndAnalyze(m_charStream->name(), source);
 	yulAssert(
 		reanalysisSuccessful,
@@ -348,16 +356,14 @@ YulStack::assembleEVMWithDeployed(std::optional<std::string_view> _deployName)
 	return {std::make_shared<evmasm::Assembly>(assembly), {}};
 }
 
-std::string YulStack::print(
-	CharStreamProvider const* _soliditySourceProvider
-) const
+std::string YulStack::print() const
 {
 	yulAssert(m_stackState >= Parsed);
 	yulAssert(m_parserResult, "");
 	yulAssert(m_parserResult->hasCode(), "");
 	return m_parserResult->toString(
 		m_debugInfoSelection,
-		_soliditySourceProvider
+		m_soliditySourceProvider
 	) + "\n";
 }
 

--- a/libyul/YulStack.h
+++ b/libyul/YulStack.h
@@ -90,6 +90,7 @@ public:
 		Language _language,
 		solidity::frontend::OptimiserSettings _optimiserSettings,
 		langutil::DebugInfoSelection const& _debugInfoSelection,
+		langutil::CharStreamProvider const* _soliditySourceProvider = nullptr,
 		std::shared_ptr<ObjectOptimizer> _objectOptimizer = nullptr
 	):
 		m_language(_language),
@@ -97,6 +98,7 @@ public:
 		m_eofVersion(_eofVersion),
 		m_optimiserSettings(std::move(_optimiserSettings)),
 		m_debugInfoSelection(_debugInfoSelection),
+		m_soliditySourceProvider(_soliditySourceProvider),
 		m_errorReporter(m_errors),
 		m_objectOptimizer(_objectOptimizer ? std::move(_objectOptimizer) : std::make_shared<ObjectOptimizer>())
 	{}
@@ -137,9 +139,7 @@ public:
 	bool hasErrors() const { return m_errorReporter.hasErrors(); }
 
 	/// Pretty-print the input after having parsed it.
-	std::string print(
-		langutil::CharStreamProvider const* _soliditySourceProvider = nullptr
-	) const;
+	std::string print() const;
 	Json astJson() const;
 
 	// return the JSON representation of the YuL CFG (experimental)
@@ -171,6 +171,11 @@ private:
 	std::optional<uint8_t> m_eofVersion;
 	solidity::frontend::OptimiserSettings m_optimiserSettings;
 	langutil::DebugInfoSelection m_debugInfoSelection{};
+
+	/// Provider of the Solidity sources that the Yul code was generated from.
+	/// Necessary when code snippets are requested as a part of debug info. When null, code snippets are omitted.
+	/// NOTE: Not owned by YulStack, the user must ensure that it is not destroyed before the stack is.
+	langutil::CharStreamProvider const* m_soliditySourceProvider{};
 
 	std::unique_ptr<langutil::CharStream> m_charStream;
 

--- a/test/cmdlineTests/ast_ir/output
+++ b/test/cmdlineTests/ast_ir/output
@@ -637,24 +637,24 @@ Optimized IR AST:
 {
     "code": {
         "block": {
-            "nativeSrc": "58:298:0",
+            "nativeSrc": "58:315:0",
             "nodeType": "YulBlock",
             "src": "-1:-1:0",
             "statements": [
                 {
-                    "nativeSrc": "68:282:0",
+                    "nativeSrc": "68:299:0",
                     "nodeType": "YulBlock",
                     "src": "-1:-1:0",
                     "statements": [
                         {
-                            "nativeSrc": "111:27:0",
+                            "nativeSrc": "128:27:0",
                             "nodeType": "YulVariableDeclaration",
                             "src": "60:13:0",
                             "value": {
                                 "arguments": [
                                     {
                                         "kind": "number",
-                                        "nativeSrc": "133:4:0",
+                                        "nativeSrc": "150:4:0",
                                         "nodeType": "YulLiteral",
                                         "src": "60:13:0",
                                         "type": "",
@@ -663,18 +663,18 @@ Optimized IR AST:
                                 ],
                                 "functionName": {
                                     "name": "memoryguard",
-                                    "nativeSrc": "121:11:0",
+                                    "nativeSrc": "138:11:0",
                                     "nodeType": "YulIdentifier",
                                     "src": "60:13:0"
                                 },
-                                "nativeSrc": "121:17:0",
+                                "nativeSrc": "138:17:0",
                                 "nodeType": "YulFunctionCall",
                                 "src": "60:13:0"
                             },
                             "variables": [
                                 {
                                     "name": "_1",
-                                    "nativeSrc": "115:2:0",
+                                    "nativeSrc": "132:2:0",
                                     "nodeType": "YulTypedName",
                                     "src": "60:13:0",
                                     "type": ""
@@ -686,7 +686,7 @@ Optimized IR AST:
                                 "arguments": [
                                     {
                                         "kind": "number",
-                                        "nativeSrc": "158:2:0",
+                                        "nativeSrc": "175:2:0",
                                         "nodeType": "YulLiteral",
                                         "src": "60:13:0",
                                         "type": "",
@@ -694,28 +694,28 @@ Optimized IR AST:
                                     },
                                     {
                                         "name": "_1",
-                                        "nativeSrc": "162:2:0",
+                                        "nativeSrc": "179:2:0",
                                         "nodeType": "YulIdentifier",
                                         "src": "60:13:0"
                                     }
                                 ],
                                 "functionName": {
                                     "name": "mstore",
-                                    "nativeSrc": "151:6:0",
+                                    "nativeSrc": "168:6:0",
                                     "nodeType": "YulIdentifier",
                                     "src": "60:13:0"
                                 },
-                                "nativeSrc": "151:14:0",
+                                "nativeSrc": "168:14:0",
                                 "nodeType": "YulFunctionCall",
                                 "src": "60:13:0"
                             },
-                            "nativeSrc": "151:14:0",
+                            "nativeSrc": "168:14:0",
                             "nodeType": "YulExpressionStatement",
                             "src": "60:13:0"
                         },
                         {
                             "body": {
-                                "nativeSrc": "193:16:0",
+                                "nativeSrc": "210:16:0",
                                 "nodeType": "YulBlock",
                                 "src": "60:13:0",
                                 "statements": [
@@ -724,7 +724,7 @@ Optimized IR AST:
                                             "arguments": [
                                                 {
                                                     "kind": "number",
-                                                    "nativeSrc": "202:1:0",
+                                                    "nativeSrc": "219:1:0",
                                                     "nodeType": "YulLiteral",
                                                     "src": "60:13:0",
                                                     "type": "",
@@ -732,7 +732,7 @@ Optimized IR AST:
                                                 },
                                                 {
                                                     "kind": "number",
-                                                    "nativeSrc": "205:1:0",
+                                                    "nativeSrc": "222:1:0",
                                                     "nodeType": "YulLiteral",
                                                     "src": "60:13:0",
                                                     "type": "",
@@ -741,15 +741,15 @@ Optimized IR AST:
                                             ],
                                             "functionName": {
                                                 "name": "revert",
-                                                "nativeSrc": "195:6:0",
+                                                "nativeSrc": "212:6:0",
                                                 "nodeType": "YulIdentifier",
                                                 "src": "60:13:0"
                                             },
-                                            "nativeSrc": "195:12:0",
+                                            "nativeSrc": "212:12:0",
                                             "nodeType": "YulFunctionCall",
                                             "src": "60:13:0"
                                         },
-                                        "nativeSrc": "195:12:0",
+                                        "nativeSrc": "212:12:0",
                                         "nodeType": "YulExpressionStatement",
                                         "src": "60:13:0"
                                     }
@@ -759,20 +759,20 @@ Optimized IR AST:
                                 "arguments": [],
                                 "functionName": {
                                     "name": "callvalue",
-                                    "nativeSrc": "181:9:0",
+                                    "nativeSrc": "198:9:0",
                                     "nodeType": "YulIdentifier",
                                     "src": "60:13:0"
                                 },
-                                "nativeSrc": "181:11:0",
+                                "nativeSrc": "198:11:0",
                                 "nodeType": "YulFunctionCall",
                                 "src": "60:13:0"
                             },
-                            "nativeSrc": "178:31:0",
+                            "nativeSrc": "195:31:0",
                             "nodeType": "YulIf",
                             "src": "60:13:0"
                         },
                         {
-                            "nativeSrc": "222:34:0",
+                            "nativeSrc": "239:34:0",
                             "nodeType": "YulVariableDeclaration",
                             "src": "60:13:0",
                             "value": {
@@ -780,7 +780,7 @@ Optimized IR AST:
                                     {
                                         "hexValue": "435f325f6465706c6f796564",
                                         "kind": "string",
-                                        "nativeSrc": "241:14:0",
+                                        "nativeSrc": "258:14:0",
                                         "nodeType": "YulLiteral",
                                         "src": "60:13:0",
                                         "type": "",
@@ -789,18 +789,18 @@ Optimized IR AST:
                                 ],
                                 "functionName": {
                                     "name": "datasize",
-                                    "nativeSrc": "232:8:0",
+                                    "nativeSrc": "249:8:0",
                                     "nodeType": "YulIdentifier",
                                     "src": "60:13:0"
                                 },
-                                "nativeSrc": "232:24:0",
+                                "nativeSrc": "249:24:0",
                                 "nodeType": "YulFunctionCall",
                                 "src": "60:13:0"
                             },
                             "variables": [
                                 {
                                     "name": "_2",
-                                    "nativeSrc": "226:2:0",
+                                    "nativeSrc": "243:2:0",
                                     "nodeType": "YulTypedName",
                                     "src": "60:13:0",
                                     "type": ""
@@ -812,7 +812,7 @@ Optimized IR AST:
                                 "arguments": [
                                     {
                                         "name": "_1",
-                                        "nativeSrc": "278:2:0",
+                                        "nativeSrc": "295:2:0",
                                         "nodeType": "YulIdentifier",
                                         "src": "60:13:0"
                                     },
@@ -821,7 +821,7 @@ Optimized IR AST:
                                             {
                                                 "hexValue": "435f325f6465706c6f796564",
                                                 "kind": "string",
-                                                "nativeSrc": "293:14:0",
+                                                "nativeSrc": "310:14:0",
                                                 "nodeType": "YulLiteral",
                                                 "src": "60:13:0",
                                                 "type": "",
@@ -830,32 +830,32 @@ Optimized IR AST:
                                         ],
                                         "functionName": {
                                             "name": "dataoffset",
-                                            "nativeSrc": "282:10:0",
+                                            "nativeSrc": "299:10:0",
                                             "nodeType": "YulIdentifier",
                                             "src": "60:13:0"
                                         },
-                                        "nativeSrc": "282:26:0",
+                                        "nativeSrc": "299:26:0",
                                         "nodeType": "YulFunctionCall",
                                         "src": "60:13:0"
                                     },
                                     {
                                         "name": "_2",
-                                        "nativeSrc": "310:2:0",
+                                        "nativeSrc": "327:2:0",
                                         "nodeType": "YulIdentifier",
                                         "src": "60:13:0"
                                     }
                                 ],
                                 "functionName": {
                                     "name": "codecopy",
-                                    "nativeSrc": "269:8:0",
+                                    "nativeSrc": "286:8:0",
                                     "nodeType": "YulIdentifier",
                                     "src": "60:13:0"
                                 },
-                                "nativeSrc": "269:44:0",
+                                "nativeSrc": "286:44:0",
                                 "nodeType": "YulFunctionCall",
                                 "src": "60:13:0"
                             },
-                            "nativeSrc": "269:44:0",
+                            "nativeSrc": "286:44:0",
                             "nodeType": "YulExpressionStatement",
                             "src": "60:13:0"
                         },
@@ -864,28 +864,28 @@ Optimized IR AST:
                                 "arguments": [
                                     {
                                         "name": "_1",
-                                        "nativeSrc": "333:2:0",
+                                        "nativeSrc": "350:2:0",
                                         "nodeType": "YulIdentifier",
                                         "src": "60:13:0"
                                     },
                                     {
                                         "name": "_2",
-                                        "nativeSrc": "337:2:0",
+                                        "nativeSrc": "354:2:0",
                                         "nodeType": "YulIdentifier",
                                         "src": "60:13:0"
                                     }
                                 ],
                                 "functionName": {
                                     "name": "return",
-                                    "nativeSrc": "326:6:0",
+                                    "nativeSrc": "343:6:0",
                                     "nodeType": "YulIdentifier",
                                     "src": "60:13:0"
                                 },
-                                "nativeSrc": "326:14:0",
+                                "nativeSrc": "343:14:0",
                                 "nodeType": "YulFunctionCall",
                                 "src": "60:13:0"
                             },
-                            "nativeSrc": "326:14:0",
+                            "nativeSrc": "343:14:0",
                             "nodeType": "YulExpressionStatement",
                             "src": "60:13:0"
                         }
@@ -901,12 +901,12 @@ Optimized IR AST:
         {
             "code": {
                 "block": {
-                    "nativeSrc": "436:101:0",
+                    "nativeSrc": "453:118:0",
                     "nodeType": "YulBlock",
                     "src": "-1:-1:0",
                     "statements": [
                         {
-                            "nativeSrc": "450:77:0",
+                            "nativeSrc": "467:94:0",
                             "nodeType": "YulBlock",
                             "src": "-1:-1:0",
                             "statements": [
@@ -915,7 +915,7 @@ Optimized IR AST:
                                         "arguments": [
                                             {
                                                 "kind": "number",
-                                                "nativeSrc": "508:1:0",
+                                                "nativeSrc": "542:1:0",
                                                 "nodeType": "YulLiteral",
                                                 "src": "60:13:0",
                                                 "type": "",
@@ -923,7 +923,7 @@ Optimized IR AST:
                                             },
                                             {
                                                 "kind": "number",
-                                                "nativeSrc": "511:1:0",
+                                                "nativeSrc": "545:1:0",
                                                 "nodeType": "YulLiteral",
                                                 "src": "60:13:0",
                                                 "type": "",
@@ -932,15 +932,15 @@ Optimized IR AST:
                                         ],
                                         "functionName": {
                                             "name": "revert",
-                                            "nativeSrc": "501:6:0",
+                                            "nativeSrc": "535:6:0",
                                             "nodeType": "YulIdentifier",
                                             "src": "60:13:0"
                                         },
-                                        "nativeSrc": "501:12:0",
+                                        "nativeSrc": "535:12:0",
                                         "nodeType": "YulFunctionCall",
                                         "src": "60:13:0"
                                     },
-                                    "nativeSrc": "501:12:0",
+                                    "nativeSrc": "535:12:0",
                                     "nodeType": "YulExpressionStatement",
                                     "src": "60:13:0"
                                 }

--- a/test/cmdlineTests/standard_irOptimized_ast_requested/output.json
+++ b/test/cmdlineTests/standard_irOptimized_ast_requested/output.json
@@ -5,12 +5,12 @@
                 "irOptimizedAst": {
                     "code": {
                         "block": {
-                            "nativeSrc": "43:622:0",
+                            "nativeSrc": "43:639:0",
                             "nodeType": "YulBlock",
                             "src": "-1:-1:0",
                             "statements": [
                                 {
-                                    "nativeSrc": "53:404:0",
+                                    "nativeSrc": "53:421:0",
                                     "nodeType": "YulBlock",
                                     "src": "-1:-1:0",
                                     "statements": [
@@ -19,7 +19,7 @@
                                                 "arguments": [
                                                     {
                                                         "kind": "number",
-                                                        "nativeSrc": "103:2:0",
+                                                        "nativeSrc": "120:2:0",
                                                         "nodeType": "YulLiteral",
                                                         "src": "56:13:0",
                                                         "type": "",
@@ -29,7 +29,7 @@
                                                         "arguments": [
                                                             {
                                                                 "kind": "number",
-                                                                "nativeSrc": "119:4:0",
+                                                                "nativeSrc": "136:4:0",
                                                                 "nodeType": "YulLiteral",
                                                                 "src": "56:13:0",
                                                                 "type": "",
@@ -38,32 +38,32 @@
                                                         ],
                                                         "functionName": {
                                                             "name": "memoryguard",
-                                                            "nativeSrc": "107:11:0",
+                                                            "nativeSrc": "124:11:0",
                                                             "nodeType": "YulIdentifier",
                                                             "src": "56:13:0"
                                                         },
-                                                        "nativeSrc": "107:17:0",
+                                                        "nativeSrc": "124:17:0",
                                                         "nodeType": "YulFunctionCall",
                                                         "src": "56:13:0"
                                                     }
                                                 ],
                                                 "functionName": {
                                                     "name": "mstore",
-                                                    "nativeSrc": "96:6:0",
+                                                    "nativeSrc": "113:6:0",
                                                     "nodeType": "YulIdentifier",
                                                     "src": "56:13:0"
                                                 },
-                                                "nativeSrc": "96:29:0",
+                                                "nativeSrc": "113:29:0",
                                                 "nodeType": "YulFunctionCall",
                                                 "src": "56:13:0"
                                             },
-                                            "nativeSrc": "96:29:0",
+                                            "nativeSrc": "113:29:0",
                                             "nodeType": "YulExpressionStatement",
                                             "src": "56:13:0"
                                         },
                                         {
                                             "body": {
-                                                "nativeSrc": "165:111:0",
+                                                "nativeSrc": "182:111:0",
                                                 "nodeType": "YulBlock",
                                                 "src": "56:13:0",
                                                 "statements": [
@@ -72,15 +72,15 @@
                                                             "arguments": [],
                                                             "functionName": {
                                                                 "name": "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb",
-                                                                "nativeSrc": "183:77:0",
+                                                                "nativeSrc": "200:77:0",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "56:13:0"
                                                             },
-                                                            "nativeSrc": "183:79:0",
+                                                            "nativeSrc": "200:79:0",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "56:13:0"
                                                         },
-                                                        "nativeSrc": "183:79:0",
+                                                        "nativeSrc": "200:79:0",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "56:13:0"
                                                     }
@@ -90,38 +90,38 @@
                                                 "arguments": [],
                                                 "functionName": {
                                                     "name": "callvalue",
-                                                    "nativeSrc": "141:9:0",
+                                                    "nativeSrc": "158:9:0",
                                                     "nodeType": "YulIdentifier",
                                                     "src": "56:13:0"
                                                 },
-                                                "nativeSrc": "141:11:0",
+                                                "nativeSrc": "158:11:0",
                                                 "nodeType": "YulFunctionCall",
                                                 "src": "56:13:0"
                                             },
-                                            "nativeSrc": "138:138:0",
+                                            "nativeSrc": "155:138:0",
                                             "nodeType": "YulIf",
                                             "src": "56:13:0"
                                         },
                                         {
-                                            "nativeSrc": "289:30:0",
+                                            "nativeSrc": "306:30:0",
                                             "nodeType": "YulVariableDeclaration",
                                             "src": "56:13:0",
                                             "value": {
                                                 "arguments": [],
                                                 "functionName": {
                                                     "name": "allocate_unbounded",
-                                                    "nativeSrc": "299:18:0",
+                                                    "nativeSrc": "316:18:0",
                                                     "nodeType": "YulIdentifier",
                                                     "src": "56:13:0"
                                                 },
-                                                "nativeSrc": "299:20:0",
+                                                "nativeSrc": "316:20:0",
                                                 "nodeType": "YulFunctionCall",
                                                 "src": "56:13:0"
                                             },
                                             "variables": [
                                                 {
                                                     "name": "_1",
-                                                    "nativeSrc": "293:2:0",
+                                                    "nativeSrc": "310:2:0",
                                                     "nodeType": "YulTypedName",
                                                     "src": "56:13:0",
                                                     "type": ""
@@ -133,7 +133,7 @@
                                                 "arguments": [
                                                     {
                                                         "name": "_1",
-                                                        "nativeSrc": "341:2:0",
+                                                        "nativeSrc": "358:2:0",
                                                         "nodeType": "YulIdentifier",
                                                         "src": "56:13:0"
                                                     },
@@ -142,7 +142,7 @@
                                                             {
                                                                 "hexValue": "435f325f6465706c6f796564",
                                                                 "kind": "string",
-                                                                "nativeSrc": "356:14:0",
+                                                                "nativeSrc": "373:14:0",
                                                                 "nodeType": "YulLiteral",
                                                                 "src": "56:13:0",
                                                                 "type": "",
@@ -151,11 +151,11 @@
                                                         ],
                                                         "functionName": {
                                                             "name": "dataoffset",
-                                                            "nativeSrc": "345:10:0",
+                                                            "nativeSrc": "362:10:0",
                                                             "nodeType": "YulIdentifier",
                                                             "src": "56:13:0"
                                                         },
-                                                        "nativeSrc": "345:26:0",
+                                                        "nativeSrc": "362:26:0",
                                                         "nodeType": "YulFunctionCall",
                                                         "src": "56:13:0"
                                                     },
@@ -164,7 +164,7 @@
                                                             {
                                                                 "hexValue": "435f325f6465706c6f796564",
                                                                 "kind": "string",
-                                                                "nativeSrc": "382:14:0",
+                                                                "nativeSrc": "399:14:0",
                                                                 "nodeType": "YulLiteral",
                                                                 "src": "56:13:0",
                                                                 "type": "",
@@ -173,26 +173,26 @@
                                                         ],
                                                         "functionName": {
                                                             "name": "datasize",
-                                                            "nativeSrc": "373:8:0",
+                                                            "nativeSrc": "390:8:0",
                                                             "nodeType": "YulIdentifier",
                                                             "src": "56:13:0"
                                                         },
-                                                        "nativeSrc": "373:24:0",
+                                                        "nativeSrc": "390:24:0",
                                                         "nodeType": "YulFunctionCall",
                                                         "src": "56:13:0"
                                                     }
                                                 ],
                                                 "functionName": {
                                                     "name": "codecopy",
-                                                    "nativeSrc": "332:8:0",
+                                                    "nativeSrc": "349:8:0",
                                                     "nodeType": "YulIdentifier",
                                                     "src": "56:13:0"
                                                 },
-                                                "nativeSrc": "332:66:0",
+                                                "nativeSrc": "349:66:0",
                                                 "nodeType": "YulFunctionCall",
                                                 "src": "56:13:0"
                                             },
-                                            "nativeSrc": "332:66:0",
+                                            "nativeSrc": "349:66:0",
                                             "nodeType": "YulExpressionStatement",
                                             "src": "56:13:0"
                                         },
@@ -201,7 +201,7 @@
                                                 "arguments": [
                                                     {
                                                         "name": "_1",
-                                                        "nativeSrc": "418:2:0",
+                                                        "nativeSrc": "435:2:0",
                                                         "nodeType": "YulIdentifier",
                                                         "src": "56:13:0"
                                                     },
@@ -210,7 +210,7 @@
                                                             {
                                                                 "hexValue": "435f325f6465706c6f796564",
                                                                 "kind": "string",
-                                                                "nativeSrc": "431:14:0",
+                                                                "nativeSrc": "448:14:0",
                                                                 "nodeType": "YulLiteral",
                                                                 "src": "56:13:0",
                                                                 "type": "",
@@ -219,26 +219,26 @@
                                                         ],
                                                         "functionName": {
                                                             "name": "datasize",
-                                                            "nativeSrc": "422:8:0",
+                                                            "nativeSrc": "439:8:0",
                                                             "nodeType": "YulIdentifier",
                                                             "src": "56:13:0"
                                                         },
-                                                        "nativeSrc": "422:24:0",
+                                                        "nativeSrc": "439:24:0",
                                                         "nodeType": "YulFunctionCall",
                                                         "src": "56:13:0"
                                                     }
                                                 ],
                                                 "functionName": {
                                                     "name": "return",
-                                                    "nativeSrc": "411:6:0",
+                                                    "nativeSrc": "428:6:0",
                                                     "nodeType": "YulIdentifier",
                                                     "src": "56:13:0"
                                                 },
-                                                "nativeSrc": "411:36:0",
+                                                "nativeSrc": "428:36:0",
                                                 "nodeType": "YulFunctionCall",
                                                 "src": "56:13:0"
                                             },
-                                            "nativeSrc": "411:36:0",
+                                            "nativeSrc": "428:36:0",
                                             "nodeType": "YulExpressionStatement",
                                             "src": "56:13:0"
                                         }
@@ -246,19 +246,19 @@
                                 },
                                 {
                                     "body": {
-                                        "nativeSrc": "514:23:0",
+                                        "nativeSrc": "531:23:0",
                                         "nodeType": "YulBlock",
                                         "src": "56:13:0",
                                         "statements": [
                                             {
-                                                "nativeSrc": "516:19:0",
+                                                "nativeSrc": "533:19:0",
                                                 "nodeType": "YulAssignment",
                                                 "src": "56:13:0",
                                                 "value": {
                                                     "arguments": [
                                                         {
                                                             "kind": "number",
-                                                            "nativeSrc": "532:2:0",
+                                                            "nativeSrc": "549:2:0",
                                                             "nodeType": "YulLiteral",
                                                             "src": "56:13:0",
                                                             "type": "",
@@ -267,18 +267,18 @@
                                                     ],
                                                     "functionName": {
                                                         "name": "mload",
-                                                        "nativeSrc": "526:5:0",
+                                                        "nativeSrc": "543:5:0",
                                                         "nodeType": "YulIdentifier",
                                                         "src": "56:13:0"
                                                     },
-                                                    "nativeSrc": "526:9:0",
+                                                    "nativeSrc": "543:9:0",
                                                     "nodeType": "YulFunctionCall",
                                                     "src": "56:13:0"
                                                 },
                                                 "variableNames": [
                                                     {
                                                         "name": "memPtr",
-                                                        "nativeSrc": "516:6:0",
+                                                        "nativeSrc": "533:6:0",
                                                         "nodeType": "YulIdentifier",
                                                         "src": "56:13:0"
                                                     }
@@ -287,12 +287,12 @@
                                         ]
                                     },
                                     "name": "allocate_unbounded",
-                                    "nativeSrc": "466:71:0",
+                                    "nativeSrc": "483:71:0",
                                     "nodeType": "YulFunctionDefinition",
                                     "returnVariables": [
                                         {
                                             "name": "memPtr",
-                                            "nativeSrc": "499:6:0",
+                                            "nativeSrc": "516:6:0",
                                             "nodeType": "YulTypedName",
                                             "src": "56:13:0",
                                             "type": ""
@@ -302,7 +302,7 @@
                                 },
                                 {
                                     "body": {
-                                        "nativeSrc": "643:16:0",
+                                        "nativeSrc": "660:16:0",
                                         "nodeType": "YulBlock",
                                         "src": "56:13:0",
                                         "statements": [
@@ -311,7 +311,7 @@
                                                     "arguments": [
                                                         {
                                                             "kind": "number",
-                                                            "nativeSrc": "652:1:0",
+                                                            "nativeSrc": "669:1:0",
                                                             "nodeType": "YulLiteral",
                                                             "src": "56:13:0",
                                                             "type": "",
@@ -319,7 +319,7 @@
                                                         },
                                                         {
                                                             "kind": "number",
-                                                            "nativeSrc": "655:1:0",
+                                                            "nativeSrc": "672:1:0",
                                                             "nodeType": "YulLiteral",
                                                             "src": "56:13:0",
                                                             "type": "",
@@ -328,22 +328,22 @@
                                                     ],
                                                     "functionName": {
                                                         "name": "revert",
-                                                        "nativeSrc": "645:6:0",
+                                                        "nativeSrc": "662:6:0",
                                                         "nodeType": "YulIdentifier",
                                                         "src": "56:13:0"
                                                     },
-                                                    "nativeSrc": "645:12:0",
+                                                    "nativeSrc": "662:12:0",
                                                     "nodeType": "YulFunctionCall",
                                                     "src": "56:13:0"
                                                 },
-                                                "nativeSrc": "645:12:0",
+                                                "nativeSrc": "662:12:0",
                                                 "nodeType": "YulExpressionStatement",
                                                 "src": "56:13:0"
                                             }
                                         ]
                                     },
                                     "name": "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb",
-                                    "nativeSrc": "546:113:0",
+                                    "nativeSrc": "563:113:0",
                                     "nodeType": "YulFunctionDefinition",
                                     "src": "56:13:0"
                                 }
@@ -357,12 +357,12 @@
                         {
                             "code": {
                                 "block": {
-                                    "nativeSrc": "730:344:0",
+                                    "nativeSrc": "747:361:0",
                                     "nodeType": "YulBlock",
                                     "src": "-1:-1:0",
                                     "statements": [
                                         {
-                                            "nativeSrc": "744:190:0",
+                                            "nativeSrc": "761:207:0",
                                             "nodeType": "YulBlock",
                                             "src": "-1:-1:0",
                                             "statements": [
@@ -371,7 +371,7 @@
                                                         "arguments": [
                                                             {
                                                                 "kind": "number",
-                                                                "nativeSrc": "802:2:0",
+                                                                "nativeSrc": "836:2:0",
                                                                 "nodeType": "YulLiteral",
                                                                 "src": "56:13:0",
                                                                 "type": "",
@@ -381,7 +381,7 @@
                                                                 "arguments": [
                                                                     {
                                                                         "kind": "number",
-                                                                        "nativeSrc": "818:4:0",
+                                                                        "nativeSrc": "852:4:0",
                                                                         "nodeType": "YulLiteral",
                                                                         "src": "56:13:0",
                                                                         "type": "",
@@ -390,26 +390,26 @@
                                                                 ],
                                                                 "functionName": {
                                                                     "name": "memoryguard",
-                                                                    "nativeSrc": "806:11:0",
+                                                                    "nativeSrc": "840:11:0",
                                                                     "nodeType": "YulIdentifier",
                                                                     "src": "56:13:0"
                                                                 },
-                                                                "nativeSrc": "806:17:0",
+                                                                "nativeSrc": "840:17:0",
                                                                 "nodeType": "YulFunctionCall",
                                                                 "src": "56:13:0"
                                                             }
                                                         ],
                                                         "functionName": {
                                                             "name": "mstore",
-                                                            "nativeSrc": "795:6:0",
+                                                            "nativeSrc": "829:6:0",
                                                             "nodeType": "YulIdentifier",
                                                             "src": "56:13:0"
                                                         },
-                                                        "nativeSrc": "795:29:0",
+                                                        "nativeSrc": "829:29:0",
                                                         "nodeType": "YulFunctionCall",
                                                         "src": "56:13:0"
                                                     },
-                                                    "nativeSrc": "795:29:0",
+                                                    "nativeSrc": "829:29:0",
                                                     "nodeType": "YulExpressionStatement",
                                                     "src": "56:13:0"
                                                 },
@@ -418,15 +418,15 @@
                                                         "arguments": [],
                                                         "functionName": {
                                                             "name": "revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74",
-                                                            "nativeSrc": "841:77:0",
+                                                            "nativeSrc": "875:77:0",
                                                             "nodeType": "YulIdentifier",
                                                             "src": "56:13:0"
                                                         },
-                                                        "nativeSrc": "841:79:0",
+                                                        "nativeSrc": "875:79:0",
                                                         "nodeType": "YulFunctionCall",
                                                         "src": "56:13:0"
                                                     },
-                                                    "nativeSrc": "841:79:0",
+                                                    "nativeSrc": "875:79:0",
                                                     "nodeType": "YulExpressionStatement",
                                                     "src": "56:13:0"
                                                 }
@@ -434,7 +434,7 @@
                                         },
                                         {
                                             "body": {
-                                                "nativeSrc": "1048:16:0",
+                                                "nativeSrc": "1082:16:0",
                                                 "nodeType": "YulBlock",
                                                 "src": "56:13:0",
                                                 "statements": [
@@ -443,7 +443,7 @@
                                                             "arguments": [
                                                                 {
                                                                     "kind": "number",
-                                                                    "nativeSrc": "1057:1:0",
+                                                                    "nativeSrc": "1091:1:0",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "56:13:0",
                                                                     "type": "",
@@ -451,7 +451,7 @@
                                                                 },
                                                                 {
                                                                     "kind": "number",
-                                                                    "nativeSrc": "1060:1:0",
+                                                                    "nativeSrc": "1094:1:0",
                                                                     "nodeType": "YulLiteral",
                                                                     "src": "56:13:0",
                                                                     "type": "",
@@ -460,22 +460,22 @@
                                                             ],
                                                             "functionName": {
                                                                 "name": "revert",
-                                                                "nativeSrc": "1050:6:0",
+                                                                "nativeSrc": "1084:6:0",
                                                                 "nodeType": "YulIdentifier",
                                                                 "src": "56:13:0"
                                                             },
-                                                            "nativeSrc": "1050:12:0",
+                                                            "nativeSrc": "1084:12:0",
                                                             "nodeType": "YulFunctionCall",
                                                             "src": "56:13:0"
                                                         },
-                                                        "nativeSrc": "1050:12:0",
+                                                        "nativeSrc": "1084:12:0",
                                                         "nodeType": "YulExpressionStatement",
                                                         "src": "56:13:0"
                                                     }
                                                 ]
                                             },
                                             "name": "revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74",
-                                            "nativeSrc": "947:117:0",
+                                            "nativeSrc": "981:117:0",
                                             "nodeType": "YulFunctionDefinition",
                                             "src": "56:13:0"
                                         }


### PR DESCRIPTION
This fixes the issue with shifted source locations we're seeing in https://github.com/ethereum/solidity/pull/15451#issuecomment-2371628772. Or, more accurately, turns it into a proper fix, because the shift is actually correct and it's the test expectation that was wrong.

Turns out that my assumption in #15309 that we don't need access to code snippets in `YulStack` when reparsing Obviously, if we parse different source than we output, we'll get wrong AST locations.

I think that Yul AST is the only artifact affected. We normally only include origin source locations in the output and print nothing if the native location is the only thing we have. The only way to see native locations is to look into the AST.