### PR TITLE
Yul: Change Dialect definition into a class.

### DIFF
--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -49,7 +49,7 @@ namespace solidity::yul
 {
 // Forward-declaration to <yul/AST.h>
 class AST;
-struct Dialect;
+class Dialect;
 }
 
 namespace solidity::frontend

--- a/libsolidity/ast/ASTAnnotations.h
+++ b/libsolidity/ast/ASTAnnotations.h
@@ -39,7 +39,7 @@ namespace solidity::yul
 {
 struct AsmAnalysisInfo;
 struct Identifier;
-struct Dialect;
+class Dialect;
 }
 
 namespace solidity::frontend

--- a/libyul/AST.h
+++ b/libyul/AST.h
@@ -37,7 +37,7 @@
 namespace solidity::yul
 {
 
-struct Dialect;
+class Dialect;
 
 struct NameWithDebugData { langutil::DebugData::ConstPtr debugData; YulName name; };
 using NameWithDebugDataList = std::vector<NameWithDebugData>;

--- a/libyul/AsmJsonConverter.h
+++ b/libyul/AsmJsonConverter.h
@@ -33,7 +33,7 @@
 namespace solidity::yul
 {
 
-struct Dialect;
+class Dialect;
 
 /**
  * Converter of the yul AST into JSON format

--- a/libyul/AsmJsonImporter.h
+++ b/libyul/AsmJsonImporter.h
@@ -32,7 +32,7 @@
 namespace solidity::yul
 {
 
-struct Dialect;
+class Dialect;
 
 /**
  * Component that imports an AST from json format to the internal format

--- a/libyul/AsmPrinter.h
+++ b/libyul/AsmPrinter.h
@@ -37,7 +37,7 @@
 namespace solidity::yul
 {
 
-struct Dialect;
+class Dialect;
 
 /**
  * Converts a parsed Yul AST into readable string representation.

--- a/libyul/ControlFlowSideEffectsCollector.h
+++ b/libyul/ControlFlowSideEffectsCollector.h
@@ -29,7 +29,7 @@
 namespace solidity::yul
 {
 
-struct Dialect;
+class Dialect;
 
 struct ControlFlowNode
 {

--- a/libyul/Dialect.h
+++ b/libyul/Dialect.h
@@ -57,8 +57,9 @@ struct BuiltinFunction
 	}
 };
 
-struct Dialect
+class Dialect
 {
+public:
 	/// Noncopiable.
 	Dialect(Dialect const&) = delete;
 	Dialect& operator=(Dialect const&) = delete;

--- a/libyul/Object.h
+++ b/libyul/Object.h
@@ -36,7 +36,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 struct AsmAnalysisInfo;
 
 using SourceNameMap = std::map<unsigned, std::shared_ptr<std::string const>>;

--- a/libyul/Utilities.h
+++ b/libyul/Utilities.h
@@ -30,7 +30,7 @@
 namespace solidity::yul
 {
 
-struct Dialect;
+class Dialect;
 class EVMDialect;
 struct BuiltinFunction;
 struct BuiltinFunctionForEVM;

--- a/libyul/backends/evm/ConstantOptimiser.h
+++ b/libyul/backends/evm/ConstantOptimiser.h
@@ -37,7 +37,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 class GasMeter;
 
 /**

--- a/libyul/optimiser/CommonSubexpressionEliminator.h
+++ b/libyul/optimiser/CommonSubexpressionEliminator.h
@@ -32,7 +32,7 @@
 namespace solidity::yul
 {
 
-struct Dialect;
+class Dialect;
 struct SideEffects;
 
 /**

--- a/libyul/optimiser/ControlFlowSimplifier.h
+++ b/libyul/optimiser/ControlFlowSimplifier.h
@@ -22,7 +22,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 struct OptimiserStepContext;
 
 /**

--- a/libyul/optimiser/DataFlowAnalyzer.h
+++ b/libyul/optimiser/DataFlowAnalyzer.h
@@ -37,7 +37,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 struct SideEffects;
 class KnowledgeBase;
 

--- a/libyul/optimiser/DeadCodeEliminator.h
+++ b/libyul/optimiser/DeadCodeEliminator.h
@@ -30,7 +30,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 struct OptimiserStepContext;
 
 /**

--- a/libyul/optimiser/Disambiguator.h
+++ b/libyul/optimiser/Disambiguator.h
@@ -31,7 +31,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 
 /**
  * Creates a copy of a Yul AST replacing all identifiers by unique names.

--- a/libyul/optimiser/ExpressionInliner.h
+++ b/libyul/optimiser/ExpressionInliner.h
@@ -29,7 +29,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 struct OptimiserStepContext;
 
 /**

--- a/libyul/optimiser/ExpressionSimplifier.h
+++ b/libyul/optimiser/ExpressionSimplifier.h
@@ -27,7 +27,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 struct OptimiserStepContext;
 
 /**

--- a/libyul/optimiser/ExpressionSplitter.h
+++ b/libyul/optimiser/ExpressionSplitter.h
@@ -31,7 +31,7 @@
 namespace solidity::yul
 {
 
-struct Dialect;
+class Dialect;
 struct OptimiserStepContext;
 
 /**

--- a/libyul/optimiser/FunctionCallFinder.h
+++ b/libyul/optimiser/FunctionCallFinder.h
@@ -28,7 +28,7 @@
 namespace solidity::yul
 {
 
-struct Dialect;
+class Dialect;
 
 /**
  * Finds all calls to a function of a given name using an ASTModifier.

--- a/libyul/optimiser/KnowledgeBase.h
+++ b/libyul/optimiser/KnowledgeBase.h
@@ -34,7 +34,7 @@
 namespace solidity::yul
 {
 
-struct Dialect;
+class Dialect;
 struct AssignedValue;
 
 /**

--- a/libyul/optimiser/Metrics.h
+++ b/libyul/optimiser/Metrics.h
@@ -27,7 +27,7 @@
 namespace solidity::yul
 {
 
-struct Dialect;
+class Dialect;
 class EVMDialect;
 
 /**

--- a/libyul/optimiser/NameDispenser.h
+++ b/libyul/optimiser/NameDispenser.h
@@ -28,7 +28,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 
 /**
  * Optimizer component that can be used to generate new names that

--- a/libyul/optimiser/NameDisplacer.h
+++ b/libyul/optimiser/NameDisplacer.h
@@ -29,7 +29,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 
 /**
  * Optimiser component that renames identifiers to free up certain names.

--- a/libyul/optimiser/NameSimplifier.h
+++ b/libyul/optimiser/NameSimplifier.h
@@ -30,7 +30,7 @@
 namespace solidity::yul
 {
 
-struct Dialect;
+class Dialect;
 
 /**
  * Pass to "simplify" all identifier names.

--- a/libyul/optimiser/OptimiserStep.h
+++ b/libyul/optimiser/OptimiserStep.h
@@ -27,7 +27,7 @@
 namespace solidity::yul
 {
 
-struct Dialect;
+class Dialect;
 struct Block;
 class NameDispenser;
 

--- a/libyul/optimiser/Semantics.h
+++ b/libyul/optimiser/Semantics.h
@@ -31,7 +31,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 
 /**
  * Specific AST walker that determines side-effect free-ness and movability of code.

--- a/libyul/optimiser/SimplificationRules.h
+++ b/libyul/optimiser/SimplificationRules.h
@@ -40,7 +40,7 @@
 namespace solidity::yul
 {
 struct AssignedValue;
-struct Dialect;
+class Dialect;
 class EVMDialect;
 class Pattern;
 

--- a/libyul/optimiser/StackCompressor.h
+++ b/libyul/optimiser/StackCompressor.h
@@ -29,7 +29,7 @@
 namespace solidity::yul
 {
 
-struct Dialect;
+class Dialect;
 class Object;
 struct FunctionDefinition;
 

--- a/libyul/optimiser/Suite.h
+++ b/libyul/optimiser/Suite.h
@@ -36,7 +36,7 @@ namespace solidity::yul
 {
 
 struct AsmAnalysisInfo;
-struct Dialect;
+class Dialect;
 class GasMeter;
 class Object;
 

--- a/libyul/optimiser/UnusedAssignEliminator.h
+++ b/libyul/optimiser/UnusedAssignEliminator.h
@@ -33,7 +33,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 
 /**
  * Optimiser component that removes assignments to variables that are not used

--- a/libyul/optimiser/UnusedPruner.h
+++ b/libyul/optimiser/UnusedPruner.h
@@ -30,7 +30,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 struct SideEffects;
 
 /**

--- a/libyul/optimiser/UnusedStoreBase.h
+++ b/libyul/optimiser/UnusedStoreBase.h
@@ -31,7 +31,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 
 /**
  * Base class for both UnusedAssignEliminator and UnusedStoreEliminator.

--- a/libyul/optimiser/UnusedStoreEliminator.h
+++ b/libyul/optimiser/UnusedStoreEliminator.h
@@ -36,7 +36,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 struct AssignedValue;
 
 /**

--- a/libyul/optimiser/VarNameCleaner.h
+++ b/libyul/optimiser/VarNameCleaner.h
@@ -31,7 +31,7 @@
 namespace solidity::yul
 {
 
-struct Dialect;
+class Dialect;
 
 /**
  * Pass to normalize identifier suffixes.

--- a/test/libyul/Common.h
+++ b/test/libyul/Common.h
@@ -38,7 +38,7 @@ namespace solidity::yul
 struct AsmAnalysisInfo;
 struct Block;
 class Object;
-struct Dialect;
+class Dialect;
 class AST;
 }
 

--- a/test/libyul/ControlFlowGraphTest.h
+++ b/test/libyul/ControlFlowGraphTest.h
@@ -22,7 +22,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 
 namespace test
 {

--- a/test/libyul/SSAControlFlowGraphTest.h
+++ b/test/libyul/SSAControlFlowGraphTest.h
@@ -24,7 +24,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 
 namespace test
 {

--- a/test/libyul/StackLayoutGeneratorTest.h
+++ b/test/libyul/StackLayoutGeneratorTest.h
@@ -22,7 +22,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 
 namespace test
 {

--- a/test/libyul/YulOptimizerTest.h
+++ b/test/libyul/YulOptimizerTest.h
@@ -30,7 +30,7 @@ namespace solidity::yul
 {
 struct AsmAnalysisInfo;
 class Object;
-struct Dialect;
+class Dialect;
 }
 
 namespace solidity::yul::test

--- a/test/libyul/YulOptimizerTestCommon.h
+++ b/test/libyul/YulOptimizerTestCommon.h
@@ -30,7 +30,7 @@ namespace solidity::yul
 {
 struct AsmAnalysisInfo;
 class Object;
-struct Dialect;
+class Dialect;
 class AST;
 }
 

--- a/test/tools/yulInterpreter/Interpreter.h
+++ b/test/tools/yulInterpreter/Interpreter.h
@@ -35,7 +35,7 @@
 
 namespace solidity::yul
 {
-struct Dialect;
+class Dialect;
 }
 
 namespace solidity::yul::test

--- a/tools/yulPhaser/Program.h
+++ b/tools/yulPhaser/Program.h
@@ -43,7 +43,7 @@ namespace solidity::yul
 {
 
 struct AsmAnalysisInfo;
-struct Dialect;
+class Dialect;
 struct CodeWeights;
 
 }


### PR DESCRIPTION
Changes Yul dialect from `struct` to `class` to be consistent with `EVMDialect`. Follow-up of PR #15347.