### PR TITLE
Prune unused code from UnusedPruner

### DIFF
--- a/libyul/optimiser/UnusedPruner.cpp
+++ b/libyul/optimiser/UnusedPruner.cpp
@@ -55,20 +55,6 @@ UnusedPruner::UnusedPruner(
 		++m_references[f];
 }
 
-UnusedPruner::UnusedPruner(
-	Dialect const& _dialect,
-	FunctionDefinition& _function,
-	bool _allowMSizeOptimization,
-	std::set<YulName> const& _externallyUsedFunctions
-):
-	m_dialect(_dialect),
-	m_allowMSizeOptimization(_allowMSizeOptimization)
-{
-	m_references = ReferencesCounter::countReferences(_function);
-	for (auto const& f: _externallyUsedFunctions)
-		++m_references[f];
-}
-
 void UnusedPruner::operator()(Block& _block)
 {
 	for (auto&& statement: _block.statements)
@@ -142,8 +128,12 @@ void UnusedPruner::runUntilStabilised(
 	while (true)
 	{
 		UnusedPruner pruner(
-			_dialect, _ast, _allowMSizeOptimization, _functionSideEffects,
-							_externallyUsedFunctions);
+			_dialect,
+			_ast,
+			_allowMSizeOptimization,
+			_functionSideEffects,
+			_externallyUsedFunctions
+		);
 		pruner(_ast);
 		if (!pruner.shouldRunAgain())
 			return;
@@ -160,22 +150,6 @@ void UnusedPruner::runUntilStabilisedOnFullAST(
 		SideEffectsPropagator::sideEffects(_dialect, CallGraphGenerator::callGraph(_ast));
 	bool allowMSizeOptimization = !MSizeFinder::containsMSize(_dialect, _ast);
 	runUntilStabilised(_dialect, _ast, allowMSizeOptimization, &functionSideEffects, _externallyUsedFunctions);
-}
-
-void UnusedPruner::runUntilStabilised(
-	Dialect const& _dialect,
-	FunctionDefinition& _function,
-	bool _allowMSizeOptimization,
-	std::set<YulName> const& _externallyUsedFunctions
-)
-{
-	while (true)
-	{
-		UnusedPruner pruner(_dialect, _function, _allowMSizeOptimization, _externallyUsedFunctions);
-		pruner(_function);
-		if (!pruner.shouldRunAgain())
-			return;
-	}
 }
 
 bool UnusedPruner::used(YulName _name) const

--- a/libyul/optimiser/UnusedPruner.h
+++ b/libyul/optimiser/UnusedPruner.h
@@ -68,15 +68,6 @@ public:
 		std::set<YulName> const& _externallyUsedFunctions = {}
 	);
 
-	static void run(
-		Dialect const& _dialect,
-		Block& _ast,
-		std::set<YulName> const& _externallyUsedFunctions = {}
-	)
-	{
-		runUntilStabilisedOnFullAST(_dialect, _ast, _externallyUsedFunctions);
-	}
-
 	/// Run the pruner until the code does not change anymore.
 	/// The provided block has to be a full AST.
 	/// The pruner itself determines if msize is used and which user-defined functions
@@ -87,30 +78,12 @@ public:
 		std::set<YulName> const& _externallyUsedFunctions = {}
 	);
 
-	// Run the pruner until the code does not change anymore.
-	// Only run on the given function.
-	// @param _allowMSizeOptimization if true, allows to remove instructions
-	//        whose only side-effect is a potential change of the return value of
-	//        the msize instruction.
-	static void runUntilStabilised(
-		Dialect const& _dialect,
-		FunctionDefinition& _functionDefinition,
-		bool _allowMSizeOptimization,
-		std::set<YulName> const& _externallyUsedFunctions = {}
-	);
-
 private:
 	UnusedPruner(
 		Dialect const& _dialect,
 		Block& _ast,
 		bool _allowMSizeOptimization,
 		std::map<YulName, SideEffects> const* _functionSideEffects = nullptr,
-		std::set<YulName> const& _externallyUsedFunctions = {}
-	);
-	UnusedPruner(
-		Dialect const& _dialect,
-		FunctionDefinition& _function,
-		bool _allowMSizeOptimization,
 		std::set<YulName> const& _externallyUsedFunctions = {}
 	);
 


### PR DESCRIPTION
Related to #15508.

During profiling I discovered that some of the duplicated bits are actually unused.