### PR TITLE
test: Pass `evmVersion` and `eofVersion` to `YulStack` in `ObjectCompilerTest`

### DIFF
--- a/test/libyul/ControlFlowSideEffectsTest.cpp
+++ b/test/libyul/ControlFlowSideEffectsTest.cpp
@@ -62,9 +62,9 @@ TestCase::TestResult ControlFlowSideEffectsTest::run(std::ostream& _stream, std:
 	if (!obj.hasCode())
 		BOOST_THROW_EXCEPTION(std::runtime_error("Parsing input failed."));
 
-	// TODO: Add EOF support
 	ControlFlowSideEffectsCollector sideEffects(
-		EVMDialect::strictAssemblyForEVMObjects(langutil::EVMVersion(), std::nullopt),
+		EVMDialect::strictAssemblyForEVMObjects(solidity::test::CommonOptions::get().evmVersion(),
+			solidity::test::CommonOptions::get().eofVersion()),
 		obj.code()->root()
 	);
 	m_obtainedResult.clear();

--- a/test/libyul/EVMCodeTransformTest.cpp
+++ b/test/libyul/EVMCodeTransformTest.cpp
@@ -67,14 +67,13 @@ TestCase::TestResult EVMCodeTransformTest::run(std::ostream& _stream, std::strin
 		return TestResult::FatalError;
 	}
 
-	// TODO: Add EOF support
 	evmasm::Assembly assembly{solidity::test::CommonOptions::get().evmVersion(), false, std::nullopt, {}};
 	EthAssemblyAdapter adapter(assembly);
 	EVMObjectCompiler::compile(
 		*stack.parserResult(),
 		adapter,
-		// TODO: Make sure that why we cannot pass here solidity::test::CommonOptions::get().evmVersion() and assembly.eofVersion()
-		EVMDialect::strictAssemblyForEVMObjects(EVMVersion{}, std::nullopt),
+		EVMDialect::strictAssemblyForEVMObjects(solidity::test::CommonOptions::get().evmVersion(),
+			solidity::test::CommonOptions::get().eofVersion()),
 		m_stackOpt,
 		std::nullopt
 	);

--- a/test/libyul/FunctionSideEffects.cpp
+++ b/test/libyul/FunctionSideEffects.cpp
@@ -88,9 +88,9 @@ TestCase::TestResult FunctionSideEffects::run(std::ostream& _stream, std::string
 	if (!obj.hasCode())
 		BOOST_THROW_EXCEPTION(std::runtime_error("Parsing input failed."));
 
-	// TODO: Add EOF support
 	std::map<YulName, SideEffects> functionSideEffects = SideEffectsPropagator::sideEffects(
-		EVMDialect::strictAssemblyForEVMObjects(langutil::EVMVersion(), std::nullopt),
+		EVMDialect::strictAssemblyForEVMObjects(solidity::test::CommonOptions::get().evmVersion(),
+			solidity::test::CommonOptions::get().eofVersion()),
 		CallGraphGenerator::callGraph(obj.code()->root())
 	);
 

--- a/test/libyul/KnowledgeBaseTest.cpp
+++ b/test/libyul/KnowledgeBaseTest.cpp
@@ -63,8 +63,8 @@ protected:
 		return KnowledgeBase([this](YulName _var) { return util::valueOrNullptr(m_values, _var); });
 	}
 
-	// TODO: Add EOF support
-	EVMDialect m_dialect{EVMVersion{}, std::nullopt, true};
+	EVMDialect m_dialect{solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion(), true};
 	std::shared_ptr<Object> m_object;
 	SSAValueTracker m_ssaValues;
 	std::map<YulName, AssignedValue> m_values;

--- a/test/libyul/ObjectCompilerTest.cpp
+++ b/test/libyul/ObjectCompilerTest.cpp
@@ -46,7 +46,7 @@ using namespace solidity::frontend;
 using namespace solidity::frontend::test;
 
 ObjectCompilerTest::ObjectCompilerTest(std::string const& _filename):
-	TestCase(_filename)
+	solidity::frontend::test::EVMVersionRestrictedTestCase(_filename)
 {
 	m_source = m_reader.source();
 	m_optimisationPreset = m_reader.enumSetting<OptimisationPreset>(
@@ -65,8 +65,8 @@ ObjectCompilerTest::ObjectCompilerTest(std::string const& _filename):
 TestCase::TestResult ObjectCompilerTest::run(std::ostream& _stream, std::string const& _linePrefix, bool const _formatted)
 {
 	YulStack stack(
-		EVMVersion(),
-		std::nullopt,
+		solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion(),
 		YulStack::Language::StrictAssembly,
 		OptimiserSettings::preset(m_optimisationPreset),
 		DebugInfoSelection::All()

--- a/test/libyul/ObjectCompilerTest.h
+++ b/test/libyul/ObjectCompilerTest.h
@@ -38,7 +38,7 @@ struct Block;
 namespace solidity::yul::test
 {
 
-class ObjectCompilerTest: public solidity::frontend::test::TestCase
+class ObjectCompilerTest: public solidity::frontend::test::EVMVersionRestrictedTestCase
 {
 public:
 	static std::unique_ptr<TestCase> create(Config const& _config)

--- a/test/libyul/ObjectParser.cpp
+++ b/test/libyul/ObjectParser.cpp
@@ -112,8 +112,8 @@ std::tuple<std::optional<SourceNameMap>, ErrorList> tryGetSourceLocationMapping(
 
 	ErrorList errors;
 	ErrorReporter reporter(errors);
-	// TODO: Add EOF support
-	Dialect const& dialect = yul::EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	Dialect const& dialect = yul::EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	ObjectParser objectParser{reporter, dialect};
 	CharStream stream(std::move(source), "");
 	auto object = objectParser.parse(std::make_shared<Scanner>(stream), false);

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -162,8 +162,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_empty_block)
 	auto const sourceText =
 		"/// @src 0:234:543\n"
 		"{}\n";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->root().debugData->originLocation, "source0", 234, 543);
@@ -181,8 +181,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_block_with_children)
 			"let z := true\n"
 			"let y := add(1, 2)\n"
 		"}\n";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result);
 	CHECK_LOCATION(result->root().debugData->originLocation, "source0", 234, 543);
@@ -205,8 +205,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_block_different_sources)
 			"let z := true\n"
 			"let y := add(1, 2)\n"
 		"}\n";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->root().debugData->originLocation, "source0", 234, 543);
@@ -228,8 +228,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_block_nested)
 			"/// @src 0:343:434\n"
 			"switch y case 0 {} default {}\n"
 		"}\n";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->root().debugData->originLocation, "source0", 234, 543);
