### PR TITLE
Add `outputs` setting to `ObjectCompilerTest`

### DIFF
--- a/test/libyul/ObjectCompilerTest.h
+++ b/test/libyul/ObjectCompilerTest.h
@@ -54,6 +54,7 @@ private:
 	void disambiguate();
 
 	frontend::OptimisationPreset m_optimisationPreset;
+	std::vector<std::string> m_outputSetting;
 };
 
 }


### PR DESCRIPTION
This PR add `outputs` setting which allows to define what output we want to print in ObjectCompilerTest expectations.