### PR TITLE
fix: typos in `libsolidity/analysis/`

### DIFF
--- a/libsolidity/analysis/ControlFlowAnalyzer.cpp
+++ b/libsolidity/analysis/ControlFlowAnalyzer.cpp
@@ -74,12 +74,12 @@ void ControlFlowAnalyzer::checkUninitializedAccess(CFGNode const* _entry, CFGNod
 		bool propagateFrom(NodeInfo const& _entryNode)
 		{
 			size_t previousUnassignedVariablesAtEntry = unassignedVariablesAtEntry.size();
-			size_t previousUninitializedVariableAccessess = uninitializedVariableAccesses.size();
+			size_t previousUninitializedVariableAccesses = uninitializedVariableAccesses.size();
 			unassignedVariablesAtEntry += _entryNode.unassignedVariablesAtExit;
 			uninitializedVariableAccesses += _entryNode.uninitializedVariableAccesses;
 			return
 				unassignedVariablesAtEntry.size() > previousUnassignedVariablesAtEntry ||
-				uninitializedVariableAccesses.size() > previousUninitializedVariableAccessess
+				uninitializedVariableAccesses.size() > previousUninitializedVariableAccesses
 			;
 		}
 	};

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -716,7 +716,7 @@ void DeclarationRegistrationHelper::registerDeclaration(Declaration& _declaratio
 		);
 
 		// NOTE: We're registering the function outside of its scope(). This will only affect
-		// name lookups. An more general alternative would be to modify Scoper to simply assign it
+		// name lookups. A more general alternative would be to modify Scoper to simply assign it
 		// that scope in the first place, but this would complicate the AST traversal here, which
 		// currently assumes that scopes follow ScopeOpener nesting.
 		registerDeclaration(*m_scopes.at(quantifier->scope()), _declaration, nullptr, nullptr, false /* inactive */, m_errorReporter);


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `previousUninitializedVariableAccessess` to `previousUninitializedVariableAccesses`
Corrected `An more general` to `A more general`

Please review the changes and let me know if any additional changes are needed.