### PR TITLE
eof: Disallow EOF builtins in inline assembly.

### DIFF
--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -381,50 +381,51 @@ std::vector<std::optional<BuiltinFunctionForEVM>> createBuiltins(langutil::EVMVe
 	}
 	else // EOF context
 	{
-		builtins.emplace_back(createFunction(
-			"auxdataloadn",
-			1,
-			1,
-			EVMDialect::sideEffectsOfInstruction(evmasm::Instruction::DATALOADN),
-			ControlFlowSideEffects::fromInstruction(evmasm::Instruction::DATALOADN),
-			{LiteralKind::Number},
-			[](
-				FunctionCall const& _call,
-				AbstractAssembly& _assembly,
-				BuiltinContext&
-			) {
-				yulAssert(_call.arguments.size() == 1);
-				Literal const* literal = std::get_if<Literal>(&_call.arguments.front());
-				yulAssert(literal, "");
-				yulAssert(literal->value.value() <= std::numeric_limits<uint16_t>::max());
-				_assembly.appendAuxDataLoadN(static_cast<uint16_t>(literal->value.value()));
-			}
-		));
-
-		builtins.emplace_back(createFunction(
-			"eofcreate",
-			5,
-			1,
-			EVMDialect::sideEffectsOfInstruction(evmasm::Instruction::EOFCREATE),
-			ControlFlowSideEffects::fromInstruction(evmasm::Instruction::EOFCREATE),
-			{LiteralKind::String, std::nullopt, std::nullopt, std::nullopt, std::nullopt},
-			[](
-				FunctionCall const& _call,
-				AbstractAssembly& _assembly,
-				BuiltinContext& context
-			) {
-				yulAssert(_call.arguments.size() == 5);
-				Literal const* literal = std::get_if<Literal>(&_call.arguments.front());
-				auto const formattedLiteral = formatLiteral(*literal);
-				yulAssert(!util::contains(formattedLiteral, '.'));
-				auto const* containerID = valueOrNullptr(context.subIDs, formattedLiteral);
-				yulAssert(containerID != nullptr);
-				yulAssert(*containerID <= std::numeric_limits<AbstractAssembly::ContainerID>::max());
-				_assembly.appendEOFCreate(static_cast<AbstractAssembly::ContainerID>(*containerID));
-			}
+		if (_objectAccess)
+		{
+			builtins.emplace_back(createFunction(
+				"auxdataloadn",
+				1,
+				1,
+				EVMDialect::sideEffectsOfInstruction(evmasm::Instruction::DATALOADN),
+				ControlFlowSideEffects::fromInstruction(evmasm::Instruction::DATALOADN),
+				{LiteralKind::Number},
+				[](
+					FunctionCall const& _call,
+					AbstractAssembly& _assembly,
+					BuiltinContext&
+				) {
+					yulAssert(_call.arguments.size() == 1);
+					Literal const* literal = std::get_if<Literal>(&_call.arguments.front());
+					yulAssert(literal, "");
+					yulAssert(literal->value.value() <= std::numeric_limits<uint16_t>::max());
+					_assembly.appendAuxDataLoadN(static_cast<uint16_t>(literal->value.value()));
+				}
 			));
 
-		if (_objectAccess)
+			builtins.emplace_back(createFunction(
+				"eofcreate",
+				5,
+				1,
+				EVMDialect::sideEffectsOfInstruction(evmasm::Instruction::EOFCREATE),
+				ControlFlowSideEffects::fromInstruction(evmasm::Instruction::EOFCREATE),
+				{LiteralKind::String, std::nullopt, std::nullopt, std::nullopt, std::nullopt},
+				[](
+					FunctionCall const& _call,
+					AbstractAssembly& _assembly,
+					BuiltinContext& context
+				) {
+					yulAssert(_call.arguments.size() == 5);
+					Literal const* literal = std::get_if<Literal>(&_call.arguments.front());
+					auto const formattedLiteral = formatLiteral(*literal);
+					yulAssert(!util::contains(formattedLiteral, '.'));
+					auto const* containerID = valueOrNullptr(context.subIDs, formattedLiteral);
+					yulAssert(containerID != nullptr);
+					yulAssert(*containerID <= std::numeric_limits<AbstractAssembly::ContainerID>::max());
+					_assembly.appendEOFCreate(static_cast<AbstractAssembly::ContainerID>(*containerID));
+				}
+				));
+
 			builtins.emplace_back(createFunction(
 				"returncontract",
 				3,
@@ -448,6 +449,7 @@ std::vector<std::optional<BuiltinFunctionForEVM>> createBuiltins(langutil::EVMVe
 					_assembly.appendReturnContract(static_cast<AbstractAssembly::ContainerID>(*containerID));
 				}
 			));
+		}
 	}
 	yulAssert(
 		ranges::all_of(builtins, [](std::optional<BuiltinFunctionForEVM> const& _builtinFunction){

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/eof/eof_builtins_disallowed.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/eof/eof_builtins_disallowed.sol
@@ -1,0 +1,15 @@
+contract C {
+    function f() view public {
+        assembly {
+            eofcreate("a", 0, 0, 0, 0)
+            returncontract("a", 0)
+            auxdataloadn(0)
+        }
+    }
+}
+// ====
+// bytecodeFormat: legacy
+// ----
+// DeclarationError 7223: (75-84): Builtin function "eofcreate" is only available in EOF.
+// DeclarationError 7223: (114-128): Builtin function "returncontract" is only available in EOF.
+// DeclarationError 7223: (149-161): Builtin function "auxdataloadn" is only available in EOF.

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/eof/eof_builtins_disallowed_in_inline_assembly.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/eof/eof_builtins_disallowed_in_inline_assembly.sol
@@ -1,0 +1,16 @@
+// TODO: They should be available in some way in the context of inline assembly. For now it's disallowed them.
+contract C {
+    function f() view public {
+        assembly {
+            eofcreate("a", 0, 0, 0, 0)
+            returncontract("a", 0)
+            auxdataloadn(0)
+        }
+    }
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// DeclarationError 4619: (186-195): Function "eofcreate" not found.
+// DeclarationError 4619: (225-239): Function "returncontract" not found.
+// DeclarationError 4619: (260-272): Function "auxdataloadn" not found.


### PR DESCRIPTION
This PRs disallows eof builtins in solidity inline assembly statement. It has to be properly designed in the language level how to allow developers to use them. It should be allowed back when it's done.

Depends on: ~~https://github.com/ethereum/solidity/pull/15784~~ Merged