### PR TITLE
Make messages mandatory in errors

### DIFF
--- a/liblangutil/ErrorReporter.cpp
+++ b/liblangutil/ErrorReporter.cpp
@@ -63,6 +63,7 @@ void ErrorReporter::warning(
 
 void ErrorReporter::error(ErrorId _errorId, Error::Type _type, SourceLocation const& _location, std::string const& _description)
 {
+	solAssert(!_description.empty(), "Errors must include a message for the user.");
 	if (checkForExcessiveErrors(_type))
 		return;
 
@@ -71,6 +72,7 @@ void ErrorReporter::error(ErrorId _errorId, Error::Type _type, SourceLocation co
 
 void ErrorReporter::error(ErrorId _errorId, Error::Type _type, SourceLocation const& _location, SecondarySourceLocation const& _secondaryLocation, std::string const& _description)
 {
+	solAssert(!_description.empty(), "Errors must include a message for the user.");
 	if (checkForExcessiveErrors(_type))
 		return;
 

--- a/liblangutil/Exceptions.h
+++ b/liblangutil/Exceptions.h
@@ -72,16 +72,7 @@ struct InvalidAstError: virtual util::Exception {};
 
 
 /// Assertion that throws an UnimplementedFeatureError containing the given description if it is not met.
-#if !BOOST_PP_VARIADICS_MSVC
-#define solUnimplementedAssert(...) BOOST_PP_OVERLOAD(solUnimplementedAssert_,__VA_ARGS__)(__VA_ARGS__)
-#else
-#define solUnimplementedAssert(...) BOOST_PP_CAT(BOOST_PP_OVERLOAD(solUnimplementedAssert_,__VA_ARGS__)(__VA_ARGS__),BOOST_PP_EMPTY())
-#endif
-
-#define solUnimplementedAssert_1(CONDITION) \
-	solUnimplementedAssert_2((CONDITION), "")
-
-#define solUnimplementedAssert_2(CONDITION, DESCRIPTION) \
+#define solUnimplementedAssert(CONDITION, DESCRIPTION) \
 	assertThrowWithDefaultDescription( \
 		(CONDITION), \
 		::solidity::langutil::UnimplementedFeatureError, \

--- a/libsolidity/analysis/ControlFlowBuilder.cpp
+++ b/libsolidity/analysis/ControlFlowBuilder.cpp
@@ -604,7 +604,7 @@ void ControlFlowBuilder::operator()(yul::FunctionDefinition const&)
 void ControlFlowBuilder::operator()(yul::Leave const&)
 {
 	// This has to be implemented, if we ever decide to visit functions.
-	solUnimplemented("");
+	solAssert(false);
 }
 
 bool ControlFlowBuilder::visit(VariableDeclaration const& _variableDeclaration)

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -2302,11 +2302,12 @@ bool ExpressionCompiler::visit(IndexRangeAccess const& _indexAccess)
 		if (ArraySliceType const* sliceType = dynamic_cast<ArraySliceType const*>(&baseType))
 			arrayType = &sliceType->arrayType();
 
-	solAssert(arrayType, "");
+	solAssert(arrayType);
 	solUnimplementedAssert(
 		arrayType->location() == DataLocation::CallData &&
 		arrayType->isDynamicallySized() &&
-		!arrayType->baseType()->isDynamicallyEncoded()
+		!arrayType->baseType()->isDynamicallyEncoded(),
+		"Slicing is supported only for dynamically-sized calldata arrays of statically-encoded types."
 	);
 
 	if (_indexAccess.startExpression())
@@ -2440,7 +2441,10 @@ void ExpressionCompiler::appendCompareOperatorCode(Token _operator, Type const& 
 		FunctionType const* functionType = dynamic_cast<decltype(functionType)>(&_type);
 		if (functionType && functionType->kind() == FunctionType::Kind::External)
 		{
-			solUnimplementedAssert(functionType->sizeOnStack() == 2, "");
+			solUnimplementedAssert(
+				functionType->sizeOnStack() == 2,
+				"Comparisons are implemented only for external function types."
+			);
 			m_context << Instruction::SWAP3;
 
 			m_context << ((u256(1) << 160) - 1) << Instruction::AND;

--- a/libsolidity/codegen/LValue.cpp
+++ b/libsolidity/codegen/LValue.cpp
@@ -155,7 +155,7 @@ ImmutableItem::ImmutableItem(CompilerContext& _compilerContext, VariableDeclarat
 
 void ImmutableItem::retrieveValue(SourceLocation const&, bool) const
 {
-	solUnimplementedAssert(m_dataType->isValueType());
+	solUnimplementedAssert(m_dataType->isValueType(), "Immutables of non-value types not supported yet.");
 
 	if (m_context.runtimeContext())
 		CompilerUtils(m_context).loadFromMemory(
@@ -172,8 +172,8 @@ void ImmutableItem::retrieveValue(SourceLocation const&, bool) const
 void ImmutableItem::storeValue(Type const& _sourceType, SourceLocation const&, bool _move) const
 {
 	CompilerUtils utils(m_context);
-	solUnimplementedAssert(m_dataType->isValueType());
-	solAssert(_sourceType.isValueType(), "");
+	solUnimplementedAssert(m_dataType->isValueType(), "Immutables of non-value types not supported yet.");
+	solAssert(_sourceType.isValueType());
 
 	utils.convertType(_sourceType, *m_dataType, true);
 	m_context << m_context.immutableMemoryOffset(m_variable);
@@ -188,7 +188,7 @@ void ImmutableItem::storeValue(Type const& _sourceType, SourceLocation const&, b
 void ImmutableItem::setToZero(SourceLocation const&, bool _removeReference) const
 {
 	CompilerUtils utils(m_context);
-	solUnimplementedAssert(m_dataType->isValueType());
+	solUnimplementedAssert(m_dataType->isValueType(), "Immutables of non-value types not supported yet.");
 	solAssert(_removeReference);
 
 	m_context << m_context.immutableMemoryOffset(m_variable);

--- a/libsolidity/codegen/ir/IRGenerationContext.cpp
+++ b/libsolidity/codegen/ir/IRGenerationContext.cpp
@@ -153,8 +153,8 @@ size_t IRGenerationContext::reservedMemory()
 	size_t immutableVariablesSize = 0;
 	for (auto const* var: keys(m_immutableVariables))
 	{
-		solUnimplementedAssert(var->type()->isValueType());
-		solUnimplementedAssert(var->type()->sizeOnStack() == 1);
+		solUnimplementedAssert(var->type()->isValueType(), "Immutables of non-value types not supported yet.");
+		solUnimplementedAssert(var->type()->sizeOnStack() == 1, "Multi-slot immutables not supported yet.");
 		immutableVariablesSize += var->type()->sizeOnStack() * 32;
 	}
 

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -562,7 +562,7 @@ std::string IRGenerator::generateGetter(VariableDeclaration const& _varDecl)
 		if (_varDecl.immutable())
 		{
 			solAssert(paramTypes.empty(), "");
-			solUnimplementedAssert(type->sizeOnStack() == 1);
+			solUnimplementedAssert(type->sizeOnStack() == 1, "Multi-slot immutables not supported yet.");
 
 			auto t = Whiskers(R"(
 				<astIDComment><sourceLocationComment>
@@ -1019,8 +1019,8 @@ std::string IRGenerator::deployCode(ContractDefinition const& _contract)
 	{
 		for (VariableDeclaration const* immutable: ContractType(_contract).immutableVariables())
 		{
-			solUnimplementedAssert(immutable->type()->isValueType());
-			solUnimplementedAssert(immutable->type()->sizeOnStack() == 1);
+			solUnimplementedAssert(immutable->type()->isValueType(), "Immutables of non-value types not supported yet.");
+			solUnimplementedAssert(immutable->type()->sizeOnStack() == 1, "Multi-slot immutables not supported yet.");
 			if (!eof)
 				immutables.emplace_back(std::map<std::string, std::string>{
 					{"immutableName"s, std::to_string(immutable->id())},

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -109,7 +109,7 @@ private:
 	{
 		auto const& reference = m_references.at(&_identifier);
 		auto const varDecl = dynamic_cast<VariableDeclaration const*>(reference.declaration);
-		solUnimplementedAssert(varDecl);
+		solUnimplementedAssert(varDecl, "translateReference() is only implemented for variable declarations.");
 		std::string const& suffix = reference.suffix;
 
 		std::string value;
@@ -888,7 +888,7 @@ bool IRGeneratorForStatements::visit(BinaryOperation const& _binOp)
 
 		if (functionType && functionType->kind() ==  FunctionType::Kind::External)
 		{
-			solUnimplementedAssert(functionType->sizeOnStack() == 2, "");
+			solUnimplementedAssert(functionType->sizeOnStack() == 2, "Comparisons are implemented only for external function types.");
 			expr = m_utils.externalFunctionPointersEqualFunction() +
 				"(" +
 				IRVariable{_binOp.leftExpression()}.part("address").name() + "," +
@@ -1732,7 +1732,7 @@ void IRGeneratorForStatements::endVisit(FunctionCallOptions const& _options)
 	setLocation(_options);
 	FunctionType const& previousType = dynamic_cast<FunctionType const&>(*_options.expression().annotation().type);
 
-	solUnimplementedAssert(!previousType.hasBoundFirstArgument());
+	solUnimplementedAssert(!previousType.hasBoundFirstArgument(), "Call options not implemented for bound library functions.");
 
 	// Copy over existing values.
 	for (auto const& item: previousType.stackItems())
@@ -1913,7 +1913,7 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 		}
 		else if (member == "address")
 		{
-			solUnimplementedAssert(
+			solAssert(
 				dynamic_cast<FunctionType const&>(*_memberAccess.expression().annotation().type).kind() ==
 				FunctionType::Kind::External
 			);
@@ -3202,8 +3202,8 @@ void IRGeneratorForStatements::writeToLValue(IRLValue const& _lvalue, IRVariable
 			[&](IRLValue::Stack const& _stack) { assign(_stack.variable, _value); },
 			[&](IRLValue::Immutable const& _immutable)
 			{
-				solUnimplementedAssert(_lvalue.type.isValueType());
-				solUnimplementedAssert(_lvalue.type.sizeOnStack() == 1);
+				solUnimplementedAssert(_lvalue.type.isValueType(), "Immutables of non-value types not supported yet.");
+				solUnimplementedAssert(_lvalue.type.sizeOnStack() == 1, "Multi-slot immutables not supported yet.");
 				solAssert(_lvalue.type == *_immutable.variable->type());
 				size_t memOffset = m_context.immutableMemoryOffset(*_immutable.variable);
 
@@ -3280,8 +3280,8 @@ IRVariable IRGeneratorForStatements::readFromLValue(IRLValue const& _lvalue)
 			define(result, _stack.variable);
 		},
 		[&](IRLValue::Immutable const& _immutable) {
-			solUnimplementedAssert(_lvalue.type.isValueType());
-			solUnimplementedAssert(_lvalue.type.sizeOnStack() == 1);
+			solUnimplementedAssert(_lvalue.type.isValueType(), "Immutables of non-value types not supported yet.");
+			solUnimplementedAssert(_lvalue.type.sizeOnStack() == 1, "Multi-slot immutables not supported yet.");
 			solAssert(_lvalue.type == *_immutable.variable->type());
 			if (m_context.executionContext() == IRGenerationContext::ExecutionContext::Creation)
 			{

--- a/libsolidity/experimental/codegen/IRGeneratorForStatements.cpp
+++ b/libsolidity/experimental/codegen/IRGeneratorForStatements.cpp
@@ -117,7 +117,7 @@ bool IRGeneratorForStatements::visit(TupleExpression const& _tupleExpression)
 	std::vector<std::string> components;
 	for (auto const& component: _tupleExpression.components())
 	{
-		solUnimplementedAssert(component);
+		solUnimplementedAssert(component, "Tuple expressions with empty components not supported.");
 		component->accept(*this);
 		components.emplace_back(IRNames::localVariable(*component));
 	}

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -278,7 +278,7 @@ void CompilerStack::setOptimiserSettings(OptimiserSettings _settings)
 void CompilerStack::setRevertStringBehaviour(RevertStrings _revertStrings)
 {
 	solAssert(m_stackState < ParsedAndImported, "Must set revert string settings before parsing.");
-	solUnimplementedAssert(_revertStrings != RevertStrings::VerboseDebug);
+	solUnimplementedAssert(_revertStrings != RevertStrings::VerboseDebug, "VerboseDebug revert strings not implemented yet.");
 	m_revertStrings = _revertStrings;
 }
 
@@ -432,7 +432,7 @@ void CompilerStack::importASTs(std::map<std::string, Json> const& _sources)
 		ASTJsonImporter(m_evmVersion, m_eofVersion).jsonToSourceUnit(_sources);
 	for (auto& src: reconstructedSources)
 	{
-		solUnimplementedAssert(!src.second->experimentalSolidity());
+		solUnimplementedAssert(!src.second->experimentalSolidity(), "AST import not implemented for experimental Solidity yet.");
 		std::string const& path = src.first;
 		Source source;
 		source.ast = src.second;
@@ -978,7 +978,7 @@ std::optional<std::string> const& CompilerStack::yulIR(std::string const& _contr
 std::optional<Json> CompilerStack::yulIRAst(std::string const& _contractName) const
 {
 	solAssert(m_stackState == CompilationSuccessful, "Compilation was not successful.");
-	solUnimplementedAssert(!isExperimentalSolidity());
+	solUnimplementedAssert(!isExperimentalSolidity(), "IR AST export not implemented for experimental Solidity yet.");
 
 	// NOTE: Intentionally not using LazyInit. The artifact can get very large and we don't want to
 	// keep it around when compiling a large project containing many contracts.
@@ -993,7 +993,7 @@ std::optional<Json> CompilerStack::yulIRAst(std::string const& _contractName) co
 std::optional<Json> CompilerStack::yulCFGJson(std::string const& _contractName) const
 {
 	solAssert(m_stackState == CompilationSuccessful, "Compilation was not successful.");
-	solUnimplementedAssert(!isExperimentalSolidity());
+	solUnimplementedAssert(!isExperimentalSolidity(), "Yul CFG export not implemented for experimental Solidity yet.");
 
 	// NOTE: Intentionally not using LazyInit. The artifact can get very large and we don't want to
 	// keep it around when compiling a large project containing many contracts.
@@ -1014,7 +1014,7 @@ std::optional<std::string> const& CompilerStack::yulIROptimized(std::string cons
 std::optional<Json> CompilerStack::yulIROptimizedAst(std::string const& _contractName) const
 {
 	solAssert(m_stackState == CompilationSuccessful, "Compilation was not successful.");
-	solUnimplementedAssert(!isExperimentalSolidity());
+	solUnimplementedAssert(!isExperimentalSolidity(), "Optimized IR AST export not implemented for experimental Solidity yet.");
 
 	// NOTE: Intentionally not using LazyInit. The artifact can get very large and we don't want to
 	// keep it around when compiling a large project containing many contracts.
@@ -1054,7 +1054,7 @@ std::string CompilerStack::assemblyString(std::string const& _contractName, Stri
 Json CompilerStack::assemblyJSON(std::string const& _contractName) const
 {
 	solAssert(m_stackState == CompilationSuccessful, "Compilation was not successful.");
-	solUnimplementedAssert(!isExperimentalSolidity());
+	solUnimplementedAssert(!isExperimentalSolidity(), "Assembly JSON export not implemented for experimental Solidity yet.");
 
 	Contract const& currentContract = contract(_contractName);
 	if (currentContract.evmAssembly)
@@ -1089,7 +1089,7 @@ Json const& CompilerStack::contractABI(Contract const& _contract) const
 {
 	solAssert(m_stackState >= AnalysisSuccessful, "Analysis was not successful.");
 	solAssert(_contract.contract);
-	solUnimplementedAssert(!isExperimentalSolidity());
+	solUnimplementedAssert(!isExperimentalSolidity(), "ABI generation not implemented for experimental Solidity yet.");
 	return _contract.abi.init([&]{ return ABI::generate(*_contract.contract); });
 }
 
@@ -1103,7 +1103,7 @@ Json const& CompilerStack::storageLayout(Contract const& _contract) const
 {
 	solAssert(m_stackState >= AnalysisSuccessful, "Analysis was not successful.");
 	solAssert(_contract.contract);
-	solUnimplementedAssert(!isExperimentalSolidity());
+	solUnimplementedAssert(!isExperimentalSolidity(), "Storage layout generation not implemented for experimental Solidity yet.");
 
 	return _contract.storageLayout.init([&]{ return StorageLayout().generate(*_contract.contract, DataLocation::Storage); });
 }
@@ -1118,7 +1118,7 @@ Json const& CompilerStack::transientStorageLayout(Contract const& _contract) con
 {
 	solAssert(m_stackState >= AnalysisSuccessful, "Analysis was not successful.");
 	solAssert(_contract.contract);
-	solUnimplementedAssert(!isExperimentalSolidity());
+	solUnimplementedAssert(!isExperimentalSolidity(), "Transient storage layout generation not implemented for experimental Solidity yet.");
 
 	return _contract.transientStorageLayout.init([&]{ return StorageLayout().generate(*_contract.contract, DataLocation::Transient); });
 }
@@ -1133,7 +1133,7 @@ Json const& CompilerStack::natspecUser(Contract const& _contract) const
 {
 	solAssert(m_stackState >= AnalysisSuccessful, "Analysis was not successful.");
 	solAssert(_contract.contract);
-	solUnimplementedAssert(!isExperimentalSolidity());
+	solUnimplementedAssert(!isExperimentalSolidity(), "User Natspec generation not implemented for experimental Solidity yet.");
 	return _contract.userDocumentation.init([&]{ return Natspec::userDocumentation(*_contract.contract); });
 }
 
@@ -1147,14 +1147,14 @@ Json const& CompilerStack::natspecDev(Contract const& _contract) const
 {
 	solAssert(m_stackState >= AnalysisSuccessful, "Analysis was not successful.");
 	solAssert(_contract.contract);
-	solUnimplementedAssert(!isExperimentalSolidity());
+	solUnimplementedAssert(!isExperimentalSolidity(), "Dev Natspec generation not implemented for experimental Solidity yet.");
 	return _contract.devDocumentation.init([&]{ return Natspec::devDocumentation(*_contract.contract); });
 }
 
 Json CompilerStack::interfaceSymbols(std::string const& _contractName) const
 {
 	solAssert(m_stackState >= AnalysisSuccessful, "Analysis was not successful.");
-	solUnimplementedAssert(!isExperimentalSolidity());
+	solUnimplementedAssert(!isExperimentalSolidity(), "Interface symbol export not implemented for experimental Solidity yet.");
 
 	Json interfaceSymbols;
 	// Always have a methods object
@@ -1191,7 +1191,7 @@ std::string const& CompilerStack::metadata(Contract const& _contract) const
 {
 	solAssert(m_stackState >= AnalysisSuccessful, "Analysis was not successful.");
 	solAssert(_contract.contract);
-	solUnimplementedAssert(!isExperimentalSolidity());
+	solUnimplementedAssert(!isExperimentalSolidity(), "Metadata generation not implemented for experimental Solidity yet.");
 	return _contract.metadata.init([&]{ return createMetadata(_contract, m_viaIR); });
 }
 
@@ -1206,7 +1206,7 @@ SourceUnit const& CompilerStack::ast(std::string const& _sourceName) const
 {
 	solAssert(m_stackState >= Parsed, "Parsing not yet performed.");
 	solAssert(source(_sourceName).ast, "Parsing was not successful.");
-	solUnimplementedAssert(!isExperimentalSolidity());
+	solUnimplementedAssert(!isExperimentalSolidity(), "AST export not implemented for experimental Solidity yet.");
 	return *source(_sourceName).ast;
 }
 
@@ -1927,7 +1927,7 @@ Json gasToJson(GasEstimator::GasConsumption const& _gas)
 Json CompilerStack::gasEstimates(std::string const& _contractName) const
 {
 	solAssert(m_stackState == CompilationSuccessful, "Compilation was not successful.");
-	solUnimplementedAssert(!isExperimentalSolidity());
+	solUnimplementedAssert(!isExperimentalSolidity(), "Gas estimation not implemented for experimental Solidity yet.");
 
 	if (!assemblyItems(_contractName) && !runtimeAssemblyItems(_contractName))
 		return Json();

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -593,7 +593,7 @@ bool SemanticTest::checkGasCostExpectation(TestFunctionCall& io_test, bool _comp
 
 	// NOTE: Cost excluding code is unlikely to be negative but it may still be possible due to refunds.
 	// We'll deal with it when we actually have a test case like that.
-	solUnimplementedAssert(m_gasUsed >= m_gasUsedForCodeDeposit);
+	solUnimplementedAssert(m_gasUsed >= m_gasUsedForCodeDeposit, "Negative gas expectations not supported.");
 	io_test.setGasCostExcludingCode(setting, m_gasUsed - m_gasUsedForCodeDeposit);
 	io_test.setCodeDepositGasCost(setting, m_gasUsedForCodeDeposit);
 

--- a/test/libsolidity/util/TestFunctionCall.cpp
+++ b/test/libsolidity/util/TestFunctionCall.cpp
@@ -343,8 +343,8 @@ std::string formatGasDiff(std::optional<u256> const& _gasUsed, std::optional<u25
 	if (!_reference.has_value() || !_gasUsed.has_value() || _gasUsed == _reference)
 		return "";
 
-	solUnimplementedAssert(*_gasUsed < u256(1) << 255);
-	solUnimplementedAssert(*_reference < u256(1) << 255);
+	solUnimplementedAssert(*_gasUsed < u256(1) << 255, "Gas values >= 2^255 not supported by gas diff.");
+	solUnimplementedAssert(*_reference < u256(1) << 255, "Gas values >= 2^255 not supported by gas diff.");
 	s256 difference = static_cast<s256>(*_gasUsed) - static_cast<s256>(*_reference);
 
 	if (*_reference == 0)


### PR DESCRIPTION
Errors shown to the user should always have a message. One situation where it is not always the case now are unimplemented feature errors. Those used to be treated as asserts but often they can actually reach the user. This PR deals with them by either converting to asserts or adding a message. Then makes the message mandatory in `solUnimplemented()`/`solUnimplementedAssert()` and in the error reporter.

This partially addresses cases like #15669, which currently get properly reported but in a very confusing way.

I could probably convert many more of these to asserts but in cases where I wasn't sure I decided to err on the side of keeping them as is.