### PR TITLE
Add test::CommonOptions::evmDialect method

### DIFF
--- a/test/Common.cpp
+++ b/test/Common.cpp
@@ -16,18 +16,24 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
-#include <stdexcept>
-#include <iostream>
 #include <test/Common.h>
+
 #include <test/EVMHost.h>
 #include <test/libsolidity/util/SoltestErrors.h>
 
+#include <libyul/backends/evm/EVMDialect.h>
+
 #include <libsolutil/Assertions.h>
 #include <libsolutil/StringUtils.h>
+
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
+
 #include <range/v3/all.hpp>
+
+#include <iostream>
+#include <stdexcept>
 
 namespace fs = boost::filesystem;
 namespace po = boost::program_options;
@@ -259,6 +265,12 @@ langutil::EVMVersion CommonOptions::evmVersion() const
 	else
 		return langutil::EVMVersion();
 }
+
+yul::EVMDialect const& CommonOptions::evmDialect() const
+{
+	return yul::EVMDialect::strictAssemblyForEVMObjects(evmVersion(), eofVersion());
+}
+
 
 CommonOptions const& CommonOptions::get()
 {

--- a/test/Common.h
+++ b/test/Common.h
@@ -29,6 +29,11 @@
 #include <boost/program_options.hpp>
 #include <boost/test/unit_test.hpp>
 
+namespace solidity::yul
+{
+class EVMDialect;
+}
+
 namespace solidity::test
 {
 
@@ -66,6 +71,7 @@ struct CommonOptions
 
 	langutil::EVMVersion evmVersion() const;
 	std::optional<uint8_t> eofVersion() const { return m_eofVersion; }
+	yul::EVMDialect const& evmDialect() const;
 
 	virtual void addOptions();
 	// @returns true if the program should continue, false if it should exit immediately without

--- a/test/libsolidity/MemoryGuardTest.cpp
+++ b/test/libsolidity/MemoryGuardTest.cpp
@@ -59,7 +59,7 @@ TestCase::TestResult MemoryGuardTest::run(std::ostream& _stream, std::string con
 	m_obtainedResult.clear();
 	for (std::string contractName: compiler().contractNames())
 	{
-		auto const& dialect = EVMDialect::strictAssemblyForEVMObjects(CommonOptions::get().evmVersion(), CommonOptions::get().eofVersion());
+		auto const& dialect = CommonOptions::get().evmDialect();
 		ErrorList errors;
 		std::optional<std::string> const& ir = compiler().yulIR(contractName);
 		solAssert(ir);

--- a/test/libyul/ControlFlowSideEffectsTest.cpp
+++ b/test/libyul/ControlFlowSideEffectsTest.cpp
@@ -28,6 +28,7 @@
 #include <libyul/backends/evm/EVMDialect.h>
 
 using namespace solidity;
+using namespace solidity::test;
 using namespace solidity::yul;
 using namespace solidity::yul::test;
 using namespace solidity::frontend::test;
@@ -56,12 +57,9 @@ ControlFlowSideEffectsTest::ControlFlowSideEffectsTest(std::string const& _filen
 
 TestCase::TestResult ControlFlowSideEffectsTest::run(std::ostream& _stream, std::string const& _linePrefix, bool _formatted)
 {
-	auto const& dialect = EVMDialect::strictAssemblyForEVMObjects(
-		solidity::test::CommonOptions::get().evmVersion(),
-		solidity::test::CommonOptions::get().eofVersion()
-	);
+	auto const& dialect = CommonOptions::get().evmDialect();
 	Object obj;
-	auto parsingResult = yul::test::parse(m_source);
+	auto parsingResult = parse(m_source);
 	obj.setCode(parsingResult.first, parsingResult.second);
 	if (!obj.hasCode())
 		BOOST_THROW_EXCEPTION(std::runtime_error("Parsing input failed."));

--- a/test/libyul/EVMCodeTransformTest.cpp
+++ b/test/libyul/EVMCodeTransformTest.cpp
@@ -32,6 +32,7 @@
 #include <libsolutil/AnsiColorized.h>
 
 using namespace solidity;
+using namespace solidity::test;
 using namespace solidity::util;
 using namespace solidity::langutil;
 using namespace solidity::yul;
@@ -67,13 +68,12 @@ TestCase::TestResult EVMCodeTransformTest::run(std::ostream& _stream, std::strin
 		return TestResult::FatalError;
 	}
 
-	evmasm::Assembly assembly{solidity::test::CommonOptions::get().evmVersion(), false, std::nullopt, {}};
+	evmasm::Assembly assembly{CommonOptions::get().evmVersion(), false, std::nullopt, {}};
 	EthAssemblyAdapter adapter(assembly);
 	EVMObjectCompiler::compile(
 		*stack.parserResult(),
 		adapter,
-		EVMDialect::strictAssemblyForEVMObjects(solidity::test::CommonOptions::get().evmVersion(),
-			solidity::test::CommonOptions::get().eofVersion()),
+		CommonOptions::get().evmDialect(),
 		m_stackOpt,
 		std::nullopt
 	);

--- a/test/libyul/FunctionSideEffects.cpp
+++ b/test/libyul/FunctionSideEffects.cpp
@@ -35,6 +35,7 @@
 
 
 using namespace solidity;
+using namespace solidity::test;
 using namespace solidity::util;
 using namespace solidity::langutil;
 using namespace solidity::yul;
@@ -83,12 +84,9 @@ FunctionSideEffects::FunctionSideEffects(std::string const& _filename):
 
 TestCase::TestResult FunctionSideEffects::run(std::ostream& _stream, std::string const& _linePrefix, bool _formatted)
 {
-	auto const& dialect = EVMDialect::strictAssemblyForEVMObjects(
-		solidity::test::CommonOptions::get().evmVersion(),
-		solidity::test::CommonOptions::get().eofVersion()
-	);
+	auto const& dialect = CommonOptions::get().evmDialect();
 	Object obj;
-	auto parsingResult = yul::test::parse(m_source);
+	auto parsingResult = parse(m_source);
 	obj.setCode(parsingResult.first, parsingResult.second);
 	if (!obj.hasCode())
 		BOOST_THROW_EXCEPTION(std::runtime_error("Parsing input failed."));

--- a/test/libyul/StackShufflingTest.cpp
+++ b/test/libyul/StackShufflingTest.cpp
@@ -25,6 +25,7 @@
 #include <liblangutil/Scanner.h>
 #include <libsolutil/AnsiColorized.h>
 
+using namespace solidity::test;
 using namespace solidity::util;
 using namespace solidity::langutil;
 using namespace solidity::yul;
@@ -141,10 +142,7 @@ StackShufflingTest::StackShufflingTest(std::string const& _filename):
 
 TestCase::TestResult StackShufflingTest::run(std::ostream& _stream, std::string const& _linePrefix, bool _formatted)
 {
-	auto const& dialect = EVMDialect::strictAssemblyForEVMObjects(
-		solidity::test::CommonOptions::get().evmVersion(),
-		solidity::test::CommonOptions::get().eofVersion()
-	);
+	auto const& dialect = CommonOptions::get().evmDialect();
 	if (!parse(m_source))
 	{
 		AnsiColorized(_stream, _formatted, {formatting::BOLD, formatting::RED}) << _linePrefix << "Error parsing source." << std::endl;

--- a/test/libyul/YulInterpreterTest.cpp
+++ b/test/libyul/YulInterpreterTest.cpp
@@ -39,6 +39,7 @@
 #include <fstream>
 
 using namespace solidity;
+using namespace solidity::test;
 using namespace solidity::util;
 using namespace solidity::langutil;
 using namespace solidity::yul;
@@ -67,10 +68,10 @@ TestCase::TestResult YulInterpreterTest::run(std::ostream& _stream, std::string 
 bool YulInterpreterTest::parse(std::ostream& _stream, std::string const& _linePrefix, bool const _formatted)
 {
 	YulStack stack(
-		solidity::test::CommonOptions::get().evmVersion(),
-		solidity::test::CommonOptions::get().eofVersion(),
+		CommonOptions::get().evmVersion(),
+		CommonOptions::get().eofVersion(),
 		YulStack::Language::StrictAssembly,
-		solidity::frontend::OptimiserSettings::none(),
+		OptimiserSettings::none(),
 		DebugInfoSelection::All()
 	);
 	if (stack.parseAndAnalyze("", m_source))
@@ -98,8 +99,7 @@ std::string YulInterpreterTest::interpret()
 	{
 		Interpreter::run(
 			state,
-			EVMDialect::strictAssemblyForEVMObjects(solidity::test::CommonOptions::get().evmVersion(),
-				solidity::test::CommonOptions::get().eofVersion()),
+			CommonOptions::get().evmDialect(),
 			m_ast->root(),
 			/*disableExternalCalls=*/ !m_simulateExternalCallsToSelf,
 			/*disableMemoryTracing=*/ false


### PR DESCRIPTION
to replace the

```cpp
auto const& dialect = EVMDialect::strictAssemblyForEVMObjects(
    solidity::test::CommonOptions::get().evmVersion(),
    solidity::test::CommonOptions::get().eofVersion()
);
```

pattern.

Follow-up of PR #15347