### PR TITLE
fix typo in `ExpressionNestingLimitReached` enum value

### DIFF
--- a/test/tools/ossfuzz/yulFuzzerCommon.cpp
+++ b/test/tools/ossfuzz/yulFuzzerCommon.cpp
@@ -64,7 +64,7 @@ yulFuzzerUtil::TerminationReason yulFuzzerUtil::interpret(
 	}
 	catch (ExpressionNestingLimitReached const&)
 	{
-		reason = TerminationReason::ExpresionNestingLimitReached;
+		reason = TerminationReason::ExpressionNestingLimitReached;
 	}
 	catch (ExplicitlyTerminated const&)
 	{
@@ -83,5 +83,5 @@ bool yulFuzzerUtil::resourceLimitsExceeded(TerminationReason _reason)
 	return
 		_reason == yulFuzzerUtil::TerminationReason::StepLimitReached ||
 		_reason == yulFuzzerUtil::TerminationReason::TraceLimitReached ||
-		_reason == yulFuzzerUtil::TerminationReason::ExpresionNestingLimitReached;
+		_reason == yulFuzzerUtil::TerminationReason::ExpressionNestingLimitReached;
 }

--- a/test/tools/ossfuzz/yulFuzzerCommon.h
+++ b/test/tools/ossfuzz/yulFuzzerCommon.h
@@ -28,7 +28,7 @@ struct yulFuzzerUtil
 		ExplicitlyTerminated,
 		StepLimitReached,
 		TraceLimitReached,
-		ExpresionNestingLimitReached,
+		ExpressionNestingLimitReached,
 		None
 	};
 


### PR DESCRIPTION
Fixed a typo in the enum value name from `ExpresionNestingLimitReached` to `ExpressionNestingLimitReached` in `yulFuzzerUtil.h` and corresponding usage in `yulFuzzerCommon.cpp`

**Changes:**
- Corrected spelling of `ExpressionNestingLimitReached` in enum definition
- Updated all references to use the corrected spelling