### PR TITLE
Avoid unnecessary copy in full inliner.

### DIFF
--- a/libyul/optimiser/FullInliner.cpp
+++ b/libyul/optimiser/FullInliner.cpp
@@ -106,7 +106,7 @@ void FullInliner::run(Pass _pass)
 	for (auto& statement: m_ast.statements)
 		if (std::holds_alternative<FunctionDefinition>(statement))
 			functions.emplace_back(&std::get<FunctionDefinition>(statement));
-	std::stable_sort(functions.begin(), functions.end(), [depths](
+	std::stable_sort(functions.begin(), functions.end(), [&depths](
 		FunctionDefinition const* _a,
 		FunctionDefinition const* _b
 	) {


### PR DESCRIPTION
Somewhat random, but I saw it the other day when checking the optimizer step runtime numbers and skimming through it...
Whoever can tell me for sure how many copies this saves gets a beer - whoever can give me a closed arithmetic expression describing the number of ``YulName`` comparisons this saves gets five beers.

But yeah, at some point we need to properly systematically look through these things and reduce their computational complexity.