### PR TITLE
eof: Update `dataloadn` test with new immediate arguments formating

### DIFF
--- a/test/libyul/objectCompiler/eof/dataloadn.yul
+++ b/test/libyul/objectCompiler/eof/dataloadn.yul
@@ -9,12 +9,12 @@ object "a" {
 }
 
 // ====
-// bytecodeFormat: >=EOFv1
 // EVMVersion: >=prague
+// bytecodeFormat: >=EOFv1
 // ----
 // Assembly:
 //     /* "source":56:71   */
-//   auxdataloadn(0)
+//   auxdataloadn{0}
 //     /* "source":53:54   */
 //   0x00
 //     /* "source":46:72   */


### PR DESCRIPTION
Update expected test results. They are not enabled in CI yet but I found that one of them does not pass after changing the format of printing immediate arguments.  