### PR TITLE
Small fixes for liveness

### DIFF
--- a/libyul/backends/evm/ControlFlow.cpp
+++ b/libyul/backends/evm/ControlFlow.cpp
@@ -26,3 +26,8 @@ ControlFlowLiveness::ControlFlowLiveness(ControlFlow const& _controlFlow):
 	mainLiveness(std::make_unique<SSACFGLiveness>(*_controlFlow.mainGraph)),
 	functionLiveness(_controlFlow.functionGraphs | ranges::views::transform([](auto const& _cfg) { return std::make_unique<SSACFGLiveness>(*_cfg); }) | ranges::to<std::vector>)
 { }
+
+std::string ControlFlowLiveness::toDot() const
+{
+	return controlFlow.get().toDot(this);
+}

--- a/libyul/backends/evm/ControlFlow.h
+++ b/libyul/backends/evm/ControlFlow.h
@@ -34,6 +34,8 @@ struct ControlFlowLiveness{
 	std::reference_wrapper<ControlFlow const> controlFlow;
 	std::unique_ptr<SSACFGLiveness> mainLiveness;
 	std::vector<std::unique_ptr<SSACFGLiveness>> functionLiveness;
+
+	std::string toDot() const;
 };
 
 struct ControlFlow

--- a/libyul/backends/evm/SSACFGLiveness.cpp
+++ b/libyul/backends/evm/SSACFGLiveness.cpp
@@ -37,6 +37,29 @@ constexpr auto literalsFilter(SSACFG const& _cfg)
 }
 }
 
+std::set<SSACFG::ValueId> SSACFGLiveness::blockExitValues(SSACFG::BlockId const& _blockId) const
+{
+	std::set<SSACFG::ValueId> result;
+	util::GenericVisitor exitVisitor {
+		[](SSACFG::BasicBlock::MainExit const&) {},
+		[&](SSACFG::BasicBlock::FunctionReturn const& _functionReturn) {
+			result += _functionReturn.returnValues | ranges::views::filter(literalsFilter(m_cfg));
+		},
+		[&](SSACFG::BasicBlock::JumpTable const& _jt) {
+			if (literalsFilter(m_cfg)(_jt.value))
+				result.emplace(_jt.value);
+		},
+		[](SSACFG::BasicBlock::Jump const&) {},
+		[&](SSACFG::BasicBlock::ConditionalJump const& _conditionalJump) {
+			if (literalsFilter(m_cfg)(_conditionalJump.condition))
+				result.emplace(_conditionalJump.condition);
+		},
+		[](SSACFG::BasicBlock::Terminated const&) {}
+	};
+	std::visit(exitVisitor, m_cfg.block(_blockId).exit);
+	return result;
+}
+
 SSACFGLiveness::SSACFGLiveness(SSACFG const& _cfg):
 	m_cfg(_cfg),
 	m_topologicalSort(_cfg),
@@ -70,12 +93,7 @@ void SSACFGLiveness::runDagDfs()
 				{
 					auto const& info = m_cfg.valueInfo(phi);
 					yulAssert(std::holds_alternative<SSACFG::PhiValue>(info), "value info of phi wasn't PhiValue");
-					auto const& entries = m_cfg.block(std::get<SSACFG::PhiValue>(info).block).entries;
-					// this is getting the argument index of the phi function corresponding to the path going
-					// through "blockId", ie, the currently handled block
-					auto const it = entries.find(blockId);
-					yulAssert(it != entries.end());
-					auto const argIndex = static_cast<size_t>(std::distance(entries.begin(), it));
+					auto const argIndex = m_cfg.phiArgumentIndex(blockId, _successor);
 					yulAssert(argIndex < std::get<SSACFG::PhiValue>(info).arguments.size());
 					auto const arg = std::get<SSACFG::PhiValue>(info).arguments.at(argIndex);
 					if (!std::holds_alternative<SSACFG::LiteralValue>(m_cfg.valueInfo(arg)))
@@ -103,23 +121,7 @@ void SSACFGLiveness::runDagDfs()
 		// for each program point p in B, backwards, do:
 		{
 			// add value ids to the live set that are used in exit blocks
-			util::GenericVisitor exitVisitor {
-				[](SSACFG::BasicBlock::MainExit const&) {},
-				[&](SSACFG::BasicBlock::FunctionReturn const& _functionReturn) {
-					live += _functionReturn.returnValues | ranges::views::filter(literalsFilter(m_cfg));
-				},
-				[&](SSACFG::BasicBlock::JumpTable const& _jt) {
-					if (literalsFilter(m_cfg)(_jt.value))
-						live.emplace(_jt.value);
-				},
-				[](SSACFG::BasicBlock::Jump const&) {},
-				[&](SSACFG::BasicBlock::ConditionalJump const& _conditionalJump) {
-					if (literalsFilter(m_cfg)(_conditionalJump.condition))
-						live.emplace(_conditionalJump.condition);
-				},
-				[](SSACFG::BasicBlock::Terminated const&) {}
-			};
-			std::visit(exitVisitor, block.exit);
+			live += blockExitValues(blockId);
 
 			for (auto const& op: block.operations | ranges::views::reverse)
 			{
@@ -163,12 +165,13 @@ void SSACFGLiveness::fillOperationsLiveOut()
 {
 	for (size_t blockIdValue = 0; blockIdValue < m_cfg.numBlocks(); ++blockIdValue)
 	{
-		auto const& operations = m_cfg.block(SSACFG::BlockId{blockIdValue}).operations;
+		SSACFG::BlockId const blockId{blockIdValue};
+		auto const& operations = m_cfg.block(blockId).operations;
 		auto& liveOuts = m_operationLiveOuts[blockIdValue];
 		liveOuts.resize(operations.size());
 		if (!operations.empty())
 		{
-			auto live = m_liveOuts[blockIdValue];
+			auto live = m_liveOuts[blockIdValue] + blockExitValues(blockId);
 			auto rit = liveOuts.rbegin();
 			for (auto const& op: operations | ranges::views::reverse)
 			{

--- a/libyul/backends/evm/SSACFGLiveness.h
+++ b/libyul/backends/evm/SSACFGLiveness.h
@@ -47,6 +47,7 @@ private:
 	void runDagDfs();
 	void runLoopTreeDfs(size_t _loopHeader);
 	void fillOperationsLiveOut();
+	std::set<SSACFG::ValueId> blockExitValues(SSACFG::BlockId const& _blockId) const;
 
 	SSACFG const& m_cfg;
 	ForwardSSACFGTopologicalSort m_topologicalSort;

--- a/libyul/backends/evm/SSACFGTopologicalSort.cpp
+++ b/libyul/backends/evm/SSACFGTopologicalSort.cpp
@@ -28,11 +28,7 @@ ForwardSSACFGTopologicalSort::ForwardSSACFGTopologicalSort(SSACFG const& _cfg):
 	yulAssert(m_cfg.entry.value == 0);
 	m_preOrder.reserve(m_cfg.numBlocks());
 	m_postOrder.reserve(m_cfg.numBlocks());
-	for (size_t id = 0; id < m_cfg.numBlocks(); ++id)
-	{
-		if (!m_explored[id])
-			dfs(id);
-	}
+	dfs(0);
 
 	for (auto const& [v1, v2]: m_potentialBackEdges)
 		if (ancestor(v2, v1))


### PR DESCRIPTION
- add exit operations to live set of operation-wise liveness info
- perform topological sort only on root, st unreachable blocks are ignored in liveness analysis
- deal with dollar signs in ssa cfg dot graphs
- convenience `toDot` function on `ControlFlowLiveness`