### PR TITLE
Introduce Yul builtin handles for its dialects

### DIFF
--- a/libsolidity/analysis/ControlFlowBuilder.cpp
+++ b/libsolidity/analysis/ControlFlowBuilder.cpp
@@ -582,13 +582,14 @@ void ControlFlowBuilder::operator()(yul::FunctionCall const& _functionCall)
 	solAssert(m_currentNode && m_inlineAssembly, "");
 	yul::ASTWalker::operator()(_functionCall);
 
-	if (auto const *builtinFunction = m_inlineAssembly->dialect().builtin(_functionCall.functionName.name))
+	if (auto const& builtinHandle = m_inlineAssembly->dialect().findBuiltin(_functionCall.functionName.name.str()))
 	{
-		if (builtinFunction->controlFlowSideEffects.canTerminate)
+		auto const& builtinFunction = m_inlineAssembly->dialect().builtin(*builtinHandle);
+		if (builtinFunction.controlFlowSideEffects.canTerminate)
 			connect(m_currentNode, m_transactionReturnNode);
-		if (builtinFunction->controlFlowSideEffects.canRevert)
+		if (builtinFunction.controlFlowSideEffects.canRevert)
 			connect(m_currentNode, m_revertNode);
-		if (!builtinFunction->controlFlowSideEffects.canContinue)
+		if (!builtinFunction.controlFlowSideEffects.canContinue)
 			m_currentNode = newLabel();
 	}
 }

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -66,9 +66,9 @@ public:
 	void operator()(yul::FunctionCall const& _funCall)
 	{
 		if (yul::EVMDialect const* dialect = dynamic_cast<decltype(dialect)>(&m_dialect))
-			if (yul::BuiltinFunctionForEVM const* fun = dialect->builtin(_funCall.functionName.name))
-				if (fun->instruction)
-					checkInstruction(nativeLocationOf(_funCall), *fun->instruction);
+			if (std::optional<yul::BuiltinHandle> builtinHandle = dialect->findBuiltin(_funCall.functionName.name.str()))
+				if (auto const& instruction = dialect->builtin(*builtinHandle).instruction)
+					checkInstruction(nativeLocationOf(_funCall), *instruction);
 
 		for (auto const& arg: _funCall.arguments)
 			std::visit(*this, arg);

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -84,7 +84,7 @@ struct CopyTranslate: public yul::ASTCopier
 		// from the Yul dialect we are compiling to. So we are assuming here that the builtin
 		// functions are identical. This should not be a problem for now since everything
 		// is EVM anyway.
-		if (m_dialect.builtin(_name))
+		if (m_dialect.findBuiltin(_name.str()))
 			return _name;
 		else
 			return yul::YulName{"usr$" + _name.str()};

--- a/libsolidity/experimental/codegen/IRGeneratorForStatements.cpp
+++ b/libsolidity/experimental/codegen/IRGeneratorForStatements.cpp
@@ -72,7 +72,7 @@ struct CopyTranslate: public yul::ASTCopier
 
 	yul::YulName translateIdentifier(yul::YulName _name) override
 	{
-		if (m_dialect.builtin(_name))
+		if (m_dialect.findBuiltin(_name.str()))
 			return _name;
 		else
 			return yul::YulName{"usr$" + _name.str()};

--- a/libyul/Builtins.h
+++ b/libyul/Builtins.h
@@ -1,0 +1,35 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <cstddef>
+
+namespace solidity::yul
+{
+
+/// Handle to reference a builtin function in the AST
+struct BuiltinHandle
+{
+	size_t id;
+
+	bool operator==(BuiltinHandle const& _other) const { return id == _other.id; }
+	bool operator<(BuiltinHandle const& _other) const { return id < _other.id; }
+};
+
+}

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(yul
 	AsmParser.h
 	AsmPrinter.cpp
 	AsmPrinter.h
+	Builtins.h
 	YulStack.h
 	YulStack.cpp
 	CompilabilityChecker.cpp

--- a/libyul/ControlFlowSideEffectsCollector.cpp
+++ b/libyul/ControlFlowSideEffectsCollector.cpp
@@ -271,8 +271,8 @@ ControlFlowNode const* ControlFlowSideEffectsCollector::nextProcessableNode(Func
 
 ControlFlowSideEffects const& ControlFlowSideEffectsCollector::sideEffects(FunctionCall const& _call) const
 {
-	if (auto const* builtin = m_dialect.builtin(_call.functionName.name))
-		return builtin->controlFlowSideEffects;
+	if (std::optional<BuiltinHandle> builtinHandle = m_dialect.findBuiltin(_call.functionName.name.str()))
+		return m_dialect.builtin(*builtinHandle).controlFlowSideEffects;
 	else
 		return m_functionSideEffects.at(m_functionReferences.at(&_call));
 }

--- a/libyul/Dialect.h
+++ b/libyul/Dialect.h
@@ -74,16 +74,15 @@ struct Dialect
 	/// @returns true if the identifier is reserved. This includes the builtins too.
 	virtual bool reservedIdentifier(std::string_view _name) const { return findBuiltin(_name).has_value(); }
 
-	// todo these are handles, not functions
-	virtual std::optional<BuiltinHandle> discardFunction() const { return std::nullopt; }
-	virtual std::optional<BuiltinHandle> equalityFunction() const { return std::nullopt; }
-	virtual std::optional<BuiltinHandle> booleanNegationFunction() const { return std::nullopt; }
+	virtual std::optional<BuiltinHandle> discardFunctionHandle() const { return std::nullopt; }
+	virtual std::optional<BuiltinHandle> equalityFunctionHandle() const { return std::nullopt; }
+	virtual std::optional<BuiltinHandle> booleanNegationFunctionHandle() const { return std::nullopt; }
 
-	virtual std::optional<BuiltinHandle> memoryStoreFunction() const { return std::nullopt; }
-	virtual std::optional<BuiltinHandle> memoryLoadFunction() const { return std::nullopt; }
-	virtual std::optional<BuiltinHandle> storageStoreFunction() const { return std::nullopt; }
-	virtual std::optional<BuiltinHandle> storageLoadFunction() const { return std::nullopt; }
-	virtual std::optional<BuiltinHandle> hashFunction() const { return std::nullopt; }
+	virtual std::optional<BuiltinHandle> memoryStoreFunctionHandle() const { return std::nullopt; }
+	virtual std::optional<BuiltinHandle> memoryLoadFunctionHandle() const { return std::nullopt; }
+	virtual std::optional<BuiltinHandle> storageStoreFunctionHandle() const { return std::nullopt; }
+	virtual std::optional<BuiltinHandle> storageLoadFunctionHandle() const { return std::nullopt; }
+	virtual std::optional<BuiltinHandle> hashFunctionHandle() const { return std::nullopt; }
 
 	Literal zeroLiteral() const;
 

--- a/libyul/Dialect.h
+++ b/libyul/Dialect.h
@@ -59,16 +59,16 @@ struct BuiltinFunction
 
 struct Dialect
 {
-	static size_t constexpr verbatimMaxInputSlots = 100;
-	static size_t constexpr verbatimMaxOutputSlots = 100;
-
 	/// Noncopiable.
 	Dialect(Dialect const&) = delete;
 	Dialect& operator=(Dialect const&) = delete;
 
-	/// @returns the builtin function of the given name or a null if it is not a builtin function.
+    /// Finds a builtin by name and returns the corresponding handle.
+	/// @returns Builtin handle or null if the name does not match any builtin in the dialect.
 	virtual std::optional<BuiltinHandle> findBuiltin(std::string_view /*_name*/) const { return std::nullopt; }
 
+    /// Retrieves the description of a builtin function by its handle.
+    /// Note that handles are dialect-specific and can be used only with a dialect that created them.
 	virtual BuiltinFunction const& builtin(BuiltinHandle const&) const { yulAssert(false); }
 
 	/// @returns true if the identifier is reserved. This includes the builtins too.

--- a/libyul/Dialect.h
+++ b/libyul/Dialect.h
@@ -21,13 +21,16 @@
 
 #pragma once
 
-#include <libyul/YulName.h>
+#include <libyul/Builtins.h>
 #include <libyul/ControlFlowSideEffects.h>
+#include <libyul/Exceptions.h>
 #include <libyul/SideEffects.h>
+#include <libyul/YulString.h>
 
-#include <vector>
-#include <set>
 #include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
 
 namespace solidity::yul
 {
@@ -38,7 +41,7 @@ struct Literal;
 
 struct BuiltinFunction
 {
-	YulName name;
+	std::string name;
 	size_t numParameters;
 	size_t numReturns;
 	SideEffects sideEffects;
@@ -56,25 +59,31 @@ struct BuiltinFunction
 
 struct Dialect
 {
+	static size_t constexpr verbatimMaxInputSlots = 100;
+	static size_t constexpr verbatimMaxOutputSlots = 100;
+
 	/// Noncopiable.
 	Dialect(Dialect const&) = delete;
 	Dialect& operator=(Dialect const&) = delete;
 
-	/// @returns the builtin function of the given name or a nullptr if it is not a builtin function.
-	virtual BuiltinFunction const* builtin(YulName /*_name*/) const { return nullptr; }
+	/// @returns the builtin function of the given name or a null if it is not a builtin function.
+	virtual std::optional<BuiltinHandle> findBuiltin(std::string_view /*_name*/) const { return std::nullopt; }
+
+	virtual BuiltinFunction const& builtin(BuiltinHandle const&) const { yulAssert(false); }
 
 	/// @returns true if the identifier is reserved. This includes the builtins too.
-	virtual bool reservedIdentifier(YulName _name) const { return builtin(_name) != nullptr; }
+	virtual bool reservedIdentifier(std::string_view _name) const { return findBuiltin(_name).has_value(); }
 
-	virtual BuiltinFunction const* discardFunction() const { return nullptr; }
-	virtual BuiltinFunction const* equalityFunction() const { return nullptr; }
-	virtual BuiltinFunction const* booleanNegationFunction() const { return nullptr; }
+	// todo these are handles, not functions
+	virtual std::optional<BuiltinHandle> discardFunction() const { return std::nullopt; }
+	virtual std::optional<BuiltinHandle> equalityFunction() const { return std::nullopt; }
+	virtual std::optional<BuiltinHandle> booleanNegationFunction() const { return std::nullopt; }
 
-	virtual BuiltinFunction const* memoryStoreFunction() const { return nullptr; }
-	virtual BuiltinFunction const* memoryLoadFunction() const { return nullptr; }
-	virtual BuiltinFunction const* storageStoreFunction() const { return nullptr; }
-	virtual BuiltinFunction const* storageLoadFunction() const { return nullptr; }
-	virtual YulName hashFunction() const { return YulName{}; }
+	virtual std::optional<BuiltinHandle> memoryStoreFunction() const { return std::nullopt; }
+	virtual std::optional<BuiltinHandle> memoryLoadFunction() const { return std::nullopt; }
+	virtual std::optional<BuiltinHandle> storageStoreFunction() const { return std::nullopt; }
+	virtual std::optional<BuiltinHandle> storageLoadFunction() const { return std::nullopt; }
+	virtual std::optional<BuiltinHandle> hashFunction() const { return std::nullopt; }
 
 	Literal zeroLiteral() const;
 

--- a/libyul/Dialect.h
+++ b/libyul/Dialect.h
@@ -78,8 +78,6 @@ struct Dialect
 
 	Literal zeroLiteral() const;
 
-	virtual std::set<YulName> fixedFunctionNames() const { return {}; }
-
 	Dialect() = default;
 	virtual ~Dialect() = default;
 };

--- a/libyul/YulControlFlowGraphExporter.cpp
+++ b/libyul/YulControlFlowGraphExporter.cpp
@@ -193,7 +193,7 @@ Json YulControlFlowGraphExporter::toJson(Json& _ret, SSACFG const& _cfg, SSACFG:
 			if (!builtinArgsJson.empty())
 				opJson["builtinArgs"] = builtinArgsJson;
 
-			opJson["op"] = _call.builtin.get().name.str();
+			opJson["op"] = _call.builtin.get().name;
 		},
 	}, _operation.kind);
 

--- a/libyul/backends/evm/ControlFlowGraphBuilder.cpp
+++ b/libyul/backends/evm/ControlFlowGraphBuilder.cpp
@@ -360,10 +360,11 @@ void ControlFlowGraphBuilder::operator()(Switch const& _switch)
 			yul::Identifier{{}, "eq"_yulname},
 			{*_case.value, Identifier{{}, ghostVariableName}}
 		});
+		BuiltinFunction const& equalityBuiltin = m_dialect.builtin(*equalityBuiltinHandle);
 		CFG::Operation& operation = m_currentBlock->operations.emplace_back(CFG::Operation{
 			Stack{ghostVarSlot, LiteralSlot{_case.value->value.value(), debugDataOf(*_case.value)}},
 			Stack{TemporarySlot{ghostCall, 0}},
-			CFG::BuiltinCall{debugDataOf(_case), m_dialect.builtin(*equalityBuiltinHandle), ghostCall, 2},
+			CFG::BuiltinCall{debugDataOf(_case), equalityBuiltin, ghostCall, 2},
 		});
 		return operation.output.front();
 	};

--- a/libyul/backends/evm/ControlFlowGraphBuilder.cpp
+++ b/libyul/backends/evm/ControlFlowGraphBuilder.cpp
@@ -349,7 +349,7 @@ void ControlFlowGraphBuilder::operator()(Switch const& _switch)
 		CFG::Assignment{_switch.debugData, {ghostVarSlot}}
 	});
 
