### PR TITLE
Add ASTNodeRegistry to AST

### DIFF
--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -944,7 +944,7 @@ bool ContractCompiler::visit(InlineAssembly const& _inlineAssembly)
 		solAssert(dialect, "");
 
 		// Create a modifiable copy of the code and analysis
-		object.setCode(std::make_shared<yul::AST>(_inlineAssembly.dialect(), yul::ASTCopier().translate(code->root())));
+		object.setCode(std::make_shared<yul::AST>(_inlineAssembly.dialect(), yul::ASTLabelRegistry{}, yul::ASTCopier().translate(code->root())));
 		object.analysisInfo = std::make_shared<yul::AsmAnalysisInfo>(yul::AsmAnalyzer::analyzeStrictAssertCorrect(object));
 
 		m_context.optimizeYul(object, m_optimiserSettings);

--- a/libyul/AST.h
+++ b/libyul/AST.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <libyul/ASTForward.h>
+#include <libyul/ASTLabelRegistry.h>
 #include <libyul/Builtins.h>
 #include <libyul/YulName.h>
 
@@ -109,12 +110,18 @@ struct Leave { langutil::DebugData::ConstPtr debugData; };
 class AST
 {
 public:
-	AST(Dialect const& _dialect, Block _root): m_dialect(_dialect), m_root(std::move(_root)) {}
+	AST(Dialect const& _dialect, ASTLabelRegistry _labels, Block _root):
+		m_dialect(_dialect),
+		m_labels(std::move(_labels)),
+		m_root(std::move(_root))
+	{}
 
 	Dialect const& dialect() const { return m_dialect; }
 	Block const& root() const { return m_root; }
+	ASTLabelRegistry const& labels() const { return m_labels; }
 private:
 	Dialect const& m_dialect;
+	ASTLabelRegistry m_labels;
 	Block m_root;
 };
 

--- a/libyul/ASTLabelRegistry.cpp
+++ b/libyul/ASTLabelRegistry.cpp
@@ -1,0 +1,166 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libyul/ASTLabelRegistry.h>
+
+#include <libyul/Exceptions.h>
+
+#include <fmt/format.h>
+
+using namespace solidity::yul;
+
+ASTLabelRegistry::ASTLabelRegistry(): m_labels{""}, m_idToLabelMapping{0} {}
+
+ASTLabelRegistry::ASTLabelRegistry(std::vector<std::string> _labels, std::vector<size_t> _idToLabelMapping):
+	m_labels(std::move(_labels)),
+	m_idToLabelMapping(std::move(_idToLabelMapping))
+{
+	yulAssert(!m_labels.empty());
+	yulAssert(m_labels[0].empty());
+	yulAssert(!m_idToLabelMapping.empty());
+	yulAssert(m_idToLabelMapping[0] == 0);
+	// using vector<uint8_t> over vector<bool>, as the latter is optimized for space-efficiency
+	std::vector<uint8_t> labelVisited (m_labels.size(), false);
+	size_t numLabels = 0;
+	for (auto const& labelIndex: m_idToLabelMapping)
+	{
+		if (labelIndex == ghostLabelIndex())
+			continue;
+		yulAssert(labelIndex < m_labels.size());
+		// it is possible to have multiple references to the empty label index
+		// only the id == 0 refers to an actually empty label, otherwise the LabelID is unused
+		yulAssert(
+			labelIndex == 0 || !labelVisited[labelIndex],
+			fmt::format("LabelID {} (label \"{}\") is not unique.", labelIndex, m_labels[labelIndex])
+		);
+		labelVisited[labelIndex] = true;
+		if (labelIndex >= 1)
+			++numLabels;
+	}
+	yulAssert(numLabels + 1 == m_labels.size(), "Unreferenced labels present.");
+}
+
+ASTLabelRegistry::LabelID ASTLabelRegistry::maxID() const
+{
+	yulAssert(!m_idToLabelMapping.empty());
+	return m_idToLabelMapping.size() - 1;
+}
+
+size_t ASTLabelRegistry::idToLabelIndex(LabelID const _id) const
+{
+	yulAssert(_id < m_idToLabelMapping.size());
+	return m_idToLabelMapping[_id];
+}
+
+std::string_view ASTLabelRegistry::operator[](LabelID const _id) const
+{
+	auto const labelIndex = idToLabelIndex(_id);
+	yulAssert(labelIndex != ghostLabelIndex(), "Ghost ids are not explicitly labelled in the registry.");
+	// not using `unused` here, as we already have evaluated the label index
+	// an id is unused if it is not id == 0 (empty label) but points at label index 0
+	yulAssert(empty(_id) || labelIndex != 0, "Can only query ids that are not unused");
+	return m_labels[labelIndex];
+}
+
+bool ASTLabelRegistry::ghost(LabelID const _id) const
+{
+	return idToLabelIndex(_id) == ghostLabelIndex();
+}
+
+bool ASTLabelRegistry::unused(LabelID const _id) const
+{
+	return !empty(_id) && idToLabelIndex(_id) == 0;
+}
+
+std::optional<ASTLabelRegistry::LabelID> ASTLabelRegistry::findIDForLabel(std::string_view const _label) const
+{
+	for (LabelID id = 0; id <= maxID(); ++id)
+		if ((*this)[id] == _label)
+			return id;
+	return std::nullopt;
+}
+
+std::tuple<ASTLabelRegistry::LabelID, bool> ASTLabelRegistryBuilder::DefinedLabels::tryInsert(
+	std::string_view const _label,
+	ASTLabelRegistry::LabelID const _id
+)
+{
+	auto const [it, emplaced] = m_labelToIDMapping.try_emplace(std::string{_label}, _id);
+	return std::make_tuple(it->second, emplaced);
+}
+
+ASTLabelRegistryBuilder::ASTLabelRegistryBuilder():
+	m_nextID(1)
+{}
+
+ASTLabelRegistryBuilder::ASTLabelRegistryBuilder(ASTLabelRegistry const& _existingRegistry)
+{
+	yulAssert(!_existingRegistry.labels().empty() && _existingRegistry[0].empty());
+	for (size_t id = 1; id <= _existingRegistry.maxID(); ++id)
+	{
+		if (!ASTLabelRegistry::empty(id) && !_existingRegistry.unused(id))
+		{
+			// ghost ids are not added to the map as they are not explicitly labeled
+			if (_existingRegistry.ghost(id))
+				m_ghosts.push_back(id);
+			else
+			{
+				auto const [_, inserted] = m_definedLabels.tryInsert(_existingRegistry[id], id);
+				yulAssert(inserted, "Existing registry cannot contain duplicate labels.");
+			}
+		}
+	}
+	m_nextID = _existingRegistry.maxID() + 1;
+}
+
+ASTLabelRegistry::LabelID ASTLabelRegistryBuilder::define(std::string_view const _label)
+{
+	auto const [id, inserted] = m_definedLabels.tryInsert(_label, m_nextID);
+	if (inserted)
+		m_nextID++;
+	return id;
+}
+
+ASTLabelRegistry::LabelID ASTLabelRegistryBuilder::addGhost()
+{
+	m_ghosts.push_back(m_nextID);
+	return m_nextID++;
+}
+
+ASTLabelRegistry ASTLabelRegistryBuilder::build() const
+{
+	auto const& labelToIDMapping = m_definedLabels.labelToIDMapping();
+	yulAssert(labelToIDMapping.contains(""));
+	yulAssert(labelToIDMapping.at("") == 0);
+
+	std::vector<std::string> labels{""};
+	labels.reserve(labelToIDMapping.size());
+	std::vector<size_t> idToLabelMapping( m_nextID + 1, 0);
+	yulAssert(!idToLabelMapping.empty(), "Mapping must at least contain empty label");
+	for (auto const& [label, id]: labelToIDMapping)
+	{
+		if (ASTLabelRegistry::empty(id))
+			continue;
+
+		labels.emplace_back(label);
+		idToLabelMapping[id] = labels.size() - 1;
+	}
+	for (auto const ghostId: m_ghosts)
+		idToLabelMapping[ghostId] = ASTLabelRegistry::ghostLabelIndex();
+	return ASTLabelRegistry{std::move(labels), std::move(idToLabelMapping)};
+}

