### PR TITLE
More info about unreported fatal errors

### DIFF
--- a/liblangutil/ErrorReporter.cpp
+++ b/liblangutil/ErrorReporter.cpp
@@ -23,6 +23,9 @@
 
 #include <liblangutil/ErrorReporter.h>
 #include <liblangutil/SourceLocation.h>
+
+#include <libsolutil/Exceptions.h>
+
 #include <range/v3/algorithm/find_if.hpp>
 #include <memory>
 
@@ -121,7 +124,7 @@ bool ErrorReporter::checkForExcessiveErrors(Error::Type _type)
 		if (m_errorCount > c_maxErrorsAllowed)
 		{
 			m_errorList.push_back(std::make_shared<Error>(4013_error, Error::Type::Warning, "There are more than 256 errors. Aborting."));
-			BOOST_THROW_EXCEPTION(FatalError());
+			solThrow(FatalError, "There are more than 256 errors. Aborting.");
 		}
 	}
 
@@ -131,13 +134,13 @@ bool ErrorReporter::checkForExcessiveErrors(Error::Type _type)
 void ErrorReporter::fatalError(ErrorId _error, Error::Type _type, SourceLocation const& _location, SecondarySourceLocation const& _secondaryLocation, std::string const& _description)
 {
 	error(_error, _type, _location, _secondaryLocation, _description);
-	BOOST_THROW_EXCEPTION(FatalError());
+	solThrow(FatalError, _description);
 }
 
 void ErrorReporter::fatalError(ErrorId _error, Error::Type _type, SourceLocation const& _location, std::string const& _description)
 {
 	error(_error, _type, _location, _description);
-	BOOST_THROW_EXCEPTION(FatalError());
+	solThrow(FatalError, _description);
 }
 
 ErrorList const& ErrorReporter::errors() const

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -61,9 +61,14 @@ bool NameAndTypeResolver::registerDeclarations(SourceUnit& _sourceUnit, ASTNode 
 	{
 		DeclarationRegistrationHelper registrar(m_scopes, _sourceUnit, m_errorReporter, m_globalContext, _currentScope);
 	}
-	catch (langutil::FatalError const& error)
+	catch (FatalError const&)
 	{
-		solAssert(m_errorReporter.hasErrors(), "Unreported fatal error: "s + error.what());
+		if (!m_errorReporter.hasErrors())
+		{
+			std::cerr << "Unreported fatal error:" << std::endl;
+			std::cerr << boost::current_exception_diagnostic_information() << std::endl;
+			solAssert(false, "Unreported fatal error.");
+		}
 		return false;
 	}
 	return true;
@@ -135,9 +140,14 @@ bool NameAndTypeResolver::resolveNamesAndTypes(SourceUnit& _source)
 				return false;
 		}
 	}
-	catch (langutil::FatalError const& error)
+	catch (FatalError const&)
 	{
-		solAssert(m_errorReporter.hasErrors(), "Unreported fatal error: "s + error.what());
+		if (!m_errorReporter.hasErrors())
+		{
+			std::cerr << "Unreported fatal error:" << std::endl;
+			std::cerr << boost::current_exception_diagnostic_information() << std::endl;
+			solAssert(false, "Unreported fatal error.");
+		}
 		return false;
 	}
 	return true;
@@ -150,9 +160,14 @@ bool NameAndTypeResolver::updateDeclaration(Declaration const& _declaration)
 		m_scopes[nullptr]->registerDeclaration(_declaration, false, true);
 		solAssert(_declaration.scope() == nullptr, "Updated declaration outside global scope.");
 	}
-	catch (langutil::FatalError const& error)
+	catch (FatalError const&)
 	{
-		solAssert(m_errorReporter.hasErrors(), "Unreported fatal error: "s + error.what());
+		if (!m_errorReporter.hasErrors())
+		{
+			std::cerr << "Unreported fatal error:" << std::endl;
+			std::cerr << boost::current_exception_diagnostic_information() << std::endl;
+			solAssert(false, "Unreported fatal error.");
+		}
 		return false;
 	}
 	return true;

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1327,7 +1327,7 @@ bool TypeChecker::visit(VariableDeclarationStatement const& _statement)
 		solAssert(m_errorReporter.hasErrors(), "Should have errors!");
 		for (auto const& var: variables)
 			if (var && !var->annotation().type)
-				BOOST_THROW_EXCEPTION(FatalError());
+				solThrow(FatalError, "Type checker failed to determine types of all variables within the declaration.");
 	}
 
 	return false;
@@ -1380,7 +1380,7 @@ bool TypeChecker::visit(Conditional const& _conditional)
 		commonType = falseType;
 
 	if (!trueType && !falseType)
-		BOOST_THROW_EXCEPTION(FatalError());
+		solThrow(FatalError, "Both sides of the ternary expression have invalid types.");
 	else if (trueType && falseType)
 	{
 		commonType = Type::commonType(trueType, falseType);

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -507,9 +507,14 @@ bool CompilerStack::analyze()
 		else if (!analyzeLegacy(noErrors))
 			noErrors = false;
 	}
-	catch (FatalError const& error)
+	catch (FatalError const&)
 	{
-		solAssert(m_errorReporter.hasErrors(), "Unreported fatal error: "s + error.what());
+		if (!m_errorReporter.hasErrors())
+		{
+			std::cerr << "Unreported fatal error:" << std::endl;
+			std::cerr << boost::current_exception_diagnostic_information() << std::endl;
+			solAssert(false, "Unreported fatal error.");
+		}
 		noErrors = false;
 	}
 	catch (UnimplementedFeatureError const& _error)
