### PR TITLE
Fix minor text errors in READMEs and checklists

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -2,7 +2,7 @@
 
 ### Docker images
 
-The docker images are build locally on the developer machine:
+The docker images are built locally on the developer machine:
 
 ```sh
 cd .circleci/docker/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 You can talk to us on Gitter and Matrix, tweet at us on X (previously Twitter) or create a new topic in the Solidity forum. Questions, feedback, and suggestions are welcome!
 
-Solidity is a statically typed, contract-oriented, high-level language for implementing smart contracts on the Ethereum platform.
+Solidity is a statically-typed, contract-oriented, high-level language for implementing smart contracts on the Ethereum platform.
 
 For a good overview and starting point, please check out the official [Solidity Language Portal](https://soliditylang.org).
 

--- a/ReviewChecklist.md
+++ b/ReviewChecklist.md
@@ -123,7 +123,7 @@ The following points are all covered by the coding style but come up so often th
 - If it is a bugfix:
     - [ ] **The PR must include tests that reproduce the bug.**
     - [ ] **Are there gaps in test coverage of the buggy feature?** Fill them by adding more tests.
-    - [ ] **Try to break it.** Can you of any similar features that could also be buggy?
+    - [ ] **Try to break it.** Can you think of any similar features that could also be buggy?
         Play with the repro and include prominent variants as separate test cases, even if they don't trigger a bug.
 - [ ] **Positive cases (code that compiles) should have a semantic test.**
 - [ ] **Negative cases (code with compilation errors) should have a syntax test.**


### PR DESCRIPTION
1. In .circleci/README.md:
  build → built
Reason: Correct past participle form
2. In README.md:
  statically typed → statically-typed
Reason: Added hyphen for compound adjective
3. In ReviewChecklist.md:
  Can you of → Can you think of
Reason: Missing word in phrase