### PR TITLE
Update example of subscribing to a transaction in accordance with changes in web3.js

### DIFF
--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -186,16 +186,17 @@ and any user interface calls the automatically generated ``balances`` function f
 
 .. code-block:: javascript
 
-    Coin.Sent().watch({}, '', function(error, result) {
-        if (!error) {
-            console.log("Coin transfer: " + result.args.amount +
-                " coins were sent from " + result.args.from +
-                " to " + result.args.to + ".");
-            console.log("Balances now:\n" +
-                "Sender: " + Coin.balances.call(result.args.from) +
-                "Receiver: " + Coin.balances.call(result.args.to));
-        }
+    Coin.events.Sent().on('data', async function (event) {
+    console.log("Coin transfer: " + event.returnValues.amount +
+        " coins were sent from " + event.returnValues.from +
+        " to " + event.returnValues.to + ".")
+    const senderBalance = await Coin.methods.balances(event.returnValues.from).call();
+    const receiverBalance = await Coin.methods.balances(event.returnValues.to).call();
+    console.log("Balances now:\n" +
+        "Sender: " + senderBalance +
+        "\nReceiver: " + receiverBalance);
     })
+    Coin.events.Sent().on('error', console.error);
 
 .. index:: coin
 


### PR DESCRIPTION
web3.js changed the way how we subscribe to events, update this example accordingly.
See e.g. https://web3js.readthedocs.io/en/v1.2.11/web3-eth-contract.html#id50

Optionally querying the balances may be removed for this example to be concise.