### PR TITLE
eof: Disable `gasTests` for EOF

### DIFF
--- a/.circleci/soltest.sh
+++ b/.circleci/soltest.sh
@@ -56,18 +56,6 @@ EOF_EXCLUDES=(
     --run_test='!SolidityInlineAssembly/Analysis/large_constant'
     --run_test='!SolidityInlineAssembly/Analysis/staticcall'
     --run_test='!ViewPureChecker/assembly_staticcall'
-    --run_test='!gasTests/abiv2'
-    --run_test='!gasTests/abiv2_optimised'
-    --run_test='!gasTests/data_storage'
-    --run_test='!gasTests/dispatch_large'
-    --run_test='!gasTests/dispatch_large_optimised'
-    --run_test='!gasTests/dispatch_medium'
-    --run_test='!gasTests/dispatch_medium_optimised'
-    --run_test='!gasTests/dispatch_small'
-    --run_test='!gasTests/dispatch_small_optimised'
-    --run_test='!gasTests/exp'
-    --run_test='!gasTests/exp_optimized'
-    --run_test='!gasTests/storage_costs'
     --run_test='!yulStackLayout/literal_loop'
 )
 

--- a/test/libsolidity/GasTest.cpp
+++ b/test/libsolidity/GasTest.cpp
@@ -37,7 +37,7 @@ using namespace solidity;
 using namespace boost::unit_test;
 
 GasTest::GasTest(std::string const& _filename):
-	TestCase(_filename)
+	EVMVersionRestrictedTestCase(_filename)
 {
 	m_source = m_reader.source();
 	m_optimise = m_reader.boolSetting("optimize", false);
@@ -114,10 +114,6 @@ void GasTest::setupCompiler(CompilerStack& _compiler)
 	}
 	settings.expectedExecutionsPerDeployment = m_optimiseRuns;
 	_compiler.setOptimiserSettings(settings);
-
-	// Intentionally ignoring EVM version specified on the command line.
-	// Gas expectations are only valid for the default version.
-	_compiler.setEVMVersion(EVMVersion{});
 }
 
 TestCase::TestResult GasTest::run(std::ostream& _stream, std::string const& _linePrefix, bool _formatted)

