### PR TITLE
Unify Yul parsing across test suites                                          

### DIFF
--- a/libyul/YulStack.cpp
+++ b/libyul/YulStack.cpp
@@ -430,6 +430,13 @@ std::shared_ptr<Object> YulStack::parserResult() const
 	return m_parserResult;
 }
 
+Dialect const& YulStack::dialect() const
+{
+	yulAssert(m_stackState >= AnalysisSuccessful);
+	yulAssert(m_parserResult && m_parserResult->dialect());
+	return *m_parserResult->dialect();
+}
+
 void YulStack::reportUnimplementedFeatureError(UnimplementedFeatureError const& _error)
 {
 	yulAssert(_error.comment(), "Errors must include a message for the user.");

--- a/libyul/YulStack.h
+++ b/libyul/YulStack.h
@@ -139,6 +139,7 @@ public:
 	/// @returns the errors generated during parsing, analysis (and potentially assembly).
 	langutil::ErrorList const& errors() const { return m_errors; }
 	bool hasErrors() const { return m_errorReporter.hasErrors(); }
+	bool hasErrorsWarningsOrInfos() const { return m_errorReporter.hasErrorsWarningsOrInfos(); }
 
 	/// Pretty-print the input after having parsed it.
 	std::string print() const;
@@ -149,6 +150,8 @@ public:
 
 	/// Return the parsed and analyzed object.
 	std::shared_ptr<Object> parserResult() const;
+
+	Dialect const& dialect() const;
 
 	langutil::DebugInfoSelection debugInfoSelection() const { return m_debugInfoSelection; }
 

--- a/test/libsolidity/MemoryGuardTest.cpp
+++ b/test/libsolidity/MemoryGuardTest.cpp
@@ -20,13 +20,17 @@
 
 #include <test/Common.h>
 #include <test/libyul/Common.h>
+
 #include <libsolidity/codegen/ir/Common.h>
+
 #include <libsolutil/Algorithms.h>
 #include <libsolutil/StringUtils.h>
+
 #include <libyul/Object.h>
-#include <libyul/backends/evm/EVMDialect.h>
 #include <libyul/optimiser/FunctionCallFinder.h>
 #include <libyul/AST.h>
+#include <libyul/YulStack.h>
+
 #include <fstream>
 #include <memory>
 #include <stdexcept>
@@ -38,6 +42,7 @@ using namespace solidity::langutil;
 using namespace solidity::frontend;
 using namespace solidity::frontend::test;
 using namespace solidity::test;
+using namespace solidity::yul::test;
 using namespace yul;
 
 void MemoryGuardTest::setupCompiler(CompilerStack& _compiler)
@@ -59,20 +64,14 @@ TestCase::TestResult MemoryGuardTest::run(std::ostream& _stream, std::string con
 	m_obtainedResult.clear();
 	for (std::string contractName: compiler().contractNames())
 	{
-		auto const& dialect = CommonOptions::get().evmDialect();
 		ErrorList errors;
 		std::optional<std::string> const& ir = compiler().yulIR(contractName);
-		solAssert(ir);
-		auto [object, analysisInfo] = yul::test::parse(
-			*ir,
-			dialect,
-			errors
-		);
+		soltestAssert(ir);
 
-		if (!object || !analysisInfo || Error::containsErrors(errors))
+		YulStack yulStack = parseYul(*ir);
+		if (yulStack.hasErrors())
 		{
-			AnsiColorized(_stream, _formatted, {formatting::BOLD, formatting::RED}) << _linePrefix << "Error parsing IR:" << std::endl;
-			printPrefixed(_stream, formatErrors(filterErrors(errors), _formatted), _linePrefix);
+			printYulErrors(yulStack, _stream, _linePrefix, _formatted);
 			return TestResult::FatalError;
 		}
 
@@ -80,14 +79,14 @@ TestCase::TestResult MemoryGuardTest::run(std::ostream& _stream, std::string con
 			m_obtainedResult += contractName + "(" + _kind + ") " + (findFunctionCalls(
 				_object.code()->root(),
 				"memoryguard",
-				dialect
+				yulStack.dialect()
 			).empty() ? "false" : "true") + "\n";
 		};
-		handleObject("creation", *object);
-		size_t deployedIndex = object->subIndexByName.at(
+		handleObject("creation", *yulStack.parserResult());
+		size_t deployedIndex = yulStack.parserResult()->subIndexByName.at(
 			IRNames::deployedObject(compiler().contractDefinition(contractName))
 		);
-		handleObject("runtime", dynamic_cast<Object const&>(*object->subObjects[deployedIndex]));
+		handleObject("runtime", dynamic_cast<Object const&>(*yulStack.parserResult()->subObjects[deployedIndex]));
 	}
 	return checkResult(_stream, _linePrefix, _formatted);
 }

--- a/test/libyul/Common.h
+++ b/test/libyul/Common.h
@@ -21,11 +21,14 @@
 
 #pragma once
 
+#include <libsolidity/interface/OptimiserSettings.h>
+
 #include <liblangutil/EVMVersion.h>
 
 #include <string>
 #include <vector>
 #include <memory>
+#include <optional>
 
 namespace solidity::langutil
 {
@@ -40,20 +43,28 @@ struct Block;
 class Object;
 class Dialect;
 class AST;
+class YulStack;
 }
 
 namespace solidity::yul::test
 {
 
-std::pair<std::shared_ptr<AST const>, std::shared_ptr<AsmAnalysisInfo>>
-parse(std::string const& _source);
-
-std::pair<std::shared_ptr<Object>, std::shared_ptr<AsmAnalysisInfo>>
-parse(std::string const& _source, Dialect const& _dialect, langutil::ErrorList& _errors);
+yul::YulStack parseYul(
+	std::string const& _source,
+	std::string _sourceUnitName = "",
+	std::optional<frontend::OptimiserSettings> _optimiserSettings = std::nullopt
+);
 
 Block disambiguate(std::string const& _source);
 std::string format(std::string const& _source);
 
 solidity::yul::Dialect const& dialect(std::string const& _name, langutil::EVMVersion _evmVersion, std::optional<uint8_t> _eofVersion);
+
+void printYulErrors(
+	yul::YulStack const& _yulStack,
+	std::ostream& _stream,
+	std::string const& _linePrefix,
+	bool const _formatted
+);
 
 }

--- a/test/libyul/CompilabilityChecker.cpp
+++ b/test/libyul/CompilabilityChecker.cpp
@@ -20,10 +20,12 @@
 
 #include <test/Common.h>
 
+#include <test/libsolidity/util/SoltestErrors.h>
+
 #include <test/libyul/Common.h>
-#include <libyul/backends/evm/EVMDialect.h>
 
 #include <libyul/CompilabilityChecker.h>
+#include <libyul/YulStack.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -34,12 +36,11 @@ namespace
 {
 std::string check(std::string const& _input)
 {
-	Object obj;
-	auto parsingResult = yul::test::parse(_input);
-	obj.setCode(parsingResult.first, parsingResult.second);
-	BOOST_REQUIRE(obj.hasCode());
-	BOOST_REQUIRE(obj.dialect());
-	auto functions = CompilabilityChecker(obj, true).stackDeficit;
+	YulStack yulStack = parseYul(_input);
+	solUnimplementedAssert(yulStack.parserResult()->subObjects.empty(), "Tests with subobjects not supported.");
+	soltestAssert(!yulStack.hasErrorsWarningsOrInfos());
+
+	auto functions = CompilabilityChecker(*yulStack.parserResult(), true).stackDeficit;
 	std::string out;
 	for (auto const& function: functions)
 		out += function.first.str() + ": " + std::to_string(function.second) + " ";

--- a/test/libyul/ControlFlowGraphTest.cpp
+++ b/test/libyul/ControlFlowGraphTest.cpp
@@ -24,8 +24,8 @@
 #include <libyul/backends/evm/ControlFlowGraphBuilder.h>
 #include <libyul/backends/evm/StackHelpers.h>
 #include <libyul/Object.h>
+#include <libyul/YulStack.h>
 
-#include <libsolutil/AnsiColorized.h>
 #include <libsolutil/Visitor.h>
 
 #ifdef ISOLTEST
@@ -45,11 +45,7 @@ ControlFlowGraphTest::ControlFlowGraphTest(std::string const& _filename):
 {
 	m_source = m_reader.source();
 	auto dialectName = m_reader.stringSetting("dialect", "evm");
-	m_dialect = &dialect(
-		dialectName,
-		solidity::test::CommonOptions::get().evmVersion(),
-		solidity::test::CommonOptions::get().eofVersion()
-	);
+	soltestAssert(dialectName == "evm"); // We only have one dialect now
 	m_expectation = m_reader.simpleExpectations();
 }
 
@@ -201,20 +197,24 @@ private:
 
 TestCase::TestResult ControlFlowGraphTest::run(std::ostream& _stream, std::string const& _linePrefix, bool const _formatted)
 {
-	ErrorList errors;
-	auto [object, analysisInfo] = parse(m_source, *m_dialect, errors);
-	if (!object || !analysisInfo || Error::containsErrors(errors))
+	YulStack yulStack = parseYul(m_source);
+	solUnimplementedAssert(yulStack.parserResult()->subObjects.empty(), "Tests with subobjects not supported.");
+	if (yulStack.hasErrors())
 	{
-		AnsiColorized(_stream, _formatted, {formatting::BOLD, formatting::RED}) << _linePrefix << "Error parsing source." << std::endl;
+		printYulErrors(yulStack, _stream, _linePrefix, _formatted);
 		return TestResult::FatalError;
 	}
 
 	std::ostringstream output;
 
-	std::unique_ptr<CFG> cfg = ControlFlowGraphBuilder::build(*analysisInfo, *m_dialect, object->code()->root());
+	std::unique_ptr<CFG> cfg = ControlFlowGraphBuilder::build(
+		*yulStack.parserResult()->analysisInfo,
+		yulStack.dialect(),
+		yulStack.parserResult()->code()->root()
+	);
 
 	output << "digraph CFG {\nnodesep=0.7;\nnode[shape=box];\n\n";
-	ControlFlowGraphPrinter printer{output, *m_dialect};
+	ControlFlowGraphPrinter printer{output, yulStack.dialect()};
 	printer(*cfg->entry);
 	for (auto function: cfg->functions)
 		printer(cfg->functionInfo.at(function));

--- a/test/libyul/ControlFlowGraphTest.h
+++ b/test/libyul/ControlFlowGraphTest.h
@@ -20,11 +20,7 @@
 
 #include <test/TestCase.h>
 
-namespace solidity::yul
-{
-class Dialect;
-
-namespace test
+namespace solidity::yul::test
 {
 
 class ControlFlowGraphTest: public frontend::test::EVMVersionRestrictedTestCase
@@ -36,8 +32,6 @@ public:
 	}
 	explicit ControlFlowGraphTest(std::string const& _filename);
 	TestResult run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
-private:
-	Dialect const* m_dialect = nullptr;
 };
-}
+
 }

--- a/test/libyul/FunctionSideEffects.cpp
+++ b/test/libyul/FunctionSideEffects.cpp
@@ -20,12 +20,11 @@
 #include <test/Common.h>
 #include <test/libyul/Common.h>
 
-#include <libsolutil/AnsiColorized.h>
-
 #include <libyul/SideEffects.h>
 #include <libyul/optimiser/CallGraphGenerator.h>
 #include <libyul/optimiser/Semantics.h>
 #include <libyul/Object.h>
+#include <libyul/YulStack.h>
 #include <libyul/backends/evm/EVMDialect.h>
 
 #include <libsolutil/StringUtils.h>
@@ -84,16 +83,18 @@ FunctionSideEffects::FunctionSideEffects(std::string const& _filename):
 
 TestCase::TestResult FunctionSideEffects::run(std::ostream& _stream, std::string const& _linePrefix, bool _formatted)
 {
-	auto const& dialect = CommonOptions::get().evmDialect();
-	Object obj;
-	auto parsingResult = parse(m_source);
-	obj.setCode(parsingResult.first, parsingResult.second);
-	if (!obj.hasCode())
-		BOOST_THROW_EXCEPTION(std::runtime_error("Parsing input failed."));
+	YulStack yulStack = parseYul(m_source);
+	solUnimplementedAssert(yulStack.parserResult()->subObjects.empty(), "Tests with subobjects not supported.");
+
+	if (yulStack.hasErrors())
+	{
+		printYulErrors(yulStack, _stream, _linePrefix, _formatted);
+		return TestResult::FatalError;
+	}
 
 	std::map<FunctionHandle, SideEffects> functionSideEffects = SideEffectsPropagator::sideEffects(
-		dialect,
-		CallGraphGenerator::callGraph(obj.code()->root())
+		yulStack.dialect(),
+		CallGraphGenerator::callGraph(yulStack.parserResult()->code()->root())
 	);
 
 	std::map<std::string, std::string> functionSideEffectsStr;
@@ -101,7 +102,7 @@ TestCase::TestResult FunctionSideEffects::run(std::ostream& _stream, std::string
 	{
 		auto const& functionNameStr = std::visit(GenericVisitor{
 			[](YulName const& _name) { return _name.str(); },
-			[&](BuiltinHandle const& _builtin) { return dialect.builtin(_builtin).name; }
+			[&](BuiltinHandle const& _builtin) { return yulStack.dialect().builtin(_builtin).name; }
 		}, fun.first);
 		functionSideEffectsStr[functionNameStr] = toString(fun.second);
 	}

--- a/test/libyul/FunctionSideEffects.h
+++ b/test/libyul/FunctionSideEffects.h
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include <libsolutil/AnsiColorized.h>
 #include <test/TestCase.h>
 
 #include <iosfwd>

--- a/test/libyul/Metrics.cpp
+++ b/test/libyul/Metrics.cpp
@@ -20,11 +20,14 @@
 
 #include <test/Common.h>
 
+#include <test/libsolidity/util/SoltestErrors.h>
+
 #include <test/libyul/Common.h>
 
 #include <libyul/optimiser/Metrics.h>
 #include <libyul/AST.h>
 #include <libyul/Object.h>
+#include <libyul/YulStack.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -38,9 +41,10 @@ namespace
 
 size_t codeSize(std::string const& _source, CodeWeights const _weights = {})
 {
-	std::shared_ptr<AST const> ast = parse(_source).first;
-	BOOST_REQUIRE(ast);
-	return CodeSize::codeSize(ast->root(), _weights);
+	YulStack yulStack = parseYul(_source);
+	solUnimplementedAssert(yulStack.parserResult()->subObjects.empty(), "Tests with subobjects not supported.");
+	soltestAssert(!yulStack.hasErrors());
+	return CodeSize::codeSize(yulStack.parserResult()->code()->root(), _weights);
 }
 
 }

--- a/test/libyul/ObjectCompilerTest.cpp
+++ b/test/libyul/ObjectCompilerTest.cpp
@@ -21,8 +21,7 @@
 #include <test/libsolidity/util/SoltestErrors.h>
 
 #include <test/Common.h>
-
-#include <libsolutil/AnsiColorized.h>
+#include <test/libyul/Common.h>
 
 #include <libyul/YulStack.h>
 
@@ -31,11 +30,10 @@
 #include <libevmasm/Instruction.h>
 
 #include <liblangutil/DebugInfoSelection.h>
-#include <liblangutil/SourceReferenceFormatter.h>
 
 #include <boost/algorithm/string.hpp>
 
-#include <fstream>
+#include <ostream>
 
 using namespace solidity;
 using namespace solidity::util;
@@ -64,31 +62,23 @@ ObjectCompilerTest::ObjectCompilerTest(std::string const& _filename):
 
 TestCase::TestResult ObjectCompilerTest::run(std::ostream& _stream, std::string const& _linePrefix, bool const _formatted)
 {
-	YulStack stack(
-		solidity::test::CommonOptions::get().evmVersion(),
-		solidity::test::CommonOptions::get().eofVersion(),
-		YulStack::Language::StrictAssembly,
-		OptimiserSettings::preset(m_optimisationPreset),
-		DebugInfoSelection::All()
-	);
-	bool successful = stack.parseAndAnalyze("source", m_source);
+	YulStack yulStack = parseYul(m_source, "source", OptimiserSettings::preset(m_optimisationPreset));
 	MachineAssemblyObject obj;
-	if (successful)
+	if (!yulStack.hasErrors())
 	{
-		stack.optimize();
-		obj = stack.assemble(YulStack::Machine::EVM);
+		yulStack.optimize();
+		obj = yulStack.assemble(YulStack::Machine::EVM);
 	}
-	if (stack.hasErrors())
+	if (yulStack.hasErrors())
 	{
-		AnsiColorized(_stream, _formatted, {formatting::BOLD, formatting::RED}) << _linePrefix << "Error parsing source." << std::endl;
-		SourceReferenceFormatter{_stream, stack, true, false}
-			.printErrorInformation(stack.errors());
+		printYulErrors(yulStack, _stream, _linePrefix, _formatted);
 		return TestResult::FatalError;
 	}
+
 	solAssert(obj.bytecode);
 	solAssert(obj.sourceMappings);
 
-	m_obtainedResult = "Assembly:\n" + obj.assembly->assemblyString(stack.debugInfoSelection());
+	m_obtainedResult = "Assembly:\n" + obj.assembly->assemblyString(yulStack.debugInfoSelection());
 	if (obj.bytecode->bytecode.empty())
 		m_obtainedResult += "-- empty bytecode --\n";
 	else

--- a/test/libyul/ObjectCompilerTest.h
+++ b/test/libyul/ObjectCompilerTest.h
@@ -51,7 +51,6 @@ public:
 	TestResult run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
 
 private:
-	bool parse(std::ostream& _stream, std::string const& _linePrefix, bool const _formatted);
 	void disambiguate();
 
 	frontend::OptimisationPreset m_optimisationPreset;

--- a/test/libyul/SSAControlFlowGraphTest.h
+++ b/test/libyul/SSAControlFlowGraphTest.h
@@ -22,11 +22,7 @@
 
 #include <memory>
 
-namespace solidity::yul
-{
-class Dialect;
-
-namespace test
+namespace solidity::yul::test
 {
 
 class SSAControlFlowGraphTest: public solidity::frontend::test::TestCase
@@ -35,8 +31,6 @@ public:
 	static std::unique_ptr<TestCase> create(Config const& _config);
 	explicit SSAControlFlowGraphTest(std::string const& _filename);
 	TestResult run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
-private:
-	Dialect const* m_dialect = nullptr;
 };
-}
+
 }

--- a/test/libyul/StackLayoutGeneratorTest.cpp
+++ b/test/libyul/StackLayoutGeneratorTest.cpp
@@ -26,9 +26,8 @@
 #include <libyul/backends/evm/StackLayoutGenerator.h>
 #include <libyul/backends/evm/EVMDialect.h>
 #include <libyul/Object.h>
-#include <liblangutil/SourceReferenceFormatter.h>
+#include <libyul/YulStack.h>
 
-#include <libsolutil/AnsiColorized.h>
 #include <libsolutil/Visitor.h>
 
 #include <range/v3/view/reverse.hpp>
@@ -50,11 +49,7 @@ StackLayoutGeneratorTest::StackLayoutGeneratorTest(std::string const& _filename)
 {
 	m_source = m_reader.source();
 	auto dialectName = m_reader.stringSetting("dialect", "evm");
-	m_dialect = &dialect(
-		dialectName,
-		solidity::test::CommonOptions::get().evmVersion(),
-		solidity::test::CommonOptions::get().eofVersion()
-	);
+	soltestAssert(dialectName == "evm"); // We only have one dialect now
 	m_expectation = m_reader.simpleExpectations();
 }
 
@@ -220,26 +215,31 @@ private:
 
 TestCase::TestResult StackLayoutGeneratorTest::run(std::ostream& _stream, std::string const& _linePrefix, bool const _formatted)
 {
-	ErrorList errors;
-	auto [object, analysisInfo] = parse(m_source, *m_dialect, errors);
-	if (!object || !analysisInfo || Error::containsErrors(errors))
+	YulStack yulStack = parseYul(m_source);
+	solUnimplementedAssert(yulStack.parserResult()->subObjects.empty(), "Tests with subobjects not supported.");
+
+	if (yulStack.hasErrors())
 	{
-		AnsiColorized(_stream, _formatted, {formatting::BOLD, formatting::RED}) << _linePrefix << "Error parsing source." << std::endl;
+		printYulErrors(yulStack, _stream, _linePrefix, _formatted);
 		return TestResult::FatalError;
 	}
 
 	std::ostringstream output;
 
-	std::unique_ptr<CFG> cfg = ControlFlowGraphBuilder::build(*analysisInfo, *m_dialect, object->code()->root());
+	std::unique_ptr<CFG> cfg = ControlFlowGraphBuilder::build(
+		*yulStack.parserResult()->analysisInfo,
+		yulStack.dialect(),
+		yulStack.parserResult()->code()->root()
+	);
 
 	bool simulateFunctionsWithJumps = true;
-	if (auto const* evmDialect = dynamic_cast<EVMDialect const*>(m_dialect))
+	if (auto const* evmDialect = dynamic_cast<EVMDialect const*>(&yulStack.dialect()))
 		simulateFunctionsWithJumps = !evmDialect->eofVersion().has_value();
 
 	StackLayout stackLayout = StackLayoutGenerator::run(*cfg, simulateFunctionsWithJumps);
 
 	output << "digraph CFG {\nnodesep=0.7;\nnode[shape=box];\n\n";
-	StackLayoutPrinter printer{output, stackLayout, *m_dialect};
+	StackLayoutPrinter printer{output, stackLayout, yulStack.dialect()};
 	printer(*cfg->entry);
 	for (auto function: cfg->functions)
 		printer(cfg->functionInfo.at(function));

--- a/test/libyul/StackLayoutGeneratorTest.h
+++ b/test/libyul/StackLayoutGeneratorTest.h
@@ -20,11 +20,7 @@
 
 #include <test/TestCase.h>
 
-namespace solidity::yul
-{
-class Dialect;
-
-namespace test
+namespace solidity::yul::test
 {
 
 class StackLayoutGeneratorTest: public frontend::test::EVMVersionRestrictedTestCase
@@ -36,8 +32,6 @@ public:
 	}
 	explicit StackLayoutGeneratorTest(std::string const& _filename);
 	TestResult run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
-private:
-	Dialect const* m_dialect = nullptr;
 };
-}
+
 }

--- a/test/libyul/SyntaxTest.cpp
+++ b/test/libyul/SyntaxTest.cpp
@@ -16,39 +16,32 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
-#include <libyul/AsmAnalysis.h>
-#include <libyul/AsmAnalysisInfo.h>
-
-#include <liblangutil/EVMVersion.h>
-#include <liblangutil/Exceptions.h>
+#include <test/libyul/SyntaxTest.h>
 
 #include <test/libyul/Common.h>
-#include <test/libyul/SyntaxTest.h>
 #include <test/TestCaseReader.h>
 
 #include <test/libsolidity/util/SoltestErrors.h>
 
 #include <test/Common.h>
 
+#include <libyul/YulStack.h>
+
 using namespace solidity;
 using namespace solidity::util;
 using namespace solidity::langutil;
+using namespace solidity::test;
 using namespace solidity::yul::test;
+using namespace solidity::frontend;
 using namespace solidity::frontend::test;
 
 void SyntaxTest::parseAndAnalyze()
 {
-	if (m_sources.sources.size() != 1)
-		BOOST_THROW_EXCEPTION(std::runtime_error{"Expected only one source for yul test."});
+	solUnimplementedAssert(m_sources.sources.size() == 1, "Multi-source Yul tests are not supported.");
+	auto const& [sourceUnitName, source] = *m_sources.sources.begin();
 
-	std::string const& name = m_sources.sources.begin()->first;
-	std::string const& source = m_sources.sources.begin()->second;
-
-	ErrorList errorList{};
-	soltestAssert(m_dialect, "");
-	// Silently ignoring the results.
-	yul::test::parse(source, *m_dialect, errorList);
-	for (auto const& error: errorList)
+	YulStack yulStack = parseYul(source);
+	for (auto const& error: yulStack.errors())
 	{
 		int locationStart = -1;
 		int locationEnd = -1;
@@ -63,21 +56,16 @@ void SyntaxTest::parseAndAnalyze()
 			error->type(),
 			error->errorId(),
 			errorMessage(*error),
-			name,
+			sourceUnitName,
 			locationStart,
 			locationEnd
 		});
 	}
-
 }
 
 SyntaxTest::SyntaxTest(std::string const& _filename, langutil::EVMVersion _evmVersion):
 	CommonSyntaxTest(_filename, _evmVersion)
 {
 	std::string dialectName = m_reader.stringSetting("dialect", "evm");
-	m_dialect = &dialect(
-		dialectName,
-		solidity::test::CommonOptions::get().evmVersion(),
-		solidity::test::CommonOptions::get().eofVersion()
-	);
+	soltestAssert(dialectName == "evm"); // We only have one dialect now
 }

--- a/test/libyul/SyntaxTest.h
+++ b/test/libyul/SyntaxTest.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include <test/CommonSyntaxTest.h>
-#include <libyul/Dialect.h>
 
 namespace solidity::yul::test
 {
@@ -37,9 +36,6 @@ public:
 	~SyntaxTest() override {}
 protected:
 	void parseAndAnalyze() override;
-
-private:
-	Dialect const* m_dialect = nullptr;
 };
 
 }

