### PR TITLE
Optimize Address Masking for Bytecode Size

### DIFF
--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -33,6 +33,7 @@
 #include <libsolidity/ast/TypeProvider.h>
 
 #include <libevmasm/GasMeter.h>
+#include <libevmasm/Instruction.h>
 #include <libsolutil/Common.h>
 #include <libsolutil/FunctionSelector.h>
 #include <libsolutil/Keccak256.h>
@@ -1524,6 +1525,23 @@ bool ExpressionCompiler::visit(FunctionCall const& _functionCall)
 		}
 	}
 	return false;
+}
+
+void ExpressionCompiler::emitAddressMasking()
+{
+    if (m_context.optimizeForBytecodeSize())
+    {
+        m_context << Instruction::PUSH0    
+                  << Instruction::NOT      
+                  << Instruction::PUSH1    
+                  << u256(12)              
+                  << Instruction::SHR;     
+    }
+    else
+    {
+        m_context << Instruction::PUSH20  
+                  << u256(0xffffffffffffffffffffffffffffffffffffffff);
+    }
 }
 
 bool ExpressionCompiler::visit(FunctionCallOptions const& _functionCallOptions)

--- a/libsolidity/codegen/ExpressionCompiler.h
+++ b/libsolidity/codegen/ExpressionCompiler.h
@@ -91,6 +91,7 @@ private:
 	bool visit(IndexRangeAccess const& _indexAccess) override;
 	void endVisit(Identifier const& _identifier) override;
 	void endVisit(Literal const& _literal) override;
+	void emitAddressMasking();
 
 	///@{
 	///@name Append code for various operator types


### PR DESCRIPTION
issue: #15762

Implemented an optimization for address masking to reduce bytecode size and gas usage by using a more compact instruction sequence when bytecode optimization is enabled.
