### PR TITLE
Fix missing `library` template parameter in IR codegen on EOF

### DIFF
--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -986,6 +986,7 @@ std::string IRGenerator::deployCode(ContractDefinition const& _contract)
 	t("allocateUnbounded", m_utils.allocateUnboundedFunction());
 	t("codeOffset", m_context.newYulVariable());
 	t("object", IRNames::deployedObject(_contract));
+	t("library", _contract.isLibrary());
 
 	std::vector<std::map<std::string, std::string>> immutables;
 	if (_contract.isLibrary())

--- a/test/libsolidity/semanticTests/immutable/stub.sol
+++ b/test/libsolidity/semanticTests/immutable/stub.sol
@@ -9,5 +9,7 @@ contract C {
 		return (x+x,y);
 	}
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // f() -> 84, 23

--- a/test/libyul/yulSyntaxTests/eof/callf_jumpf_retf.yul
+++ b/test/libyul/yulSyntaxTests/eof/callf_jumpf_retf.yul
@@ -5,6 +5,8 @@ object "a" {
         retf()
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // DeclarationError 4619: (32-37): Function "callf" not found.
 // DeclarationError 4619: (48-53): Function "jumpf" not found.


### PR DESCRIPTION
Fixes a small bug that went unnoticed in #15512 because we don't run most tests on EOF yet: the IR codegen template is missing a parameter.

Running tests for immutables without the fix results in:
```
semanticTests/immutable/stub.sol: Unhandled exception during test: /solidity/libsolutil/Whiskers.cpp(213): Throw in function solidity::util::Whiskers::replace(const std::string&, const StringMap&, const std::map<std::__cxx11::basic_string<char>, bool>&, const std::map<std::__cxx11::basic_string<char>, std::vector<std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > > >&)::<lambda(std::__cxx11::match_results<__gnu_cxx::__normal_iterator<const char*, std::__cxx11::basic_string<char> > >)>
Dynamic exception type: boost::wrapexcept<solidity::util::WhiskersError>
std::exception::what: WhiskersError
[solidity::util::tag_comment*] = Condition parameter library not set.
```

I'm also including a commit that makes the test mentioned in https://github.com/ethereum/solidity/pull/15550#pullrequestreview-2471118145 actually run on EOF too.