### PR TITLE
eof: Disable legacy-specific C++ tests and need to be rewritten for EOF later

### DIFF
--- a/.circleci/soltest.sh
+++ b/.circleci/soltest.sh
@@ -45,17 +45,6 @@ IFS=" " read -r -a SOLTEST_FLAGS <<< "$SOLTEST_FLAGS"
 
 # TODO: [EOF] These won't pass on EOF yet. Reenable them when the implementation is complete.
 EOF_EXCLUDES=(
-    --run_test='!Assembler/all_assembly_items'
-    --run_test='!Assembler/immutable'
-    --run_test='!Assembler/immutables_and_its_source_maps'
-    --run_test='!Optimiser/jumpdest_removal_subassemblies'
-    --run_test='!Optimiser/jumpdest_removal_subassemblies/*'
-    --run_test='!SolidityCompiler/does_not_include_creation_time_only_internal_functions'
-    --run_test='!SolidityInlineAssembly/Analysis/create2'
-    --run_test='!SolidityInlineAssembly/Analysis/inline_assembly_shadowed_instruction_declaration'
-    --run_test='!SolidityInlineAssembly/Analysis/large_constant'
-    --run_test='!SolidityInlineAssembly/Analysis/staticcall'
-    --run_test='!ViewPureChecker/assembly_staticcall'
     --run_test='!yulStackLayout/literal_loop'
 )
 

--- a/test/Common.cpp
+++ b/test/Common.cpp
@@ -302,6 +302,13 @@ bool isValidSemanticTestPath(boost::filesystem::path const& _testPath)
 	return true;
 }
 
