### PR TITLE
eof: Fix immutables

### DIFF
--- a/libsolidity/codegen/ir/IRGenerationContext.h
+++ b/libsolidity/codegen/ir/IRGenerationContext.h
@@ -165,6 +165,19 @@ public:
 
 	langutil::DebugInfoSelection debugInfoSelection() const { return m_debugInfoSelection; }
 	langutil::CharStreamProvider const* soliditySourceProvider() const { return m_soliditySourceProvider; }
+	std::map<VariableDeclaration const*, size_t> const& immutableVariables() const { return m_immutableVariables; }
+	void setImmutableVariables(std::map<VariableDeclaration const*, size_t> _immutableVariables)
+	{
+		solAssert(m_eofVersion.has_value());
+		solAssert(m_executionContext == ExecutionContext::Deployed);
+		m_immutableVariables = std::move(_immutableVariables);
+	}
+	void setLibraryAddressImmutableOffset(size_t _libraryAddressImmutableOffset)
+	{
+		solAssert(m_eofVersion.has_value());
+		solAssert(m_executionContext == ExecutionContext::Deployed);
+		m_libraryAddressImmutableOffset = _libraryAddressImmutableOffset;
+	}
 
 private:
 	langutil::EVMVersion m_evmVersion;
@@ -176,7 +189,7 @@ private:
 	ContractDefinition const* m_mostDerivedContract = nullptr;
 	std::map<VariableDeclaration const*, IRVariable> m_localVariables;
 	/// Memory offsets reserved for the values of immutable variables during contract creation.
-	/// This map is empty in the runtime context.
+	/// This map is empty in the legacy runtime context and may be not empty in EOF runtime context.
 	std::map<VariableDeclaration const*, size_t> m_immutableVariables;
 	std::optional<size_t> m_libraryAddressImmutableOffset;
 	/// Total amount of reserved memory. Reserved memory is used to store

--- a/test/libsolidity/semanticTests/immutable/stub.sol
+++ b/test/libsolidity/semanticTests/immutable/stub.sol
@@ -9,5 +9,7 @@ contract C {
 		return (x+x,y);
 	}
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // f() -> 84, 23

--- a/test/libyul/yulSyntaxTests/eof/callf_jumpf_retf.yul
+++ b/test/libyul/yulSyntaxTests/eof/callf_jumpf_retf.yul
@@ -5,6 +5,8 @@ object "a" {
         retf()
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // DeclarationError 4619: (32-37): Function "callf" not found.
 // DeclarationError 4619: (48-53): Function "jumpf" not found.


### PR DESCRIPTION
Fix immutables bug. EOF implementation needs to have `m_immutbalesVariables` and `m_libraryAddressOffset` members of `IRGenerationContext` properly initialized because their values contains offsets to immutables variables values in EOF data section and they are needed when generating `Deployed` container.

Enable one semantic test which failed before the fix

~Depends on #15626~. Merged.
~Depends on #15635~. Merged.
Closes #15606.