--- a/test/libyul/YulInterpreterTest.h
+++ b/test/libyul/YulInterpreterTest.h
@@ -22,8 +22,7 @@
 
 namespace solidity::yul
 {
-struct AsmAnalysisInfo;
-class AST;
+class Object;
 }
 
 namespace solidity::yul::test
@@ -42,11 +41,8 @@ public:
 	TestResult run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
 
 private:
-	bool parse(std::ostream& _stream, std::string const& _linePrefix, bool const _formatted);
-	std::string interpret();
+	std::string interpret(std::shared_ptr<Object const> const& _object);
 
-	std::shared_ptr<AST const> m_ast;
-	std::shared_ptr<AsmAnalysisInfo const> m_analysisInfo;
 	bool m_simulateExternalCallsToSelf = false;
 };
 

--- a/test/libyul/YulOptimizerTest.cpp
+++ b/test/libyul/YulOptimizerTest.cpp
@@ -26,6 +26,7 @@
 #include <libyul/Object.h>
 #include <libyul/AsmPrinter.h>
 #include <libyul/AST.h>
+#include <libyul/YulStack.h>
 
 #include <liblangutil/CharStreamProvider.h>
 #include <liblangutil/SourceReferenceFormatter.h>
@@ -56,24 +57,17 @@ YulOptimizerTest::YulOptimizerTest(std::string const& _filename):
 	m_source = m_reader.source();
 
 	auto dialectName = m_reader.stringSetting("dialect", "evm");