-	std::optional<BuiltinHandle> const& equalityBuiltinHandle = m_dialect.equalityFunction();
+	std::optional<BuiltinHandle> const& equalityBuiltinHandle = m_dialect.equalityFunctionHandle();
 	yulAssert(equalityBuiltinHandle);
 
 	// Artificially generate:

--- a/libyul/backends/evm/EVMCodeTransform.cpp
+++ b/libyul/backends/evm/EVMCodeTransform.cpp
@@ -230,13 +230,14 @@ void CodeTransform::operator()(FunctionCall const& _call)
 	yulAssert(m_scope, "");
 
 	m_assembly.setSourceLocation(originLocationOf(_call));
-	if (BuiltinFunctionForEVM const* builtin = m_dialect.builtin(_call.functionName.name))
+	if (std::optional<BuiltinHandle> builtinHandle = m_dialect.findBuiltin(_call.functionName.name.str()))
 	{
+		BuiltinFunctionForEVM const& builtin = m_dialect.builtin(*builtinHandle);
 		for (auto&& [i, arg]: _call.arguments | ranges::views::enumerate | ranges::views::reverse)
-			if (!builtin->literalArgument(i))
+			if (!builtin.literalArgument(i))
 				visitExpression(arg);
 		m_assembly.setSourceLocation(originLocationOf(_call));
-		builtin->generateCode(_call, m_assembly, m_builtinContext);
+		builtin.generateCode(_call, m_assembly, m_builtinContext);
 	}
 	else
 	{

--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -25,13 +25,17 @@
 #include <libevmasm/SemanticInformation.h>
 #include <libsolutil/StringUtils.h>
 #include <libyul/AST.h>
-#include <libyul/AsmAnalysisInfo.h>
 #include <libyul/Exceptions.h>
 #include <libyul/Object.h>
 #include <libyul/Utilities.h>
 #include <libyul/backends/evm/AbstractAssembly.h>
 
+#include <range/v3/algorithm/all_of.hpp>
+#include <range/v3/view/enumerate.hpp>
+
 #include <regex>
+#include <utility>
+#include <vector>
 
 using namespace std::string_literals;
 using namespace solidity;
@@ -41,15 +45,15 @@ using namespace solidity::util;
 namespace
 {
 
-std::pair<YulName, BuiltinFunctionForEVM> createEVMFunction(
+BuiltinFunctionForEVM createEVMFunction(
 	langutil::EVMVersion _evmVersion,
 	std::string const& _name,
 	evmasm::Instruction _instruction
 )
 {
-	evmasm::InstructionInfo info = evmasm::instructionInfo(_instruction, _evmVersion);
 	BuiltinFunctionForEVM f;
-	f.name = YulName{_name};
+	evmasm::InstructionInfo info = evmasm::instructionInfo(_instruction, _evmVersion);
+	f.name = _name;
 	f.numParameters = static_cast<size_t>(info.args);
 	f.numReturns = static_cast<size_t>(info.ret);
 	f.sideEffects = EVMDialect::sideEffectsOfInstruction(_instruction);
@@ -77,13 +81,11 @@ std::pair<YulName, BuiltinFunctionForEVM> createEVMFunction(
 	) {
 		_assembly.appendInstruction(_instruction);
 	};
-
-	YulName name = f.name;
-	return {name, std::move(f)};
+	return f;
 }
 
-std::pair<YulName, BuiltinFunctionForEVM> createFunction(
-	std::string _name,
+BuiltinFunctionForEVM createFunction(
+	std::string const& _name,
 	size_t _params,
 	size_t _returns,
 	SideEffects _sideEffects,
@@ -93,20 +95,19 @@ std::pair<YulName, BuiltinFunctionForEVM> createFunction(
 {
 	yulAssert(_literalArguments.size() == _params || _literalArguments.empty(), "");
 
-	YulName name{std::move(_name)};
 	BuiltinFunctionForEVM f;
-	f.name = name;
+	f.name = _name;
 	f.numParameters = _params;
 	f.numReturns = _returns;
-	f.sideEffects = std::move(_sideEffects);
+	f.sideEffects = _sideEffects;
 	f.literalArguments = std::move(_literalArguments);
 	f.isMSize = false;
 	f.instruction = {};
 	f.generateCode = std::move(_generateCode);
-	return {name, f};
+	return f;
 }
 
-std::set<YulName> createReservedIdentifiers(langutil::EVMVersion _evmVersion)
+std::set<std::string, std::less<>> createReservedIdentifiers(langutil::EVMVersion _evmVersion)
 {
 	// TODO remove this in 0.9.0. We allow creating functions or identifiers in Yul with the name
 	// basefee for VMs before london.
@@ -152,7 +153,7 @@ std::set<YulName> createReservedIdentifiers(langutil::EVMVersion _evmVersion)
 			(_instr == evmasm::Instruction::TSTORE || _instr == evmasm::Instruction::TLOAD);
 	};
 
-	std::set<YulName> reserved;
+	std::set<std::string, std::less<>> reserved;
 	for (auto const& instr: evmasm::c_instructions)
 	{
 		std::string name = toLower(instr.first);
@@ -166,18 +167,18 @@ std::set<YulName> createReservedIdentifiers(langutil::EVMVersion _evmVersion)
 		)
 			reserved.emplace(name);
 	}
-	reserved += std::vector<YulName>{
-		"linkersymbol"_yulname,
-		"datasize"_yulname,
-		"dataoffset"_yulname,
-		"datacopy"_yulname,
-		"setimmutable"_yulname,
-		"loadimmutable"_yulname,
+	reserved += std::vector<std::string>{
+		"linkersymbol",
+		"datasize",
+		"dataoffset",
+		"datacopy",
+		"setimmutable",
+		"loadimmutable",
 	};
 	return reserved;
 }
 
-std::map<YulName, BuiltinFunctionForEVM> createBuiltins(langutil::EVMVersion _evmVersion, std::optional<uint8_t> _eofVersion, bool _objectAccess)
+std::vector<std::optional<BuiltinFunctionForEVM>> createBuiltins(langutil::EVMVersion _evmVersion, std::optional<uint8_t> _eofVersion, bool _objectAccess)
 {
 
 	// Exclude prevrandao as builtin for VMs before paris and difficulty for VMs after paris.
@@ -186,7 +187,7 @@ std::map<YulName, BuiltinFunctionForEVM> createBuiltins(langutil::EVMVersion _ev
 		return (_instrName == "prevrandao" && _evmVersion < langutil::EVMVersion::paris()) || (_instrName == "difficulty" && _evmVersion >= langutil::EVMVersion::paris());
 	};
 
-	std::map<YulName, BuiltinFunctionForEVM> builtins;
+	std::vector<std::optional<BuiltinFunctionForEVM>> builtins;
 	for (auto const& instr: evmasm::c_instructions)
 	{
 		std::string name = toLower(instr.first);
@@ -203,23 +204,165 @@ std::map<YulName, BuiltinFunctionForEVM> createBuiltins(langutil::EVMVersion _ev
 			_evmVersion.hasOpcode(opcode, _eofVersion) &&
 			!prevRandaoException(name)
 		)
-			builtins.emplace(createEVMFunction(_evmVersion, name, opcode));
+			builtins.emplace_back(createEVMFunction(_evmVersion, name, opcode));
+		else
+			builtins.emplace_back(std::nullopt);
 	}
 
-	if (_objectAccess)
+	auto const createIfObjectAccess = [_objectAccess](
+		std::string const& _name,
+		size_t _params,
+		size_t _returns,
+		SideEffects _sideEffects,
+		std::vector<std::optional<LiteralKind>> _literalArguments,
+		std::function<void(FunctionCall const&, AbstractAssembly&, BuiltinContext&)> _generateCode
+	) -> std::optional<BuiltinFunctionForEVM>
 	{
-		builtins.emplace(createFunction("linkersymbol", 1, 1, SideEffects{}, {LiteralKind::String}, [](
+		if (!_objectAccess)
+			return std::nullopt;
+		return createFunction(_name, _params, _returns, _sideEffects, std::move(_literalArguments), std::move(_generateCode));
+	};
+
+	builtins.emplace_back(createIfObjectAccess("linkersymbol", 1, 1, SideEffects{}, {LiteralKind::String}, [](
+		FunctionCall const& _call,
+		AbstractAssembly& _assembly,
+		BuiltinContext&
+	) {
+		yulAssert(_call.arguments.size() == 1, "");
+		Expression const& arg = _call.arguments.front();
+		_assembly.appendLinkerSymbol(formatLiteral(std::get<Literal>(arg)));
+	}));
+	builtins.emplace_back(createIfObjectAccess(
+		"memoryguard",
+		1,
+		1,
+		SideEffects{},
+		{LiteralKind::Number},
+		[](
 			FunctionCall const& _call,
 			AbstractAssembly& _assembly,
 			BuiltinContext&
 		) {
 			yulAssert(_call.arguments.size() == 1, "");
+			Literal const* literal = std::get_if<Literal>(&_call.arguments.front());
+			yulAssert(literal, "");
+			_assembly.appendConstant(literal->value.value());
+		})
+	);
+	if (!_eofVersion.has_value())
+	{
+		builtins.emplace_back(createIfObjectAccess("datasize", 1, 1, SideEffects{}, {LiteralKind::String}, [](
+			FunctionCall const& _call,
+			AbstractAssembly& _assembly,
+			BuiltinContext& _context
+		) {
+			yulAssert(_context.currentObject, "No object available.");
+			yulAssert(_call.arguments.size() == 1, "");
 			Expression const& arg = _call.arguments.front();
-			_assembly.appendLinkerSymbol(formatLiteral(std::get<Literal>(arg)));
+			YulName const dataName (formatLiteral(std::get<Literal>(arg)));
+			if (_context.currentObject->name == dataName.str())
+				_assembly.appendAssemblySize();
+			else
+			{
+			std::vector<size_t> subIdPath =
+					_context.subIDs.count(dataName.str()) == 0 ?
+						_context.currentObject->pathToSubObject(dataName.str()) :
+						std::vector<size_t>{_context.subIDs.at(dataName.str())};
+				yulAssert(!subIdPath.empty(), "Could not find assembly object <" + dataName.str() + ">.");
+				_assembly.appendDataSize(subIdPath);
+			}
 		}));
-
-		builtins.emplace(createFunction(
-			"memoryguard",
+		builtins.emplace_back(createIfObjectAccess("dataoffset", 1, 1, SideEffects{}, {LiteralKind::String}, [](
+			FunctionCall const& _call,
+			AbstractAssembly& _assembly,
+			BuiltinContext& _context
+		) {
+			yulAssert(_context.currentObject, "No object available.");
+			yulAssert(_call.arguments.size() == 1, "");
+			Expression const& arg = _call.arguments.front();
+			YulName const dataName (formatLiteral(std::get<Literal>(arg)));
+			if (_context.currentObject->name == dataName.str())
+				_assembly.appendConstant(0);
+			else
+			{
+			std::vector<size_t> subIdPath =
+					_context.subIDs.count(dataName.str()) == 0 ?
+						_context.currentObject->pathToSubObject(dataName.str()) :
+						std::vector<size_t>{_context.subIDs.at(dataName.str())};
+				yulAssert(!subIdPath.empty(), "Could not find assembly object <" + dataName.str() + ">.");
+				_assembly.appendDataOffset(subIdPath);
+			}
+		}));
+		builtins.emplace_back(createIfObjectAccess(
+			"datacopy",
+			3,
+			0,
+			SideEffects{
+				false,               // movable
+				true,                // movableApartFromEffects
+				false,               // canBeRemoved
+				false,               // canBeRemovedIfNotMSize
+				true,                // cannotLoop
+				SideEffects::None,   // otherState
+				SideEffects::None,   // storage
+				SideEffects::Write,  // memory
+				SideEffects::None    // transientStorage
+			},
+			{},
+			[](
+				FunctionCall const&,
+				AbstractAssembly& _assembly,
+				BuiltinContext&
+			) {
+				_assembly.appendInstruction(evmasm::Instruction::CODECOPY);
+			}
+		));
+		builtins.emplace_back(createIfObjectAccess(
+			"setimmutable",
+			3,
+			0,
+			SideEffects{
+				false,               // movable
+				false,               // movableApartFromEffects
+				false,               // canBeRemoved
+				false,               // canBeRemovedIfNotMSize
+				true,                // cannotLoop
+				SideEffects::None,   // otherState
+				SideEffects::None,   // storage
+				SideEffects::Write,  // memory
+				SideEffects::None    // transientStorage
+			},
+			{std::nullopt, LiteralKind::String, std::nullopt},
+			[](
+				FunctionCall const& _call,
+				AbstractAssembly& _assembly,
+				BuiltinContext&
+			) {
+				yulAssert(_call.arguments.size() == 3, "");
+				auto const identifier = (formatLiteral(std::get<Literal>(_call.arguments[1])));
+				_assembly.appendImmutableAssignment(identifier);
+			}
+		));
+		builtins.emplace_back(createIfObjectAccess(
+			"loadimmutable",
+			1,
+			1,
+			SideEffects{},
+			{LiteralKind::String},
+			[](
+				FunctionCall const& _call,
+				AbstractAssembly& _assembly,
+				BuiltinContext&
+			) {
+				yulAssert(_call.arguments.size() == 1, "");
+				_assembly.appendImmutable(formatLiteral(std::get<Literal>(_call.arguments.front())));
+			}
+		));
+	}
+	else
+	{
+		builtins.emplace_back(createFunction(
+			"auxdataloadn",
 			1,
 			1,
 			SideEffects{},
@@ -232,142 +375,17 @@ std::map<YulName, BuiltinFunctionForEVM> createBuiltins(langutil::EVMVersion _ev
 				yulAssert(_call.arguments.size() == 1, "");
 				Literal const* literal = std::get_if<Literal>(&_call.arguments.front());
 				yulAssert(literal, "");
-				_assembly.appendConstant(literal->value.value());
-			})
-		);
-
-		if (!_eofVersion.has_value()) // non-EOF context
-		{
-			builtins.emplace(createFunction("datasize", 1, 1, SideEffects{}, {LiteralKind::String}, [](
-				FunctionCall const& _call,
-				AbstractAssembly& _assembly,
-				BuiltinContext& _context
-			) {
-				yulAssert(_context.currentObject, "No object available.");
-				yulAssert(_call.arguments.size() == 1, "");
-				Expression const& arg = _call.arguments.front();
-				YulName const dataName (formatLiteral(std::get<Literal>(arg)));
-				if (_context.currentObject->name == dataName.str())
-					_assembly.appendAssemblySize();
-				else
-				{
-				std::vector<size_t> subIdPath =
-						_context.subIDs.count(dataName.str()) == 0 ?
-							_context.currentObject->pathToSubObject(dataName.str()) :
-							std::vector<size_t>{_context.subIDs.at(dataName.str())};
-					yulAssert(!subIdPath.empty(), "Could not find assembly object <" + dataName.str() + ">.");
-					_assembly.appendDataSize(subIdPath);
-				}
-			}));
-			builtins.emplace(createFunction("dataoffset", 1, 1, SideEffects{}, {LiteralKind::String}, [](
-				FunctionCall const& _call,
-				AbstractAssembly& _assembly,
-				BuiltinContext& _context
-			) {
-				yulAssert(_context.currentObject, "No object available.");
-				yulAssert(_call.arguments.size() == 1, "");
-				Expression const& arg = _call.arguments.front();
-				YulName const dataName (formatLiteral(std::get<Literal>(arg)));
-				if (_context.currentObject->name == dataName.str())
-					_assembly.appendConstant(0);
-				else
-				{
-				std::vector<size_t> subIdPath =
-						_context.subIDs.count(dataName.str()) == 0 ?
-							_context.currentObject->pathToSubObject(dataName.str()) :
-							std::vector<size_t>{_context.subIDs.at(dataName.str())};
-					yulAssert(!subIdPath.empty(), "Could not find assembly object <" + dataName.str() + ">.");
-					_assembly.appendDataOffset(subIdPath);
-				}
-			}));
-			builtins.emplace(createFunction(
-				"datacopy",
-				3,
-				0,
-				SideEffects{
-					false,               // movable
-					true,                // movableApartFromEffects
-					false,               // canBeRemoved
-					false,               // canBeRemovedIfNotMSize
-					true,                // cannotLoop
-					SideEffects::None,   // otherState
-					SideEffects::None,   // storage
-					SideEffects::Write,  // memory
-					SideEffects::None    // transientStorage
-				},
-				{},
-				[](
-					FunctionCall const&,
-					AbstractAssembly& _assembly,
-					BuiltinContext&
-				) {
-					_assembly.appendInstruction(evmasm::Instruction::CODECOPY);
-				}
-			));
-			builtins.emplace(createFunction(
-				"setimmutable",
-				3,
-				0,
-				SideEffects{
-					false,               // movable
-					false,               // movableApartFromEffects
-					false,               // canBeRemoved
-					false,               // canBeRemovedIfNotMSize
-					true,                // cannotLoop
-					SideEffects::None,   // otherState
-					SideEffects::None,   // storage
-					SideEffects::Write,  // memory
-					SideEffects::None    // transientStorage
-				},
-				{std::nullopt, LiteralKind::String, std::nullopt},
-				[](
-					FunctionCall const& _call,
-					AbstractAssembly& _assembly,
-					BuiltinContext&
-				) {
-					yulAssert(_call.arguments.size() == 3, "");
-					auto const identifier = (formatLiteral(std::get<Literal>(_call.arguments[1])));
-					_assembly.appendImmutableAssignment(identifier);
-				}
-			));
-			builtins.emplace(createFunction(
-				"loadimmutable",
-				1,
-				1,
-				SideEffects{},
-				{LiteralKind::String},
-				[](
-					FunctionCall const& _call,
-					AbstractAssembly& _assembly,
-					BuiltinContext&
-				) {
-					yulAssert(_call.arguments.size() == 1, "");
-					_assembly.appendImmutable(formatLiteral(std::get<Literal>(_call.arguments.front())));
-				}
-			));
-		}
-		else // EOF context
-		{
-			builtins.emplace(createFunction(
-				"auxdataloadn",
-				1,
-				1,
-				SideEffects{},
-				{LiteralKind::Number},
-				[](
-					FunctionCall const& _call,
-					AbstractAssembly& _assembly,
-					BuiltinContext&
-				) {
-					yulAssert(_call.arguments.size() == 1, "");
-					Literal const* literal = std::get_if<Literal>(&_call.arguments.front());
-					yulAssert(literal, "");
-					yulAssert(literal->value.value() <= std::numeric_limits<uint16_t>::max(), "");
-					_assembly.appendAuxDataLoadN(static_cast<uint16_t>(literal->value.value()));
-				}
-			));
-		}
+				yulAssert(literal->value.value() <= std::numeric_limits<uint16_t>::max(), "");
+				_assembly.appendAuxDataLoadN(static_cast<uint16_t>(literal->value.value()));
+			}
+		));
 	}
+	yulAssert(
+		ranges::all_of(builtins, [](std::optional<BuiltinFunctionForEVM> const& _builtinFunction){
+			return !_builtinFunction || _builtinFunction->name.substr(0, "verbatim_"s.size()) != "verbatim_";
+		}),
+		"Builtin functions besides verbatim should not start with the verbatim_ prefix."
+	);
 	return builtins;
 }
 
@@ -387,27 +405,58 @@ EVMDialect::EVMDialect(langutil::EVMVersion _evmVersion, std::optional<uint8_t> 
 	m_functions(createBuiltins(_evmVersion, _eofVersion, _objectAccess)),
 	m_reserved(createReservedIdentifiers(_evmVersion))
 {
+	for (auto const& [index, maybeBuiltin]: m_functions | ranges::views::enumerate)
+		if (maybeBuiltin)
+			// ids are offset by the maximum number of verbatim functions
+			m_builtinFunctionsByName[maybeBuiltin->name] = BuiltinHandle{index + verbatimIdOffset};
+
+	m_discardFunction = findBuiltin("pop");
+	m_equalityFunction = findBuiltin("eq");
+	m_booleanNegationFunction = findBuiltin("iszero");
+	m_memoryStoreFunction = findBuiltin("mstore");
+	m_memoryLoadFunction = findBuiltin("mload");
+	m_storageStoreFunction = findBuiltin("sstore");
+	m_storageLoadFunction = findBuiltin("sload");
+	m_hashFunction = findBuiltin("keccak256");
 }
 
-BuiltinFunctionForEVM const* EVMDialect::builtin(YulName _name) const
+std::optional<BuiltinHandle> EVMDialect::findBuiltin(std::string_view _name) const
 {
 	if (m_objectAccess)
 	{
 		std::smatch match;
-		if (regex_match(_name.str(), match, verbatimPattern()))
+		std::string name(_name);
+		if (regex_match(name, match, verbatimPattern()))
 			return verbatimFunction(stoul(match[1]), stoul(match[2]));
 	}
-	auto it = m_functions.find(_name);
-	if (it != m_functions.end())
-		return &it->second;
-	else
-		return nullptr;
+	auto it = std::find_if(m_functions.begin(), m_functions.end(), [&_name](auto const& builtin) { return builtin && builtin.value().name == _name; });
+	if (it != m_functions.end() && *it && it->value().name == _name)
+		// ids are offset by the maximum number of verbatim functions
+		return BuiltinHandle{static_cast<size_t>(std::distance(m_functions.begin(), it)) + verbatimIdOffset};
+	return std::nullopt;
 }
 
-bool EVMDialect::reservedIdentifier(YulName _name) const
+BuiltinFunctionForEVM const& EVMDialect::builtin(BuiltinHandle const& handle) const
+{
+	if (isVerbatimHandle(handle))
+	{
+		yulAssert(handle.id < verbatimIDOffset);
+		auto const& verbatimFunctionPtr = m_verbatimFunctions[handle.id];
+		yulAssert(verbatimFunctionPtr);
+		return *verbatimFunctionPtr;
+	}
+
+	yulAssert(handle.id - verbatimIDOffset < m_functions.size());
+	auto const& maybeBuiltin = m_functions[handle.id - verbatimIDOffset];
+	yulAssert(maybeBuiltin.has_value());
+	return *maybeBuiltin;
+}
+
+
+bool EVMDialect::reservedIdentifier(std::string_view _name) const
 {
 	if (m_objectAccess)
-		if (_name.str().substr(0, "verbatim"s.size()) == "verbatim")
+		if (_name.substr(0, "verbatim"s.size()) == "verbatim")
 			return true;
 	return m_reserved.count(_name) != 0;
 }
@@ -450,35 +499,49 @@ SideEffects EVMDialect::sideEffectsOfInstruction(evmasm::Instruction _instructio
 	};
 }
 
-BuiltinFunctionForEVM const* EVMDialect::verbatimFunction(size_t _arguments, size_t _returnVariables) const
+BuiltinHandle EVMDialect::verbatimFunction(size_t _arguments, size_t _returnVariables) const
 {
-	std::pair<size_t, size_t> key{_arguments, _returnVariables};
-	std::shared_ptr<BuiltinFunctionForEVM const>& function = m_verbatimFunctions[key];
-	if (!function)
-	{
-		BuiltinFunctionForEVM builtinFunction = createFunction(
-			"verbatim_" + std::to_string(_arguments) + "i_" + std::to_string(_returnVariables) + "o",
-			1 + _arguments,
-			_returnVariables,
-			SideEffects::worst(),
-			std::vector<std::optional<LiteralKind>>{LiteralKind::String} + std::vector<std::optional<LiteralKind>>(_arguments),
-			[=](
-				FunctionCall const& _call,
-				AbstractAssembly& _assembly,
-				BuiltinContext&
-			) {
-				yulAssert(_call.arguments.size() == (1 + _arguments), "");
-				Expression const& bytecode = _call.arguments.front();
+	auto const it = std::find_if(m_verbatimFunctions.begin(), m_verbatimFunctions.end(), [&](BuiltinFunctionForEVM const& _function) {
+		return _function.numParameters == 1 + _arguments && _function.numReturns == _returnVariables;
+	});
+	yulAssert(_arguments <= verbatimMaxInputSlots);
+	yulAssert(_returnVariables <= verbatimMaxOutputSlots);
+	if (it != m_verbatimFunctions.end())
+		return {static_cast<size_t>(std::distance(m_verbatimFunctions.begin(), it))};
 
-				_assembly.appendVerbatim(
-					asBytes(formatLiteral(std::get<Literal>(bytecode))),
-					_arguments,
-					_returnVariables
-				);
-			}
-		).second;
-		builtinFunction.isMSize = true;
-		function = std::make_shared<BuiltinFunctionForEVM const>(std::move(builtinFunction));
-	}
-	return function.get();
+	BuiltinFunctionForEVM builtinFunction = createFunction(
+		"verbatim_" + std::to_string(_arguments) + "i_" + std::to_string(_returnVariables) + "o",
+		1 + _arguments,
+		_returnVariables,
+		SideEffects::worst(),
+		std::vector<std::optional<LiteralKind>>{LiteralKind::String} + std::vector<std::optional<LiteralKind>>(_arguments),
+		[=](
+			FunctionCall const& _call,
+			AbstractAssembly& _assembly,
+			BuiltinContext&
+		) {
+			yulAssert(_call.arguments.size() == (1 + _arguments), "");
+			Expression const& bytecode = _call.arguments.front();
+
+			_assembly.appendVerbatim(
+				asBytes(formatLiteral(std::get<Literal>(bytecode))),
+				_arguments,
+				_returnVariables
+			);
+		}
+	);
+	builtinFunction.isMSize = true;
+	m_verbatimFunctions.push_back(std::move(builtinFunction));
+	yulAssert(m_verbatimFunctions.size() <= verbatimIdOffset);
+	return {m_verbatimFunctions.size() - 1};
+}
+
+BuiltinFunctionForEVM const& EVMDialect::builtin(BuiltinHandle const& handle) const
+{
+	if (handle.id < verbatimIdOffset)
+		return m_verbatimFunctions.at(handle.id);
+
+	auto const& maybeBuiltin = m_functions.at(handle.id - verbatimIdOffset);
+	yulAssert(maybeBuiltin.has_value());
+	return *maybeBuiltin;
 }

--- a/libyul/backends/evm/EVMDialect.h
+++ b/libyul/backends/evm/EVMDialect.h
@@ -72,17 +72,16 @@ public:
 
 	BuiltinFunctionForEVM const& builtin(BuiltinHandle const& _handle) const override;
 
-	/// @returns true if the identifier is reserved. This includes the builtins too.
 	bool reservedIdentifier(std::string_view _name) const override;
 
-	std::optional<BuiltinHandle> discardFunction() const override { return m_discardFunction; }
-	std::optional<BuiltinHandle> equalityFunction() const override { return m_equalityFunction; }
-	std::optional<BuiltinHandle> booleanNegationFunction() const override { return m_booleanNegationFunction; }
-	std::optional<BuiltinHandle> memoryStoreFunction() const override { return m_memoryStoreFunction; }
-	std::optional<BuiltinHandle> memoryLoadFunction() const override { return m_memoryLoadFunction; }
-	std::optional<BuiltinHandle> storageStoreFunction() const override { return m_storageStoreFunction; }
-	std::optional<BuiltinHandle> storageLoadFunction() const override { return m_storageLoadFunction; }
-	std::optional<BuiltinHandle> hashFunction() const override { return m_hashFunction; }
+	std::optional<BuiltinHandle> discardFunctionHandle() const override { return m_discardFunction; }
+	std::optional<BuiltinHandle> equalityFunctionHandle() const override { return m_equalityFunction; }
+	std::optional<BuiltinHandle> booleanNegationFunctionHandle() const override { return m_booleanNegationFunction; }
+	std::optional<BuiltinHandle> memoryStoreFunctionHandle() const override { return m_memoryStoreFunction; }
+	std::optional<BuiltinHandle> memoryLoadFunctionHandle() const override { return m_memoryLoadFunction; }
+	std::optional<BuiltinHandle> storageStoreFunctionHandle() const override { return m_storageStoreFunction; }
+	std::optional<BuiltinHandle> storageLoadFunctionHandle() const override { return m_storageLoadFunction; }
+	std::optional<BuiltinHandle> hashFunctionHandle() const override { return m_hashFunction; }
 
 	static EVMDialect const& strictAssemblyForEVM(langutil::EVMVersion _evmVersion, std::optional<uint8_t> _eofVersion);
 	static EVMDialect const& strictAssemblyForEVMObjects(langutil::EVMVersion _evmVersion, std::optional<uint8_t> _eofVersion);

--- a/libyul/backends/evm/EVMDialect.h
+++ b/libyul/backends/evm/EVMDialect.h
@@ -70,7 +70,7 @@ public:
 
 	std::optional<BuiltinHandle> findBuiltin(std::string_view _name) const override;
 
-	BuiltinFunctionForEVM const& builtin(BuiltinHandle const& handle) const override;
+	BuiltinFunctionForEVM const& builtin(BuiltinHandle const& _handle) const override;
 
 	/// @returns true if the identifier is reserved. This includes the builtins too.
 	bool reservedIdentifier(std::string_view _name) const override;
@@ -108,6 +108,7 @@ protected:
 	bool const m_objectAccess;
 	langutil::EVMVersion const m_evmVersion;
 	std::optional<uint8_t> m_eofVersion;
+	std::unordered_map<std::string_view, BuiltinHandle> m_builtinFunctionsByName;
 	std::vector<std::optional<BuiltinFunctionForEVM>> m_functions;
 	std::array<std::unique_ptr<BuiltinFunctionForEVM>, verbatimIDOffset> mutable m_verbatimFunctions{};
 	std::set<std::string, std::less<>> m_reserved;

--- a/libyul/backends/evm/EVMDialect.h
+++ b/libyul/backends/evm/EVMDialect.h
@@ -62,25 +62,26 @@ struct BuiltinFunctionForEVM: public BuiltinFunction
  * The main difference is that the builtin functions take an AbstractAssembly for the
  * code generation.
  */
-struct EVMDialect: public Dialect
+struct EVMDialect: Dialect
 {
 	/// Constructor, should only be used internally. Use the factory functions below.
 	EVMDialect(langutil::EVMVersion _evmVersion, std::optional<uint8_t> _eofVersion, bool _objectAccess);
 
-	/// @returns the builtin function of the given name or a nullptr if it is not a builtin function.
-	BuiltinFunctionForEVM const* builtin(YulName _name) const override;
+	std::optional<BuiltinHandle> findBuiltin(std::string_view _name) const override;
+
+	BuiltinFunctionForEVM const& builtin(BuiltinHandle const& handle) const override;
 
 	/// @returns true if the identifier is reserved. This includes the builtins too.
-	bool reservedIdentifier(YulName _name) const override;
+	bool reservedIdentifier(std::string_view _name) const override;
 
-	BuiltinFunctionForEVM const* discardFunction() const override { return builtin("pop"_yulname); }
-	BuiltinFunctionForEVM const* equalityFunction() const override { return builtin("eq"_yulname); }
-	BuiltinFunctionForEVM const* booleanNegationFunction() const override { return builtin("iszero"_yulname); }
-	BuiltinFunctionForEVM const* memoryStoreFunction() const override { return builtin("mstore"_yulname); }
-	BuiltinFunctionForEVM const* memoryLoadFunction() const override { return builtin("mload"_yulname); }
-	BuiltinFunctionForEVM const* storageStoreFunction() const override { return builtin("sstore"_yulname); }
-	BuiltinFunctionForEVM const* storageLoadFunction() const override { return builtin("sload"_yulname); }
-	YulName hashFunction() const override { return "keccak256"_yulname; }
+	std::optional<BuiltinHandle> discardFunction() const override { return m_discardFunction; }
+	std::optional<BuiltinHandle> equalityFunction() const override { return m_equalityFunction; }
+	std::optional<BuiltinHandle> booleanNegationFunction() const override { return m_booleanNegationFunction; }
+	std::optional<BuiltinHandle> memoryStoreFunction() const override { return m_memoryStoreFunction; }
+	std::optional<BuiltinHandle> memoryLoadFunction() const override { return m_memoryLoadFunction; }
+	std::optional<BuiltinHandle> storageStoreFunction() const override { return m_storageStoreFunction; }
+	std::optional<BuiltinHandle> storageLoadFunction() const override { return m_storageLoadFunction; }
+	std::optional<BuiltinHandle> hashFunction() const override { return m_hashFunction; }
 
 	static EVMDialect const& strictAssemblyForEVM(langutil::EVMVersion _evmVersion, std::optional<uint8_t> _eofVersion);
 	static EVMDialect const& strictAssemblyForEVMObjects(langutil::EVMVersion _evmVersion, std::optional<uint8_t> _eofVersion);
@@ -92,15 +93,28 @@ struct EVMDialect: public Dialect
 
 	static SideEffects sideEffectsOfInstruction(evmasm::Instruction _instruction);
 
+	std::vector<BuiltinFunctionForEVM> const& verbatimFunctions() const { return m_verbatimFunctions; }
+
 protected:
-	BuiltinFunctionForEVM const* verbatimFunction(size_t _arguments, size_t _returnVariables) const;
+	BuiltinHandle verbatimFunction(size_t _arguments, size_t _returnVariables) const;
+
+	static size_t constexpr verbatimIdOffset = verbatimMaxInputSlots * verbatimMaxOutputSlots;
 
 	bool const m_objectAccess;
 	langutil::EVMVersion const m_evmVersion;
 	std::optional<uint8_t> m_eofVersion;
-	std::map<YulName, BuiltinFunctionForEVM> m_functions;
-	std::map<std::pair<size_t, size_t>, std::shared_ptr<BuiltinFunctionForEVM const>> mutable m_verbatimFunctions;
-	std::set<YulName> m_reserved;
+	std::vector<std::optional<BuiltinFunctionForEVM>> m_functions;
+	std::vector<BuiltinFunctionForEVM> mutable m_verbatimFunctions;
+	std::set<std::string, std::less<>> m_reserved;
+
+	std::optional<BuiltinHandle> m_discardFunction;
+	std::optional<BuiltinHandle> m_equalityFunction;
+	std::optional<BuiltinHandle> m_booleanNegationFunction;
+	std::optional<BuiltinHandle> m_memoryStoreFunction;
+	std::optional<BuiltinHandle> m_memoryLoadFunction;
+	std::optional<BuiltinHandle> m_storageStoreFunction;
+	std::optional<BuiltinHandle> m_storageLoadFunction;
+	std::optional<BuiltinHandle> m_hashFunction;
 };
 
 }

--- a/libyul/backends/evm/EVMMetrics.cpp
+++ b/libyul/backends/evm/EVMMetrics.cpp
@@ -76,10 +76,10 @@ std::pair<bigint, bigint> GasMeterVisitor::instructionCosts(
 void GasMeterVisitor::operator()(FunctionCall const& _funCall)
 {
 	ASTWalker::operator()(_funCall);
-	if (BuiltinFunctionForEVM const* f = m_dialect.builtin(_funCall.functionName.name))
-		if (f->instruction)
+	if (std::optional<BuiltinHandle> handle = m_dialect.findBuiltin(_funCall.functionName.name.str()))
+		if (std::optional<evmasm::Instruction> const& instruction = m_dialect.builtin(*handle).instruction)
 		{
-			instructionCostsInternal(*f->instruction);
+			instructionCostsInternal(*instruction);
 			return;
 		}
 	yulAssert(false, "Functions not implemented.");

--- a/libyul/backends/evm/EVMMetrics.h
+++ b/libyul/backends/evm/EVMMetrics.h
@@ -29,7 +29,7 @@
 namespace solidity::yul
 {
 
-struct EVMDialect;
+class EVMDialect;
 
 /**
  * Gas meter for expressions only involving literals, identifiers and

--- a/libyul/backends/evm/EVMObjectCompiler.h
+++ b/libyul/backends/evm/EVMObjectCompiler.h
@@ -28,7 +28,7 @@ namespace solidity::yul
 {
 struct Object;
 class AbstractAssembly;
-struct EVMDialect;
+class EVMDialect;
 
 class EVMObjectCompiler
 {

--- a/libyul/backends/evm/NoOutputAssembly.cpp
+++ b/libyul/backends/evm/NoOutputAssembly.cpp
@@ -38,13 +38,13 @@ namespace
 
 void modifyBuiltinToNoOutput(BuiltinFunctionForEVM& _builtin)
 {
-	_builtin.generateCode = [fun=_builtin](FunctionCall const& _call, AbstractAssembly& _assembly, BuiltinContext&)
+	_builtin.generateCode = [_builtin](FunctionCall const& _call, AbstractAssembly& _assembly, BuiltinContext&)
 	{
 		for (size_t i: ranges::views::iota(0u, _call.arguments.size()))
-			if (!fun.literalArgument(i))
+			if (!_builtin.literalArgument(i))
 				_assembly.appendInstruction(evmasm::Instruction::POP);
 
-		for (size_t i = 0; i < fun.numReturns; i++)
+		for (size_t i = 0; i < _builtin.numReturns; i++)
 			_assembly.appendConstant(u256(0));
 	};
 }

--- a/libyul/backends/evm/NoOutputAssembly.h
+++ b/libyul/backends/evm/NoOutputAssembly.h
@@ -90,9 +90,12 @@ private:
 /**
  * EVM dialect that does not generate any code.
  */
-struct NoOutputEVMDialect: public EVMDialect
+class NoOutputEVMDialect: public EVMDialect
 {
+public:
 	explicit NoOutputEVMDialect(EVMDialect const& _copyFrom);
+
+	BuiltinFunctionForEVM const& builtin(BuiltinHandle const& _handle) const override;
 };
 
 

--- a/libyul/backends/evm/SSAControlFlowGraph.cpp
+++ b/libyul/backends/evm/SSAControlFlowGraph.cpp
@@ -147,7 +147,7 @@ private:
 						return _call.function.get().name.str();
 					},
 					[&](SSACFG::BuiltinCall const& _call) {
-						return _call.builtin.get().name.str();
+						return _call.builtin.get().name;
 					},
 				}, operation.kind);
 				if (!operation.outputs.empty())

--- a/libyul/optimiser/CommonSubexpressionEliminator.cpp
+++ b/libyul/optimiser/CommonSubexpressionEliminator.cpp
@@ -72,13 +72,14 @@ void CommonSubexpressionEliminator::visit(Expression& _e)
 	{
 		FunctionCall& funCall = std::get<FunctionCall>(_e);
 
-		if (BuiltinFunction const* builtin = m_dialect.builtin(funCall.functionName.name))
+		if (std::optional<BuiltinHandle> builtinHandle = m_dialect.findBuiltin(funCall.functionName.name.str()))
 		{
+			BuiltinFunction const& builtin = m_dialect.builtin(*builtinHandle);
 			for (size_t i = funCall.arguments.size(); i > 0; i--)
 				// We should not modify function arguments that have to be literals
 				// Note that replacing the function call entirely is fine,
 				// if the function call is movable.
-				if (!builtin->literalArgument(i - 1))
+				if (!builtin.literalArgument(i - 1))
 					visit(funCall.arguments[i - 1]);
 
 			descend = false;

--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -54,13 +54,13 @@ DataFlowAnalyzer::DataFlowAnalyzer(
 {
 	if (m_analyzeStores)
 	{
-		if (auto const& builtinHandle = _dialect.memoryStoreFunction())
+		if (auto const& builtinHandle = _dialect.memoryStoreFunctionHandle())
 			m_storeFunctionName[static_cast<unsigned>(StoreLoadLocation::Memory)] = YulName{_dialect.builtin(*builtinHandle).name};
-		if (auto const& builtinHandle = _dialect.memoryLoadFunction())
+		if (auto const& builtinHandle = _dialect.memoryLoadFunctionHandle())
 			m_loadFunctionName[static_cast<unsigned>(StoreLoadLocation::Memory)] = YulName{_dialect.builtin(*builtinHandle).name};
-		if (auto const& builtinHandle = _dialect.storageStoreFunction())
+		if (auto const& builtinHandle = _dialect.storageStoreFunctionHandle())
 			m_storeFunctionName[static_cast<unsigned>(StoreLoadLocation::Storage)] = YulName{_dialect.builtin(*builtinHandle).name};
-		if (auto const& builtinHandle = _dialect.storageLoadFunction())
+		if (auto const& builtinHandle = _dialect.storageLoadFunctionHandle())
 			m_loadFunctionName[static_cast<unsigned>(StoreLoadLocation::Storage)] = YulName{_dialect.builtin(*builtinHandle).name};
 	}
 }
@@ -446,7 +446,7 @@ std::optional<YulName> DataFlowAnalyzer::isSimpleLoad(
 std::optional<std::pair<YulName, YulName>> DataFlowAnalyzer::isKeccak(Expression const& _expression) const
 {
 	if (FunctionCall const* funCall = std::get_if<FunctionCall>(&_expression))
-		if (funCall->functionName.name.str() == m_dialect.builtin(*m_dialect.hashFunction()).name)
+		if (funCall->functionName.name.str() == m_dialect.builtin(*m_dialect.hashFunctionHandle()).name)
 			if (Identifier const* start = std::get_if<Identifier>(&funCall->arguments.at(0)))
 				if (Identifier const* length = std::get_if<Identifier>(&funCall->arguments.at(1)))
 					return std::make_pair(start->name, length->name);

--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -54,14 +54,14 @@ DataFlowAnalyzer::DataFlowAnalyzer(
 {
 	if (m_analyzeStores)
 	{
-		if (auto const* builtin = _dialect.memoryStoreFunction())
-			m_storeFunctionName[static_cast<unsigned>(StoreLoadLocation::Memory)] = builtin->name;
-		if (auto const* builtin = _dialect.memoryLoadFunction())
-			m_loadFunctionName[static_cast<unsigned>(StoreLoadLocation::Memory)] = builtin->name;
-		if (auto const* builtin = _dialect.storageStoreFunction())
-			m_storeFunctionName[static_cast<unsigned>(StoreLoadLocation::Storage)] = builtin->name;
-		if (auto const* builtin = _dialect.storageLoadFunction())
-			m_loadFunctionName[static_cast<unsigned>(StoreLoadLocation::Storage)] = builtin->name;
+		if (auto const& builtinHandle = _dialect.memoryStoreFunction())
+			m_storeFunctionName[static_cast<unsigned>(StoreLoadLocation::Memory)] = YulName{_dialect.builtin(*builtinHandle).name};
+		if (auto const& builtinHandle = _dialect.memoryLoadFunction())
+			m_loadFunctionName[static_cast<unsigned>(StoreLoadLocation::Memory)] = YulName{_dialect.builtin(*builtinHandle).name};
+		if (auto const& builtinHandle = _dialect.storageStoreFunction())
+			m_storeFunctionName[static_cast<unsigned>(StoreLoadLocation::Storage)] = YulName{_dialect.builtin(*builtinHandle).name};
+		if (auto const& builtinHandle = _dialect.storageLoadFunction())
+			m_loadFunctionName[static_cast<unsigned>(StoreLoadLocation::Storage)] = YulName{_dialect.builtin(*builtinHandle).name};
 	}
 }
 
@@ -446,7 +446,7 @@ std::optional<YulName> DataFlowAnalyzer::isSimpleLoad(
 std::optional<std::pair<YulName, YulName>> DataFlowAnalyzer::isKeccak(Expression const& _expression) const
 {
 	if (FunctionCall const* funCall = std::get_if<FunctionCall>(&_expression))
-		if (funCall->functionName.name == m_dialect.hashFunction())
+		if (funCall->functionName.name.str() == m_dialect.builtin(*m_dialect.hashFunction()).name)
 			if (Identifier const* start = std::get_if<Identifier>(&funCall->arguments.at(0)))
 				if (Identifier const* length = std::get_if<Identifier>(&funCall->arguments.at(1)))
 					return std::make_pair(start->name, length->name);

--- a/libyul/optimiser/Disambiguator.cpp
+++ b/libyul/optimiser/Disambiguator.cpp
@@ -32,7 +32,7 @@ using namespace solidity::util;
 
 YulName Disambiguator::translateIdentifier(YulName _originalName)
 {
-	if (m_dialect.builtin(_originalName) || m_externallyUsedIdentifiers.count(_originalName))
+	if (m_dialect.findBuiltin(_originalName.str()) || m_externallyUsedIdentifiers.count(_originalName))
 		return _originalName;
 
 	assertThrow(!m_scopes.empty() && m_scopes.back(), OptimizerException, "");

--- a/libyul/optimiser/ExpressionSplitter.cpp
+++ b/libyul/optimiser/ExpressionSplitter.cpp
@@ -41,10 +41,10 @@ void ExpressionSplitter::run(OptimiserStepContext& _context, Block& _ast)
 
 void ExpressionSplitter::operator()(FunctionCall& _funCall)
 {
-	BuiltinFunction const* builtin = m_dialect.builtin(_funCall.functionName.name);
+	std::optional<BuiltinHandle> builtinHandle = m_dialect.findBuiltin(_funCall.functionName.name.str());
 
 	for (size_t i = _funCall.arguments.size(); i > 0; i--)
-		if (!builtin || !builtin->literalArgument(i - 1))
+		if (!builtinHandle || !m_dialect.builtin(*builtinHandle).literalArgument(i - 1))
 			outlineExpression(_funCall.arguments[i - 1]);
 }
 

--- a/libyul/optimiser/ForLoopConditionIntoBody.cpp
+++ b/libyul/optimiser/ForLoopConditionIntoBody.cpp
@@ -33,7 +33,7 @@ void ForLoopConditionIntoBody::run(OptimiserStepContext& _context, Block& _ast)
 void ForLoopConditionIntoBody::operator()(ForLoop& _forLoop)
 {
 	if (
-		m_dialect.booleanNegationFunction() &&
+		m_dialect.booleanNegationFunctionHandle() &&
 		!std::holds_alternative<Literal>(*_forLoop.condition) &&
 		!std::holds_alternative<Identifier>(*_forLoop.condition)
 	)
@@ -47,7 +47,7 @@ void ForLoopConditionIntoBody::operator()(ForLoop& _forLoop)
 				std::make_unique<Expression>(
 					FunctionCall {
 						debugData,
-						{debugData, YulName{m_dialect.builtin(*m_dialect.booleanNegationFunction()).name}},
+						{debugData, YulName{m_dialect.builtin(*m_dialect.booleanNegationFunctionHandle()).name}},
 						util::make_vector<Expression>(std::move(*_forLoop.condition))
 					}
 				),

--- a/libyul/optimiser/ForLoopConditionIntoBody.cpp
+++ b/libyul/optimiser/ForLoopConditionIntoBody.cpp
@@ -47,7 +47,7 @@ void ForLoopConditionIntoBody::operator()(ForLoop& _forLoop)
 				std::make_unique<Expression>(
 					FunctionCall {
 						debugData,
-						{debugData, m_dialect.booleanNegationFunction()->name},
+						{debugData, YulName{m_dialect.builtin(*m_dialect.booleanNegationFunction()).name}},
 						util::make_vector<Expression>(std::move(*_forLoop.condition))
 					}
 				),

--- a/libyul/optimiser/ForLoopConditionOutOfBody.cpp
+++ b/libyul/optimiser/ForLoopConditionOutOfBody.cpp
@@ -53,7 +53,7 @@ void ForLoopConditionOutOfBody::operator()(ForLoop& _forLoop)
 	if (!SideEffectsCollector(m_dialect, *firstStatement.condition).movable())
 		return;
 
-	YulName const iszero = YulName{m_dialect.builtin(*m_dialect.booleanNegationFunctionHandle()).name};
+	YulName const iszero{m_dialect.builtin(*m_dialect.booleanNegationFunctionHandle()).name};
 	langutil::DebugData::ConstPtr debugData = debugDataOf(*firstStatement.condition);
 
 	if (

--- a/libyul/optimiser/ForLoopConditionOutOfBody.cpp
+++ b/libyul/optimiser/ForLoopConditionOutOfBody.cpp
@@ -36,7 +36,7 @@ void ForLoopConditionOutOfBody::operator()(ForLoop& _forLoop)
 	ASTModifier::operator()(_forLoop);
 
 	if (
-		!m_dialect.booleanNegationFunction() ||
+		!m_dialect.booleanNegationFunctionHandle() ||
 		!std::holds_alternative<Literal>(*_forLoop.condition) ||
 		std::get<Literal>(*_forLoop.condition).value.value() == 0 ||
 		_forLoop.body.statements.empty() ||
@@ -53,7 +53,7 @@ void ForLoopConditionOutOfBody::operator()(ForLoop& _forLoop)
 	if (!SideEffectsCollector(m_dialect, *firstStatement.condition).movable())
 		return;
 
-	YulName iszero = m_dialect.booleanNegationFunction()->name;
+	YulName const iszero = YulName{m_dialect.builtin(*m_dialect.booleanNegationFunctionHandle()).name};
 	langutil::DebugData::ConstPtr debugData = debugDataOf(*firstStatement.condition);
 
 	if (

--- a/libyul/optimiser/FullInliner.cpp
+++ b/libyul/optimiser/FullInliner.cpp
@@ -131,7 +131,7 @@ std::map<YulName, size_t> FullInliner::callDepths() const
 	// Remove calls to builtin functions.
 	for (auto& call: cg.functionCalls)
 		for (auto it = call.second.begin(); it != call.second.end();)
-			if (m_dialect.builtin(*it))
+			if (m_dialect.findBuiltin(it->str()))
 				it = call.second.erase(it);
 			else
 				++it;

--- a/libyul/optimiser/FunctionSpecializer.cpp
+++ b/libyul/optimiser/FunctionSpecializer.cpp
@@ -55,7 +55,7 @@ void FunctionSpecializer::operator()(FunctionCall& _f)
 
 	// TODO When backtracking is implemented, the restriction of recursive functions can be lifted.
 	if (
-		m_dialect.builtin(_f.functionName.name) ||
+		m_dialect.findBuiltin(_f.functionName.name.str()) ||
 		m_recursiveFunctions.count(_f.functionName.name)
 	)
 		return;

--- a/libyul/optimiser/LoadResolver.cpp
+++ b/libyul/optimiser/LoadResolver.cpp
@@ -62,7 +62,7 @@ void LoadResolver::visit(Expression& _e)
 			tryResolve(_e, StoreLoadLocation::Memory, funCall->arguments);
 		else if (funCall->functionName.name == m_loadFunctionName[static_cast<unsigned>(StoreLoadLocation::Storage)])
 			tryResolve(_e, StoreLoadLocation::Storage, funCall->arguments);
-		else if (!m_containsMSize && funCall->functionName.name.str() == m_dialect.builtin(*m_dialect.hashFunction()).name)
+		else if (!m_containsMSize && funCall->functionName.name.str() == m_dialect.builtin(*m_dialect.hashFunctionHandle()).name)
 		{
 			Identifier const* start = std::get_if<Identifier>(&funCall->arguments.at(0));
 			Identifier const* length = std::get_if<Identifier>(&funCall->arguments.at(1));

--- a/libyul/optimiser/LoadResolver.cpp
+++ b/libyul/optimiser/LoadResolver.cpp
@@ -62,7 +62,7 @@ void LoadResolver::visit(Expression& _e)
 			tryResolve(_e, StoreLoadLocation::Memory, funCall->arguments);
 		else if (funCall->functionName.name == m_loadFunctionName[static_cast<unsigned>(StoreLoadLocation::Storage)])
 			tryResolve(_e, StoreLoadLocation::Storage, funCall->arguments);
-		else if (!m_containsMSize && funCall->functionName.name == m_dialect.hashFunction())
+		else if (!m_containsMSize && funCall->functionName.name.str() == m_dialect.builtin(*m_dialect.hashFunction()).name)
 		{
 			Identifier const* start = std::get_if<Identifier>(&funCall->arguments.at(0));
 			Identifier const* length = std::get_if<Identifier>(&funCall->arguments.at(1));

--- a/libyul/optimiser/Metrics.h
+++ b/libyul/optimiser/Metrics.h
@@ -28,7 +28,7 @@ namespace solidity::yul
 {
 
 struct Dialect;
-struct EVMDialect;
+class EVMDialect;
 
 /**
  * Weights to be assigned to specific yul statements and expressions by a metric.

--- a/libyul/optimiser/NameSimplifier.cpp
+++ b/libyul/optimiser/NameSimplifier.cpp
@@ -67,7 +67,7 @@ void NameSimplifier::operator()(Identifier& _identifier)
 void NameSimplifier::operator()(FunctionCall& _funCall)
 {
 	// The visitor on its own does not visit the function name.
-	if (!m_context.dialect.builtin(_funCall.functionName.name))
+	if (!m_context.dialect.findBuiltin(_funCall.functionName.name.str()))
 		(*this)(_funCall.functionName);
 	ASTModifier::operator()(_funCall);
 }

--- a/libyul/optimiser/OptimizerUtilities.cpp
+++ b/libyul/optimiser/OptimizerUtilities.cpp
@@ -57,14 +57,14 @@ void yul::removeEmptyBlocks(Block& _block)
 
 bool yul::isRestrictedIdentifier(Dialect const& _dialect, YulName const& _identifier)
 {
-	return _identifier.empty() || hasLeadingOrTrailingDot(_identifier.str()) || TokenTraits::isYulKeyword(_identifier.str()) || _dialect.reservedIdentifier(_identifier);
+	return _identifier.empty() || hasLeadingOrTrailingDot(_identifier.str()) || TokenTraits::isYulKeyword(_identifier.str()) || _dialect.reservedIdentifier(_identifier.str());
 }
 
 std::optional<evmasm::Instruction> yul::toEVMInstruction(Dialect const& _dialect, YulName const& _name)
 {
 	if (auto const* dialect = dynamic_cast<EVMDialect const*>(&_dialect))
-		if (BuiltinFunctionForEVM const* builtin = dialect->builtin(_name))
-			return builtin->instruction;
+		if (std::optional<BuiltinHandle> const builtinHandle = dialect->findBuiltin(_name.str()))
+			return dialect->builtin(*builtinHandle).instruction;
 	return std::nullopt;
 }
 

--- a/libyul/optimiser/SimplificationRules.cpp
+++ b/libyul/optimiser/SimplificationRules.cpp
@@ -79,9 +79,9 @@ std::optional<std::pair<evmasm::Instruction, std::vector<Expression> const*>>
 {
 	if (std::holds_alternative<FunctionCall>(_expr))
 		if (auto const* dialect = dynamic_cast<EVMDialect const*>(&_dialect))
-			if (auto const* builtin = dialect->builtin(std::get<FunctionCall>(_expr).functionName.name))
-				if (builtin->instruction)
-					return std::make_pair(*builtin->instruction, &std::get<FunctionCall>(_expr).arguments);
+			if (std::optional<BuiltinHandle> const builtinHandle = dialect->findBuiltin(std::get<FunctionCall>(_expr).functionName.name.str()))
+				if (auto const& instruction = dialect->builtin(*builtinHandle).instruction)
+					return std::make_pair(*instruction, &std::get<FunctionCall>(_expr).arguments);
 
 	return {};
 }

--- a/libyul/optimiser/StackToMemoryMover.cpp
+++ b/libyul/optimiser/StackToMemoryMover.cpp
@@ -58,7 +58,7 @@ std::vector<Statement> generateMemoryStore(
 
 FunctionCall generateMemoryLoad(Dialect const& _dialect, langutil::DebugData::ConstPtr const& _debugData, LiteralValue const& _mpos)
 {
-	std::optional<BuiltinHandle> const& memoryLoadHandle = _dialect.memoryStoreFunctionHandle();
+	std::optional<BuiltinHandle> const& memoryLoadHandle = _dialect.memoryLoadFunctionHandle();
 	yulAssert(memoryLoadHandle);
 	return FunctionCall{
 		_debugData,

--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -106,7 +106,6 @@ void OptimiserSuite::run(
 		evmDialect->evmVersion().canOverchargeGasForCall() &&
 		evmDialect->providesObjectAccess();
 	std::set<YulName> reservedIdentifiers = _externallyUsedIdentifiers;
-	reservedIdentifiers += _dialect.fixedFunctionNames();
 
 	auto astRoot = std::get<Block>(Disambiguator(
 		_dialect,

--- a/libyul/optimiser/UnusedAssignEliminator.cpp
+++ b/libyul/optimiser/UnusedAssignEliminator.cpp
@@ -79,8 +79,8 @@ void UnusedAssignEliminator::operator()(FunctionCall const& _functionCall)
 	UnusedStoreBase::operator()(_functionCall);
 
 	ControlFlowSideEffects sideEffects;
-	if (auto builtin = m_dialect.builtin(_functionCall.functionName.name))
-		sideEffects = builtin->controlFlowSideEffects;
+	if (std::optional<BuiltinHandle> const builtinHandle = m_dialect.findBuiltin(_functionCall.functionName.name.str()))
+		sideEffects = m_dialect.builtin(*builtinHandle).controlFlowSideEffects;
 	else
 		sideEffects = m_controlFlowSideEffects.at(_functionCall.functionName.name);
 

--- a/libyul/optimiser/UnusedPruner.cpp
+++ b/libyul/optimiser/UnusedPruner.cpp
@@ -94,7 +94,7 @@ void UnusedPruner::operator()(Block& _block)
 				else if (varDecl.variables.size() == 1 && m_dialect.discardFunction())
 					statement = ExpressionStatement{varDecl.debugData, FunctionCall{
 						varDecl.debugData,
-						{varDecl.debugData, m_dialect.discardFunction()->name},
+						{varDecl.debugData, YulName{m_dialect.builtin(*m_dialect.discardFunction()).name}},
 						{*std::move(varDecl.value)}
 					}};
 			}

--- a/libyul/optimiser/UnusedPruner.cpp
+++ b/libyul/optimiser/UnusedPruner.cpp
@@ -91,10 +91,10 @@ void UnusedPruner::operator()(Block& _block)
 					subtractReferences(ReferencesCounter::countReferences(*varDecl.value));
 					statement = Block{std::move(varDecl.debugData), {}};
 				}
-				else if (varDecl.variables.size() == 1 && m_dialect.discardFunction())
+				else if (varDecl.variables.size() == 1 && m_dialect.discardFunctionHandle())
 					statement = ExpressionStatement{varDecl.debugData, FunctionCall{
 						varDecl.debugData,
-						{varDecl.debugData, YulName{m_dialect.builtin(*m_dialect.discardFunction()).name}},
+						{varDecl.debugData, YulName{m_dialect.builtin(*m_dialect.discardFunctionHandle()).name}},
 						{*std::move(varDecl.value)}
 					}};
 			}

--- a/libyul/optimiser/UnusedStoreEliminator.cpp
+++ b/libyul/optimiser/UnusedStoreEliminator.cpp
@@ -114,8 +114,8 @@ void UnusedStoreEliminator::operator()(FunctionCall const& _functionCall)
 		applyOperation(op);
 
 	ControlFlowSideEffects sideEffects;
-	if (auto builtin = m_dialect.builtin(_functionCall.functionName.name))
-		sideEffects = builtin->controlFlowSideEffects;
+	if (std::optional<BuiltinHandle> const builtinHandle = m_dialect.findBuiltin(_functionCall.functionName.name.str()))
+		sideEffects = m_dialect.builtin(*builtinHandle).controlFlowSideEffects;
 	else
 		sideEffects = m_controlFlowSideEffects.at(_functionCall.functionName.name);
 
@@ -230,8 +230,8 @@ std::vector<UnusedStoreEliminator::Operation> UnusedStoreEliminator::operationsF
 
 	YulName functionName = _functionCall.functionName.name;
 	SideEffects sideEffects;
-	if (BuiltinFunction const* f = m_dialect.builtin(functionName))
-		sideEffects = f->sideEffects;
+	if (std::optional<BuiltinHandle> const builtinHandle = m_dialect.findBuiltin(functionName.str()))
+		sideEffects = m_dialect.builtin(*builtinHandle).sideEffects;
 	else
 		sideEffects = m_functionSideEffects.at(functionName);
 

--- a/test/libyul/Parser.cpp
+++ b/test/libyul/Parser.cpp
@@ -133,13 +133,21 @@ BOOST_AUTO_TEST_SUITE(YulParser)
 
 BOOST_AUTO_TEST_CASE(builtins_analysis)
 {
-	struct SimpleDialect: public Dialect
+	struct SimpleDialect: Dialect
 	{
-		BuiltinFunction const* builtin(YulName _name) const override
+		std::optional<BuiltinHandle> findBuiltin(std::string_view _name) const override
 		{
-			return _name == "builtin"_yulname ? &f : nullptr;
+			if (_name == "builtin")
+				return BuiltinHandle{std::numeric_limits<size_t>::max()};
+			return std::nullopt;
 		}
-		BuiltinFunction f{"builtin"_yulname, 2, 3, {}, {}, false, {}};
+
+		BuiltinFunction const& builtin(BuiltinHandle const& handle) const override
+		{
+			BOOST_REQUIRE(handle.id == std::numeric_limits<size_t>::max());
+			return f;
+		}
+		BuiltinFunction f{"builtin", 2, 3, {}, {}, false, {}};
 	};
 
 	SimpleDialect dialect;

--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
@@ -503,7 +503,7 @@ u256 EVMInstructionInterpreter::evalBuiltin(
 	if (_fun.instruction)
 		return eval(*_fun.instruction, _evaluatedArguments);
 
-	std::string fun = _fun.name.str();
+	std::string const& fun = _fun.name;
 	// Evaluate datasize/offset/copy instructions
 	if (fun == "datasize" || fun == "dataoffset")
 	{


### PR DESCRIPTION
- removes `fixedFunctionNames` from `yul::Dialect`
- introduces `yul::BuiltinHandle` struct that functions as a reference to a builtin function
- modifies `yul::EVMDialect` handling of builtins and verbatims so that fetching the function from a handle is `O(1)`; the lookup of a handle from a builtin name (string identifier) is managed through lookup in an `unordered_map`
- the dialect's function `builtin` converts a handle to the corresponding builtin function; a new function `findBuiltin` tries to determine a handle corresponding to a builtin's string identifier