### PR TITLE
Yul SSACFG JSON export fix

### DIFF
--- a/libyul/YulControlFlowGraphExporter.cpp
+++ b/libyul/YulControlFlowGraphExporter.cpp
@@ -76,9 +76,7 @@ Json YulControlFlowGraphExporter::exportFunction(SSACFG const& _cfg)
 	functionJson["entry"] = "Block" + std::to_string(_cfg.entry.value);
 	static auto constexpr argsTransform = [](auto const& _arg) { return fmt::format("v{}", std::get<1>(_arg).value); };
 	functionJson["arguments"] = _cfg.arguments | ranges::views::transform(argsTransform) | ranges::to<std::vector>;
-	functionJson["returns"] = Json::array();
-	for (auto const& ret: _cfg.returns)
-		functionJson["returns"].emplace_back(ret.get().name.str());
+	functionJson["numReturns"] = _cfg.returns.size();
 	functionJson["blocks"] = exportBlock(_cfg, _cfg.entry);
 	return functionJson;
 }

--- a/libyul/YulControlFlowGraphExporter.cpp
+++ b/libyul/YulControlFlowGraphExporter.cpp
@@ -74,9 +74,8 @@ Json YulControlFlowGraphExporter::exportFunction(SSACFG const& _cfg)
 	Json functionJson = Json::object();
 	functionJson["type"] = "Function";
 	functionJson["entry"] = "Block" + std::to_string(_cfg.entry.value);
-	functionJson["arguments"] = Json::array();
-	for (auto const& [arg, valueId]: _cfg.arguments)
-		functionJson["arguments"].emplace_back(arg.get().name.str());
+	static auto constexpr argsTransform = [](auto const& _arg) { return fmt::format("v{}", std::get<1>(_arg).value); };
+	functionJson["arguments"] = _cfg.arguments | ranges::views::transform(argsTransform) | ranges::to<std::vector>;
 	functionJson["returns"] = Json::array();
 	for (auto const& ret: _cfg.returns)
 		functionJson["returns"].emplace_back(ret.get().name.str());

