### PR TITLE
Adapts to new Boost download location

### DIFF
--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -66,7 +66,7 @@ then
   boost_version="1.84.0"
   boost_package="boost_${boost_version//./_}.tar.bz2"
   boost_dir="boost_${boost_version//./_}"
-  wget "https://boostorg.jfrog.io/artifactory/main/release/$boost_version/source/$boost_package"
+  wget "https://archives.boost.io/release/$boost_version/source/$boost_package"
   tar xf "$boost_package"
   rm "$boost_package"
   cd "$boost_dir"

--- a/scripts/docker/buildpack-deps/Dockerfile.emscripten
+++ b/scripts/docker/buildpack-deps/Dockerfile.emscripten
@@ -33,7 +33,7 @@
 # Using $(em-config CACHE)/sysroot/usr seems to work, though, and still has cmake find the
 # dependencies automatically.
 FROM emscripten/emsdk:3.1.19 AS base
-LABEL version="19"
+LABEL version="20"
 
 ADD emscripten.jam /usr/src
 RUN set -ex && \
@@ -70,7 +70,7 @@ RUN set -ex && \
 # Install Boost
 RUN set -ex && \
 	cd /usr/src && \
-	wget -q 'https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source/boost_1_75_0.tar.bz2' -O boost.tar.bz2 && \
+	wget -q 'https://archives.boost.io/release/1.75.0/source/boost_1_75_0.tar.bz2' -O boost.tar.bz2 && \
 	test "$(sha256sum boost.tar.bz2)" = "953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb  boost.tar.bz2" && \
 	tar -xf boost.tar.bz2 && \
 	rm boost.tar.bz2 && \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu.clang.ossfuzz
@@ -22,7 +22,7 @@
 # (c) 2016-2021 solidity contributors.
 #------------------------------------------------------------------------------
 FROM gcr.io/oss-fuzz-base/base-clang:latest as base
-LABEL version="7"
+LABEL version="8"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -73,7 +73,7 @@ FROM base AS libraries
 # Boost
 RUN set -ex; \
     cd /usr/src; \
-    wget -q 'https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.bz2' -O boost.tar.bz2; \
+    wget -q 'https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.bz2' -O boost.tar.bz2; \
     test "$(sha256sum boost.tar.bz2)" = "83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1  boost.tar.bz2" && \
     tar -xf boost.tar.bz2; \
     rm boost.tar.bz2; \

--- a/scripts/install_deps.ps1
+++ b/scripts/install_deps.ps1
@@ -16,7 +16,7 @@ if ( -not (Test-Path "$PSScriptRoot\..\deps\boost") ) {
 
   # FIXME: The default user agent results in Artifactory treating Invoke-WebRequest as a browser
   # and serving it a page that requires JavaScript.
-  Invoke-WebRequest -URI "https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.zip" -OutFile boost.zip -UserAgent ""
+  Invoke-WebRequest -URI "https://archives.boost.io/release/1.83.0/source/boost_1_83_0.zip" -OutFile boost.zip -UserAgent ""
   if ((Get-FileHash boost.zip).Hash -ne "c86bd9d9eef795b4b0d3802279419fde5221922805b073b9bd822edecb1ca28e") {
     throw 'Downloaded Boost source package has wrong checksum.'
   }


### PR DESCRIPTION
Fixes #15690 

PR switching to the new emscripten docker file: https://github.com/ethereum/solidity/pull/15693