### PR TITLE
Re-enable euler external test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -760,9 +760,6 @@ defaults:
       name: t_native_compile_ext_euler
       project: euler
       binary_type: native
-      # NOTE: test suite disabled due to dependence on a specific version of Hardhat
-      # which does not support shanghai EVM.
-      compile_only: 1
       resource_class: medium
 
   - job_native_test_ext_yield_liquidator: &job_native_test_ext_yield_liquidator


### PR DESCRIPTION
This test was disabled because of issues with `shanghai` EVM version in hardhat. The issue seems fixed and the test runs with no errors now.
Mentioned [here](https://github.com/ethereum/solidity/pull/15461#pullrequestreview-2341600997).