### PR TITLE
Fix wrong comment about blobhash behavior

### DIFF
--- a/test/libsolidity/semanticTests/inlineAssembly/blobhash_index_exceeding_blob_count.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/blobhash_index_exceeding_blob_count.sol
@@ -1,7 +1,7 @@
 contract C {
     function f() public view returns (bytes32 ret) {
         assembly {
-            // EIP-4844 specifies that if `index < len(tx.blob_versioned_hashes)`, `blobhash(index)` should return 0.
+            // EIP-4844 specifies that if `index >= len(tx.blob_versioned_hashes)`, `blobhash(index)` should return 0.
             // Thus, as we injected only two blob hashes in the transaction context in EVMHost,
             // the return value of the function below MUST be zero.
             ret := blobhash(2)


### PR DESCRIPTION
While reviewing https://github.com/ethereum/solidity/pull/15796, I noticed an incorrect comment in one of the tests regarding the blobhash output.