### PR TITLE
Yul: Introduces ASTNodeRegistry

### DIFF
--- a/libyul/ASTLabelRegistry.cpp
+++ b/libyul/ASTLabelRegistry.cpp
@@ -1,0 +1,166 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libyul/ASTLabelRegistry.h>
+
+#include <libyul/Exceptions.h>
+
+#include <fmt/format.h>
+
+using namespace solidity::yul;
+
+ASTLabelRegistry::ASTLabelRegistry(): m_labels{""}, m_idToLabelMapping{0} {}
+
+ASTLabelRegistry::ASTLabelRegistry(std::vector<std::string> _labels, std::vector<size_t> _idToLabelMapping):
+	m_labels(std::move(_labels)),
+	m_idToLabelMapping(std::move(_idToLabelMapping))
+{
+	yulAssert(!m_labels.empty());
+	yulAssert(m_labels[0].empty());
+	yulAssert(!m_idToLabelMapping.empty());
+	yulAssert(m_idToLabelMapping[0] == 0);
+	// using vector<uint8_t> over vector<bool>, as the latter is optimized for space-efficiency
+	std::vector<uint8_t> labelVisited (m_labels.size(), false);
+	size_t numLabels = 0;
+	for (auto const& labelIndex: m_idToLabelMapping)
+	{
+		if (labelIndex == ghostLabelIndex())
+			continue;
+		yulAssert(labelIndex < m_labels.size());
+		// it is possible to have multiple references to the empty label index
+		// only the id == 0 refers to an actually empty label, otherwise the LabelID is unused
+		yulAssert(
+			labelIndex == 0 || !labelVisited[labelIndex],
+			fmt::format("LabelID {} (label \"{}\") is not unique.", labelIndex, m_labels[labelIndex])
+		);
+		labelVisited[labelIndex] = true;
+		if (labelIndex >= 1)
+			++numLabels;
+	}
+	yulAssert(numLabels + 1 == m_labels.size(), "Unreferenced labels present.");
+}
+
+ASTLabelRegistry::LabelID ASTLabelRegistry::maxID() const
+{
+	yulAssert(!m_idToLabelMapping.empty());
+	return m_idToLabelMapping.size() - 1;
+}
+
+size_t ASTLabelRegistry::idToLabelIndex(LabelID const _id) const
+{
+	yulAssert(_id < m_idToLabelMapping.size());
+	return m_idToLabelMapping[_id];
+}
+
+std::string_view ASTLabelRegistry::operator[](LabelID const _id) const
+{
+	auto const labelIndex = idToLabelIndex(_id);
+	yulAssert(labelIndex != ghostLabelIndex(), "Ghost ids are not explicitly labelled in the registry.");
+	// not using `unused` here, as we already have evaluated the label index
+	// an id is unused if it is not id == 0 (empty label) but points at label index 0
+	yulAssert(empty(_id) || labelIndex != 0, "Can only query ids that are not unused");
+	return m_labels[labelIndex];
+}
+
+bool ASTLabelRegistry::ghost(LabelID const _id) const
+{
+	return idToLabelIndex(_id) == ghostLabelIndex();
+}
+
+bool ASTLabelRegistry::unused(LabelID const _id) const
+{
+	return !empty(_id) && idToLabelIndex(_id) == 0;
+}
+
+std::optional<ASTLabelRegistry::LabelID> ASTLabelRegistry::findIDForLabel(std::string_view const _label) const
+{
+	for (LabelID id = 0; id <= maxID(); ++id)
+		if ((*this)[id] == _label)
+			return id;
+	return std::nullopt;
+}
+
+std::tuple<ASTLabelRegistry::LabelID, bool> ASTLabelRegistryBuilder::DefinedLabels::tryInsert(
+	std::string_view const _label,
+	ASTLabelRegistry::LabelID const _id
+)
+{
+	auto const [it, emplaced] = m_labelToIDMapping.try_emplace(std::string{_label}, _id);
+	return std::make_tuple(it->second, emplaced);
+}
+
+ASTLabelRegistryBuilder::ASTLabelRegistryBuilder():
+	m_nextID(1)
+{}
+
+ASTLabelRegistryBuilder::ASTLabelRegistryBuilder(ASTLabelRegistry const& _existingRegistry)
+{
+	yulAssert(!_existingRegistry.labels().empty() && _existingRegistry[0].empty());
+	for (size_t id = 1; id <= _existingRegistry.maxID(); ++id)
+	{
+		if (!ASTLabelRegistry::empty(id) && !_existingRegistry.unused(id))
+		{
+			// ghost ids are not added to the map as they are not explicitly labeled
+			if (_existingRegistry.ghost(id))
+				m_ghosts.push_back(id);
+			else
+			{
+				auto const [_, inserted] = m_definedLabels.tryInsert(_existingRegistry[id], id);
+				yulAssert(inserted, "Existing registry cannot contain duplicate labels.");
+			}
+		}
+	}
+	m_nextID = _existingRegistry.maxID() + 1;
+}
+
+ASTLabelRegistry::LabelID ASTLabelRegistryBuilder::define(std::string_view const _label)
+{
+	auto const [id, inserted] = m_definedLabels.tryInsert(_label, m_nextID);
+	if (inserted)
+		m_nextID++;
+	return id;
+}
+
+ASTLabelRegistry::LabelID ASTLabelRegistryBuilder::addGhost()
+{
+	m_ghosts.push_back(m_nextID);
+	return m_nextID++;
+}
+
+ASTLabelRegistry ASTLabelRegistryBuilder::build() const
+{
+	auto const& labelToIDMapping = m_definedLabels.labelToIDMapping();
+	yulAssert(labelToIDMapping.contains(""));
+	yulAssert(labelToIDMapping.at("") == 0);
+
+	std::vector<std::string> labels{""};
+	labels.reserve(labelToIDMapping.size());
+	std::vector<size_t> idToLabelMapping( m_nextID + 1, 0);
+	yulAssert(!idToLabelMapping.empty(), "Mapping must at least contain empty label");
+	for (auto const& [label, id]: labelToIDMapping)
+	{
+		if (ASTLabelRegistry::empty(id))
+			continue;
+
+		labels.emplace_back(label);
+		idToLabelMapping[id] = labels.size() - 1;
+	}
+	for (auto const ghostId: m_ghosts)
+		idToLabelMapping[ghostId] = ASTLabelRegistry::ghostLabelIndex();
+	return ASTLabelRegistry{std::move(labels), std::move(idToLabelMapping)};
+}

