### PR TITLE
eof: Update yul legacy tests

### DIFF
--- a/test/libyul/yulControlFlowGraph/ambiguous_names.yul
+++ b/test/libyul/yulControlFlowGraph/ambiguous_names.yul
@@ -14,6 +14,8 @@
     function b() {}
   }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // digraph CFG {
 // nodesep=0.7;

--- a/test/libyul/yulControlFlowGraph/complex.yul
+++ b/test/libyul/yulControlFlowGraph/complex.yul
@@ -43,6 +43,8 @@
     }
     pop(f(1,2))
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // digraph CFG {
 // nodesep=0.7;

--- a/test/libyul/yulControlFlowGraph/eof/function.yul
+++ b/test/libyul/yulControlFlowGraph/eof/function.yul
@@ -19,7 +19,7 @@
     h(y)
 }
 // ====
-// bytecodeFormat: legacy
+// bytecodeFormat: >=EOFv1
 // ----
 // digraph CFG {
 // nodesep=0.7;
@@ -28,7 +28,7 @@
 // Entry [label="Entry"];
 // Entry -> Block0;
 // Block0 [label="\
-// i: [ RET[i] ] => [ TMP[i, 0] TMP[i, 1] ]\l\
+// i: [ ] => [ TMP[i, 0] TMP[i, 1] ]\l\
 // Assignment(x, y): [ TMP[i, 0] TMP[i, 1] ] => [ x y ]\l\
 // h: [ x ] => [ ]\l\
 // "];
@@ -49,7 +49,7 @@
 // FunctionEntry_h_2 [label="function h(x)"];
 // FunctionEntry_h_2 -> Block2;
 // Block2 [label="\
-// f: [ RET[f] 0x00 x ] => [ TMP[f, 0] ]\l\
+// f: [ 0x00 x ] => [ TMP[f, 0] ]\l\
 // h: [ TMP[f, 0] ] => [ ]\l\
 // "];
 // Block2Exit [label="Terminated"];

--- a/test/libyul/yulControlFlowGraph/leave.yul
+++ b/test/libyul/yulControlFlowGraph/leave.yul
@@ -11,6 +11,8 @@
 
     pop(f(0,1))
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // digraph CFG {
 // nodesep=0.7;

--- a/test/libyul/yulInterpreterTests/and_create.yul
+++ b/test/libyul/yulInterpreterTests/and_create.yul
@@ -4,6 +4,8 @@
     let b := and(u160max, create(0, u160max, 0))
     mstore(0, eq(a, b))
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // Trace:
 //   CREATE(0, 0, 0)

--- a/test/libyul/yulInterpreterTests/and_create2.yul
+++ b/test/libyul/yulInterpreterTests/and_create2.yul
@@ -6,6 +6,7 @@
 }
 // ====
 // EVMVersion: >=constantinople
+// bytecodeFormat: legacy
 // ----
 // Trace:
 //   CREATE2(0, 0, 0, 0)

--- a/test/libyul/yulInterpreterTests/create2.yul
+++ b/test/libyul/yulInterpreterTests/create2.yul
@@ -5,6 +5,7 @@
 }
 // ====
 // EVMVersion: >=constantinople
+// bytecodeFormat: legacy
 // ----
 // Trace:
 //   CREATE2(0, 0, 32, 32)

--- a/test/libyul/yulInterpreterTests/datacopy.yul
+++ b/test/libyul/yulInterpreterTests/datacopy.yul
@@ -8,6 +8,8 @@ object "main"
     }
     object "sub" { code { sstore(0, 1) } }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // Trace:
 // Memory dump:

--- a/test/libyul/yulInterpreterTests/dataoffset.yul
+++ b/test/libyul/yulInterpreterTests/dataoffset.yul
@@ -6,6 +6,8 @@ object "main"
     }
     object "sub" { code { sstore(0, 1) } }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // Trace:
 // Memory dump:

--- a/test/libyul/yulInterpreterTests/datasize.yul
+++ b/test/libyul/yulInterpreterTests/datasize.yul
@@ -6,6 +6,8 @@ object "main"
     }
     object "sub" { code { sstore(0, 1) } }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // Trace:
 // Memory dump:

--- a/test/libyul/yulInterpreterTests/external_call_to_self.yul
+++ b/test/libyul/yulInterpreterTests/external_call_to_self.yul
@@ -11,6 +11,7 @@
 }
 // ====
 // simulateExternalCall: true
+// bytecodeFormat: legacy
 // ----
 // Trace:
 //   CALL(153, 0x11111111, 0, 64, 32, 256, 32)

--- a/test/libyul/yulInterpreterTests/external_call_unexecuted.yul
+++ b/test/libyul/yulInterpreterTests/external_call_unexecuted.yul
@@ -2,6 +2,8 @@
 	let x := call(gas(), 0x45, 0x5, 0, 0x20, 0x30, 0x20)
 	sstore(0x64, x)
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // Trace:
 //   CALL(153, 69, 5, 0, 32, 48, 32)

--- a/test/libyul/yulInterpreterTests/external_callcode_unexecuted.yul
+++ b/test/libyul/yulInterpreterTests/external_callcode_unexecuted.yul
@@ -2,6 +2,8 @@
 	let x := callcode(gas(), 0x45, 0x5, 0, 0x20, 0x30, 0x20)
 	sstore(100, x)
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // Trace:
 //   CALLCODE(153, 69, 5, 0, 32, 48, 32)

