### PR TITLE
Don't ignore errors reported after analysis

### DIFF
--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -419,6 +419,7 @@ bool CompilerStack::parse()
 	catch (UnimplementedFeatureError const& _error)
 	{
 		reportUnimplementedFeatureError(_error);
+		return false;
 	}
 
 	return true;

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -784,14 +784,17 @@ bool CompilerStack::compile(State _stopAfter)
 						// but CodeGenerationError is one case where someone decided to just throw Error.
 						solAssert(_error.type() == Error::Type::CodeGenerationError);
 						m_errorReporter.error(_error.errorId(), _error.type(), SourceLocation(), _error.what());
-						return false;
 					}
 					catch (UnimplementedFeatureError const& _error)
 					{
 						reportUnimplementedFeatureError(_error);
-						return false;
 					}
+
+					if (m_errorReporter.hasErrors())
+						return false;
 				}
+
+	solAssert(!m_errorReporter.hasErrors());
 	m_stackState = CompilationSuccessful;
 	this->link();
 	return true;
@@ -1611,6 +1614,14 @@ void CompilerStack::generateEVMFromIR(ContractDefinition const& _contract)
 	std::string deployedName = IRNames::deployedObject(_contract);
 	solAssert(!deployedName.empty(), "");
 	tie(compiledContract.evmAssembly, compiledContract.evmRuntimeAssembly) = stack.assembleEVMWithDeployed(deployedName);
+
+	if (stack.hasErrors())
+	{
+		for (std::shared_ptr<Error const> const& error: stack.errors())
+			reportIRPostAnalysisError(error.get());
+		return;
+	}
+
 	assembleYul(_contract, compiledContract.evmAssembly, compiledContract.evmRuntimeAssembly);
 }
 
@@ -2005,6 +2016,27 @@ experimental::Analysis const& CompilerStack::experimentalAnalysis() const
 
 void CompilerStack::reportUnimplementedFeatureError(UnimplementedFeatureError const& _error)
 {
-	solAssert(_error.comment(), "Unimplemented feature errors must include a message for the user");
+	solAssert(_error.comment(), "Errors must include a message for the user.");
+
 	m_errorReporter.unimplementedFeatureError(1834_error, _error.sourceLocation(), *_error.comment());
+}
+
+void CompilerStack::reportIRPostAnalysisError(Error const* _error)
+{
+	solAssert(_error);
+	solAssert(_error->comment(), "Errors must include a message for the user.");
+	solAssert(!_error->secondarySourceLocation());
+
+	// Do not report Yul warnings and infos. These are only reported in pure Yul compilation.
+	if (!Error::isError(_error->severity()))
+		return;
+
+	m_errorReporter.error(
+		_error->errorId(),
+		_error->type(),
+		// Ignore the original location. It's likely missing, but even if not, it points at Yul source.
+		// CompilerStack can only point at locations in Solidity sources.
+		SourceLocation{},
+		*_error->comment()
+	);
 }

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -579,6 +579,7 @@ private:
 	) const;
 
 	void reportUnimplementedFeatureError(langutil::UnimplementedFeatureError const& _error);
+	void reportIRPostAnalysisError(langutil::Error const* _error);
 
 	ReadCallback::Callback m_readFile;
 	OptimiserSettings m_optimiserSettings;

--- a/libyul/YulStack.cpp
+++ b/libyul/YulStack.cpp
@@ -62,6 +62,7 @@ bool YulStack::parse(std::string const& _sourceName, std::string const& _source)
 	catch (UnimplementedFeatureError const& _error)
 	{
 		reportUnimplementedFeatureError(_error);
+		return false;
 	}
 
 	if (!m_errorReporter.hasErrors())

--- a/libyul/YulStack.cpp
+++ b/libyul/YulStack.cpp
@@ -249,9 +249,14 @@ MachineAssemblyObject YulStack::assemble(Machine _machine)
 std::pair<MachineAssemblyObject, MachineAssemblyObject>
 YulStack::assembleWithDeployed(std::optional<std::string_view> _deployName)
 {
+	yulAssert(m_charStream);
+
 	auto [creationAssembly, deployedAssembly] = assembleEVMWithDeployed(_deployName);
-	yulAssert(creationAssembly, "");
-	yulAssert(m_charStream, "");
+	if (!creationAssembly)
+	{
+		yulAssert(!deployedAssembly);
+		return {MachineAssemblyObject{}, MachineAssemblyObject{}};
+	}
 
 	MachineAssemblyObject creationObject;
 	MachineAssemblyObject deployedObject;
@@ -285,6 +290,7 @@ YulStack::assembleWithDeployed(std::optional<std::string_view> _deployName)
 	catch (UnimplementedFeatureError const& _error)
 	{
 		reportUnimplementedFeatureError(_error);
+		return {MachineAssemblyObject{}, MachineAssemblyObject{}};
 	}
 
 	return {std::move(creationObject), std::move(deployedObject)};
@@ -341,9 +347,10 @@ YulStack::assembleEVMWithDeployed(std::optional<std::string_view> _deployName)
 	catch (UnimplementedFeatureError const& _error)
 	{
 		reportUnimplementedFeatureError(_error);
+		return {nullptr, nullptr};
 	}
 
-	return {std::make_shared<evmasm::Assembly>(assembly), {}};
+	return {std::make_shared<evmasm::Assembly>(assembly), nullptr};
 }
 
 std::string YulStack::print() const
@@ -415,6 +422,6 @@ std::shared_ptr<Object> YulStack::parserResult() const
 
 void YulStack::reportUnimplementedFeatureError(UnimplementedFeatureError const& _error)
 {
-	solAssert(_error.comment(), "Unimplemented feature errors must include a message for the user");
+	yulAssert(_error.comment(), "Errors must include a message for the user.");
 	m_errorReporter.unimplementedFeatureError(1920_error, _error.sourceLocation(), *_error.comment());
 }


### PR DESCRIPTION
Follow-up to #15168.

Originally this was a part of #15610, but I decided to extract it because it's really an issue of its own, even though before #15610 we weren't throwing any errors that could trigger it.

The issue is that CLI and Standard JSON interface don't check for errors after analysis and just happily proceed with assembling. `CompilerStack` also makes the same mistake when using `YulStack` internally. As a result, if an `UnimplementedFeatureError` were to be reported it would be ignored and we'd report empty bytecode, or run into an assertion/segfault in the process.

In addition to that `UnimplementedFeatureError`s caught during parsing were not reported as a parsing failure.