### PR TITLE
fix: typos in `SymbolicTypes.cpp`

### DIFF
--- a/libsolidity/formal/SymbolicTypes.cpp
+++ b/libsolidity/formal/SymbolicTypes.cpp
@@ -126,15 +126,15 @@ SortPointer smtSort(frontend::Type const& _type)
 				tupleName = tupleSort->name;
 			else if (isContract(*baseType))
 				// use a common sort for contracts so inheriting contracts do not cause conflicting SMT types
-				// solc handles types mismtach
+				// solc handles types mismatch
 				tupleName = "contract";
 			else if (isFunction(*baseType))
 				// use a common sort for functions so pure and view modifier do not cause conflicting SMT types
-				// solc handles types mismtach
+				// solc handles types mismatch
 				tupleName = "function";
 			else if (isAddress(*baseType))
 				// use a common sort for address and address payable so it does not cause conflicting SMT types
-				// solc handles types mismtach
+				// solc handles types mismatch
 				tupleName = "address";
 			else if (
 				baseType->category() == frontend::Type::Category::Integer ||


### PR DESCRIPTION
Corrected `mismtach` to `mismatch` x3