### PR TITLE
SMTChecker: Make innermostTuple return reference

### DIFF
--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -71,7 +71,7 @@ public:
 
 	/// @returns the innermost element in a chain of 1-tuples if applicable,
 	/// otherwise _expr.
-	static Expression const* innermostTuple(Expression const& _expr);
+	static Expression const& innermostTuple(Expression const& _expr);
 
 	/// @returns the underlying type if _type is UserDefinedValueType,
 	/// and _type otherwise.


### PR DESCRIPTION
Instead of returning a pointer, to indicate that the method always returns a valid value (and does not need a check for null pointer), we can return a reference.

As part of the refactoring, we can actually eliminate one usage of this method.