### PR TITLE
Set correct `movableApartFromEffects` flag for `datacopy()`

### DIFF
--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -307,17 +307,7 @@ std::vector<std::optional<BuiltinFunctionForEVM>> createBuiltins(langutil::EVMVe
 			"datacopy",
 			3,
 			0,
-			SideEffects{
-				false,               // movable
-				true,                // movableApartFromEffects
-				false,               // canBeRemoved
-				false,               // canBeRemovedIfNotMSize
-				true,                // cannotLoop
-				SideEffects::None,   // otherState
-				SideEffects::None,   // storage
-				SideEffects::Write,  // memory
-				SideEffects::None    // transientStorage
-			},
+			EVMDialect::sideEffectsOfInstruction(evmasm::Instruction::CODECOPY),
 			ControlFlowSideEffects::fromInstruction(evmasm::Instruction::CODECOPY),
 			{},
 			[](


### PR DESCRIPTION
Discovered in https://github.com/ethereum/solidity/pull/15535#discussion_r1813296743.

The PR replaces hard-coded side-effects with a helper that ensures they're identical with those of the `DATACOPY` instruction, which the builtin uses internally.

The discrepancy was introduced in a refactor (#9283) and appears to have been a mistake.

Fortunately it had no user-visible effects. The only place where the flag is used is the `LoopInvariantCodeMotion` optimizer step, via `SideEffectsCollector::movableRelativeTo()`: https://github.com/ethereum/solidity/blob/b5b8084f58cbc1663701045ce920cad01ae9154a/libyul/optimiser/Semantics.h#L77-L84

Since `m_sideEffects.memory == SideEffects::Write` makes the condition true anyway, the value of this flag does not actually matter for this instruction.

