### PR TITLE
eof: Fix constructor argument copying for EOF

### DIFF
--- a/libsolidity/codegen/ABIFunctions.h
+++ b/libsolidity/codegen/ABIFunctions.h
@@ -56,13 +56,14 @@ class ABIFunctions
 public:
 	explicit ABIFunctions(
 		langutil::EVMVersion _evmVersion,
+		std::optional<uint8_t> _eofVersion,
 		RevertStrings _revertStrings,
 		MultiUseYulFunctionCollector& _functionCollector
 	):
 		m_evmVersion(_evmVersion),
 		m_revertStrings(_revertStrings),
 		m_functionCollector(_functionCollector),
-		m_utils(_evmVersion, m_revertStrings, m_functionCollector)
+		m_utils(_evmVersion, _eofVersion, m_revertStrings, m_functionCollector)
 	{}
 
 	/// @returns name of an assembly function to ABI-encode values of @a _givenTypes

--- a/libsolidity/codegen/Compiler.h
+++ b/libsolidity/codegen/Compiler.h
@@ -37,10 +37,15 @@ namespace solidity::frontend
 class Compiler
 {
 public:
-	Compiler(langutil::EVMVersion _evmVersion, RevertStrings _revertStrings, OptimiserSettings _optimiserSettings):
+	Compiler(
+		langutil::EVMVersion _evmVersion,
+		std::optional<uint8_t> _eofVersion,
+		RevertStrings _revertStrings,
+		OptimiserSettings _optimiserSettings
+	):
 		m_optimiserSettings(std::move(_optimiserSettings)),
-		m_runtimeContext(_evmVersion, _revertStrings),
-		m_context(_evmVersion, _revertStrings, &m_runtimeContext)
+		m_runtimeContext(_evmVersion, _eofVersion, _revertStrings),
+		m_context(_evmVersion, _eofVersion, _revertStrings, &m_runtimeContext)
 	{ }
 
 	/// Compiles a contract.

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -62,6 +62,7 @@ class CompilerContext
 public:
 	explicit CompilerContext(
 		langutil::EVMVersion _evmVersion,
+		std::optional<uint8_t> _eofVersion,
 		RevertStrings _revertStrings,
 		CompilerContext* _runtimeContext = nullptr
 	):
@@ -70,8 +71,8 @@ public:
 		m_revertStrings(_revertStrings),
 		m_reservedMemory{0},
 		m_runtimeContext(_runtimeContext),
-		m_abiFunctions(m_evmVersion, m_revertStrings, m_yulFunctionCollector),
-		m_yulUtilFunctions(m_evmVersion, m_revertStrings, m_yulFunctionCollector)
+		m_abiFunctions(m_evmVersion, _eofVersion, m_revertStrings, m_yulFunctionCollector),
+		m_yulUtilFunctions(m_evmVersion, _eofVersion, m_revertStrings, m_yulFunctionCollector)
 	{
 		if (m_runtimeContext)
 			m_runtimeSub = size_t(m_asm->newSub(m_runtimeContext->m_asm).data());

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -285,7 +285,7 @@ std::string YulUtilFunctions::revertWithError(
 		errorArgumentTypes.push_back(arg->annotation().type);
 	}
 	templ("argumentVars", joinHumanReadablePrefixed(errorArgumentVars));
-	templ("encode", ABIFunctions(m_evmVersion, m_revertStrings, m_functionCollector).tupleEncoder(errorArgumentTypes, _parameterTypes));
+	templ("encode", ABIFunctions(m_evmVersion, m_eofVersion, m_revertStrings, m_functionCollector).tupleEncoder(errorArgumentTypes, _parameterTypes));
 
 	return templ.render();
 }
@@ -2592,7 +2592,7 @@ std::string YulUtilFunctions::copyArrayFromStorageToMemoryFunction(ArrayType con
 		if (_from.baseType()->isValueType())
 		{
 			solAssert(*_from.baseType() == *_to.baseType(), "");
-			ABIFunctions abi(m_evmVersion, m_revertStrings, m_functionCollector);
+			ABIFunctions abi(m_evmVersion, m_eofVersion, m_revertStrings, m_functionCollector);
 			return Whiskers(R"(
 				function <functionName>(slot) -> memPtr {
 					memPtr := <allocateUnbounded>()
@@ -2697,7 +2697,7 @@ std::string YulUtilFunctions::bytesOrStringConcatFunction(
 		templ("finalizeAllocation", finalizeAllocationFunction());
 		templ(
 			"encodePacked",
-			ABIFunctions{m_evmVersion, m_revertStrings, m_functionCollector}.tupleEncoderPacked(
+			ABIFunctions{m_evmVersion, m_eofVersion, m_revertStrings, m_functionCollector}.tupleEncoderPacked(
 				_argumentTypes,
 				targetTypes
 			)
@@ -3578,7 +3578,7 @@ std::string YulUtilFunctions::conversionFunction(Type const& _from, Type const& 
 					)")
 					(
 						"abiDecode",
-						ABIFunctions(m_evmVersion, m_revertStrings, m_functionCollector).abiDecodingFunctionStruct(
+						ABIFunctions(m_evmVersion, m_eofVersion, m_revertStrings, m_functionCollector).abiDecodingFunctionStruct(
 							toStructType,
 							false
 						)
@@ -3907,6 +3907,7 @@ std::string YulUtilFunctions::arrayConversionFunction(ArrayType const& _from, Ar
 					_from.dataStoredIn(DataLocation::CallData) ?
 					ABIFunctions(
 						m_evmVersion,
+						m_eofVersion,
 						m_revertStrings,
 						m_functionCollector
 					).abiDecodingFunctionArrayAvailableLength(_to, false) :
@@ -4105,7 +4106,10 @@ std::string YulUtilFunctions::packedHashFunction(
 		templ("variables", suffixedVariableNameList("var_", 1, 1 + sizeOnStack));
 		templ("comma", sizeOnStack > 0 ? "," : "");
 		templ("allocateUnbounded", allocateUnboundedFunction());
-		templ("packedEncode", ABIFunctions(m_evmVersion, m_revertStrings, m_functionCollector).tupleEncoderPacked(_givenTypes, _targetTypes));
+		templ(
+			"packedEncode",
+			ABIFunctions(m_evmVersion, m_eofVersion, m_revertStrings, m_functionCollector).tupleEncoderPacked(_givenTypes, _targetTypes)
+		);
 		return templ.render();
 	});
 }
@@ -4726,15 +4730,21 @@ std::string YulUtilFunctions::copyConstructorArgumentsToMemoryFunction(
 
 	return m_functionCollector.createFunction(functionName, [&]() {
 		std::string returnParams = suffixedVariableNameList("ret_param_",0, CompilerUtils::sizeOnStack(_contract.constructor()->parameters()));
-		ABIFunctions abiFunctions(m_evmVersion, m_revertStrings, m_functionCollector);
+		ABIFunctions abiFunctions(m_evmVersion, m_eofVersion, m_revertStrings, m_functionCollector);
 
 		return util::Whiskers(R"(
 			function <functionName>() -> <retParams> {
-				let programSize := datasize("<object>")
-				let argSize := sub(codesize(), programSize)
+				<?eof>
+					let argSize := calldatasize()
+					let memoryDataOffset := <allocate>(argSize)
+					calldatacopy(memoryDataOffset, 0, argSize)
+				<!eof>
+					let programSize := datasize("<object>")
+					let argSize := sub(codesize(), programSize)
 
-				let memoryDataOffset := <allocate>(argSize)
-				codecopy(memoryDataOffset, programSize, argSize)
+					let memoryDataOffset := <allocate>(argSize)
+					codecopy(memoryDataOffset, programSize, argSize)
+				</eof>
 
 				<retParams> := <abiDecode>(memoryDataOffset, add(memoryDataOffset, argSize))
 			}
@@ -4744,6 +4754,7 @@ std::string YulUtilFunctions::copyConstructorArgumentsToMemoryFunction(
 		("object", _creationObjectName)
 		("allocate", allocationFunction())
 		("abiDecode", abiFunctions.tupleDecoder(FunctionType(*_contract.constructor()).parameterTypes(), true))
+		("eof", m_eofVersion.has_value())
 		.render();
 	});
 }

--- a/libsolidity/codegen/YulUtilFunctions.h
+++ b/libsolidity/codegen/YulUtilFunctions.h
@@ -52,10 +52,12 @@ class YulUtilFunctions
 public:
 	explicit YulUtilFunctions(
 		langutil::EVMVersion _evmVersion,
+		std::optional<uint8_t> _eofVersion,
 		RevertStrings _revertStrings,
 		MultiUseYulFunctionCollector& _functionCollector
 	):
 		m_evmVersion(_evmVersion),
+		m_eofVersion(_eofVersion),
 		m_revertStrings(_revertStrings),
 		m_functionCollector(_functionCollector)
 	{}
@@ -640,6 +642,7 @@ private:
 	std::string longByteArrayStorageIndexAccessNoCheckFunction();
 
 	langutil::EVMVersion m_evmVersion;
+	std::optional<uint8_t> m_eofVersion;
 	RevertStrings m_revertStrings;
 	MultiUseYulFunctionCollector& m_functionCollector;
 };

--- a/libsolidity/codegen/ir/IRGenerationContext.cpp
+++ b/libsolidity/codegen/ir/IRGenerationContext.cpp
@@ -224,10 +224,10 @@ void IRGenerationContext::internalFunctionCalledThroughDispatch(YulArity const& 
 
 YulUtilFunctions IRGenerationContext::utils()
 {
-	return YulUtilFunctions(m_evmVersion, m_revertStrings, m_functions);
+	return YulUtilFunctions(m_evmVersion, m_eofVersion, m_revertStrings, m_functions);
 }
 
 ABIFunctions IRGenerationContext::abiFunctions()
 {
-	return ABIFunctions(m_evmVersion, m_revertStrings, m_functions);
+	return ABIFunctions(m_evmVersion, m_eofVersion, m_revertStrings, m_functions);
 }

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -177,7 +177,10 @@ std::string IRGenerator::generate(
 			constructorParams.emplace_back(m_context.newYulVariable());
 		t(
 			"copyConstructorArguments",
-			m_utils.copyConstructorArgumentsToMemoryFunction(_contract, IRNames::creationObject(_contract))
+			m_utils.copyConstructorArgumentsToMemoryFunction(
+				_contract,
+				IRNames::creationObject(_contract)
+			)
 		);
 	}
 	t("constructorParams", joinHumanReadable(constructorParams));
@@ -768,7 +771,7 @@ std::string IRGenerator::generateExternalFunction(ContractDefinition const& _con
 		unsigned paramVars = std::make_shared<TupleType>(_functionType.parameterTypes())->sizeOnStack();
 		unsigned retVars = std::make_shared<TupleType>(_functionType.returnParameterTypes())->sizeOnStack();
 
-		ABIFunctions abiFunctions(m_evmVersion, m_context.revertStrings(), m_context.functionCollector());
+		ABIFunctions abiFunctions(m_evmVersion, m_eofVersion, m_context.revertStrings(), m_context.functionCollector());
 		t("abiDecode", abiFunctions.tupleDecoder(_functionType.parameterTypes()));
 		t("params",  suffixedVariableNameList("param_", 0, paramVars));
 		t("retParams",  suffixedVariableNameList("ret_", 0, retVars));

--- a/libsolidity/codegen/ir/IRGenerator.h
+++ b/libsolidity/codegen/ir/IRGenerator.h
@@ -66,7 +66,7 @@ public:
 			_debugInfoSelection,
 			_soliditySourceProvider
 		),
-		m_utils(_evmVersion, m_context.revertStrings(), m_context.functionCollector()),
+		m_utils(_evmVersion, _eofVersion, m_context.revertStrings(), m_context.functionCollector()),
 		m_optimiserSettings(_optimiserSettings)
 	{}
 

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1072,7 +1072,7 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 	{
 		auto const& event = dynamic_cast<EventDefinition const&>(functionType->declaration());
 		TypePointers paramTypes = functionType->parameterTypes();
-		ABIFunctions abi(m_context.evmVersion(), m_context.revertStrings(), m_context.functionCollector());
+		ABIFunctions abi(m_context.evmVersion(), m_context.eofVersion(), m_context.revertStrings(), m_context.functionCollector());
 
 		std::vector<IRVariable> indexedArgs;
 		std::vector<std::string> nonIndexedArgs;
@@ -2843,7 +2843,7 @@ void IRGeneratorForStatements::appendBareCall(
 	else
 	{
 		templ("needsEncoding", true);
-		ABIFunctions abi(m_context.evmVersion(), m_context.revertStrings(), m_context.functionCollector());
+		ABIFunctions abi(m_context.evmVersion(), m_context.eofVersion(), m_context.revertStrings(), m_context.functionCollector());
 		templ("encode", abi.tupleEncoderPacked({&argType}, {TypeProvider::bytesMemory()}));
 	}
 

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -1502,7 +1502,12 @@ void CompilerStack::compileContract(
 
 	Contract& compiledContract = m_contracts.at(_contract.fullyQualifiedName());
 
-	std::shared_ptr<Compiler> compiler = std::make_shared<Compiler>(m_evmVersion, m_revertStrings, m_optimiserSettings);
+	std::shared_ptr<Compiler> compiler = std::make_shared<Compiler>(
+		m_evmVersion,
+		m_eofVersion,
+		m_revertStrings,
+		m_optimiserSettings
+	);
 
 	solAssert(!m_viaIR, "");
 	bytes cborEncodedMetadata = createCBORMetadata(compiledContract, /* _forIR */ false);

--- a/test/cmdlineTests/standard_debug_info_in_yul_location/output.json
+++ b/test/cmdlineTests/standard_debug_info_in_yul_location/output.json
@@ -84,6 +84,7 @@ object \"C_54\" {
         }
 
         function copy_arguments_for_constructor_20_object_C_54() -> ret_param_0 {
+
             let programSize := datasize(\"C_54\")
             let argSize := sub(codesize(), programSize)
 
@@ -850,6 +851,7 @@ object \"D_72\" {
         }
 
         function copy_arguments_for_constructor_71_object_D_72() -> ret_param_0 {
+
             let programSize := datasize(\"D_72\")
             let argSize := sub(codesize(), programSize)
 

--- a/test/libsolidity/Assembly.cpp
+++ b/test/libsolidity/Assembly.cpp
@@ -94,6 +94,7 @@ evmasm::AssemblyItems compileContract(std::shared_ptr<CharStream> _sourceCode)
 		{
 			Compiler compiler(
 				solidity::test::CommonOptions::get().evmVersion(),
+				solidity::test::CommonOptions::get().eofVersion(),
 				RevertStrings::Default,
 				solidity::test::CommonOptions::get().optimize ? OptimiserSettings::standard() : OptimiserSettings::minimal()
 			);

--- a/test/libsolidity/SolidityExpressionCompiler.cpp
+++ b/test/libsolidity/SolidityExpressionCompiler.cpp
@@ -147,6 +147,7 @@ bytes compileFirstExpression(
 
 			CompilerContext context(
 				solidity::test::CommonOptions::get().evmVersion(),
+				solidity::test::CommonOptions::get().eofVersion(),
 				RevertStrings::Default
 			);
 			context.resetVisitedNodes(contract);

--- a/test/libsolidity/semanticTests/constructor/arrays_in_constructors.sol
+++ b/test/libsolidity/semanticTests/constructor/arrays_in_constructors.sol
@@ -22,6 +22,8 @@ contract Creator {
         ch = c.part(x);
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // f(uint256,address[]): 7, 0x40, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 -> 7, 8
 // gas irOptimized: 327784

--- a/test/libsolidity/semanticTests/constructor/base_constructor_arguments.sol
+++ b/test/libsolidity/semanticTests/constructor/base_constructor_arguments.sol
@@ -19,5 +19,7 @@ contract Derived is Base {
         return m_a;
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // getA() -> 49

--- a/test/libsolidity/semanticTests/constructor/bytes_in_constructors_packer.sol
+++ b/test/libsolidity/semanticTests/constructor/bytes_in_constructors_packer.sol
@@ -22,6 +22,8 @@ contract Creator {
         ch = c.part(x);
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // f(uint256,bytes): 7, 0x40, 78, "abcdefghijklmnopqrstuvwxyzabcdef", "ghijklmnopqrstuvwxyzabcdefghijkl", "mnopqrstuvwxyz" -> 7, "h"
 // gas irOptimized: 169292

--- a/test/libsolidity/semanticTests/constructor/bytes_in_constructors_unpacker.sol
+++ b/test/libsolidity/semanticTests/constructor/bytes_in_constructors_unpacker.sol
@@ -6,6 +6,8 @@ contract Test {
         m_s = s;
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // constructor(): 7, 0x40, 78, "abcdefghijklmnopqrstuvwxyzabcdef", "ghijklmnopqrstuvwxyzabcdefghijkl", "mnopqrstuvwxyz" ->
 // gas irOptimized: 181465

--- a/test/libsolidity/semanticTests/constructor/constructor_arguments_external.sol
+++ b/test/libsolidity/semanticTests/constructor/constructor_arguments_external.sol
@@ -15,6 +15,8 @@ contract Main {
         return flag;
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // constructor(): "abc", true
 // gas irOptimized: 80174

--- a/test/libsolidity/semanticTests/constructor/constructor_arguments_internal.sol
+++ b/test/libsolidity/semanticTests/constructor/constructor_arguments_internal.sol
@@ -32,6 +32,8 @@ contract Main {
         return h.getName();
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // getFlag() -> true
 // getName() -> "abc"

--- a/test/libsolidity/semanticTests/constructor/constructor_function_argument.sol
+++ b/test/libsolidity/semanticTests/constructor/constructor_function_argument.sol
@@ -3,5 +3,7 @@ contract D {
     constructor(function() external returns (uint)) {
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // constructor(): 0xfdd67305928fcac8d213d1e47bfa6165cd0b87b946644cd0000000000000000 ->

--- a/test/libsolidity/semanticTests/constructor/constructor_function_complex.sol
+++ b/test/libsolidity/semanticTests/constructor/constructor_function_complex.sol
@@ -15,6 +15,8 @@ contract C {
         return 16;
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // f() -> 16
 // gas legacy: 78477

--- a/test/libsolidity/semanticTests/constructor/constructor_static_array_argument.sol
+++ b/test/libsolidity/semanticTests/constructor/constructor_static_array_argument.sol
@@ -7,6 +7,8 @@ contract C {
         b = _b;
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // constructor(): 1, 2, 3, 4 ->
 // gas irOptimized: 148129

--- a/test/libsolidity/semanticTests/constructor/evm_exceptions_in_constructor_call_fail.sol
+++ b/test/libsolidity/semanticTests/constructor/evm_exceptions_in_constructor_call_fail.sol
@@ -13,6 +13,8 @@ contract B {
         ++test;
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // testIt() ->
 // test() -> 2

--- a/test/libsolidity/semanticTests/constructor/function_usage_in_constructor_arguments.sol
+++ b/test/libsolidity/semanticTests/constructor/function_usage_in_constructor_arguments.sol
@@ -19,5 +19,7 @@ contract Derived is Base {
         return m_a;
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // getA() -> 2

--- a/test/libsolidity/semanticTests/constructor/functions_called_by_constructor.sol
+++ b/test/libsolidity/semanticTests/constructor/functions_called_by_constructor.sol
@@ -14,5 +14,7 @@ contract Test {
         name = _name;
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // getName() -> "abc"

--- a/test/libsolidity/semanticTests/constructor/functions_called_by_constructor_through_dispatch.sol
+++ b/test/libsolidity/semanticTests/constructor/functions_called_by_constructor_through_dispatch.sol
@@ -24,5 +24,7 @@ contract Test {
         name = _shiftOperator(name, _bytes);
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // getName() -> "def\x00\x00\x00"

--- a/test/libsolidity/semanticTests/constructor/inline_member_init_inheritence_without_constructor.sol
+++ b/test/libsolidity/semanticTests/constructor/inline_member_init_inheritence_without_constructor.sol
@@ -14,6 +14,8 @@ contract Derived is Base {
         return m_derived;
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // getBMember() -> 5
 // getDMember() -> 6

--- a/test/libsolidity/semanticTests/constructor/order_of_evaluation.sol
+++ b/test/libsolidity/semanticTests/constructor/order_of_evaluation.sol
@@ -18,5 +18,7 @@ contract X is D, C, B, A {
     function g() public view returns (uint[] memory) { return x; }
     constructor() A(f(1)) C(f(2)) B(f(3)) D(f(4)) {}
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // g() -> 0x20, 4, 1, 3, 2, 4

--- a/test/libsolidity/semanticTests/constructor/payable_constructor.sol
+++ b/test/libsolidity/semanticTests/constructor/payable_constructor.sol
@@ -1,5 +1,7 @@
 contract C {
     constructor() payable {}
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // constructor(), 27 wei ->

--- a/test/libsolidity/semanticTests/constructor/store_function_in_constructor.sol
+++ b/test/libsolidity/semanticTests/constructor/store_function_in_constructor.sol
@@ -15,6 +15,8 @@ contract C {
         return x(_arg);
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // use(uint256): 3 -> 6
 // result_in_constructor() -> 4

--- a/test/libsolidity/semanticTests/constructor/store_function_in_constructor_packed.sol
+++ b/test/libsolidity/semanticTests/constructor/store_function_in_constructor_packed.sol
@@ -16,6 +16,8 @@ contract C {
         return x(_arg);
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // use(uint16): 3 -> 0xfff9
 // result_in_constructor() -> 0xfffb

--- a/test/libsolidity/semanticTests/constructor/store_internal_unused_function_in_constructor.sol
+++ b/test/libsolidity/semanticTests/constructor/store_internal_unused_function_in_constructor.sol
@@ -13,5 +13,7 @@ contract C {
         return x();
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // t() -> 7

--- a/test/libsolidity/semanticTests/constructor/store_internal_unused_library_function_in_constructor.sol
+++ b/test/libsolidity/semanticTests/constructor/store_internal_unused_library_function_in_constructor.sol
@@ -16,5 +16,7 @@ contract C {
         return x();
     }
 }
+// ====
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // t() -> 7

--- a/test/libsolidity/semanticTests/constructor/transient_state_variable_initialization.sol
+++ b/test/libsolidity/semanticTests/constructor/transient_state_variable_initialization.sol
@@ -14,5 +14,6 @@ contract C {
 
 // ====
 // EVMVersion: >=cancun
+// bytecodeFormat: legacy,>=EOFv1
 // ----
 // f() -> 100


### PR DESCRIPTION
Contract constructor argument copying needs specific handling for EOF. 

~Depends on #15635.~ Merged.