### PR TITLE
Yul optimizer suite: Call name simplifier only once

### DIFF
--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -127,10 +127,6 @@ void OptimiserSuite::run(
 	// ForLoopInitRewriter. Run them first to be able to run arbitrary sequences safely.
 	suite.runSequence("hgfo", astRoot);
 
-	{
-		PROFILER_PROBE("NameSimplifier", probe);
-		NameSimplifier::run(suite.m_context, astRoot);
-	}
 	// Now the user-supplied part
 	suite.runSequence(_optimisationSequence, astRoot);
 


### PR DESCRIPTION
In https://github.com/ethereum/solidity/pull/15518#discussion_r1803403869, @cameel discovered that the name simplifier is always run twice in the yul optimizer suite. This PR removes one of the two calls. @ekpyron are we missing some corner case here? 