### PR TITLE
SMTChecker + CI: Update versions of solvers and test expectations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,16 +9,16 @@ version: 2.1
 parameters:
   ubuntu-2004-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2004-25
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:b3f321fb2d8e7a41ca9328672061c1840e5cd3fb5be503aa158d1c508deacf0a"
+    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2004-26
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:1f387a77be889f65a2a25986a5c5eccc88cec23fabe6aeaf351790751145c81e"
   ubuntu-2404-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2404-1
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:5d6d27551104321a30326d6024bd4e96d9d899a97a78eb9feea364996f1d18b5"
+    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2404-2
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:92efa8581887e5389b29d3a150112a8433a04ebf5fddf2c65ed6794b4cdf1fe3"
   ubuntu-2404-clang-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2404.clang-2
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:bc99a858ba18e088c1cb889ce631e3e707bb3348f0ae452bfe69116dbb931173"
+    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2404.clang-3
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:534c4eea1ba370a85cf3c106b4a30b43152ba4f695fab5e18577009a5e272146"
   ubuntu-clang-ossfuzz-docker-image:
     type: string
     # solbuildpackpusher/solidity-buildpack-deps:ubuntu.clang.ossfuzz-6
@@ -26,8 +26,8 @@ parameters:
   emscripten-docker-image:
     type: string
     # NOTE: Please remember to update the `scripts/build_emscripten.sh` whenever the hash of this image changes.
-    # solbuildpackpusher/solidity-buildpack-deps:emscripten-17
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:c57f2bfb8c15d70fe290629358dd1c73dc126e3760f443b54764797556b887d4"
+    # solbuildpackpusher/solidity-buildpack-deps:emscripten-19
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:170b159c82ce70e639500551394460f01798c18a5e17b45ea91277b0cf8eae37"
   evm-version:
     type: string
     default: cancun

--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -106,7 +106,7 @@ then
   mkdir build
   cd build
   cmake -DCMAKE_OSX_ARCHITECTURES:STRING="x86_64;arm64" -DZ3_BUILD_LIBZ3_SHARED=false ..
-  make -j
+  make -j "$(nproc)"
   sudo make install
   cd ../..
   rm -rf "$z3_dir"

--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -85,21 +85,19 @@ then
   rm -rf /tmp/{eldarica,eld_binaries.zip}
 
   #cvc5
-  cvc5_version="1.1.2"
-  wget "https://github.com/cvc5/cvc5/releases/download/cvc5-${cvc5_version}/cvc5-macOS-arm64-static.zip" -O /tmp/cvc5.zip
-  validate_checksum /tmp/cvc5.zip 2017d683d924676cb713865c6d4fcf70115c65b7ec2848f242ab938902f115b5
-  unzip /tmp/cvc5.zip -x "cvc5-macOS-arm64-static/lib/cmake/*" -d /tmp
-  sudo mv /tmp/cvc5-macOS-arm64-static/bin/* /usr/local/bin
-  sudo mv /tmp/cvc5-macOS-arm64-static/include/* /usr/local/include
-  sudo mv /tmp/cvc5-macOS-arm64-static/lib/* /usr/local/lib
-  rm -rf /tmp/{cvc5-macOS-arm64-static,cvc5.zip}
+  cvc5_version="1.2.0"
+  cvc5_archive_name="cvc5-macOS-arm64-static"
+  wget "https://github.com/cvc5/cvc5/releases/download/cvc5-${cvc5_version}/${cvc5_archive_name}.zip" -O /tmp/cvc5.zip
+  validate_checksum /tmp/cvc5.zip 57d2d4855af3f3865110a254e415098b4e150a655f297010e27eb292f48f7da7
+  sudo unzip -j /tmp/cvc5.zip "${cvc5_archive_name}/bin/cvc5" -d /usr/local/bin
+  rm -f /tmp/cvc5.zip
 
   # z3
-  z3_version="4.12.1"
+  z3_version="4.13.3"
   z3_dir="z3-z3-$z3_version"
   z3_package="z3-$z3_version.tar.gz"
   wget "https://github.com/Z3Prover/z3/archive/refs/tags/$z3_package"
-  validate_checksum "$z3_package" a3735fabf00e1341adcc70394993c05fd3e2ae167a3e9bb46045e33084eb64a3
+  validate_checksum "$z3_package" f59c9cf600ea57fb64ffeffbffd0f2d2b896854f339e846f48f069d23bc14ba0
   tar xf "$z3_package"
   rm "$z3_package"
   cd "$z3_dir"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ include(EthOptions)
 configure_project(TESTS)
 
 if(EMSCRIPTEN)
-    set(TESTED_Z3_VERSION "4.12.1")
+    set(TESTED_Z3_VERSION "4.13.3")
     set(MINIMUM_Z3_VERSION "4.8.16")
     find_package(Z3)
     if (${Z3_FOUND})

--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -33,9 +33,9 @@ if (( $# != 0 )); then
     params="$(printf "%q " "${@}")"
 fi
 
-# solbuildpackpusher/solidity-buildpack-deps:emscripten-17
+# solbuildpackpusher/solidity-buildpack-deps:emscripten-19
 # NOTE: Without `safe.directory` git would assume it's not safe to operate on /root/project since it's owned by a different user.
 # See https://github.blog/2022-04-12-git-security-vulnerability-announced/
 docker run -v "$(pwd):/root/project" -w /root/project \
-    solbuildpackpusher/solidity-buildpack-deps@sha256:c57f2bfb8c15d70fe290629358dd1c73dc126e3760f443b54764797556b887d4 \
+    solbuildpackpusher/solidity-buildpack-deps@sha256:170b159c82ce70e639500551394460f01798c18a5e17b45ea91277b0cf8eae37 \
     /bin/bash -c "git config --global --add safe.directory /root/project && ./scripts/ci/build_emscripten.sh ${params}"

--- a/scripts/pylintrc
+++ b/scripts/pylintrc
@@ -29,6 +29,7 @@ disable=
     too-many-branches,
     too-many-instance-attributes,
     too-many-locals,
+    too-many-positional-arguments,
     too-many-public-methods,
     too-many-statements,
     ungrouped-imports

--- a/test/libsolidity/smtCheckerTests/types/fixed_bytes_access_3.sol
+++ b/test/libsolidity/smtCheckerTests/types/fixed_bytes_access_3.sol
@@ -30,7 +30,7 @@ contract C {
 }
 // ====
 // SMTEngine: all
-// SMTIgnoreOS: macos
 // ----
+// Warning 6368: (374-381): CHC: Out of bounds access might happen here.
 // Warning 6368: (456-462): CHC: Out of bounds access happens here.
-// Info 1391: CHC: 13 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 1391: CHC: 12 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/types/tuple_assignment_array_empty.sol
+++ b/test/libsolidity/smtCheckerTests/types/tuple_assignment_array_empty.sol
@@ -16,6 +16,7 @@ contract C
 // ====
 // SMTEngine: all
 // SMTIgnoreCex: yes
+// SMTTargets: assert
 // ----
-// Warning 6328: (198-215): CHC: Assertion violation happens here.
-// Info 1391: CHC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 6328: (198-215): CHC: Assertion violation happens here.\nCounterexample:\na = [3212, 4]\nx = 0\ny = 1\n\nTransaction trace:\nC.constructor()\nState: a = []\nC.f(3212)\nState: a = [3212]\nC.f(1573)\nState: a = [3212, 1573]\nC.g(0, 1)
+// Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.


### PR DESCRIPTION
This PR accompanies PR https://github.com/ethereum/solidity/pull/15551 to update solver versions for all platforms we use in CI.