### PR TITLE
Contract as default location in post-analysis errors

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Language Features:
 
 
 Compiler Features:
+ * Error Reporting: Errors reported during code generation now point at the location of the contract when more fine-grained location is not available.
  * SMTChecker: Z3 is now a runtime dependency, not a build dependency (except for emscripten build).
 
 

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -578,8 +578,12 @@ private:
 		FunctionDefinition const& _function
 	) const;
 
-	void reportUnimplementedFeatureError(langutil::UnimplementedFeatureError const& _error);
-	void reportIRPostAnalysisError(langutil::Error const* _error);
+	void reportUnimplementedFeatureError(
+		langutil::UnimplementedFeatureError const& _error,
+		ContractDefinition const* _contractDefinition = nullptr
+	);
+	void reportCodeGenerationError(langutil::Error const& _error, ContractDefinition const* _contractDefinition);
+	void reportIRPostAnalysisError(langutil::Error const* _error, ContractDefinition const* _contractDefinition);
 
 	ReadCallback::Callback m_readFile;
 	OptimiserSettings m_optimiserSettings;

--- a/libyul/YulStack.cpp
+++ b/libyul/YulStack.cpp
@@ -439,6 +439,9 @@ Dialect const& YulStack::dialect() const
 
 void YulStack::reportUnimplementedFeatureError(UnimplementedFeatureError const& _error)
 {
+	yulAssert(m_charStream);
 	yulAssert(_error.comment(), "Errors must include a message for the user.");
+	if (_error.sourceLocation().sourceName)
+		yulAssert(*_error.sourceLocation().sourceName == m_charStream->name());
 	m_errorReporter.unimplementedFeatureError(1920_error, _error.sourceLocation(), *_error.comment());
 }

--- a/test/cmdlineTests/standard_outputs_on_compilation_error/output.json
+++ b/test/cmdlineTests/standard_outputs_on_compilation_error/output.json
@@ -54,10 +54,19 @@
             "component": "general",
             "errorCode": "1284",
             "formattedMessage": "CodeGenerationError: Some immutables were read from but never assigned, possibly because of optimization.
+ --> C:4:1:
+  |
+4 | contract C {
+  | ^ (Relevant source part starts here and spans across multiple lines).
 
 ",
             "message": "Some immutables were read from but never assigned, possibly because of optimization.",
             "severity": "error",
+            "sourceLocation": {
+                "end": 320,
+                "file": "C",
+                "start": 56
+            },
             "type": "CodeGenerationError"
         }
     ],