-	m_dialect = &dialect(
-		dialectName,
-		solidity::test::CommonOptions::get().evmVersion(),
-		solidity::test::CommonOptions::get().eofVersion()
-	);
+	soltestAssert(dialectName == "evm"); // We only have one dialect now
 
 	m_expectation = m_reader.simpleExpectations();
 }
 
 TestCase::TestResult YulOptimizerTest::run(std::ostream& _stream, std::string const& _linePrefix, bool const _formatted)
 {
-	std::tie(m_object, m_analysisInfo) = parse(_stream, _linePrefix, _formatted, m_source);
+	m_object = parse(_stream, _linePrefix, _formatted, m_source);
 	if (!m_object)
 		return TestResult::FatalError;
 
-	soltestAssert(m_dialect, "Dialect not set.");
-
-	m_object->analysisInfo = m_analysisInfo;
 	YulOptimizerTestCommon tester(m_object);
 	tester.setStep(m_optimizerStep);
 
@@ -91,7 +85,7 @@ TestCase::TestResult YulOptimizerTest::run(std::ostream& _stream, std::string co
 		printedOptimizedObject = optimizedObject->toString();
 
 	// Re-parse new code for compilability
-	if (!std::get<0>(parse(_stream, _linePrefix, _formatted, printedOptimizedObject)))
+	if (!parse(_stream, _linePrefix, _formatted, printedOptimizedObject))
 	{
 		util::AnsiColorized(_stream, _formatted, {util::formatting::BOLD, util::formatting::CYAN})
 			<< _linePrefix << "Result after the optimiser:" << std::endl;
@@ -104,25 +98,19 @@ TestCase::TestResult YulOptimizerTest::run(std::ostream& _stream, std::string co
 	return checkResult(_stream, _linePrefix, _formatted);
 }
 
-std::pair<std::shared_ptr<Object>, std::shared_ptr<AsmAnalysisInfo>> YulOptimizerTest::parse(
+std::shared_ptr<Object> YulOptimizerTest::parse(
 	std::ostream& _stream,
 	std::string const& _linePrefix,
 	bool const _formatted,
 	std::string const& _source
 )
 {
-	ErrorList errors;
-	soltestAssert(m_dialect, "");
-	std::shared_ptr<Object> object;
-	std::shared_ptr<AsmAnalysisInfo> analysisInfo;
-	std::tie(object, analysisInfo) = yul::test::parse(_source, *m_dialect, errors);
-	if (!object || !analysisInfo || Error::containsErrors(errors))
+	YulStack yulStack = parseYul(_source);
+	if (yulStack.hasErrors())
 	{
-		AnsiColorized(_stream, _formatted, {formatting::BOLD, formatting::RED}) << _linePrefix << "Error parsing source." << std::endl;
-		CharStream charStream(_source, "");
-		SourceReferenceFormatter{_stream, SingletonCharStreamProvider(charStream), true, false}
-			.printErrorInformation(errors);
-		return {};
+		printYulErrors(yulStack, _stream, _linePrefix, _formatted);
+		return nullptr;
 	}
-	return {std::move(object), std::move(analysisInfo)};
+
+	return yulStack.parserResult();
 }

--- a/test/libyul/YulOptimizerTest.cpp
+++ b/test/libyul/YulOptimizerTest.cpp
@@ -74,7 +74,7 @@ TestCase::TestResult YulOptimizerTest::run(std::ostream& _stream, std::string co
 	soltestAssert(m_dialect, "Dialect not set.");
 
 	m_object->analysisInfo = m_analysisInfo;
-	YulOptimizerTestCommon tester(m_object, *m_dialect);
+	YulOptimizerTestCommon tester(m_object);
 	tester.setStep(m_optimizerStep);
 
 	if (!tester.runStep())

--- a/test/libyul/YulOptimizerTest.h
+++ b/test/libyul/YulOptimizerTest.h
@@ -48,16 +48,16 @@ public:
 
 	TestResult run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
 private:
-	std::pair<std::shared_ptr<Object>, std::shared_ptr<AsmAnalysisInfo>> parse(
-		std::ostream& _stream, std::string const& _linePrefix, bool const _formatted, std::string const& _source
+	std::shared_ptr<Object> parse(
+		std::ostream& _stream,
+		std::string const& _linePrefix,
+		bool const _formatted,
+		std::string const& _source
 	);
 
 	std::string m_optimizerStep;
 
-	Dialect const* m_dialect = nullptr;
-
 	std::shared_ptr<Object> m_object;
-	std::shared_ptr<AsmAnalysisInfo> m_analysisInfo;
 };
 
 }

--- a/test/libyul/YulOptimizerTestCommon.h
+++ b/test/libyul/YulOptimizerTestCommon.h
@@ -30,7 +30,6 @@ namespace solidity::yul
 {
 struct AsmAnalysisInfo;
 class Object;
-class Dialect;
 class AST;
 }
 
@@ -39,10 +38,7 @@ namespace solidity::yul::test
 class YulOptimizerTestCommon
 {
 public:
-	explicit YulOptimizerTestCommon(
-		std::shared_ptr<Object const> _obj,
-		Dialect const& _dialect
-	);
+	explicit YulOptimizerTestCommon(std::shared_ptr<Object const> _obj);
 	/// Sets optimiser step to be run to @param
 	/// _optimiserStep.
 	void setStep(std::string const& _optimizerStep);
@@ -65,7 +61,6 @@ private:
 
 	std::string m_optimizerStep;
 
-	Dialect const* m_dialect = nullptr;
 	std::set<YulName> m_reservedIdentifiers;
 	std::unique_ptr<NameDispenser> m_nameDispenser;
 	std::unique_ptr<OptimiserStepContext> m_context;

--- a/test/tools/ossfuzz/yulProtoFuzzer.cpp
+++ b/test/tools/ossfuzz/yulProtoFuzzer.cpp
@@ -80,10 +80,7 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 
 	// TODO: Add EOF support
 	// Optimize
-	YulOptimizerTestCommon optimizerTest(
-		stack.parserResult(),
-		EVMDialect::strictAssemblyForEVMObjects(version, std::nullopt)
-	);
+	YulOptimizerTestCommon optimizerTest(stack.parserResult());
 	optimizerTest.setStep(optimizerTest.randomOptimiserStep(_input.step()));
 	auto const* astRoot = optimizerTest.run();
 	yulAssert(astRoot != nullptr, "Optimiser error.");

--- a/test/tools/ossfuzz/yulProto_diff_ossfuzz.cpp
+++ b/test/tools/ossfuzz/yulProto_diff_ossfuzz.cpp
@@ -99,10 +99,7 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 		return;
 
 	// TODO: Add EOF support
-	YulOptimizerTestCommon optimizerTest(
-		stack.parserResult(),
-		EVMDialect::strictAssemblyForEVMObjects(version, std::nullopt)
-	);
+	YulOptimizerTestCommon optimizerTest(stack.parserResult());
 	optimizerTest.setStep(optimizerTest.randomOptimiserStep(_input.step()));
 	auto const* astRoot = optimizerTest.run();
 	yulAssert(astRoot != nullptr, "Optimiser error.");


### PR DESCRIPTION
~Depends on #15610.~ Merged.

Just a test refactor in preparation for another PR.

Currently most Yul test suites use the `yul::test::parse()` helper, which has two overloads which do things in wildly inconsistent ways. One uses `YulStack` but assumes no errors and reports only the top-level AST. The other manually runs `ObjectParser` and does return errors and the whole `Object` but only runs analysis on the top-level AST ignoring the others.

On top of that neither of them really suits my needs, because they don't allow continuing the compilation after parsing. The PR replaces them with a new, more flexible, helper that returns `YulStack` instead. Then makes all test suites use it.

Also:
- Most suites do accept complete Yul objects thanks to these helpers but then proceed to silently ignore any sub-objects. I made them report an unimplemented feature instead.
- Many suites do not actually print Yul compilation errors and just say that compilation failed since they're not testing the parser and assume correctness of input files. I added a helper for easy reporting of errors and made all suites consistently use it (except for those doing Boost tests).
- I made all the suites assume the EVM dialect. We still technically have a `dialect` setting but there's only one dialect and passing it to `YulStack` is a bit of a hassle so not having to do that simplifies things a lot.