--- a/test/cmdlineTests/standard_yul_cfg_json_export/output.json
+++ b/test/cmdlineTests/standard_yul_cfg_json_export/output.json
@@ -380,8 +380,8 @@
                             "functions": {
                                 "abi_decode_tuple_": {
                                     "arguments": [
-                                        "headStart",
-                                        "dataEnd"
+                                        "v0",
+                                        "v1"
                                     ],
                                     "blocks": [
                                         {
@@ -447,8 +447,8 @@
                                 },
                                 "abi_encode_t_uint256_to_t_uint256_fromStack": {
                                     "arguments": [
-                                        "value",
-                                        "pos"
+                                        "v0",
+                                        "v1"
                                     ],
                                     "blocks": [
                                         {
@@ -485,8 +485,8 @@
                                 },
                                 "abi_encode_tuple_t_uint256__to_t_uint256__fromStack": {
                                     "arguments": [
-                                        "headStart",
-                                        "value0"
+                                        "v0",
+                                        "v1"
                                     ],
                                     "blocks": [
                                         {
@@ -569,7 +569,7 @@
                                 },
                                 "cleanup_t_rational_42_by_1": {
                                     "arguments": [
-                                        "value"
+                                        "v0"
                                     ],
                                     "blocks": [
                                         {
@@ -591,7 +591,7 @@
                                 },
                                 "cleanup_t_uint256": {
                                     "arguments": [
-                                        "value"
+                                        "v0"
                                     ],
                                     "blocks": [
                                         {
@@ -613,7 +613,7 @@
                                 },
                                 "convert_t_rational_42_by_1_to_t_uint256": {
                                     "arguments": [
-                                        "value"
+                                        "v0"
                                     ],
                                     "blocks": [
                                         {
@@ -811,7 +811,7 @@
                                 },
                                 "identity": {
                                     "arguments": [
-                                        "value"
+                                        "v0"
                                     ],
                                     "blocks": [
                                         {
@@ -908,7 +908,7 @@
                                 },
                                 "shift_right_224_unsigned": {
                                     "arguments": [
-                                        "value"
+                                        "v0"
                                     ],
                                     "blocks": [
                                         {
@@ -1324,8 +1324,8 @@
                             "functions": {
                                 "abi_decode_t_uint256_fromMemory": {
                                     "arguments": [
-                                        "offset",
-                                        "end"
+                                        "v0",
+                                        "v1"
                                     ],
                                     "blocks": [
                                         {
@@ -1365,8 +1365,8 @@
                                 },
                                 "abi_decode_tuple_": {
                                     "arguments": [
-                                        "headStart",
-                                        "dataEnd"
+                                        "v0",
+                                        "v1"
                                     ],
                                     "blocks": [
                                         {
@@ -1432,8 +1432,8 @@
                                 },
                                 "abi_decode_tuple_t_uint256_fromMemory": {
                                     "arguments": [
-                                        "headStart",
-                                        "dataEnd"
+                                        "v0",
+                                        "v1"
                                     ],
                                     "blocks": [
                                         {
@@ -1525,8 +1525,8 @@
                                 },
                                 "abi_encode_t_uint256_to_t_uint256_fromStack": {
                                     "arguments": [
-                                        "value",
-                                        "pos"
+                                        "v0",
+                                        "v1"
                                     ],
                                     "blocks": [
                                         {
@@ -1563,7 +1563,7 @@
                                 },
                                 "abi_encode_tuple__to__fromStack": {
                                     "arguments": [
-                                        "headStart"
+                                        "v0"
                                     ],
                                     "blocks": [
                                         {
@@ -1597,8 +1597,8 @@
                                 },
                                 "abi_encode_tuple_t_uint256__to_t_uint256__fromStack": {
                                     "arguments": [
-                                        "headStart",
-                                        "value0"
+                                        "v0",
+                                        "v1"
                                     ],
                                     "blocks": [
                                         {
@@ -1681,7 +1681,7 @@
                                 },
                                 "cleanup_t_uint160": {
                                     "arguments": [
-                                        "value"
+                                        "v0"
                                     ],
                                     "blocks": [
                                         {
@@ -1715,7 +1715,7 @@
                                 },
                                 "cleanup_t_uint256": {
                                     "arguments": [
-                                        "value"
+                                        "v0"
                                     ],
                                     "blocks": [
                                         {
@@ -1737,7 +1737,7 @@
                                 },
                                 "convert_t_contract$_C_$19_to_t_address": {
                                     "arguments": [
-                                        "value"
+                                        "v0"
                                     ],
                                     "blocks": [
                                         {
@@ -1770,7 +1770,7 @@
                                 },
                                 "convert_t_uint160_to_t_address": {
                                     "arguments": [
-                                        "value"
+                                        "v0"
                                     ],
                                     "blocks": [
                                         {
@@ -1803,7 +1803,7 @@
                                 },
                                 "convert_t_uint160_to_t_uint160": {
                                     "arguments": [
-                                        "value"
+                                        "v0"
                                     ],
                                     "blocks": [
                                         {
@@ -1963,8 +1963,8 @@
                                 },
                                 "finalize_allocation": {
                                     "arguments": [
-                                        "memPtr",
-                                        "size"
+                                        "v0",
+                                        "v1"
                                     ],
                                     "blocks": [
                                         {
@@ -2528,7 +2528,7 @@
                                 },
                                 "identity": {
                                     "arguments": [
-                                        "value"
+                                        "v0"
                                     ],
                                     "blocks": [
                                         {
@@ -2771,7 +2771,7 @@
                                 },
                                 "round_up_to_mul_of_32": {
                                     "arguments": [
-                                        "value"
+                                        "v0"
                                     ],
                                     "blocks": [
                                         {
@@ -2824,7 +2824,7 @@
                                 },
                                 "shift_left_224": {
                                     "arguments": [
-                                        "value"
+                                        "v0"
                                     ],
                                     "blocks": [
                                         {
@@ -2858,7 +2858,7 @@
                                 },
                                 "shift_right_224_unsigned": {
                                     "arguments": [
-                                        "value"
+                                        "v0"
                                     ],
                                     "blocks": [
                                         {
@@ -2892,7 +2892,7 @@
                                 },
                                 "validator_revert_t_uint256": {
                                     "arguments": [
-                                        "value"
+                                        "v0"
                                     ],
                                     "blocks": [
                                         {
@@ -3367,8 +3367,8 @@
                                     "functions": {
                                         "abi_decode_tuple_": {
                                             "arguments": [
-                                                "headStart",
-                                                "dataEnd"
+                                                "v0",
+                                                "v1"
                                             ],
                                             "blocks": [
                                                 {
@@ -3434,8 +3434,8 @@
                                         },
                                         "abi_encode_t_uint256_to_t_uint256_fromStack": {
                                             "arguments": [
-                                                "value",
-                                                "pos"
+                                                "v0",
+                                                "v1"
                                             ],
                                             "blocks": [
                                                 {
@@ -3472,8 +3472,8 @@
                                         },
                                         "abi_encode_tuple_t_uint256__to_t_uint256__fromStack": {
                                             "arguments": [
-                                                "headStart",
-                                                "value0"
+                                                "v0",
+                                                "v1"
                                             ],
                                             "blocks": [
                                                 {
@@ -3556,7 +3556,7 @@
                                         },
                                         "cleanup_t_rational_42_by_1": {
                                             "arguments": [
-                                                "value"
+                                                "v0"
                                             ],
                                             "blocks": [
                                                 {
@@ -3578,7 +3578,7 @@
                                         },
                                         "cleanup_t_uint256": {
                                             "arguments": [
-                                                "value"
+                                                "v0"
                                             ],
                                             "blocks": [
                                                 {
@@ -3600,7 +3600,7 @@
                                         },
                                         "convert_t_rational_42_by_1_to_t_uint256": {
                                             "arguments": [
-                                                "value"
+                                                "v0"
                                             ],
                                             "blocks": [
                                                 {
@@ -3798,7 +3798,7 @@
                                         },
                                         "identity": {
                                             "arguments": [
-                                                "value"
+                                                "v0"
                                             ],
                                             "blocks": [
                                                 {
@@ -3895,7 +3895,7 @@
                                         },
                                         "shift_right_224_unsigned": {
                                             "arguments": [
-                                                "value"
+                                                "v0"
                                             ],
                                             "blocks": [
                                                 {

--- a/test/cmdlineTests/standard_yul_cfg_json_export/output.json
+++ b/test/cmdlineTests/standard_yul_cfg_json_export/output.json
@@ -154,9 +154,7 @@
                                     }
                                 ],
                                 "entry": "Block0",
-                                "returns": [
-                                    "memPtr"
-                                ],
+                                "numReturns": 1,
                                 "type": "Function"
                             },
                             "constructor_C_19": {
@@ -179,7 +177,7 @@
                                     }
                                 ],
                                 "entry": "Block0",
-                                "returns": [],
+                                "numReturns": 0,
                                 "type": "Function"
                             },
                             "constructor_I_7": {
@@ -195,7 +193,7 @@
                                     }
                                 ],
                                 "entry": "Block0",
-                                "returns": [],
+                                "numReturns": 0,
                                 "type": "Function"
                             },
                             "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb": {
@@ -220,7 +218,7 @@
                                     }
                                 ],
                                 "entry": "Block0",
-                                "returns": [],
+                                "numReturns": 0,
                                 "type": "Function"
                             }
                         }
@@ -442,7 +440,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [],
+                                    "numReturns": 0,
                                     "type": "Function"
                                 },
                                 "abi_encode_t_uint256_to_t_uint256_fromStack": {
@@ -480,7 +478,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [],
+                                    "numReturns": 0,
                                     "type": "Function"
                                 },
                                 "abi_encode_tuple_t_uint256__to_t_uint256__fromStack": {
@@ -531,9 +529,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "tail"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "allocate_unbounded": {
@@ -562,9 +558,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "memPtr"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "cleanup_t_rational_42_by_1": {
@@ -584,9 +578,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "cleaned"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "cleanup_t_uint256": {
@@ -606,9 +598,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "cleaned"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "convert_t_rational_42_by_1_to_t_uint256": {
@@ -657,9 +647,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "converted"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "external_fun_f_18": {
@@ -768,7 +756,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [],
+                                    "numReturns": 0,
                                     "type": "Function"
                                 },
                                 "fun_f_18": {
@@ -804,9 +792,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "var__13"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "identity": {
@@ -826,9 +812,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "ret"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74": {
@@ -853,7 +837,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [],
+                                    "numReturns": 0,
                                     "type": "Function"
                                 },
                                 "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb": {
@@ -878,7 +862,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [],
+                                    "numReturns": 0,
                                     "type": "Function"
                                 },
                                 "revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b": {
@@ -903,7 +887,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [],
+                                    "numReturns": 0,
                                     "type": "Function"
                                 },
                                 "shift_right_224_unsigned": {
@@ -935,9 +919,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "newValue"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "zero_value_for_split_t_uint256": {
@@ -955,9 +937,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "ret"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 }
                             }
@@ -1121,9 +1101,7 @@
                                     }
                                 ],
                                 "entry": "Block0",
-                                "returns": [
-                                    "memPtr"
-                                ],
+                                "numReturns": 1,
                                 "type": "Function"
                             },
                             "constructor_D_38": {
@@ -1139,7 +1117,7 @@
                                     }
                                 ],
                                 "entry": "Block0",
-                                "returns": [],
+                                "numReturns": 0,
                                 "type": "Function"
                             },
                             "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb": {
@@ -1164,7 +1142,7 @@
                                     }
                                 ],
                                 "entry": "Block0",
-                                "returns": [],
+                                "numReturns": 0,
                                 "type": "Function"
                             }
                         }
@@ -1358,9 +1336,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "value"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "abi_decode_tuple_": {
@@ -1427,7 +1403,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [],
+                                    "numReturns": 0,
                                     "type": "Function"
                                 },
                                 "abi_decode_tuple_t_uint256_fromMemory": {
@@ -1518,9 +1494,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "value0"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "abi_encode_t_uint256_to_t_uint256_fromStack": {
@@ -1558,7 +1532,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [],
+                                    "numReturns": 0,
                                     "type": "Function"
                                 },
                                 "abi_encode_tuple__to__fromStack": {
@@ -1590,9 +1564,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "tail"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "abi_encode_tuple_t_uint256__to_t_uint256__fromStack": {
@@ -1643,9 +1615,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "tail"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "allocate_unbounded": {
@@ -1674,9 +1644,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "memPtr"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "cleanup_t_uint160": {
@@ -1708,9 +1676,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "cleaned"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "cleanup_t_uint256": {
@@ -1730,9 +1696,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "cleaned"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "convert_t_contract$_C_$19_to_t_address": {
@@ -1763,9 +1727,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "converted"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "convert_t_uint160_to_t_address": {
@@ -1796,9 +1758,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "converted"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "convert_t_uint160_to_t_uint160": {
@@ -1847,9 +1807,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "converted"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "external_fun_f_37": {
@@ -1958,7 +1916,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [],
+                                    "numReturns": 0,
                                     "type": "Function"
                                 },
                                 "finalize_allocation": {
@@ -2064,7 +2022,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [],
+                                    "numReturns": 0,
                                     "type": "Function"
                                 },
                                 "fun_f_37": {
@@ -2521,9 +2479,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "var__22"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "identity": {
@@ -2543,9 +2499,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "ret"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "panic_error_0x41": {
@@ -2586,7 +2540,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [],
+                                    "numReturns": 0,
                                     "type": "Function"
                                 },
                                 "revert_error_0cc013b6b3b6beabea4e3a74a6d380f0df81852ca99887912475e1f66b2a2c20": {
@@ -2611,7 +2565,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [],
+                                    "numReturns": 0,
                                     "type": "Function"
                                 },
                                 "revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74": {
@@ -2636,7 +2590,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [],
+                                    "numReturns": 0,
                                     "type": "Function"
                                 },
                                 "revert_error_c1322bf8034eace5e0b5c7295db60986aa89aae5e0ea0873e4689e076861a5db": {
@@ -2661,7 +2615,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [],
+                                    "numReturns": 0,
                                     "type": "Function"
                                 },
                                 "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb": {
@@ -2686,7 +2640,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [],
+                                    "numReturns": 0,
                                     "type": "Function"
                                 },
                                 "revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b": {
@@ -2711,7 +2665,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [],
+                                    "numReturns": 0,
                                     "type": "Function"
                                 },
                                 "revert_forward_1": {
@@ -2766,7 +2720,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [],
+                                    "numReturns": 0,
                                     "type": "Function"
                                 },
                                 "round_up_to_mul_of_32": {
@@ -2817,9 +2771,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "result"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "shift_left_224": {
@@ -2851,9 +2803,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "newValue"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "shift_right_224_unsigned": {
@@ -2885,9 +2835,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "newValue"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 },
                                 "validator_revert_t_uint256": {
@@ -2964,7 +2912,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [],
+                                    "numReturns": 0,
                                     "type": "Function"
                                 },
                                 "zero_value_for_split_t_uint256": {
@@ -2982,9 +2930,7 @@
                                         }
                                     ],
                                     "entry": "Block0",
-                                    "returns": [
-                                        "ret"
-                                    ],
+                                    "numReturns": 1,
                                     "type": "Function"
                                 }
                             }
@@ -3141,9 +3087,7 @@
                                             }
                                         ],
                                         "entry": "Block0",
-                                        "returns": [
-                                            "memPtr"
-                                        ],
+                                        "numReturns": 1,
                                         "type": "Function"
                                     },
                                     "constructor_C_19": {
@@ -3166,7 +3110,7 @@
                                             }
                                         ],
                                         "entry": "Block0",
-                                        "returns": [],
+                                        "numReturns": 0,
                                         "type": "Function"
                                     },
                                     "constructor_I_7": {
@@ -3182,7 +3126,7 @@
                                             }
                                         ],
                                         "entry": "Block0",
-                                        "returns": [],
+                                        "numReturns": 0,
                                         "type": "Function"
                                     },
                                     "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb": {
@@ -3207,7 +3151,7 @@
                                             }
                                         ],
                                         "entry": "Block0",
-                                        "returns": [],
+                                        "numReturns": 0,
                                         "type": "Function"
                                     }
                                 }
@@ -3429,7 +3373,7 @@
                                                 }
                                             ],
                                             "entry": "Block0",
-                                            "returns": [],
+                                            "numReturns": 0,
                                             "type": "Function"
                                         },
                                         "abi_encode_t_uint256_to_t_uint256_fromStack": {
@@ -3467,7 +3411,7 @@
                                                 }
                                             ],
                                             "entry": "Block0",
-                                            "returns": [],
+                                            "numReturns": 0,
                                             "type": "Function"
                                         },
                                         "abi_encode_tuple_t_uint256__to_t_uint256__fromStack": {
@@ -3518,9 +3462,7 @@
                                                 }
                                             ],
                                             "entry": "Block0",
-                                            "returns": [
-                                                "tail"
-                                            ],
+                                            "numReturns": 1,
                                             "type": "Function"
                                         },
                                         "allocate_unbounded": {
@@ -3549,9 +3491,7 @@
                                                 }
                                             ],
                                             "entry": "Block0",
-                                            "returns": [
-                                                "memPtr"
-                                            ],
+                                            "numReturns": 1,
                                             "type": "Function"
                                         },
                                         "cleanup_t_rational_42_by_1": {
@@ -3571,9 +3511,7 @@
                                                 }
                                             ],
                                             "entry": "Block0",
-                                            "returns": [
-                                                "cleaned"
-                                            ],
+                                            "numReturns": 1,
                                             "type": "Function"
                                         },
                                         "cleanup_t_uint256": {
@@ -3593,9 +3531,7 @@
                                                 }
                                             ],
                                             "entry": "Block0",
-                                            "returns": [
-                                                "cleaned"
-                                            ],
+                                            "numReturns": 1,
                                             "type": "Function"
                                         },
                                         "convert_t_rational_42_by_1_to_t_uint256": {
@@ -3644,9 +3580,7 @@
                                                 }
                                             ],
                                             "entry": "Block0",
-                                            "returns": [
-                                                "converted"
-                                            ],
+                                            "numReturns": 1,
                                             "type": "Function"
                                         },
                                         "external_fun_f_18": {
@@ -3755,7 +3689,7 @@
                                                 }
                                             ],
                                             "entry": "Block0",
-                                            "returns": [],
+                                            "numReturns": 0,
                                             "type": "Function"
                                         },
                                         "fun_f_18": {
@@ -3791,9 +3725,7 @@
                                                 }
                                             ],
                                             "entry": "Block0",
-                                            "returns": [
-                                                "var__13"
-                                            ],
+                                            "numReturns": 1,
                                             "type": "Function"
                                         },
                                         "identity": {
@@ -3813,9 +3745,7 @@
                                                 }
                                             ],
                                             "entry": "Block0",
-                                            "returns": [
-                                                "ret"
-                                            ],
+                                            "numReturns": 1,
                                             "type": "Function"
                                         },
                                         "revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74": {
@@ -3840,7 +3770,7 @@
                                                 }
                                             ],
                                             "entry": "Block0",
-                                            "returns": [],
+                                            "numReturns": 0,
                                             "type": "Function"
                                         },
                                         "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb": {
@@ -3865,7 +3795,7 @@
                                                 }
                                             ],
                                             "entry": "Block0",
-                                            "returns": [],
+                                            "numReturns": 0,
                                             "type": "Function"
                                         },
                                         "revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b": {
@@ -3890,7 +3820,7 @@
                                                 }
                                             ],
                                             "entry": "Block0",
-                                            "returns": [],
+                                            "numReturns": 0,
                                             "type": "Function"
                                         },
                                         "shift_right_224_unsigned": {
@@ -3922,9 +3852,7 @@
                                                 }
                                             ],
                                             "entry": "Block0",
-                                            "returns": [
-                                                "newValue"
-                                            ],
+                                            "numReturns": 1,
                                             "type": "Function"
                                         },
                                         "zero_value_for_split_t_uint256": {
@@ -3942,9 +3870,7 @@
                                                 }
                                             ],
                                             "entry": "Block0",
-                                            "returns": [
-                                                "ret"
-                                            ],
+                                            "numReturns": 1,
                                             "type": "Function"
                                         }
                                     }

--- a/test/cmdlineTests/yul_cfg_json_export/output
+++ b/test/cmdlineTests/yul_cfg_json_export/output
@@ -153,9 +153,7 @@ Yul Control Flow Graph:
                     }
                 ],
                 "entry": "Block0",
-                "returns": [
-                    "memPtr"
-                ],
+                "numReturns": 1,
                 "type": "Function"
             },
             "constructor_C_19": {
@@ -178,7 +176,7 @@ Yul Control Flow Graph:
                     }
                 ],
                 "entry": "Block0",
-                "returns": [],
+                "numReturns": 0,
                 "type": "Function"
             },
             "constructor_I_7": {
@@ -194,7 +192,7 @@ Yul Control Flow Graph:
                     }
                 ],
                 "entry": "Block0",
-                "returns": [],
+                "numReturns": 0,
                 "type": "Function"
             },
             "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb": {
@@ -219,7 +217,7 @@ Yul Control Flow Graph:
                     }
                 ],
                 "entry": "Block0",
-                "returns": [],
+                "numReturns": 0,
                 "type": "Function"
             }
         }
@@ -441,7 +439,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [],
+                    "numReturns": 0,
                     "type": "Function"
                 },
                 "abi_encode_t_uint256_to_t_uint256_fromStack": {
@@ -479,7 +477,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [],
+                    "numReturns": 0,
                     "type": "Function"
                 },
                 "abi_encode_tuple_t_uint256__to_t_uint256__fromStack": {
@@ -530,9 +528,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "tail"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "allocate_unbounded": {
@@ -561,9 +557,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "memPtr"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "cleanup_t_rational_42_by_1": {
@@ -583,9 +577,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "cleaned"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "cleanup_t_uint256": {
@@ -605,9 +597,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "cleaned"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "convert_t_rational_42_by_1_to_t_uint256": {
@@ -656,9 +646,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "converted"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "external_fun_f_18": {
@@ -767,7 +755,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [],
+                    "numReturns": 0,
                     "type": "Function"
                 },
                 "fun_f_18": {
@@ -803,9 +791,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "var__13"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "identity": {
@@ -825,9 +811,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "ret"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74": {
@@ -852,7 +836,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [],
+                    "numReturns": 0,
                     "type": "Function"
                 },
                 "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb": {
@@ -877,7 +861,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [],
+                    "numReturns": 0,
                     "type": "Function"
                 },
                 "revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b": {
@@ -902,7 +886,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [],
+                    "numReturns": 0,
                     "type": "Function"
                 },
                 "shift_right_224_unsigned": {
@@ -934,9 +918,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "newValue"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "zero_value_for_split_t_uint256": {
@@ -954,9 +936,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "ret"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 }
             }
@@ -1121,9 +1101,7 @@ Yul Control Flow Graph:
                     }
                 ],
                 "entry": "Block0",
-                "returns": [
-                    "memPtr"
-                ],
+                "numReturns": 1,
                 "type": "Function"
             },
             "constructor_D_38": {
@@ -1139,7 +1117,7 @@ Yul Control Flow Graph:
                     }
                 ],
                 "entry": "Block0",
-                "returns": [],
+                "numReturns": 0,
                 "type": "Function"
             },
             "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb": {
@@ -1164,7 +1142,7 @@ Yul Control Flow Graph:
                     }
                 ],
                 "entry": "Block0",
-                "returns": [],
+                "numReturns": 0,
                 "type": "Function"
             }
         }
@@ -1358,9 +1336,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "value"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "abi_decode_tuple_": {
@@ -1427,7 +1403,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [],
+                    "numReturns": 0,
                     "type": "Function"
                 },
                 "abi_decode_tuple_t_uint256_fromMemory": {
@@ -1518,9 +1494,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "value0"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "abi_encode_t_uint256_to_t_uint256_fromStack": {
@@ -1558,7 +1532,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [],
+                    "numReturns": 0,
                     "type": "Function"
                 },
                 "abi_encode_tuple__to__fromStack": {
@@ -1590,9 +1564,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "tail"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "abi_encode_tuple_t_uint256__to_t_uint256__fromStack": {
@@ -1643,9 +1615,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "tail"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "allocate_unbounded": {
@@ -1674,9 +1644,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "memPtr"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "cleanup_t_uint160": {
@@ -1708,9 +1676,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "cleaned"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "cleanup_t_uint256": {
@@ -1730,9 +1696,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "cleaned"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "convert_t_contract$_C_$19_to_t_address": {
@@ -1763,9 +1727,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "converted"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "convert_t_uint160_to_t_address": {
@@ -1796,9 +1758,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "converted"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "convert_t_uint160_to_t_uint160": {
@@ -1847,9 +1807,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "converted"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "external_fun_f_37": {
@@ -1958,7 +1916,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [],
+                    "numReturns": 0,
                     "type": "Function"
                 },
                 "finalize_allocation": {
@@ -2064,7 +2022,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [],
+                    "numReturns": 0,
                     "type": "Function"
                 },
                 "fun_f_37": {
@@ -2521,9 +2479,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "var__22"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "identity": {
@@ -2543,9 +2499,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "ret"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "panic_error_0x41": {
@@ -2586,7 +2540,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [],
+                    "numReturns": 0,
                     "type": "Function"
                 },
                 "revert_error_0cc013b6b3b6beabea4e3a74a6d380f0df81852ca99887912475e1f66b2a2c20": {
@@ -2611,7 +2565,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [],
+                    "numReturns": 0,
                     "type": "Function"
                 },
                 "revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74": {
@@ -2636,7 +2590,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [],
+                    "numReturns": 0,
                     "type": "Function"
                 },
                 "revert_error_c1322bf8034eace5e0b5c7295db60986aa89aae5e0ea0873e4689e076861a5db": {
@@ -2661,7 +2615,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [],
+                    "numReturns": 0,
                     "type": "Function"
                 },
                 "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb": {
@@ -2686,7 +2640,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [],
+                    "numReturns": 0,
                     "type": "Function"
                 },
                 "revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b": {
@@ -2711,7 +2665,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [],
+                    "numReturns": 0,
                     "type": "Function"
                 },
                 "revert_forward_1": {
@@ -2766,7 +2720,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [],
+                    "numReturns": 0,
                     "type": "Function"
                 },
                 "round_up_to_mul_of_32": {
@@ -2817,9 +2771,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "result"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "shift_left_224": {
@@ -2851,9 +2803,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "newValue"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "shift_right_224_unsigned": {
@@ -2885,9 +2835,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "newValue"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 },
                 "validator_revert_t_uint256": {
@@ -2964,7 +2912,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [],
+                    "numReturns": 0,
                     "type": "Function"
                 },
                 "zero_value_for_split_t_uint256": {
@@ -2982,9 +2930,7 @@ Yul Control Flow Graph:
                         }
                     ],
                     "entry": "Block0",
-                    "returns": [
-                        "ret"
-                    ],
+                    "numReturns": 1,
                     "type": "Function"
                 }
             }
@@ -3141,9 +3087,7 @@ Yul Control Flow Graph:
                             }
                         ],
                         "entry": "Block0",
-                        "returns": [
-                            "memPtr"
-                        ],
+                        "numReturns": 1,
                         "type": "Function"
                     },
                     "constructor_C_19": {
@@ -3166,7 +3110,7 @@ Yul Control Flow Graph:
                             }
                         ],
                         "entry": "Block0",
-                        "returns": [],
+                        "numReturns": 0,
                         "type": "Function"
                     },
                     "constructor_I_7": {
@@ -3182,7 +3126,7 @@ Yul Control Flow Graph:
                             }
                         ],
                         "entry": "Block0",
-                        "returns": [],
+                        "numReturns": 0,
                         "type": "Function"
                     },
                     "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb": {
@@ -3207,7 +3151,7 @@ Yul Control Flow Graph:
                             }
                         ],
                         "entry": "Block0",
-                        "returns": [],
+                        "numReturns": 0,
                         "type": "Function"
                     }
                 }
@@ -3429,7 +3373,7 @@ Yul Control Flow Graph:
                                 }
                             ],
                             "entry": "Block0",
-                            "returns": [],
+                            "numReturns": 0,
                             "type": "Function"
                         },
                         "abi_encode_t_uint256_to_t_uint256_fromStack": {
@@ -3467,7 +3411,7 @@ Yul Control Flow Graph:
                                 }
                             ],
                             "entry": "Block0",
-                            "returns": [],
+                            "numReturns": 0,
                             "type": "Function"
                         },
                         "abi_encode_tuple_t_uint256__to_t_uint256__fromStack": {
@@ -3518,9 +3462,7 @@ Yul Control Flow Graph:
                                 }
                             ],
                             "entry": "Block0",
-                            "returns": [
-                                "tail"
-                            ],
+                            "numReturns": 1,
                             "type": "Function"
                         },
                         "allocate_unbounded": {
@@ -3549,9 +3491,7 @@ Yul Control Flow Graph:
                                 }
                             ],
                             "entry": "Block0",
-                            "returns": [
-                                "memPtr"
-                            ],
+                            "numReturns": 1,
                             "type": "Function"
                         },
                         "cleanup_t_rational_42_by_1": {
@@ -3571,9 +3511,7 @@ Yul Control Flow Graph:
                                 }
                             ],
                             "entry": "Block0",
-                            "returns": [
-                                "cleaned"
-                            ],
+                            "numReturns": 1,
                             "type": "Function"
                         },
                         "cleanup_t_uint256": {
@@ -3593,9 +3531,7 @@ Yul Control Flow Graph:
                                 }
                             ],
                             "entry": "Block0",
-                            "returns": [
-                                "cleaned"
-                            ],
+                            "numReturns": 1,
                             "type": "Function"
                         },
                         "convert_t_rational_42_by_1_to_t_uint256": {
@@ -3644,9 +3580,7 @@ Yul Control Flow Graph:
                                 }
                             ],
                             "entry": "Block0",