--- a/test/libsolidity/smtCheckerTests/operators/shifts/shr_unused.sol
+++ b/test/libsolidity/smtCheckerTests/operators/shifts/shr_unused.sol
@@ -8,4 +8,4 @@ contract C {
 // SMTEngine: all
 // ----
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
-// UnimplementedFeatureError 1834: Not yet implemented - FixedPointType.
+// UnimplementedFeatureError 1834: (0-80): Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/array/nested_calldata_storage.sol
+++ b/test/libsolidity/syntaxTests/array/nested_calldata_storage.sol
@@ -6,4 +6,4 @@ contract C {
 }
 
 // ----
-// UnimplementedFeatureError 1834: Copying nested calldata dynamic arrays to storage is not implemented in the old code generator.
+// UnimplementedFeatureError 1834: (35-127): Copying nested calldata dynamic arrays to storage is not implemented in the old code generator.

--- a/test/libsolidity/syntaxTests/array/nested_calldata_storage2.sol
+++ b/test/libsolidity/syntaxTests/array/nested_calldata_storage2.sol
@@ -6,4 +6,4 @@ contract C {
 }
 
 // ----
-// UnimplementedFeatureError 1834: Copying nested calldata dynamic arrays to storage is not implemented in the old code generator.
+// UnimplementedFeatureError 1834: (35-125): Copying nested calldata dynamic arrays to storage is not implemented in the old code generator.

--- a/test/libsolidity/syntaxTests/constants/mod_div_rational.sol
+++ b/test/libsolidity/syntaxTests/constants/mod_div_rational.sol
@@ -5,4 +5,4 @@ contract C {
     fixed a4 = 0 / -0.123;
 }
 // ----
-// UnimplementedFeatureError 1834: Not yet implemented - FixedPointType.
+// UnimplementedFeatureError 1834: (0-150): Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/experimental/builtin/builtin_type_definition.sol
+++ b/test/libsolidity/syntaxTests/experimental/builtin/builtin_type_definition.sol
@@ -89,4 +89,4 @@ contract C {
 // Info 4164: (563-574): Inferred type: (bool, word) -> word
 // Info 4164: (563-567): Inferred type: (?bm:type, ?bn:type)
 // Info 4164: (575-576): Inferred type: (bool, word)
-// UnimplementedFeatureError 1834: No support for calling functions pointers yet.
+// UnimplementedFeatureError 1834: (267-586): No support for calling functions pointers yet.

--- a/test/libsolidity/syntaxTests/immutable/no_assignments.sol
+++ b/test/libsolidity/syntaxTests/immutable/no_assignments.sol
@@ -10,4 +10,4 @@ contract C {
 // ====
 // optimize-yul: true
 // ----
-// CodeGenerationError 1284: Some immutables were read from but never assigned, possibly because of optimization.
+// CodeGenerationError 1284: (0-168): Some immutables were read from but never assigned, possibly because of optimization.

--- a/test/libsolidity/syntaxTests/inline_arrays/inline_array_fixed_types.sol
+++ b/test/libsolidity/syntaxTests/inline_arrays/inline_array_fixed_types.sol
@@ -6,4 +6,4 @@ contract test {
 // ----
 // Warning 2072: (50-67): Unused local variable.
 // Warning 2018: (20-119): Function state mutability can be restricted to pure
-// UnimplementedFeatureError 1834: Not yet implemented - FixedPointType.
+// UnimplementedFeatureError 1834: (0-121): Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/inline_arrays/inline_array_rationals.sol
+++ b/test/libsolidity/syntaxTests/inline_arrays/inline_array_rationals.sol
@@ -6,4 +6,4 @@ contract test {
 // ----
 // Warning 2072: (50-73): Unused local variable.
 // Warning 2018: (20-118): Function state mutability can be restricted to pure
-// UnimplementedFeatureError 1834: Not yet implemented - FixedPointType.
+// UnimplementedFeatureError 1834: (0-120): Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/303_fixed_type_int_conversion.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/303_fixed_type_int_conversion.sol
@@ -9,4 +9,4 @@ contract test {
 }
 // ----
 // Warning 2018: (20-147): Function state mutability can be restricted to pure
-// UnimplementedFeatureError 1834: Not yet implemented - FixedPointType.
+// UnimplementedFeatureError 1834: (0-149): Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/304_fixed_type_rational_int_conversion.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/304_fixed_type_rational_int_conversion.sol
@@ -7,4 +7,4 @@ contract test {
 }
 // ----
 // Warning 2018: (20-104): Function state mutability can be restricted to pure
-// UnimplementedFeatureError 1834: Not yet implemented - FixedPointType.
+// UnimplementedFeatureError 1834: (0-106): Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/305_fixed_type_rational_fraction_conversion.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/305_fixed_type_rational_fraction_conversion.sol
@@ -7,4 +7,4 @@ contract test {
 }
 // ----
 // Warning 2018: (20-108): Function state mutability can be restricted to pure
-// UnimplementedFeatureError 1834: Not yet implemented - FixedPointType.
+// UnimplementedFeatureError 1834: (0-110): Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/307_rational_unary_minus_operation.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/307_rational_unary_minus_operation.sol
@@ -6,4 +6,4 @@ contract test {
     }
 }
 // ----
-// UnimplementedFeatureError 1834: Not yet implemented - FixedPointType.
+// UnimplementedFeatureError 1834: (0-126): Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/312_leading_zero_rationals_convert.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/312_leading_zero_rationals_convert.sol
@@ -8,4 +8,4 @@ contract A {
     }
 }
 // ----
-// UnimplementedFeatureError 1834: Not yet implemented - FixedPointType.
+// UnimplementedFeatureError 1834: (0-289): Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/314_fixed_type_zero_handling.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/314_fixed_type_zero_handling.sol
@@ -6,4 +6,4 @@ contract test {
 }
 // ----
 // Warning 2018: (20-104): Function state mutability can be restricted to pure
-// UnimplementedFeatureError 1834: Not yet implemented - FixedPointType.
+// UnimplementedFeatureError 1834: (0-106): Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/317_fixed_type_valid_explicit_conversions.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/317_fixed_type_valid_explicit_conversions.sol
@@ -7,4 +7,4 @@ contract test {
 }
 // ----
 // Warning 2018: (20-182): Function state mutability can be restricted to pure
-// UnimplementedFeatureError 1834: Not yet implemented - FixedPointType.
+// UnimplementedFeatureError 1834: (0-184): Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/323_mapping_with_fixed_literal.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/323_mapping_with_fixed_literal.sol
@@ -5,4 +5,4 @@ contract test {
     }
 }
 // ----
-// UnimplementedFeatureError 1834: Not yet implemented - FixedPointType.
+// UnimplementedFeatureError 1834: (0-130): Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/324_fixed_points_inside_structs.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/324_fixed_points_inside_structs.sol
@@ -6,4 +6,4 @@ contract test {
     myStruct a = myStruct(3.125, 3);
 }
 // ----
-// UnimplementedFeatureError 1834: Not yet implemented - FixedPointType.
+// UnimplementedFeatureError 1834: (0-115): Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/328_rational_to_fixed_literal_expression.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/328_rational_to_fixed_literal_expression.sol
@@ -13,4 +13,4 @@ contract test {
 // ----
 // Warning 2519: (238-252): This declaration shadows an existing declaration.
 // Warning 2018: (20-339): Function state mutability can be restricted to pure
-// UnimplementedFeatureError 1834: Not yet implemented - FixedPointType.
+// UnimplementedFeatureError 1834: (0-341): Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/343_integer_and_fixed_interaction.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/343_integer_and_fixed_interaction.sol
@@ -6,4 +6,4 @@ contract test {
 // ----
 // Warning 2072: (50-58): Unused local variable.
 // Warning 2018: (20-89): Function state mutability can be restricted to pure
-// UnimplementedFeatureError 1834: Not yet implemented - FixedPointType.
+// UnimplementedFeatureError 1834: (0-91): Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/parsing/declaring_fixed_and_ufixed_variables.sol
+++ b/test/libsolidity/syntaxTests/parsing/declaring_fixed_and_ufixed_variables.sol
@@ -11,4 +11,4 @@ contract A {
 // Warning 2072: (93-104): Unused local variable.
 // Warning 2072: (114-121): Unused local variable.
 // Warning 2018: (41-128): Function state mutability can be restricted to pure
-// UnimplementedFeatureError 1834: Fixed point types not implemented.
+// UnimplementedFeatureError 1834: (0-130): Fixed point types not implemented.

--- a/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_fixed.sol
+++ b/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_fixed.sol
@@ -7,4 +7,4 @@ contract C {
   }
 }
 // ----
-// UnimplementedFeatureError 1834: Not yet implemented - FixedPointType.
+// UnimplementedFeatureError 1834: (0-109): Not yet implemented - FixedPointType.

--- a/test/libsolidity/syntaxTests/types/rational_number_literal_to_fixed_implicit.sol
+++ b/test/libsolidity/syntaxTests/types/rational_number_literal_to_fixed_implicit.sol
@@ -13,4 +13,4 @@ contract C {
     }
 }
 // ----
-// UnimplementedFeatureError 1834: Not yet implemented - FixedPointType.
+// UnimplementedFeatureError 1834: (0-317): Not yet implemented - FixedPointType.


### PR DESCRIPTION
Partially addresses #12783 and #15139.

This PR uses the current contract as the default location for errors reported after analysis of Solidity code.

Most of these errors currently do not include any location, most likely because it's hard to provide one that would work for both Solidity and Yul compilation. We actually remove location from `CodeGenerationErrors` even if it's present.

Using the contract location is not very precise but it's easy to so and is much better than nothing, especially in a big project containing many contracts.