--- a/test/libyul/yulInterpreterTests/external_delegatecall_unexecuted.yul
+++ b/test/libyul/yulInterpreterTests/external_delegatecall_unexecuted.yul
@@ -2,6 +2,8 @@
 	let x := delegatecall(gas(), 0x45, 0, 0x20, 0x30, 0x20)
 	sstore(100, x)
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // Trace:
 //   DELEGATECALL(153, 69, 0, 32, 48, 32)

--- a/test/libyul/yulInterpreterTests/external_staticcall_unexecuted.yul
+++ b/test/libyul/yulInterpreterTests/external_staticcall_unexecuted.yul
@@ -4,6 +4,7 @@
 }
 // ====
 // EVMVersion: >=byzantium
+// bytecodeFormat: legacy
 // ----
 // Trace:
 //   STATICCALL(153, 69, 0, 32, 48, 32)

--- a/test/libyul/yulInterpreterTests/long_object_name.yul
+++ b/test/libyul/yulInterpreterTests/long_object_name.yul
@@ -13,6 +13,8 @@ object "t" {
 		}
 	}
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // Trace:
 // Memory dump:

--- a/test/libyul/yulInterpreterTests/pop_byte_shr_call.yul
+++ b/test/libyul/yulInterpreterTests/pop_byte_shr_call.yul
@@ -3,6 +3,7 @@
 }
 // ====
 // EVMVersion: >=constantinople
+// bytecodeFormat: legacy
 // ----
 // Trace:
 //   CALL(0, 0, 0, 0, 0, 0, 0)

--- a/test/libyul/yulInterpreterTests/side_effect_free.yul
+++ b/test/libyul/yulInterpreterTests/side_effect_free.yul
@@ -14,6 +14,7 @@
 }
 // ====
 // EVMVersion: >=constantinople
+// bytecodeFormat: legacy
 // ----
 // Trace:
 // Memory dump:

--- a/test/libyul/yulInterpreterTests/zero_length_reads.yul
+++ b/test/libyul/yulInterpreterTests/zero_length_reads.yul
@@ -18,6 +18,7 @@
 }
 // ====
 // EVMVersion: >=constantinople
+// bytecodeFormat: legacy
 // ----
 // Trace:
 //   RETURNDATACOPY(0, 1, 0)

--- a/test/libyul/yulInterpreterTests/zero_length_reads_and_revert.yul
+++ b/test/libyul/yulInterpreterTests/zero_length_reads_and_revert.yul
@@ -18,6 +18,7 @@
 }
 // ====
 // EVMVersion: >=constantinople
+// bytecodeFormat: legacy
 // ----
 // Trace:
 //   RETURNDATACOPY(0, 1, 0)