-                            "returns": [
-                                "converted"
-                            ],
+                            "numReturns": 1,
                             "type": "Function"
                         },
                         "external_fun_f_18": {
@@ -3755,7 +3689,7 @@ Yul Control Flow Graph:
                                 }
                             ],
                             "entry": "Block0",
-                            "returns": [],
+                            "numReturns": 0,
                             "type": "Function"
                         },
                         "fun_f_18": {
@@ -3791,9 +3725,7 @@ Yul Control Flow Graph:
                                 }
                             ],
                             "entry": "Block0",
-                            "returns": [
-                                "var__13"
-                            ],
+                            "numReturns": 1,
                             "type": "Function"
                         },
                         "identity": {
@@ -3813,9 +3745,7 @@ Yul Control Flow Graph:
                                 }
                             ],
                             "entry": "Block0",
-                            "returns": [
-                                "ret"
-                            ],
+                            "numReturns": 1,
                             "type": "Function"
                         },
                         "revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74": {
@@ -3840,7 +3770,7 @@ Yul Control Flow Graph:
                                 }
                             ],
                             "entry": "Block0",
-                            "returns": [],
+                            "numReturns": 0,
                             "type": "Function"
                         },
                         "revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb": {
@@ -3865,7 +3795,7 @@ Yul Control Flow Graph:
                                 }
                             ],
                             "entry": "Block0",
