### PR TITLE
Docs & CSS: Minor Grammar Fixes and Toggle Alignment Improvements

### DIFF
--- a/docs/_static/css/toggle.css
+++ b/docs/_static/css/toggle.css
@@ -44,7 +44,7 @@ label {
     margin: 0 auto;
     display: inline-block;
     justify-content: center;
-    align-items: right;
+    align-items: flex-end;
     border-radius: 100px;
     position: relative;
     cursor: pointer;

--- a/docs/contracts/abstract-contracts.rst
+++ b/docs/contracts/abstract-contracts.rst
@@ -25,7 +25,7 @@ but no implementation was provided (no implementation body ``{ }`` was given).
         function utterance() public virtual returns (bytes32);
     }
 
-Such abstract contracts can not be instantiated directly. This is also true, if an abstract contract itself does implement
+Such abstract contracts cannot be instantiated directly. This is also true, if an abstract contract itself does implement
 all defined functions. The usage of an abstract contract as a base class is shown in the following example:
 
 .. code-block:: solidity

--- a/docs/contracts/errors.rst
+++ b/docs/contracts/errors.rst
@@ -74,7 +74,7 @@ The selector consists of the first four bytes of the keccak256-hash of the signa
 .. note::
     It is possible for a contract to revert
     with different errors of the same name or even with errors defined in different places
-    that are indistinguishable by the caller. For the outside, i.e. the ABI,
+    that are indistinguishable by the caller. From the outside, i.e. the ABI,
     only the name of the error is relevant, not the contract or file where it is defined.
 
 The statement ``require(condition, "description");`` would be equivalent to


### PR DESCRIPTION
**PR Description**  
- **Summary of Changes**  
  - **toggle.css**: Changed `align-items: right` to `align-items: flex-end` for clearer label alignment.  
  - **abstract-contracts.rst**: Corrected grammar (“can not” → “cannot”) to clarify abstract contract instantiation rules.  
  - **errors.rst**: Tweaked phrasing about errors indistinguishable by the ABI for improved readability.

- **Issue Reference**  
  - *No related issue.* This PR was created from scratch and does not close or fix any specific issue.

- **Breaking Changes**  
  - This PR introduces **no breaking changes** and is branched off `develop`.

- **Dependencies**  
  - None.

- **Tests & Documentation**  
  - No code behavior changes, so no new tests were added.  
  - Only documentation and CSS updates were made.  
  - No updates required for existing test expectations.

- **Additional Notes**  
  - Branch name: `improve-toggle-css-and-docs` (example).  
  - This PR is my only open PR, so it aligns with the requirement of working on just one at a time.  
  - Since the changes are non-breaking and purely aesthetic/documentation-related, no changelog entry is required. 

> **Checklist:**  
> - No other open PRs.  
> - Not a breaking change.  
> - No issue to reference (`Fixes #...`) because this PR is a standalone improvement.  
> - No dependencies on other PRs.  
> - Documentation changes are small clarifications; tests remain unaffected.