### PR TITLE
eof: Fix legacy `create2` and `extcodehash` error for EOF

### DIFF
--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -783,10 +783,12 @@ bool AsmAnalyzer::validateInstructions(evmasm::Instruction _instr, SourceLocatio
 		_instr == evmasm::Instruction::JUMPI ||
 		_instr == evmasm::Instruction::PC ||
 		_instr == evmasm::Instruction::CREATE ||
+		_instr == evmasm::Instruction::CREATE2 ||
 		_instr == evmasm::Instruction::CODESIZE ||
 		_instr == evmasm::Instruction::CODECOPY ||
 		_instr == evmasm::Instruction::EXTCODESIZE ||
 		_instr == evmasm::Instruction::EXTCODECOPY ||
+		_instr == evmasm::Instruction::EXTCODEHASH ||
 		_instr == evmasm::Instruction::GAS
 	))
 	{

--- a/test/libyul/yulSyntaxTests/eof/create2_in_eof.yul
+++ b/test/libyul/yulSyntaxTests/eof/create2_in_eof.yul
@@ -1,0 +1,11 @@
+object "a" {
+    code {
+        pop(create2(0, 0, 0, 0))
+    }
+}
+
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// TypeError 9132: (36-43): The "create2" instruction is only available in legacy bytecode VMs (you are currently compiling to EOF).
+// TypeError 3950: (36-55): Expected expression to evaluate to one value, but got 0 values instead.

--- a/test/libyul/yulSyntaxTests/eof/extcodehash_in_eof.yul
+++ b/test/libyul/yulSyntaxTests/eof/extcodehash_in_eof.yul
@@ -1,0 +1,11 @@
+object "a" {
+    code {
+        pop(extcodehash(0))
+    }
+}
+
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// TypeError 9132: (36-47): The "extcodehash" instruction is only available in legacy bytecode VMs (you are currently compiling to EOF).
+// TypeError 3950: (36-50): Expected expression to evaluate to one value, but got 0 values instead.


### PR DESCRIPTION
Fix errors for two forgotten opcodes which are deprecated in EOF.