### PR TITLE
eof: Pass proper EOF flag to `Assembly` used by `EVMCodeTransformTest`

### DIFF
--- a/test/libyul/EVMCodeTransformTest.cpp
+++ b/test/libyul/EVMCodeTransformTest.cpp
@@ -67,7 +67,7 @@ TestCase::TestResult EVMCodeTransformTest::run(std::ostream& _stream, std::strin
 		return TestResult::FatalError;
 	}
 
-	evmasm::Assembly assembly{CommonOptions::get().evmVersion(), false, std::nullopt, {}};
+	evmasm::Assembly assembly{CommonOptions::get().evmVersion(), false, CommonOptions::get().eofVersion(), {}};
 	EthAssemblyAdapter adapter(assembly);
 	EVMObjectCompiler::compile(
 		*yulStack.parserResult(),

--- a/test/libyul/evmCodeTransform/stackReuse/eof/function_argument_reuse_without_retparams.yul
+++ b/test/libyul/evmCodeTransform/stackReuse/eof/function_argument_reuse_without_retparams.yul
@@ -1,0 +1,45 @@
+{
+  function f(x, y) {
+    mstore(0x80, x)
+    if calldataload(0) { sstore(y, y) }
+  }
+
+  f(0, 0)
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// stackOptimization: true
+// ----
+//     /* "":95:96   */
+//   0x00
+//     /* "":90:97   */
+//   dup1
+//   callf{code_section_1}
+//     /* "":0:99   */
+//   stop
+//
+// code_section_1: assembly {
+//         /* "":34:38   */
+//       0x80
+//         /* "":27:42   */
+//       mstore
+//         /* "":63:64   */
+//       0x00
+//         /* "":50:65   */
+//       calldataload
+//         /* "":47:82   */
+//       rjumpi{tag_1}
+//         /* "":21:86   */
+//     tag_2:
+//         /* "":4:86   */
+//       pop
+//       retf
+//         /* "":66:82   */
+//     tag_1:
+//         /* "":68:80   */
+//       dup1
+//       sstore
+//         /* "":66:82   */
+//       0x00
+//       rjump{tag_2}
+// }

--- a/test/libyul/evmCodeTransform/stackReuse/function_argument_reuse_without_retparams.yul
+++ b/test/libyul/evmCodeTransform/stackReuse/function_argument_reuse_without_retparams.yul
@@ -8,6 +8,7 @@
 }
 // ====
 // EVMVersion: >=shanghai
+// bytecodeFormat: legacy
 // stackOptimization: true
 // ----
 //     /* "":90:97   */


### PR DESCRIPTION
This PR fixes `EVMCodeTransformTest` by passing EOF version to the `Assembly` used there. It also updates tests setting for one test which runs on EOF and adds it EOF's counterpart.