### PR TITLE
Fix tests with byzantium and homestead

### DIFF
--- a/libyul/YulStack.cpp
+++ b/libyul/YulStack.cpp
@@ -192,19 +192,7 @@ bool YulStack::analyzeParsed(Object& _object)
 
 void YulStack::compileEVM(AbstractAssembly& _assembly, bool _optimize) const
 {
-	EVMDialect const* dialect = nullptr;
-	switch (m_language)
-	{
-		case Language::Assembly:
-		case Language::StrictAssembly:
-			dialect = &EVMDialect::strictAssemblyForEVMObjects(m_evmVersion, m_eofVersion);
-			break;
-		default:
-			yulAssert(false, "Invalid language.");
-			break;
-	}
-
-	EVMObjectCompiler::compile(*m_parserResult, _assembly, *dialect, _optimize, m_eofVersion);
+	EVMObjectCompiler::compile(*m_parserResult, _assembly, _optimize);
 }
 
 void YulStack::reparse()

--- a/libyul/backends/evm/ConstantOptimiser.cpp
+++ b/libyul/backends/evm/ConstantOptimiser.cpp
@@ -126,7 +126,6 @@ Representation const& RepresentationFinder::findRepresentation(u256 const& _valu
 		return m_cache.at(_value);
 
 	yulAssert(m_dialect.auxiliaryBuiltinHandles().not_);
-	yulAssert(m_dialect.auxiliaryBuiltinHandles().shl);
 	yulAssert(m_dialect.auxiliaryBuiltinHandles().exp);
 	yulAssert(m_dialect.auxiliaryBuiltinHandles().mul);
 	yulAssert(m_dialect.auxiliaryBuiltinHandles().add);

--- a/libyul/backends/evm/EVMObjectCompiler.h
+++ b/libyul/backends/evm/EVMObjectCompiler.h
@@ -36,20 +36,14 @@ public:
 	static void compile(
 		Object const& _object,
 		AbstractAssembly& _assembly,
-		EVMDialect const& _dialect,
-		bool _optimize,
-		std::optional<uint8_t> _eofVersion
+		bool _optimize
 	);
 private:
-	EVMObjectCompiler(AbstractAssembly& _assembly, EVMDialect const& _dialect, std::optional<uint8_t> _eofVersion):
-		m_assembly(_assembly), m_dialect(_dialect), m_eofVersion(_eofVersion)
-	{}
+	EVMObjectCompiler(AbstractAssembly& _assembly): m_assembly(_assembly) {}
 
 	void run(Object const& _object, bool _optimize);
 
 	AbstractAssembly& m_assembly;
-	EVMDialect const& m_dialect;
-	std::optional<uint8_t> m_eofVersion;
 };
 
 }

--- a/test/libyul/EVMCodeTransformTest.cpp
+++ b/test/libyul/EVMCodeTransformTest.cpp
@@ -46,6 +46,7 @@ EVMCodeTransformTest::EVMCodeTransformTest(std::string const& _filename):
 	m_source = m_reader.source();
 	m_stackOpt = m_reader.boolSetting("stackOptimization", false);
 	m_expectation = m_reader.simpleExpectations();
+	m_shouldRun = CommonOptions::get().evmDialect().evmVersion() == EVMVersion{};
 }
 
 TestCase::TestResult EVMCodeTransformTest::run(std::ostream& _stream, std::string const& _linePrefix, bool const _formatted)

--- a/test/libyul/EVMCodeTransformTest.cpp
+++ b/test/libyul/EVMCodeTransformTest.cpp
@@ -75,9 +75,7 @@ TestCase::TestResult EVMCodeTransformTest::run(std::ostream& _stream, std::strin
 	EVMObjectCompiler::compile(
 		*stack.parserResult(),
 		adapter,
-		*dynamic_cast<EVMDialect const*>(stack.parserResult()->dialect()),
-		m_stackOpt,
-		std::nullopt
+		m_stackOpt
 	);
 
 	std::ostringstream output;

--- a/test/libyul/EVMCodeTransformTest.cpp
+++ b/test/libyul/EVMCodeTransformTest.cpp
@@ -53,6 +53,8 @@ TestCase::TestResult EVMCodeTransformTest::run(std::ostream& _stream, std::strin
 	solidity::frontend::OptimiserSettings settings = solidity::frontend::OptimiserSettings::none();
 	settings.runYulOptimiser = false;
 	settings.optimizeStackAllocation = m_stackOpt;
+	// Restrict to a single EVM/EOF version combination (the default one) as code generation
+	// can be different from version to version.
 	YulStack stack(
 		EVMVersion{},
 		std::nullopt,
@@ -73,7 +75,7 @@ TestCase::TestResult EVMCodeTransformTest::run(std::ostream& _stream, std::strin
 	EVMObjectCompiler::compile(
 		*stack.parserResult(),
 		adapter,
-		CommonOptions::get().evmDialect(),
+		*dynamic_cast<EVMDialect const*>(stack.parserResult()->dialect()),
 		m_stackOpt,
 		std::nullopt
 	);


### PR DESCRIPTION
- Constant Optimizer: Do not assert for shl builtin, it is guarded by `dialect.evmVersion().hasBitwiseShifting()`.
- `EVMCodeTransformTest`s use defaulted evm dialect instead of test-configured one: there was a mismatch between the dialect configured in the test's `YulStack` and what was used in the test's `EVMObjectCompiler`, one using the defaulted (latest) version and one the test-configured one, respectively. Also some of the code generation tests fail for `byzantium` and `homestead` if configured with the same dialect. So for now I have reverted back to default. (@cameel @rodiazet)