### PR TITLE
Update python in CI to get latest codespell

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -855,11 +855,7 @@ jobs:
             pip install --user codespell
       - run:
           name: Check spelling
-          command: |
-            ~/.local/bin/codespell \
-              --skip "*.enc,.git,Dockerfile*,LICENSE,codespell_whitelist.txt,codespell_ignored_lines.txt,deps" \
-              --ignore-words scripts/codespell_whitelist.txt \
-              --exclude-file scripts/codespell_ignored_lines.txt
+          command: ~/.local/bin/codespell
       - matrix_notify_failure_unless_pr
 
   chk_docs_examples:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -503,15 +503,6 @@ defaults:
         MAKEFLAGS: -j5
         CPUs: 5
 
-  - base_python_small: &base_python_small
-      docker:
-        - image: cimg/python:3.6
-      resource_class: small
-      environment: &base_python_small_env
-        TERM: xterm
-        MAKEFLAGS: -j 2
-        CPUs: 2
-
   - base_ubuntu_clang: &base_ubuntu_clang
       docker:
         - image: << pipeline.parameters.ubuntu-clang-ossfuzz-docker-image >>
@@ -853,7 +844,7 @@ defaults:
 jobs:
 
   chk_spelling:
-    <<: *base_python_small
+    <<: *base_ubuntu2404_small
     steps:
       - checkout
       - attach_workspace:
@@ -906,7 +897,7 @@ jobs:
       - matrix_notify_failure_unless_pr
 
   chk_errorcodes:
-    <<: *base_python_small
+    <<: *base_ubuntu2404_small
     steps:
       - checkout
       - run:

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = .git,deps,LICENSE,*.enc,Dockerfile*,codespell_whitelist.txt,codespell_ignored_lines.txt
+ignore-words = scripts/codespell_whitelist.txt
+exclude-file = scripts/codespell_ignored_lines.txt

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
+level of experience, education, socioeconomic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards

