### PR TITLE
[libyul] Fix false-negative maybe-uninitialized error on gcc.

### DIFF
--- a/libyul/optimiser/ForLoopConditionIntoBody.cpp
+++ b/libyul/optimiser/ForLoopConditionIntoBody.cpp
@@ -32,8 +32,9 @@ void ForLoopConditionIntoBody::run(OptimiserStepContext& _context, Block& _ast)
 
 void ForLoopConditionIntoBody::operator()(ForLoop& _forLoop)
 {
+	std::optional<BuiltinHandle> booleanNegationFunctionHandle = m_dialect.booleanNegationFunctionHandle();
 	if (
-		m_dialect.booleanNegationFunctionHandle() &&
+		booleanNegationFunctionHandle &&
 		!std::holds_alternative<Literal>(*_forLoop.condition) &&
 		!std::holds_alternative<Identifier>(*_forLoop.condition)
 	)
@@ -47,7 +48,7 @@ void ForLoopConditionIntoBody::operator()(ForLoop& _forLoop)
 				std::make_unique<Expression>(
 					FunctionCall {
 						debugData,
-						BuiltinName{debugData, *m_dialect.booleanNegationFunctionHandle()},
+						BuiltinName{debugData, *booleanNegationFunctionHandle},
 						util::make_vector<Expression>(std::move(*_forLoop.condition))
 					}
 				),

--- a/libyul/optimiser/UnusedPruner.cpp
+++ b/libyul/optimiser/UnusedPruner.cpp
@@ -81,6 +81,7 @@ void UnusedPruner::operator()(Block& _block)
 				[&](NameWithDebugData const& _typedName) { return used(_typedName.name); }
 			))
 			{
+				std::optional<BuiltinHandle> discardFunctionHandle = m_dialect.discardFunctionHandle();
 				if (!varDecl.value)
 					statement = Block{std::move(varDecl.debugData), {}};
 				else if (
@@ -91,10 +92,10 @@ void UnusedPruner::operator()(Block& _block)
 					subtractReferences(ReferencesCounter::countReferences(*varDecl.value));
 					statement = Block{std::move(varDecl.debugData), {}};
 				}
-				else if (varDecl.variables.size() == 1 && m_dialect.discardFunctionHandle())
+				else if (varDecl.variables.size() == 1 && discardFunctionHandle)
 					statement = ExpressionStatement{varDecl.debugData, FunctionCall{
 						varDecl.debugData,
-						BuiltinName{varDecl.debugData, *m_dialect.discardFunctionHandle()},
+						BuiltinName{varDecl.debugData, *discardFunctionHandle},
 						{*std::move(varDecl.value)}
 					}};
 			}


### PR DESCRIPTION
Building with `gcc v13.3.0` was not possible due to `maybe-uninitialized` errors, e.g.

```
In file included from /usr/include/c++/13/bits/shared_ptr.h:53,
                 from /usr/include/c++/13/memory:80,
                 from /home/parallels/git/http/solidity/liblangutil/SourceLocation.h:27,
                 from /home/parallels/git/http/solidity/libsolutil/Exceptions.h:21,
                 from /home/parallels/git/http/solidity/libyul/Exceptions.h:24,
                 from /home/parallels/git/http/solidity/libyul/optimiser/ASTWalker.h:26,
                 from /home/parallels/git/http/solidity/libyul/optimiser/ForLoopConditionIntoBody.h:20,
                 from /home/parallels/git/http/solidity/libyul/optimiser/ForLoopConditionIntoBody.cpp:19:
In destructor ‘std::__shared_count<_Lp>::~__shared_count() [with __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’,
    inlined from ‘std::__shared_ptr<_Tp, _Lp>::~__shared_ptr() [with _Tp = const solidity::langutil::DebugData; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’ at /usr/include/c++/13/bits/shared_ptr_base.h:1524:7,
    inlined from ‘std::shared_ptr<const solidity::langutil::DebugData>::~shared_ptr()’ at /usr/include/c++/13/bits/shared_ptr.h:175:11,
    inlined from ‘virtual void solidity::yul::ForLoopConditionIntoBody::operator()(solidity::yul::ForLoop&)’ at /home/parallels/git/http/solidity/libyul/optimiser/ForLoopConditionIntoBody.cpp:50:7:
/usr/include/c++/13/bits/shared_ptr_base.h:1070:13: error: ‘<unnamed>.solidity::yul::BuiltinName::debugData.std::shared_ptr<const solidity::langutil::DebugData>::<unnamed>.std::__shared_ptr<const solidity::langutil::DebugData, __gnu_cxx::_S_atomic>::_M_refcount.std::__shared_count<>::_M_pi’ may be used uninitialized [-Werror=maybe-uninitialized]
 1070 |         if (_M_pi != nullptr)
      |             ^~~~~
/home/parallels/git/http/solidity/libyul/optimiser/ForLoopConditionIntoBody.cpp: In member function ‘virtual void solidity::yul::ForLoopConditionIntoBody::operator()(solidity::yul::ForLoop&)’:
/home/parallels/git/http/solidity/libyul/optimiser/ForLoopConditionIntoBody.cpp:50:114: note: ‘<anonymous>’ declared here
   50 |                                                 BuiltinName{debugData, *m_dialect.booleanNegationFunctionHandle()},
      |                                                                                                                  ^
cc1plus: all warnings being treated as errors
make[2]: *** [libyul/CMakeFiles/yul.dir/build.make:860: libyul/CMakeFiles/yul.dir/optimiser/ForLoopConditionIntoBody.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:562: libyul/CMakeFiles/yul.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```