### PR TITLE
eof: Update `yulSyntaxTests` tests for EOF

### DIFF
--- a/test/libyul/yulSyntaxTests/builtin_function_literal.yul
+++ b/test/libyul/yulSyntaxTests/builtin_function_literal.yul
@@ -1,6 +1,8 @@
 {
   datasize(x,1)
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // TypeError 7000: (4-12): Function "datasize" expects 1 arguments but got 2.
 // TypeError 9114: (4-12): Function expects direct literals as arguments.

--- a/test/libyul/yulSyntaxTests/datacopy_shadowing.yul
+++ b/test/libyul/yulSyntaxTests/datacopy_shadowing.yul
@@ -1,5 +1,7 @@
 {
     function datacopy(a, b, c) {}
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // ParserError 5568: (15-23): Cannot use builtin function name "datacopy" as identifier name.

--- a/test/libyul/yulSyntaxTests/dataoffset_shadowing.yul
+++ b/test/libyul/yulSyntaxTests/dataoffset_shadowing.yul
@@ -1,5 +1,7 @@
 {
     function dataoffset(a) -> b {}
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // ParserError 5568: (15-25): Cannot use builtin function name "dataoffset" as identifier name.

--- a/test/libyul/yulSyntaxTests/datasize_shadowing.yul
+++ b/test/libyul/yulSyntaxTests/datasize_shadowing.yul
@@ -1,5 +1,7 @@
 {
     function datasize(a) -> b {}
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // ParserError 5568: (15-23): Cannot use builtin function name "datasize" as identifier name.

--- a/test/libyul/yulSyntaxTests/eof/builtin_function_literal.yul
+++ b/test/libyul/yulSyntaxTests/eof/builtin_function_literal.yul
@@ -1,0 +1,9 @@
+{
+    auxdataloadn(x,1)
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// TypeError 7000: (6-18): Function "auxdataloadn" expects 1 arguments but got 2.
+// TypeError 9114: (6-18): Function expects direct literals as arguments.
+// DeclarationError 8198: (19-20): Identifier "x" not found.

--- a/test/libyul/yulSyntaxTests/eof/datacopy_shadowing.yul
+++ b/test/libyul/yulSyntaxTests/eof/datacopy_shadowing.yul
@@ -1,0 +1,7 @@
+{
+    function datacopy(a, b, c) {}
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// DeclarationError 5017: (6-35): The identifier "datacopy" is reserved and can not be used.

--- a/test/libyul/yulSyntaxTests/eof/dataoffset_shadowing.yul
+++ b/test/libyul/yulSyntaxTests/eof/dataoffset_shadowing.yul
@@ -1,0 +1,7 @@
+{
+    function dataoffset(a) -> b {}
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// DeclarationError 5017: (6-36): The identifier "dataoffset" is reserved and can not be used.

--- a/test/libyul/yulSyntaxTests/eof/datasize_shadowing.yul
+++ b/test/libyul/yulSyntaxTests/eof/datasize_shadowing.yul
@@ -1,0 +1,7 @@
+{
+    function datasize(a) -> b {}
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// DeclarationError 5017: (6-34): The identifier "datasize" is reserved and can not be used.

--- a/test/libyul/yulSyntaxTests/eof/loadimmutable_shadowing.yul
+++ b/test/libyul/yulSyntaxTests/eof/loadimmutable_shadowing.yul
@@ -1,0 +1,8 @@
+{
+    function loadimmutable(a) {}
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// dialect: evm
+// ----
+// DeclarationError 5017: (6-34): The identifier "loadimmutable" is reserved and can not be used.

--- a/test/libyul/yulSyntaxTests/eof/passing_builtin_with_literal_argument_into_literal_argument.yul
+++ b/test/libyul/yulSyntaxTests/eof/passing_builtin_with_literal_argument_into_literal_argument.yul
@@ -1,8 +1,8 @@
 {
-    setimmutable(0, loadimmutable("abc"), "abc")
+    auxdataloadn(auxdataloadn(0))
 }
 // ====
+// bytecodeFormat: >=EOFv1
 // dialect: evm
-// bytecodeFormat: legacy
 // ----
 // TypeError 9114: (6-18): Function expects direct literals as arguments.

--- a/test/libyul/yulSyntaxTests/eof/selfdestruct.yul
+++ b/test/libyul/yulSyntaxTests/eof/selfdestruct.yul
@@ -1,0 +1,7 @@
+{
+	selfdestruct(0x02)
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// TypeError 9132: (3-15): The "selfdestruct" instruction is only available in legacy bytecode VMs (you are currently compiling to EOF).

--- a/test/libyul/yulSyntaxTests/eof/setimmutable_shadowing.yul
+++ b/test/libyul/yulSyntaxTests/eof/setimmutable_shadowing.yul
@@ -1,0 +1,8 @@
+{
+    function setimmutable(a, b) {}
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// dialect: evm
+// ----
+// DeclarationError 5017: (6-36): The identifier "setimmutable" is reserved and can not be used.

--- a/test/libyul/yulSyntaxTests/hex_switch_case.yul
+++ b/test/libyul/yulSyntaxTests/hex_switch_case.yul
@@ -1,5 +1,5 @@
 {
-    switch codesize()
+    switch calldataload(0)
     case hex"00" {}
     case hex"1122" {}
 }

--- a/test/libyul/yulSyntaxTests/hex_switch_case_long.yul
+++ b/test/libyul/yulSyntaxTests/hex_switch_case_long.yul
@@ -1,7 +1,7 @@
 {
-    switch codesize()
+    switch calldataload(0)
     case hex"00" {}
     case hex"112233445566778899001122334455667788990011223344556677889900112233445566778899001122334455667788990011223344556677889900" {}
 }
 // ----
-// TypeError 3069: (53-178): String literal too long (60 > 32)
+// TypeError 3069: (58-183): String literal too long (60 > 32)

--- a/test/libyul/yulSyntaxTests/invalid/pc_disallowed.yul
+++ b/test/libyul/yulSyntaxTests/invalid/pc_disallowed.yul
@@ -1,5 +1,7 @@
 {
     pop(pc())
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // SyntaxError 2450: (10-12): PC instruction is a low-level EVM feature. Because of that PC is disallowed in strict assembly.

--- a/test/libyul/yulSyntaxTests/loadimmutable.yul
+++ b/test/libyul/yulSyntaxTests/loadimmutable.yul
@@ -3,4 +3,5 @@
 }
 // ====
 // dialect: evm
+// bytecodeFormat: legacy
 // ----

--- a/test/libyul/yulSyntaxTests/loadimmutable_bad_literal.yul
+++ b/test/libyul/yulSyntaxTests/loadimmutable_bad_literal.yul
@@ -5,6 +5,7 @@
 }
 // ====
 // dialect: evm
+// bytecodeFormat: legacy
 // ----
 // TypeError 5859: (24-25): Function expects string literal.
 // TypeError 5859: (50-54): Function expects string literal.

--- a/test/libyul/yulSyntaxTests/loadimmutable_shadowing.yul
+++ b/test/libyul/yulSyntaxTests/loadimmutable_shadowing.yul
@@ -3,5 +3,6 @@
 }
 // ====
 // dialect: evm
+// bytecodeFormat: legacy
 // ----
 // ParserError 5568: (15-28): Cannot use builtin function name "loadimmutable" as identifier name.

--- a/test/libyul/yulSyntaxTests/loadimmutable_without_setimmutable.yul
+++ b/test/libyul/yulSyntaxTests/loadimmutable_without_setimmutable.yul
@@ -7,5 +7,7 @@ object "C" {
         }
     }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // CodeGenerationError 1284: Some immutables were read from but never assigned, possibly because of optimization.

--- a/test/libyul/yulSyntaxTests/metadata_access.yul
+++ b/test/libyul/yulSyntaxTests/metadata_access.yul
@@ -21,6 +21,8 @@ object "A" {
   data ".metadata" "Hello, World!"
   data ".other" "Hello, World2!"
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // TypeError 3517: (41-49): Unknown data object ".other".
 // TypeError 3517: (69-77): Unknown data object ".other".

--- a/test/libyul/yulSyntaxTests/metadata_access_2.yul
+++ b/test/libyul/yulSyntaxTests/metadata_access_2.yul
@@ -9,5 +9,7 @@ object "A" {
   data "1" "XYZ"
   data ".mightbereservedinthefuture" "TRS"
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // TypeError 3517: (90-119): Unknown data object ".mightbereservedinthefuture".

--- a/test/libyul/yulSyntaxTests/metadata_access_subobject.yul
+++ b/test/libyul/yulSyntaxTests/metadata_access_subobject.yul
@@ -8,5 +8,7 @@ object "A" {
 		data "x" "ABC"
 	}
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // TypeError 3517: (41-54): Unknown data object ".metadata.x".

--- a/test/libyul/yulSyntaxTests/objects/data.yul
+++ b/test/libyul/yulSyntaxTests/objects/data.yul
@@ -6,4 +6,6 @@ object "A" {
   data "2" hex"0011"
   data "3" "hello world this is longer than 32 bytes and should still work"
 }
+// ====
+// bytecodeFormat: legacy
 // ----

--- a/test/libyul/yulSyntaxTests/objects/data_access.yul
+++ b/test/libyul/yulSyntaxTests/objects/data_access.yul
@@ -6,4 +6,6 @@ object "A" {
 
   data "B" hex"00"
 }
+// ====
+// bytecodeFormat: legacy
 // ----

--- a/test/libyul/yulSyntaxTests/objects/datacopy.yul
+++ b/test/libyul/yulSyntaxTests/objects/datacopy.yul
@@ -6,4 +6,6 @@
     let s := ""
     datacopy(x, "11", s)
 }
+// ====
+// bytecodeFormat: legacy
 // ----

--- a/test/libyul/yulSyntaxTests/objects/dataoffset_nonliteral.yul
+++ b/test/libyul/yulSyntaxTests/objects/dataoffset_nonliteral.yul
@@ -6,5 +6,7 @@ object "A" {
 
   data "B" hex"00"
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // TypeError 9114: (47-57): Function expects direct literals as arguments.

--- a/test/libyul/yulSyntaxTests/objects/dataoffset_nonstring.yul
+++ b/test/libyul/yulSyntaxTests/objects/dataoffset_nonstring.yul
@@ -3,5 +3,7 @@ object "A" {
     pop(dataoffset(0))
   }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // TypeError 5859: (41-42): Function expects string literal.

--- a/test/libyul/yulSyntaxTests/objects/dataoffset_notfound.yul
+++ b/test/libyul/yulSyntaxTests/objects/dataoffset_notfound.yul
@@ -4,5 +4,7 @@ object "A" {
   }
   data "B" ""
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // TypeError 3517: (41-44): Unknown data object "C".

--- a/test/libyul/yulSyntaxTests/objects/datasize_nonliteral.yul
+++ b/test/libyul/yulSyntaxTests/objects/datasize_nonliteral.yul
@@ -6,5 +6,7 @@ object "A" {
 
   data "B" hex"00"
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // TypeError 9114: (47-55): Function expects direct literals as arguments.

--- a/test/libyul/yulSyntaxTests/objects/datasize_nonstring.yul
+++ b/test/libyul/yulSyntaxTests/objects/datasize_nonstring.yul
@@ -3,5 +3,7 @@ object "A" {
     pop(datasize(0))
   }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // TypeError 5859: (39-40): Function expects string literal.

--- a/test/libyul/yulSyntaxTests/objects/datasize_notfound.yul
+++ b/test/libyul/yulSyntaxTests/objects/datasize_notfound.yul
@@ -4,5 +4,7 @@ object "A" {
   }
   data "B" ""
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // TypeError 3517: (39-42): Unknown data object "C".

--- a/test/libyul/yulSyntaxTests/objects/subobject_access.yul
+++ b/test/libyul/yulSyntaxTests/objects/subobject_access.yul
@@ -8,4 +8,6 @@ object "A" {
     code {}
   }
 }
+// ====
+// bytecodeFormat: legacy
 // ----

--- a/test/libyul/yulSyntaxTests/opcode_for_function_args_1.yul
+++ b/test/libyul/yulSyntaxTests/opcode_for_function_args_1.yul
@@ -1,5 +1,5 @@
 {
-	function f(gas) {}
+	function f(mload) {}
 }
 // ----
-// ParserError 5568: (14-17): Cannot use builtin function name "gas" as identifier name.
+// ParserError 5568: (14-19): Cannot use builtin function name "mload" as identifier name.

--- a/test/libyul/yulSyntaxTests/opcode_for_function_args_2.yul
+++ b/test/libyul/yulSyntaxTests/opcode_for_function_args_2.yul
@@ -1,5 +1,5 @@
 {
-	function f() -> gas {}
+	function f() -> mload {}
 }
 // ----
-// ParserError 5568: (19-22): Cannot use builtin function name "gas" as identifier name.
+// ParserError 5568: (19-24): Cannot use builtin function name "mload" as identifier name.

--- a/test/libyul/yulSyntaxTests/opcode_for_functions.yul
+++ b/test/libyul/yulSyntaxTests/opcode_for_functions.yul
@@ -1,5 +1,5 @@
 {
-	function gas() {}
+	function mload() {}
 }
 // ----
-// ParserError 5568: (12-15): Cannot use builtin function name "gas" as identifier name.
+// ParserError 5568: (12-17): Cannot use builtin function name "mload" as identifier name.

--- a/test/libyul/yulSyntaxTests/selfdestruct.yul
+++ b/test/libyul/yulSyntaxTests/selfdestruct.yul
@@ -1,5 +1,7 @@
 {
 	selfdestruct(0x02)
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // Warning 1699: (3-15): "selfdestruct" has been deprecated. Note that, starting from the Cancun hard fork, the underlying opcode no longer deletes the code and data associated with an account and only transfers its Ether to the beneficiary, unless executed in the same transaction in which the contract was created (see EIP-6780). Any use in newly deployed contracts is strongly discouraged even if the new behavior is taken into account. Future changes to the EVM might further reduce the functionality of the opcode.

--- a/test/libyul/yulSyntaxTests/setimmutable.yul
+++ b/test/libyul/yulSyntaxTests/setimmutable.yul
@@ -3,4 +3,5 @@
 }
 // ====
 // dialect: evm
+// bytecodeFormat: legacy
 // ----

--- a/test/libyul/yulSyntaxTests/setimmutable_bad_literal.yul
+++ b/test/libyul/yulSyntaxTests/setimmutable_bad_literal.yul
@@ -5,6 +5,7 @@
 }
 // ====
 // dialect: evm
+// bytecodeFormat: legacy
 // ----
 // TypeError 5859: (22-23): Function expects string literal.
 // TypeError 5859: (89-93): Function expects string literal.

--- a/test/libyul/yulSyntaxTests/setimmutable_shadowing.yul
+++ b/test/libyul/yulSyntaxTests/setimmutable_shadowing.yul
@@ -3,5 +3,6 @@
 }
 // ====
 // dialect: evm
+// bytecodeFormat: legacy
 // ----
 // ParserError 5568: (15-27): Cannot use builtin function name "setimmutable" as identifier name.

--- a/test/libyul/yulSyntaxTests/simple_functions.yul
+++ b/test/libyul/yulSyntaxTests/simple_functions.yul
@@ -2,7 +2,7 @@
     function a() {}
     function f() { mstore(0, 1) }
     function g() { sstore(0, 1) }
-    function h() { let x := msize() }
+    function h() { let x := balance(0x0) }
     function i() { let z := mload(0) }
 }
 // ====

--- a/test/libyul/yulSyntaxTests/string_literal_switch_case.yul
+++ b/test/libyul/yulSyntaxTests/string_literal_switch_case.yul
@@ -1,5 +1,5 @@
 {
-    switch codesize()
+    switch calldataload(0)
     case "1" {}
     case "2" {}
 }

--- a/test/libyul/yulSyntaxTests/string_literal_too_long_immutable.yul
+++ b/test/libyul/yulSyntaxTests/string_literal_too_long_immutable.yul
@@ -7,4 +7,5 @@
 }
 // ====
 // dialect: evm
+// bytecodeFormat: legacy
 // ----


### PR DESCRIPTION
- Disable test which don't make sense for EOF bytecode format.
- Create EOF yul syntax tests counterparts.