### PR TITLE
fix typo in `StackCompressor` comments: `ina` -> `in a`

### DIFF
--- a/libyul/optimiser/StackCompressor.cpp
+++ b/libyul/optimiser/StackCompressor.cpp
@@ -15,7 +15,7 @@
 	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
 */
 /**
- * Optimisation stage that aggressively rematerializes certain variables ina a function to free
+ * Optimisation stage that aggressively rematerializes certain variables in a function to free
  * space on the stack until it is compilable.
  */
 

--- a/libyul/optimiser/StackCompressor.h
+++ b/libyul/optimiser/StackCompressor.h
@@ -16,7 +16,7 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 /**
- * Optimisation stage that aggressively rematerializes certain variables ina a function to free
+ * Optimisation stage that aggressively rematerializes certain variables in a function to free
  * space on the stack until it is compilable.
  */
 


### PR DESCRIPTION
fixed a typo in `StackCompressor.cpp` and `StackCompressor.h` comments where the words `in a` were incorrectly written as `ina`