### PR TITLE
Yul FunctionCallFinder uses FunctionName instead of strings as search key

### DIFF
--- a/libyul/backends/evm/EVMObjectCompiler.cpp
+++ b/libyul/backends/evm/EVMObjectCompiler.cpp
@@ -92,11 +92,12 @@ void EVMObjectCompiler::run(Object const& _object, bool _optimize)
 		);
 		if (!stackErrors.empty())
 		{
-			yulAssert(_object.dialect());
+			yulAssert(evmDialect->providesObjectAccess());
+			auto const memoryGuardHandle = evmDialect->findBuiltin("memoryguard");
+			yulAssert(memoryGuardHandle, "Compiling with object access, memoryguard should be available as builtin.");
 			std::vector<FunctionCall const*> memoryGuardCalls = findFunctionCalls(
 				_object.code()->root(),
-				"memoryguard",
-				*_object.dialect()
+				*memoryGuardHandle
 			);
 			auto stackError = stackErrors.front();
 			std::string msg = stackError.comment() ? *stackError.comment() : "";

--- a/libyul/optimiser/FullInliner.cpp
+++ b/libyul/optimiser/FullInliner.cpp
@@ -83,10 +83,13 @@ FullInliner::FullInliner(Block& _ast, NameDispenser& _dispenser, Dialect const& 
 	}
 
 	// Check for memory guard.
-	std::vector<FunctionCall*> memoryGuardCalls = findFunctionCalls(_ast, "memoryguard", m_dialect);
-	// We will perform less aggressive inlining, if no ``memoryguard`` call is found.
-	if (!memoryGuardCalls.empty())
-		m_hasMemoryGuard = true;
+	if (auto const memoryGuard = m_dialect.findBuiltin("memoryguard"))
+	{
+		std::vector<FunctionCall*> memoryGuardCalls = findFunctionCalls(_ast, *memoryGuard);
+		// We will perform less aggressive inlining, if no ``memoryguard`` call is found.
+		if (!memoryGuardCalls.empty())
+			m_hasMemoryGuard = true;
+	}
 }
 
 void FullInliner::run(Pass _pass)

--- a/libyul/optimiser/FunctionCallFinder.h
+++ b/libyul/optimiser/FunctionCallFinder.h
@@ -20,28 +20,25 @@
 
 #pragma once
 
-#include <libyul/ASTForward.h>
+#include <libyul/AST.h>
 
-#include <string_view>
 #include <vector>
 
 namespace solidity::yul
 {
-
-class Dialect;
 
 /**
  * Finds all calls to a function of a given name using an ASTModifier.
  *
  * Prerequisite: Disambiguator
  */
-std::vector<FunctionCall*> findFunctionCalls(Block& _block, std::string_view _functionName, Dialect const& _dialect);
+std::vector<FunctionCall*> findFunctionCalls(Block& _block, FunctionHandle const& _functionHandle);
 
 /**
  * Finds all calls to a function of a given name using an ASTWalker.
  *
  * Prerequisite: Disambiguator
  */
-std::vector<FunctionCall const*> findFunctionCalls(Block const& _block, std::string_view _functionName, Dialect const& _dialect);
+std::vector<FunctionCall const*> findFunctionCalls(Block const& _block, FunctionHandle const& _functionHandle);
 
 }

--- a/libyul/optimiser/StackLimitEvader.cpp
+++ b/libyul/optimiser/StackLimitEvader.cpp
@@ -201,7 +201,9 @@ void StackLimitEvader::run(
 		"StackLimitEvader does not support EOF."
 	);
 
-	std::vector<FunctionCall*> memoryGuardCalls = findFunctionCalls(_astRoot, "memoryguard", *evmDialect);
+	auto const memoryGuardHandle = evmDialect->findBuiltin("memoryguard");
+	yulAssert(memoryGuardHandle, "Compiling with object access, memoryguard should be available as builtin.");
+	std::vector<FunctionCall*> const memoryGuardCalls = findFunctionCalls(_astRoot, *memoryGuardHandle);
 	// Do not optimise, if no ``memoryguard`` call is found.
 	if (memoryGuardCalls.empty())
 		return;
