### PR TITLE
eof: Disallow `gas` option for external function call.

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2967,6 +2967,12 @@ bool TypeChecker::visit(FunctionCallOptions const& _functionCallOptions)
 					_functionCallOptions.location(),
 					"Function call option \"gas\" cannot be used with \"new\"."
 				);
+			else if (m_eofVersion.has_value())
+				m_errorReporter.typeError(
+					3765_error,
+					_functionCallOptions.location(),
+					"Function call option \"gas\" cannot be used when compiling to EOF."
+				);
 			else
 			{
 				expectType(*_functionCallOptions.options()[i], *TypeProvider::uint256());

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -47,8 +47,9 @@ class TypeChecker: private ASTConstVisitor
 {
 public:
 	/// @param _errorReporter provides the error logging functionality.
-	TypeChecker(langutil::EVMVersion _evmVersion, langutil::ErrorReporter& _errorReporter):
+	TypeChecker(langutil::EVMVersion _evmVersion, std::optional<uint8_t> _eofVersion, langutil::ErrorReporter& _errorReporter):
 		m_evmVersion(_evmVersion),
+		m_eofVersion(_eofVersion),
 		m_errorReporter(_errorReporter)
 	{}
 
@@ -192,6 +193,7 @@ private:
 	ContractDefinition const* m_currentContract = nullptr;
 
 	langutil::EVMVersion m_evmVersion;
+	std::optional<uint8_t> m_eofVersion;
 
 	langutil::ErrorReporter& m_errorReporter;
 };

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -557,7 +557,7 @@ bool CompilerStack::analyzeLegacy(bool _noErrorsSoFar)
 	//
 	// Note: this does not resolve overloaded functions. In order to do that, types of arguments are needed,
 	// which is only done one step later.
-	TypeChecker typeChecker(m_evmVersion, m_errorReporter);
+	TypeChecker typeChecker(m_evmVersion, m_eofVersion, m_errorReporter);
 	for (Source const* source: m_sourceOrder)
 		if (source->ast && !typeChecker.checkTypeRequirements(*source->ast))
 			noErrors = false;

--- a/test/libsolidity/Assembly.cpp
+++ b/test/libsolidity/Assembly.cpp
@@ -81,7 +81,11 @@ evmasm::AssemblyItems compileContract(std::shared_ptr<CharStream> _sourceCode)
 		if (Error::containsErrors(errorReporter.errors()))
 			return AssemblyItems();
 	}
-	TypeChecker checker(solidity::test::CommonOptions::get().evmVersion(), errorReporter);
+	TypeChecker checker(
+		solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion(),
+		errorReporter
+	);
 	BOOST_REQUIRE_NO_THROW(checker.checkTypeRequirements(*sourceUnit));
 	if (Error::containsErrors(errorReporter.errors()))
 		return AssemblyItems();

--- a/test/libsolidity/SolidityExpressionCompiler.cpp
+++ b/test/libsolidity/SolidityExpressionCompiler.cpp
@@ -133,7 +133,11 @@ bytes compileFirstExpression(
 	DeclarationTypeChecker declarationTypeChecker(errorReporter, solidity::test::CommonOptions::get().evmVersion());
 	for (ASTPointer<ASTNode> const& node: sourceUnit->nodes())
 		BOOST_REQUIRE(declarationTypeChecker.check(*node));
-	TypeChecker typeChecker(solidity::test::CommonOptions::get().evmVersion(), errorReporter);
+	TypeChecker typeChecker(
+		solidity::test::CommonOptions::get().evmVersion(),
+		solidity::test::CommonOptions::get().eofVersion(),
+		errorReporter
+	);
 	BOOST_REQUIRE(typeChecker.checkTypeRequirements(*sourceUnit));
 	for (ASTPointer<ASTNode> const& node: sourceUnit->nodes())
 		if (ContractDefinition* contract = dynamic_cast<ContractDefinition*>(node.get()))

--- a/test/libsolidity/syntaxTests/functionCalls/eof/external_call_with_gas_option.sol
+++ b/test/libsolidity/syntaxTests/functionCalls/eof/external_call_with_gas_option.sol
@@ -1,0 +1,12 @@
+contract C {
+    function g(bool x) public pure {
+        require(x);
+    }
+    function f(bool x) public returns (uint) {
+        this.g{gas: 8000}(x);
+    }
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// TypeError 3765: (131-148): Function call option "gas" cannot be used when compiling to EOF.


### PR DESCRIPTION
EOF `EXTCALL` opcode doesn't accept `gas` argument.