@@ -1317,9 +1322,14 @@ StringMap CompilerStack::loadMissingSources(SourceUnit const& _ast)
 				}
 			}
 	}
-	catch (FatalError const& error)
+	catch (FatalError const&)
 	{
-		solAssert(m_errorReporter.hasErrors(), "Unreported fatal error: "s + error.what());
+		if (!m_errorReporter.hasErrors())
+		{
+			std::cerr << "Unreported fatal error:" << std::endl;
+			std::cerr << boost::current_exception_diagnostic_information() << std::endl;
+			solAssert(false, "Unreported fatal error.");
+		}
 	}
 	return newSources;
 }

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -176,9 +176,14 @@ ASTPointer<SourceUnit> Parser::parse(CharStream& _charStream)
 		solAssert(m_recursionDepth == 0, "");
 		return nodeFactory.createNode<SourceUnit>(findLicenseString(nodes), nodes, m_experimentalSolidityEnabledInCurrentSourceUnit);
 	}
-	catch (FatalError const& error)
+	catch (FatalError const&)
 	{
-		solAssert(m_errorReporter.hasErrors(), "Unreported fatal error: "s + error.what());
+		if (!m_errorReporter.hasErrors())
+		{
+			std::cerr << "Unreported fatal error:" << std::endl;
+			std::cerr << boost::current_exception_diagnostic_information() << std::endl;
+			solAssert(false, "Unreported fatal error.");
+		}
 		return nullptr;
 	}
 }

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1539,7 +1539,7 @@ ASTPointer<InlineAssembly> Parser::parseInlineAssembly(ASTPointer<ASTString> con
 	yul::Parser asmParser(m_errorReporter, dialect);
 	std::shared_ptr<yul::AST> ast = asmParser.parseInline(m_scanner);
 	if (ast == nullptr)
-		BOOST_THROW_EXCEPTION(FatalError());
+		solThrow(FatalError, "Failed to parse inline assembly.");
 
 	location.end = nativeLocationOf(ast->root()).end;
 	return std::make_shared<InlineAssembly>(nextID(), location, _docString, dialect, std::move(flags), ast);

--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -75,13 +75,18 @@ bool AsmAnalyzer::analyze(Block const& _block)
 
 		(*this)(_block);
 	}
-	catch (FatalError const& error)
+	catch (FatalError const&)
 	{
 		// NOTE: There's a cap on the number of reported errors, but watcher.ok() will work fine even if
 		// we exceed it because the reporter keeps counting (it just stops adding errors to the list).
 		// Note also that fact of exceeding the cap triggers a FatalError so one can get thrown even
 		// if we don't make any of our errors fatal.
-		yulAssert(!watcher.ok(), "Unreported fatal error: "s + error.what());
+		if (watcher.ok())
+		{
+			std::cerr << "Unreported fatal error:" << std::endl;
+			std::cerr << boost::current_exception_diagnostic_information() << std::endl;
+			yulAssert(false, "Unreported fatal error.");
+		}
 	}
 	return watcher.ok();
 }

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -127,9 +127,14 @@ std::unique_ptr<AST> Parser::parseInline(std::shared_ptr<Scanner> const& _scanne
 			fetchDebugDataFromComment();
 		return std::make_unique<AST>(m_dialect, parseBlock());
 	}
-	catch (FatalError const& error)
+	catch (FatalError const&)
 	{
-		yulAssert(m_errorReporter.hasErrors(), "Unreported fatal error: "s + error.what());
+		if (!m_errorReporter.hasErrors())
+		{
+			std::cerr << "Unreported fatal error:" << std::endl;
+			std::cerr << boost::current_exception_diagnostic_information() << std::endl;
+			yulAssert(false, "Unreported fatal error.");
+		}
 	}
 
 	return nullptr;

--- a/libyul/ObjectParser.cpp
+++ b/libyul/ObjectParser.cpp
@@ -63,9 +63,14 @@ std::shared_ptr<Object> ObjectParser::parse(std::shared_ptr<Scanner> const& _sca
 			expectToken(Token::EOS);
 		return object;
 	}
-	catch (FatalError const& error)
+	catch (FatalError const&)
 	{
-		yulAssert(m_errorReporter.hasErrors(), "Unreported fatal error: "s + error.what());
+		if (!m_errorReporter.hasErrors())
+		{
+			std::cerr << "Unreported fatal error:" << std::endl;
+			std::cerr << boost::current_exception_diagnostic_information() << std::endl;
+			yulAssert(false, "Unreported fatal error.");
+		}
 	}
 	return nullptr;
 }


### PR DESCRIPTION
Another iteration on #15185.

In #15185 I replaced rethrowing of unreported fatal errors with an assert. Back then it was pointed out that we're losing extra detail by doing that (https://github.com/ethereum/solidity/pull/15185#discussion_r1632800421). I thought it didn't matter because this kind of bug should be pretty uncommon and even then fixed quickly but some recent reports proved me wrong (#15600, #15601, #15722). This happens more often than I thought and apparently no one notices that this way of reporting a fatal error is a bug in itself so we're better off having that extra info there.

To be fair, I did add more info to the output back then - the message from the original exception - which should have been enough to avoid this. The problem is that `ErrorReporter` does not provide that message, probably assuming that the message in `Error` is what matters and the one from the exception will never be shown. The only thing we get is the exception type which often tells us nothing (it's just `std::exception` in all the linked cases).

I still don't think we should just rethrow an exception that someone might assume has to be handled. The PR fixes the issue by keeping the assert but also immediately reporting all the details about the `FatalError` at the point where it's caught. It also adds messages to all `FatalError`s: both those thrown by `ErrorReporter` and a few cases where we throw them manually.