### PR TITLE
Remove request about deleting issue template notes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,8 +16,6 @@ assignees: ''
     - [Stack Overflow](https://ethereum.stackexchange.com/)
 - Ensure the issue isn't already reported.
 - The issue should be reproducible with the latest solidity version; however, this isn't a hard requirement and being reproducible with an older version is sufficient.
-
-*Delete the above section and the instructions in the sections below before submitting*
 -->
 
 ## Description

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,8 +18,6 @@ assignees: ''
 - Ensure the issue isn't already reported (check `feature` and `language design` labels).
 - If you feel uncertain about your feature request, perhaps it's better to open a language design or feedback forum thread via the issue selector, or by going to the forum directly.
     - [Solidity forum](https://forum.soliditylang.org/)
-
-*Delete the above section and the instructions in the sections below before submitting*
 -->
 
 ## Abstract


### PR DESCRIPTION
These notes are already commented out so there is no reason to request deleting it.