@@ -253,8 +253,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_block_switch_case)
 			"    let z := add(3, 4)\n"
 			"}\n"
 		"}\n";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->root().debugData->originLocation, "source0", 234, 543);
@@ -286,8 +286,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_inherit_into_outer_scope)
 			"let z := true\n"
 			"let y := add(1, 2)\n"
 		"}\n";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 
@@ -318,8 +318,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_assign_empty)
 			"/// @src 1:1:10\n"
 			"a := true\n"
 		"}\n";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0); // should still parse
 	BOOST_REQUIRE_EQUAL(2, result->root().statements.size());
@@ -340,8 +340,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_invalid_source_index)
 			"let b := true\n"
 			"\n"
 		"}\n";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result); // should still parse
 	BOOST_REQUIRE(errorList.size() == 1);
@@ -361,8 +361,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_mixed_locations_1)
 			"/// @src 0:234:2026\n"
 			":= true\n"
 		"}\n";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 
@@ -385,8 +385,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_mixed_locations_2)
 			2)
 		}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	BOOST_REQUIRE_EQUAL(1, result->root().statements.size());
@@ -420,8 +420,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_mixed_locations_3)
 			mstore(1, 2)                // FunctionCall
 		}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	BOOST_REQUIRE_EQUAL(2, result->root().statements.size());
@@ -457,8 +457,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_invalid_comments_after_valid)
 			let a := true
 		}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	BOOST_REQUIRE_EQUAL(1, result->root().statements.size());
@@ -477,8 +477,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_invalid_suffix)
 		/// @src 0:420:680foo
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result);
 	BOOST_REQUIRE(errorList.size() == 1);
