### PR TITLE
docs: Fix grammar in workflow trigger condition

### DIFF
--- a/scripts/docker/buildpack-deps/README.md
+++ b/scripts/docker/buildpack-deps/README.md
@@ -6,7 +6,7 @@ The `buildpack-deps` docker images are used to compile and test solidity within 
 
 The creation of the images is triggered by a single workflow, defined in `.github/workflows/buildpack-deps.yml`.
 For each resulting `buildpack-deps` docker image a strategy is defined in the workflow file - the image variant.
-The workflow gets triggered, if any Dockerfile defined in `scripts/docker/buildpack-deps/Dockerfile.*` were changed
+The workflow gets triggered, if any Dockerfile defined in `scripts/docker/buildpack-deps/Dockerfile.*` was changed
 within the PR.
 
 ### Versioning


### PR DESCRIPTION
A grammatical mistake in the documentation.

The phrase **"if any Dockerfile … were changed"** is incorrect because **"any Dockerfile"** is singular. The correct form is **"was changed"**.  

This update fixes that.