### PR TITLE
fix typo in `distinguishingProperty` variable name

### DIFF
--- a/libsolidity/analysis/OverrideChecker.cpp
+++ b/libsolidity/analysis/OverrideChecker.cpp
@@ -801,7 +801,7 @@ void OverrideChecker::checkAmbiguousOverridesInternal(std::set<OverrideProxy> _b
 	std::string callableName = _baseCallables.begin()->astNodeName();
 	if (_baseCallables.begin()->isVariable())
 		callableName = "function";
-	std::string distinguishigProperty = _baseCallables.begin()->distinguishingProperty();
+	std::string distinguishingProperty = _baseCallables.begin()->distinguishingProperty();
 
 	bool foundVariable = false;
 	for (auto const& base: _baseCallables)
@@ -811,7 +811,7 @@ void OverrideChecker::checkAmbiguousOverridesInternal(std::set<OverrideProxy> _b
 	std::string message =
 		"Derived contract must override " + callableName + " \"" +
 		_baseCallables.begin()->name() +
-		"\". Two or more base classes define " + callableName + " with same " + distinguishigProperty + ".";
+		"\". Two or more base classes define " + callableName + " with same " + distinguishingProperty + ".";
 
 	if (foundVariable)
 		message +=

--- a/test/FilesystemUtils.cpp
+++ b/test/FilesystemUtils.cpp
@@ -44,12 +44,12 @@ void solidity::test::createFilesWithParentDirs(std::set<boost::filesystem::path>
 void solidity::test::createFileWithContent(boost::filesystem::path const& _path, std::string const& _content)
 {
 	if (boost::filesystem::is_regular_file(_path))
-		BOOST_THROW_EXCEPTION(std::runtime_error("File already exists: \"" + _path.string() + "\".")); \
+		BOOST_THROW_EXCEPTION(std::runtime_error("File already exists: \"" + _path.string() + "\"."));
 
 	// Use binary mode to avoid line ending conversion on Windows.
 	std::ofstream newFile(_path.string(), std::ofstream::binary);
 	if (newFile.fail() || !boost::filesystem::is_regular_file(_path))
-		BOOST_THROW_EXCEPTION(std::runtime_error("Failed to create a file: \"" + _path.string() + "\".")); \
+		BOOST_THROW_EXCEPTION(std::runtime_error("Failed to create a file: \"" + _path.string() + "\"."));
 
 	newFile << _content;
 }


### PR DESCRIPTION
This PR fixes a typo in the `OverrideChecker.cpp` file where `distinguishigProperty` was incorrectly spelled (missing `n`). The variable name has been corrected to `distinguishingProperty` to maintain consistent naming throughout the codebase.

**Changes:**
- Corrected spelling of variable name in error message construction
- Updated related string concatenation to use proper variable name