@@ -495,8 +495,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_invalid_prefix)
 		/// abc@src 0:111:222
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->root().debugData->originLocation, "", -1, -1);
@@ -510,8 +510,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_unspecified)
 		/// @src -1:-1:-1
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->root().debugData->originLocation, "", -1, -1);
@@ -525,8 +525,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_non_integer)
 		/// @src a:b:c
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result);
 	BOOST_REQUIRE(errorList.size() == 1);
@@ -543,8 +543,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_bad_integer)
 		/// @src 111111111111111111111:222222222222222222222:333333333333333333333
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result);
 	BOOST_REQUIRE(errorList.size() == 1);
@@ -565,8 +565,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_ensure_last_match)
 			let x := true
 		}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	BOOST_REQUIRE(std::holds_alternative<VariableDeclaration>(result->root().statements.at(0)));
@@ -584,8 +584,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_two_locations_no_whitespace)
 		/// @src 0:111:222@src 1:333:444
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result);
 	BOOST_REQUIRE(errorList.size() == 1);
@@ -602,8 +602,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_two_locations_separated_with_single_s
 		/// @src 0:111:222 @src 1:333:444
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->root().debugData->originLocation, "source1", 333, 444);
@@ -614,8 +614,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_leading_trailing_whitespace)
 	ErrorList errorList;
 	ErrorReporter reporter(errorList);
 	auto const sourceText = "///     @src 0:111:222    \n{}";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->root().debugData->originLocation, "source0", 111, 222);
@@ -632,8 +632,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_reference_original_sloc)
 			let x := true
 		}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	BOOST_REQUIRE(std::holds_alternative<VariableDeclaration>(result->root().statements.at(0)));
@@ -655,8 +655,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_with_code_snippets)
 			let y := /** @src 1:96:165  "contract D {..." */ 128
 		}
 	)~~~";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	BOOST_REQUIRE_EQUAL(result->root().statements.size(), 2);
@@ -681,8 +681,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_with_code_snippets_empty_snippet)
 		/// @src 0:111:222 ""
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->root().debugData->originLocation, "source0", 111, 222);
@@ -696,8 +696,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_with_code_snippets_no_whitespace_befo
 		/// @src 0:111:222"abc" def
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result);
 	BOOST_REQUIRE(errorList.size() == 1);
@@ -714,8 +714,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_with_code_snippets_no_whitespace_afte
 		/// @src 0:111:222 "abc"def
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->root().debugData->originLocation, "source0", 111, 222);
@@ -729,8 +729,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_two_locations_with_snippets_no_whites
 		/// @src 0:111:222 "abc"@src 1:333:444 "abc"
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->root().debugData->originLocation, "source1", 333, 444);
@@ -744,8 +744,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_two_locations_with_snippets_untermina
 		/// @src 0:111:222 " abc @src 1:333:444
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result);
 	BOOST_REQUIRE(errorList.size() == 1);
@@ -763,8 +763,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_single_quote)
 		///
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result);
 	BOOST_REQUIRE(errorList.size() == 1);
@@ -781,8 +781,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_two_snippets_with_hex_comment)
 		/// @src 0:111:222 hex"abc"@src 1:333:444 "abc"
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	// the second source location is not parsed as such, as the hex string isn't interpreted as snippet but
@@ -798,8 +798,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_invalid_escapes)
 		/// @src 0:111:222 "\n\\x\x\w\uö\xy\z\y\fq"
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->root().debugData->originLocation, "source0", 111, 222);
@@ -814,8 +814,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_single_quote_snippet_with_whitespaces
 		/// @src 1 :		222 : 333 '\x33\u1234\t\n'
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	CHECK_LOCATION(result->root().debugData->originLocation, "source1", 222, 333);
@@ -830,8 +830,8 @@ BOOST_DATA_TEST_CASE(customSourceLocations_scanner_errors_outside_string_lits_ar
 		/// @src 1:222:333
 		{{}}
 	)", invalid);
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.empty());
 	CHECK_LOCATION(result->root().debugData->originLocation, "source1", 222, 333);
@@ -849,8 +849,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_multi_line_source_loc)
 		/// " @src 0:333:444
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.empty());
 	CHECK_LOCATION(result->root().debugData->originLocation, "source0", 333, 444);
@@ -868,8 +868,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_with_code_snippets_with_nested_locati
 			let y := /** @src 1:96:165  "function f() internal { \"\/** @src 0:6:7 *\/\"; }" */ 128
 		}
 	)~~~";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	BOOST_REQUIRE_EQUAL(result->root().statements.size(), 2);
