### PR TITLE
Fix typos in function and parameter names

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1440,7 +1440,7 @@ Language Features:
  * Introduce ``virtual`` and ``override`` keywords.
  * Modify ``push(element)`` for dynamic storage arrays such that it does not return the new length anymore.
  * Yul: Introduce ``leave`` statement that exits the current function.
- * JSON AST: Add the function selector of each externally-visible FunctonDefinition to the AST JSON export.
+ * JSON AST: Add the function selector of each externally-visible FunctionDefinition to the AST JSON export.
 
 Compiler Features:
  * Allow revert strings to be stripped from the binary using the ``--revert-strings`` option or the ``settings.debug.revertStrings`` setting.

--- a/test/libsolidity/util/ContractABIUtils.h
+++ b/test/libsolidity/util/ContractABIUtils.h
@@ -72,7 +72,7 @@ public:
 
 	/// Calculates the encoding size of given _parameters based
 	/// on the size of their types.
-	static size_t encodingSize(ParameterList const& _paremeters);
+	static size_t encodingSize(ParameterList const& _parameters);
 
 private:
 	/// Parses and translates a single type and returns a list of


### PR DESCRIPTION
Fix typos in function and parameter names.