### PR TITLE
Switch to m2 resource class for osx builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -496,12 +496,12 @@ defaults:
 
   - base_osx: &base_osx
       macos:
-        xcode: "15.0.0"
-      resource_class: macos.m1.medium.gen1
+        xcode: "16.0.0"
+      resource_class: m2pro.medium
       environment: &base_osx_env
         TERM: xterm
-        MAKEFLAGS: -j5
-        CPUs: 5
+        MAKEFLAGS: -j7
+        CPUs: 7
 
   - base_python_small: &base_python_small
       docker:


### PR DESCRIPTION
M2 pro is now available in CircleCI (see: https://discuss.circleci.com/t/announcing-m2-pro-medium-m2-pro-large-general-availability/52095). Switching to it bring some improvement to our building time for osx builds while may not increase that much in terms of cost:

| **Model**          | **CPU** | **RAM**   | **Credits/Min** |
|--------------------|---------|-----------|-----------------|
| M1 Medium          | 4       | 6 GB      | 150             |
| M2 Pro Medium      | 4       | 8 GB      | 180             |
| M1 Large           | 8       | 12 GB     | 250             |
| M2 Pro Large       | 8       | 16 GB     | 330             |

source: https://circleci.com/pricing/price-list/

From ~12m 53s using m1 on develop branch: https://app.circleci.com/pipelines/github/ethereum/solidity/36393/workflows/af589beb-dce2-4adf-a4b7-cc2226c283d6/jobs/1661285 to ~11m 41s with m2 in this branch: https://app.circleci.com/pipelines/github/ethereum/solidity/36404/workflows/1d1c077a-ed8d-45e2-b6b7-39fa79273ceb/jobs/1661847 (with 5 CPUs).

This PR also increases the number of threads for better resource utilization, which reduces the build time to ~10m 13s (https://app.circleci.com/pipelines/github/ethereum/solidity/36408/workflows/bf6134e6-6213-4905-9f1c-94c8360f87ab/jobs/1662046)