### PR TITLE
Mark prague as experimental in a few places where it was not so

### DIFF
--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -345,7 +345,7 @@ Input Description
         // Version of the EVM to compile for.
         // Affects type checking and code generation. Can be homestead,
         // tangerineWhistle, spuriousDragon, byzantium, constantinople,
-        // petersburg, istanbul, berlin, london, paris, shanghai, cancun (default) or prague.
+        // petersburg, istanbul, berlin, london, paris, shanghai, cancun (default) or prague (experimental).
         "evmVersion": "cancun",
         // Optional: Change compilation pipeline to go through the Yul intermediate representation.
         // This is false by default.

--- a/liblangutil/EVMVersion.h
+++ b/liblangutil/EVMVersion.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <libsolutil/Assertions.h>
+
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -105,7 +107,7 @@ public:
 		case Version::Cancun: return "cancun";
 		case Version::Prague: return "prague";
 		}
-		return "INVALID";
+		util::unreachable();
 	}
 
 	/// Has the RETURNDATACOPY and RETURNDATASIZE opcodes.

--- a/liblangutil/EVMVersion.h
+++ b/liblangutil/EVMVersion.h
@@ -91,6 +91,10 @@ public:
 		return std::nullopt;
 	}
 
+	bool isExperimental() const {
+		return m_version == Version::Prague;
+	}
+
 	bool operator==(EVMVersion const& _other) const { return m_version == _other.m_version; }
 	bool operator<(EVMVersion const& _other) const { return m_version < _other.m_version; }
 

--- a/liblangutil/EVMVersion.h
+++ b/liblangutil/EVMVersion.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include <boost/operators.hpp>
 
@@ -64,9 +65,8 @@ public:
 	static EVMVersion cancun() { return {Version::Cancun}; }
 	static EVMVersion prague() { return {Version::Prague}; }
 
-	static std::optional<EVMVersion> fromString(std::string const& _version)
-	{
-		for (auto const& v: {
+	static std::vector<EVMVersion> allVersions() {
+		return {
 			homestead(),
 			tangerineWhistle(),
 			spuriousDragon(),
@@ -79,8 +79,13 @@ public:
 			paris(),
 			shanghai(),
 			cancun(),
-			prague()
-		})
+			prague(),
+		};
+	}
+
+	static std::optional<EVMVersion> fromString(std::string const& _version)
+	{
+		for (auto const& v: allVersions())
 			if (_version == v.name())
 				return v;
 		return std::nullopt;

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -606,8 +606,7 @@ General Information)").c_str(),
 		(
 			g_strEVMVersion.c_str(),
 			po::value<std::string>()->value_name("version")->default_value(EVMVersion{}.name()),
-			"Select desired EVM version. Either homestead, tangerineWhistle, spuriousDragon, "
-			"byzantium, constantinople, petersburg, istanbul, berlin, london, paris, shanghai, cancun or prague."
+			("Select desired EVM version. Either " + util::joinHumanReadable(EVMVersion::allVersions(), ", ", " or ") + ".").c_str()
 		)
 	;
 	if (!_forHelp) // Note: We intentionally keep this undocumented for now.

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -592,6 +592,16 @@ General Information)").c_str(),
 	;
 	desc.add(inputOptions);
 
+	auto const annotateEVMVersion = [](EVMVersion const& _version) {
+		return _version.name() + (_version.isExperimental() ? " (experimental)" : "");
+	};
+	std::vector<EVMVersion> allEVMVersions = EVMVersion::allVersions();
+	std::string annotatedEVMVersions = util::joinHumanReadable(
+		allEVMVersions | ranges::views::transform(annotateEVMVersion),
+		", ",
+		" or "
+	);
+
 	po::options_description outputOptions("Output Options");
 	outputOptions.add_options()
 		(
@@ -606,7 +616,7 @@ General Information)").c_str(),
 		(
 			g_strEVMVersion.c_str(),
 			po::value<std::string>()->value_name("version")->default_value(EVMVersion{}.name()),
-			("Select desired EVM version. Either " + util::joinHumanReadable(EVMVersion::allVersions(), ", ", " or ") + ".").c_str()
+			("Select desired EVM version: " + annotatedEVMVersions + ".").c_str()
 		)
 	;
 	if (!_forHelp) // Note: We intentionally keep this undocumented for now.

--- a/test/tools/fuzzer_common.cpp
+++ b/test/tools/fuzzer_common.cpp
@@ -39,19 +39,7 @@ using namespace solidity::frontend;
 using namespace solidity::langutil;
 using namespace solidity::util;
 
-static std::vector<EVMVersion> s_evmVersions = {
-	EVMVersion::homestead(),
-	EVMVersion::tangerineWhistle(),
-	EVMVersion::spuriousDragon(),
-	EVMVersion::byzantium(),
-	EVMVersion::constantinople(),
-	EVMVersion::petersburg(),
-	EVMVersion::istanbul(),
-	EVMVersion::berlin(),
-	EVMVersion::london(),
-	EVMVersion::paris(),
-	EVMVersion::prague()
-};
+static std::vector<EVMVersion> s_evmVersions = EVMVersion::allVersions();
 
 void FuzzerUtil::testCompilerJsonInterface(std::string const& _input, bool _optimize, bool _quiet)
 {


### PR DESCRIPTION
Turns out we did have it in the most important place, i.e. [under Target Options](https://docs.soliditylang.org/en/v0.8.28/using-the-compiler.html#target-options). The PR just adds two more.

It also makes versions enumerable so that we have fewer places to update when switching versions.