### PR TITLE
SSACFGBuilder: Descent into constant condition for loops' conditions

### DIFF
--- a/libyul/backends/evm/SSAControlFlowGraphBuilder.cpp
+++ b/libyul/backends/evm/SSAControlFlowGraphBuilder.cpp
@@ -421,6 +421,7 @@ void SSAControlFlowGraphBuilder::operator()(ForLoop const& _loop)
 
 	if (constantCondition.has_value())
 	{
+		std::visit(*this, *_loop.condition);
 		if (*constantCondition)
 		{
 			jump(debugDataOf(*_loop.condition), loopBody);


### PR DESCRIPTION
Things like this will not validate otherwise as `true` has then no literal value id associated to it:

```js
object "object" {
    code {
        {
            for { } true { }
            {
                if iszero(addmod(keccak256(0x0, create(0x0, 0x0, 0x0)), 0x0, 0x0)) { break }
            }
        }
    }
}
```