### PR TITLE
Generalize optimizer step profiler

### DIFF
--- a/libsolutil/CMakeLists.txt
+++ b/libsolutil/CMakeLists.txt
@@ -27,6 +27,8 @@ set(sources
 	Numeric.cpp
 	Numeric.h
 	picosha2.h
+	Profiler.cpp
+	Profiler.h
 	Result.h
 	SetOnce.h
 	StackTooDeepString.h

--- a/libsolutil/Profiler.cpp
+++ b/libsolutil/Profiler.cpp
@@ -76,24 +76,25 @@ void util::Profiler::outputPerformanceMetrics()
 		totalCallCount += scopeMetrics.callCount;
 	}
 
-	std::cerr << "Performance metrics for profiled scopes" << std::endl;
-	std::cerr << "=======================================" << std::endl;
+	std::cerr << "PERFORMANCE METRICS FOR PROFILED SCOPES\n\n";
+	std::cerr << "| Time % | Time       | Calls   | Scope                          |\n";
+	std::cerr << "|-------:|-----------:|--------:|--------------------------------|\n";
+
 	constexpr double microsecondsInSecond = 1000000;
 	for (auto&& [scopeName, scopeMetrics]: sortedMetrics)
 	{
 		double percentage = 100.0 * static_cast<double>(scopeMetrics.durationInMicroseconds) / static_cast<double>(totalDurationInMicroseconds);
 		double durationInSeconds = static_cast<double>(scopeMetrics.durationInMicroseconds) / microsecondsInSecond;
 		std::cerr << fmt::format(
-			"{:>7.3f}% ({} s, {} calls): {}",
+			"| {:5.1f}% | {:8.3f} s | {:7} | {:30} |\n",
 			percentage,
 			durationInSeconds,
 			scopeMetrics.callCount,
 			scopeName
-		) << std::endl;
+		);
 	}
 	double totalDurationInSeconds = static_cast<double>(totalDurationInMicroseconds) / microsecondsInSecond;
-	std::cerr << "--------------------------------------" << std::endl;
-	std::cerr << fmt::format("{:>7}% ({:.3f} s, {} calls)", 100, totalDurationInSeconds, totalCallCount) << std::endl;
+	std::cerr << fmt::format("| {:5.1f}% | {:8.3f} s | {:7} | {:30} |\n", 100.0, totalDurationInSeconds, totalCallCount, "**TOTAL**");
 }
 
 #endif

--- a/libsolutil/Profiler.cpp
+++ b/libsolutil/Profiler.cpp
@@ -1,0 +1,88 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libsolutil/Profiler.h>
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <iostream>
+#include <vector>
+
+using namespace std::chrono;
+using namespace solidity;
+
+#ifdef PROFILE_OPTIMIZER_STEPS
+
+util::Profiler::Probe::Probe(std::string _scopeName):
+	m_scopeName(std::move(_scopeName)),
+	m_startTime(steady_clock::now())
+{
+}
+
+util::Profiler::Probe::~Probe()
+{
+	steady_clock::time_point endTime = steady_clock::now();
+	int64_t durationInMicroseconds = duration_cast<microseconds>(endTime - m_startTime).count();
+
+	auto [durationIt, inserted] = Profiler::singleton().m_durations.try_emplace(m_scopeName, 0);
+	durationIt->second += durationInMicroseconds;
+}
+
+util::Profiler::~Profiler()
+{
+	outputPerformanceMetrics();
+}
+
+util::Profiler& util::Profiler::singleton()
+{
+	static Profiler profiler;
+	return profiler;
+}
+
+void util::Profiler::outputPerformanceMetrics()
+{
+	std::vector<std::pair<std::string, int64_t>> durations(m_durations.begin(), m_durations.end());
+	std::sort(
+		durations.begin(),
+		durations.end(),
+		[](std::pair<std::string, int64_t> const& _lhs, std::pair<std::string, int64_t> const& _rhs) -> bool
+		{
+			return _lhs.second < _rhs.second;
+		}
+	);
+
+	int64_t totalDurationInMicroseconds = 0;
+	for (auto&& [scopeName, durationInMicroseconds]: durations)
+		totalDurationInMicroseconds += durationInMicroseconds;
+
+	std::cerr << "Performance metrics for profiled scopes" << std::endl;
+	std::cerr << "=======================================" << std::endl;
+	constexpr double microsecondsInSecond = 1000000;
+	for (auto&& [scopeName, durationInMicroseconds]: durations)
+	{
+		double percentage = 100.0 * static_cast<double>(durationInMicroseconds) / static_cast<double>(totalDurationInMicroseconds);
+		double durationInSeconds = static_cast<double>(durationInMicroseconds) / microsecondsInSecond;
+		std::cerr << fmt::format("{:>7.3f}% ({} s): {}", percentage, durationInSeconds, scopeName) << std::endl;
+	}
+	double totalDurationInSeconds = static_cast<double>(totalDurationInMicroseconds) / microsecondsInSecond;
+	std::cerr << "--------------------------------------" << std::endl;
+	std::cerr << fmt::format("{:>7}% ({:.3f} s)", 100, totalDurationInSeconds) << std::endl;
+}
+
+#endif