-                            "returns": [],
+                            "numReturns": 0,
                             "type": "Function"
                         },
                         "revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b": {
@@ -3890,7 +3820,7 @@ Yul Control Flow Graph:
                                 }
                             ],
                             "entry": "Block0",
-                            "returns": [],
+                            "numReturns": 0,
                             "type": "Function"
                         },
                         "shift_right_224_unsigned": {
@@ -3922,9 +3852,7 @@ Yul Control Flow Graph:
                                 }
                             ],
                             "entry": "Block0",
-                            "returns": [
-                                "newValue"
-                            ],
+                            "numReturns": 1,
                             "type": "Function"
                         },
                         "zero_value_for_split_t_uint256": {
@@ -3942,9 +3870,7 @@ Yul Control Flow Graph:
                                 }
                             ],
                             "entry": "Block0",
-                            "returns": [
-                                "ret"
-                            ],
+                            "numReturns": 1,
                             "type": "Function"
                         }
                     }

--- a/test/cmdlineTests/yul_cfg_json_export/output
+++ b/test/cmdlineTests/yul_cfg_json_export/output
@@ -379,8 +379,8 @@ Yul Control Flow Graph:
             "functions": {
                 "abi_decode_tuple_": {
                     "arguments": [
-                        "headStart",
-                        "dataEnd"
+                        "v0",
+                        "v1"
                     ],
                     "blocks": [
                         {
@@ -446,8 +446,8 @@ Yul Control Flow Graph:
                 },
                 "abi_encode_t_uint256_to_t_uint256_fromStack": {
                     "arguments": [
-                        "value",
-                        "pos"
+                        "v0",
+                        "v1"
                     ],
                     "blocks": [
                         {
@@ -484,8 +484,8 @@ Yul Control Flow Graph:
                 },
                 "abi_encode_tuple_t_uint256__to_t_uint256__fromStack": {
                     "arguments": [
-                        "headStart",
-                        "value0"
+                        "v0",
+                        "v1"
                     ],
                     "blocks": [
                         {
@@ -568,7 +568,7 @@ Yul Control Flow Graph:
                 },
                 "cleanup_t_rational_42_by_1": {
                     "arguments": [
-                        "value"
+                        "v0"
                     ],
                     "blocks": [
                         {
@@ -590,7 +590,7 @@ Yul Control Flow Graph:
                 },
                 "cleanup_t_uint256": {
                     "arguments": [
-                        "value"
+                        "v0"
                     ],
                     "blocks": [
                         {
@@ -612,7 +612,7 @@ Yul Control Flow Graph:
                 },
                 "convert_t_rational_42_by_1_to_t_uint256": {
                     "arguments": [
-                        "value"
+                        "v0"
                     ],
                     "blocks": [
                         {
@@ -810,7 +810,7 @@ Yul Control Flow Graph:
                 },
                 "identity": {
                     "arguments": [
-                        "value"
+                        "v0"
                     ],
                     "blocks": [
                         {
@@ -907,7 +907,7 @@ Yul Control Flow Graph:
                 },
                 "shift_right_224_unsigned": {
                     "arguments": [
-                        "value"
+                        "v0"
                     ],
                     "blocks": [
                         {
@@ -1324,8 +1324,8 @@ Yul Control Flow Graph:
             "functions": {
                 "abi_decode_t_uint256_fromMemory": {
                     "arguments": [
-                        "offset",
-                        "end"
+                        "v0",
+                        "v1"
                     ],
                     "blocks": [
                         {
@@ -1365,8 +1365,8 @@ Yul Control Flow Graph:
                 },
                 "abi_decode_tuple_": {
                     "arguments": [
-                        "headStart",
-                        "dataEnd"
+                        "v0",
+                        "v1"
                     ],
                     "blocks": [
                         {
@@ -1432,8 +1432,8 @@ Yul Control Flow Graph:
                 },
                 "abi_decode_tuple_t_uint256_fromMemory": {
                     "arguments": [
-                        "headStart",
-                        "dataEnd"
+                        "v0",
+                        "v1"
                     ],
                     "blocks": [
                         {
@@ -1525,8 +1525,8 @@ Yul Control Flow Graph:
                 },
                 "abi_encode_t_uint256_to_t_uint256_fromStack": {
                     "arguments": [
-                        "value",
-                        "pos"
+                        "v0",
+                        "v1"
                     ],
                     "blocks": [
                         {
@@ -1563,7 +1563,7 @@ Yul Control Flow Graph:
                 },
                 "abi_encode_tuple__to__fromStack": {
                     "arguments": [
-                        "headStart"
+                        "v0"
                     ],
                     "blocks": [
                         {
@@ -1597,8 +1597,8 @@ Yul Control Flow Graph:
                 },
                 "abi_encode_tuple_t_uint256__to_t_uint256__fromStack": {
                     "arguments": [
-                        "headStart",
-                        "value0"
+                        "v0",
+                        "v1"
                     ],
                     "blocks": [
                         {
@@ -1681,7 +1681,7 @@ Yul Control Flow Graph:
                 },
                 "cleanup_t_uint160": {
                     "arguments": [
-                        "value"
+                        "v0"
                     ],
                     "blocks": [
                         {
@@ -1715,7 +1715,7 @@ Yul Control Flow Graph:
                 },
                 "cleanup_t_uint256": {
                     "arguments": [
-                        "value"
+                        "v0"
                     ],
                     "blocks": [
                         {
@@ -1737,7 +1737,7 @@ Yul Control Flow Graph:
                 },
                 "convert_t_contract$_C_$19_to_t_address": {
                     "arguments": [
-                        "value"
+                        "v0"
                     ],
                     "blocks": [
                         {
@@ -1770,7 +1770,7 @@ Yul Control Flow Graph:
                 },
                 "convert_t_uint160_to_t_address": {
                     "arguments": [
-                        "value"
+                        "v0"
                     ],
                     "blocks": [
                         {
@@ -1803,7 +1803,7 @@ Yul Control Flow Graph:
                 },
                 "convert_t_uint160_to_t_uint160": {
                     "arguments": [
-                        "value"
+                        "v0"
                     ],
                     "blocks": [
                         {
@@ -1963,8 +1963,8 @@ Yul Control Flow Graph:
                 },
                 "finalize_allocation": {
                     "arguments": [
-                        "memPtr",
-                        "size"
+                        "v0",
+                        "v1"
                     ],
                     "blocks": [
                         {
@@ -2528,7 +2528,7 @@ Yul Control Flow Graph:
                 },
                 "identity": {
                     "arguments": [
-                        "value"
+                        "v0"
                     ],
                     "blocks": [
                         {
@@ -2771,7 +2771,7 @@ Yul Control Flow Graph:
                 },
                 "round_up_to_mul_of_32": {
                     "arguments": [
-                        "value"
+                        "v0"
                     ],
                     "blocks": [
                         {
@@ -2824,7 +2824,7 @@ Yul Control Flow Graph:
                 },
                 "shift_left_224": {
                     "arguments": [
-                        "value"
+                        "v0"
                     ],
                     "blocks": [
                         {
@@ -2858,7 +2858,7 @@ Yul Control Flow Graph:
                 },
                 "shift_right_224_unsigned": {
                     "arguments": [
-                        "value"
+                        "v0"
                     ],
                     "blocks": [
                         {
@@ -2892,7 +2892,7 @@ Yul Control Flow Graph:
                 },
                 "validator_revert_t_uint256": {
                     "arguments": [
-                        "value"
+                        "v0"
                     ],
                     "blocks": [
                         {
@@ -3367,8 +3367,8 @@ Yul Control Flow Graph:
                     "functions": {
                         "abi_decode_tuple_": {
                             "arguments": [
-                                "headStart",
-                                "dataEnd"
+                                "v0",
+                                "v1"
                             ],
                             "blocks": [
                                 {
@@ -3434,8 +3434,8 @@ Yul Control Flow Graph:
                         },
                         "abi_encode_t_uint256_to_t_uint256_fromStack": {
                             "arguments": [
-                                "value",
-                                "pos"
+                                "v0",
+                                "v1"
                             ],
                             "blocks": [
                                 {
@@ -3472,8 +3472,8 @@ Yul Control Flow Graph:
                         },
                         "abi_encode_tuple_t_uint256__to_t_uint256__fromStack": {
                             "arguments": [
-                                "headStart",
-                                "value0"
+                                "v0",
+                                "v1"
                             ],
                             "blocks": [
                                 {
@@ -3556,7 +3556,7 @@ Yul Control Flow Graph:
                         },
                         "cleanup_t_rational_42_by_1": {
                             "arguments": [
-                                "value"
+                                "v0"
                             ],
                             "blocks": [
                                 {
@@ -3578,7 +3578,7 @@ Yul Control Flow Graph:
                         },
                         "cleanup_t_uint256": {
                             "arguments": [
-                                "value"
+                                "v0"
                             ],
                             "blocks": [
                                 {
@@ -3600,7 +3600,7 @@ Yul Control Flow Graph:
                         },
                         "convert_t_rational_42_by_1_to_t_uint256": {
                             "arguments": [
-                                "value"
+                                "v0"
                             ],
                             "blocks": [
                                 {
@@ -3798,7 +3798,7 @@ Yul Control Flow Graph:
                         },
                         "identity": {
                             "arguments": [
-                                "value"
+                                "v0"
                             ],
                             "blocks": [
                                 {
@@ -3895,7 +3895,7 @@ Yul Control Flow Graph:
                         },
                         "shift_right_224_unsigned": {
                             "arguments": [
-                                "value"
+                                "v0"
                             ],
                             "blocks": [
                                 {


### PR DESCRIPTION
Function arguments are referenced by their value ids instead of names that were given in the original AST