--- a/libyul/ASTLabelRegistry.h
+++ b/libyul/ASTLabelRegistry.h
@@ -1,0 +1,110 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <limits>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace solidity::yul
+{
+
+/// Instances of the `ASTLabelRegistry` are immutable containers describing a labelling of nodes inside the AST.
+/// Each element of the AST that possesses a label has a `ASTLabelRegistry::LabelID`, with which the label can
+/// be queried in O(1).
+/// Preferred way of creating instances is via `ASTLabelRegistryBuilder` when parsing/importing and
+/// via `LabelIDDispenser` during/after optimization.
+/// Note: The id == 0 always corresponds to the empty label. Other ids can point at the label index 0, which means that
+/// they are unused. To check, whether an id is unused, the `unused` function can be used.
+/// Note: There is a special case of ghost ids, which are added during CFG construction.
+/// They do not directly correspond to elements of an AST but live inside the CFG. They are assigned the
+/// special `std::numeric_limits<LabelID>::max` label index. The labels themselves are - if required - generated from
+/// the CFG.
+class ASTLabelRegistry
+{
+public:
+	/// unsafe to use from a different registry instance, it is up to the user to safeguard against this
+	using LabelID = size_t;
+
+	ASTLabelRegistry();
+	ASTLabelRegistry(std::vector<std::string> _labels, std::vector<size_t> _idToLabelMapping);
+
+	std::string_view operator[](LabelID _id) const;
+
+	static bool constexpr empty(LabelID const _id) { return _id == emptyID(); }
+	static LabelID constexpr emptyID() { return 0; }
+	static size_t constexpr ghostLabelIndex() { return std::numeric_limits<size_t>::max(); }
+
+	bool unused(LabelID _id) const;
+	bool ghost(LabelID _id) const;
+	std::vector<std::string> const& labels() const { return m_labels; }
+	LabelID maxID() const;
+
+	size_t idToLabelIndex(LabelID _id) const;
+	/// this is a potentially expensive operation
+	std::optional<LabelID> findIDForLabel(std::string_view _label) const;
+
+private:
+	/// All Yul AST labels present in the registry.
+	/// Always contains at least an empty label which also serves as a null-state for non-contiguous ID ranges.
+	/// All items must be unique.
+	std::vector<std::string> const m_labels;
+
+	/// Assignment of labels to `LabelID`s. Indices are `LabelID`s and values are indices into `m_labels`.
+	/// Every label except empty always has exactly one `LabelID` pointing at it.
+	/// The empty label has one canonical ID, but unused IDs point to it as well.
+	std::vector<size_t> const m_idToLabelMapping;
+};
+
+/// Produces instances of `ASTLabelRegistry`. Preferably used during parsing/importing.
+class ASTLabelRegistryBuilder
+{
+public:
+	ASTLabelRegistryBuilder();
+	/// Creates a new builder taking an already existing label registry into account.
+	/// Unused IDs are skipped, ghost IDs are recorded and inserted back into the newly built registry.
+	explicit ASTLabelRegistryBuilder(ASTLabelRegistry const& _existingRegistry);
+
+	ASTLabelRegistry::LabelID define(std::string_view _label);
+	ASTLabelRegistry::LabelID addGhost();
+
+	/// Creates a new label registry based on what was defined and potentially an existing registry. If such registry
+	/// was provided, all labels (including unused and ghost label IDs) carry over.
+	ASTLabelRegistry build() const;
+
+private:
+	class DefinedLabels
+	{
+	public:
+		std::tuple<ASTLabelRegistry::LabelID, bool> tryInsert(std::string_view _label, ASTLabelRegistry::LabelID _id);
+		auto const& labelToIDMapping() const { return m_labelToIDMapping; }
+
+	private:
+		std::map<std::string, size_t, std::less<>> m_labelToIDMapping = {{"", 0}};
+	};
+
+	DefinedLabels m_definedLabels;
+	std::vector<ASTLabelRegistry::LabelID> m_ghosts;
+	size_t m_nextID{};
+};
+
+}

