### PR TITLE
Fix missing comma in Natspec JSON example in the docs

### DIFF
--- a/docs/natspec-format.rst
+++ b/docs/natspec-format.rst
@@ -209,7 +209,7 @@ JSON file as output for the ``Tree`` contract:
         "age(uint256)" :
         {
           "notice" : "Calculate tree age in years, rounded up, for live trees"
-        }
+        },
         "leaves()" :
         {
             "notice" : "Returns the amount of leaves the tree has."


### PR DESCRIPTION
Fixed the missing comma after the `age(uint256)` block, which caused invalid JSON syntax. Adding this comma ensures that the subsequent `leaves()` block is recognized as a separate field within the object.
