### PR TITLE
Fix spelling mistakes and silence false-positives newly reported by codespell

### DIFF
--- a/scripts/codespell_ignored_lines.txt
+++ b/scripts/codespell_ignored_lines.txt
@@ -19,3 +19,4 @@ docker run --rm -v "${OUTPUTDIR}":/tmp/output -v "${SCRIPTDIR}":/tmp/scripts:ro 
 			templ("assignEnd", "end := tail");
 			templ("assignEnd", "");
         self.assertIn('401 Client Error: Unauthorized', str(manager.exception))
+        a = abd;

--- a/test/libsolidity/util/SoltestTypes.h
+++ b/test/libsolidity/util/SoltestTypes.h
@@ -32,7 +32,7 @@ namespace solidity::frontend::test
 	T(Invalid, "invalid", 0)           \
 	T(EOS, "EOS", 0)                   \
 	T(Whitespace, "_", 0)              \
-	/* punctuations */                 \
+	/* punctuation */                  \
 	T(LParen, "(", 0)                  \
 	T(RParen, ")", 0)                  \
 	T(LBrack, "[", 0)                  \


### PR DESCRIPTION
Addresses the new [codespell job failures](https://app.circleci.com/pipelines/github/ethereum/solidity/37732/workflows/df159eb9-20b0-463f-9688-0ff8eaa90f90/jobs/1731700) that appeared in #15749, probably due to a new codespell release:

```
./test/libsolidity/syntaxTests/nameAndTypeResolution/581_improve_name_suggestion_three_letters.sol:4: abd ==> and, bad
./test/libsolidity/util/SoltestTypes.h:35: punctuations ==> punctuation, punctuation's
```