--- a/libyul/AsmJsonImporter.cpp
+++ b/libyul/AsmJsonImporter.cpp
@@ -53,7 +53,7 @@ SourceLocation const AsmJsonImporter::createSourceLocation(Json const& _node)
 
 AST AsmJsonImporter::createAST(solidity::Json const& _node)
 {
-	return {m_dialect, createBlock(_node)};
+	return {m_dialect, ASTNodeRegistry{}, createBlock(_node)};
 }
 
 template <class T>

--- a/libyul/AsmJsonImporter.cpp
+++ b/libyul/AsmJsonImporter.cpp
@@ -53,7 +53,8 @@ SourceLocation const AsmJsonImporter::createSourceLocation(Json const& _node)
 
 AST AsmJsonImporter::createAST(solidity::Json const& _node)
 {
-	return {m_dialect, ASTNodeRegistry{}, createBlock(_node)};
+	auto block = createBlock(_node);
+	return {m_dialect, m_labelRegistryBuilder.build(), std::move(block)};
 }
 
 template <class T>
@@ -80,6 +81,7 @@ NameWithDebugData AsmJsonImporter::createNameWithDebugData(Json const& _node)
 {
 	auto nameWithDebugData = createAsmNode<NameWithDebugData>(_node);
 	nameWithDebugData.name = YulName{member(_node, "name").get<std::string>()};
+	std::ignore = m_labelRegistryBuilder.define(nameWithDebugData.name.str());
 	return nameWithDebugData;
 }
 
@@ -235,6 +237,7 @@ Identifier AsmJsonImporter::createIdentifier(Json const& _node)
 {
 	auto identifier = createAsmNode<Identifier>(_node);
 	identifier.name = YulName(member(_node, "name").get<std::string>());
+	std::ignore = m_labelRegistryBuilder.define(identifier.name.str());
 	return identifier;
 }
 
