### PR TITLE
Use boost's predefined cpp integer types

### DIFF
--- a/libsolutil/Numeric.h
+++ b/libsolutil/Numeric.h
@@ -48,6 +48,8 @@ namespace solidity
 using bigint = boost::multiprecision::cpp_int;
 using u256 = boost::multiprecision::uint256_t;
 using s256 = boost::multiprecision::int256_t;
+using u512 = boost::multiprecision::uint512_t;
+
 
 /// Interprets @a _u as a two's complement signed number and returns the resulting s256.
 inline s256 u2s(u256 _u)

--- a/libsolutil/Numeric.h
+++ b/libsolutil/Numeric.h
@@ -45,9 +45,9 @@ namespace solidity
 {
 
 // Numeric types.
-using bigint = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<>>;
-using u256 = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<256, 256, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void>>;
-using s256 = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<256, 256, boost::multiprecision::signed_magnitude, boost::multiprecision::unchecked, void>>;
+using bigint = boost::multiprecision::cpp_int;
+using u256 = boost::multiprecision::uint256_t;
+using s256 = boost::multiprecision::int256_t;
 
 /// Interprets @a _u as a two's complement signed number and returns the resulting s256.
 inline s256 u2s(u256 _u)

--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
@@ -106,8 +106,6 @@ void copyZeroExtendedWithOverlap(
 
 }
 
-using u512 = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<512, 256, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void>>;
-
 u256 EVMInstructionInterpreter::eval(
 	evmasm::Instruction _instruction,
 	std::vector<u256> const& _arguments


### PR DESCRIPTION
Part of #15435/#15464.

This should help _fix_ a minor issue in `test/tools/yulInterpreter/EVMInstructionInterpreter.cpp`. Here the type `u512` is defined with `MaxBits` greater than `MinBits`. This does not cause any error since boost use the max of `MaxBits` and MinBits` for `void` allocator. Though it should be fixed to avoid confusion.

The reference for the types is here https://www.boost.org/doc/libs/1_84_0/libs/multiprecision/doc/html/boost_multiprecision/tut/ints/cpp_int.html