### PR TITLE
Fix Docker Example: Use a Specific Version Tag

### DIFF
--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -81,13 +81,13 @@ and runs it in a new container, passing the ``--help`` argument.
 
 .. code-block:: bash
 
-    docker run ethereum/solc:stable --help
+    docker run ethereum/solc:0.8.23 --help
 
 You can specify release build versions in the tag. For example:
 
 .. code-block:: bash
 
-    docker run ethereum/solc:stable --help
+    docker run ethereum/solc:0.8.23 --help
 
 Note
 


### PR DESCRIPTION
It duplicates the ‘stable’ example, where it would be more appropriate to show an example using a specific version (0.8.23).
