### PR TITLE
eof: Temporarily disable assert verifying backward jumps in topologically-sorted code

### DIFF
--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -1019,8 +1019,9 @@ uint16_t calculateMaxStackHeight(Assembly::CodeSection const& _section)
 			auto const tagIt = std::find(items.begin(), items.end(), item.tag());
 			solAssert(tagIt != items.end(), "Tag not found.");
 			successors.emplace_back(static_cast<size_t>(std::distance(items.begin(), tagIt)));
+			// TODO: This assert fails until the code is not topologically sorted. Uncomment when sorting introduced.
 			// If backward jump the successor must be already visited.
-			solAssert(idx <= successors.back() || maxStackHeights[successors.back()] != UNVISITED);
+			// solAssert(idx <= successors.back() || maxStackHeights[successors.back()] != UNVISITED);
 		}
 
 		solRequire(


### PR DESCRIPTION
Allow backward jumps to unvisited Assembly item.