### PR TITLE
eof: Fix stack height calculation for non-returning function.

### DIFF
--- a/libevmasm/Assembly.h
+++ b/libevmasm/Assembly.h
@@ -61,7 +61,7 @@ public:
 		m_name(std::move(_name))
 	{
 		// Code section number 0 has to be non-returning.
-		m_codeSections.emplace_back(CodeSection{0, 0x80, {}});
+		m_codeSections.emplace_back(CodeSection{0, 0, true, {}});
 	}
 
 	std::optional<uint8_t> eofVersion() const { return m_eofVersion; }
@@ -72,7 +72,7 @@ public:
 
 	AssemblyItem newFunctionCall(uint16_t _functionID) const;
 	AssemblyItem newFunctionReturn() const;
-	uint16_t createFunction(uint8_t _args, uint8_t _rets);
+	uint16_t createFunction(uint8_t _args, uint8_t _rets, bool _nonReturning);
 	void beginFunction(uint16_t _functionID);
 	void endFunction();
 
@@ -221,7 +221,10 @@ public:
 	struct CodeSection
 	{
 		uint8_t inputs = 0;
+		// Number of outputs needs to be set properly even for non-returning function.
+		// It matters in case of stack height calculation of the function call instruction.
 		uint8_t outputs = 0;
+		bool nonReturning = false;
 		AssemblyItems items{};
 	};
 

--- a/libevmasm/AssemblyItem.cpp
+++ b/libevmasm/AssemblyItem.cpp
@@ -249,7 +249,7 @@ size_t AssemblyItem::returnValues() const
 		return 1;
 	case JumpF:
 	case CallF:
-		return functionSignature().canContinue() ? functionSignature().retsNum : 0;
+		return functionSignature().retsNum;
 	case AssignImmutable:
 	case UndefinedItem:
 		break;

--- a/libevmasm/AssemblyItem.h
+++ b/libevmasm/AssemblyItem.h
@@ -120,7 +120,7 @@ public:
 	static AssemblyItem jumpToFunction(uint16_t _functionID, uint8_t _args, uint8_t _rets, langutil::DebugData::ConstPtr _debugData = langutil::DebugData::create())
 	{
 		AssemblyItem result(JumpF, Instruction::JUMPF, _functionID, _debugData);
-		solAssert(_args <= 127 && _rets <= 128);
+		solAssert(_args <= 127 && _rets <= 127);
 		result.m_functionSignature = {_args, _rets};
 		return result;
 	}
@@ -292,12 +292,10 @@ public:
 
 	struct FunctionSignature
 	{
-		/// Number of EOF function arguments. must be less than 127
+		/// Number of EOF function arguments. must be less than 128
 		uint8_t argsNum;
-		/// Number of EOF function return values. Must be less than 128. 128(0x80) means that it's non-returning.
+		/// Number of EOF function return values. Must be less than 128.
 		uint8_t retsNum;
-
-		bool canContinue() const { return retsNum != 0x80;}
 	};
 
 	FunctionSignature const& functionSignature() const

--- a/libyul/backends/evm/AbstractAssembly.h
+++ b/libyul/backends/evm/AbstractAssembly.h
@@ -105,7 +105,8 @@ public:
 
 	/// Registers a new function with given signature and returns its ID.
 	/// The function is initially empty and its body must be filled with instructions.
-	virtual FunctionID registerFunction(uint8_t _args, uint8_t _rets) = 0;
+	/// `_rets` even for non-returning function matters in case of stack height calculation.
+	virtual FunctionID registerFunction(uint8_t _args, uint8_t _rets, bool _nonReturning) = 0;
 	/// Selects a function as a target for newly appended instructions.
 	/// May only be called after the main code section is already filled and
 	/// must not be called when another function is already selected.

--- a/libyul/backends/evm/EthAssemblyAdapter.cpp
+++ b/libyul/backends/evm/EthAssemblyAdapter.cpp
@@ -145,9 +145,9 @@ std::pair<std::shared_ptr<AbstractAssembly>, AbstractAssembly::SubID> EthAssembl
 	return {std::make_shared<EthAssemblyAdapter>(*assembly), static_cast<size_t>(sub.data())};
 }
 
-AbstractAssembly::FunctionID EthAssemblyAdapter::registerFunction(uint8_t _args, uint8_t _rets)
+AbstractAssembly::FunctionID EthAssemblyAdapter::registerFunction(uint8_t _args, uint8_t _rets, bool _nonReturning)
 {
-	return m_assembly.createFunction(_args, _rets);
+	return m_assembly.createFunction(_args, _rets, _nonReturning);
 }
 
 void EthAssemblyAdapter::beginFunction(AbstractAssembly::FunctionID _functionID)

--- a/libyul/backends/evm/EthAssemblyAdapter.h
+++ b/libyul/backends/evm/EthAssemblyAdapter.h
@@ -56,7 +56,7 @@ public:
 	void appendJumpToIf(LabelID _labelId, JumpType _jumpType) override;
 	void appendAssemblySize() override;
 	std::pair<std::shared_ptr<AbstractAssembly>, SubID> createSubAssembly(bool _creation, std::string _name = {}) override;
