### PR TITLE
fix errors in comments 

### DIFF
--- a/libsolc/libsolc.cpp
+++ b/libsolc/libsolc.cpp
@@ -63,7 +63,7 @@ std::string takeOverAllocation(char const* _data)
 	abort();
 }
 
-/// Resizes a std::std::string to the proper length based on the occurrence of a zero terminator.
+/// Resizes a std::string to the proper length based on the occurrence of a zero terminator.
 void truncateCString(std::string& _data)
 {
 	size_t pos = _data.find('\0');

--- a/libsolidity/analysis/ControlFlowBuilder.h
+++ b/libsolidity/analysis/ControlFlowBuilder.h
@@ -137,7 +137,7 @@ private:
 	}
 
 	/// Merges the control flow of @a _nodes to @a _endNode.
-	/// If @a _endNode is nullptr, a new node is creates and used as end node.
+	/// If @a _endNode is nullptr, a new node is created and used as end node.
 	/// Sets the merge destination as current node.
 	/// Note: @a _endNode may be one of the nodes in @a _nodes.
 	template<typename C>

--- a/libsolidity/interface/ABI.h
+++ b/libsolidity/interface/ABI.h
@@ -37,7 +37,7 @@ class ABI
 public:
 	/// Get the ABI Interface of the contract
 	/// @param _contractDef The contract definition
-	/// @return             A JSONrepresentation of the contract's ABI Interface
+	/// @return             A JSON representation of the contract's ABI Interface
 	static Json generate(ContractDefinition const& _contractDef);
 private:
 	/// @returns a json value suitable for a list of types in function input or output


### PR DESCRIPTION

libsolc/libsolc.cpp
std::std::string --> std::std::string `fix duplicate std::`

libsolidity/analysis/ControlFlowBuilder.h
is creates -->  is created 

libsolidity/interface/ABI.h
JSONrepresentation --> JSON representation 