--- a/libsolutil/Profiler.h
+++ b/libsolutil/Profiler.h
@@ -1,0 +1,75 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <chrono>
+#include <map>
+#include <optional>
+#include <string>
+
+#ifdef PROFILE_OPTIMIZER_STEPS
+#define PROFILER_PROBE(_scopeName, _variable) solidity::util::Profiler::Probe _variable(_scopeName);
+#else
+#define PROFILER_PROBE(_scopeName, _variable) void(0);
+#endif
+
+namespace solidity::util
+{
+
+#ifdef PROFILE_OPTIMIZER_STEPS
+
+/// Simpler profiler class that gathers metrics during program execution and prints them out on exit.
+///
+/// To gather metrics, create a Probe instance and let it live until the end of the scope.
+/// The probe will register its creation and destruction time and store the results in the profiler
+/// singleton.
+///
+/// Use the PROFILER_PROBE macro to create probes conditionally, in a way that will not affect performance
+/// unless profiling is enabled at compilation time via PROFILE_OPTIMIZER_STEPS CMake option.
+///
+/// Scopes are identified by the name supplied to the probe. Using the same name multiple times
+/// will result in metrics for those scopes being aggregated together as if they were the same scope.
+class Profiler
+{
+public:
+	class Probe
+	{
+	public:
+		Probe(std::string _scopeName);
+		~Probe();
+
+	private:
+		std::string m_scopeName;
+		std::chrono::steady_clock::time_point m_startTime;
+	};
+
+	static Profiler& singleton();
+
+private:
+	~Profiler();
+
+	/// Summarizes gathered metric and prints a report to standard error output.
+	void outputPerformanceMetrics();
+
+	std::map<std::string, int64_t> m_durations;
+};
+
+#endif
+
+}

--- a/libsolutil/Profiler.h
+++ b/libsolutil/Profiler.h
@@ -64,10 +64,16 @@ public:
 private:
 	~Profiler();
 
+	struct Metrics
+	{
+		int64_t durationInMicroseconds;
+		size_t callCount;
+	};
+
 	/// Summarizes gathered metric and prints a report to standard error output.
 	void outputPerformanceMetrics();
 
-	std::map<std::string, int64_t> m_durations;
+	std::map<std::string, Metrics> m_metrics;
 };
 
 #endif

--- a/libsolutil/Profiler.h
+++ b/libsolutil/Profiler.h
@@ -66,7 +66,7 @@ private:
 
 	struct Metrics
 	{
-		int64_t durationInMicroseconds;
+		std::chrono::microseconds durationInMicroseconds;
 		size_t callCount;
 	};
 

--- a/libyul/optimiser/Suite.h
+++ b/libyul/optimiser/Suite.h
@@ -91,9 +91,6 @@ public:
 private:
 	OptimiserStepContext& m_context;
 	Debug m_debug;
-#ifdef PROFILE_OPTIMIZER_STEPS
-	std::map<std::string, int64_t> m_durationPerStepInMicroseconds;
-#endif
 };
 
 }


### PR DESCRIPTION
This PR moves the simple profiling setup we had in `Suite.cpp` and moves it into a separate class that can be easily used in random places.

It also switches to static storage for the metrics, which means that we get a single report with total running time over all the Yul objects rather than one per object. Originally the profiler was used with small contracts from `test/benchmarks/` where it was probably manageable, but when profiling big projects like Uniswap or OpenZeppelin, the aggregate data is much more useful.

Using the profiler is now as easy as dropping a `PROFILER_PROBE()` macro in the scope that is meant to be measured. The default probes are still placed only around the optimizer steps, but new ones can be added ad-hoc, locally.

The PR also tweaks the output to make it easy to post it in comments in a readable form. It also tracks the number of calls in addition to the timing.