### PR TITLE
Fix silent value truncation in assembly import

### DIFF
--- a/test/cmdlineTests/standard_import_asm_json_invalid_push_data_value_bad_hex/input.json
+++ b/test/cmdlineTests/standard_import_asm_json_invalid_push_data_value_bad_hex/input.json
@@ -1,0 +1,28 @@
+{
+    "language": "EVMAssembly",
+    "sources": {
+        "A": {
+            "assemblyJson": {
+                ".code": [
+                    {
+                        "begin": 0,
+                        "end": 0,
+                        "name": "PUSH data",
+                        "source": 0,
+                        "value": "112233445566778899aabbccddeeff00112233445566778899aabbccddeeffgg"
+                    }
+                ],
+                "sourceList": [
+                    "<stdin>"
+                ]
+            }
+        }
+    },
+    "settings": {
+        "outputSelection": {
+            "*": {
+                "": ["evm.bytecode"]
+            }
+        }
+    }
+}

--- a/test/cmdlineTests/standard_import_asm_json_invalid_push_data_value_bad_hex/output.json
+++ b/test/cmdlineTests/standard_import_asm_json_invalid_push_data_value_bad_hex/output.json
@@ -1,0 +1,11 @@
+{
+    "errors": [
+        {
+            "component": "general",
+            "formattedMessage": "Assembly import error: Value provided for instruction 'PUSH data' is not a valid 256-bit hexadecimal number.",
+            "message": "Assembly import error: Value provided for instruction 'PUSH data' is not a valid 256-bit hexadecimal number.",
+            "severity": "error",
+            "type": "Exception"
+        }
+    ]
+}

--- a/test/cmdlineTests/standard_import_asm_json_invalid_push_data_value_too_long/input.json
+++ b/test/cmdlineTests/standard_import_asm_json_invalid_push_data_value_too_long/input.json
@@ -1,0 +1,28 @@
+{
+    "language": "EVMAssembly",
+    "sources": {
+        "A": {
+            "assemblyJson": {
+                ".code": [
+                    {
+                        "begin": 0,
+                        "end": 0,
+                        "name": "PUSH data",
+                        "source": 0,
+                        "value": "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00"
+                    }
+                ],
+                "sourceList": [
+                    "<stdin>"
+                ]
+            }
+        }
+    },
+    "settings": {
+        "outputSelection": {
+            "*": {
+                "": ["evm.bytecode"]
+            }
+        }
+    }
+}

--- a/test/cmdlineTests/standard_import_asm_json_invalid_push_data_value_too_long/output.json
+++ b/test/cmdlineTests/standard_import_asm_json_invalid_push_data_value_too_long/output.json
@@ -1,0 +1,11 @@
+{
+    "errors": [
+        {
+            "component": "general",
+            "formattedMessage": "Assembly import error: Value provided for instruction 'PUSH data' is not a valid 256-bit hexadecimal number.",
+            "message": "Assembly import error: Value provided for instruction 'PUSH data' is not a valid 256-bit hexadecimal number.",
+            "severity": "error",
+            "type": "Exception"
+        }
+    ]
+}

--- a/test/cmdlineTests/standard_import_asm_json_invalid_push_sub_size_value/input.json
+++ b/test/cmdlineTests/standard_import_asm_json_invalid_push_sub_size_value/input.json
@@ -1,0 +1,28 @@
+{
+    "language": "EVMAssembly",
+    "sources": {
+        "A": {
+            "assemblyJson": {
+                ".code": [
+                    {
+                        "begin": 0,
+                        "end": 0,
+                        "name": "PUSH #[$]",
+                        "source": 0,
+                        "value": "10000000000000000"
+                    }
+                ],
+                "sourceList": [
+                    "<stdin>"
+                ]
+            }
+        }
+    },
+    "settings": {
+        "outputSelection": {
+            "*": {
+                "": ["evm.bytecode"]
+            }
+        }
+    }
+}

--- a/test/cmdlineTests/standard_import_asm_json_invalid_push_sub_size_value/output.json
+++ b/test/cmdlineTests/standard_import_asm_json_invalid_push_sub_size_value/output.json
@@ -1,0 +1,11 @@
+{
+    "errors": [
+        {
+            "component": "general",
+            "formattedMessage": "Assembly import error: Value provided for instruction 'PUSH #[$]' is out of the allowed range [0, 0xffffffffffffffff].",
+            "message": "Assembly import error: Value provided for instruction 'PUSH #[$]' is out of the allowed range [0, 0xffffffffffffffff].",
+            "severity": "error",
+            "type": "Exception"
+        }
+    ]
+}

--- a/test/cmdlineTests/standard_import_asm_json_invalid_push_sub_value/input.json
+++ b/test/cmdlineTests/standard_import_asm_json_invalid_push_sub_value/input.json
@@ -1,0 +1,28 @@
+{
+    "language": "EVMAssembly",
+    "sources": {
+        "A": {
+            "assemblyJson": {
+                ".code": [
+                    {
+                        "begin": 0,
+                        "end": 0,
+                        "name": "PUSH [$]",
+                        "source": 0,
+                        "value": "10000000000000000"
+                    }
+                ],
+                "sourceList": [
+                    "<stdin>"
+                ]
+            }
+        }
+    },
+    "settings": {
+        "outputSelection": {
+            "*": {
+                "": ["evm.bytecode"]
+            }
+        }
+    }
+}