--- a/test/libyul/yulOptimizerTests/commonSubexpressionEliminator/branches_for.yul
+++ b/test/libyul/yulOptimizerTests/commonSubexpressionEliminator/branches_for.yul
@@ -1,17 +1,17 @@
 {
 	let a := 1
-	let b := codesize()
-	for { } lt(1, codesize()) { mstore(1, codesize()) a := add(a, codesize()) } {
-		mstore(1, codesize())
+	let b := calldataload(0)
+	for { } lt(1, calldataload(0)) { mstore(1, calldataload(0)) a := add(a, calldataload(0)) } {
+		mstore(1, calldataload(0))
 	}
-	mstore(1, codesize())
+	mstore(1, calldataload(0))
 }
 // ----
 // step: commonSubexpressionEliminator
 //
 // {
 //     let a := 1
-//     let b := codesize()
+//     let b := calldataload(0)
 //     for { }
 //     lt(1, b)
 //     {

--- a/test/libyul/yulOptimizerTests/commonSubexpressionEliminator/long_literals_as_builtin_args.yul
+++ b/test/libyul/yulOptimizerTests/commonSubexpressionEliminator/long_literals_as_builtin_args.yul
@@ -10,6 +10,8 @@ object "AccessControlDefaultAdminRules4233_14" {
     data "AccessControlDefaultAdminRules4233_14_deployed" "AccessControlDefaultAdminRules4233_14_deployed"
 
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: commonSubexpressionEliminator
 //

--- a/test/libyul/yulOptimizerTests/commonSubexpressionEliminator/non_movable_instr2.yul
+++ b/test/libyul/yulOptimizerTests/commonSubexpressionEliminator/non_movable_instr2.yul
@@ -2,6 +2,8 @@
     let a := gas()
     let b := gas()
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: commonSubexpressionEliminator
 //

--- a/test/libyul/yulOptimizerTests/commonSubexpressionEliminator/object_access.yul
+++ b/test/libyul/yulOptimizerTests/commonSubexpressionEliminator/object_access.yul
@@ -14,6 +14,8 @@ object "main" {
     }
     data "abc" "Hello, World!"
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: commonSubexpressionEliminator
 //

--- a/test/libyul/yulOptimizerTests/commonSubexpressionEliminator/trivial.yul
+++ b/test/libyul/yulOptimizerTests/commonSubexpressionEliminator/trivial.yul
@@ -1,11 +1,11 @@
 {
-    let a := mul(1, codesize())
-    let b := mul(1, codesize())
+    let a := mul(1, calldataload(0))
+    let b := mul(1, calldataload(0))
 }
 // ----
 // step: commonSubexpressionEliminator
 //
 // {
-//     let a := mul(1, codesize())
+//     let a := mul(1, calldataload(0))
 //     let b := a
 // }

--- a/test/libyul/yulOptimizerTests/disambiguator/string_as_hex_and_hex_as_string.yul
+++ b/test/libyul/yulOptimizerTests/disambiguator/string_as_hex_and_hex_as_string.yul
@@ -4,6 +4,8 @@ object "A" {
     }
     data 'abc' "1234"
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: disambiguator
 //

--- a/test/libyul/yulOptimizerTests/equalStoreEliminator/branching.yul
+++ b/test/libyul/yulOptimizerTests/equalStoreEliminator/branching.yul
@@ -4,7 +4,7 @@
     sstore(a, b)
     if calldataload(32) {
         sstore(a, b)
-        pop(staticcall(0, 0, 0, 0, 0, 0))
+        pop(sload(a))
         sstore(a, b)
     }
     sstore(a, b)
@@ -18,8 +18,5 @@
 //     let a := calldataload(0)
 //     let b := 20
 //     sstore(a, b)
-//     if calldataload(32)
-//     {
-//         pop(staticcall(0, 0, 0, 0, 0, 0))
-//     }
+//     if calldataload(32) { pop(sload(a)) }
 // }

--- a/test/libyul/yulOptimizerTests/equalStoreEliminator/functionbody.yul
+++ b/test/libyul/yulOptimizerTests/equalStoreEliminator/functionbody.yul
@@ -10,7 +10,7 @@
     }
 
     function g() {
-        pop(staticcall(0, 0, 0, 0, 0, 0))
+        pop(sload(calldataload(0)))
     }
 
     function h(a_, b_) {
@@ -21,7 +21,7 @@
     }
 
     function i() {
-        pop(delegatecall(0, 0, 0, 0, 0, 0))
+        sstore(calldataload(64), 42)
     }
 
 
@@ -40,9 +40,7 @@
 //         g()
 //     }
 //     function g()
-//     {
-//         pop(staticcall(0, 0, 0, 0, 0, 0))
-//     }
+//     { pop(sload(calldataload(0))) }
 //     function h(a_, b_)
 //     {
 //         sstore(a_, b_)
@@ -50,7 +48,5 @@
 //         sstore(a_, b_)
 //     }
 //     function i()
-//     {
-//         pop(delegatecall(0, 0, 0, 0, 0, 0))
-//     }
+//     { sstore(calldataload(64), 42) }
 // }

--- a/test/libyul/yulOptimizerTests/equalStoreEliminator/verbatim.yul
+++ b/test/libyul/yulOptimizerTests/equalStoreEliminator/verbatim.yul
@@ -4,7 +4,7 @@
     sstore(a, b)
     if calldataload(32) {
         sstore(a, b)
-        pop(staticcall(0, 0, 0, 0, 0, 0))
+        pop(sload(a))
         verbatim_0i_0o("xyz")
     }
     sstore(a, b)
@@ -20,7 +20,7 @@
 //     sstore(a, b)
 //     if calldataload(32)
 //     {
-//         pop(staticcall(0, 0, 0, 0, 0, 0))
+//         pop(sload(a))
 //         verbatim_0i_0o("xyz")
 //     }
 //     sstore(a, b)

--- a/test/libyul/yulOptimizerTests/equivalentFunctionCombiner/constant_representation_datasize.yul
+++ b/test/libyul/yulOptimizerTests/equivalentFunctionCombiner/constant_representation_datasize.yul
@@ -26,6 +26,8 @@ object "test"
   data 'A' "A"
 }
 
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: equivalentFunctionCombiner
 //

--- a/test/libyul/yulOptimizerTests/expressionSimplifier/create2_and_mask.yul
+++ b/test/libyul/yulOptimizerTests/expressionSimplifier/create2_and_mask.yul
@@ -8,6 +8,7 @@
 }
 // ====
 // EVMVersion: >=constantinople
+// bytecodeFormat: legacy
 // ----
 // step: expressionSimplifier
 //

--- a/test/libyul/yulOptimizerTests/expressionSimplifier/create_and_mask.yul
+++ b/test/libyul/yulOptimizerTests/expressionSimplifier/create_and_mask.yul
@@ -7,6 +7,8 @@
     let b := and(0xffffffffffffffffffffffffffffffffffffffff, create(0, 0, 0x20))
     sstore(a, b)
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: expressionSimplifier
 //

--- a/test/libyul/yulOptimizerTests/expressionSimplifier/large_byte_access.yul
+++ b/test/libyul/yulOptimizerTests/expressionSimplifier/large_byte_access.yul
@@ -9,6 +9,8 @@
     sstore(9, c)
     sstore(10, d)
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: expressionSimplifier
 //

--- a/test/libyul/yulOptimizerTests/expressionSimplifier/side_effects_in_for_condition.yul
+++ b/test/libyul/yulOptimizerTests/expressionSimplifier/side_effects_in_for_condition.yul
@@ -5,6 +5,7 @@
 }
 // ====
 // EVMVersion: >byzantium
+// bytecodeFormat: legacy
 // ----
 // step: expressionSimplifier
 //

--- a/test/libyul/yulOptimizerTests/expressionSimplifier/zero_length_read.yul
+++ b/test/libyul/yulOptimizerTests/expressionSimplifier/zero_length_read.yul
@@ -1,9 +1,7 @@
 {
 	revert(calldataload(0), 0)
-	revert(call(0,0,0,0,0,0,0), 0)
 	calldatacopy(calldataload(1), calldataload(2), 0)
 	return(calldataload(3), 0)
-	codecopy(calldataload(4), calldataload(5), sub(42,42))
 }
 // ----
 // step: expressionSimplifier
@@ -12,10 +10,7 @@
 //     {
 //         let _1 := 0
 //         revert(0, _1)
-//         pop(call(_1, _1, _1, _1, _1, _1, _1))
-//         revert(0, _1)
 //         calldatacopy(0, calldataload(2), _1)
 //         return(0, _1)
