### PR TITLE
docs: fixed a mismatch in the name of the function referenced in the micropayment example

### DIFF
--- a/docs/examples/micropayment.rst
+++ b/docs/examples/micropayment.rst
@@ -274,8 +274,8 @@ Opening the Payment Channel
 
 To open the payment channel, Alice deploys the smart contract, attaching
 the Ether to be escrowed and specifying the intended recipient and a
-maximum duration for the channel to exist. This is the function
-``SimplePaymentChannel`` in the contract, at the end of this section.
+maximum duration for the channel to exist. This is the ``constructor``
+in the ``SimplePaymentChannel`` contract, at the end of this section.
 
 Making Payments
 ---------------


### PR DESCRIPTION
Updated docs.
The micropayment example specifies that we need to see the `SimplePaymentChannel` function in the contract at the end of the section. This is likely a holdover from previous versions, when the constructor had the same name as the contract. I've fixed it.