### PR TITLE
ParserBase: avoid copying around currentLiteral

### DIFF
--- a/liblangutil/ParserBase.cpp
+++ b/liblangutil/ParserBase.cpp
@@ -43,7 +43,7 @@ Token ParserBase::peekNextToken() const
 	return m_scanner->peekNextToken();
 }
 
-std::string ParserBase::currentLiteral() const
+std::string_view ParserBase::currentLiteral() const
 {
 	return m_scanner->currentLiteral();
 }

--- a/liblangutil/ParserBase.h
+++ b/liblangutil/ParserBase.h
@@ -71,7 +71,8 @@ protected:
 	Token currentToken() const;
 	Token peekNextToken() const;
 	std::string tokenName(Token _token);
-	std::string currentLiteral() const;
+	/// Points to the current literal. The string view invalidates when the parser advances.
+	std::string_view currentLiteral() const;
 	virtual Token advance();
 	///@}
 

--- a/libsolutil/CommonData.h
+++ b/libsolutil/CommonData.h
@@ -470,7 +470,7 @@ inline std::string asString(bytesConstRef _b)
 }
 
 /// Converts a string to a byte array containing the string's (byte) data.
-inline bytes asBytes(std::string const& _b)
+inline bytes asBytes(std::string_view const _b)
 {
 	return bytes((uint8_t const*)_b.data(), (uint8_t const*)(_b.data() + _b.size()));
 }

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -779,7 +779,7 @@ void Parser::checkBreakContinuePosition(std::string const& _which)
 	}
 }
 
-bool Parser::isValidNumberLiteral(std::string const& _literal)
+bool Parser::isValidNumberLiteral(std::string_view const _literal)
 {
 	try
 	{
@@ -793,7 +793,7 @@ bool Parser::isValidNumberLiteral(std::string const& _literal)
 	if (boost::starts_with(_literal, "0x"))
 		return true;
 	else
-		return _literal.find_first_not_of("0123456789") == std::string::npos;
+		return _literal.find_first_not_of("0123456789") == std::string_view::npos;
 }
 
 void Parser::raiseUnsupportedTypesError(SourceLocation const& _location) const

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -152,7 +152,7 @@ protected:
 	/// Reports an error if we are currently not inside the body part of a for loop.
 	void checkBreakContinuePosition(std::string const& _which);
 
-	static bool isValidNumberLiteral(std::string const& _literal);
+	static bool isValidNumberLiteral(std::string_view _literal);
 
 private:
 	Dialect const& m_dialect;

--- a/libyul/ObjectParser.cpp
+++ b/libyul/ObjectParser.cpp
@@ -198,7 +198,7 @@ void ObjectParser::parseData(Object& _containingObject)
 std::string ObjectParser::parseUniqueName(Object const* _containingObject)
 {
 	expectToken(Token::StringLiteral, false);
-	auto const name = currentLiteral();
+	std::string const name{currentLiteral()};
 	if (name.empty())
 		parserError(3287_error, "Object name cannot be empty.");
 	else if (_containingObject && _containingObject->name == name)


### PR DESCRIPTION
This is something that I randomly stumbled upon when looking at #15712.

The function `ParserBase::currentLiteral()` is called very frequently, in particular also in a lookup-style (e.g., `m_dialect.findBuiltin(currentLiteral())`). Currently, each invocation takes a full copy of the string value of whatever the scanner is pointing to.