-//         codecopy(0, calldataload(5), 0)
 //     }
 // }

--- a/test/libyul/yulOptimizerTests/expressionSimplifier/zero_length_read_call.yul
+++ b/test/libyul/yulOptimizerTests/expressionSimplifier/zero_length_read_call.yul
@@ -1,8 +1,7 @@
 {
-  sstore(0, byte(0, shr(0x8, call(0, 0, 0, 0, 0, 0, 0))))
+	revert(call(0,0,0,0,0,0,0), 0)
 }
 // ====
-// EVMVersion: >=constantinople
 // bytecodeFormat: legacy
 // ----
 // step: expressionSimplifier
@@ -11,6 +10,6 @@
 //     {
 //         let _1 := 0
 //         pop(call(_1, _1, _1, _1, _1, _1, _1))
-//         sstore(_1, 0)
+//         revert(0, _1)
 //     }
 // }

--- a/test/libyul/yulOptimizerTests/expressionSimplifier/zero_length_read_codecopy.yul
+++ b/test/libyul/yulOptimizerTests/expressionSimplifier/zero_length_read_codecopy.yul
@@ -1,0 +1,13 @@
+{
+	codecopy(calldataload(4), calldataload(5), sub(42,42))
+}
+// ====
+// bytecodeFormat: legacy
+// ----
+// step: expressionSimplifier
+//
+// {
+//     {
+//         codecopy(0, calldataload(5), 0)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/expressionSplitter/object_access.yul
+++ b/test/libyul/yulOptimizerTests/expressionSplitter/object_access.yul
@@ -9,6 +9,8 @@ object "main" {
     }
     data "abc" "Hello, World!"
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: expressionSplitter
 //

--- a/test/libyul/yulOptimizerTests/fullSimplify/not_applied_removes_non_constant_and_not_movable.yul
+++ b/test/libyul/yulOptimizerTests/fullSimplify/not_applied_removes_non_constant_and_not_movable.yul
@@ -3,6 +3,8 @@
 	let a := div(create(0, 0, 0), 0)
 	mstore(0, a)
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: fullSimplify
 //

--- a/test/libyul/yulOptimizerTests/fullSimplify/scoped_var_ref_in_function_call.yul
+++ b/test/libyul/yulOptimizerTests/fullSimplify/scoped_var_ref_in_function_call.yul
@@ -6,6 +6,8 @@
     }
     f(call(2, 0, 1, mod(x, 8), 1, 1, 1))
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: fullSimplify
 //

