### PR TITLE
Optimize collection of references in dataflow analyzer clearValues

### DIFF
--- a/libsolutil/CommonData.h
+++ b/libsolutil/CommonData.h
@@ -551,6 +551,29 @@ void iterateReplacingWindow(std::vector<T>& _vector, F const& _f, std::index_seq
 
 }
 
+/// Checks if two collections possess a non-empty intersection.
+/// Assumes that both inputs are sorted in ascending order.
+template<typename Collection1, typename Collection2>
+requires (
+	std::forward_iterator<std::ranges::iterator_t<Collection1>> &&
+	std::forward_iterator<std::ranges::iterator_t<Collection2>>
+)
+bool hasNonemptyIntersectionSorted(Collection1 const& _collection1, Collection2 const& _collection2)
+{
+	auto it1 = std::ranges::begin(_collection1);
+	auto it2 = std::ranges::begin(_collection2);
+	while (it1 != std::ranges::end(_collection1) && it2 != std::ranges::end(_collection2))
+	{
+		if (*it1 == *it2)
+			return true;
+		if (*it1 < *it2)
+			++it1;
+		else
+			++it2;
+	}
+	return false;
+}
+
 /// Function that iterates over the vector @param _vector,
 /// calling the function @param _f on sequences of @tparam N of its
 /// elements. If @param _f returns a vector, these elements are replaced by

--- a/libyul/optimiser/DataFlowAnalyzer.h
+++ b/libyul/optimiser/DataFlowAnalyzer.h
@@ -104,7 +104,7 @@ public:
 
 	/// @returns the current value of the given variable, if known - always movable.
 	AssignedValue const* variableValue(YulName _variable) const { return util::valueOrNullptr(m_state.value, _variable); }
-	std::set<YulName> const* references(YulName _variable) const { return util::valueOrNullptr(m_state.references, _variable); }
+	std::vector<YulName> const* sortedReferences(YulName _variable) const { return util::valueOrNullptr(m_state.sortedReferences, _variable); }
 	std::map<YulName, AssignedValue> const& allValues() const { return m_state.value; }
 	std::optional<YulName> storageValue(YulName _key) const;
 	std::optional<YulName> memoryValue(YulName _key) const;
@@ -122,7 +122,7 @@ protected:
 
 	/// Clears information about the values assigned to the given variables,
 	/// for example at points where control flow is merged.
-	void clearValues(std::set<YulName> _names);
+	void clearValues(std::set<YulName> const& _variablesToClear);
 
 	virtual void assignValue(YulName _variable, Expression const* _value);
 
@@ -180,7 +180,8 @@ private:
 		/// Current values of variables, always movable.
 		std::map<YulName, AssignedValue> value;
 		/// m_references[a].contains(b) <=> the current expression assigned to a references b
-		std::unordered_map<YulName, std::set<YulName>> references;
+		/// The mapped vectors _must always_ be sorted
+		std::unordered_map<YulName, std::vector<YulName>> sortedReferences;
 
 		Environment environment;
 	};

--- a/libyul/optimiser/Rematerialiser.cpp
+++ b/libyul/optimiser/Rematerialiser.cpp
@@ -71,7 +71,7 @@ void Rematerialiser::visit(Expression& _e)
 			)
 			{
 				assertThrow(m_referenceCounts[name] > 0, OptimizerException, "");
-				auto variableReferences = references(name);
+				auto variableReferences = sortedReferences(name);
 				if (!variableReferences || ranges::all_of(*variableReferences, [&](auto const& ref) { return inScope(ref); }))
 				{
 					// update reference counts


### PR DESCRIPTION
Previously, when clearing values in the data flow analyzer, referencing values were gathered by iterating over all variables and checking if they are contained inside any of the gathered references, reflected in a datastructure of form `map: variable -> set<variable>`.

Now, it is just checked, if there is any nonempty intersection between the set of variables to clean and the values of the aforementioned map. The check makes use of sets being sorted.

In pathological cases like the chains.sol benchmark, this can bring down the compilation time by approx. 50%.

No functional changes, overall behavior stays the same.