### PR TITLE
Make name clash with a builtin non-fatal in Yul parser

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Language Features:
 Compiler Features:
  * Error Reporting: Errors reported during code generation now point at the location of the contract when more fine-grained location is not available.
  * SMTChecker: Z3 is now a runtime dependency, not a build dependency (except for emscripten build).
+ * Yul Parser: Make name clash with a builtin a non-fatal error.
 
 
 Bugfixes:

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -755,7 +755,13 @@ YulName Parser::expectAsmIdentifier()
 {
 	YulName name{currentLiteral()};
 	if (currentToken() == Token::Identifier && m_dialect.findBuiltin(name.str()))
-		fatalParserError(5568_error, "Cannot use builtin function name \"" + name.str() + "\" as identifier name.");
+		// Non-fatal. We'll continue and wrongly parse it as an identifier. May lead to some spurious
+		// errors after this point, but likely also much more useful ones.
+		m_errorReporter.parserError(
+			5568_error,
+			currentLocation(),
+			"Cannot use builtin function name \"" + name.str() + "\" as identifier name."
+		);
 	// NOTE: We keep the expectation here to ensure the correct source location for the error above.
 	expectToken(Token::Identifier);
 	return name;

--- a/test/libsolidity/syntaxTests/inlineAssembly/basefee_reserved_london.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/basefee_reserved_london.sol
@@ -10,3 +10,4 @@ contract C {
 // EVMVersion: =london
 // ----
 // ParserError 5568: (98-105): Cannot use builtin function name "basefee" as identifier name.
+// ParserError 7104: (137-144): Builtin function "basefee" must be called.

--- a/test/libsolidity/syntaxTests/inlineAssembly/blobbasefee_reserved_cancun.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/blobbasefee_reserved_cancun.sol
@@ -10,3 +10,4 @@ contract C {
 // EVMVersion: >=cancun
 // ----
 // ParserError 5568: (98-109): Cannot use builtin function name "blobbasefee" as identifier name.
+// ParserError 7104: (141-152): Builtin function "blobbasefee" must be called.

--- a/test/libsolidity/syntaxTests/inlineAssembly/clash_with_non_reserved_pure_yul_builtin.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/clash_with_non_reserved_pure_yul_builtin.sol
@@ -1,0 +1,10 @@
+contract C {
+    function f() public pure {
+        // NOTE: memoryguard is a builtin but only in pure Yul, not inline assembly.
+        // NOTE: memoryguard is not a reserved identifier.
+        assembly { function memoryguard() {} }
+        assembly { function f(memoryguard) {} }
+        assembly { function f() -> memoryguard {} }
+        assembly { let memoryguard }
+    }
+}

--- a/test/libsolidity/syntaxTests/inlineAssembly/clash_with_reserved_builtin.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/clash_with_reserved_builtin.sol
@@ -10,3 +10,6 @@ contract C {
 }
 // ----
 // ParserError 5568: (245-248): Cannot use builtin function name "add" as identifier name.
+// ParserError 5568: (249-255): Cannot use builtin function name "mstore" as identifier name.
+// ParserError 5568: (260-266): Cannot use builtin function name "sstore" as identifier name.
+// ParserError 5568: (286-294): Cannot use builtin function name "coinbase" as identifier name.

--- a/test/libsolidity/syntaxTests/inlineAssembly/clash_with_reserved_builtin.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/clash_with_reserved_builtin.sol
@@ -1,0 +1,12 @@
+contract C {
+    function f() public view {
+        assembly {
+            // NOTE: All EVM instruction names are reserved identifiers in Yul.
+            // NOTE: We do provide builtins corresponding to these instructions.
+            function add(mstore) -> sstore {}
+            let coinbase
+        }
+    }
+}
+// ----
+// ParserError 5568: (245-248): Cannot use builtin function name "add" as identifier name.

--- a/test/libsolidity/syntaxTests/inlineAssembly/clash_with_reserved_non_builtin.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/clash_with_reserved_non_builtin.sol
@@ -1,0 +1,15 @@
+contract C {
+    function f() public pure {
+        assembly {
+            // NOTE: All EVM instruction names are reserved identifiers in Yul.
+            // NOTE: We don't provide builtins corresponding to these instructions.
+            function dup1(dup2) -> dup3 {}
+            let dup4
+        }
+    }
+}
+// ----
+// DeclarationError 5017: (239-269): The identifier "dup1" is reserved and can not be used.
+// DeclarationError 5017: (253-257): The identifier "dup2" is reserved and can not be used.
+// DeclarationError 5017: (262-266): The identifier "dup3" is reserved and can not be used.
+// DeclarationError 5017: (286-290): The identifier "dup4" is reserved and can not be used.

--- a/test/libsolidity/syntaxTests/inlineAssembly/clash_with_reserved_pure_yul_builtin.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/clash_with_reserved_pure_yul_builtin.sol
@@ -1,0 +1,15 @@
+contract C {
+    function f() public view {
+        assembly {
+            // NOTE: These are builtins but only in pure Yul, not inline assembly.
+            // NOTE: Names of these builtins are also reserved identifiers.
+            function loadimmutable(setimmutable) -> datasize {}
+            let dataoffset
+        }
+    }
+}
+// ----
+// DeclarationError 5017: (234-285): The identifier "loadimmutable" is reserved and can not be used.
+// DeclarationError 5017: (257-269): The identifier "setimmutable" is reserved and can not be used.
+// DeclarationError 5017: (274-282): The identifier "datasize" is reserved and can not be used.
+// DeclarationError 5017: (302-312): The identifier "dataoffset" is reserved and can not be used.

--- a/test/libsolidity/syntaxTests/inlineAssembly/difficulty_disallowed_function_pre_paris.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/difficulty_disallowed_function_pre_paris.sol
@@ -19,3 +19,4 @@ contract C {
 // EVMVersion: <paris
 // ----
 // ParserError 5568: (101-111): Cannot use builtin function name "difficulty" as identifier name.
+// ParserError 7104: (143-153): Builtin function "difficulty" must be called.

--- a/test/libsolidity/syntaxTests/inlineAssembly/mcopy_reserved_cancun.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/mcopy_reserved_cancun.sol
@@ -19,3 +19,4 @@ contract C {
 // EVMVersion: >=cancun
 // ----
 // ParserError 5568: (101-106): Cannot use builtin function name "mcopy" as identifier name.
+// ParserError 7104: (134-139): Builtin function "mcopy" must be called.

--- a/test/libsolidity/syntaxTests/inlineAssembly/prevrandao_disallowed_function_post_paris.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/prevrandao_disallowed_function_post_paris.sol
@@ -19,3 +19,4 @@ contract C {
 // EVMVersion: >=paris
 // ----
 // ParserError 5568: (101-111): Cannot use builtin function name "prevrandao" as identifier name.
+// ParserError 7104: (143-153): Builtin function "prevrandao" must be called.

--- a/test/libsolidity/syntaxTests/inlineAssembly/tload_reserved_cancun.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/tload_reserved_cancun.sol
@@ -10,3 +10,4 @@ contract C {
 // EVMVersion: >=cancun
 // ----
 // ParserError 5568: (98-103): Cannot use builtin function name "tload" as identifier name.
+// ParserError 7104: (135-140): Builtin function "tload" must be called.

--- a/test/libsolidity/syntaxTests/inlineAssembly/tstore_reserved_cancun.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/tstore_reserved_cancun.sol
@@ -10,3 +10,4 @@ contract C {
 // EVMVersion: >=cancun
 // ----
 // ParserError 5568: (98-104): Cannot use builtin function name "tstore" as identifier name.
+// ParserError 7104: (136-142): Builtin function "tstore" must be called.

--- a/test/libyul/yulSyntaxTests/blobhash.yul
+++ b/test/libyul/yulSyntaxTests/blobhash.yul
@@ -13,3 +13,4 @@
 // EVMVersion: >=cancun
 // ----
 // ParserError 5568: (20-28): Cannot use builtin function name "blobhash" as identifier name.
+// ParserError 5568: (64-72): Cannot use builtin function name "blobhash" as identifier name.

--- a/test/libyul/yulSyntaxTests/eof/extcall_function_in_eof.yul
+++ b/test/libyul/yulSyntaxTests/eof/extcall_function_in_eof.yul
@@ -8,4 +8,3 @@ object "a" {
 // bytecodeFormat: >=EOFv1
 // ----
 // ParserError 5568: (41-48): Cannot use builtin function name "extcall" as identifier name.
-// ParserError 8143: (41-48): Expected keyword "data" or "object" or "}".

--- a/test/libyul/yulSyntaxTests/eof/extdelegatecall_function_in_eof.yul
+++ b/test/libyul/yulSyntaxTests/eof/extdelegatecall_function_in_eof.yul
@@ -8,4 +8,3 @@ object "a" {
 // bytecodeFormat: >=EOFv1
 // ----
 // ParserError 5568: (41-56): Cannot use builtin function name "extdelegatecall" as identifier name.
-// ParserError 8143: (41-56): Expected keyword "data" or "object" or "}".

--- a/test/libyul/yulSyntaxTests/eof/extstaticcall_function_in_eof.yul
+++ b/test/libyul/yulSyntaxTests/eof/extstaticcall_function_in_eof.yul
@@ -8,4 +8,3 @@ object "a" {
 // bytecodeFormat: >=EOFv1
 // ----
 // ParserError 5568: (41-54): Cannot use builtin function name "extstaticcall" as identifier name.
-// ParserError 8143: (41-54): Expected keyword "data" or "object" or "}".

--- a/test/libyul/yulSyntaxTests/invalid/builtin_name_as_type.yul
+++ b/test/libyul/yulSyntaxTests/invalid/builtin_name_as_type.yul
@@ -1,0 +1,8 @@
+{
+    let x: datacopy
+    x := true: loadimmutable
+
+    function f(y: linkersymbol) {}
+}
+// ----
+// ParserError 5568: (13-21): Cannot use builtin function name "datacopy" as identifier name.

--- a/test/libyul/yulSyntaxTests/invalid/builtin_name_as_type.yul
+++ b/test/libyul/yulSyntaxTests/invalid/builtin_name_as_type.yul
@@ -6,3 +6,8 @@
 }
 // ----
 // ParserError 5568: (13-21): Cannot use builtin function name "datacopy" as identifier name.
+// ParserError 5473: (10-21): Types are not supported in untyped Yul.
+// ParserError 5568: (37-50): Cannot use builtin function name "loadimmutable" as identifier name.
+// ParserError 5473: (31-50): Types are not supported in untyped Yul.
+// ParserError 5568: (70-82): Cannot use builtin function name "linkersymbol" as identifier name.
+// ParserError 5473: (67-82): Types are not supported in untyped Yul.

--- a/test/libyul/yulSyntaxTests/invalid/clash_with_non_reserved_pure_yul_builtin.yul
+++ b/test/libyul/yulSyntaxTests/invalid/clash_with_non_reserved_pure_yul_builtin.yul
@@ -6,3 +6,6 @@
 }
 // ----
 // ParserError 5568: (17-28): Cannot use builtin function name "memoryguard" as identifier name.
+// ParserError 5568: (53-64): Cannot use builtin function name "memoryguard" as identifier name.
+// ParserError 5568: (93-104): Cannot use builtin function name "memoryguard" as identifier name.
+// ParserError 5568: (120-131): Cannot use builtin function name "memoryguard" as identifier name.

--- a/test/libyul/yulSyntaxTests/invalid/clash_with_non_reserved_pure_yul_builtin.yul
+++ b/test/libyul/yulSyntaxTests/invalid/clash_with_non_reserved_pure_yul_builtin.yul
@@ -1,0 +1,8 @@
+{
+    { function memoryguard() {} }
+    { function f(memoryguard) {} }
+    { function f() -> memoryguard {} }
+    { let memoryguard }
+}
+// ----
+// ParserError 5568: (17-28): Cannot use builtin function name "memoryguard" as identifier name.

--- a/test/libyul/yulSyntaxTests/invalid/clash_with_reserved_builtin.yul
+++ b/test/libyul/yulSyntaxTests/invalid/clash_with_reserved_builtin.yul
@@ -1,0 +1,8 @@
+{
+    // NOTE: All EVM instruction names are reserved identifiers in Yul.
+    // NOTE: We do provide builtins corresponding to these instructions.
+    function add(mstore) -> sstore {}
+    let coinbase
+}
+// ----
+// ParserError 5568: (160-163): Cannot use builtin function name "add" as identifier name.

--- a/test/libyul/yulSyntaxTests/invalid/clash_with_reserved_builtin.yul
+++ b/test/libyul/yulSyntaxTests/invalid/clash_with_reserved_builtin.yul
@@ -6,3 +6,6 @@
 }
 // ----
 // ParserError 5568: (160-163): Cannot use builtin function name "add" as identifier name.
+// ParserError 5568: (164-170): Cannot use builtin function name "mstore" as identifier name.
+// ParserError 5568: (175-181): Cannot use builtin function name "sstore" as identifier name.
+// ParserError 5568: (193-201): Cannot use builtin function name "coinbase" as identifier name.

--- a/test/libyul/yulSyntaxTests/invalid/clash_with_reserved_non_builtin.yul
+++ b/test/libyul/yulSyntaxTests/invalid/clash_with_reserved_non_builtin.yul
@@ -1,0 +1,11 @@
+{
+    // NOTE: All EVM instruction names are reserved identifiers in Yul.
+    // NOTE: We don't provide builtins corresponding to these instructions.
+    function dup1(dup2) -> dup3 {}
+    let dup4
+}
+// ----
+// DeclarationError 5017: (154-184): The identifier "dup1" is reserved and can not be used.
+// DeclarationError 5017: (168-172): The identifier "dup2" is reserved and can not be used.
+// DeclarationError 5017: (177-181): The identifier "dup3" is reserved and can not be used.
+// DeclarationError 5017: (193-197): The identifier "dup4" is reserved and can not be used.

--- a/test/libyul/yulSyntaxTests/invalid/clash_with_reserved_pure_yul_builtin.yul
+++ b/test/libyul/yulSyntaxTests/invalid/clash_with_reserved_pure_yul_builtin.yul
@@ -6,3 +6,6 @@
 }
 // ----
 // ParserError 5568: (158-171): Cannot use builtin function name "loadimmutable" as identifier name.
+// ParserError 5568: (172-184): Cannot use builtin function name "setimmutable" as identifier name.
+// ParserError 5568: (189-197): Cannot use builtin function name "datasize" as identifier name.
+// ParserError 5568: (209-219): Cannot use builtin function name "dataoffset" as identifier name.

--- a/test/libyul/yulSyntaxTests/invalid/clash_with_reserved_pure_yul_builtin.yul
+++ b/test/libyul/yulSyntaxTests/invalid/clash_with_reserved_pure_yul_builtin.yul
@@ -1,0 +1,8 @@
+{
+    // NOTE: These are builtins but only in pure Yul, not inline assembly.
+    // NOTE: Names of these builtins are also reserved identifiers.
+    function loadimmutable(setimmutable) -> datasize {}
+    let dataoffset
+}
+// ----
+// ParserError 5568: (158-171): Cannot use builtin function name "loadimmutable" as identifier name.

--- a/test/libyul/yulSyntaxTests/invalid/reserved_identifier_as_type.yul
+++ b/test/libyul/yulSyntaxTests/invalid/reserved_identifier_as_type.yul
@@ -1,0 +1,10 @@
+{
+    let x: jump
+    x := true: dup12
+
+    function f(y: jumpi) {}
+}
+// ----
+// ParserError 5473: (10-17): Types are not supported in untyped Yul.
+// ParserError 5473: (27-38): Types are not supported in untyped Yul.
+// ParserError 5473: (55-63): Types are not supported in untyped Yul.

--- a/test/libyul/yulSyntaxTests/mcopy_as_identifier.yul
+++ b/test/libyul/yulSyntaxTests/mcopy_as_identifier.yul
@@ -12,3 +12,4 @@
 // EVMVersion: >=cancun
 // ----
 // ParserError 5568: (20-25): Cannot use builtin function name "mcopy" as identifier name.
+// ParserError 5568: (61-66): Cannot use builtin function name "mcopy" as identifier name.


### PR DESCRIPTION
Currently Yul parser stops immediately when it notices that a function or variable being declared has a name matching a Yul builtin. I don't see any good reason for this to be a fatal error. In fact the same exact error is already non-fatal in inline assembly. Clashes with reserved identifiers are also non-fatal.

This is a minor thing but, aside from unnecessarily giving users less information than we can, it also makes writing some kinds of tests a bit more annoying (e.g. in #15700 it makes it impossible to have one test covering all Yul builtins).