--- a/test/libyul/yulOptimizerTests/fullSuite/aztec.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/aztec.yul
@@ -1,3 +1,4 @@
+// TODO: Add EOF version of this contract and compare with legacy to see which optimizations are missed.
 /**
  * @title Library to validate AZTEC zero-knowledge proofs
  * @author Zachary Williamson, AZTEC
@@ -230,6 +231,7 @@
 }
 // ====
 // EVMVersion: >=istanbul
+// bytecodeFormat: legacy
 // ----
 // step: fullSuite
 //

--- a/test/libyul/yulOptimizerTests/fullSuite/create2_and_mask.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/create2_and_mask.yul
@@ -8,6 +8,7 @@
 }
 // ====
 // EVMVersion: >=shanghai
+// bytecodeFormat: legacy
 // ----
 // step: fullSuite
 //

--- a/test/libyul/yulOptimizerTests/fullSuite/create_and_mask.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/create_and_mask.yul
@@ -8,6 +8,7 @@
 }
 // ====
 // EVMVersion: >=istanbul
+// bytecodeFormat: legacy
 // ----
 // step: fullSuite
 //

--- a/test/libyul/yulOptimizerTests/fullSuite/extcodelength.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/extcodelength.yul
@@ -18,6 +18,7 @@
 }
 // ====
 // EVMVersion: >byzantium
+// bytecodeFormat: legacy
 // ----
 // step: fullSuite
 //

--- a/test/libyul/yulOptimizerTests/fullSuite/stack_compressor_msize.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/stack_compressor_msize.yul
@@ -22,7 +22,7 @@
 
 	function foo_singlereturn_1(in_1, in_2) -> out
 	{
-		extcodecopy(1,msize(),1,1)
+		mstore8(msize(), 42)
 	}
 
 	a := foo_singlereturn_0()
@@ -60,5 +60,5 @@
 //         default { out := gcd(_b, mod(_a, _b)) }
 //     }
 //     function foo_singlereturn()
-//     { extcodecopy(1, msize(), 1, 1) }
+//     { mstore8(msize(), 42) }
 // }

--- a/test/libyul/yulOptimizerTests/fullSuite/unusedFunctionParameterPruner.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/unusedFunctionParameterPruner.yul
@@ -9,7 +9,7 @@
         out1 := mload(32)
         out1 := sload(out1)
         out2 := add(out1, 1)
-        extcodecopy(out1, out2, 1, b)
+        calldatacopy(out2, out1, b)
         // to prevent foo from getting inlined
         if iszero(out1) { leave }
     }
@@ -27,7 +27,7 @@
 //     {
 //         out1 := sload(mload(32))
 //         out2 := add(out1, 1)
-//         extcodecopy(out1, out2, 1, b)
+//         calldatacopy(out2, out1, b)
 //         if iszero(out1) { leave }
 //     }
 // }

--- a/test/libyul/yulOptimizerTests/fullSuite/unusedFunctionParameterPruner_return.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/unusedFunctionParameterPruner_return.yul
@@ -16,6 +16,8 @@
         if iszero(out1) { leave }
     }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: fullSuite
 //

--- a/test/libyul/yulOptimizerTests/loadResolver/extstaticcall.yul
+++ b/test/libyul/yulOptimizerTests/loadResolver/extstaticcall.yul
@@ -4,14 +4,14 @@
     let c := 2
     sstore(a, b)
     mstore(900, 7)
-    let d := staticcall(10000, 10, 0, 200, 0, 200)
+    let d := extstaticcall(10, 0, 200)
     sstore(add(a, 1), mload(900))
     // Main test objective: replace this sload.
     mstore(0, sload(a))
 }
 // ====
 // EVMVersion: >=byzantium
-// bytecodeFormat: legacy
+// bytecodeFormat: >=EOFv1
 // ----
 // step: loadResolver
 //
@@ -21,11 +21,9 @@
 //         let b := 1
 //         sstore(a, b)
 //         let _1 := 7
-//         let _2 := 900
-//         mstore(_2, _1)
-//         let _3 := 200
-//         pop(staticcall(10000, 10, a, _3, a, _3))
-//         sstore(1, mload(_2))
+//         mstore(900, _1)
+//         pop(extstaticcall(10, a, 200))
+//         sstore(1, _1)
 //         mstore(a, b)
 //     }
 // }

--- a/test/libyul/yulOptimizerTests/loadResolver/keccak_crash.yul
+++ b/test/libyul/yulOptimizerTests/loadResolver/keccak_crash.yul
@@ -2,6 +2,8 @@
 {
   for {} addmod(keccak256(0x0,create(0x0, 0x0, 0x0)), 0x0, 0x0) {} {}
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: loadResolver
 //

--- a/test/libyul/yulOptimizerTests/loadResolver/memory_with_call_invalidation.yul
+++ b/test/libyul/yulOptimizerTests/loadResolver/memory_with_call_invalidation.yul
@@ -3,17 +3,9 @@
     sstore(0, mload(2))
     pop(call(0, 0, 0, 0, 0, 0, 0))
     sstore(0, mload(2))
-
-    mstore(2, 10)
-    mstore8(calldataload(0), 4)
-    sstore(0, mload(2))
-
-    mstore(2, 10)
-    g()
-    sstore(0, mload(2))
-
-    function g() {}
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: loadResolver
 //
@@ -27,11 +19,5 @@
 //         sstore(_5, _4)
 //         pop(call(_5, _5, _5, _5, _5, _5, _5))
 //         sstore(_5, mload(_2))
-//         let _17 := 10
-//         mstore(_2, _17)
-//         mstore8(calldataload(_5), 4)
-//         sstore(_5, mload(_2))
-//         mstore(_2, _17)
-//         sstore(_5, _17)
 //     }
 // }

--- a/test/libyul/yulOptimizerTests/loadResolver/memory_with_extcall_invalidation.yul
+++ b/test/libyul/yulOptimizerTests/loadResolver/memory_with_extcall_invalidation.yul
@@ -1,0 +1,22 @@
+{
+    mstore(2, 9)
+    sstore(0, mload(2))
+    pop(extcall(0, 0, 0, 0))
+    sstore(0, mload(2))
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// step: loadResolver
+//
+// {
+//     {
+//         let _1 := 9
+//         mstore(2, _1)
+//         let _4 := _1
+//         let _5 := 0
+//         sstore(_5, _4)
+//         pop(extcall(_5, _5, _5, _5))
+//         sstore(_5, _1)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/loadResolver/memory_with_function_call_invalidation.yul
+++ b/test/libyul/yulOptimizerTests/loadResolver/memory_with_function_call_invalidation.yul
@@ -1,0 +1,17 @@
+{
+    mstore(2, 10)
+    g()
+    sstore(0, mload(2))
+
+    function g() {}
+}
+// ----
+// step: loadResolver
+//
+// {
+//     {
+//         let _1 := 10
+//         mstore(2, _1)
+//         sstore(0, _1)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/loadResolver/memory_with_mstore_invalidation.yul
+++ b/test/libyul/yulOptimizerTests/loadResolver/memory_with_mstore_invalidation.yul
@@ -1,0 +1,19 @@
+{
+    mstore(2, 10)
+    mstore8(calldataload(0), 4)
+    sstore(0, mload(2))
+}
+// ----
+// step: loadResolver
+//
+// {
+//     {
+//         let _1 := 10
+//         let _2 := 2
+//         mstore(_2, _1)
+//         let _3 := 4
+//         let _4 := 0
+//         mstore8(calldataload(_4), _3)
+//         sstore(_4, mload(_2))
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/loadResolver/zero_length_reads.yul
+++ b/test/libyul/yulOptimizerTests/loadResolver/zero_length_reads.yul
@@ -18,6 +18,7 @@
 }
 // ====
 // EVMVersion: >=constantinople
+// bytecodeFormat: legacy
 // ----
 // step: loadResolver
 //

--- a/test/libyul/yulOptimizerTests/loadResolver/zero_length_reads_eof.yul
+++ b/test/libyul/yulOptimizerTests/loadResolver/zero_length_reads_eof.yul
@@ -1,0 +1,39 @@
+{
+    // TODO: The current implementation of YulOptimizerTests ignores subobjects that are not Data. It's impossbile to test
+    // eofcreate and returncontract now.
+    returndatacopy(1, 1, 0)
+    calldatacopy(1, 1, 0)
+    log0(1, 0)
+    log1(1, 0, 1)
+    log2(1, 0, 1, 1)
+    log3(1, 0, 1, 1, 1)
+    log4(1, 0, 1, 1, 1, 1)
+    //pop(eofcreate("a", 1, 1, 1, 0))
+    //returncontract("b", 1, 0)
+    pop(extcall(1, 1, 1, 0))
+    pop(extdelegatecall(1, 1, 0))
+    pop(extstaticcall(1, 1, 0))
+    return(1, 0)
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// step: loadResolver
+//
+// {
+//     {
+//         let _1 := 0
+//         let _2 := 1
+//         returndatacopy(0, _2, _1)
+//         calldatacopy(0, _2, _1)
+//         log0(0, _1)
+//         log1(0, _1, _2)
+//         log2(0, _1, _2, _2)
+//         log3(0, _1, _2, _2, _2)
+//         log4(0, _1, _2, _2, _2, _2)
+//         pop(extcall(_2, _2, _2, _1))
+//         pop(extdelegatecall(_2, 0, _1))
+//         pop(extstaticcall(_2, 0, _1))
+//         return(0, _1)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/complex_move.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/complex_move.yul
@@ -2,7 +2,7 @@
   let b := 1
   for { let a := 1 } iszero(eq(a, 10)) { a := add(a, 1) } {
     let inv := add(b, 42)
-    let x := extcodesize(keccak256(mul(mload(inv), 3), 32))
+    let x := balance(keccak256(mul(mload(inv), 3), 32))
     a := add(x, 1)
     sstore(a, inv)
   }
@@ -14,7 +14,7 @@
 //     let b := 1
 //     let a := 1
 //     let inv := add(b, 42)
-//     let x := extcodesize(keccak256(mul(mload(inv), 3), 32))
+//     let x := balance(keccak256(mul(mload(inv), 3), 32))
 //     for { } iszero(eq(a, 10)) { a := add(a, 1) }
 //     {
 //         a := add(x, 1)

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/create_sload.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/create_sload.yul
@@ -11,6 +11,8 @@
     let z := f()
   }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: loopInvariantCodeMotion
 //

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/move_state_function.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/move_state_function.yul
@@ -4,7 +4,7 @@
 
   let b := 1
   for { let a := 1 } iszero(eq(a, 10)) { a := add(a, 1) } {
-    let t := extcodesize(f())
+    let t := balance(f())
     let q := g()
   }
 }
@@ -14,7 +14,7 @@
 // {
 //     let b := 1
 //     let a := 1
-//     let t := extcodesize(f())
+//     let t := balance(f())
 //     let q := g()
 //     for { } iszero(eq(a, 10)) { a := add(a, 1) }
 //     { }

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_gas.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_gas.yul
@@ -1,0 +1,15 @@
+{
+    for { let a := 1 } iszero(eq(a, 10)) { a := add(a, 1) } {
+        let c := gas()
+    }
+}
+// ====
+// bytecodeFormat: legacy
+// ----
+// step: loopInvariantCodeMotion
+//
+// {
+//     let a := 1
+//     for { } iszero(eq(a, 10)) { a := add(a, 1) }
+//     { let c := gas() }
+// }

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_immovables.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_immovables.yul
@@ -1,24 +1,20 @@
 {
-  let a := 1
-  function f() -> x {invalid()}
-  function g() -> y {return(0, 0)}
-  for { let i := 1 } iszero(eq(i, 10)) { a := add(i, 1) } {
-    let b := f()
-    let c := gas()
-    let d := g()
-    let e := sload(g())
-  }
+    function f() -> x {invalid()}
+    function g() -> y {return(0, 0)}
+    for { let a := 1 } iszero(eq(a, 10)) { a := add(a, 1) } {
+        let b := f()
+        let d := g()
+        let e := sload(g())
+    }
 }
 // ----
 // step: loopInvariantCodeMotion
 //
 // {
 //     let a := 1
-//     let i := 1
-//     for { } iszero(eq(i, 10)) { a := add(i, 1) }
+//     for { } iszero(eq(a, 10)) { a := add(a, 1) }
 //     {
 //         let b := f()
-//         let c := gas()
 //         let d := g()
 //         let e := sload(g())
 //     }

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_memory.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_memory.yul
@@ -9,7 +9,7 @@
   for { let a := 1 } iszero(eq(a, 10)) { a := add(a, 1) } {
     let inv := add(b, 42)
     // mload prevents moving of extcodesize
-    let x := extcodesize(mload(mul(inv, 3)))
+    let x := balance(mload(mul(inv, 3)))
     a := add(x, 1)
     mstore(a, inv)
   }
@@ -31,7 +31,7 @@
 //     let inv_2 := add(b, 42)
 //     for { } iszero(eq(a_1, 10)) { a_1 := add(a_1, 1) }
 //     {
-//         let x_3 := extcodesize(mload(mul(inv_2, 3)))
+//         let x_3 := balance(mload(mul(inv_2, 3)))
 //         a_1 := add(x_3, 1)
 //         mstore(a_1, inv_2)
 //     }

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_memory_msize.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_memory_msize.yul
@@ -8,7 +8,7 @@
   }
   for { let a := 1 } iszero(eq(a, 10)) { a := add(a, 1) } {
     let inv := add(b, 42)
-    let x := extcodesize(mload(mul(inv, 3)))
+    let x := balance(mload(mul(inv, 3)))
     a := add(x, 1)
   }
 }
@@ -29,7 +29,7 @@
 //     let inv_2 := add(b, 42)
 //     for { } iszero(eq(a_1, 10)) { a_1 := add(a_1, 1) }
 //     {
-//         let x_3 := extcodesize(mload(mul(inv_2, 3)))
+//         let x_3 := balance(mload(mul(inv_2, 3)))
 //         a_1 := add(x_3, 1)
 //     }
 // }

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_state.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_state.yul
@@ -25,6 +25,8 @@
   }
 
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: loopInvariantCodeMotion
 //

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_state_function.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_state_function.yul
@@ -7,7 +7,7 @@
 
   let b := 1
   for { let a := 1 } iszero(eq(a, 10)) { a := add(a, 1) } {
-    let t := extcodesize(f())
+    let t := balance(f())
     let q := sload(g())
   }
 }
@@ -19,7 +19,7 @@
 //     let a := 1
 //     for { } iszero(eq(a, 10)) { a := add(a, 1) }
 //     {
-//         let t := extcodesize(f())
+//         let t := balance(f())
 //         let q := sload(g())
 //     }
 //     function f() -> x

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_state_loop.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_state_loop.yul
@@ -4,7 +4,7 @@
 
   let b := 1
   for { let a := 1 } iszero(eq(a, 10)) { a := add(a, 1) } {
-    let t := extcodesize(f())
+    let t := balance(f())
     let q := g()
   }
 }
@@ -16,7 +16,7 @@
 //     let a := 1
 //     for { } iszero(eq(a, 10)) { a := add(a, 1) }
 //     {
-//         let t := extcodesize(f())
+//         let t := balance(f())
 //         let q := g()
 //     }
 //     function f() -> x

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_state_recursive_function.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_state_recursive_function.yul
@@ -4,7 +4,7 @@
 
   let b := 1
   for { let a := 1 } iszero(eq(a, 10)) { a := add(a, 1) } {
-    let t := extcodesize(f())
+    let t := balance(f())
     let q := sload(g())
   }
 }
@@ -16,7 +16,7 @@
 //     let a := 1
 //     for { } iszero(eq(a, 10)) { a := add(a, 1) }
 //     {
-//         let t := extcodesize(f())
+//         let t := balance(f())
 //         let q := sload(g())
 //     }
 //     function f() -> x

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_staticall_returndatasize.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_staticall_returndatasize.yul
@@ -10,6 +10,8 @@
   }
 }
 // ====
+// bytecodeFormat: legacy
+// ====
 // EVMVersion: >=byzantium
 // ----
 // step: loopInvariantCodeMotion

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_storage_in_body.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_storage_in_body.yul
@@ -1,15 +1,13 @@
 {
     let b := 1
-    // invalidates state in body
+    // invalidates storage in body
     for { let a := 1 } iszero(eq(a, 10)) { a := add(a, 1) } {
         let inv := add(b, 42)
-        pop(callcode(100, 0x010, 10, 0x00, 32, 0x0100, 32))
         let x := sload(mul(inv, 3))
         a := add(x, 1)
+        sstore(a, inv)
     }
 }
-// ====
-// bytecodeFormat: legacy
 // ----
 // step: loopInvariantCodeMotion
 //
@@ -19,8 +17,8 @@
 //     let inv := add(b, 42)
 //     for { } iszero(eq(a, 10)) { a := add(a, 1) }
 //     {
-//         pop(callcode(100, 0x010, 10, 0x00, 32, 0x0100, 32))
 //         let x := sload(mul(inv, 3))
 //         a := add(x, 1)
+//         sstore(a, inv)
 //     }
 // }

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_storage_in_post.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/no_move_storage_in_post.yul
@@ -1,15 +1,13 @@
 {
     let b := 1
-    // invalidates state in body
-    for { let a := 1 } iszero(eq(a, 10)) { a := add(a, 1) } {
+    // invalidates storage in post
+    for { let a := 1 } iszero(eq(a, 10)) { sstore(0x00, 0x01)} {
         let inv := add(b, 42)
-        pop(callcode(100, 0x010, 10, 0x00, 32, 0x0100, 32))
         let x := sload(mul(inv, 3))
         a := add(x, 1)
+        mstore(a, inv)
     }
 }
-// ====
-// bytecodeFormat: legacy
 // ----
 // step: loopInvariantCodeMotion
 //
@@ -17,10 +15,10 @@
 //     let b := 1
 //     let a := 1
 //     let inv := add(b, 42)
-//     for { } iszero(eq(a, 10)) { a := add(a, 1) }
+//     for { } iszero(eq(a, 10)) { sstore(0x00, 0x01) }
 //     {
-//         pop(callcode(100, 0x010, 10, 0x00, 32, 0x0100, 32))
 //         let x := sload(mul(inv, 3))
 //         a := add(x, 1)
+//         mstore(a, inv)
 //     }
 // }

--- a/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/simple_state.yul
+++ b/test/libyul/yulOptimizerTests/loopInvariantCodeMotion/simple_state.yul
@@ -2,7 +2,7 @@
   let b := 1
   for { let a := 1 } iszero(eq(a, 10)) { a := add(a, 1) } {
     let inv := add(b, 42)
-    let x := extcodesize(mul(inv, 3))
+    let x := balance(mul(inv, 3))
     a := add(x, 1)
     mstore(a, inv)
   }
@@ -14,7 +14,7 @@
 //     let b := 1
 //     let a := 1
 //     let inv := add(b, 42)
-//     let x := extcodesize(mul(inv, 3))
+//     let x := balance(mul(inv, 3))
 //     for { } iszero(eq(a, 10)) { a := add(a, 1) }
 //     {
 //         a := add(x, 1)

--- a/test/libyul/yulOptimizerTests/rematerialiser/reassign.yul
+++ b/test/libyul/yulOptimizerTests/rematerialiser/reassign.yul
@@ -1,5 +1,5 @@
 {
-    let a := extcodesize(0)
+    let a := balance(0)
     let b := a
     let c := b
     a := 2
@@ -10,7 +10,7 @@
 // step: rematerialiser
 //
 // {
-//     let a := extcodesize(0)
+//     let a := balance(0)
 //     let b := a
 //     let c := a
 //     a := 2

--- a/test/libyul/yulOptimizerTests/rematerialiser/update_asignment_remat.yul
+++ b/test/libyul/yulOptimizerTests/rematerialiser/update_asignment_remat.yul
@@ -1,6 +1,6 @@
 // We cannot substitute `a` in `let b := a`
 {
-	let a := extcodesize(0)
+	let a := balance(0)
 	a := mul(a, 2)
 	let b := a
 }
@@ -8,7 +8,7 @@
 // step: rematerialiser
 //
 // {
-//     let a := extcodesize(0)
+//     let a := balance(0)
 //     a := mul(a, 2)
 //     let b := a
 // }

--- a/test/libyul/yulOptimizerTests/unusedStoreEliminator/call_does_not_need_to_write.yul
+++ b/test/libyul/yulOptimizerTests/unusedStoreEliminator/call_does_not_need_to_write.yul
@@ -12,6 +12,8 @@
   sstore(0, mload(0))
 }
 
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: unusedStoreEliminator
 //

--- a/test/libyul/yulOptimizerTests/unusedStoreEliminator/create.yul
+++ b/test/libyul/yulOptimizerTests/unusedStoreEliminator/create.yul
@@ -4,6 +4,8 @@
     pop(create(0, 0, 0))
     sstore(x, 20)
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: unusedStoreEliminator
 //

--- a/test/libyul/yulOptimizerTests/unusedStoreEliminator/create_inside_function.yul
+++ b/test/libyul/yulOptimizerTests/unusedStoreEliminator/create_inside_function.yul
@@ -7,6 +7,8 @@
     f()
     sstore(x, 20)
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: unusedStoreEliminator
 //

--- a/test/libyul/yulStackLayout/complex.yul
+++ b/test/libyul/yulStackLayout/complex.yul
@@ -48,6 +48,8 @@
     }
     pop(f(1,2))
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // digraph CFG {
 // nodesep=0.7;

--- a/test/libyul/yulStackLayout/eof/function.yul
+++ b/test/libyul/yulStackLayout/eof/function.yul
@@ -21,7 +21,7 @@
     g()
 }
 // ====
-// bytecodeFormat: legacy
+// bytecodeFormat: >=EOFv1
 // ----
 // digraph CFG {
 // nodesep=0.7;
@@ -31,7 +31,7 @@
 // Entry -> Block0;
 // Block0 [label="\
 // [ ]\l\
-// [ RET[i] ]\l\
+// [ ]\l\
 // i\l\
 // [ TMP[i, 0] TMP[i, 1] ]\l\
 // [ TMP[i, 0] TMP[i, 1] ]\l\
@@ -49,20 +49,20 @@
 // [ RET b a ]"];
 // FunctionEntry_f -> Block1;
 // Block1 [label="\
-// [ RET a b ]\l\
-// [ RET a b a ]\l\
+// [ a b ]\l\
+// [ a b a ]\l\
 // add\l\
-// [ RET a TMP[add, 0] ]\l\
-// [ RET a TMP[add, 0] ]\l\
+// [ a TMP[add, 0] ]\l\
+// [ a TMP[add, 0] ]\l\
 // Assignment(x)\l\
-// [ RET a x ]\l\
-// [ RET a x ]\l\
+// [ a x ]\l\
+// [ a x ]\l\
 // sub\l\
-// [ RET TMP[sub, 0] ]\l\
-// [ RET TMP[sub, 0] ]\l\
+// [ TMP[sub, 0] ]\l\
+// [ TMP[sub, 0] ]\l\
 // Assignment(r)\l\
-// [ RET r ]\l\
-// [ r RET ]\l\
+// [ r ]\l\
+// [ r ]\l\
 // "];
 // Block1Exit [label="FunctionReturn[f]"];
 // Block1 -> Block1Exit;
@@ -71,8 +71,8 @@
 // [ RET x ]"];
 // FunctionEntry_h -> Block2;
 // Block2 [label="\
-// [ RET[f] 0x00 x ]\l\
-// [ RET[f] 0x00 x ]\l\
+// [ 0x00 x ]\l\
+// [ 0x00 x ]\l\
 // f\l\
 // [ TMP[f, 0] ]\l\
 // [ TMP[f, 0] ]\l\
@@ -87,14 +87,14 @@
 // [ RET ]"];
 // FunctionEntry_i -> Block3;
 // Block3 [label="\
-// [ RET ]\l\
-// [ RET 0x0202 ]\l\
+// [ ]\l\
+// [ 0x0202 ]\l\
 // Assignment(v)\l\
-// [ RET v ]\l\
-// [ v RET 0x0303 ]\l\
+// [ v ]\l\
+// [ v 0x0303 ]\l\
 // Assignment(w)\l\
-// [ v RET w ]\l\
-// [ v w RET ]\l\
+// [ v w ]\l\
+// [ v w ]\l\
 // "];
 // Block3Exit [label="FunctionReturn[i]"];
 // Block3 -> Block3Exit;

--- a/test/libyul/yulStackLayout/literal_loop.yul
+++ b/test/libyul/yulStackLayout/literal_loop.yul
@@ -4,6 +4,8 @@
 			{}
 			{}
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // digraph CFG {
 // nodesep=0.7;


### PR DESCRIPTION
Add `bytecodeFormat: legacy` to all tests which are supposed to run in legacy bytecode mode only.