--- a/libyul/ASTLabelRegistry.h
+++ b/libyul/ASTLabelRegistry.h
@@ -1,0 +1,110 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <limits>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace solidity::yul
+{
+
+/// Instances of the `ASTLabelRegistry` are immutable containers describing a labelling of nodes inside the AST.
+/// Each element of the AST that possesses a label has a `ASTLabelRegistry::LabelID`, with which the label can
+/// be queried in O(1).
+/// Preferred way of creating instances is via `ASTLabelRegistryBuilder` when parsing/importing and
+/// via `LabelIDDispenser` during/after optimization.
+/// Note: The id == 0 always corresponds to the empty label. Other ids can point at the label index 0, which means that
+/// they are unused. To check, whether an id is unused, the `unused` function can be used.
+/// Note: There is a special case of ghost ids, which are added during CFG construction.
+/// They do not directly correspond to elements of an AST but live inside the CFG. They are assigned the
+/// special `std::numeric_limits<LabelID>::max` label index. The labels themselves are - if required - generated from
+/// the CFG.
+class ASTLabelRegistry
+{
+public:
+	/// unsafe to use from a different registry instance, it is up to the user to safeguard against this
+	using LabelID = size_t;
+
+	ASTLabelRegistry();
+	ASTLabelRegistry(std::vector<std::string> _labels, std::vector<size_t> _idToLabelMapping);
+
+	std::string_view operator[](LabelID _id) const;
+
+	static bool constexpr empty(LabelID const _id) { return _id == emptyID(); }
+	static LabelID constexpr emptyID() { return 0; }
+	static size_t constexpr ghostLabelIndex() { return std::numeric_limits<size_t>::max(); }
+
+	bool unused(LabelID _id) const;
+	bool ghost(LabelID _id) const;
+	std::vector<std::string> const& labels() const { return m_labels; }
+	LabelID maxID() const;
+
+	size_t idToLabelIndex(LabelID _id) const;
+	/// this is a potentially expensive operation
+	std::optional<LabelID> findIDForLabel(std::string_view _label) const;
+
+private:
+	/// All Yul AST labels present in the registry.
+	/// Always contains at least an empty label which also serves as a null-state for non-contiguous ID ranges.
+	/// All items must be unique.
+	std::vector<std::string> const m_labels;
+
+	/// Assignment of labels to `LabelID`s. Indices are `LabelID`s and values are indices into `m_labels`.
+	/// Every label except empty always has exactly one `LabelID` pointing at it.
+	/// The empty label has one canonical ID, but unused IDs point to it as well.
+	std::vector<size_t> const m_idToLabelMapping;
+};
+
+/// Produces instances of `ASTLabelRegistry`. Preferably used during parsing/importing.
+class ASTLabelRegistryBuilder
+{
+public:
+	ASTLabelRegistryBuilder();
+	/// Creates a new builder taking an already existing label registry into account.
+	/// Unused IDs are skipped, ghost IDs are recorded and inserted back into the newly built registry.
+	explicit ASTLabelRegistryBuilder(ASTLabelRegistry const& _existingRegistry);
+
+	ASTLabelRegistry::LabelID define(std::string_view _label);
+	ASTLabelRegistry::LabelID addGhost();
+
+	/// Creates a new label registry based on what was defined and potentially an existing registry. If such registry
+	/// was provided, all labels (including unused and ghost label IDs) carry over.
+	ASTLabelRegistry build() const;
+
+private:
+	class DefinedLabels
+	{
+	public:
+		std::tuple<ASTLabelRegistry::LabelID, bool> tryInsert(std::string_view _label, ASTLabelRegistry::LabelID _id);
+		auto const& labelToIDMapping() const { return m_labelToIDMapping; }
+
+	private:
+		std::map<std::string, size_t, std::less<>> m_labelToIDMapping = {{"", 0}};
+	};
+
+	DefinedLabels m_definedLabels;
+	std::vector<ASTLabelRegistry::LabelID> m_ghosts;
+	size_t m_nextID{};
+};
+
+}

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -7,6 +7,8 @@ add_library(yul
 	AST.h
 	AST.cpp
 	ASTForward.h
+	ASTLabelRegistry.cpp
+	ASTLabelRegistry.h
 	AsmJsonConverter.h
 	AsmJsonConverter.cpp
 	AsmJsonImporter.h


### PR DESCRIPTION
This PR supersedes PR #15242. ~~Depends on PR #15821.~~

It introduces `yul::ASTNodeRegistryBuilder` and `yul::ASTNodeRegistry`. Most important bits of the API:

```
┌──────────────────────────────────────────────────────────────────────────┐                                      
│ASTNodeRegistryBuilder                                                    │                                      
├──────────────────────────────────────────────────────────────────────────┤                                      
│ ASTNodeRegistryBuilder()                                                 │                                      
│ explicit ASTNodeRegistryBuilder(ASTNodeRegistry const& _existingRegistry)│                                      
│                                                                          │                                      
│ ASTNodeRegistry::NodeIdidefine(std::string_view _label)                  │                                      
│ ASTNodeRegistry build() const                                            │                                      
└────────────────────────────────────┬─────────────────────────────────────┘                                      
                                     │                                                                            
                                     │                                                                            
                                     │                                                                            
┌────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────┐  
│ASTNodeRegistry                                                                                               │  
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────┤  
│ ASTNodeRegistry()                                                                                            │  
│ ASTNodeRegistry(std::vector<std::string> const& _labels, std::vector<size_t> const& _nameToLabelMapping)     │  
│                                                                                                              │  
│ std::string_view operator()(NodeIde_id)                                                                      │  
│ std::optional<YulName> findNameForLabel(std::string_view _label) const                                       │  
└────────────────────────────────────┬─────────────────────────────────────────────────────────────────────────┘  
                                     │                                                                            
                                     │                                                                            
                                     │                                                                            
┌────────────────────────────────────┴───────────────────────────────────────────────────────────────────────────┐
│NodeIdDispenser                                                                                                 │
├────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ explicit NodeIdDispenser(ASTNodeRegistry const& _existingRegistry, std::set<std::string> const& _reserved = {})│
│                                                                                                                │
│ NodeId newId(NodeId _parent = 0)                                                                               │
│ NodeId newGhost()                                                                                              │
│ ASTNodeRegistry generate(Block const& _root, Dialect const& _dialect) const;                                   │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

I have not yet included the `NodeIdDispenser`, this can be done in a separate PR.

The `ASTNodeRegistry` lives (immutably) in the `AST` and can be used to query labels for particular nodes in the AST. But potentially this could store more metadata than just string labels.

A `ASTNodeRegistry` can be created by using the `ASTNodeRegistryBuilder` - which would be the preferred way when importing or parsing (see PR #15833):

https://github.com/ethereum/solidity/blob/c2cea376075775cbf81561b5dc270ca372c9c688/libyul/AsmJsonImporter.cpp#L82-L87

https://github.com/ethereum/solidity/blob/c2cea376075775cbf81561b5dc270ca372c9c688/libyul/AsmJsonImporter.cpp#L56-L60

Or, during/after optimization, from the `NodeIdDispenser` based on the root block, discarding everything that is not part of the current AST, and the dialect to check for collisions with reserved identifiers:

https://github.com/ethereum/solidity/blob/c2cea376075775cbf81561b5dc270ca372c9c688/libyul/optimiser/Suite.cpp#L200

https://github.com/ethereum/solidity/blob/c2cea376075775cbf81561b5dc270ca372c9c688/libyul/AST.cpp#L110-L114