### PR TITLE
SMTChecker: Fix crash on external function call wrapped in 1-tuple

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ Compiler Features:
 Bugfixes:
  * General: Fix internal compiler error when requesting IR AST outputs for interfaces and abstract contracts.
  * SMTChecker: Fix SMT logic error when analyzing cross-contract getter call with BMC.
+ * SMTChecker: Fix SMT logic error when external call has extra effectless parentheses.
  * SMTChecker: Fix SMT logic error when initializing a fixed-sized-bytes array using string literals.
  * SMTChecker: Fix SMT logic error when translating invariants involving array store and select operations.
  * SMTChecker: Fix wrong encoding of string literals as arguments of ``ecrecover`` precompile.

--- a/libsolidity/formal/CHC.cpp
+++ b/libsolidity/formal/CHC.cpp
@@ -927,17 +927,6 @@ void CHC::internalFunctionCall(FunctionCall const& _funCall)
 	Expression const* calledExpr = &_funCall.expression();
 	auto funType = dynamic_cast<FunctionType const*>(calledExpr->annotation().type);
 
-	auto contractAddressValue = [this](FunctionCall const& _f) {
-		auto [callExpr, callOptions] = functionCallExpression(_f);
-
-		FunctionType const& funType = dynamic_cast<FunctionType const&>(*callExpr->annotation().type);
-		if (funType.kind() == FunctionType::Kind::Internal)
-			return state().thisAddress();
-		if (MemberAccess const* callBase = dynamic_cast<MemberAccess const*>(callExpr))
-			return expr(callBase->expression());
-		solAssert(false, "Unreachable!");
-	};
-
 	std::vector<Expression const*> arguments;
 	for (auto& arg: _funCall.sortedArguments())
 		arguments.push_back(&(*arg));

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -2869,7 +2869,7 @@ smtutil::Expression SMTEncoder::contractAddressValue(FunctionCall const& _f)
 	auto [funExpr, funOptions] = functionCallExpression(_f);
 	if (MemberAccess const* callBase = dynamic_cast<MemberAccess const*>(funExpr))
 		return expr(callBase->expression());
-	solAssert(false, "Unreachable!");
+	smtAssert(false, "Unexpected function call type encountered while getting contract address!");
 }
 
 VariableDeclaration const* SMTEncoder::publicGetter(Expression const& _expr) const {

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -2771,7 +2771,7 @@ TypePointers SMTEncoder::replaceUserTypes(TypePointers const& _types)
 
 std::pair<Expression const*, FunctionCallOptions const*> SMTEncoder::functionCallExpression(FunctionCall const& _funCall)
 {
-	Expression const* callExpr = &_funCall.expression();
+	Expression const* callExpr = innermostTuple(_funCall.expression());
 	auto const* callOptions = dynamic_cast<FunctionCallOptions const*>(callExpr);
 	if (callOptions)
 		callExpr = &callOptions->expression();

--- a/test/libsolidity/smtCheckerTests/external_calls/external_call_extra_parentheses_1.sol
+++ b/test/libsolidity/smtCheckerTests/external_calls/external_call_extra_parentheses_1.sol
@@ -1,0 +1,9 @@
+contract C {
+	function f() external {}
+	function g() public {
+		(this.f)();
+	}
+}
+// ====
+// SMTEngine: chc
+// ----

--- a/test/libsolidity/smtCheckerTests/external_calls/external_call_extra_parentheses_2.sol
+++ b/test/libsolidity/smtCheckerTests/external_calls/external_call_extra_parentheses_2.sol
@@ -1,0 +1,12 @@
+contract D {
+	function f() external {}
+}
+
+contract C {
+	function g(D d) public {
+		((d.f))();
+	}
+}
+// ====
+// SMTEngine: chc
+// ----


### PR DESCRIPTION
The function call needs to be unwrapped from within nested parentheses to get the proper call expression.

Fixes #15817.