### PR TITLE
eof: Change convention for printing immediate arguments in assembly

### DIFF
--- a/libevmasm/AssemblyItem.cpp
+++ b/libevmasm/AssemblyItem.cpp
@@ -342,7 +342,7 @@ std::string AssemblyItem::toAssemblyText(Assembly const& _assembly) const
 		break;
 	case AuxDataLoadN:
 		assertThrow(data() <= std::numeric_limits<size_t>::max(), AssemblyException, "Invalid auxdataloadn argument.");
-		text = "auxdataloadn(" +  std::to_string(static_cast<size_t>(data())) + ")";
+		text = "auxdataloadn{" +  std::to_string(static_cast<size_t>(data())) + "}";
 		break;
 	}
 	if (m_jumpType == JumpType::IntoFunction || m_jumpType == JumpType::OutOfFunction)

--- a/test/cmdlineTests/strict_asm_eof_dataloadn_prague/output
+++ b/test/cmdlineTests/strict_asm_eof_dataloadn_prague/output
@@ -17,7 +17,7 @@ Binary representation:
 ef0001010004020001000904002d000080ffffd1000d5f5260205ff348656c6c6f2c20576f726c6421
 
 Text representation:
-  auxdataloadn(0)
+  auxdataloadn{0}
   0x00
   mstore
   0x20


### PR DESCRIPTION
Reasoning: https://github.com/ethereum/solidity/pull/15512#discussion_r1815837491