@@ -898,8 +898,8 @@ BOOST_AUTO_TEST_CASE(astid)
 			mstore(1, 2)
 		}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result);
 	BOOST_CHECK(result->root().debugData->astID == int64_t(7));
@@ -921,8 +921,8 @@ BOOST_AUTO_TEST_CASE(astid_reset)
 			mstore(1, 2)
 		}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result);
 	BOOST_CHECK(result->root().debugData->astID == int64_t(7));
@@ -940,8 +940,8 @@ BOOST_AUTO_TEST_CASE(astid_multi)
 		/// @src -1:-1:-1 @ast-id 7 @src 1:1:1 @ast-id 8
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result);
 	BOOST_CHECK(result->root().debugData->astID == int64_t(8));
@@ -955,8 +955,8 @@ BOOST_AUTO_TEST_CASE(astid_invalid)
 		/// @src -1:-1:-1 @ast-id abc @src 1:1:1
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result);
 	BOOST_REQUIRE(errorList.size() == 1);
@@ -973,8 +973,8 @@ BOOST_AUTO_TEST_CASE(astid_too_large)
 		/// @ast-id 9223372036854775808
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result);
 	BOOST_REQUIRE(errorList.size() == 1);
@@ -990,8 +990,8 @@ BOOST_AUTO_TEST_CASE(astid_way_too_large)
 		/// @ast-id 999999999999999999999999999999999999999
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result);
 	BOOST_REQUIRE(errorList.size() == 1);
@@ -1007,8 +1007,8 @@ BOOST_AUTO_TEST_CASE(astid_not_fully_numeric)
 		/// @ast-id 9x
 		{}
 	)";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result);
 	BOOST_REQUIRE(errorList.size() == 1);
@@ -1030,8 +1030,8 @@ BOOST_AUTO_TEST_CASE(customSourceLocations_multiple_src_tags_on_one_line)
 		"\n"
 		"    let x := 123\n"
 		"}\n";
-	// TODO: Add EOF support
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(EVMVersion{}, std::nullopt);
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion());
 	std::shared_ptr<AST> result = parse(sourceText, dialect, reporter);
 	BOOST_REQUIRE(!!result && errorList.size() == 0);
 	BOOST_REQUIRE_EQUAL(result->root().statements.size(), 1);

--- a/test/libyul/YulInterpreterTest.cpp
+++ b/test/libyul/YulInterpreterTest.cpp
@@ -98,7 +98,8 @@ std::string YulInterpreterTest::interpret()
 	{
 		Interpreter::run(
 			state,
-			EVMDialect::strictAssemblyForEVMObjects(solidity::test::CommonOptions::get().evmVersion(), std::nullopt),
+			EVMDialect::strictAssemblyForEVMObjects(solidity::test::CommonOptions::get().evmVersion(),
+				solidity::test::CommonOptions::get().eofVersion()),
 			m_ast->root(),
 			/*disableExternalCalls=*/ !m_simulateExternalCallsToSelf,
 			/*disableMemoryTracing=*/ false

--- a/test/libyul/objectCompiler/datacopy.yul
+++ b/test/libyul/objectCompiler/datacopy.yul
@@ -11,6 +11,8 @@ object "a" {
     data "data1" "Hello, World!"
   }
 }
+// ====
+// EVMVersion: >=shanghai
 // ----
 // Assembly:
 //     /* "source":77:92   */

--- a/test/libyul/objectCompiler/dataoffset_code.yul
+++ b/test/libyul/objectCompiler/dataoffset_code.yul
@@ -5,6 +5,8 @@ object "a" {
     data "data1" "Hello, World!"
   }
 }
+// ====
+// EVMVersion: >=shanghai
 // ----
 // Assembly:
 //     /* "source":44:61   */

--- a/test/libyul/objectCompiler/dataoffset_data.yul
+++ b/test/libyul/objectCompiler/dataoffset_data.yul
@@ -2,6 +2,8 @@ object "a" {
   code { sstore(0, dataoffset("data1")) }
   data "data1" "Hello, World!"
 }
+// ====
+// EVMVersion: >=shanghai
 // ----
 // Assembly:
 //     /* "source":56:75   */

