### PR TITLE
Yulopti: Fix error during parsing stage

### DIFF
--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -91,7 +91,7 @@ public:
 		try
 		{
 			auto ast = yul::Parser(errorReporter, m_dialect).parse(_charStream);
-			if (!m_astRoot || errorReporter.hasErrors())
+			if (!ast || errorReporter.hasErrors())
 			{
 				std::cerr << "Error parsing source." << std::endl;
 				printErrors(_charStream, errors);


### PR DESCRIPTION
yulopti would error out right away because it thinks it found a parsing error