### PR TITLE
Yul: Avoid expensive operations in functions called very often

### DIFF
--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -147,12 +147,17 @@ void Parser::fetchDebugDataFromComment()
 {
 	solAssert(m_sourceNames.has_value(), "");
 
+	std::string_view commentLiteral = m_scanner->currentCommentLiteral();
+	if (commentLiteral.empty())
+	{
+		m_astIDFromComment = std::nullopt;
+		return;
+	}
 	static std::regex const tagRegex = std::regex(
 		R"~~((?:^|\s+)(@[a-zA-Z0-9\-_]+)(?:\s+|$))~~", // tag, e.g: @src
 		std::regex_constants::ECMAScript | std::regex_constants::optimize
 	);
 
-	std::string_view commentLiteral = m_scanner->currentCommentLiteral();
 	std::match_results<std::string_view::const_iterator> match;
 
 	langutil::SourceLocation originLocation = m_locationFromComment;

--- a/libyul/optimiser/SyntacticalEquality.cpp
+++ b/libyul/optimiser/SyntacticalEquality.cpp
@@ -64,9 +64,8 @@ bool SyntacticallyEqual::expressionEqual(Identifier const& _lhs, Identifier cons
 }
 bool SyntacticallyEqual::expressionEqual(Literal const& _lhs, Literal const& _rhs)
 {
-	yulAssert(validLiteral(_lhs), "Invalid lhs literal during syntactical equality check");
-	yulAssert(validLiteral(_rhs), "Invalid rhs literal during syntactical equality check");
-
+	assert(validLiteral(_lhs));
+	assert(validLiteral(_rhs));
 	return _lhs.value == _rhs.value;
 }
 


### PR DESCRIPTION
Two changes are proposed here:

1. Do not include expensive assertion check in the equality operator.
2. Avoid expansive regex match (`std::regex`) whenever possible.

Add 1: The equality comparison is called very often in `CommonSubexpressionEliminator`, presumably because it is the comparison operator used for the map `CommonSubexpressionEliminator::m_replacementCandidates`. The method `validLiteral` is nontrivial and should not be called (twice!) on every call to the equality comparison.
It might be desirable to re-introduce the check in a more suitable place.

Add 2: Method `Parser::fetchDebugDataFromComment` was matching against a regex, but most of the time it was trying to match against an empty string. `std::regex` is known to be extremely slow. This would not be such a problem if this method was not called after every parsed token, see `Parser::advance`.
I believe even better solution would be to move the call to `fetchDebugDataFromComment` to a more appropriate place; my intuition says it is currently misplaced.
