### PR TITLE
eof: Test that EOF sets the `experimental` flag in metadata

### DIFF
--- a/test/libsolidity/Metadata.cpp
+++ b/test/libsolidity/Metadata.cpp
@@ -225,6 +225,48 @@ BOOST_AUTO_TEST_CASE(metadata_stamp_experimental)
 		}
 }
 
+BOOST_AUTO_TEST_CASE(metadata_eof_experimental)
+{
+	// Check that setting an EOF version results in the experimental flag being set.
+	char const* sourceCode = R"(
+		pragma solidity >=0.0;
+		contract test {
+			function g(function(uint) external returns (uint) x) public {}
+		}
+	)";
+	for (auto metadataFormat: std::set<CompilerStack::MetadataFormat>{
+		CompilerStack::MetadataFormat::NoMetadata,
+		CompilerStack::MetadataFormat::WithReleaseVersionTag,
+		CompilerStack::MetadataFormat::WithPrereleaseVersionTag
+	})
+	{
+		CompilerStack compilerStack;
+		compilerStack.setMetadataFormat(metadataFormat);
+		compilerStack.setSources({{"", sourceCode}});
+		compilerStack.setEVMVersion(solidity::test::CommonOptions::get().evmVersion());
+		compilerStack.setViaIR(true);
+		compilerStack.setEOFVersion(solidity::test::CommonOptions::get().eofVersion());
+		compilerStack.setOptimiserSettings(solidity::test::CommonOptions::get().optimize);
+		BOOST_REQUIRE_MESSAGE(compilerStack.compile(), "Compiling contract failed");
+		bytes const& bytecode = compilerStack.runtimeObject("test").bytecode;
+		std::string const& metadata = compilerStack.metadata("test");
+		BOOST_CHECK(solidity::test::isValidMetadata(metadata));
+
+		auto const cborMetadata = requireParsedCBORMetadata(bytecode, metadataFormat);
+
+		if (
+			metadataFormat == CompilerStack::MetadataFormat::NoMetadata ||
+			!solidity::test::CommonOptions::get().eofVersion().has_value()
+		)
+			BOOST_CHECK(cborMetadata.count("experimental") == 0);
+		else
+		{
+			BOOST_CHECK(cborMetadata.count("experimental") == 1);
+			BOOST_CHECK(cborMetadata.at("experimental") == "true");
+		}
+	}
+}
+
 BOOST_AUTO_TEST_CASE(metadata_relevant_sources)
 {
 	CompilerStack compilerStack;


### PR DESCRIPTION
 Add test which checks that setting an EOF version results in the experimental flag being set.