+boost::unit_test::precondition::predicate_t nonEOF()
+{
+	return [](boost::unit_test::test_unit_id) {
+		return !solidity::test::CommonOptions::get().eofVersion().has_value();
+	};
+}
+
 boost::unit_test::precondition::predicate_t minEVMVersionCheck(langutil::EVMVersion _minEVMVersion)
 {
 	return [_minEVMVersion](boost::unit_test::test_unit_id) {

--- a/test/Common.h
+++ b/test/Common.h
@@ -112,6 +112,10 @@ bool isValidSemanticTestPath(boost::filesystem::path const& _testPath);
 /// @return A predicate (function) that can be passed into @a boost::unit_test::precondition().
 boost::unit_test::precondition::predicate_t minEVMVersionCheck(langutil::EVMVersion _minEVMVersion);
 
+/// Helper that can be used to skip tests when the EOF is not supported by the test case.
+/// @return A predicate (function) that can be passed into @a boost::unit_test::precondition().
+boost::unit_test::precondition::predicate_t nonEOF();
+
 bool loadVMs(CommonOptions const& _options);
 
 /**

--- a/test/libevmasm/Assembler.cpp
+++ b/test/libevmasm/Assembler.cpp
@@ -37,6 +37,7 @@
 
 using namespace solidity::langutil;
 using namespace solidity::evmasm;
+using namespace solidity::test;
 using namespace std::string_literals;
 
 namespace solidity::frontend::test
@@ -54,7 +55,7 @@ namespace
 
 BOOST_AUTO_TEST_SUITE(Assembler)
 
-BOOST_AUTO_TEST_CASE(all_assembly_items)
+BOOST_AUTO_TEST_CASE(all_assembly_items, *boost::unit_test::precondition(nonEOF()))
 {
 	std::map<std::string, unsigned> indices = {
 		{ "root.asm", 0 },
@@ -216,7 +217,8 @@ BOOST_AUTO_TEST_CASE(all_assembly_items)
 	BOOST_CHECK_EQUAL(util::jsonCompactPrint(_assembly.assemblyJSON(indices)), util::jsonCompactPrint(jsonValue));
 }
 
-BOOST_AUTO_TEST_CASE(immutables_and_its_source_maps)
+// TODO: Implement EOF counterpart
+BOOST_AUTO_TEST_CASE(immutables_and_its_source_maps, *boost::unit_test::precondition(nonEOF()))
 {
 	EVMVersion evmVersion = solidity::test::CommonOptions::get().evmVersion();
 	// Tests for 1, 2, 3 number of immutables.
@@ -301,7 +303,8 @@ BOOST_AUTO_TEST_CASE(immutables_and_its_source_maps)
 	}
 }
 
-BOOST_AUTO_TEST_CASE(immutable)
+// TODO: Implement EOF counterpart
+BOOST_AUTO_TEST_CASE(immutable, *boost::unit_test::precondition(nonEOF()))
 {
 	std::map<std::string, unsigned> indices = {
 		{ "root.asm", 0 },

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -41,6 +41,7 @@
 
 using namespace solidity::langutil;
 using namespace solidity::evmasm;
+using namespace solidity::test;
 
 namespace solidity::frontend::test
 {
@@ -1329,13 +1330,14 @@ BOOST_AUTO_TEST_CASE(jumpdest_removal)
 	);
 }
 
-BOOST_AUTO_TEST_CASE(jumpdest_removal_subassemblies)
+BOOST_AUTO_TEST_CASE(jumpdest_removal_subassemblies, *boost::unit_test::precondition(nonEOF()))
 {
 	// This tests that tags from subassemblies are not removed
 	// if they are referenced by a super-assembly. Furthermore,
 	// tag unifications (due to block deduplication) is also
 	// visible at the super-assembly.
 
+	solAssert(!solidity::test::CommonOptions::get().eofVersion().has_value());
 	Assembly::OptimiserSettings settings;
 	settings.runInliner = false;
 	settings.runJumpdestRemover = true;
@@ -1346,8 +1348,8 @@ BOOST_AUTO_TEST_CASE(jumpdest_removal_subassemblies)
 	settings.evmVersion = solidity::test::CommonOptions::get().evmVersion();
 	settings.expectedExecutionsPerDeployment = OptimiserSettings{}.expectedExecutionsPerDeployment;
 
-	Assembly main{settings.evmVersion, false, solidity::test::CommonOptions::get().eofVersion(), {}};
-	AssemblyPointer sub = std::make_shared<Assembly>(settings.evmVersion, true, solidity::test::CommonOptions::get().eofVersion(), std::string{});
+	Assembly main{settings.evmVersion, false, std::nullopt, {}};
+	AssemblyPointer sub = std::make_shared<Assembly>(settings.evmVersion, true, std::nullopt, std::string{});
 
 	sub->append(u256(1));
 	auto t1 = sub->newTag();

--- a/test/libsolidity/InlineAssembly.cpp
+++ b/test/libsolidity/InlineAssembly.cpp
@@ -44,6 +44,7 @@
 
 using namespace solidity::langutil;
 using namespace solidity::yul;
+using namespace solidity::test;
 
 namespace solidity::frontend::test
 {
@@ -294,7 +295,8 @@ BOOST_AUTO_TEST_CASE(designated_invalid_instruction)
 	BOOST_CHECK(successAssemble("{ invalid() }"));
 }
 
-BOOST_AUTO_TEST_CASE(inline_assembly_shadowed_instruction_declaration)
+// TODO: Implement EOF counterpart
+BOOST_AUTO_TEST_CASE(inline_assembly_shadowed_instruction_declaration, *boost::unit_test::precondition(nonEOF()))
 {
 	CHECK_ASSEMBLE_ERROR("{ let gas := 1 }", ParserError, "Cannot use builtin");
 }
@@ -333,14 +335,14 @@ BOOST_AUTO_TEST_CASE(returndatacopy)
 	BOOST_CHECK(successAssemble("{ returndatacopy(0, 32, 64) }"));
 }
 
-BOOST_AUTO_TEST_CASE(staticcall)
+BOOST_AUTO_TEST_CASE(staticcall, *boost::unit_test::precondition(nonEOF()))
 {
 	if (!solidity::test::CommonOptions::get().evmVersion().hasStaticCall())
 		return;
 	BOOST_CHECK(successAssemble("{ pop(staticcall(10000, 0x123, 64, 0x10, 128, 0x10)) }"));
 }
 
-BOOST_AUTO_TEST_CASE(create2)
+BOOST_AUTO_TEST_CASE(create2, *boost::unit_test::precondition(nonEOF()))
 {
 	if (!solidity::test::CommonOptions::get().evmVersion().hasCreate2())
 		return;

--- a/test/libsolidity/SolidityCompiler.cpp
+++ b/test/libsolidity/SolidityCompiler.cpp
@@ -24,6 +24,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+using namespace solidity::test;
 
 namespace solidity::frontend::test
 {
@@ -42,7 +43,8 @@ class SolidityCompilerFixture: protected AnalysisFramework
 
 BOOST_FIXTURE_TEST_SUITE(SolidityCompiler, SolidityCompilerFixture)
 
-BOOST_AUTO_TEST_CASE(does_not_include_creation_time_only_internal_functions)
+// TODO: Implement EOF counterpart
+BOOST_AUTO_TEST_CASE(does_not_include_creation_time_only_internal_functions, *boost::unit_test::precondition(nonEOF()))
 {
 	char const* sourceCode = R"(
 		contract C {

--- a/test/libsolidity/ViewPureChecker.cpp
+++ b/test/libsolidity/ViewPureChecker.cpp
@@ -28,6 +28,7 @@
 #include <tuple>
 
 using namespace solidity::langutil;
+using namespace solidity::test;
 
 namespace solidity::frontend::test
 {
@@ -133,7 +134,7 @@ BOOST_AUTO_TEST_CASE(address_staticcall)
 }
 
 
-BOOST_AUTO_TEST_CASE(assembly_staticcall)
+BOOST_AUTO_TEST_CASE(assembly_staticcall, *boost::unit_test::precondition(nonEOF()))
 {
 	std::string text = R"(
 		contract C {


### PR DESCRIPTION
- Add predicate to filter out legacy bytecode specific tests.
- Filter out legacy bytecode specific tests.
- Re-enable disables C++ tests.