--- a/docs/bugs.json
+++ b/docs/bugs.json
@@ -151,7 +151,7 @@
     {
         "uid": "SOL-2021-1",
         "name": "KeccakCaching",
-        "summary": "The bytecode optimizer incorrectly re-used previously evaluated Keccak-256 hashes. You are unlikely to be affected if you do not compute Keccak-256 hashes in inline assembly.",
+        "summary": "The bytecode optimizer incorrectly reused previously evaluated Keccak-256 hashes. You are unlikely to be affected if you do not compute Keccak-256 hashes in inline assembly.",
         "description": "Solidity's bytecode optimizer has a step that can compute Keccak-256 hashes, if the contents of the memory are known during compilation time. This step also has a mechanism to determine that two Keccak-256 hashes are equal even if the values in memory are not known during compile time. This mechanism had a bug where Keccak-256 of the same memory content, but different sizes were considered equal. More specifically, ``keccak256(mpos1, length1)`` and ``keccak256(mpos2, length2)`` in some cases were considered equal if ``length1`` and ``length2``, when rounded up to nearest multiple of 32 were the same, and when the memory contents at ``mpos1`` and ``mpos2`` can be deduced to be equal. You maybe affected if you compute multiple Keccak-256 hashes of the same content, but with different lengths inside inline assembly. You are unaffected if your code uses ``keccak256`` with a length that is not a compile-time constant or if it is always a multiple of 32.",
         "link": "https://blog.soliditylang.org/2021/03/23/keccak-optimizer-bug/",
         "fixed": "0.8.3",
@@ -200,7 +200,7 @@
         "uid": "SOL-2020-7",
         "name": "MissingEscapingInFormatting",
         "summary": "String literals containing double backslash characters passed directly to external or encoding function calls can lead to a different string being used when ABIEncoderV2 is enabled.",
-        "description": "When ABIEncoderV2 is enabled, string literals passed directly to encoding functions or external function calls are stored as strings in the intemediate code. Characters outside the printable range are handled correctly, but backslashes are not escaped in this procedure. This leads to double backslashes being reduced to single backslashes and consequently re-interpreted as escapes potentially resulting in a different string being encoded.",
+        "description": "When ABIEncoderV2 is enabled, string literals passed directly to encoding functions or external function calls are stored as strings in the intermediate code. Characters outside the printable range are handled correctly, but backslashes are not escaped in this procedure. This leads to double backslashes being reduced to single backslashes and consequently re-interpreted as escapes potentially resulting in a different string being encoded.",
         "introduced": "0.5.14",
         "fixed": "0.6.8",
         "severity": "very low",

--- a/docs/internals/optimizer.rst
+++ b/docs/internals/optimizer.rst
@@ -982,7 +982,7 @@ no other store in between and the values of ``k`` and ``v`` did not change.
 
 This simple step is effective if run after the SSATransform and the
 CommonSubexpressionEliminator, because SSA will make sure that the variables
-will not change and the CommonSubexpressionEliminator re-uses exactly the same
+will not change and the CommonSubexpressionEliminator reuses exactly the same
 variable if the value is known to be the same.
 
 Prerequisites: Disambiguator, ForLoopInitRewriter.
@@ -1287,7 +1287,7 @@ UnusedPruner.
 
 The SSA form we generate is detrimental to code generation
 because it produces many local variables. It would
-be better to just re-use existing variables with assignments instead of
+be better to just reuse existing variables with assignments instead of
 fresh variable declarations.
 
 The SSATransform rewrites

--- a/docs/yul.rst
+++ b/docs/yul.rst
@@ -1069,7 +1069,7 @@ by two, without the optimizer touching the constant two, you can use
     let double := verbatim_1i_1o(hex"600202", x)
 
 This code will result in a ``dup1`` opcode to retrieve ``x``
-(the optimizer might directly re-use result of the
+(the optimizer might directly reuse result of the
 ``calldataload`` opcode, though)
 directly followed by ``600202``. The code is assumed to
 consume the copied value of ``x`` and produce the result

--- a/scripts/codespell_ignored_lines.txt
+++ b/scripts/codespell_ignored_lines.txt
@@ -18,3 +18,4 @@ docker run --rm -v "${OUTPUTDIR}":/tmp/output -v "${SCRIPTDIR}":/tmp/scripts:ro 
 			templ("assignEnd", "end := pos");
 			templ("assignEnd", "end := tail");
 			templ("assignEnd", "");
+        self.assertIn('401 Client Error: Unauthorized', str(manager.exception))

--- a/scripts/codespell_whitelist.txt
+++ b/scripts/codespell_whitelist.txt
@@ -1,3 +1,4 @@
 nd
 compilability
 keypair
+wast

--- a/test/libsolidity/semanticTests/abiencodedecode/abi_encode_with_signature.sol
+++ b/test/libsolidity/semanticTests/abiencodedecode/abi_encode_with_signature.sol
@@ -20,7 +20,7 @@ contract C {
 		y[2] = type(uint).max - 2;
 		y[3] = type(uint).max - 3;
 		r = abi.encodeWithSignature(x, y);
-		// The hash uses temporary memory. This allocation re-uses the memory
+		// The hash uses temporary memory. This allocation reuses the memory
 		// and should initialize it properly.
 		ar = new uint[](2);
 	}

--- a/test/libsolidity/semanticTests/abiencodedecode/abi_encode_with_signaturev2.sol
+++ b/test/libsolidity/semanticTests/abiencodedecode/abi_encode_with_signaturev2.sol
@@ -20,7 +20,7 @@ contract C {
         y[2] = type(uint).max - 2;
         y[3] = type(uint).max - 3;
         r = abi.encodeWithSignature(x, y);
-        // The hash uses temporary memory. This allocation re-uses the memory
+        // The hash uses temporary memory. This allocation reuses the memory
         // and should initialize it properly.
         ar = new uint[](2);
     }

--- a/test/libyul/evmCodeTransform/stackReuse/function_params_and_retparams.yul
+++ b/test/libyul/evmCodeTransform/stackReuse/function_params_and_retparams.yul
@@ -1,25 +1,25 @@
-// This does not re-use the parameters for the return parameters
+// This does not reuse the parameters for the return parameters
 // We do not expect parameters to be fully unused, so the stack
 // layout for a function is still fixed, even though parameters
-// can be re-used.
+// can be reused.
 {
     function f(a, b, c, d) -> x, y { }
 }
 // ====
 // stackOptimization: true
 // ----
-//     /* "":212:254   */
+//     /* "":210:252   */
 //   stop
-//     /* "":218:252   */
+//     /* "":216:250   */
 // tag_1:
 //   pop
 //   pop
 //   pop
 //   pop
-//     /* "":247:248   */
+//     /* "":245:246   */
 //   0x00
-//     /* "":244:245   */
+//     /* "":242:243   */
 //   0x00
-//     /* "":218:252   */
+//     /* "":216:250   */
 //   swap2
 //   jump	// out

--- a/test/libyul/yulOptimizerTests/commonSubexpressionEliminator/unassigned_return.yul
+++ b/test/libyul/yulOptimizerTests/commonSubexpressionEliminator/unassigned_return.yul
@@ -1,11 +1,11 @@
 {
     function f() -> x {
-        // can re-use x
+        // can reuse x
         let y := 0
         mstore(y, 7)
     }
     let a
-    // can re-use a
+    // can reuse a
     let b := 0
     sstore(a, b)
 }


### PR DESCRIPTION
I'm finding a lot of typos in PRs like #15550 even though we have a codespell job that should be detecting them automatically. Apparently this is because we're using `cimg/python:3.6` image, which ships an old version of codespell (2.2.1). The latest one has a better dictionary that does detect the typos.

This PR replaces `cimg/python:3.6` with our Ubuntu image, which we keep up to date.

It also adds a config file for codespell to make it easier to run it locally with the right arguments. It's now enough to simply run `codespell` without arguments.