### PR TITLE
Fix typos and grammar in documentation files

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -13,7 +13,7 @@ docker push ethereum/solidity-buildpack-deps:ubuntu2404-<revision>
 
 The current revisions per docker image are stored in [circle ci pipeline parameters](https://github.com/CircleCI-Public/api-preview-docs/blob/master/docs/pipeline-parameters.md#pipeline-parameters) called `<image-desc>-docker-image-rev` (e.g., `ubuntu-2404-docker-image-rev`). Please update the value assigned to the parameter(s) corresponding to the docker image(s) being updated at the time of the update. Please verify that the value assigned to the parameter matches the revision part of the docker image tag (`<revision>` in the docker build/push snippet shown above). Otherwise, the docker image used by circle ci and the one actually pushed to docker hub will differ.
 
-Once the docker image has been built and pushed to Dockerhub, you can find it at:
+Once the docker image has been built and pushed to Docker Hub, you can find it at:
 
     https://hub.docker.com/r/ethereum/solidity-buildpack-deps:ubuntu2404-<revision>
 

--- a/scripts/docker/buildpack-deps/README.md
+++ b/scripts/docker/buildpack-deps/README.md
@@ -4,7 +4,7 @@ The `buildpack-deps` docker images are used to compile and test solidity within 
 
 ## GitHub Workflow
 
-The creation of the images are triggered by a single workflow, defined in `.github/workflows/buildpack-deps.yml`.
+The creation of the images is triggered by a single workflow, defined in `.github/workflows/buildpack-deps.yml`.
 For each resulting `buildpack-deps` docker image a strategy is defined in the workflow file - the image variant.
 The workflow gets triggered, if any Dockerfile defined in `scripts/docker/buildpack-deps/Dockerfile.*` were changed
 within the PR.

--- a/test/externalTests/README.md
+++ b/test/externalTests/README.md
@@ -15,7 +15,7 @@ these projects *can* be upgraded at all.
 #### Adding a new external project
 1. If the upstream code cannot be compiled without modifications, create a fork of the repository
    in https://github.com/solidity-external-tests/.
-2. In our fork, remove all the branches except for main one (`master`, `develop`, `main`, etc).
+2. In our fork, remove all the branches except for the main one (`master`, `develop`, `main`, etc).
     This branch is going to be always kept up to date with the upstream repository and should not
     contain any extra commits.
     - If the project is not up to date with the latest compiler version but has a branch that is,


### PR DESCRIPTION


This PR fixes several typos and improves consistency in documentation files:

1. .circleci/README.md:
- Changed "Dockerhub" to "Docker Hub"
Reason: Using the official product name for better clarity and consistency.

2. scripts/docker/buildpack-deps/README.md:
- Changed "are" to "is" in "The creation of the images is triggered..."
Reason: Proper subject-verb agreement for better grammar.

3. test/externalTests/README.md:
- Changed "main" to "the main" in "remove all the branches except for the main one"
Reason: Added article for proper English grammar and readability.

These changes improve documentation readability and maintain consistent terminology throughout the codebase. The modifications are minor but important for maintaining professional quality in our documentation.

Technical Notes:
- Only documentation files were modified
- No code changes were made
- All changes are grammatical improvements