### PR TITLE
More informative output for failed CLI tests in CI

### DIFF
--- a/.circleci/parallel_cli_tests.py
+++ b/.circleci/parallel_cli_tests.py
@@ -37,10 +37,13 @@ if '*' in selected_tests:
 else:
     filters = list(selected_tests)
 
-subprocess.run(
-    ['test/cmdlineTests.sh'] + filters,
-    stdin=sys.stdin,
-    stdout=sys.stdout,
-    stderr=sys.stderr,
-    check=True,
-)
+try:
+    subprocess.run(
+        ['test/cmdlineTests.sh'] + filters,
+        stdin=sys.stdin,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+        check=True,
+    )
+except subprocess.CalledProcessError as exception:
+    sys.exit(exception)

--- a/test/cmdlineTests.sh
+++ b/test/cmdlineTests.sh
@@ -275,12 +275,18 @@ EOF
     sed -i.bak -e 's/^\(Dynamic exception type:\).*/\1/' "$stderr_path"
     rm "$stderr_path.bak"
 
-    if [[ $exitCode -ne "$exit_code_expected" ]]
+    if [[ "$(cat "$stderr_path")" != "${stderr_expected}" ]]
     then
-        printError "Incorrect exit code. Expected $exit_code_expected but got $exitCode."
+        printError "Incorrect output on stderr received. Expected:"
+        echo -e "${stderr_expected}"
 
-        [[ $exit_code_expectation_file != "" ]] && ask_expectation_update "$exitCode" "$exit_code_expectation_file"
-        [[ $exit_code_expectation_file == "" ]] && fail
+        printError "But got:"
+        echo -e "$(cat "$stderr_path")"
+
+        printError "When running $solc_command"
+
+        [[ $stderr_expectation_file != "" ]] && ask_expectation_update "$(cat "$stderr_path")" "$stderr_expectation_file"
+        [[ $stderr_expectation_file == "" ]] && fail
     fi
 
     if [[ "$(cat "$stdout_path")" != "${stdout_expected}" ]]
@@ -297,18 +303,12 @@ EOF
         [[ $stdout_expectation_file == "" ]] && fail
     fi
 
-    if [[ "$(cat "$stderr_path")" != "${stderr_expected}" ]]
+    if [[ $exitCode -ne "$exit_code_expected" ]]
     then
-        printError "Incorrect output on stderr received. Expected:"
-        echo -e "${stderr_expected}"
+        printError "Incorrect exit code. Expected $exit_code_expected but got $exitCode."
 
-        printError "But got:"
-        echo -e "$(cat "$stderr_path")"
-
-        printError "When running $solc_command"
-
-        [[ $stderr_expectation_file != "" ]] && ask_expectation_update "$(cat "$stderr_path")" "$stderr_expectation_file"
-        [[ $stderr_expectation_file == "" ]] && fail
+        [[ $exit_code_expectation_file != "" ]] && ask_expectation_update "$exitCode" "$exit_code_expectation_file"
+        [[ $exit_code_expectation_file == "" ]] && fail
     fi
 
     rm "$stdout_path" "$stderr_path"


### PR DESCRIPTION
Currently `cmdlineTests.sh` compares the exit codes first, then stdout, and only last stderr. This makes CI output quite confusing, e.g. from [`t_osx_cli` (1677888)](https://app.circleci.com/pipelines/github/ethereum/solidity/36701/workflows/51f34d8f-cc88-4b92-a6ed-7505feff5897/jobs/1677888):

```
 - strict_asm_debug_info_print_none
 - strict_asm_debug_info_print_snippet_only
 - strict_asm_eof_container_prague
Incorrect exit code. Expected 0 but got 1.

Traceback (most recent call last):
  File "/Users/distiller/project/.circleci/parallel_cli_tests.py", line 40, in <module>
    subprocess.run(
  File "/Users/distiller/.pyenv/versions/3.11.5/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['test/cmdlineTests.sh', '--exclude', '~ast_export_with_stop_after_parsing', '--exclude', '~soljson_via_fuzzer', '--exclude', '~compilation_tests', '--exclude', '~ast_import_export', '--exclude', '~documentation_examples', '--exclude', '~via_ir_equivalence', '--exclude', '~evmasm_import_export']' returned non-zero exit status 1.

Exited with code exit status 1
```

`Incorrect exit code. Expected 0 but got 1.` actually refers to compiler's exit code but it's not very clear here. And then we don't see what the error is.

The PR fixes this by comparing stderr first, which will always show the errors if there are any. Exit code is compared last, because it's the least informative.

The PR also makes `parallel_cli_tests.py` gracefully handle test failures. It now displays a short message instead of the whole stack trace.