### PR TITLE
Correct Minor Typos in CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -27,7 +27,7 @@ Examples of unacceptable behavior by participants include:
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
 * Publishing others' private information, such as a physical or electronic
-  addressess, without explicit permission
+  addresses, without explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,7 @@
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
+contributors and maintainers pledge to make participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
 level of experience, education, socioeconomic status, nationality, personal
@@ -27,7 +27,7 @@ Examples of unacceptable behavior by participants include:
 * Trolling, insulting/derogatory comments, and personal or political attacks
 * Public or private harassment
 * Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
+  addressess, without explicit permission
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 


### PR DESCRIPTION
This PR fixes minor typos in the `CODE_OF_CONDUCT.md` file:

1. Changed "making participation" to "make participation" to correct the verb tense.
2. Corrected "address" to "addresses" to match the plural form.

**Why is this important?**
These changes improve the clarity and grammatical accuracy of the document. Proper grammar ensures the Code of Conduct is professional and easier to understand, promoting a more inclusive environment for all contributors and maintainers.

No functional changes, only documentation improvements.
