### PR TITLE
soltest pass for EOF

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1141,6 +1141,7 @@ jobs:
     environment:
       <<: *base_osx_env
       EVM: << pipeline.parameters.evm-version >>
+      EOF_VERSION: 0
       OPTIMIZE: 0
     steps:
       - checkout
@@ -1233,6 +1234,7 @@ jobs:
     environment:
       <<: *base_archlinux_env
       EVM: << pipeline.parameters.evm-version >>
+      EOF_VERSION: 0
       OPTIMIZE: 0
       # For Archlinux we do not have prebuilt docker images and we would need to build evmone from source,
       # thus we forgo semantics tests to speed things up.
@@ -1250,6 +1252,7 @@ jobs:
     environment:
       <<: *base_ubuntu2404_clang_env
       EVM: << pipeline.parameters.evm-version >>
+      EOF_VERSION: 0
       OPTIMIZE: 0
       # The high parallelism in this job is causing the SMT tests to run out of memory,
       # so disabling for now.
@@ -1299,6 +1302,7 @@ jobs:
     environment:
       <<: *base_ubuntu2404_env
       EVM: << pipeline.parameters.evm-version >>
+      EOF_VERSION: 0
       OPTIMIZE: 0
       SOLTEST_FLAGS: --no-smt
       ASAN_OPTIONS: check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2
@@ -1314,6 +1318,7 @@ jobs:
     environment:
       <<: *base_ubuntu2404_clang_env
       EVM: << pipeline.parameters.evm-version >>
+      EOF_VERSION: 0
       OPTIMIZE: 0
       SOLTEST_FLAGS: --no-smt
       ASAN_OPTIONS: check_initialization_order=true:detect_stack_use_after_return=true:strict_init_order=true:strict_string_checks=true:detect_invalid_pointer_pairs=2
@@ -1326,6 +1331,7 @@ jobs:
     environment:
       <<: *base_ubuntu2404_clang_env
       EVM: << pipeline.parameters.evm-version >>
+      EOF_VERSION: 0
       SOLTEST_FLAGS: --no-smt
     steps:
       - soltest

--- a/.circleci/soltest.sh
+++ b/.circleci/soltest.sh
@@ -36,11 +36,43 @@ set -e
 
 OPTIMIZE=${OPTIMIZE:-"0"}
 EVM=${EVM:-"invalid"}
+EOF_VERSION=${EOF_VERSION:-0}
 CPUs=${CPUs:-3}
 REPODIR="$(realpath "$(dirname "$0")/..")"
 
 IFS=" " read -r -a BOOST_TEST_ARGS <<< "$BOOST_TEST_ARGS"
 IFS=" " read -r -a SOLTEST_FLAGS <<< "$SOLTEST_FLAGS"
+
+# TODO: [EOF] These won't pass on EOF yet. Reenable them when the implementation is complete.
+EOF_EXCLUDES=(
+    --run_test='!Assembler/all_assembly_items'
+    --run_test='!Assembler/immutable'
+    --run_test='!Assembler/immutables_and_its_source_maps'
+    --run_test='!Optimiser/jumpdest_removal_subassemblies'
+    --run_test='!Optimiser/jumpdest_removal_subassemblies/*'
+    --run_test='!SolidityCompiler/does_not_include_creation_time_only_internal_functions'
+    --run_test='!SolidityInlineAssembly/Analysis/create2'
+    --run_test='!SolidityInlineAssembly/Analysis/inline_assembly_shadowed_instruction_declaration'
+    --run_test='!SolidityInlineAssembly/Analysis/large_constant'
+    --run_test='!SolidityInlineAssembly/Analysis/staticcall'
+    --run_test='!ViewPureChecker/assembly_staticcall'
+    --run_test='!functionSideEffects/otherImmovables'
+    --run_test='!functionSideEffects/state'
+    --run_test='!functionSideEffects/storage'
+    --run_test='!gasTests/abiv2'
+    --run_test='!gasTests/abiv2_optimised'
+    --run_test='!gasTests/data_storage'
+    --run_test='!gasTests/dispatch_large'
+    --run_test='!gasTests/dispatch_large_optimised'
+    --run_test='!gasTests/dispatch_medium'
+    --run_test='!gasTests/dispatch_medium_optimised'
+    --run_test='!gasTests/dispatch_small'
+    --run_test='!gasTests/dispatch_small_optimised'
+    --run_test='!gasTests/exp'
+    --run_test='!gasTests/exp_optimized'
+    --run_test='!gasTests/storage_costs'
+    --run_test='!yulStackLayout/literal_loop'
+)
 
 # shellcheck source=scripts/common.sh
 source "${REPODIR}/scripts/common.sh"
@@ -55,6 +87,7 @@ get_logfile_basename() {
     local filename="${EVM}"
     test "${OPTIMIZE}" = "1" && filename="${filename}_opt"
     test "${ABI_ENCODER_V1}" = "1" && filename="${filename}_abiv1"
+    (( EOF_VERSION != 0 )) && filename="${filename}_eofv${EOF_VERSION}"
     filename="${filename}_${run}"
 
     echo -ne "${filename}"
@@ -78,10 +111,12 @@ do
         "--logger=HRF,error,stdout"
         "${BOOST_TEST_ARGS[@]}"
     )
+    (( EOF_VERSION != 0 )) && BOOST_TEST_ARGS_RUN+=("${EOF_EXCLUDES[@]}")
     SOLTEST_ARGS=("--evm-version=$EVM" "${SOLTEST_FLAGS[@]}")
 
     test "${OPTIMIZE}" = "1" && SOLTEST_ARGS+=(--optimize)
     test "${ABI_ENCODER_V1}" = "1" && SOLTEST_ARGS+=(--abiencoderv1)
+    (( EOF_VERSION != 0 )) && SOLTEST_ARGS+=(--eof-version "$EOF_VERSION")
 
     BATCH_ARGS=("--batches" "$((CPUs * CIRCLE_NODE_TOTAL))" "--selected-batch" "$((CPUs * CIRCLE_NODE_INDEX + run))")
 

--- a/test/cmdlineTests/~via_ir_equivalence/test.sh
+++ b/test/cmdlineTests/~via_ir_equivalence/test.sh
@@ -86,7 +86,7 @@ requiresOptimizer=(
 
 for contractFile in "${externalContracts[@]}"
 do
-    if ! [[ "${requiresOptimizer[*]}" =~ $contractFile ]]
+    if ! [[ " ${requiresOptimizer[*]} " == *" $contractFile "* ]]
     then
         printTask "    - ${contractFile}"
         test_via_ir_equivalence "${REPO_ROOT}/test/${contractFile}"


### PR DESCRIPTION
We already have some tests for EOF, but the whole test suite doesn't pass yet, so we were not running them in CI. This often results in failing tests not being noticed in EOF PRs.

This PR adds a soltest pass with `--eof-version 1` in CI but with a temporary blacklist for tests that are not expected to pass yet.

Note that syntax and semantic tests are not blacklisted. They all pass because for them (and any other tests based on `EVMVersionRestrictedTestCase`) EOF is excluded unless explicitly requested via `EOFVersion: >=EOFv1` setting. This will allow us to enable them on a case-by-case basis for now and only when all of them are ready we'll flip the default to include EOF.