### PR TITLE
eof: Update subassembly link references in parent container

### DIFF
--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -1657,7 +1657,16 @@ LinkerObject const& Assembly::assembleEOF() const
 	}
 
 	for (auto i: referencedSubIds)
-		ret.bytecode += m_subs[i]->assemble().bytecode;
+	{
+		size_t const subAssemblyPostionInParentObject = ret.bytecode.size();
+		auto const& subAssemblyLinkerObject = m_subs[i]->assemble();
+		// Append subassembly bytecode to the parent assembly result bytecode
+		ret.bytecode += subAssemblyLinkerObject.bytecode;
+		// Add subassembly link references to parent linker object.
+		// Offset accordingly to subassembly position in parent object bytecode
+		for (auto const& [subAssemblyLinkRefPosition, linkRef]: subAssemblyLinkerObject.linkReferences)
+			ret.linkReferences[subAssemblyPostionInParentObject + subAssemblyLinkRefPosition] = linkRef;
+	}
 
 	// TODO: Fill functionDebugData for EOF. It probably should be handled for new code section in the loop above.
 	solRequire(m_namedTags.empty(), AssemblyException, "Named tags must be empty in EOF context.");

--- a/test/libsolidity/semanticTests/libraries/library_address.sol
+++ b/test/libsolidity/semanticTests/libraries/library_address.sol
@@ -36,6 +36,7 @@ contract C {
 }
 // ====
 // EVMVersion: >=byzantium
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // library: L
 // addr() -> false


### PR DESCRIPTION
- Add subassembly link references to parent linker object.
- Offset accordingly to subassembly position in parent object bytecode

~Depends on #15628~. Merged.
~Depends on #15633~. Merged.