-	AbstractAssembly::FunctionID registerFunction(uint8_t _args, uint8_t _rets) override;
+	AbstractAssembly::FunctionID registerFunction(uint8_t _args, uint8_t _rets, bool _nonReturning) override;
 	void beginFunction(AbstractAssembly::FunctionID _functionID) override;
 	void endFunction() override;
 	void appendFunctionCall(FunctionID _functionID) override;

--- a/libyul/backends/evm/NoOutputAssembly.cpp
+++ b/libyul/backends/evm/NoOutputAssembly.cpp
@@ -148,6 +148,7 @@ void NoOutputAssembly::appendFunctionCall(FunctionID _functionID)
 {
 	auto [args, rets] = m_context.functionSignatures.at(_functionID);
 	m_stackHeight += static_cast<int>(rets) - static_cast<int>(args);
+	solAssert(m_stackHeight >= 0);
 }
 
 void NoOutputAssembly::appendFunctionReturn()

--- a/libyul/backends/evm/NoOutputAssembly.cpp
+++ b/libyul/backends/evm/NoOutputAssembly.cpp
@@ -120,11 +120,11 @@ std::pair<std::shared_ptr<AbstractAssembly>, AbstractAssembly::SubID> NoOutputAs
 	return {};
 }
 
-AbstractAssembly::FunctionID NoOutputAssembly::registerFunction(uint8_t _args, uint8_t _rets)
+AbstractAssembly::FunctionID NoOutputAssembly::registerFunction(uint8_t _args, uint8_t _rets, bool)
 {
 	yulAssert(m_context.numFunctions <= std::numeric_limits<AbstractAssembly::FunctionID>::max());
 	AbstractAssembly::FunctionID id = static_cast<AbstractAssembly::FunctionID>(m_context.numFunctions++);
-	m_context.functionSignatures[id] = std::make_pair(_args, _rets);
+	m_context.functionSignatures[id] = {_args, _rets};
 	return id;
 }
 
@@ -139,8 +139,8 @@ void NoOutputAssembly::beginFunction(FunctionID _functionID)
 void NoOutputAssembly::endFunction()
 {
 	yulAssert(m_currentFunctionID != 0, "End function without begin function.");
-	auto const rets = m_context.functionSignatures.at(m_currentFunctionID).second;
-	yulAssert(rets == 0x80 || m_stackHeight == rets, "Stack height mismatch at function end.");
+	auto const [_, rets] = m_context.functionSignatures.at(m_currentFunctionID);
+	yulAssert(m_stackHeight == rets, "Stack height mismatch at function end.");
 	m_currentFunctionID = 0;
 }
 
@@ -153,8 +153,8 @@ void NoOutputAssembly::appendFunctionCall(FunctionID _functionID)
 void NoOutputAssembly::appendFunctionReturn()
 {
 	yulAssert(m_currentFunctionID != 0, "End function without begin function.");
-	auto const rets = m_context.functionSignatures.at(m_currentFunctionID).second;
-	yulAssert(rets == 0x80 || m_stackHeight == rets, "Stack height mismatch at function end.");
+	auto const [_, rets] = m_context.functionSignatures.at(m_currentFunctionID);
+	yulAssert(m_stackHeight == rets, "Stack height mismatch at function end.");
 }
 
 void NoOutputAssembly::appendDataOffset(std::vector<AbstractAssembly::SubID> const&)

--- a/libyul/backends/evm/NoOutputAssembly.h
+++ b/libyul/backends/evm/NoOutputAssembly.h
@@ -73,7 +73,7 @@ public:
 
 	void appendAssemblySize() override;
 	std::pair<std::shared_ptr<AbstractAssembly>, SubID> createSubAssembly(bool _creation, std::string _name = "") override;
-	FunctionID registerFunction(uint8_t _args, uint8_t _rets) override;
+	FunctionID registerFunction(uint8_t _args, uint8_t _rets, bool _nonReturning) override;
 	void beginFunction(FunctionID) override;
 	void endFunction() override;
 	void appendFunctionCall(FunctionID _functionID) override;

--- a/test/libsolidity/semanticTests/inlineAssembly/inline_assembly_in_modifiers.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/inline_assembly_in_modifiers.sol
@@ -27,6 +27,8 @@ contract C {
         return true;
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // f() -> true
 // g() -> FAILURE


### PR DESCRIPTION
`OptimizedEVMCodeTransform` requires `Assembly` stack height for non-returning function call to be equal to `rets-args`. For EVM `Assembly` for EOF it's calculated based on `CodeSection` inputs and outputs. It means that we need to store number of rets for a code section equal to number of return values based in function declaration. Additional flag `canContinue` is needed to properly generate code section type in EOF container and to decide if we should use JumpF or CallF when creating AssemblyItem for the function call. 

~Depends on #15635~. Merged.