### PR TITLE
SMTChecker: Remove code left over after switch to SMT-LIB interface

### DIFF
--- a/libsolidity/formal/BMC.cpp
+++ b/libsolidity/formal/BMC.cpp
@@ -58,17 +58,6 @@ BMC::BMC(
 	if (_settings.solvers.z3 )
 		solvers.emplace_back(std::make_unique<Z3SMTLib2Interface>(_smtCallback, _settings.timeout));
 	m_interface = std::make_unique<SMTPortfolio>(std::move(solvers), _settings.timeout);
-#if defined (HAVE_Z3)
-	if (m_settings.solvers.z3)
-		if (!_smtlib2Responses.empty())
-			m_errorReporter.warning(
-				5622_error,
-				"SMT-LIB2 query responses were given in the auxiliary input, "
-				"but this Solidity binary uses an SMT solver Z3 directly."
-				"These responses will be ignored."
-				"Consider disabling Z3 at compilation time in order to use SMT-LIB2 responses."
-			);
-#endif
 }
 
 void BMC::analyze(SourceUnit const& _source, std::map<ASTNode const*, std::set<VerificationTargetType>, smt::EncodingContext::IdCompare> _solvedTargets)

--- a/scripts/error_codes.py
+++ b/scripts/error_codes.py
@@ -246,7 +246,6 @@ def examine_id_coverage(top_dir, source_id_to_file_names, new_ids_only=False):
         "4802",
         "4902",
         "5272",
-        "5622",
         "5798",
         "5840",
         "7128",


### PR DESCRIPTION
This is the last occurence of the HAVE_Z3 macro in the codebase.