### PR TITLE
Update nightly CI to work with c++20 and restrict some tests to >= constantinople

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1040,6 +1040,8 @@ jobs:
       # See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105562#c27
       CMAKE_OPTIONS: -DSANITIZE=address -DPEDANTIC=OFF
       CMAKE_BUILD_TYPE: Release
+      # Set the number of jobs to two instead of the default three, so that we do not run out of memory
+      MAKEFLAGS: -j 2
     steps:
       - build
 

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER chriseth <chris@ethereum.org>
 WORKDIR /solidity
 
 # Build dependencies
-RUN apk update && apk add boost-dev boost-static build-base cmake git
+RUN apk update && apk add boost-dev boost-static build-base cmake git clang
 
 #Copy working directory on travis to the image
 COPY / $WORKDIR
@@ -17,7 +17,7 @@ ARG BUILD_CONCURRENCY="0"
 
 #Install dependencies, eliminate annoying warnings
 RUN sed -i -E -e 's/include <sys\/poll.h>/include <poll.h>/' /usr/include/boost/asio/detail/socket_types.hpp
-RUN cmake -DCMAKE_BUILD_TYPE=Release -DTESTS=0 -DSOLC_LINK_STATIC=1
+RUN cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Release -DTESTS=0 -DSOLC_LINK_STATIC=1
 RUN make solc \
     -j$(awk "BEGIN {                                       \
         if (${BUILD_CONCURRENCY} != 0) {                   \

--- a/test/libsolidity/semanticTests/constructor/no_callvalue_check.sol
+++ b/test/libsolidity/semanticTests/constructor/no_callvalue_check.sol
@@ -15,6 +15,8 @@ contract C {
 		return true;
 	}
 }
+// ====
+// EVMVersion: >=constantinople
 // ----
 // f(), 2000 ether -> true
 // gas irOptimized: 117688

--- a/test/libsolidity/semanticTests/functionCall/failed_create.sol
+++ b/test/libsolidity/semanticTests/functionCall/failed_create.sol
@@ -14,7 +14,7 @@ contract C {
 	}
 }
 // ====
-// EVMVersion: >=byzantium
+// EVMVersion: >=constantinople
 // ----
 // constructor(), 20 wei
 // gas irOptimized: 59688

--- a/test/libsolidity/semanticTests/immutable/multi_creation.sol
+++ b/test/libsolidity/semanticTests/immutable/multi_creation.sol
@@ -25,6 +25,8 @@ contract C {
 		return (a, (new A{salt: hex"01"}()).f(), (new B{salt: hex"01"}()).f());
 	}
 }
+// ====
+// EVMVersion: >=constantinople
 // ----
 // f() -> 3, 7, 5
 // gas irOptimized: 86892

--- a/test/libsolidity/semanticTests/inheritance/address_overload_resolution.sol
+++ b/test/libsolidity/semanticTests/inheritance/address_overload_resolution.sol
@@ -18,6 +18,8 @@ contract D {
         return (new C{salt: hex"01"}()).transfer(5);
     }
 }
+// ====
+// EVMVersion: >=constantinople
 // ----
 // f() -> 1
 // gas irOptimized: 77051

--- a/test/libsolidity/semanticTests/inheritance/member_notation_ctor.sol
+++ b/test/libsolidity/semanticTests/inheritance/member_notation_ctor.sol
@@ -17,6 +17,8 @@ contract A {
 		return d.getX();
 	}
 }
+// ====
+// EVMVersion: >=constantinople
 // ----
 // g(int256): -1 -> -1
 // gas legacy: 77955

--- a/test/libsolidity/semanticTests/operators/userDefined/operator_making_pure_external_call.sol
+++ b/test/libsolidity/semanticTests/operators/userDefined/operator_making_pure_external_call.sol
@@ -50,6 +50,8 @@ contract C {
         return -x;
     }
 }
+// ====
+// EVMVersion: >=constantinople
 // ----
 // testMul(int32,int32): 42, 10 -> 420
 // gas irOptimized: 102563

--- a/test/libsolidity/semanticTests/operators/userDefined/operator_making_view_external_call.sol
+++ b/test/libsolidity/semanticTests/operators/userDefined/operator_making_view_external_call.sol
@@ -56,6 +56,8 @@ contract C {
         return -x;
     }
 }
+// ====
+// EVMVersion: >=constantinople
 // ----
 // testMul(int32,int32): 42, 10 -> 420
 // gas irOptimized: 102563

--- a/test/libsolidity/semanticTests/various/many_subassemblies.sol
+++ b/test/libsolidity/semanticTests/various/many_subassemblies.sol
@@ -28,6 +28,8 @@ contract D {
         new C10{salt: hex"0a"}();
     }
 }
+// ====
+// EVMVersion: >=constantinople
 // ----
 // run() ->
 // gas irOptimized: 375192


### PR DESCRIPTION
- use clang in alpine docker container due to (suspected) compiler bug in gcc 14.2.0
- reduce parallelism from `-j3` to `-j2` for `b_ubu_asan`
- restrict some tests to `>=constantinople` if salted creation was used (related PR: #15768)