### PR TITLE
Yul AST contains dialect

### DIFF
--- a/libsolidity/ast/ASTJsonImporter.cpp
+++ b/libsolidity/ast/ASTJsonImporter.cpp
@@ -742,7 +742,7 @@ ASTPointer<InlineAssembly> ASTJsonImporter::createInlineAssembly(Json const& _no
 			flags->emplace_back(std::make_shared<ASTString>(flag.get<std::string>()));
 		}
 	}
-	std::shared_ptr<yul::AST> operations = std::make_shared<yul::AST>(yul::AsmJsonImporter(m_sourceNames).createAST(member(_node, "AST")));
+	std::shared_ptr<yul::AST> operations = std::make_shared<yul::AST>(yul::AsmJsonImporter(dialect, m_sourceNames).createAST(member(_node, "AST")));
 	return createASTNode<InlineAssembly>(
 		_node,
 		nullOrASTString(_node, "documentation"),

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -544,7 +544,6 @@ void CompilerContext::optimizeYul(yul::Object& _object, OptimiserSettings const&
 	bool const isCreation = runtimeContext() != nullptr;
 	yul::GasMeter meter(*evmDialect, isCreation, _optimiserSettings.expectedExecutionsPerDeployment);
 	yul::OptimiserSuite::run(
-		*evmDialect,
 		&meter,
 		_object,
 		_optimiserSettings.optimizeStackAllocation,

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -485,7 +485,7 @@ void CompilerContext::appendInlineAssembly(
 		obj.setCode(parserResult, std::make_shared<yul::AsmAnalysisInfo>(analysisInfo));
 
 		solAssert(!dialect.providesObjectAccess());
-		optimizeYul(obj, dialect, _optimiserSettings, externallyUsedIdentifiers);
+		optimizeYul(obj, _optimiserSettings, externallyUsedIdentifiers);
 
 		if (_system)
 		{
@@ -532,16 +532,19 @@ void CompilerContext::appendInlineAssembly(
 }
 
 
-void CompilerContext::optimizeYul(yul::Object& _object, yul::EVMDialect const& _dialect, OptimiserSettings const& _optimiserSettings, std::set<yul::YulName> const& _externalIdentifiers)
+void CompilerContext::optimizeYul(yul::Object& _object, OptimiserSettings const& _optimiserSettings, std::set<yul::YulName> const& _externalIdentifiers)
 {
+	yulAssert(_object.dialect());
+	auto const* evmDialect = dynamic_cast<yul::EVMDialect const*>(_object.dialect());
+	yulAssert(evmDialect);
 #ifdef SOL_OUTPUT_ASM
 	std::cout << yul::AsmPrinter::format(*_object.code()) << std::endl;
 #endif
 
 	bool const isCreation = runtimeContext() != nullptr;
-	yul::GasMeter meter(_dialect, isCreation, _optimiserSettings.expectedExecutionsPerDeployment);
+	yul::GasMeter meter(*evmDialect, isCreation, _optimiserSettings.expectedExecutionsPerDeployment);
 	yul::OptimiserSuite::run(
-		_dialect,
+		*evmDialect,
 		&meter,
 		_object,
 		_optimiserSettings.optimizeStackAllocation,

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -444,7 +444,7 @@ void CompilerContext::appendInlineAssembly(
 		yul::Parser(errorReporter, dialect, std::move(locationOverride))
 		.parse(charStream);
 #ifdef SOL_OUTPUT_ASM
-	cout << yul::AsmPrinter(&dialect)(*parserResult) << endl;
+	std::cout << yul::AsmPrinter::format(*parserResult) << std::endl;
 #endif
 
 	auto reportError = [&](std::string const& _context)
@@ -491,9 +491,7 @@ void CompilerContext::appendInlineAssembly(
 		{
 			// Store as generated sources, but first re-parse to update the source references.
 			solAssert(m_generatedYulUtilityCode.empty(), "");
-			solAssert(obj.dialect());
-			m_generatedYulUtilityCode = yul::AsmPrinter(*obj.dialect())(obj.code()->root());
-			std::string code = yul::AsmPrinter{*obj.dialect()}(obj.code()->root());
+			m_generatedYulUtilityCode = yul::AsmPrinter::format(*obj.code());
 			langutil::CharStream charStream(m_generatedYulUtilityCode, _sourceName);
 			obj.setCode(yul::Parser(errorReporter, dialect).parse(charStream));
 			obj.analysisInfo = std::make_shared<yul::AsmAnalysisInfo>(yul::AsmAnalyzer::analyzeStrictAssertCorrect(dialect, obj));
@@ -503,8 +501,8 @@ void CompilerContext::appendInlineAssembly(
 		toBeAssembledAST = obj.code();
 
 #ifdef SOL_OUTPUT_ASM
-		cout << "After optimizer:" << endl;
-		cout << yul::AsmPrinter(&dialect)(*parserResult) << endl;
+		std::cout << "After optimizer:" << std::endl;
+		std::cout << yul::AsmPrinter::format(*parserResult) << std::endl;
 #endif
 	}
 	else if (_system)
@@ -537,7 +535,7 @@ void CompilerContext::appendInlineAssembly(
 void CompilerContext::optimizeYul(yul::Object& _object, yul::EVMDialect const& _dialect, OptimiserSettings const& _optimiserSettings, std::set<yul::YulName> const& _externalIdentifiers)
 {
 #ifdef SOL_OUTPUT_ASM
-	cout << yul::AsmPrinter(*dialect)(*_object.code) << endl;
+	std::cout << yul::AsmPrinter::format(*_object.code()) << std::endl;
 #endif
 
 	bool const isCreation = runtimeContext() != nullptr;
@@ -554,8 +552,8 @@ void CompilerContext::optimizeYul(yul::Object& _object, yul::EVMDialect const& _
 	);
 
 #ifdef SOL_OUTPUT_ASM
-	cout << "After optimizer:" << endl;
-	cout << yul::AsmPrinter(*dialect)(*object.code) << endl;
+	std::cout << "After optimizer:" << std::endl;
+	std::cout << yul::AsmPrinter::format(*_object.code()) << std::endl;
 #endif
 }
 

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -494,7 +494,7 @@ void CompilerContext::appendInlineAssembly(
 			m_generatedYulUtilityCode = yul::AsmPrinter::format(*obj.code());
 			langutil::CharStream charStream(m_generatedYulUtilityCode, _sourceName);
 			obj.setCode(yul::Parser(errorReporter, dialect).parse(charStream));
-			obj.analysisInfo = std::make_shared<yul::AsmAnalysisInfo>(yul::AsmAnalyzer::analyzeStrictAssertCorrect(dialect, obj));
+			obj.analysisInfo = std::make_shared<yul::AsmAnalysisInfo>(yul::AsmAnalyzer::analyzeStrictAssertCorrect(obj));
 		}
 
 		analysisInfo = std::move(*obj.analysisInfo);

--- a/libsolidity/codegen/CompilerContext.cpp
+++ b/libsolidity/codegen/CompilerContext.cpp
@@ -481,7 +481,7 @@ void CompilerContext::appendInlineAssembly(
 	// so we essentially only optimize the ABI functions.
 	if (_optimiserSettings.runYulOptimiser && _localVariables.empty())
 	{
-		yul::Object obj{dialect};
+		yul::Object obj;
 		obj.setCode(parserResult, std::make_shared<yul::AsmAnalysisInfo>(analysisInfo));
 
 		solAssert(!dialect.providesObjectAccess());
@@ -491,8 +491,9 @@ void CompilerContext::appendInlineAssembly(
 		{
 			// Store as generated sources, but first re-parse to update the source references.
 			solAssert(m_generatedYulUtilityCode.empty(), "");
-			m_generatedYulUtilityCode = yul::AsmPrinter(obj.dialect())(obj.code()->root());
-			std::string code = yul::AsmPrinter{obj.dialect()}(obj.code()->root());
+			solAssert(obj.dialect());
+			m_generatedYulUtilityCode = yul::AsmPrinter(*obj.dialect())(obj.code()->root());
+			std::string code = yul::AsmPrinter{*obj.dialect()}(obj.code()->root());
 			langutil::CharStream charStream(m_generatedYulUtilityCode, _sourceName);
 			obj.setCode(yul::Parser(errorReporter, dialect).parse(charStream));
 			obj.analysisInfo = std::make_shared<yul::AsmAnalysisInfo>(yul::AsmAnalyzer::analyzeStrictAssertCorrect(dialect, obj));

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -277,7 +277,7 @@ public:
 	/// Otherwise returns "revert(0, 0)".
 	std::string revertReasonIfDebug(std::string const& _message = "");
 
-	void optimizeYul(yul::Object& _object, yul::EVMDialect const& _dialect, OptimiserSettings const& _optimiserSetting, std::set<yul::YulName> const& _externalIdentifiers = {});
+	void optimizeYul(yul::Object& _object, OptimiserSettings const& _optimiserSetting, std::set<yul::YulName> const& _externalIdentifiers = {});
 
 	/// Appends arbitrary data to the end of the bytecode.
 	void appendToAuxiliaryData(bytes const& _data) { m_asm->appendToAuxiliaryData(_data); }

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -945,7 +945,7 @@ bool ContractCompiler::visit(InlineAssembly const& _inlineAssembly)
 
 		// Create a modifiable copy of the code and analysis
 		object.setCode(std::make_shared<yul::AST>(_inlineAssembly.dialect(), yul::ASTCopier().translate(code->root())));
-		object.analysisInfo = std::make_shared<yul::AsmAnalysisInfo>(yul::AsmAnalyzer::analyzeStrictAssertCorrect(*dialect, object));
+		object.analysisInfo = std::make_shared<yul::AsmAnalysisInfo>(yul::AsmAnalyzer::analyzeStrictAssertCorrect(object));
 
 		m_context.optimizeYul(object, m_optimiserSettings);
 

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -947,7 +947,7 @@ bool ContractCompiler::visit(InlineAssembly const& _inlineAssembly)
 		object.setCode(std::make_shared<yul::AST>(_inlineAssembly.dialect(), yul::ASTCopier().translate(code->root())));
 		object.analysisInfo = std::make_shared<yul::AsmAnalysisInfo>(yul::AsmAnalyzer::analyzeStrictAssertCorrect(*dialect, object));
 
-		m_context.optimizeYul(object, *dialect, m_optimiserSettings);
+		m_context.optimizeYul(object, m_optimiserSettings);
 
 		code = object.code().get();
 		analysisInfo = object.analysisInfo.get();

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -932,7 +932,7 @@ bool ContractCompiler::visit(InlineAssembly const& _inlineAssembly)
 
 	// Only used in the scope below, but required to live outside to keep the
 	// std::shared_ptr's alive
-	yul::Object object{_inlineAssembly.dialect()};
+	yul::Object object;
 
 	// The optimiser cannot handle external references
 	if (
@@ -944,7 +944,7 @@ bool ContractCompiler::visit(InlineAssembly const& _inlineAssembly)
 		solAssert(dialect, "");
 
 		// Create a modifiable copy of the code and analysis
-		object.setCode(std::make_shared<yul::AST>(yul::ASTCopier().translate(code->root())));
+		object.setCode(std::make_shared<yul::AST>(_inlineAssembly.dialect(), yul::ASTCopier().translate(code->root())));
 		object.analysisInfo = std::make_shared<yul::AsmAnalysisInfo>(yul::AsmAnalyzer::analyzeStrictAssertCorrect(*dialect, object));
 
 		m_context.optimizeYul(object, *dialect, m_optimiserSettings);

--- a/libyul/AST.h
+++ b/libyul/AST.h
@@ -36,6 +36,8 @@
 namespace solidity::yul
 {
 
+struct Dialect;
+
 struct NameWithDebugData { langutil::DebugData::ConstPtr debugData; YulName name; };
 using NameWithDebugDataList = std::vector<NameWithDebugData>;
 
@@ -103,10 +105,12 @@ struct Leave { langutil::DebugData::ConstPtr debugData; };
 class AST
 {
 public:
-	explicit AST(Block _root): m_root(std::move(_root)) {}
+	AST(Dialect const& _dialect, Block _root): m_dialect(_dialect), m_root(std::move(_root)) {}
 
-	[[nodiscard]] Block const& root() const { return m_root; }
+	Dialect const& dialect() const { return m_dialect; }
+	Block const& root() const { return m_root; }
 private:
+	Dialect const& m_dialect;
 	Block m_root;
 };
 

--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -86,9 +86,10 @@ bool AsmAnalyzer::analyze(Block const& _block)
 	return watcher.ok();
 }
 
-AsmAnalysisInfo AsmAnalyzer::analyzeStrictAssertCorrect(Dialect const& _dialect, Object const& _object)
+AsmAnalysisInfo AsmAnalyzer::analyzeStrictAssertCorrect(Object const& _object)
 {
-	return analyzeStrictAssertCorrect(_dialect, _object.code()->root(), _object.summarizeStructure());
+	yulAssert(_object.dialect());
+	return analyzeStrictAssertCorrect(*_object.dialect(), _object.code()->root(), _object.summarizeStructure());
 }
 
 AsmAnalysisInfo AsmAnalyzer::analyzeStrictAssertCorrect(

--- a/libyul/AsmAnalysis.h
+++ b/libyul/AsmAnalysis.h
@@ -81,7 +81,7 @@ public:
 
 	/// Performs analysis on the outermost code of the given object and returns the analysis info.
 	/// Asserts on failure.
-	static AsmAnalysisInfo analyzeStrictAssertCorrect(Dialect const& _dialect, Object const& _object);
+	static AsmAnalysisInfo analyzeStrictAssertCorrect(Object const& _object);
 	static AsmAnalysisInfo analyzeStrictAssertCorrect(
 		Dialect const& _dialect,
 		Block const& _astRoot,

--- a/libyul/AsmJsonImporter.cpp
+++ b/libyul/AsmJsonImporter.cpp
@@ -51,7 +51,7 @@ SourceLocation const AsmJsonImporter::createSourceLocation(Json const& _node)
 
 AST AsmJsonImporter::createAST(solidity::Json const& _node)
 {
-	return AST(createBlock(_node));
+	return {m_dialect, createBlock(_node)};
 }
 
 template <class T>

--- a/libyul/AsmJsonImporter.h
+++ b/libyul/AsmJsonImporter.h
@@ -32,13 +32,16 @@
 namespace solidity::yul
 {
 
+struct Dialect;
+
 /**
  * Component that imports an AST from json format to the internal format
  */
 class AsmJsonImporter
 {
 public:
-	explicit AsmJsonImporter(std::vector<std::shared_ptr<std::string const>> const& _sourceNames):
+	explicit AsmJsonImporter(Dialect const& _dialect, std::vector<std::shared_ptr<std::string const>> const& _sourceNames):
+		m_dialect(_dialect),
 		m_sourceNames(_sourceNames)
 	{}
 
@@ -73,6 +76,7 @@ private:
 	yul::Break createBreak(Json const& _node);
 	yul::Continue createContinue(Json const& _node);
 
+	Dialect const& m_dialect;
 	std::vector<std::shared_ptr<std::string const>> const& m_sourceNames;
 };
 

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -125,7 +125,7 @@ std::unique_ptr<AST> Parser::parseInline(std::shared_ptr<Scanner> const& _scanne
 		m_scanner = _scanner;
 		if (m_useSourceLocationFrom == UseSourceLocationFrom::Comments)
 			fetchDebugDataFromComment();
-		return std::make_unique<AST>(parseBlock());
+		return std::make_unique<AST>(m_dialect, parseBlock());
 	}
 	catch (FatalError const& error)
 	{

--- a/libyul/AsmPrinter.cpp
+++ b/libyul/AsmPrinter.cpp
@@ -42,6 +42,16 @@ using namespace solidity::langutil;
 using namespace solidity::util;
 using namespace solidity::yul;
 
+std::string AsmPrinter::format(
+	AST const& _ast,
+	std::optional<std::map<unsigned, std::shared_ptr<std::string const>>> const& _sourceIndexToName,
+	DebugInfoSelection const& _debugInfoSelection,
+	CharStreamProvider const* _soliditySourceProvider)
+{
+	return AsmPrinter{_ast.dialect(), _sourceIndexToName, _debugInfoSelection, _soliditySourceProvider}(_ast.root());
+}
+
+
 std::string AsmPrinter::operator()(Literal const& _literal)
 {
 	yulAssert(validLiteral(_literal));

--- a/libyul/AsmPrinter.h
+++ b/libyul/AsmPrinter.h
@@ -46,9 +46,16 @@ struct Dialect;
 class AsmPrinter
 {
 public:
+	static std::string format(
+		AST const& _ast,
+		std::optional<std::map<unsigned, std::shared_ptr<std::string const>>> const& _sourceIndexToName = {},
+		langutil::DebugInfoSelection const& _debugInfoSelection = langutil::DebugInfoSelection::Default(),
+		langutil::CharStreamProvider const* _soliditySourceProvider = nullptr
+	);
+
 	explicit AsmPrinter(
 		Dialect const&,
-		std::optional<std::map<unsigned, std::shared_ptr<std::string const>>> _sourceIndexToName = {},
+		std::optional<std::map<unsigned, std::shared_ptr<std::string const>>> const& _sourceIndexToName = {},
 		langutil::DebugInfoSelection const& _debugInfoSelection = langutil::DebugInfoSelection::Default(),
 		langutil::CharStreamProvider const* _soliditySourceProvider = nullptr
 	):

--- a/libyul/CompilabilityChecker.cpp
+++ b/libyul/CompilabilityChecker.cpp
@@ -31,13 +31,12 @@ using namespace solidity::yul;
 using namespace solidity::util;
 
 CompilabilityChecker::CompilabilityChecker(
-	Dialect const& _dialect,
 	Object const& _object,
 	bool _optimizeStackAllocation
 )
 {
 	yulAssert(_object.hasCode());
-	if (auto const* evmDialect = dynamic_cast<EVMDialect const*>(&_dialect))
+	if (auto const* evmDialect = dynamic_cast<EVMDialect const*>(_object.dialect()))
 	{
 		NoOutputEVMDialect noOutputDialect(*evmDialect);
 

--- a/libyul/CompilabilityChecker.h
+++ b/libyul/CompilabilityChecker.h
@@ -45,7 +45,6 @@ namespace solidity::yul
 struct CompilabilityChecker
 {
 	CompilabilityChecker(
-		Dialect const& _dialect,
 		Object const& _object,
 		bool _optimizeStackAllocation
 	);

--- a/libyul/Object.cpp
+++ b/libyul/Object.cpp
@@ -49,10 +49,11 @@ std::string Object::toString(
 ) const
 {
 	yulAssert(hasCode(), "No code");
+	yulAssert(dialect(), "No dialect");
 	yulAssert(debugData, "No debug data");
 
 	std::string inner = "code " + AsmPrinter(
-		m_dialect,
+		*dialect(),
 		debugData->sourceNames,
 		_debugInfoSelection,
 		_soliditySourceProvider
@@ -94,10 +95,11 @@ std::string ObjectDebugData::formatUseSrcComment() const
 Json Object::toJson() const
 {
 	yulAssert(hasCode(), "No code");
+	yulAssert(dialect(), "No dialect");
 
 	Json codeJson;
 	codeJson["nodeType"] = "YulCode";
-	codeJson["block"] = AsmJsonConverter(m_dialect, 0 /* sourceIndex */)(code()->root());
+	codeJson["block"] = AsmJsonConverter(*dialect(), 0 /* sourceIndex */)(code()->root());
 
 	Json subObjectsJson = Json::array();
 	for (std::shared_ptr<ObjectNode> const& subObject: subObjects)
@@ -239,4 +241,11 @@ bool Object::hasContiguousSourceIndices() const
 
 	solAssert(maxSourceIndex + 1 >= indices.size());
 	return indices.size() == 0 || indices.size() == maxSourceIndex + 1;
+}
+
+Dialect const* Object::dialect() const
+{
+	if (!m_code)
+		return nullptr;
+	return &m_code->dialect();
 }

--- a/libyul/Object.cpp
+++ b/libyul/Object.cpp
@@ -52,12 +52,12 @@ std::string Object::toString(
 	yulAssert(dialect(), "No dialect");
 	yulAssert(debugData, "No debug data");
 
-	std::string inner = "code " + AsmPrinter(
-		*dialect(),
+	std::string inner = "code " + AsmPrinter::format(
+		*code(),
 		debugData->sourceNames,
 		_debugInfoSelection,
 		_soliditySourceProvider
-	)(code()->root());
+	);
 
 	for (auto const& obj: subObjects)
 		inner += "\n" + obj->toString(_debugInfoSelection, _soliditySourceProvider);

--- a/libyul/Object.h
+++ b/libyul/Object.h
@@ -21,8 +21,8 @@
 
 #pragma once
 
-#include <libyul/AsmPrinter.h>
 #include <libyul/ASTForward.h>
+#include <libyul/AsmPrinter.h>
 
 #include <liblangutil/CharStreamProvider.h>
 #include <liblangutil/DebugInfoSelection.h>
@@ -91,7 +91,6 @@ struct ObjectDebugData
 class Object: public ObjectNode
 {
 public:
-	explicit Object(Dialect const& _dialect): m_dialect(_dialect) {}
 	/// @returns a (parseable) string representation.
 	std::string toString(
 		langutil::DebugInfoSelection const& _debugInfoSelection = langutil::DebugInfoSelection::Default(),
@@ -162,10 +161,9 @@ public:
 	/// @returns the name of the special metadata data object.
 	static std::string metadataName() { return ".metadata"; }
 
-	Dialect const& dialect() const { return m_dialect; }
+	Dialect const* dialect() const;
 
 private:
-	Dialect const& m_dialect;
 	std::shared_ptr<AST const> m_code;
 };
 

--- a/libyul/ObjectOptimizer.cpp
+++ b/libyul/ObjectOptimizer.cpp
@@ -118,12 +118,12 @@ void ObjectOptimizer::overwriteWithOptimizedObject(util::h256 _cacheKey, Object&
 	CachedObject const& cachedObject = m_cachedObjects.at(_cacheKey);
 
 	yulAssert(cachedObject.optimizedAST);
-	_object.setCode(std::make_shared<AST>(ASTCopier{}.translate(*cachedObject.optimizedAST)));
+	yulAssert(cachedObject.dialect);
+	_object.setCode(std::make_shared<AST>(*cachedObject.dialect, ASTCopier{}.translate(*cachedObject.optimizedAST)));
 	yulAssert(_object.code());
 
 	// There's no point in caching AnalysisInfo because it references AST nodes. It can't be shared
 	// by multiple ASTs and it's easier to recalculate it than properly clone it.
-	yulAssert(cachedObject.dialect);
 	_object.analysisInfo = std::make_shared<AsmAnalysisInfo>(
 		AsmAnalyzer::analyzeStrictAssertCorrect(
 			*cachedObject.dialect,

--- a/libyul/ObjectOptimizer.cpp
+++ b/libyul/ObjectOptimizer.cpp
@@ -90,7 +90,6 @@ void ObjectOptimizer::optimize(Object& _object, Settings const& _settings, bool 
 	}
 
 	OptimiserSuite::run(
-		dialect,
 		meter.get(),
 		_object,
 		_settings.optimizeStackAllocation,

--- a/libyul/ObjectOptimizer.cpp
+++ b/libyul/ObjectOptimizer.cpp
@@ -121,12 +121,12 @@ void ObjectOptimizer::overwriteWithOptimizedObject(util::h256 _cacheKey, Object&
 	yulAssert(cachedObject.dialect);
 	_object.setCode(std::make_shared<AST>(*cachedObject.dialect, ASTCopier{}.translate(*cachedObject.optimizedAST)));
 	yulAssert(_object.code());
+	yulAssert(_object.dialect());
 
 	// There's no point in caching AnalysisInfo because it references AST nodes. It can't be shared
 	// by multiple ASTs and it's easier to recalculate it than properly clone it.
 	_object.analysisInfo = std::make_shared<AsmAnalysisInfo>(
 		AsmAnalyzer::analyzeStrictAssertCorrect(
-			*cachedObject.dialect,
 			_object
 		)
 	);

--- a/libyul/ObjectParser.cpp
+++ b/libyul/ObjectParser.cpp
@@ -49,7 +49,7 @@ std::shared_ptr<Object> ObjectParser::parse(std::shared_ptr<Scanner> const& _sca
 		if (currentToken() == Token::LBrace)
 		{
 			// Special case: Code-only form.
-			object = std::make_shared<Object>(m_dialect);
+			object = std::make_shared<Object>();
 			object->name = "object";
 			auto sourceNameMapping = tryParseSourceNameMapping();
 			object->debugData = std::make_shared<ObjectDebugData>(ObjectDebugData{sourceNameMapping});
@@ -74,7 +74,7 @@ std::shared_ptr<Object> ObjectParser::parseObject(Object* _containingObject)
 {
 	RecursionGuard guard(*this);
 
-	std::shared_ptr<Object> ret = std::make_shared<Object>(m_dialect);
+	std::shared_ptr<Object> ret = std::make_shared<Object>();
 
 	auto sourceNameMapping = tryParseSourceNameMapping();
 	ret->debugData = std::make_shared<ObjectDebugData>(ObjectDebugData{sourceNameMapping});

--- a/libyul/YulStack.cpp
+++ b/libyul/YulStack.cpp
@@ -94,7 +94,7 @@ void YulStack::optimize()
 	{
 		if (
 			!m_optimiserSettings.runYulOptimiser &&
-			yul::MSizeFinder::containsMSize(languageToDialect(m_language, m_evmVersion, m_eofVersion), *m_parserResult)
+			yul::MSizeFinder::containsMSize(*m_parserResult)
 		)
 			return;
 
@@ -317,7 +317,7 @@ YulStack::assembleEVMWithDeployed(std::optional<std::string_view> _deployName)
 	// it with the minimal steps required to avoid "stack too deep".
 	bool optimize = m_optimiserSettings.optimizeStackAllocation || (
 		!m_optimiserSettings.runYulOptimiser &&
-		!yul::MSizeFinder::containsMSize(languageToDialect(m_language, m_evmVersion, m_eofVersion), *m_parserResult)
+		!yul::MSizeFinder::containsMSize(*m_parserResult)
 	);
 	try
 	{

--- a/libyul/optimiser/Semantics.cpp
+++ b/libyul/optimiser/Semantics.cpp
@@ -93,14 +93,15 @@ bool MSizeFinder::containsMSize(Dialect const& _dialect, Block const& _ast)
 	return finder.m_msizeFound;
 }
 
-bool MSizeFinder::containsMSize(Dialect const& _dialect, Object const& _object)
+bool MSizeFinder::containsMSize(Object const& _object)
 {
-	if (containsMSize(_dialect, _object.code()->root()))
+	yulAssert(_object.dialect());
+	if (containsMSize(*_object.dialect(), _object.code()->root()))
 		return true;
 
 	for (std::shared_ptr<ObjectNode> const& node: _object.subObjects)
 		if (auto const* object = dynamic_cast<Object const*>(node.get()))
-			if (containsMSize(_dialect, *object))
+			if (containsMSize(*object))
 				return true;
 
 	return false;

--- a/libyul/optimiser/Semantics.h
+++ b/libyul/optimiser/Semantics.h
@@ -149,7 +149,7 @@ class MSizeFinder: public ASTWalker
 {
 public:
 	static bool containsMSize(Dialect const& _dialect, Block const& _ast);
-	static bool containsMSize(Dialect const& _dialect, Object const& _object);
+	static bool containsMSize(Object const& _object);
 
 	using ASTWalker::operator();
 	void operator()(FunctionCall const& _funCall) override;

--- a/libyul/optimiser/StackCompressor.cpp
+++ b/libyul/optimiser/StackCompressor.cpp
@@ -243,6 +243,7 @@ std::tuple<bool, Block> StackCompressor::run(
 	size_t _maxIterations)
 {
 	yulAssert(_object.hasCode());
+	yulAssert(_object.dialect(), "No dialect");
 	yulAssert(
 		!_object.code()->root().statements.empty() && std::holds_alternative<Block>(_object.code()->root().statements.at(0)),
 		"Need to run the function grouper before the stack compressor."
@@ -279,7 +280,7 @@ std::tuple<bool, Block> StackCompressor::run(
 		for (size_t iterations = 0; iterations < _maxIterations; iterations++)
 		{
 			Object object(_object);
-			object.setCode(std::make_shared<AST>(std::get<Block>(ASTCopier{}(astRoot))));
+			object.setCode(std::make_shared<AST>(*_object.dialect(), std::get<Block>(ASTCopier{}(astRoot))));
 			std::map<YulName, int> stackSurplus = CompilabilityChecker(_dialect, object, _optimizeStackAllocation).stackDeficit;
 			if (stackSurplus.empty())
 				return std::make_tuple(true, std::move(astRoot));

--- a/libyul/optimiser/StackCompressor.cpp
+++ b/libyul/optimiser/StackCompressor.cpp
@@ -280,7 +280,7 @@ std::tuple<bool, Block> StackCompressor::run(
 		{
 			Object object(_object);
 			object.setCode(std::make_shared<AST>(*_object.dialect(), std::get<Block>(ASTCopier{}(astRoot))));
-			std::map<YulName, int> stackSurplus = CompilabilityChecker(*object.dialect(), object, _optimizeStackAllocation).stackDeficit;
+			std::map<YulName, int> stackSurplus = CompilabilityChecker(object, _optimizeStackAllocation).stackDeficit;
 			if (stackSurplus.empty())
 				return std::make_tuple(true, std::move(astRoot));
 			eliminateVariables(

--- a/libyul/optimiser/StackCompressor.cpp
+++ b/libyul/optimiser/StackCompressor.cpp
@@ -237,7 +237,6 @@ void eliminateVariablesOptimizedCodegen(
 }
 
 std::tuple<bool, Block> StackCompressor::run(
-	Dialect const& _dialect,
 	Object const& _object,
 	bool _optimizeStackAllocation,
 	size_t _maxIterations)
@@ -250,7 +249,7 @@ std::tuple<bool, Block> StackCompressor::run(
 	);
 	bool usesOptimizedCodeGenerator = false;
 	bool simulateFunctionsWithJumps = true;
-	if (auto evmDialect = dynamic_cast<EVMDialect const*>(&_dialect))
+	if (auto evmDialect = dynamic_cast<EVMDialect const*>(_object.dialect()))
 	{
 		usesOptimizedCodeGenerator =
 			_optimizeStackAllocation &&
@@ -258,18 +257,18 @@ std::tuple<bool, Block> StackCompressor::run(
 			evmDialect->providesObjectAccess();
 		simulateFunctionsWithJumps = !evmDialect->eofVersion().has_value();
 	}
-	bool allowMSizeOptimization = !MSizeFinder::containsMSize(_dialect, _object.code()->root());
+	bool allowMSizeOptimization = !MSizeFinder::containsMSize(*_object.dialect(), _object.code()->root());
 	Block astRoot = std::get<Block>(ASTCopier{}(_object.code()->root()));
 	if (usesOptimizedCodeGenerator)
 	{
 		yul::AsmAnalysisInfo analysisInfo = yul::AsmAnalyzer::analyzeStrictAssertCorrect(
-			_dialect,
+			*_object.dialect(),
 			astRoot,
 			_object.summarizeStructure()
 		);
-		std::unique_ptr<CFG> cfg = ControlFlowGraphBuilder::build(analysisInfo, _dialect, astRoot);
+		std::unique_ptr<CFG> cfg = ControlFlowGraphBuilder::build(analysisInfo, *_object.dialect(), astRoot);
 		eliminateVariablesOptimizedCodegen(
-			_dialect,
+			*_object.dialect(),
 			astRoot,
 			StackLayoutGenerator::reportStackTooDeep(*cfg, simulateFunctionsWithJumps),
 			allowMSizeOptimization
@@ -281,11 +280,11 @@ std::tuple<bool, Block> StackCompressor::run(
 		{
 			Object object(_object);
 			object.setCode(std::make_shared<AST>(*_object.dialect(), std::get<Block>(ASTCopier{}(astRoot))));
-			std::map<YulName, int> stackSurplus = CompilabilityChecker(_dialect, object, _optimizeStackAllocation).stackDeficit;
+			std::map<YulName, int> stackSurplus = CompilabilityChecker(*object.dialect(), object, _optimizeStackAllocation).stackDeficit;
 			if (stackSurplus.empty())
 				return std::make_tuple(true, std::move(astRoot));
 			eliminateVariables(
-				_dialect,
+				*object.dialect(),
 				astRoot,
 				stackSurplus,
 				allowMSizeOptimization

--- a/libyul/optimiser/StackCompressor.h
+++ b/libyul/optimiser/StackCompressor.h
@@ -47,7 +47,6 @@ public:
 	/// Try to remove local variables until the AST is compilable.
 	/// @returns tuple with true if it was successful as first element, second element is the modified AST.
 	static std::tuple<bool, Block> run(
-		Dialect const& _dialect,
 		Object const& _object,
 		bool _optimizeStackAllocation,
 		size_t _maxIterations

--- a/libyul/optimiser/StackLimitEvader.cpp
+++ b/libyul/optimiser/StackLimitEvader.cpp
@@ -143,7 +143,6 @@ Block StackLimitEvader::run(
 	else
 	{
 		run(_context, astRoot, CompilabilityChecker{
-			_context.dialect,
 			_object,
 			true,
 		}.unreachableVariables);

--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -140,7 +140,6 @@ void OptimiserSuite::run(
 		PROFILER_PROBE("StackCompressor", probe);
 		_object.setCode(std::make_shared<AST>(_dialect, std::move(astRoot)));
 		astRoot = std::get<1>(StackCompressor::run(
-			_dialect,
 			_object,
 			_optimizeStackAllocation,
 			stackCompressorMaxIterations
@@ -167,7 +166,6 @@ void OptimiserSuite::run(
 				PROFILER_PROBE("StackCompressor", probe);
 				_object.setCode(std::make_shared<AST>(_dialect, std::move(astRoot)));
 				astRoot = std::get<1>(StackCompressor::run(
-					_dialect,
 					_object,
 					_optimizeStackAllocation,
 					stackCompressorMaxIterations

--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -138,7 +138,7 @@ void OptimiserSuite::run(
 	if (!usesOptimizedCodeGenerator)
 	{
 		PROFILER_PROBE("StackCompressor", probe);
-		_object.setCode(std::make_shared<AST>(std::move(astRoot)));
+		_object.setCode(std::make_shared<AST>(_dialect, std::move(astRoot)));
 		astRoot = std::get<1>(StackCompressor::run(
 			_dialect,
 			_object,
@@ -165,7 +165,7 @@ void OptimiserSuite::run(
 		{
 			{
 				PROFILER_PROBE("StackCompressor", probe);
-				_object.setCode(std::make_shared<AST>(std::move(astRoot)));
+				_object.setCode(std::make_shared<AST>(_dialect, std::move(astRoot)));
 				astRoot = std::get<1>(StackCompressor::run(
 					_dialect,
 					_object,
@@ -176,14 +176,14 @@ void OptimiserSuite::run(
 			if (evmDialect->providesObjectAccess())
 			{
 				PROFILER_PROBE("StackLimitEvader", probe);
-				_object.setCode(std::make_shared<AST>(std::move(astRoot)));
+				_object.setCode(std::make_shared<AST>(_dialect, std::move(astRoot)));
 				astRoot = StackLimitEvader::run(suite.m_context, _object);
 			}
 		}
 		else if (evmDialect->providesObjectAccess() && _optimizeStackAllocation)
 		{
 			PROFILER_PROBE("StackLimitEvader", probe);
-			_object.setCode(std::make_shared<AST>(std::move(astRoot)));
+			_object.setCode(std::make_shared<AST>(_dialect, std::move(astRoot)));
 			astRoot = StackLimitEvader::run(suite.m_context, _object);
 		}
 	}
@@ -198,7 +198,7 @@ void OptimiserSuite::run(
 		VarNameCleaner::run(suite.m_context, astRoot);
 	}
 
-	_object.setCode(std::make_shared<AST>(std::move(astRoot)));
+	_object.setCode(std::make_shared<AST>(_dialect, std::move(astRoot)));
 	_object.analysisInfo = std::make_shared<AsmAnalysisInfo>(AsmAnalyzer::analyzeStrictAssertCorrect(_dialect, _object));
 }
 

--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -199,7 +199,7 @@ void OptimiserSuite::run(
 	}
 
 	_object.setCode(std::make_shared<AST>(_dialect, std::move(astRoot)));
-	_object.analysisInfo = std::make_shared<AsmAnalysisInfo>(AsmAnalyzer::analyzeStrictAssertCorrect(_dialect, _object));
+	_object.analysisInfo = std::make_shared<AsmAnalysisInfo>(AsmAnalyzer::analyzeStrictAssertCorrect(_object));
 }
 
 namespace

--- a/libyul/optimiser/Suite.h
+++ b/libyul/optimiser/Suite.h
@@ -63,7 +63,6 @@ public:
 
 	/// The value nullopt for `_expectedExecutionsPerDeployment` represents creation code.
 	static void run(
-		Dialect const& _dialect,
 		GasMeter const* _meter,
 		Object& _object,
 		bool _optimizeStackAllocation,

--- a/test/libyul/Common.cpp
+++ b/test/libyul/Common.cpp
@@ -99,12 +99,7 @@ yul::Block yul::test::disambiguate(std::string const& _source)
 
 std::string yul::test::format(std::string const& _source)
 {
-	Dialect const& dialect = languageToDialect(
-		YulStack::Language::StrictAssembly,
-		solidity::test::CommonOptions::get().evmVersion(),
-		solidity::test::CommonOptions::get().eofVersion()
-	);
-	return AsmPrinter(dialect)(parse(_source).first->root());
+	return AsmPrinter::format(*parse(_source).first);
 }
 
 namespace

--- a/test/libyul/CompilabilityChecker.cpp
+++ b/test/libyul/CompilabilityChecker.cpp
@@ -38,10 +38,11 @@ std::string check(std::string const& _input)
 		solidity::test::CommonOptions::get().evmVersion(),
 		solidity::test::CommonOptions::get().eofVersion()
 	);
-	Object obj{dialect};
+	Object obj;
 	auto parsingResult = yul::test::parse(_input);
 	obj.setCode(parsingResult.first, parsingResult.second);
 	BOOST_REQUIRE(obj.hasCode());
+	BOOST_REQUIRE(obj.dialect());
 	auto functions = CompilabilityChecker(dialect, obj, true).stackDeficit;
 	std::string out;
 	for (auto const& function: functions)

--- a/test/libyul/CompilabilityChecker.cpp
+++ b/test/libyul/CompilabilityChecker.cpp
@@ -34,16 +34,12 @@ namespace
 {
 std::string check(std::string const& _input)
 {
-	auto const& dialect = EVMDialect::strictAssemblyForEVM(
-		solidity::test::CommonOptions::get().evmVersion(),
-		solidity::test::CommonOptions::get().eofVersion()
-	);
 	Object obj;
 	auto parsingResult = yul::test::parse(_input);
 	obj.setCode(parsingResult.first, parsingResult.second);
 	BOOST_REQUIRE(obj.hasCode());
 	BOOST_REQUIRE(obj.dialect());
-	auto functions = CompilabilityChecker(dialect, obj, true).stackDeficit;
+	auto functions = CompilabilityChecker(obj, true).stackDeficit;
 	std::string out;
 	for (auto const& function: functions)
 		out += function.first.str() + ": " + std::to_string(function.second) + " ";

--- a/test/libyul/ControlFlowSideEffectsTest.cpp
+++ b/test/libyul/ControlFlowSideEffectsTest.cpp
@@ -60,7 +60,7 @@ TestCase::TestResult ControlFlowSideEffectsTest::run(std::ostream& _stream, std:
 		solidity::test::CommonOptions::get().evmVersion(),
 		solidity::test::CommonOptions::get().eofVersion()
 	);
-	Object obj{dialect};
+	Object obj;
 	auto parsingResult = yul::test::parse(m_source);
 	obj.setCode(parsingResult.first, parsingResult.second);
 	if (!obj.hasCode())

--- a/test/libyul/FunctionSideEffects.cpp
+++ b/test/libyul/FunctionSideEffects.cpp
@@ -86,7 +86,7 @@ TestCase::TestResult FunctionSideEffects::run(std::ostream& _stream, std::string
 		solidity::test::CommonOptions::get().evmVersion(),
 		solidity::test::CommonOptions::get().eofVersion()
 	);
-	Object obj{dialect};
+	Object obj;
 	auto parsingResult = yul::test::parse(m_source);
 	obj.setCode(parsingResult.first, parsingResult.second);
 	if (!obj.hasCode())

--- a/test/libyul/KnowledgeBaseTest.cpp
+++ b/test/libyul/KnowledgeBaseTest.cpp
@@ -59,7 +59,7 @@ protected:
 		for (auto const& [name, expression]: m_ssaValues.values())
 			m_values[name].value = expression;
 
-		m_object->setCode(std::make_shared<AST>(std::move(astRoot)));
+		m_object->setCode(std::make_shared<AST>(m_dialect, std::move(astRoot)));
 		return KnowledgeBase([this](YulName _var) { return util::valueOrNullptr(m_values, _var); });
 	}
 

--- a/test/libyul/SSAControlFlowGraphTest.cpp
+++ b/test/libyul/SSAControlFlowGraphTest.cpp
@@ -66,7 +66,7 @@ TestCase::TestResult SSAControlFlowGraphTest::run(std::ostream& _stream, std::st
 		return TestResult::FatalError;
 	}
 
-	auto info = AsmAnalyzer::analyzeStrictAssertCorrect(*m_dialect, *object);
+	auto info = AsmAnalyzer::analyzeStrictAssertCorrect(*object);
 	std::unique_ptr<ControlFlow> controlFlow = SSAControlFlowGraphBuilder::build(
 		info,
 		*m_dialect,

--- a/test/libyul/YulOptimizerTest.cpp
+++ b/test/libyul/YulOptimizerTest.cpp
@@ -84,8 +84,9 @@ TestCase::TestResult YulOptimizerTest::run(std::ostream& _stream, std::string co
 	}
 	auto optimizedObject = tester.optimizedObject();
 	std::string printedOptimizedObject;
+	soltestAssert(optimizedObject->dialect());
 	if (optimizedObject->subObjects.empty())
-		printedOptimizedObject = AsmPrinter{optimizedObject->dialect()}(optimizedObject->code()->root());
+		printedOptimizedObject = AsmPrinter{*optimizedObject->dialect()}(optimizedObject->code()->root());
 	else
 		printedOptimizedObject = optimizedObject->toString();
 

--- a/test/libyul/YulOptimizerTest.cpp
+++ b/test/libyul/YulOptimizerTest.cpp
@@ -86,7 +86,7 @@ TestCase::TestResult YulOptimizerTest::run(std::ostream& _stream, std::string co
 	std::string printedOptimizedObject;
 	soltestAssert(optimizedObject->dialect());
 	if (optimizedObject->subObjects.empty())
-		printedOptimizedObject = AsmPrinter{*optimizedObject->dialect()}(optimizedObject->code()->root());
+		printedOptimizedObject = AsmPrinter::format(*optimizedObject->code());
 	else
 		printedOptimizedObject = optimizedObject->toString();
 

--- a/test/libyul/YulOptimizerTestCommon.cpp
+++ b/test/libyul/YulOptimizerTestCommon.cpp
@@ -410,7 +410,7 @@ YulOptimizerTestCommon::YulOptimizerTestCommon(
 			size_t maxIterations = 16;
 			{
 				Object object(*m_optimizedObject);
-				object.setCode(std::make_shared<AST>(std::get<Block>(ASTCopier{}(block))));
+				object.setCode(std::make_shared<AST>(*m_dialect, std::get<Block>(ASTCopier{}(block))));
 				block = std::get<1>(StackCompressor::run(*m_dialect, object, true, maxIterations));
 			}
 			BlockFlattener::run(*m_context, block);
@@ -433,7 +433,7 @@ YulOptimizerTestCommon::YulOptimizerTestCommon(
 			auto block = disambiguate();
 			updateContext(block);
 			Object object(*m_optimizedObject);
-			object.setCode(std::make_shared<AST>(std::get<Block>(ASTCopier{}(block))));
+			object.setCode(std::make_shared<AST>(*m_dialect, std::get<Block>(ASTCopier{}(block))));
 			auto const unreachables = CompilabilityChecker{
 				*m_dialect,
 				object,
@@ -500,7 +500,7 @@ bool YulOptimizerTestCommon::runStep()
 	if (m_namedSteps.count(m_optimizerStep))
 	{
 		auto block = m_namedSteps[m_optimizerStep]();
-		m_optimizedObject->setCode(std::make_shared<AST>(std::move(block)));
+		m_optimizedObject->setCode(std::make_shared<AST>(*m_dialect, std::move(block)));
 	}
 	else
 		return false;

--- a/test/libyul/YulOptimizerTestCommon.cpp
+++ b/test/libyul/YulOptimizerTestCommon.cpp
@@ -411,7 +411,7 @@ YulOptimizerTestCommon::YulOptimizerTestCommon(
 			{
 				Object object(*m_optimizedObject);
 				object.setCode(std::make_shared<AST>(*m_dialect, std::get<Block>(ASTCopier{}(block))));
-				block = std::get<1>(StackCompressor::run(*m_dialect, object, true, maxIterations));
+				block = std::get<1>(StackCompressor::run(object, true, maxIterations));
 			}
 			BlockFlattener::run(*m_context, block);
 			return block;

--- a/test/libyul/YulOptimizerTestCommon.cpp
+++ b/test/libyul/YulOptimizerTestCommon.cpp
@@ -434,7 +434,6 @@ YulOptimizerTestCommon::YulOptimizerTestCommon(
 			Object object(*m_optimizedObject);
 			object.setCode(std::make_shared<AST>(*m_dialect, std::get<Block>(ASTCopier{}(block))));
 			auto const unreachables = CompilabilityChecker{
-				*m_dialect,
 				object,
 				true
 			}.unreachableVariables;

--- a/test/libyul/YulOptimizerTestCommon.cpp
+++ b/test/libyul/YulOptimizerTestCommon.cpp
@@ -419,7 +419,6 @@ YulOptimizerTestCommon::YulOptimizerTestCommon(
 		{"fullSuite", [&]() {
 			GasMeter meter(dynamic_cast<EVMDialect const&>(*m_dialect), false, 200);
 			OptimiserSuite::run(
-				*m_dialect,
 				&meter,
 				*m_optimizedObject,
 				true,

--- a/test/tools/ossfuzz/StackReuseCodegenFuzzer.cpp
+++ b/test/tools/ossfuzz/StackReuseCodegenFuzzer.cpp
@@ -56,7 +56,6 @@ bool recursiveFunctionExists(Dialect const& _dialect, yul::Object& _object)
 {
 	auto recursiveFunctions = CallGraphGenerator::callGraph(_object.code()->root()).recursiveFunctions();
 	for(auto&& [function, variables]: CompilabilityChecker{
-			_dialect,
 			_object,
 			true
 		}.unreachableVariables

--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -219,7 +219,7 @@ public:
 					{
 						Object obj;
 						obj.setCode(std::make_shared<AST>(m_dialect, std::get<yul::Block>(ASTCopier{}(*m_astRoot))));
-						*m_astRoot = std::get<1>(StackCompressor::run(m_dialect, obj, true, 16));
+						*m_astRoot = std::get<1>(StackCompressor::run(obj, true, 16));
 						break;
 					}
 					default:

--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -217,8 +217,8 @@ public:
 						break;
 					case ';':
 					{
-						Object obj{m_dialect};
-						obj.setCode(std::make_shared<AST>(std::get<yul::Block>(ASTCopier{}(*m_astRoot))));
+						Object obj;
+						obj.setCode(std::make_shared<AST>(m_dialect, std::get<yul::Block>(ASTCopier{}(*m_astRoot))));
 						*m_astRoot = std::get<1>(StackCompressor::run(m_dialect, obj, true, 16));
 						break;
 					}

--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -106,7 +106,7 @@ void Program::optimise(std::vector<std::string> const& _optimisationSteps)
 
 std::ostream& phaser::operator<<(std::ostream& _stream, Program const& _program)
 {
-	return _stream << AsmPrinter(_program.m_dialect)(_program.m_ast->root());
+	return _stream << AsmPrinter::format(*_program.m_ast);
 }
 
 std::string Program::toJson() const

--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -59,7 +59,7 @@ std::ostream& operator<<(std::ostream& _stream, Program const& _program);
 }
 
 Program::Program(Program const& program):
-	m_ast(std::make_unique<AST>(std::get<Block>(ASTCopier{}(program.m_ast->root())))),
+	m_ast(std::make_unique<AST>(program.m_dialect, std::get<Block>(ASTCopier{}(program.m_ast->root())))),
 	m_dialect{program.m_dialect},
 	m_nameDispenser(program.m_nameDispenser)
 {
@@ -150,7 +150,7 @@ std::variant<std::unique_ptr<AST>, ErrorList> Program::parseObject(Dialect const
 	// The public API of the class does not provide access to the smart pointer so it won't be hard
 	// to switch to shared_ptr if the copying turns out to be an issue (though it would be better
 	// to refactor ObjectParser and Object to use unique_ptr instead).
-	auto astCopy = std::make_unique<AST>(std::get<Block>(ASTCopier{}(selectedObject->code()->root())));
+	auto astCopy = std::make_unique<AST>(_dialect, std::get<Block>(ASTCopier{}(selectedObject->code()->root())));
 
 	return std::variant<std::unique_ptr<AST>, ErrorList>(std::move(astCopy));
 }
@@ -179,7 +179,7 @@ std::unique_ptr<AST> Program::disambiguateAST(
 	std::set<YulName> const externallyUsedIdentifiers = {};
 	Disambiguator disambiguator(_dialect, _analysisInfo, externallyUsedIdentifiers);
 
-	return std::make_unique<AST>(std::get<Block>(disambiguator(_ast.root())));
+	return std::make_unique<AST>(_dialect, std::get<Block>(disambiguator(_ast.root())));
 }
 
 std::unique_ptr<AST> Program::applyOptimisationSteps(
@@ -203,7 +203,7 @@ std::unique_ptr<AST> Program::applyOptimisationSteps(
 	for (std::string const& step: _optimisationSteps)
 		OptimiserSuite::allSteps().at(step)->run(context, astRoot);
 
-	return std::make_unique<AST>(std::move(astRoot));
+	return std::make_unique<AST>(_dialect, std::move(astRoot));
 }
 
 size_t Program::computeCodeSize(Block const& _ast, CodeWeights const& _weights)


### PR DESCRIPTION
Follow up of #15534.

I streamlined some interfaces which would take an object as well as the dialect to just take the object and instead pull the dialect out of it. I think a lot more could be done potentially by reworking most optimizer steps to optionally run on an instance of `yul::AST` instead of the root block - that way dialect <-> ast consistency would be harder to break.