--- a/test/cmdlineTests/standard_import_asm_json_invalid_push_sub_value/output.json
+++ b/test/cmdlineTests/standard_import_asm_json_invalid_push_sub_value/output.json
@@ -1,0 +1,11 @@
+{
+    "errors": [
+        {
+            "component": "general",
+            "formattedMessage": "Assembly import error: Value provided for instruction 'PUSH [$]' is out of the allowed range [0, 0xffffffffffffffff].",
+            "message": "Assembly import error: Value provided for instruction 'PUSH [$]' is out of the allowed range [0, 0xffffffffffffffff].",
+            "severity": "error",
+            "type": "Exception"
+        }
+    ]
+}

--- a/test/cmdlineTests/standard_import_asm_json_invalid_push_tag_value/input.json
+++ b/test/cmdlineTests/standard_import_asm_json_invalid_push_tag_value/input.json
@@ -1,0 +1,28 @@
+{
+    "language": "EVMAssembly",
+    "sources": {
+        "A": {
+            "assemblyJson": {
+                ".code": [
+                    {
+                        "begin": 0,
+                        "end": 0,
+                        "name": "PUSH [tag]",
+                        "source": 0,
+                        "value": "0x100000000"
+                    }
+                ],
+                "sourceList": [
+                    "<stdin>"
+                ]
+            }
+        }
+    },
+    "settings": {
+        "outputSelection": {
+            "*": {
+                "": ["evm.bytecode"]
+            }
+        }
+    }
+}

--- a/test/cmdlineTests/standard_import_asm_json_invalid_push_tag_value/output.json
+++ b/test/cmdlineTests/standard_import_asm_json_invalid_push_tag_value/output.json
@@ -1,0 +1,11 @@
+{
+    "errors": [
+        {
+            "component": "general",
+            "formattedMessage": "Assembly import error: Value provided for instruction 'PUSH [tag]' is out of the allowed range [0, 0xffffffff].",
+            "message": "Assembly import error: Value provided for instruction 'PUSH [tag]' is out of the allowed range [0, 0xffffffff].",
+            "severity": "error",
+            "type": "Exception"
+        }
+    ]
+}

--- a/test/cmdlineTests/standard_import_asm_json_invalid_push_value/input.json
+++ b/test/cmdlineTests/standard_import_asm_json_invalid_push_value/input.json
@@ -1,0 +1,28 @@
+{
+    "language": "EVMAssembly",
+    "sources": {
+        "A": {
+            "assemblyJson": {
+                ".code": [
+                    {
+                        "begin": 0,
+                        "end": 10,
+                        "name": "PUSH",
+                        "source": 0,
+                        "value": "00112233445566778899001122334455667788990011223344556677889900112233445566778899"
+                    }
+                ],
+                "sourceList": [
+                    "<stdin>"
+                ]
+            }
+        }
+    },
+    "settings": {
+        "outputSelection": {
+            "*": {
+                "": ["evm.bytecode"]
+            }
+        }
+    }
+}

--- a/test/cmdlineTests/standard_import_asm_json_invalid_push_value/output.json
+++ b/test/cmdlineTests/standard_import_asm_json_invalid_push_value/output.json
@@ -1,0 +1,11 @@
+{
+    "errors": [
+        {
+            "component": "general",
+            "formattedMessage": "Assembly import error: Value provided for instruction 'PUSH' is out of the allowed range [0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff].",
+            "message": "Assembly import error: Value provided for instruction 'PUSH' is out of the allowed range [0, 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff].",
+            "severity": "error",
+            "type": "Exception"
+        }
+    ]
+}

--- a/test/cmdlineTests/standard_import_asm_json_invalid_tag_value/input.json
+++ b/test/cmdlineTests/standard_import_asm_json_invalid_tag_value/input.json
@@ -1,0 +1,28 @@
+{
+    "language": "EVMAssembly",
+    "sources": {
+        "A": {
+            "assemblyJson": {
+                ".code": [
+                    {
+                        "begin": 0,
+                        "end": 0,
+                        "name": "tag",
+                        "source": 0,
+                        "value": "0x100000000"
+                    }
+                ],
+                "sourceList": [
+                    "<stdin>"
+                ]
+            }
+        }
+    },
+    "settings": {
+        "outputSelection": {
+            "*": {
+                "": ["evm.bytecode"]
+            }
+        }
+    }
+}

--- a/test/cmdlineTests/standard_import_asm_json_invalid_tag_value/output.json
+++ b/test/cmdlineTests/standard_import_asm_json_invalid_tag_value/output.json
@@ -1,0 +1,11 @@
+{
+    "errors": [
+        {
+            "component": "general",
+            "formattedMessage": "Assembly import error: Value provided for instruction 'tag' is out of the allowed range [0, 0xffffffff].",
+            "message": "Assembly import error: Value provided for instruction 'tag' is out of the allowed range [0, 0xffffffff].",
+            "severity": "error",
+            "type": "Exception"
+        }
+    ]
+}


### PR DESCRIPTION
While doing #15596 I noticed that the validation against using PUSH with more than 32 bytes does not get triggered in assembly import. Turns out that this is because the import code blindly converts the `value` field to `u256`, truncating it if it's too long. This happens for several other assembly item types as well.

Validations for assembly import are generally a mess, but the PR does not attempt to clean that up. It only adds rough checks that should be enough to disallow cases affected by the truncation bug.