### PR TITLE
Add Wake to resources docs

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -19,6 +19,9 @@ General Resources
 Integrated (Ethereum) Development Environments
 ==============================================
 
+    * `Wake <https://getwake.io/>`_
+        Python-based development and testing framework with built-in vulnerability detectors.
+
     * `Brownie <https://eth-brownie.readthedocs.io/en/stable/>`_
         Python-based development and testing framework for smart contracts targeting the Ethereum Virtual Machine.
 
@@ -70,6 +73,9 @@ Editor Integrations
 
     * `Ethereum Remix Visual Studio Code extension <https://github.com/ethereum/remix-vscode>`_
         Ethereum Remix extension pack for VS Code
+
+    * `Solidity Visual Studio Code extension, by Ackee Blockchain <https://marketplace.visualstudio.com/items?itemName=AckeeBlockchain.tools-for-solidity>`_
+        This extension adds language and navigation support, as well as vulnerability detectors, and provides a Remix-like experience for testing contracts on your local network.
 
     * `Solidity Visual Studio Code extension, by Juan Blanco <https://juan.blanco.ws/solidity-contracts-in-visual-studio-code/>`_
         Solidity plugin for Microsoft Visual Studio Code that includes syntax highlighting and the Solidity compiler.


### PR DESCRIPTION
Hi guys, based on the discussion at the Solidity booth at Devcon, I suggest adding Wake to the resources documentation.

Also I would suggest remove/replace some items, it can be done either in this PR or another one.

- Brownie is no longer maintained and could be replaced by Ape (https://github.com/ApeWorX/ape)
- Truffle can also be removed :'(
- The remix vscode extension is also deprecated


Let me know if I should also put commit for these ones