@@ -294,6 +297,7 @@ FunctionDefinition AsmJsonImporter::createFunctionDefinition(Json const& _node)
 {
 	auto funcDef = createAsmNode<FunctionDefinition>(_node);
 	funcDef.name = YulName{member(_node, "name").get<std::string>()};
+	std::ignore = m_labelRegistryBuilder.define(funcDef.name.str());
 
 	if (_node.contains("parameters"))
 		for (auto const& var: member(_node, "parameters"))

--- a/libyul/AsmJsonImporter.h
+++ b/libyul/AsmJsonImporter.h
@@ -23,11 +23,15 @@
 
 #pragma once
 
-#include <libsolutil/JSON.h>
-#include <liblangutil/SourceLocation.h>
 #include <libyul/ASTForward.h>
+#include <libyul/ASTLabelRegistry.h>
 
-#include <utility>
+#include <libsolutil/JSON.h>
+
+#include <liblangutil/SourceLocation.h>
+
+#include <memory>
+#include <vector>
 
 namespace solidity::yul
 {
@@ -78,6 +82,7 @@ private:
 
 	Dialect const& m_dialect;
 	std::vector<std::shared_ptr<std::string const>> const& m_sourceNames;
+	ASTLabelRegistryBuilder m_labelRegistryBuilder;
 };
 
 }

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -122,10 +122,12 @@ std::unique_ptr<AST> Parser::parseInline(std::shared_ptr<Scanner> const& _scanne
 
 	try
 	{
+		ASTLabelRegistryBuilder labelRegistryBuilder;
 		m_scanner = _scanner;
 		if (m_useSourceLocationFrom == UseSourceLocationFrom::Comments)
 			fetchDebugDataFromComment();
-		return std::make_unique<AST>(m_dialect, ASTNodeRegistry{}, parseBlock());
+		auto block = parseBlock(labelRegistryBuilder);
+		return std::make_unique<AST>(m_dialect, labelRegistryBuilder.build(), std::move(block));
 	}
 	catch (FatalError const& error)
 	{
@@ -324,35 +326,35 @@ std::optional<std::pair<std::string_view, std::optional<int>>> Parser::parseASTI
 		return std::nullopt;
 }
 
-Block Parser::parseBlock()
+Block Parser::parseBlock(ASTLabelRegistryBuilder& _labelRegistryBuilder)
 {
 	RecursionGuard recursionGuard(*this);
 	Block block = createWithDebugData<Block>();
 	expectToken(Token::LBrace);
 	while (currentToken() != Token::RBrace)
-		block.statements.emplace_back(parseStatement());
+		block.statements.emplace_back(parseStatement(_labelRegistryBuilder));
 	updateLocationEndFrom(block.debugData, currentLocation());
 	advance();
 	return block;
 }
 
-Statement Parser::parseStatement()
+Statement Parser::parseStatement(ASTLabelRegistryBuilder& _labelRegistryBuilder)
 {
 	RecursionGuard recursionGuard(*this);
 	switch (currentToken())
 	{
 	case Token::Let:
-		return parseVariableDeclaration();
+		return parseVariableDeclaration(_labelRegistryBuilder);
 	case Token::Function:
-		return parseFunctionDefinition();
+		return parseFunctionDefinition(_labelRegistryBuilder);
 	case Token::LBrace:
-		return parseBlock();
+		return parseBlock(_labelRegistryBuilder);
 	case Token::If:
 	{
 		If _if = createWithDebugData<If>();
 		advance();
-		_if.condition = std::make_unique<Expression>(parseExpression());
-		_if.body = parseBlock();
+		_if.condition = std::make_unique<Expression>(parseExpression(_labelRegistryBuilder));
+		_if.body = parseBlock(_labelRegistryBuilder);
 		updateLocationEndFrom(_if.debugData, nativeLocationOf(_if.body));
 		return Statement{std::move(_if)};
 	}
@@ -360,11 +362,11 @@ Statement Parser::parseStatement()
 	{
 		Switch _switch = createWithDebugData<Switch>();
 		advance();
-		_switch.expression = std::make_unique<Expression>(parseExpression());
+		_switch.expression = std::make_unique<Expression>(parseExpression(_labelRegistryBuilder));
 		while (currentToken() == Token::Case)
-			_switch.cases.emplace_back(parseCase());
+			_switch.cases.emplace_back(parseCase(_labelRegistryBuilder));
 		if (currentToken() == Token::Default)
-			_switch.cases.emplace_back(parseCase());
+			_switch.cases.emplace_back(parseCase(_labelRegistryBuilder));
 		if (currentToken() == Token::Default)
 			fatalParserError(6931_error, "Only one default case allowed.");
 		else if (currentToken() == Token::Case)
@@ -375,7 +377,7 @@ Statement Parser::parseStatement()
 		return Statement{std::move(_switch)};
 	}
 	case Token::For:
-		return parseForLoop();
+		return parseForLoop(_labelRegistryBuilder);
 	case Token::Break:
 	{
 		Statement stmt{createWithDebugData<Break>()};
@@ -405,13 +407,13 @@ Statement Parser::parseStatement()
 	// Options left:
 	// Expression/FunctionCall
 	// Assignment
-	std::variant<Literal, Identifier, BuiltinName> elementary(parseLiteralOrIdentifier());
+	std::variant<Literal, Identifier, BuiltinName> elementary(parseLiteralOrIdentifier(_labelRegistryBuilder));
 
 	switch (currentToken())
 	{
 	case Token::LParen:
 	{
-		Expression expr = parseCall(std::move(elementary));
+		Expression expr = parseCall(_labelRegistryBuilder, std::move(elementary));
 		return ExpressionStatement{debugDataOf(expr), std::move(expr)};
 	}
 	case Token::Comma:
@@ -455,7 +457,7 @@ Statement Parser::parseStatement()
 					else
 					{
 						expectToken(Token::Comma);
-						elementary = parseLiteralOrIdentifier();
+						elementary = parseLiteralOrIdentifier(_labelRegistryBuilder);
 					}
 				}
 			}, elementary);
@@ -464,7 +466,7 @@ Statement Parser::parseStatement()
 
 		expectToken(Token::AssemblyAssign);
 
-		assignment.value = std::make_unique<Expression>(parseExpression());
+		assignment.value = std::make_unique<Expression>(parseExpression(_labelRegistryBuilder));
 		updateLocationEndFrom(assignment.debugData, nativeLocationOf(*assignment.value));
 
 		return Statement{std::move(assignment)};
@@ -478,7 +480,7 @@ Statement Parser::parseStatement()
 	return {};
 }
 
-Case Parser::parseCase()
+Case Parser::parseCase(ASTLabelRegistryBuilder& _labelRegistryBuilder)
 {
 	RecursionGuard recursionGuard(*this);
 	Case _case = createWithDebugData<Case>();
@@ -487,19 +489,19 @@ Case Parser::parseCase()
 	else if (currentToken() == Token::Case)
 	{
 		advance();
-		std::variant<Literal, Identifier, BuiltinName> literal = parseLiteralOrIdentifier();
+		std::variant<Literal, Identifier, BuiltinName> literal = parseLiteralOrIdentifier(_labelRegistryBuilder);
 		if (!std::holds_alternative<Literal>(literal))
 			fatalParserError(4805_error, "Literal expected.");
 		_case.value = std::make_unique<Literal>(std::get<Literal>(std::move(literal)));
 	}
 	else
 		yulAssert(false, "Case or default case expected.");
-	_case.body = parseBlock();
+	_case.body = parseBlock(_labelRegistryBuilder);
 	updateLocationEndFrom(_case.debugData, nativeLocationOf(_case.body));
 	return _case;
 }
 
-ForLoop Parser::parseForLoop()
+ForLoop Parser::parseForLoop(ASTLabelRegistryBuilder& _labelRegistryBuilder)
 {
 	RecursionGuard recursionGuard(*this);
 
@@ -508,13 +510,13 @@ ForLoop Parser::parseForLoop()
 	ForLoop forLoop = createWithDebugData<ForLoop>();
 	expectToken(Token::For);
 	m_currentForLoopComponent = ForLoopComponent::ForLoopPre;
-	forLoop.pre = parseBlock();
+	forLoop.pre = parseBlock(_labelRegistryBuilder);
 	m_currentForLoopComponent = ForLoopComponent::None;
-	forLoop.condition = std::make_unique<Expression>(parseExpression());
+	forLoop.condition = std::make_unique<Expression>(parseExpression(_labelRegistryBuilder));
 	m_currentForLoopComponent = ForLoopComponent::ForLoopPost;
-	forLoop.post = parseBlock();
+	forLoop.post = parseBlock(_labelRegistryBuilder);
 	m_currentForLoopComponent = ForLoopComponent::ForLoopBody;
-	forLoop.body = parseBlock();
+	forLoop.body = parseBlock(_labelRegistryBuilder);
 	updateLocationEndFrom(forLoop.debugData, nativeLocationOf(forLoop.body));
 
 	m_currentForLoopComponent = outerForLoopComponent;
@@ -522,22 +524,25 @@ ForLoop Parser::parseForLoop()
 	return forLoop;
 }
 
-Expression Parser::parseExpression(bool _unlimitedLiteralArgument)
+Expression Parser::parseExpression(ASTLabelRegistryBuilder& _labelRegistryBuilder, bool const _unlimitedLiteralArgument)
 {
 	RecursionGuard recursionGuard(*this);
 
-	std::variant<Literal, Identifier, BuiltinName> operation = parseLiteralOrIdentifier(_unlimitedLiteralArgument);
+	std::variant<Literal, Identifier, BuiltinName> operation = parseLiteralOrIdentifier(
+		_labelRegistryBuilder,
+		_unlimitedLiteralArgument
+	);
 	return visit(GenericVisitor{
 		[&](Identifier& _identifier) -> Expression
 		{
 			if (currentToken() == Token::LParen)
-				return parseCall(std::move(operation));
+				return parseCall(_labelRegistryBuilder, std::move(operation));
 			return std::move(_identifier);
 		},
 		[&](BuiltinName& _builtin) -> Expression
 		{
 			if (currentToken() == Token::LParen)
-				return parseCall(std::move(operation));
+				return parseCall(_labelRegistryBuilder, std::move(operation));
 			fatalParserError(
 				7104_error,
 				nativeLocationOf(_builtin),
@@ -552,7 +557,10 @@ Expression Parser::parseExpression(bool _unlimitedLiteralArgument)
 	}, operation);
 }
 
-std::variant<Literal, Identifier, BuiltinName> Parser::parseLiteralOrIdentifier(bool _unlimitedLiteralArgument)
+std::variant<Literal, Identifier, BuiltinName> Parser::parseLiteralOrIdentifier(
+	ASTLabelRegistryBuilder& _labelRegistryBuilder,
+	bool const _unlimitedLiteralArgument
+)
 {
 	RecursionGuard recursionGuard(*this);
 	switch (currentToken())
@@ -563,7 +571,10 @@ std::variant<Literal, Identifier, BuiltinName> Parser::parseLiteralOrIdentifier(
 		if (std::optional<BuiltinHandle> const builtinHandle = m_dialect.findBuiltin(currentLiteral()))
 			literalOrIdentifier = BuiltinName{createDebugData(), *builtinHandle};
 		else
+		{
+			std::ignore = _labelRegistryBuilder.define(currentLiteral());
 			literalOrIdentifier = Identifier{createDebugData(), YulName{currentLiteral()}};
+		}
 		advance();
 		return literalOrIdentifier;
 	}
@@ -605,7 +616,7 @@ std::variant<Literal, Identifier, BuiltinName> Parser::parseLiteralOrIdentifier(
 			expectToken(Token::Colon);
 			updateLocationEndFrom(literal.debugData, currentLocation());
 			auto const typedLiteralLocation = SourceLocation::smallestCovering(literalLocation, currentLocation());
-			std::ignore = expectAsmIdentifier();
+			std::ignore = expectAsmIdentifier(_labelRegistryBuilder);
 			raiseUnsupportedTypesError(typedLiteralLocation);
 		}
 
@@ -620,14 +631,14 @@ std::variant<Literal, Identifier, BuiltinName> Parser::parseLiteralOrIdentifier(
 	return {};
 }
 
-VariableDeclaration Parser::parseVariableDeclaration()
+VariableDeclaration Parser::parseVariableDeclaration(ASTLabelRegistryBuilder& _labelRegistryBuilder)
 {
 	RecursionGuard recursionGuard(*this);
 	VariableDeclaration varDecl = createWithDebugData<VariableDeclaration>();
 	expectToken(Token::Let);
 	while (true)
 	{
-		varDecl.variables.emplace_back(parseNameWithDebugData());
+		varDecl.variables.emplace_back(parseNameWithDebugData(_labelRegistryBuilder));
 		if (currentToken() == Token::Comma)
 			expectToken(Token::Comma);
 		else
@@ -636,7 +647,7 @@ VariableDeclaration Parser::parseVariableDeclaration()
 	if (currentToken() == Token::AssemblyAssign)
 	{
 		expectToken(Token::AssemblyAssign);
-		varDecl.value = std::make_unique<Expression>(parseExpression());
+		varDecl.value = std::make_unique<Expression>(parseExpression(_labelRegistryBuilder));
 		updateLocationEndFrom(varDecl.debugData, nativeLocationOf(*varDecl.value));
 	}
 	else
@@ -645,7 +656,7 @@ VariableDeclaration Parser::parseVariableDeclaration()
 	return varDecl;
 }
 
-FunctionDefinition Parser::parseFunctionDefinition()
+FunctionDefinition Parser::parseFunctionDefinition(ASTLabelRegistryBuilder& _labelRegistryBuilder)
 {
 	RecursionGuard recursionGuard(*this);
 
@@ -661,11 +672,11 @@ FunctionDefinition Parser::parseFunctionDefinition()
 
 	FunctionDefinition funDef = createWithDebugData<FunctionDefinition>();
 	expectToken(Token::Function);
-	funDef.name = expectAsmIdentifier();
+	funDef.name = expectAsmIdentifier(_labelRegistryBuilder);
 	expectToken(Token::LParen);
 	while (currentToken() != Token::RParen)
 	{
-		funDef.parameters.emplace_back(parseNameWithDebugData());
+		funDef.parameters.emplace_back(parseNameWithDebugData(_labelRegistryBuilder));
 		if (currentToken() == Token::RParen)
 			break;
 		expectToken(Token::Comma);
@@ -676,7 +687,7 @@ FunctionDefinition Parser::parseFunctionDefinition()
 		expectToken(Token::RightArrow);
 		while (true)
 		{
-			funDef.returnVariables.emplace_back(parseNameWithDebugData());
+			funDef.returnVariables.emplace_back(parseNameWithDebugData(_labelRegistryBuilder));
 			if (currentToken() == Token::LBrace)
 				break;
 			expectToken(Token::Comma);
@@ -684,7 +695,7 @@ FunctionDefinition Parser::parseFunctionDefinition()
 	}
 	bool preInsideFunction = m_insideFunction;
 	m_insideFunction = true;
-	funDef.body = parseBlock();
+	funDef.body = parseBlock(_labelRegistryBuilder);
 	m_insideFunction = preInsideFunction;
 	updateLocationEndFrom(funDef.debugData, nativeLocationOf(funDef.body));
 
@@ -692,7 +703,10 @@ FunctionDefinition Parser::parseFunctionDefinition()
 	return funDef;
 }
 
-FunctionCall Parser::parseCall(std::variant<Literal, Identifier, BuiltinName>&& _initialOp)
+FunctionCall Parser::parseCall(
+	ASTLabelRegistryBuilder& _labelRegistryBuilder,
+	std::variant<Literal, Identifier, BuiltinName>&& _initialOp
+)
 {
 	RecursionGuard recursionGuard(*this);
 
@@ -721,11 +735,21 @@ FunctionCall Parser::parseCall(std::variant<Literal, Identifier, BuiltinName>&& 
 	expectToken(Token::LParen);
 	if (currentToken() != Token::RParen)
 	{
-		functionCall.arguments.emplace_back(parseExpression(isUnlimitedLiteralArgument(argumentIndex++)));
+		functionCall.arguments.emplace_back(
+			parseExpression(
+				_labelRegistryBuilder,
+				isUnlimitedLiteralArgument(argumentIndex++)
+			)
+		);
 		while (currentToken() != Token::RParen)
 		{
 			expectToken(Token::Comma);
-			functionCall.arguments.emplace_back(parseExpression(isUnlimitedLiteralArgument(argumentIndex++)));
+			functionCall.arguments.emplace_back(
+				parseExpression(
+					_labelRegistryBuilder,
+					isUnlimitedLiteralArgument(argumentIndex++)
+				)
+			);
 		}
 	}
 	updateLocationEndFrom(functionCall.debugData, currentLocation());
@@ -733,35 +757,37 @@ FunctionCall Parser::parseCall(std::variant<Literal, Identifier, BuiltinName>&& 
 	return functionCall;
 }
 
-NameWithDebugData Parser::parseNameWithDebugData()
+NameWithDebugData Parser::parseNameWithDebugData(ASTLabelRegistryBuilder& _labelRegistryBuilder)
 {
 	RecursionGuard recursionGuard(*this);
 	NameWithDebugData typedName = createWithDebugData<NameWithDebugData>();
 	auto const nameLocation = currentLocation();
-	typedName.name = expectAsmIdentifier();
+	typedName.name = expectAsmIdentifier(_labelRegistryBuilder);
 	if (currentToken() == Token::Colon)
 	{
 		expectToken(Token::Colon);
 		updateLocationEndFrom(typedName.debugData, currentLocation());
 		auto const typedNameLocation = SourceLocation::smallestCovering(nameLocation, currentLocation());
-		std::ignore = expectAsmIdentifier();
+		std::ignore = expectAsmIdentifier(_labelRegistryBuilder);
 		raiseUnsupportedTypesError(typedNameLocation);
 	}
 
 	return typedName;
 }
 
-YulName Parser::expectAsmIdentifier()
+YulName Parser::expectAsmIdentifier(ASTLabelRegistryBuilder& _labelRegistryBuilder)
 {
-	YulName name{currentLiteral()};
-	if (currentToken() == Token::Identifier && m_dialect.findBuiltin(name.str()))
+	std::string_view const identifier = currentLiteral();
+	if (currentToken() == Token::Identifier && m_dialect.findBuiltin(identifier))
 		// Non-fatal. We'll continue and wrongly parse it as an identifier. May lead to some spurious
 		// errors after this point, but likely also much more useful ones.
 		m_errorReporter.parserError(
 			5568_error,
 			currentLocation(),
-			"Cannot use builtin function name \"" + name.str() + "\" as identifier name."
+			fmt::format("Cannot use builtin function name \"{}\" as identifier name.", identifier)
 		);
+	YulName const name{identifier};
+	std::ignore = _labelRegistryBuilder.define(identifier);
 	// NOTE: We keep the expectation here to ensure the correct source location for the error above.
 	expectToken(Token::Identifier);
 	return name;

--- a/libyul/AsmParser.cpp
+++ b/libyul/AsmParser.cpp
@@ -125,7 +125,7 @@ std::unique_ptr<AST> Parser::parseInline(std::shared_ptr<Scanner> const& _scanne
 		m_scanner = _scanner;
 		if (m_useSourceLocationFrom == UseSourceLocationFrom::Comments)
 			fetchDebugDataFromComment();
-		return std::make_unique<AST>(m_dialect, parseBlock());
+		return std::make_unique<AST>(m_dialect, ASTNodeRegistry{}, parseBlock());
 	}
 	catch (FatalError const& error)
 	{

--- a/libyul/AsmParser.h
+++ b/libyul/AsmParser.h
@@ -133,20 +133,26 @@ protected:
 		return r;
 	}
 
-	Block parseBlock();
-	Statement parseStatement();
-	Case parseCase();
-	ForLoop parseForLoop();
+	Block parseBlock(ASTLabelRegistryBuilder& _labelRegistryBuilder);
+	Statement parseStatement(ASTLabelRegistryBuilder& _labelRegistryBuilder);
+	Case parseCase(ASTLabelRegistryBuilder& _labelRegistryBuilder);
+	ForLoop parseForLoop(ASTLabelRegistryBuilder& _labelRegistryBuilder);
 	/// Parses a functional expression that has to push exactly one stack element
-	Expression parseExpression(bool _unlimitedLiteralArgument = false);
+	Expression parseExpression(ASTLabelRegistryBuilder& _labelRegistryBuilder, bool _unlimitedLiteralArgument = false);
 	/// Parses an elementary operation, i.e. a literal, identifier, instruction or
 	/// builtin function call (only the name).
-	std::variant<Literal, Identifier, BuiltinName> parseLiteralOrIdentifier(bool _unlimitedLiteralArgument = false);
-	VariableDeclaration parseVariableDeclaration();
-	FunctionDefinition parseFunctionDefinition();
-	FunctionCall parseCall(std::variant<Literal, Identifier, BuiltinName>&& _index);
-	NameWithDebugData parseNameWithDebugData();
-	YulName expectAsmIdentifier();
+	std::variant<Literal, Identifier, BuiltinName> parseLiteralOrIdentifier(
+		ASTLabelRegistryBuilder& _labelRegistryBuilder,
+		bool _unlimitedLiteralArgument = false
+	);
+	VariableDeclaration parseVariableDeclaration(ASTLabelRegistryBuilder& _labelRegistryBuilder);
+	FunctionDefinition parseFunctionDefinition(ASTLabelRegistryBuilder& _labelRegistryBuilder);
+	FunctionCall parseCall(
+		ASTLabelRegistryBuilder& _labelRegistryBuilder,
+		std::variant<Literal, Identifier, BuiltinName>&& _index
+	);
+	NameWithDebugData parseNameWithDebugData(ASTLabelRegistryBuilder& _labelRegistryBuilder);
+	YulName expectAsmIdentifier(ASTLabelRegistryBuilder& _labelRegistryBuilder);
 	void raiseUnsupportedTypesError(langutil::SourceLocation const& _location) const;
 
 	/// Reports an error if we are currently not inside the body part of a for loop.

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -7,6 +7,8 @@ add_library(yul
 	AST.h
 	AST.cpp
 	ASTForward.h
+	ASTLabelRegistry.cpp
+	ASTLabelRegistry.h
 	AsmJsonConverter.h
 	AsmJsonConverter.cpp
 	AsmJsonImporter.h

--- a/libyul/ObjectOptimizer.cpp
+++ b/libyul/ObjectOptimizer.cpp
@@ -118,7 +118,13 @@ void ObjectOptimizer::overwriteWithOptimizedObject(util::h256 _cacheKey, Object&
 
 	yulAssert(cachedObject.optimizedAST);
 	yulAssert(cachedObject.dialect);
-	_object.setCode(std::make_shared<AST>(*cachedObject.dialect, ASTCopier{}.translate(*cachedObject.optimizedAST)));
+	_object.setCode(
+		std::make_shared<AST>(
+			*cachedObject.dialect,
+			ASTLabelRegistry{},
+			ASTCopier{}.translate(*cachedObject.optimizedAST)
+		)
+	);
 	yulAssert(_object.code());
 	yulAssert(_object.dialect());
 

--- a/libyul/optimiser/StackCompressor.cpp
+++ b/libyul/optimiser/StackCompressor.cpp
@@ -279,7 +279,7 @@ std::tuple<bool, Block> StackCompressor::run(
 		for (size_t iterations = 0; iterations < _maxIterations; iterations++)
 		{
 			Object object(_object);
-			object.setCode(std::make_shared<AST>(*_object.dialect(), std::get<Block>(ASTCopier{}(astRoot))));
+			object.setCode(std::make_shared<AST>(*_object.dialect(), ASTLabelRegistry{}, std::get<Block>(ASTCopier{}(astRoot))));
 			std::map<YulName, int> stackSurplus = CompilabilityChecker(object, _optimizeStackAllocation).stackDeficit;
 			if (stackSurplus.empty())
 				return std::make_tuple(true, std::move(astRoot));

--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -139,7 +139,7 @@ void OptimiserSuite::run(
 	if (!usesOptimizedCodeGenerator)
 	{
 		PROFILER_PROBE("StackCompressor", probe);
-		_object.setCode(std::make_shared<AST>(dialect, std::move(astRoot)));
+		_object.setCode(std::make_shared<AST>(dialect, ASTLabelRegistry{}, std::move(astRoot)));
 		astRoot = std::get<1>(StackCompressor::run(
 			_object,
 			_optimizeStackAllocation,
@@ -165,7 +165,7 @@ void OptimiserSuite::run(
 		{
 			{
 				PROFILER_PROBE("StackCompressor", probe);
-				_object.setCode(std::make_shared<AST>(dialect, std::move(astRoot)));
+				_object.setCode(std::make_shared<AST>(dialect, ASTLabelRegistry{}, std::move(astRoot)));
 				astRoot = std::get<1>(StackCompressor::run(
 					_object,
 					_optimizeStackAllocation,
@@ -175,14 +175,14 @@ void OptimiserSuite::run(
 			if (evmDialect->providesObjectAccess())
 			{
 				PROFILER_PROBE("StackLimitEvader", probe);
-				_object.setCode(std::make_shared<AST>(dialect, std::move(astRoot)));
+				_object.setCode(std::make_shared<AST>(dialect, ASTLabelRegistry{}, std::move(astRoot)));
 				astRoot = StackLimitEvader::run(suite.m_context, _object);
 			}
 		}
 		else if (evmDialect->providesObjectAccess() && _optimizeStackAllocation)
 		{
 			PROFILER_PROBE("StackLimitEvader", probe);
-			_object.setCode(std::make_shared<AST>(dialect, std::move(astRoot)));
+			_object.setCode(std::make_shared<AST>(dialect, ASTLabelRegistry{}, std::move(astRoot)));
 			astRoot = StackLimitEvader::run(suite.m_context, _object);
 		}
 	}
@@ -197,7 +197,7 @@ void OptimiserSuite::run(
 		VarNameCleaner::run(suite.m_context, astRoot);
 	}
 
-	_object.setCode(std::make_shared<AST>(dialect, std::move(astRoot)));
+	_object.setCode(std::make_shared<AST>(dialect, ASTLabelRegistry{}, std::move(astRoot)));
 	_object.analysisInfo = std::make_shared<AsmAnalysisInfo>(AsmAnalyzer::analyzeStrictAssertCorrect(_object));
 }
 

--- a/test/libyul/KnowledgeBaseTest.cpp
+++ b/test/libyul/KnowledgeBaseTest.cpp
@@ -60,7 +60,7 @@ protected:
 		for (auto const& [name, expression]: m_ssaValues.values())
 			m_values[name].value = expression;
 
-		m_object->setCode(std::make_shared<AST>(*m_object->dialect(), std::move(astRoot)));
+		m_object->setCode(std::make_shared<AST>(*m_object->dialect(), ASTLabelRegistry{}, std::move(astRoot)));
 		return KnowledgeBase(
 			[this](YulName _var) { return util::valueOrNullptr(m_values, _var); },
 			*m_object->dialect()

--- a/test/libyul/YulOptimizerTestCommon.cpp
+++ b/test/libyul/YulOptimizerTestCommon.cpp
@@ -413,7 +413,7 @@ YulOptimizerTestCommon::YulOptimizerTestCommon(std::shared_ptr<Object const> _ob
 			size_t maxIterations = 16;
 			{
 				Object object(*m_optimizedObject);
-				object.setCode(std::make_shared<AST>(*m_object->dialect(), std::get<Block>(ASTCopier{}(block))));
+				object.setCode(std::make_shared<AST>(*m_object->dialect(), ASTLabelRegistry{}, std::get<Block>(ASTCopier{}(block))));
 				block = std::get<1>(StackCompressor::run(object, true, maxIterations));
 			}
 			BlockFlattener::run(*m_context, block);
@@ -435,7 +435,7 @@ YulOptimizerTestCommon::YulOptimizerTestCommon(std::shared_ptr<Object const> _ob
 			auto block = disambiguate();
 			updateContext(block);
 			Object object(*m_optimizedObject);
-			object.setCode(std::make_shared<AST>(*m_object->dialect(), std::get<Block>(ASTCopier{}(block))));
+			object.setCode(std::make_shared<AST>(*m_object->dialect(), ASTLabelRegistry{}, std::get<Block>(ASTCopier{}(block))));
 			auto const unreachables = CompilabilityChecker{
 				object,
 				true
@@ -499,7 +499,7 @@ bool YulOptimizerTestCommon::runStep()
 	if (m_namedSteps.count(m_optimizerStep))
 	{
 		auto block = m_namedSteps[m_optimizerStep]();
-		m_optimizedObject->setCode(std::make_shared<AST>(*m_object->dialect(), std::move(block)));
+		m_optimizedObject->setCode(std::make_shared<AST>(*m_object->dialect(), ASTLabelRegistry{}, std::move(block)));
 	}
 	else
 		return false;

--- a/test/tools/yulopti.cpp
+++ b/test/tools/yulopti.cpp
@@ -218,7 +218,7 @@ public:
 					case ';':
 					{
 						Object obj;
-						obj.setCode(std::make_shared<AST>(m_dialect, std::get<yul::Block>(ASTCopier{}(*m_astRoot))));
+						obj.setCode(std::make_shared<AST>(m_dialect, ASTLabelRegistry{}, std::get<yul::Block>(ASTCopier{}(*m_astRoot))));
 						*m_astRoot = std::get<1>(StackCompressor::run(obj, true, 16));
 						break;
 					}

--- a/tools/yulPhaser/Program.cpp
+++ b/tools/yulPhaser/Program.cpp
@@ -59,7 +59,7 @@ std::ostream& operator<<(std::ostream& _stream, Program const& _program);
 }
 
 Program::Program(Program const& program):
-	m_ast(std::make_unique<AST>(program.m_dialect, std::get<Block>(ASTCopier{}(program.m_ast->root())))),
+	m_ast(std::make_unique<AST>(program.m_dialect, ASTLabelRegistry{}, std::get<Block>(ASTCopier{}(program.m_ast->root())))),
 	m_dialect{program.m_dialect},
 	m_nameDispenser(program.m_nameDispenser)
 {
@@ -150,7 +150,7 @@ std::variant<std::unique_ptr<AST>, ErrorList> Program::parseObject(Dialect const
 	// The public API of the class does not provide access to the smart pointer so it won't be hard
 	// to switch to shared_ptr if the copying turns out to be an issue (though it would be better
 	// to refactor ObjectParser and Object to use unique_ptr instead).
-	auto astCopy = std::make_unique<AST>(_dialect, std::get<Block>(ASTCopier{}(selectedObject->code()->root())));
+	auto astCopy = std::make_unique<AST>(_dialect, ASTLabelRegistry{}, std::get<Block>(ASTCopier{}(selectedObject->code()->root())));
 
 	return std::variant<std::unique_ptr<AST>, ErrorList>(std::move(astCopy));
 }
@@ -179,7 +179,7 @@ std::unique_ptr<AST> Program::disambiguateAST(
 	std::set<YulName> const externallyUsedIdentifiers = {};
 	Disambiguator disambiguator(_dialect, _analysisInfo, externallyUsedIdentifiers);
 
-	return std::make_unique<AST>(_dialect, std::get<Block>(disambiguator(_ast.root())));
+	return std::make_unique<AST>(_dialect, ASTLabelRegistry{}, std::get<Block>(disambiguator(_ast.root())));
 }
 
 std::unique_ptr<AST> Program::applyOptimisationSteps(
@@ -203,7 +203,7 @@ std::unique_ptr<AST> Program::applyOptimisationSteps(
 	for (std::string const& step: _optimisationSteps)
 		OptimiserSuite::allSteps().at(step)->run(context, astRoot);
 
-	return std::make_unique<AST>(_dialect, std::move(astRoot));
+	return std::make_unique<AST>(_dialect, ASTLabelRegistry{}, std::move(astRoot));
 }
 
 size_t Program::computeCodeSize(Block const& _ast, CodeWeights const& _weights)


### PR DESCRIPTION
~Depends on PR #15823.~ Merged.

- adds `ASTNodeRegistry` to `AST` as member
- introduces `ASTNodeRegistryBuilder` into `AsmParser` and `AsmJsonImporter` with the caveat that the generated ids are not yet incorporated into the components of the AST themselves (ie `YulName` still points to `YulString`)