@@ -233,7 +235,7 @@ void StackLimitEvader::run(
 	StackToMemoryMover::run(_context, reservedMemory, memoryOffsetAllocator.slotAllocations, requiredSlots, _astRoot);
 
 	reservedMemory += 32 * requiredSlots;
-	for (FunctionCall* memoryGuardCall: findFunctionCalls(_astRoot, "memoryguard", *evmDialect))
+	for (FunctionCall* memoryGuardCall: findFunctionCalls(_astRoot, *memoryGuardHandle))
 	{
 		Literal* literal = std::get_if<Literal>(&memoryGuardCall->arguments.front());
 		yulAssert(literal && literal->kind == LiteralKind::Number, "");

--- a/test/cmdlineTests/memoryguard_shadowing_by_inline_assembly_identifiers/args
+++ b/test/cmdlineTests/memoryguard_shadowing_by_inline_assembly_identifiers/args
@@ -1,0 +1,1 @@
+--ir --debug-info none

--- a/test/cmdlineTests/memoryguard_shadowing_by_inline_assembly_identifiers/input.sol
+++ b/test/cmdlineTests/memoryguard_shadowing_by_inline_assembly_identifiers/input.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+
+contract C {
+    function f() public pure {
+        // NOTE: memoryguard is a builtin but only in pure Yul, not inline assembly.
+        // NOTE: memoryguard is not a reserved identifier.
+        // The expectation of this test is to not see the shadowed memoryguard within the generated Yul code but rather
+        // a mangled version of it
+        assembly { function memoryguard() {} }
+        assembly { function f(memoryguard) {} }
+        assembly { function f() -> memoryguard {} }
+        assembly { let memoryguard }
+    }
+}

--- a/test/cmdlineTests/memoryguard_shadowing_by_inline_assembly_identifiers/output
+++ b/test/cmdlineTests/memoryguard_shadowing_by_inline_assembly_identifiers/output
@@ -1,0 +1,123 @@
+IR:
+
+/// @use-src 0:"memoryguard_shadowing_by_inline_assembly_identifiers/input.sol"
+object "C_10" {
+    code {
+
+        mstore(64, memoryguard(128))
+        if callvalue() { revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb() }
+
+        constructor_C_10()
+
+        let _1 := allocate_unbounded()
+        codecopy(_1, dataoffset("C_10_deployed"), datasize("C_10_deployed"))
+
+        return(_1, datasize("C_10_deployed"))
+
+        function allocate_unbounded() -> memPtr {
+            memPtr := mload(64)
+        }
+
+        function revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb() {
+            revert(0, 0)
+        }
+
+        function constructor_C_10() {
+
+        }
+
+    }
+    /// @use-src 0:"memoryguard_shadowing_by_inline_assembly_identifiers/input.sol"
+    object "C_10_deployed" {
+        code {
+
+            mstore(64, memoryguard(128))
+
+            if iszero(lt(calldatasize(), 4))
+            {
+                let selector := shift_right_224_unsigned(calldataload(0))
+                switch selector
+
+                case 0x26121ff0
+                {
+                    // f()
+
+                    external_fun_f_9()
+                }
+
+                default {}
+            }
+
+            revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74()
+
+            function shift_right_224_unsigned(value) -> newValue {
+                newValue :=
+
+                shr(224, value)
+
+            }
+
+            function allocate_unbounded() -> memPtr {
+                memPtr := mload(64)
+            }
+
+            function revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb() {
+                revert(0, 0)
+            }
+
+            function revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b() {
+                revert(0, 0)
+            }
+
+            function abi_decode_tuple_(headStart, dataEnd)   {
+                if slt(sub(dataEnd, headStart), 0) { revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b() }
+
+            }
+
+            function abi_encode_tuple__to__fromStack(headStart ) -> tail {
+                tail := add(headStart, 0)
+
+            }
+
+            function external_fun_f_9() {
+
+                if callvalue() { revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb() }
+                abi_decode_tuple_(4, calldatasize())
+                fun_f_9()
+                let memPos := allocate_unbounded()
+                let memEnd := abi_encode_tuple__to__fromStack(memPos  )
+                return(memPos, sub(memEnd, memPos))
+
+            }
+
+            function revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74() {
+                revert(0, 0)
+            }
+
+            function fun_f_9() {
+
+                {
+                    function usr$memoryguard()
+                    { }
+                }
+
+                {
+                    function usr$f(usr$memoryguard)
+                    { }
+                }
+
+                {
+                    function usr$f() -> usr$memoryguard
+                    { }
+                }
+
+                { let usr$memoryguard }
+
+            }
+
+        }
+
+        data ".metadata" hex"<BYTECODE REMOVED>"
+    }
+
+}

--- a/test/libsolidity/MemoryGuardTest.cpp
+++ b/test/libsolidity/MemoryGuardTest.cpp
@@ -76,11 +76,15 @@ TestCase::TestResult MemoryGuardTest::run(std::ostream& _stream, std::string con
 		}
 
 		auto handleObject = [&](std::string const& _kind, Object const& _object) {
-			m_obtainedResult += contractName + "(" + _kind + ") " + (findFunctionCalls(
+			auto const memoryGuardHandle = yulStack.dialect().findBuiltin("memoryguard");
+			m_obtainedResult += contractName + "(" + _kind + ") ";
+			if (memoryGuardHandle && !findFunctionCalls(
 				_object.code()->root(),
-				"memoryguard",
-				yulStack.dialect()
-			).empty() ? "false" : "true") + "\n";
+				*memoryGuardHandle
+			).empty())
+				m_obtainedResult += "true\n";
+			else
+				m_obtainedResult += "false\n";
 		};
 		handleObject("creation", *yulStack.parserResult());
 		size_t deployedIndex = yulStack.parserResult()->subIndexByName.at(

--- a/test/libsolidity/memoryGuardTests/shadowing_memoryguard_with_inline_assembly_identifiers.sol
+++ b/test/libsolidity/memoryGuardTests/shadowing_memoryguard_with_inline_assembly_identifiers.sol
@@ -1,0 +1,26 @@
+// NOTE: memoryguard is a builtin but only in pure Yul, not inline assembly.
+// NOTE: memoryguard is not a reserved identifier.
+
+contract C {
+    constructor() {
+        // The expectation of this test is to see a 'true' outcome, indicating the memoryguard builtin being used
+        // due to explicitly marking the inline assembly as memory-safe
+
+        assembly ("memory-safe") { mstore(42, 42) function memoryguard() {} }
+        assembly ("memory-safe") { mstore(42, 42) function f(memoryguard) {} }
+        assembly ("memory-safe") { mstore(42, 42) function f() -> memoryguard {} }
+        assembly ("memory-safe") { mstore(42, 42) let memoryguard }
+    }
+
+    function f() public pure {
+        // The expectation of this test is to see a 'false' outcome, indicating the memoryguard builtin not being used
+
+        assembly { mstore(42, 42) function memoryguard() {} }
+        assembly { mstore(42, 42) function f(memoryguard) {} }
+        assembly { mstore(42, 42) function f() -> memoryguard {} }
+        assembly { mstore(42, 42) let memoryguard }
+    }
+}
+// ----
+// :C(creation) true
+// :C(runtime) false


### PR DESCRIPTION
description is in the title