### PR TITLE
Restrict object compiler tests to exclude deprecated EVM versions

### DIFF
--- a/test/libyul/objectCompiler/data.yul
+++ b/test/libyul/objectCompiler/data.yul
@@ -3,6 +3,8 @@ object "a" {
   // Unreferenced data is not added to the assembled bytecode.
   data "str" "Hello, World!"
 }
+// ====
+// EVMVersion: >=constantinople
 // ----
 // Assembly:
 //     /* "source":22:29   */

--- a/test/libyul/objectCompiler/namedObject.yul
+++ b/test/libyul/objectCompiler/namedObject.yul
@@ -1,6 +1,8 @@
 object "a" {
   code {}
 }
+// ====
+// EVMVersion: >=constantinople
 // ----
 // Assembly:
 //     /* "source":22:29   */

--- a/test/libyul/objectCompiler/smoke.yul
+++ b/test/libyul/objectCompiler/smoke.yul
@@ -1,5 +1,7 @@
 {
 }
+// ====
+// EVMVersion: >=constantinople
 // ----
 // Assembly:
 //     /* "source":27:34   */

--- a/test/libyul/objectCompiler/subObject.yul
+++ b/test/libyul/objectCompiler/subObject.yul
@@ -4,6 +4,8 @@ object "a" {
   data "str" "Hello, World!"
   object "sub" { code { sstore(0, 1) } }
 }
+// ====
+// EVMVersion: >=constantinople
 // ----
 // Assembly:
 //     /* "source":22:29   */

--- a/test/libyul/objectCompiler/subSubObject.yul
+++ b/test/libyul/objectCompiler/subSubObject.yul
@@ -10,6 +10,8 @@ object "a" {
     }
   }
 }
+// ====
+// EVMVersion: >=constantinople
 // ----
 // Assembly:
 //     /* "source":22:29   */


### PR DESCRIPTION
Missing items from: https://github.com/ethereum/solidity/pull/15511

You can view a successful nightly build based on this change here: https://app.circleci.com/pipelines/github/ethereum/solidity/36502/workflows/85eae54f-b233-4d75-8d3a-e0b829c84309/jobs/1667526