### PR TITLE
SMTChecker: Fix internal error involving string to bytes conversion

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ Compiler Features:
 Bugfixes:
  * General: Fix internal compiler error when requesting IR AST outputs for interfaces and abstract contracts.
  * SMTChecker: Fix SMT logic error when analyzing cross-contract getter call with BMC.
+ * SMTChecker: Fix SMT logic error when contract deployment involves string literal to fixed bytes conversion.
  * SMTChecker: Fix SMT logic error when external call has extra effectless parentheses.
  * SMTChecker: Fix SMT logic error when initializing a fixed-sized-bytes array using string literals.
  * SMTChecker: Fix SMT logic error when translating invariants involving array store and select operations.

--- a/libsolidity/formal/CHC.cpp
+++ b/libsolidity/formal/CHC.cpp
@@ -854,7 +854,7 @@ void CHC::visitDeployment(FunctionCall const& _funCall)
 		auto const& params = constructor->parameters();
 		solAssert(args.size() == params.size(), "");
 		for (auto [arg, param]: ranges::zip_view(args, params))
-			m_context.addAssertion(expr(*arg) == m_context.variable(*param)->currentValue());
+			m_context.addAssertion(expr(*arg, param->type()) == m_context.variable(*param)->currentValue());
 	}
 	for (auto var: stateVariablesIncludingInheritedAndPrivate(*contract))
 		m_context.variable(*var)->increaseIndex();

--- a/test/libsolidity/smtCheckerTests/typecast/string_literal_to_fixed_bytes_constructor_for_deployment.sol
+++ b/test/libsolidity/smtCheckerTests/typecast/string_literal_to_fixed_bytes_constructor_for_deployment.sol
@@ -1,0 +1,21 @@
+contract A {
+    bytes3 public a;
+
+    constructor(bytes3 _a) payable {
+        a = _a;
+    }
+}
+
+contract B {
+    A a;
+
+    constructor() payable {
+        a = (new A){value: 10}("abc");
+        assert(a.a() == 0x616263);
+    }
+}
+// ====
+// SMTEngine: chc
+// SMTExtCalls: trusted
+// ----
+// Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.


### PR DESCRIPTION
This happened when analyzing deployment of a contract and the type conversion was necessary for the constructor argument.

Fixes #15813.