### PR TITLE
eof: Hide rjumps in yul

### DIFF
--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -209,6 +209,8 @@ std::vector<std::optional<BuiltinFunctionForEVM>> createBuiltins(langutil::EVMVe
 			opcode != evmasm::Instruction::DATALOADN &&
 			opcode != evmasm::Instruction::EOFCREATE &&
 			opcode != evmasm::Instruction::RETURNCONTRACT &&
+			opcode != evmasm::Instruction::RJUMP &&
+			opcode != evmasm::Instruction::RJUMPI &&
 			opcode != evmasm::Instruction::CALLF &&
 			opcode != evmasm::Instruction::JUMPF &&
 			opcode != evmasm::Instruction::RETF &&

--- a/test/libyul/yulSyntaxTests/eof/rjump_rjumpi.yul
+++ b/test/libyul/yulSyntaxTests/eof/rjump_rjumpi.yul
@@ -1,0 +1,11 @@
+object "a" {
+    code {
+        rjump()
+        rjumpi()
+    }
+}
+// ====
+// bytecodeFormat: legacy,>=EOFv1
+// ----
+// DeclarationError 4619: (32-37): Function "rjump" not found.
+// DeclarationError 4619: (48-54): Function "rjumpi" not found.


### PR DESCRIPTION
- Fix `rjump` and `rjumpi` visibility in yul code