### PR TITLE
Fix build with GCC 14

### DIFF
--- a/test/yulPhaser/Chromosome.cpp
+++ b/test/yulPhaser/Chromosome.cpp
@@ -85,8 +85,8 @@ BOOST_AUTO_TEST_CASE(makeRandom_should_use_every_possible_step_with_the_same_pro
 	const double expectedValue = double(stepIndices.size() - 1) / 2.0;
 	const double variance = double(stepIndices.size() * stepIndices.size() - 1) / 12.0;
 
-	BOOST_TEST(abs(mean(samples) - expectedValue) < expectedValue * relativeTolerance);
-	BOOST_TEST(abs(meanSquaredError(samples, expectedValue) - variance) < variance * relativeTolerance);
+	BOOST_TEST(fabs(mean(samples) - expectedValue) < expectedValue * relativeTolerance);
+	BOOST_TEST(fabs(meanSquaredError(samples, expectedValue) - variance) < variance * relativeTolerance);
 }
 
 BOOST_AUTO_TEST_CASE(constructor_should_store_genes)
@@ -159,8 +159,8 @@ BOOST_AUTO_TEST_CASE(randomOptimisationStep_should_return_each_step_with_same_pr
 	const double expectedValue = double(stepIndices.size() - 1) / 2.0;
 	const double variance = double(stepIndices.size() * stepIndices.size() - 1) / 12.0;
 
-	BOOST_TEST(abs(mean(samples) - expectedValue) < expectedValue * relativeTolerance);
-	BOOST_TEST(abs(meanSquaredError(samples, expectedValue) - variance) < variance * relativeTolerance);
+	BOOST_TEST(fabs(mean(samples) - expectedValue) < expectedValue * relativeTolerance);
+	BOOST_TEST(fabs(meanSquaredError(samples, expectedValue) - variance) < variance * relativeTolerance);
 }
 
 BOOST_AUTO_TEST_CASE(stepsToGenes_should_translate_optimisation_step_names_to_abbreviations)


### PR DESCRIPTION
I was getting the following error at the end of the compilation (at least on `aarch64-linux`):
```
[100%] Linking CXX executable solc
In file included from include/boost/test/test_tools.hpp:52,
                 from include/boost/test/unit_test.hpp:18,
                 from /build/source/test/yulPhaser/Chromosome.cpp:41:
/build/source/test/yulPhaser/Chromosome.cpp: In member function 'void solidity::phaser::test::Phaser::ChromosomeTest::makeRandom_should_use_every_possible_step_with_the_same_probability::test_method()':
/build/source/test/yulPhaser/Chromosome.cpp:88:38: error: conversion from 'double' to 'int' may change value [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wfloat-conversion-Werror=float-conversion8;;]
   88 |         BOOST_TEST(abs(mean(samples) - expectedValue) < expectedValue * relativeTolerance);
      |                        ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
/build/source/test/yulPhaser/Chromosome.cpp:89:65: error: conversion from 'double' to 'int' may change value [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wfloat-conversion-Werror=float-conversion8;;]
   89 |         BOOST_TEST(abs(meanSquaredError(samples, expectedValue) - variance) < variance * relativeTolerance);
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
[100%] Built target solc
/build/source/test/yulPhaser/Chromosome.cpp: In member function 'void solidity::phaser::test::Phaser::ChromosomeTest::randomOptimisationStep_should_return_each_step_with_same_probability::test_method()':
/build/source/test/yulPhaser/Chromosome.cpp:162:38: error: conversion from 'double' to 'int' may change value [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wfloat-conversion-Werror=float-conversion8;;]
  162 |         BOOST_TEST(abs(mean(samples) - expectedValue) < expectedValue * relativeTolerance);
      |                        ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
/build/source/test/yulPhaser/Chromosome.cpp:163:65: error: conversion from 'double' to 'int' may change value [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wfloat-conversion-Werror=float-conversion8;;]
  163 |         BOOST_TEST(abs(meanSquaredError(samples, expectedValue) - variance) < variance * relativeTolerance);
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [test/CMakeFiles/soltest.dir/build.make:1518: test/CMakeFiles/soltest.dir/yulPhaser/Chromosome.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:785: test/CMakeFiles/soltest.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

This patch seems to fix it.
