### PR TITLE
Add an explicit check against out-of-range proposal ID to the voting example

### DIFF
--- a/docs/examples/voting.rst
+++ b/docs/examples/voting.rst
@@ -156,6 +156,10 @@ of votes.
             Voter storage sender = voters[msg.sender];
             require(sender.weight != 0, "Has no right to vote");
             require(!sender.voted, "Already voted.");
+            require(
+                0 <= proposal && proposal < proposals.length,
+                "Not a valid proposal id"
+            );
             sender.voted = true;
             sender.vote = proposal;
 


### PR DESCRIPTION
Added an additional require call to the vote function to check if the proposal number is valid. That problem with the function doesn't seem intentional because it isn't present in the "Possible Improvements" section.