### PR TITLE
Docker: Update Z3 and cvc5 versions in docker images

### DIFF
--- a/scripts/ci/build_emscripten.sh
+++ b/scripts/ci/build_emscripten.sh
@@ -37,12 +37,13 @@ set -ev
 SCRIPT_DIR="$(realpath "$(dirname "$0")/..")"
 # shellcheck source=scripts/common.sh
 source "${SCRIPT_DIR}/common.sh"
+ROOT_DIR="${SCRIPT_DIR}/.."
 
 function build() {
     local build_dir="$1"
     local prerelease_source="${2:-ci}"
 
-    cd /root/project
+    cd "${ROOT_DIR}"
 
     # shellcheck disable=SC2166
     if [[ "$CIRCLE_BRANCH" = release || -n "$CIRCLE_TAG" || -n "$FORCE_RELEASE" || "$(git tag --points-at HEAD 2>/dev/null)" == v* ]]

--- a/scripts/ci/build_ossfuzz.sh
+++ b/scripts/ci/build_ossfuzz.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ROOTDIR="/root/project"
+ROOTDIR="$(realpath "$(dirname "$0")/../..")"
 BUILDDIR="${ROOTDIR}/build"
 mkdir -p "${BUILDDIR}" && mkdir -p "$BUILDDIR/deps"
 

--- a/scripts/ci/docker_upgrade.sh
+++ b/scripts/ci/docker_upgrade.sh
@@ -51,17 +51,12 @@ docker build "scripts/docker/${IMAGE_NAME}" --file "scripts/docker/${IMAGE_NAME}
 
 echo "-- test_docker @ '${PWD}'"
 
-# NOTE: Since /root/project/ is a dir from outside the container and the owner of the files is different,
-# git show in the script refuses to work. It must be marked as safe to use first.
-# See https://github.blog/2022-04-12-git-security-vulnerability-announced/
 docker run \
   --rm \
-  --volume "${PWD}:/root/project" \
+  --volume "${PWD}:/project" \
+  -u "$(id -u "${USER}"):$(id -g "${USER}")" \
   "${IMAGE_NAME}" \
-  bash -c "
-    git config --global --add safe.directory /root/project &&
-    /root/project/scripts/ci/${IMAGE_NAME}_test_${IMAGE_VARIANT}.sh
-  "
+  bash -c "/project/scripts/ci/${IMAGE_NAME}_test_${IMAGE_VARIANT}.sh"
 
 echo "-- push_docker"
 

--- a/scripts/docker/buildpack-deps/Dockerfile.emscripten
+++ b/scripts/docker/buildpack-deps/Dockerfile.emscripten
@@ -33,7 +33,7 @@
 # Using $(em-config CACHE)/sysroot/usr seems to work, though, and still has cmake find the
 # dependencies automatically.
 FROM emscripten/emsdk:3.1.19 AS base
-LABEL version="18"
+LABEL version="19"
 
 ADD emscripten.jam /usr/src
 RUN set -ex && \
@@ -49,7 +49,7 @@ RUN set -ex && \
 # Install Z3
 RUN set -ex && \
 	cd /usr/src && \
-	git clone https://github.com/Z3Prover/z3.git -b z3-4.12.1 --depth 1 && \
+	git clone https://github.com/Z3Prover/z3.git -b z3-4.13.3 --depth 1 && \
 	cd z3 && \
 	mkdir build && \
 	cd build && \
@@ -86,11 +86,9 @@ RUN set -ex && \
 
 # CVC5
 RUN set -ex; \
-	cvc5_version="1.1.2"; \
-	wget "https://github.com/cvc5/cvc5/releases/download/cvc5-${cvc5_version}/cvc5-Linux-static.zip" -O /opt/cvc5.zip; \
-	test "$(sha256sum /opt/cvc5.zip)" = "cf291aef67da8eaa8d425a51f67f3f72f36db8b1040655dc799b64e3d69e6086  /opt/cvc5.zip"; \
-	unzip /opt/cvc5.zip -x "cvc5-Linux-static/lib/cmake/*" -d /opt; \
-	mv /opt/cvc5-Linux-static/bin/* /usr/bin; \
-	mv /opt/cvc5-Linux-static/include/* /usr/include; \
-	mv /opt/cvc5-Linux-static/lib/* /usr/lib; \
-	rm -rf /opt/cvc5-Linux-static /opt/cvc5.zip;
+        cvc5_version="1.2.0"; \
+        cvc5_archive_name="cvc5-Linux-x86_64-static"; \
+        wget "https://github.com/cvc5/cvc5/releases/download/cvc5-${cvc5_version}/${cvc5_archive_name}.zip" -O /opt/cvc5.zip; \
+        test "$(sha256sum /opt/cvc5.zip)" = "d18f174ff9a11923c32c3f871f844ed16bd77a28f51050b8e7c8d821c98a1c2e  /opt/cvc5.zip"; \
+        unzip -j /opt/cvc5.zip "${cvc5_archive_name}/bin/cvc5" -d /usr/bin; \
+        rm -f /opt/cvc5.zip;

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2004
@@ -22,7 +22,7 @@
 # (c) 2016-2019 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:focal AS base
-LABEL version="25"
+LABEL version="26"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -39,15 +39,13 @@ RUN set -ex; \
 		libboost-program-options-dev \
 		libboost-system-dev \
 		libboost-test-dev \
-		libz3-static-dev \
 		lsof \
 		ninja-build \
 		python3-pip \
 		python3-sphinx \
 		software-properties-common \
 		sudo \
-		unzip \
-		z3-static; \
+		unzip; \
 	pip3 install \
 		codecov \
 		colorama \
@@ -76,14 +74,21 @@ RUN set -ex; \
 
 # CVC5
 RUN set -ex; \
-	cvc5_version="1.1.2"; \
-	wget "https://github.com/cvc5/cvc5/releases/download/cvc5-${cvc5_version}/cvc5-Linux-static.zip" -O /opt/cvc5.zip; \
-	test "$(sha256sum /opt/cvc5.zip)" = "cf291aef67da8eaa8d425a51f67f3f72f36db8b1040655dc799b64e3d69e6086  /opt/cvc5.zip"; \
-	unzip /opt/cvc5.zip -x "cvc5-Linux-static/lib/cmake/*" -d /opt; \
-	mv /opt/cvc5-Linux-static/bin/* /usr/bin; \
-	mv /opt/cvc5-Linux-static/include/* /usr/include; \
-	mv /opt/cvc5-Linux-static/lib/* /usr/lib; \
-	rm -rf /opt/cvc5-Linux-static /opt/cvc5.zip;
+	cvc5_version="1.2.0"; \
+	cvc5_archive_name="cvc5-Linux-x86_64-static"; \
+	wget "https://github.com/cvc5/cvc5/releases/download/cvc5-${cvc5_version}/${cvc5_archive_name}.zip" -O /opt/cvc5.zip; \
+	test "$(sha256sum /opt/cvc5.zip)" = "d18f174ff9a11923c32c3f871f844ed16bd77a28f51050b8e7c8d821c98a1c2e  /opt/cvc5.zip"; \
+	unzip -j /opt/cvc5.zip "${cvc5_archive_name}/bin/cvc5" -d /usr/bin; \
+	rm -f /opt/cvc5.zip;
+
+# Z3
+RUN set -ex; \
+	z3_version="4.13.3"; \
+	z3_archive_name="z3-${z3_version}-x64-glibc-2.35"; \
+	wget "https://github.com/Z3Prover/z3/releases/download/z3-${z3_version}/${z3_archive_name}.zip" -O /opt/z3.zip; \
+	test "$(sha256sum /opt/z3.zip)" = "32c7377026733c9d7b33c21cd77a68f50ba682367207b031a6bfd80140a8722f  /opt/z3.zip"; \
+	unzip -j /opt/z3.zip "${z3_archive_name}/bin/z3" -d /usr/bin; \
+	rm -f /opt/z3.zip;
 
 FROM base AS libraries
 

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2404
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2404
@@ -22,7 +22,7 @@
 # (c) 2016-2024 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:noble AS base
-LABEL version="1"
+LABEL version="2"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -44,7 +44,6 @@ RUN set -ex; \
 		libboost-system-dev \
 		libboost-test-dev \
 		libcln-dev \
-		libz3-static-dev \
 		locales-all \
 		lsof \
 		ninja-build \
@@ -53,7 +52,6 @@ RUN set -ex; \
 		software-properties-common \
 		sudo \
 		unzip \
-		z3-static \
 		zip; \
 	pip3 install \
 		codecov \
@@ -79,14 +77,21 @@ RUN set -ex; \
 
 # CVC5
 RUN set -ex; \
-	cvc5_version="1.1.2"; \
-	wget "https://github.com/cvc5/cvc5/releases/download/cvc5-${cvc5_version}/cvc5-Linux-static.zip" -O /opt/cvc5.zip; \
-	test "$(sha256sum /opt/cvc5.zip)" = "cf291aef67da8eaa8d425a51f67f3f72f36db8b1040655dc799b64e3d69e6086  /opt/cvc5.zip"; \
-	unzip /opt/cvc5.zip -x "cvc5-Linux-static/lib/cmake/*" -d /opt; \
-	mv /opt/cvc5-Linux-static/bin/* /usr/bin; \
-	mv /opt/cvc5-Linux-static/include/* /usr/include; \
-	mv /opt/cvc5-Linux-static/lib/* /usr/lib; \
-	rm -rf /opt/cvc5-Linux-static /opt/cvc5.zip;
+	cvc5_version="1.2.0"; \
+	cvc5_archive_name="cvc5-Linux-x86_64-static"; \
+	wget "https://github.com/cvc5/cvc5/releases/download/cvc5-${cvc5_version}/${cvc5_archive_name}.zip" -O /opt/cvc5.zip; \
+	test "$(sha256sum /opt/cvc5.zip)" = "d18f174ff9a11923c32c3f871f844ed16bd77a28f51050b8e7c8d821c98a1c2e  /opt/cvc5.zip"; \
+	unzip -j /opt/cvc5.zip "${cvc5_archive_name}/bin/cvc5" -d /usr/bin; \
+	rm -f /opt/cvc5.zip;
+
+# Z3
+RUN set -ex; \
+	z3_version="4.13.3"; \
+	z3_archive_name="z3-${z3_version}-x64-glibc-2.35"; \
+	wget "https://github.com/Z3Prover/z3/releases/download/z3-${z3_version}/${z3_archive_name}.zip" -O /opt/z3.zip; \
+	test "$(sha256sum /opt/z3.zip)" = "32c7377026733c9d7b33c21cd77a68f50ba682367207b031a6bfd80140a8722f  /opt/z3.zip"; \
+	unzip -j /opt/z3.zip "${z3_archive_name}/bin/z3" -d /usr/bin; \
+	rm -f /opt/z3.zip;
 
 FROM base AS libraries
 

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2404.clang
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2404.clang
@@ -22,7 +22,7 @@
 # (c) 2016-2024 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:noble AS base
-LABEL version="2"
+LABEL version="3"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -46,13 +46,11 @@ RUN set -ex; \
 		libboost-test-dev \
 		libclang-rt-dev \
 		libcln-dev \
-		libz3-static-dev \
 		lsof \
 		ninja-build \
 		python3-pip \
 		software-properties-common \
-		sudo \
-		z3-static; \
+		sudo; \
 	pip3 install \
 		codecov \
 		colorama \
@@ -78,14 +76,21 @@ RUN set -ex; \
 
 # CVC5
 RUN set -ex; \
-	cvc5_version="1.1.2"; \
-	wget "https://github.com/cvc5/cvc5/releases/download/cvc5-${cvc5_version}/cvc5-Linux-static.zip" -O /opt/cvc5.zip; \
-	test "$(sha256sum /opt/cvc5.zip)" = "cf291aef67da8eaa8d425a51f67f3f72f36db8b1040655dc799b64e3d69e6086  /opt/cvc5.zip"; \
-	unzip /opt/cvc5.zip -x "cvc5-Linux-static/lib/cmake/*" -d /opt; \
-	mv /opt/cvc5-Linux-static/bin/* /usr/bin; \
-	mv /opt/cvc5-Linux-static/lib/* /usr/lib; \
-	mv /opt/cvc5-Linux-static/include/* /usr/include; \
-	rm -rf /opt/cvc5-Linux-static /opt/cvc5.zip;
+	cvc5_version="1.2.0"; \
+	cvc5_archive_name="cvc5-Linux-x86_64-static"; \
+	wget "https://github.com/cvc5/cvc5/releases/download/cvc5-${cvc5_version}/${cvc5_archive_name}.zip" -O /opt/cvc5.zip; \
+	test "$(sha256sum /opt/cvc5.zip)" = "d18f174ff9a11923c32c3f871f844ed16bd77a28f51050b8e7c8d821c98a1c2e  /opt/cvc5.zip"; \
+	unzip -j /opt/cvc5.zip "${cvc5_archive_name}/bin/cvc5" -d /usr/bin; \
+	rm -f /opt/cvc5.zip;
+
+# Z3
+RUN set -ex; \
+	z3_version="4.13.3"; \
+	z3_archive_name="z3-${z3_version}-x64-glibc-2.35"; \
+	wget "https://github.com/Z3Prover/z3/releases/download/z3-${z3_version}/${z3_archive_name}.zip" -O /opt/z3.zip; \
+	test "$(sha256sum /opt/z3.zip)" = "32c7377026733c9d7b33c21cd77a68f50ba682367207b031a6bfd80140a8722f  /opt/z3.zip"; \
+	unzip -j /opt/z3.zip "${z3_archive_name}/bin/z3" -d /usr/bin; \
+	rm -f /opt/z3.zip;
 
 FROM base AS libraries
 


### PR DESCRIPTION
Flow of changes (updated from #13738)

1. Open a PR (PR1) like this one bumping the dockerfile versions and updating the z3 version where applicable.
2. When the new images are built, the bot will post the 4 new hashes here. In a different PR (PR2 is #15558 here): 
     - Update the docker hashes
     - Update the z3 version in .circleci/osx_install_dependencies.sh
     - Update the SMT tests 
3. Merge PR2
4. Rebase PR1, merge PR1.
5. Done