--- a/test/libyul/objectCompiler/dataoffset_self.yul
+++ b/test/libyul/objectCompiler/dataoffset_self.yul
@@ -2,6 +2,8 @@ object "a" {
   code { sstore(0, dataoffset("a")) }
   data "data1" "Hello, World!"
 }
+// ====
+// EVMVersion: >=shanghai
 // ----
 // Assembly:
 //     /* "source":44:59   */

--- a/test/libyul/objectCompiler/datasize_code.yul
+++ b/test/libyul/objectCompiler/datasize_code.yul
@@ -5,6 +5,8 @@ object "a" {
     data "data1" "Hello, World!"
   }
 }
+// ====
+// EVMVersion: >=shanghai
 // ----
 // Assembly:
 //     /* "source":44:59   */

--- a/test/libyul/objectCompiler/datasize_data.yul
+++ b/test/libyul/objectCompiler/datasize_data.yul
@@ -2,6 +2,8 @@ object "a" {
   code { sstore(0, datasize("data1")) }
   data "data1" "Hello, World!"
 }
+// ====
+// EVMVersion: >=shanghai
 // ----
 // Assembly:
 //     /* "source":44:61   */

--- a/test/libyul/objectCompiler/datasize_self.yul
+++ b/test/libyul/objectCompiler/datasize_self.yul
@@ -2,6 +2,8 @@ object "a" {
   code { sstore(0, datasize("a")) }
   data "data1" "Hello, World!"
 }
+// ====
+// EVMVersion: >=shanghai
 // ----
 // Assembly:
 //     /* "source":36:49   */

--- a/test/libyul/objectCompiler/function_series.yul
+++ b/test/libyul/objectCompiler/function_series.yul
@@ -11,6 +11,7 @@ object "Contract" {
 }
 
 // ====
+// EVMVersion: >=shanghai
 // optimizationPreset: none
 // ----
 // Assembly:

--- a/test/libyul/objectCompiler/identical_subobjects_full_debug_info.yul
+++ b/test/libyul/objectCompiler/identical_subobjects_full_debug_info.yul
@@ -64,6 +64,7 @@ object "A" {
     }
 }
 // ====
+// EVMVersion: >=shanghai
 // optimizationPreset: full
 // ----
 // Assembly:

--- a/test/libyul/objectCompiler/identical_subobjects_no_debug_info.yul
+++ b/test/libyul/objectCompiler/identical_subobjects_no_debug_info.yul
@@ -50,6 +50,7 @@ object "A" {
     }
 }
 // ====
+// EVMVersion: >=shanghai
 // optimizationPreset: full
 // ----
 // Assembly:

--- a/test/libyul/objectCompiler/identical_subobjects_partial_debug_info.yul
+++ b/test/libyul/objectCompiler/identical_subobjects_partial_debug_info.yul
@@ -69,6 +69,7 @@ object "A" {
     }
 }
 // ====
+// EVMVersion: >=shanghai
 // optimizationPreset: full
 // ----
 // Assembly:

--- a/test/libyul/objectCompiler/identical_subobjects_partial_debug_info_no_use_src.yul
+++ b/test/libyul/objectCompiler/identical_subobjects_partial_debug_info_no_use_src.yul
@@ -56,6 +56,7 @@ object "A" {
     }
 }
 // ====
+// EVMVersion: >=shanghai
 // optimizationPreset: full
 // ----
 // Assembly:

--- a/test/libyul/objectCompiler/identical_subobjects_with_subject_references.yul
+++ b/test/libyul/objectCompiler/identical_subobjects_with_subject_references.yul
@@ -95,6 +95,7 @@ object "A" {
     }
 }
 // ====
+// EVMVersion: >=shanghai
 // optimizationPreset: full
 // ----
 // Assembly:

--- a/test/libyul/objectCompiler/immutable_long_name_does_not_end_up_in_bytecode.yul
+++ b/test/libyul/objectCompiler/immutable_long_name_does_not_end_up_in_bytecode.yul
@@ -7,6 +7,8 @@ object "a" {
         )
     }
 }
+// ====
+// EVMVersion: >=shanghai
 // ----
 // Assembly:
 //     /* "source":143:185   */

--- a/test/libyul/objectCompiler/leading_and_trailing_dots.yul
+++ b/test/libyul/objectCompiler/leading_and_trailing_dots.yul
@@ -12,6 +12,8 @@
     }
     g(2)
 }
