### PR TITLE
test: Populate AuctionRegistrar hall-of-fame entries

### DIFF
--- a/test/contracts/AuctionRegistrar.cpp
+++ b/test/contracts/AuctionRegistrar.cpp
@@ -115,7 +115,28 @@ contract GlobalRegistrar is Registrar, AuctionSystem {
 	uint constant c_freeBytes = 12;
 
 	constructor() {
-		// TODO: Populate with hall-of-fame.
+		// Initialize hall-of-fame with significant Ethereum contributors
+		entries["vitalik"] = Record(
+			msg.sender,
+			address(0),
+			address(0),
+			0x0,
+			block.timestamp + c_renewalInterval
+		);
+		entries["gavin"] = Record(
+			msg.sender,
+			address(0),
+			address(0),
+			0x0,
+			block.timestamp + c_renewalInterval
+		);
+		entries["jeff"] = Record(
+			msg.sender,
+			address(0),
+			address(0),
+			0x0,
+			block.timestamp + c_renewalInterval
+		);
 	}
 
 	function onAuctionEnd(string memory _name) internal override {
@@ -452,6 +473,18 @@ BOOST_AUTO_TEST_CASE(auction_bidding)
 	registrar.setNextValue(20);
 	registrar.reserve(name);
 	BOOST_CHECK_EQUAL(registrar.owner(name), account(1));
+}
+
+BOOST_AUTO_TEST_CASE(hall_of_fame)
+{
+	AuctionRegistrarTestFramework framework;
+	framework.deployRegistrar();
+	auto registrar = framework.getRegistrar();
+
+	// Check that hall-of-fame entries were properly initialized
+	BOOST_CHECK(registrar.owner("vitalik") == framework.getAddress());
+	BOOST_CHECK(registrar.owner("gavin") == framework.getAddress());
+	BOOST_CHECK(registrar.owner("jeff") == framework.getAddress());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add initial hall-of-fame entries to the AuctionRegistrar contract constructor and add a test case to verify the initialization. This addresses the TODO comment about populating the hall of fame.

The implementation:
- Adds three initial entries for significant Ethereum contributors
- Sets up these entries with default values and renewal dates
- Includes a test case to verify the entries are properly initialized

The hall-of-fame entries serve as reserved names in the registrar system, preserving important identifiers in the Ethereum ecosystem.