### PR TITLE
eof: Disable `smtCheckerTests` when compiling to EOF

### DIFF
--- a/test/libsolidity/SMTCheckerTest.cpp
+++ b/test/libsolidity/SMTCheckerTest.cpp
@@ -136,6 +136,10 @@ SMTCheckerTest::SMTCheckerTest(std::string const& _filename):
 
 	auto const& bmcLoopIterations = m_reader.sizetSetting("BMCLoopIterations", 1);
 	m_modelCheckerSettings.bmcLoopIterations = std::optional<unsigned>{bmcLoopIterations};
+
+	// TODO: Enable EOF testing when EOF gets stable and smtCheckerTest starts using IR.
+	if (CommonOptions::get().eofVersion().has_value())
+		m_shouldRun = false;
 }
 
 void SMTCheckerTest::setupCompiler(CompilerStack& _compiler)


### PR DESCRIPTION
All `smtCheckerTests` are run for `current` EVM version which is incompatible with EOF. 