+// ====
+// EVMVersion: >=shanghai
 // ----
 // Assembly:
 //     /* "source":53:54   */

--- a/test/libyul/objectCompiler/linkersymbol.yul
+++ b/test/libyul/objectCompiler/linkersymbol.yul
@@ -5,6 +5,8 @@ object "a" {
         let success := call(gas(), addr, 0, 128, 4, 128, 0)
     }
 }
+// ====
+// EVMVersion: >=shanghai
 // ----
 // Assembly:
 //     /* "source":190:191   */

--- a/test/libyul/objectCompiler/long_object_name.yul
+++ b/test/libyul/objectCompiler/long_object_name.yul
@@ -7,6 +7,7 @@ object "t" {
 	}
 }
 // ====
+// EVMVersion: >=shanghai
 // optimizationPreset: full
 // ----
 // Assembly:

--- a/test/libyul/objectCompiler/manySubObjects.yul
+++ b/test/libyul/objectCompiler/manySubObjects.yul
@@ -134,6 +134,8 @@ object "root" {
         }
     }
 }
+// ====
+// EVMVersion: >=shanghai
 // ----
 // Assembly:
 //     /* "source":59:75   */

--- a/test/libyul/objectCompiler/metadata.yul
+++ b/test/libyul/objectCompiler/metadata.yul
@@ -19,6 +19,8 @@ object "A" {
   data ".metadata" "M2"
   data "x" "Hello, World2!"
 }
+// ====
+// EVMVersion: >=shanghai
 // ----
 // Assembly:
 //     /* "source":55:68   */

--- a/test/libyul/objectCompiler/namedObjectCode.yul
+++ b/test/libyul/objectCompiler/namedObjectCode.yul
@@ -1,6 +1,8 @@
 object "a" {
   code { sstore(0, 1) }
 }
+// ====
+// EVMVersion: >=shanghai
 // ----
 // Assembly:
 //     /* "source":36:37   */

--- a/test/libyul/objectCompiler/nested_optimizer.yul
+++ b/test/libyul/objectCompiler/nested_optimizer.yul
@@ -15,6 +15,7 @@ object "a" {
   }
 }
 // ====
+// EVMVersion: >=shanghai
 // optimizationPreset: full
 // ----
 // Assembly:

--- a/test/libyul/objectCompiler/simple.yul
+++ b/test/libyul/objectCompiler/simple.yul
@@ -1,6 +1,8 @@
 {
   sstore(0, 1)
 }
+// ====
+// EVMVersion: >=shanghai
 // ----
 // Assembly:
 //     /* "source":41:42   */

--- a/test/libyul/objectCompiler/simple_optimizer.yul
+++ b/test/libyul/objectCompiler/simple_optimizer.yul
@@ -5,6 +5,7 @@
   sstore(add(x, 0), z)
 }
 // ====
+// EVMVersion: >=shanghai
 // optimizationPreset: full
 // ----
 // Assembly:

--- a/test/libyul/objectCompiler/sourceLocations.yul
+++ b/test/libyul/objectCompiler/sourceLocations.yul
@@ -28,6 +28,8 @@ object "a" {
     data "data1" "Hello, World!"
   }
 }
+// ====
+// EVMVersion: >=shanghai
 // ----
 // Assembly:
 //     /* "abc.sol":0:2   */

--- a/test/libyul/objectCompiler/subObjectAccess.yul
+++ b/test/libyul/objectCompiler/subObjectAccess.yul
@@ -65,6 +65,8 @@ object "A" {
     }
   }
 }
+// ====
+// EVMVersion: >=shanghai
 // ----
 // Assembly:
 //     /* "source":57:72   */

--- a/test/libyul/objectCompiler/verbatim_bug.yul
+++ b/test/libyul/objectCompiler/verbatim_bug.yul
@@ -23,6 +23,7 @@ object "a" {
     }
 }
 // ====
+// EVMVersion: >=shanghai
 // optimizationPreset: full
 // ----
 // Assembly:


### PR DESCRIPTION
- Make `ObjectCompilerTest` inherits from `EVMVersionRestrictedTestCase`
- Update object compiler test to EVM versions which enables `PUSH0`. These tests utilize this instruction. 