### PR TITLE
Add submodule path to git safe.directory before initialize the submodule

### DIFF
--- a/cmake/submodules.cmake
+++ b/cmake/submodules.cmake
@@ -10,14 +10,25 @@ macro(initialize_submodule SUBMODULE_PATH)
 			if(NOT Git_FOUND)
 				message(FATAL_ERROR "Failed to initialize submodules: 'git' command not found.")
 			endif()
+			# Temporarily add the submodule path to safe.directory
 			execute_process(
-					COMMAND git submodule update --init ${CMAKE_SOURCE_DIR}/deps/${SUBMODULE_PATH}
-					WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-					RESULT_VARIABLE result
+				COMMAND git config --global --add safe.directory ${CMAKE_SOURCE_DIR}/deps/${SUBMODULE_PATH}
+				WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+			)
+			execute_process(
+				COMMAND git submodule update --init ${CMAKE_SOURCE_DIR}/deps/${SUBMODULE_PATH}
+				WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+				RESULT_VARIABLE result
 			)
 			if(NOT result EQUAL 0)
 				message(FATAL_ERROR "Failed to initialize submodules: 'git submodule update --init' failed.")
 			endif()
+			# Clean up the safe.directory entry after initialization
+			execute_process(
+				COMMAND git config --global --unset safe.directory ${CMAKE_SOURCE_DIR}/deps/${SUBMODULE_PATH}
+				WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+				ERROR_QUIET
+			)
 		endif()
 	endif()
 endmacro()


### PR DESCRIPTION
We recently encountered errors while updating Z3 and CVC5 in the buildpack images for https://github.com/ethereum/solidity/pull/15551.

See the build logs here: https://github.com/ethereum/solidity/actions/runs/11575096134/job/32220871629?pr=15551 and https://github.com/ethereum/solidity/actions/runs/11575096134/job/32220870627?pr=15551

```txt
 -- git submodule 'fmtlib' seem not to be initialized: implicitly executing 'git submodule update --init '/root/project/deps/fmtlib'.
-- Found Git: /usr/bin/git (found version "2.25.1") 
Submodule 'deps/fmtlib' (https://github.com/fmtlib/fmt.git) registered for path 'deps/fmtlib'
Cloning into '/root/project/deps/fmtlib'...
fatal: detected dubious ownership in repository at '/root/project/deps/fmtlib'
To add an exception for this directory, call:

	git config --global --add safe.directory /root/project/deps/fmtlib
Unable to fetch in submodule path 'deps/fmtlib'; trying to directly fetch 0c9fce2ffefecfdce794e1859584e25877b7b592:
fatal: detected dubious ownership in repository at '/root/project/deps/fmtlib'
To add an exception for this directory, call:

	git config --global --add safe.directory /root/project/deps/fmtlib
fatal: detected dubious ownership in repository at '/root/project/deps/fmtlib'
To add an exception for this directory, call:

	git config --global --add safe.directory /root/project/deps/fmtlib
Fetched in submodule path 'deps/fmtlib', but it did not contain 0c9fce2ffefecfdce794e1859584e25877b7b592. Direct fetching of that commit failed.
CMake Error at cmake/submodules.cmake:19 (message):
  Failed to initialize submodules: 'git submodule update --init' failed.
Call Stack (most recent call first):
  cmake/fmtlib.cmake:2 (initialize_submodule)
  CMakeLists.txt:61 (include)
```

This PR aims to address these issues by temporarily marking the submodules directory as a `safe.directory` before attempting to initialize it.