### PR TITLE
Typo Update control-structures.rst docs

### DIFF
--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -239,7 +239,7 @@ to limit the amount of gas.
 If the creation fails (due to out-of-stack, not enough balance or other problems),
 an exception is thrown.
 
-Salted contract creations / create2
+Salted contract creations / CREATE2
 -----------------------------------
 
 When creating a contract, the address of the contract is computed from


### PR DESCRIPTION
**Description:**

In the section about "Salted contract creations / create2," I've updated the term "create2" to "CREATE2" to match Solidity's official usage. In Solidity, "CREATE2" is a special opcode and keyword, and it's important to maintain consistency with its proper formatting, which uses uppercase letters. This change ensures clarity and aligns the documentation with the correct conventions, making it easier for developers to follow and preventing any confusion when referring to this specific keyword.