--- a/test/libsolidity/GasTest.h
+++ b/test/libsolidity/GasTest.h
@@ -32,7 +32,7 @@
 namespace solidity::frontend::test
 {
 
-class GasTest: AnalysisFramework, public TestCase
+class GasTest: AnalysisFramework, public EVMVersionRestrictedTestCase
 {
 public:
 	static std::unique_ptr<TestCase> create(Config const& _config)

--- a/test/libsolidity/gasTests/abiv2.sol
+++ b/test/libsolidity/gasTests/abiv2.sol
@@ -12,6 +12,9 @@ contract C {
     function f7(uint[31] memory, string[20] memory, C, address) public returns (bytes[] memory, uint16[] memory) {}
     function f8(uint[32] memory, string[] memory, uint32, address) public returns (uint[] memory, uint16[] memory) {}
 }
+// ====
+// EVMVersion: =current
+// bytecodeFormat: legacy
 // ----
 // creation:
 //   codeDepositCost: 1208000

--- a/test/libsolidity/gasTests/abiv2_optimised.sol
+++ b/test/libsolidity/gasTests/abiv2_optimised.sol
@@ -13,6 +13,8 @@ contract C {
     function f8(uint[32] memory, string[] memory, uint32, address) public returns (uint[] memory, uint16[] memory) {}
 }
 // ====
+// EVMVersion: =current
+// bytecodeFormat: legacy
 // optimize: true
 // optimize-yul: true
 // ----

--- a/test/libsolidity/gasTests/data_storage.sol
+++ b/test/libsolidity/gasTests/data_storage.sol
@@ -11,6 +11,9 @@ contract C {
         require(false, "12345678901234567890123456789012123456789012345678901234567890123");
     }
 }
+// ====
+// EVMVersion: =current
+// bytecodeFormat: legacy
 // ----
 // creation:
 //   codeDepositCost: 377800

--- a/test/libsolidity/gasTests/dispatch_large.sol
+++ b/test/libsolidity/gasTests/dispatch_large.sol
@@ -22,6 +22,9 @@ contract Large {
     function g9(uint x) public payable returns (uint) { b[uint8(msg.data[8])] = x; }
     function g0(uint x) public payable returns (uint) { require(x > 10); }
 }
+// ====
+// EVMVersion: =current
+// bytecodeFormat: legacy
 // ----
 // creation:
 //   codeDepositCost: 618400

--- a/test/libsolidity/gasTests/dispatch_large_optimised.sol
+++ b/test/libsolidity/gasTests/dispatch_large_optimised.sol
@@ -23,6 +23,8 @@ contract Large {
     function g0(uint x) public payable returns (uint) { require(x > 10); }
 }
 // ====
+// EVMVersion: =current
+// bytecodeFormat: legacy
 // optimize: true
 // optimize-runs: 2
 // ----

--- a/test/libsolidity/gasTests/dispatch_medium.sol
+++ b/test/libsolidity/gasTests/dispatch_medium.sol
@@ -9,6 +9,9 @@ contract Medium {
     function g9(uint x) public payable returns (uint) { b[uint8(msg.data[8])] = x; }
     function g0(uint x) public payable returns (uint) { require(x > 10); }
 }
+// ====
+// EVMVersion: =current
+// bytecodeFormat: legacy
 // ----
 // creation:
 //   codeDepositCost: 259600

--- a/test/libsolidity/gasTests/dispatch_medium_optimised.sol
+++ b/test/libsolidity/gasTests/dispatch_medium_optimised.sol
@@ -10,6 +10,9 @@ contract Medium {
     function g0(uint x) public payable returns (uint) { require(x > 10); }
 }
 // ====
+// EVMVersion: =current
+// bytecodeFormat: legacy
+// ====
 // optimize: true
 // optimize-runs: 2
 // ----

--- a/test/libsolidity/gasTests/dispatch_small.sol
+++ b/test/libsolidity/gasTests/dispatch_small.sol
@@ -4,6 +4,9 @@ contract Small {
     function f1(uint x) public returns (uint) { a = x; b[uint8(msg.data[0])] = x; }
     fallback () external payable {}
 }
+// ====
+// EVMVersion: =current
+// bytecodeFormat: legacy
 // ----
 // creation:
 //   codeDepositCost: 103800

--- a/test/libsolidity/gasTests/dispatch_small_optimised.sol
+++ b/test/libsolidity/gasTests/dispatch_small_optimised.sol
@@ -5,8 +5,10 @@ contract Small {
     fallback () external payable {}
 }
 // ====
+// EVMVersion: =current
 // optimize: true
 // optimize-runs: 2
+// bytecodeFormat: legacy
 // ----
 // creation:
 //   codeDepositCost: 58200

--- a/test/libsolidity/gasTests/exp.sol
+++ b/test/libsolidity/gasTests/exp.sol
@@ -15,6 +15,8 @@ contract C {
 	}
 }
 // ====
+// EVMVersion: =current
+// bytecodeFormat: legacy
 // optimize: false
 // optimize-yul: false
 // ----

--- a/test/libsolidity/gasTests/exp_optimized.sol
+++ b/test/libsolidity/gasTests/exp_optimized.sol
@@ -15,6 +15,8 @@ contract C {
 	}
 }
 // ====
+// EVMVersion: =current
+// bytecodeFormat: legacy
 // optimize: true
 // optimize-yul: true
 // ----

--- a/test/libsolidity/gasTests/storage_costs.sol
+++ b/test/libsolidity/gasTests/storage_costs.sol
@@ -11,8 +11,10 @@ contract C {
     }
 }
 // ====
+// EVMVersion: =current
 // optimize: true
 // optimize-yul: true
+// bytecodeFormat: legacy
 // ----
 // creation:
 //   codeDepositCost: 25600


### PR DESCRIPTION
`gasTests` are supposed to be run not via IR. As long as they are run this way they cannot be compiled to EOF. 
- Make `GasTest` supports `bytecodeFormat` flag and mark them all to run only for `current` EVM version
- Enable excluded earlier `gasTests` in CI testing for EOF.
- Add `bytecodeFormat: legacy` flag to `gasTests`