### PR TITLE
Do not cache instances of `Compiler` in `CompilerStack`

### DIFF
--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -424,8 +424,6 @@ private:
 		util::LazyInit<Json const> transientStorageLayout;
 		util::LazyInit<Json const> userDocumentation;
 		util::LazyInit<Json const> devDocumentation;
-		util::LazyInit<Json const> generatedSources;
-		util::LazyInit<Json const> runtimeGeneratedSources;
 		mutable std::optional<std::string const> sourceMapping;
 		mutable std::optional<std::string const> runtimeSourceMapping;
 	};

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -409,9 +409,11 @@ private:
 	struct Contract
 	{
 		ContractDefinition const* contract = nullptr;
-		std::shared_ptr<Compiler> compiler;
+
 		std::shared_ptr<evmasm::Assembly> evmAssembly;
 		std::shared_ptr<evmasm::Assembly> evmRuntimeAssembly;
+		std::optional<std::string> generatedYulUtilityCode; ///< Extra Yul utility code that was used when compiling the creation assembly
+		std::optional<std::string> runtimeGeneratedYulUtilityCode; ///< Extra Yul utility code that was used when compiling the deployed assembly
 		evmasm::LinkerObject object; ///< Deployment object (includes the runtime sub-object).
 		evmasm::LinkerObject runtimeObject; ///< Runtime object.
 		std::string yulIR; ///< Yul IR code straight from the code generator.


### PR DESCRIPTION
~Depends on #15451.~ Merged.
Related to #15459.

Another follow-up to #15451, this time removing the `Compiler` instances stored in `CompilerStack`.

This is a test PR to benchmark it see if it's even worth it. But TBH storing these objects in CompilerStack seems like a weird design choice. Apparently the only thing we need from them are the generated sources. And it's not even like they're generated on demand - they're stored in compiler context and simply copied from there. For this reason I'd be in favor of merging this even it does not improve performance. Just not making it worse would be enough.