### PR TITLE
Fix: Styling and Documentation Errors

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -229,7 +229,7 @@ small * {
 .wy-side-nav-search {
     background-color: transparent !important;
     color: var(--color-a) !important;
-    box-shadow: 0 4 4 0 var(--color-a);
+    box-shadow: 0 4px 4px 0 var(--color-a);
     border-bottom: 1px solid var(--color-d) !important;
 }
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -134,7 +134,7 @@ extension ``.so`` on Linux, ``.dll`` on Windows systems and ``.dylib`` on macOS.
 
 For running SMT tests, the ``z3`` executable must be present in ``PATH``.
 A few SMT tests use ``Eldarica`` instead of ``z3``.
-These requry its executable (``eld``) to be present in ``PATH`` for the tests to pass.
+These require its executable (``eld``) to be present in ``PATH`` for the tests to pass.
 However, if ``Eldarica`` is not found, these tests will be automatically skipped.
 
 If ``z3`` is not present on your system, you should disable the


### PR DESCRIPTION
## Description  
This pull request addresses two issues:  

1. **Styling Fix in `custom.css`**  
   - Corrected the `box-shadow` property for the `.wy-side-nav-search` class to ensure proper CSS syntax by adding the missing `px` units.  [developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow)

2. **Documentation Typo Fix in `contributing.rst`**  
   - Corrected a typo: changed "requry" to "require" for improved clarity and correctness.
