### PR TITLE
eof: Fix condition when generating custom error for builtins available in EOF but not in legacy

### DIFF
--- a/test/libyul/yulSyntaxTests/eof/eof_identifiers_not_defined_in_legacy.yul
+++ b/test/libyul/yulSyntaxTests/eof/eof_identifiers_not_defined_in_legacy.yul
@@ -18,7 +18,7 @@
 // DeclarationError 7223: (6-18): Builtin function "auxdataloadn" is only available in EOF.
 // DeclarationError 4619: (26-35): Function "dataloadn" not found.
 // DeclarationError 7223: (43-52): Builtin function "eofcreate" is only available in EOF.
-// DeclarationError 4619: (77-91): Function "returncontract" not found.
+// DeclarationError 7223: (77-91): Builtin function "returncontract" is only available in EOF.
 // DeclarationError 4619: (110-115): Function "rjump" not found.
 // DeclarationError 4619: (122-128): Function "rjumpi" not found.
 // DeclarationError 4619: (135-140): Function "callf" not found.


### PR DESCRIPTION
This PR fixes custom error printing when accessing buildins which are available in EOF only but not in legacy.