### PR TITLE
eof: Make use of EOF's SWAPN/DUPN

### DIFF
--- a/libevmasm/GasMeter.cpp
+++ b/libevmasm/GasMeter.cpp
@@ -263,12 +263,11 @@ GasMeter::GasConsumption GasMeter::memoryGas(int _stackPosOffset, int _stackPosS
 		}));
 }
 
-unsigned GasMeter::runGas(Instruction _instruction, langutil::EVMVersion _evmVersion)
+namespace
 {
-	if (_instruction == Instruction::JUMPDEST)
-		return 1;
-
-	switch (instructionInfo(_instruction, _evmVersion).gasPriceTier)
+std::optional<unsigned> gasCostForTier(Tier _tier)
+{
+	switch (_tier)
 	{
 	case Tier::Zero:        return GasCosts::tier0Gas;
 	case Tier::Base:        return GasCosts::tier1Gas;
@@ -286,9 +285,20 @@ unsigned GasMeter::runGas(Instruction _instruction, langutil::EVMVersion _evmVer
 
 	case Tier::Special:
 	case Tier::Invalid:
-		assertThrow(false, OptimizerException, "Invalid gas tier for instruction " + instructionInfo(_instruction, _evmVersion).name);
+		return std::nullopt;
 	}
 	util::unreachable();
+}
+}
+
+unsigned GasMeter::runGas(Instruction _instruction, langutil::EVMVersion _evmVersion)
+{
+	if (_instruction == Instruction::JUMPDEST)
+		return 1;
+
+	if (auto gasCost = gasCostForTier(instructionInfo(_instruction, _evmVersion).gasPriceTier))
+		return *gasCost;
+	solAssert(false, "Invalid gas tier for instruction " + instructionInfo(_instruction, _evmVersion).name);
 }
 
 unsigned GasMeter::pushGas(u256 _value, langutil::EVMVersion _evmVersion)
@@ -297,6 +307,24 @@ unsigned GasMeter::pushGas(u256 _value, langutil::EVMVersion _evmVersion)
 		(_evmVersion.hasPush0() && _value == u256(0)) ? Instruction::PUSH0 : Instruction::PUSH1,
 		_evmVersion
 	);
+}
+
+unsigned GasMeter::swapGas(size_t _depth, langutil::EVMVersion _evmVersion)
+{
+	if (_depth <= 16)
+		return runGas(evmasm::swapInstruction(static_cast<unsigned>(_depth)), _evmVersion);
+	auto gasCost = gasCostForTier(instructionInfo(evmasm::Instruction::SWAPN, _evmVersion).gasPriceTier);
+	solAssert(gasCost.has_value(), "Expected gas cost for SWAPN to be defined.");
+	return *gasCost;
+}
+
+unsigned GasMeter::dupGas(size_t _depth, langutil::EVMVersion _evmVersion)
+{
+	if (_depth <= 16)
+		return runGas(evmasm::swapInstruction(static_cast<unsigned>(_depth)), _evmVersion);
+	auto gasCost = gasCostForTier(instructionInfo(evmasm::Instruction::DUPN, _evmVersion).gasPriceTier);
+	solAssert(gasCost.has_value(), "Expected gas cost for DUPN to be defined.");
+	return *gasCost;
 }
 
 u256 GasMeter::dataGas(bytes const& _data, bool _inCreation, langutil::EVMVersion _evmVersion)
@@ -309,7 +337,7 @@ u256 GasMeter::dataGas(bytes const& _data, bool _inCreation, langutil::EVMVersio
 	}
 	else
 		gas = bigint(GasCosts::createDataGas) * _data.size();
-	assertThrow(gas < bigint(u256(-1)), OptimizerException, "Gas cost exceeds 256 bits.");
+	solAssert(gas < bigint(u256(-1)), "Gas cost exceeds 256 bits.");
 	return u256(gas);
 }
 
@@ -317,6 +345,6 @@ u256 GasMeter::dataGas(bytes const& _data, bool _inCreation, langutil::EVMVersio
 u256 GasMeter::dataGas(uint64_t _length, bool _inCreation, langutil::EVMVersion _evmVersion)
 {
 	bigint gas = bigint(_length) * (_inCreation ? GasCosts::txDataNonZeroGas(_evmVersion) : GasCosts::createDataGas);
-	assertThrow(gas < bigint(u256(-1)), OptimizerException, "Gas cost exceeds 256 bits.");
+	solAssert(gas < bigint(u256(-1)), "Gas cost exceeds 256 bits.");
 	return u256(gas);
 }

--- a/libevmasm/GasMeter.h
+++ b/libevmasm/GasMeter.h
@@ -226,8 +226,17 @@ public:
 	/// change with EVM versions)
 	static unsigned runGas(Instruction _instruction, langutil::EVMVersion _evmVersion);
 
-	/// @returns gas costs for push instructions (may change depending on EVM version)
+	/// @returns gas costs for the cheapest push instructions for the given @a _value
+	/// (may change depending on EVM version)
 	static unsigned pushGas(u256 _value, langutil::EVMVersion _evmVersion);
+
+	/// @returns gas costs for the cheapest swap instructions for the given @a _depth
+	/// (may change depending on EVM version)
+	static unsigned swapGas(size_t _depth, langutil::EVMVersion _evmVersion);
+
+	/// @returns gas costs for the cheapest dup instructions for the given @a _depth
+	/// (may change depending on EVM version)
+	static unsigned dupGas(size_t _depth, langutil::EVMVersion _evmVersion);
 
 	/// @returns the gas cost of the supplied data, depending whether it is in creation code, or not.
 	/// In case of @a _inCreation, the data is only sent as a transaction and is not stored, whereas

--- a/libyul/backends/evm/EVMDialect.h
+++ b/libyul/backends/evm/EVMDialect.h
@@ -104,6 +104,7 @@ public:
 
 	langutil::EVMVersion evmVersion() const { return m_evmVersion; }
 	std::optional<uint8_t> eofVersion() const { return m_eofVersion; }
+	size_t reachableStackDepth() const { return m_eofVersion.has_value() ? 256 : 16; }
 
 	bool providesObjectAccess() const { return m_objectAccess; }
 

--- a/libyul/backends/evm/OptimizedEVMCodeTransform.cpp
+++ b/libyul/backends/evm/OptimizedEVMCodeTransform.cpp
@@ -49,7 +49,7 @@ std::vector<StackTooDeepError> OptimizedEVMCodeTransform::run(
 )
 {
 	std::unique_ptr<CFG> dfg = ControlFlowGraphBuilder::build(_analysisInfo, _dialect, _block);
-	StackLayout stackLayout = StackLayoutGenerator::run(*dfg, !_dialect.eofVersion().has_value(), _dialect.reachableStackDepth());
+	StackLayout stackLayout = StackLayoutGenerator::run(*dfg, _dialect);
 
 	if (_dialect.eofVersion().has_value())
 	{

--- a/libyul/backends/evm/OptimizedEVMCodeTransform.h
+++ b/libyul/backends/evm/OptimizedEVMCodeTransform.h
@@ -87,6 +87,9 @@ private:
 	/// Sets the source locations to the one in @a _debugData.
 	void createStackLayout(langutil::DebugData::ConstPtr _debugData, Stack _targetStack);
 
+	void appendSwap(size_t _depth);
+	void appendDup(size_t _depth);
+
 	/// Generate code for the given block @a _block.
 	/// Expects the current stack layout m_stack to be a stack layout that is compatible with the
 	/// entry layout expected by the block.
@@ -116,6 +119,7 @@ private:
 	std::vector<StackTooDeepError> m_stackErrors;
 	/// True if it simulates functions with jumps. False otherwise. True for legacy bytecode
 	bool m_simulateFunctionsWithJumps = true;
+	size_t const m_reachableStackDepth{};
 };
 
 }

--- a/libyul/backends/evm/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/StackLayoutGenerator.cpp
@@ -45,28 +45,47 @@
 using namespace solidity;
 using namespace solidity::yul;
 
-StackLayout StackLayoutGenerator::run(CFG const& _cfg, bool _simulateFunctionsWithJumps)
+StackLayout StackLayoutGenerator::run(CFG const& _cfg, bool _simulateFunctionsWithJumps, size_t _reachableStackDepth)
 {
 	StackLayout stackLayout{{}, {}};
-	StackLayoutGenerator{stackLayout, nullptr, _simulateFunctionsWithJumps}.processEntryPoint(*_cfg.entry);
+	StackLayoutGenerator{
+		stackLayout,
+		nullptr,
+		_simulateFunctionsWithJumps,
+		_reachableStackDepth
+	}.processEntryPoint(*_cfg.entry);
 
 	for (auto& functionInfo: _cfg.functionInfo | ranges::views::values)
-		StackLayoutGenerator{stackLayout, &functionInfo, _simulateFunctionsWithJumps}.processEntryPoint(*functionInfo.entry, &functionInfo);
+		StackLayoutGenerator{
+			stackLayout,
+			&functionInfo,
+			_simulateFunctionsWithJumps,
+			_reachableStackDepth
+		}.processEntryPoint(*functionInfo.entry, &functionInfo);
 
 	return stackLayout;
 }
 
-std::map<YulName, std::vector<StackLayoutGenerator::StackTooDeep>> StackLayoutGenerator::reportStackTooDeep(CFG const& _cfg, bool _simulateFunctionsWithJumps)
+std::map<YulName, std::vector<StackLayoutGenerator::StackTooDeep>> StackLayoutGenerator::reportStackTooDeep(
+	CFG const& _cfg,
+	bool _simulateFunctionsWithJumps,
+	size_t _reachableStackDepth
+)
 {
 	std::map<YulName, std::vector<StackLayoutGenerator::StackTooDeep>> stackTooDeepErrors;
-	stackTooDeepErrors[YulName{}] = reportStackTooDeep(_cfg, YulName{}, _simulateFunctionsWithJumps);
+	stackTooDeepErrors[YulName{}] = reportStackTooDeep(_cfg, YulName{}, _simulateFunctionsWithJumps, _reachableStackDepth);
 	for (auto const& function: _cfg.functions)
-		if (auto errors = reportStackTooDeep(_cfg, function->name, _simulateFunctionsWithJumps); !errors.empty())
+		if (auto errors = reportStackTooDeep(_cfg, function->name, _simulateFunctionsWithJumps, _reachableStackDepth); !errors.empty())
 			stackTooDeepErrors[function->name] = std::move(errors);
 	return stackTooDeepErrors;
 }
 
-std::vector<StackLayoutGenerator::StackTooDeep> StackLayoutGenerator::reportStackTooDeep(CFG const& _cfg, YulName _functionName, bool _simulateFunctionsWithJumps)
+std::vector<StackLayoutGenerator::StackTooDeep> StackLayoutGenerator::reportStackTooDeep(
+	CFG const& _cfg,
+	YulName _functionName,
+	bool _simulateFunctionsWithJumps,
+	size_t _reachableStackDepth
+)
 {
 	StackLayout stackLayout{{}, {}};
 	CFG::FunctionInfo const* functionInfo = nullptr;
@@ -80,23 +99,33 @@ std::vector<StackLayoutGenerator::StackTooDeep> StackLayoutGenerator::reportStac
 		yulAssert(functionInfo, "Function not found.");
 	}
 
-	StackLayoutGenerator generator{stackLayout, functionInfo, _simulateFunctionsWithJumps};
+	StackLayoutGenerator generator{stackLayout, functionInfo, _simulateFunctionsWithJumps, _reachableStackDepth};
 	CFG::BasicBlock const* entry = functionInfo ? functionInfo->entry : _cfg.entry;
 	generator.processEntryPoint(*entry);
 	return generator.reportStackTooDeep(*entry);
 }
 
-StackLayoutGenerator::StackLayoutGenerator(StackLayout& _layout, CFG::FunctionInfo const* _functionInfo, bool _simulateFunctionsWithJumps):
+StackLayoutGenerator::StackLayoutGenerator(
+	StackLayout& _layout,
+	CFG::FunctionInfo const* _functionInfo,
+	bool _simulateFunctionsWithJumps,
+	size_t _reachableStackDepth
+):
 	m_layout(_layout),
 	m_currentFunctionInfo(_functionInfo),
-	m_simulateFunctionsWithJumps(_simulateFunctionsWithJumps)
+	m_simulateFunctionsWithJumps(_simulateFunctionsWithJumps),
+	m_reachableStackDepth(_reachableStackDepth)
 {
 }
 
 namespace
 {
 /// @returns all stack too deep errors that would occur when shuffling @a _source to @a _target.
-std::vector<StackLayoutGenerator::StackTooDeep> findStackTooDeep(Stack const& _source, Stack const& _target)
+std::vector<StackLayoutGenerator::StackTooDeep> findStackTooDeep(
+	Stack const& _source,
+	Stack const& _target,
+	size_t _reachableStackDepth
+)
 {
 	Stack currentStack = _source;
 	std::vector<StackLayoutGenerator::StackTooDeep> stackTooDeepErrors;
@@ -113,9 +142,9 @@ std::vector<StackLayoutGenerator::StackTooDeep> findStackTooDeep(Stack const& _s
 		_target,
 		[&](unsigned _i)
 		{
-			if (_i > 16)
+			if (_i > _reachableStackDepth)
 				stackTooDeepErrors.emplace_back(StackLayoutGenerator::StackTooDeep{
-					_i - 16,
+					_i - _reachableStackDepth,
 					getVariableChoices(currentStack | ranges::views::take_last(_i + 1))
 				});
 		},
@@ -125,14 +154,15 @@ std::vector<StackLayoutGenerator::StackTooDeep> findStackTooDeep(Stack const& _s
 				return;
 			if (
 				auto depth = util::findOffset(currentStack | ranges::views::reverse, _slot);
-				depth && *depth >= 16
+				depth && *depth >= _reachableStackDepth
 			)
 				stackTooDeepErrors.emplace_back(StackLayoutGenerator::StackTooDeep{
-					*depth - 15,
+					*depth - (_reachableStackDepth - 1),
 					getVariableChoices(currentStack | ranges::views::take_last(*depth + 1))
 				});
 		},
-		[&]() {}
+		[&]() {},
+		_reachableStackDepth
 	);
 	return stackTooDeepErrors;
 }
@@ -142,7 +172,7 @@ std::vector<StackLayoutGenerator::StackTooDeep> findStackTooDeep(Stack const& _s
 /// If @a _generateSlotOnTheFly returns true for a slot, this slot should not occur in the ideal stack, but
 /// rather be generated on the fly during shuffling.
 template<typename Callable>
-Stack createIdealLayout(Stack const& _operationOutput, Stack const& _post, Callable _generateSlotOnTheFly)
+Stack createIdealLayout(Stack const& _operationOutput, Stack const& _post, Callable _generateSlotOnTheFly, size_t _reachableStackDepth)
 {
 	struct PreviousSlot { size_t slot; };
 
@@ -174,11 +204,13 @@ Stack createIdealLayout(Stack const& _operationOutput, Stack const& _post, Calla
 		std::set<StackSlot> outputs;
 		Multiplicity multiplicity;
 		Callable generateSlotOnTheFly;
+		size_t const reachableStackDepth;
 		ShuffleOperations(
 			std::vector<std::variant<PreviousSlot, StackSlot>>& _layout,
 			Stack const& _post,
-			Callable _generateSlotOnTheFly
-		): layout(_layout), post(_post), generateSlotOnTheFly(_generateSlotOnTheFly)
+			Callable _generateSlotOnTheFly,
+			size_t _reachableStackDepth
+		): layout(_layout), post(_post), generateSlotOnTheFly(_generateSlotOnTheFly), reachableStackDepth(_reachableStackDepth)
 		{
 			for (auto const& layoutSlot: layout)
 				if (StackSlot const* slot = std::get_if<StackSlot>(&layoutSlot))
@@ -241,7 +273,7 @@ Stack createIdealLayout(Stack const& _operationOutput, Stack const& _post, Calla
 		void pop() { layout.pop_back(); }
 		void pushOrDupTarget(size_t _offset) { layout.push_back(post.at(_offset)); }
 	};
-	Shuffler<ShuffleOperations>::shuffle(layout, _post, _generateSlotOnTheFly);
+	Shuffler<ShuffleOperations>::shuffle(layout, _post, _generateSlotOnTheFly, _reachableStackDepth);
 
 	// Now we can construct the ideal layout before the operation.
 	// "layout" has shuffled the PreviousSlot{x} to new places using minimal operations to move the operation
@@ -280,7 +312,7 @@ Stack StackLayoutGenerator::propagateStackThroughOperation(Stack _exitStack, CFG
 
 	// Determine the ideal permutation of the slots in _exitLayout that are not operation outputs (and not to be
 	// generated on the fly), s.t. shuffling the `stack + _operation.output` to _exitLayout is cheap.
-	Stack stack = createIdealLayout(_operation.output, _exitStack, generateSlotOnTheFly);
+	Stack stack = createIdealLayout(_operation.output, _exitStack, generateSlotOnTheFly, m_reachableStackDepth);
 
 	// Make sure the resulting previous slots do not overlap with any assignmed variables.
 	if (auto const* assignment = std::get_if<CFG::Assignment>(&_operation.operation))
@@ -304,7 +336,7 @@ Stack StackLayoutGenerator::propagateStackThroughOperation(Stack _exitStack, CFG
 			stack.pop_back();
 		else if (auto offset = util::findOffset(stack | ranges::views::reverse | ranges::views::drop(1), stack.back()))
 		{
-			if (*offset + 2 < 16)
+			if (*offset + 2 < m_reachableStackDepth)
 				stack.pop_back();
 			else
 				break;
@@ -322,7 +354,7 @@ Stack StackLayoutGenerator::propagateStackThroughBlock(Stack _exitStack, CFG::Ba
 	for (auto&& [idx, operation]: _block.operations | ranges::views::enumerate | ranges::views::reverse)
 	{
 		Stack newStack = propagateStackThroughOperation(stack, operation, _aggressiveStackCompression);
-		if (!_aggressiveStackCompression && !findStackTooDeep(newStack, stack).empty())
+		if (!_aggressiveStackCompression && !findStackTooDeep(newStack, stack, m_reachableStackDepth).empty())
 			// If we had stack errors, run again with aggressive stack compression.
 			return propagateStackThroughBlock(std::move(_exitStack), _block, true);
 		stack = std::move(newStack);
@@ -443,7 +475,8 @@ std::optional<Stack> StackLayoutGenerator::getExitLayoutOrStageDependencies(
 				// If the current iteration has already visited both jump targets, start from its entry layout.
 				Stack stack = combineStack(
 					m_layout.blockInfos.at(_conditionalJump.zero).entryLayout,
-					m_layout.blockInfos.at(_conditionalJump.nonZero).entryLayout
+					m_layout.blockInfos.at(_conditionalJump.nonZero).entryLayout,
+					m_reachableStackDepth
 				);
 				// Additionally, the jump condition has to be at the stack top at exit.
 				stack.emplace_back(_conditionalJump.condition);
@@ -546,7 +579,7 @@ void StackLayoutGenerator::stitchConditionalJumps(CFG::BasicBlock const& _block)
 	});
 }
 
-Stack StackLayoutGenerator::combineStack(Stack const& _stack1, Stack const& _stack2)
+Stack StackLayoutGenerator::combineStack(Stack const& _stack1, Stack const& _stack2, size_t _reachableStackDepth)
 {
 	// TODO: it would be nicer to replace this by a constructive algorithm.
 	// Currently it uses a reduced version of the Heap Algorithm to partly brute-force, which seems
@@ -564,9 +597,9 @@ Stack StackLayoutGenerator::combineStack(Stack const& _stack1, Stack const& _sta
 	Stack stack2Tail = _stack2 | ranges::views::drop(commonPrefix.size()) | ranges::to<Stack>;
 
 	if (stack1Tail.empty())
-		return commonPrefix + compressStack(stack2Tail);
+		return commonPrefix + compressStack(stack2Tail, _reachableStackDepth);
 	if (stack2Tail.empty())
-		return commonPrefix + compressStack(stack1Tail);
+		return commonPrefix + compressStack(stack1Tail, _reachableStackDepth);
 
 	Stack candidate;
 	for (auto slot: stack1Tail)
@@ -582,18 +615,18 @@ Stack StackLayoutGenerator::combineStack(Stack const& _stack1, Stack const& _sta
 	auto evaluate = [&](Stack const& _candidate) -> size_t {
 		size_t numOps = 0;
 		Stack testStack = _candidate;
-		auto swap = [&](unsigned _swapDepth) { ++numOps; if (_swapDepth > 16) numOps += 1000; };
+		auto swap = [&](unsigned _swapDepth) { ++numOps; if (_swapDepth > _reachableStackDepth) numOps += 1000; };
 		auto dupOrPush = [&](StackSlot const& _slot)
 		{
 			if (canBeFreelyGenerated(_slot))
 				return;
 			auto depth = util::findOffset(ranges::concat_view(commonPrefix, testStack) | ranges::views::reverse, _slot);
-			if (depth && *depth >= 16)
+			if (depth && *depth >= _reachableStackDepth)
 				numOps += 1000;
 		};
-		createStackLayout(testStack, stack1Tail, swap, dupOrPush, [&](){});
+		createStackLayout(testStack, stack1Tail, swap, dupOrPush, [&](){}, _reachableStackDepth);
 		testStack = _candidate;
-		createStackLayout(testStack, stack2Tail, swap, dupOrPush, [&](){});
+		createStackLayout(testStack, stack2Tail, swap, dupOrPush, [&](){}, _reachableStackDepth);
 		return numOps;
 	};
 
@@ -644,7 +677,7 @@ std::vector<StackLayoutGenerator::StackTooDeep> StackLayoutGenerator::reportStac
 		{
 			Stack& operationEntry = m_layout.operationEntryLayout.at(&operation);
 
-			stackTooDeepErrors += findStackTooDeep(currentStack, operationEntry);
+			stackTooDeepErrors += findStackTooDeep(currentStack, operationEntry, m_reachableStackDepth);
 			currentStack = operationEntry;
 			for (size_t i = 0; i < operation.input.size(); i++)
 				currentStack.pop_back();
@@ -658,7 +691,7 @@ std::vector<StackLayoutGenerator::StackTooDeep> StackLayoutGenerator::reportStac
 			[&](CFG::BasicBlock::Jump const& _jump)
 			{
 				Stack const& targetLayout = m_layout.blockInfos.at(_jump.target).entryLayout;
-				stackTooDeepErrors += findStackTooDeep(currentStack, targetLayout);
+				stackTooDeepErrors += findStackTooDeep(currentStack, targetLayout, m_reachableStackDepth);
 
 				if (!_jump.backwards)
 					_addChild(_jump.target);
@@ -669,7 +702,7 @@ std::vector<StackLayoutGenerator::StackTooDeep> StackLayoutGenerator::reportStac
 					m_layout.blockInfos.at(_conditionalJump.zero).entryLayout,
 					m_layout.blockInfos.at(_conditionalJump.nonZero).entryLayout
 				})
-					stackTooDeepErrors += findStackTooDeep(currentStack, targetLayout);
+					stackTooDeepErrors += findStackTooDeep(currentStack, targetLayout, m_reachableStackDepth);
 
 				_addChild(_conditionalJump.zero);
 				_addChild(_conditionalJump.nonZero);
@@ -681,7 +714,7 @@ std::vector<StackLayoutGenerator::StackTooDeep> StackLayoutGenerator::reportStac
 	return stackTooDeepErrors;
 }
 
-Stack StackLayoutGenerator::compressStack(Stack _stack)
+Stack StackLayoutGenerator::compressStack(Stack _stack, size_t _reachableStackDepth)
 {
 	std::optional<size_t> firstDupOffset;
 	do
@@ -699,7 +732,7 @@ Stack StackLayoutGenerator::compressStack(Stack _stack)
 				break;
 			}
 			else if (auto dupDepth = util::findOffset(_stack | ranges::views::reverse | ranges::views::drop(depth + 1), slot))
-				if (depth + *dupDepth <= 16)
+				if (depth + *dupDepth <= _reachableStackDepth)
 				{
 					firstDupOffset = _stack.size() - depth - 1;
 					break;
@@ -746,10 +779,10 @@ void StackLayoutGenerator::fillInJunk(CFG::BasicBlock const& _block, CFG::Functi
 		size_t opGas = 0;
 		auto swap = [&](unsigned _swapDepth)
 		{
-			if (_swapDepth > 16)
+			if (_swapDepth > m_reachableStackDepth)
 				opGas += 1000;
 			else
-				opGas += evmasm::GasMeter::runGas(evmasm::swapInstruction(_swapDepth), langutil::EVMVersion());
+				opGas += evmasm::GasMeter::swapGas(_swapDepth, langutil::EVMVersion{});
 		};
 		auto dupOrPush = [&](StackSlot const& _slot)
 		{
@@ -759,8 +792,8 @@ void StackLayoutGenerator::fillInJunk(CFG::BasicBlock const& _block, CFG::Functi
 			{
 				if (auto depth = util::findOffset(_source | ranges::views::reverse, _slot))
 				{
-					if (*depth < 16)
-						opGas += evmasm::GasMeter::runGas(evmasm::dupInstruction(static_cast<unsigned>(*depth + 1)), langutil::EVMVersion());
+					if (*depth < m_reachableStackDepth)
+						opGas += evmasm::GasMeter::dupGas(*depth + 1, langutil::EVMVersion{});
 					else
 						opGas += 1000;
 				}
@@ -777,7 +810,7 @@ void StackLayoutGenerator::fillInJunk(CFG::BasicBlock const& _block, CFG::Functi
 			}
 		};
 		auto pop = [&]() { opGas += evmasm::GasMeter::runGas(evmasm::Instruction::POP,langutil::EVMVersion()); };
-		createStackLayout(_source, _target, swap, dupOrPush, pop);
+		createStackLayout(_source, _target, swap, dupOrPush, pop, m_reachableStackDepth);
 		return opGas;
 	};
 	/// @returns the number of junk slots to be prepended to @a _targetLayout for an optimal transition from

--- a/libyul/backends/evm/StackLayoutGenerator.h
+++ b/libyul/backends/evm/StackLayoutGenerator.h
@@ -55,18 +55,32 @@ public:
 		std::vector<YulName> variableChoices;
 	};
 
-	static StackLayout run(CFG const& _cfg, bool _simulateFunctionsWithJumps);
+	static StackLayout run(CFG const& _cfg, bool _simulateFunctionsWithJumps, size_t _reachableStackDepth);
 	/// @returns a map from function names to the stack too deep errors occurring in that function.
 	/// Requires @a _cfg to be a control flow graph generated from disambiguated Yul.
 	/// The empty string is mapped to the stack too deep errors of the main entry point.
-	static std::map<YulName, std::vector<StackTooDeep>> reportStackTooDeep(CFG const& _cfg, bool _simulateFunctionsWithJumps);
+	static std::map<YulName, std::vector<StackTooDeep>> reportStackTooDeep(
+		CFG const& _cfg,
+		bool _simulateFunctionsWithJumps,
+		size_t _reachableStackDepth
+	);
 	/// @returns all stack too deep errors in the function named @a _functionName.
 	/// Requires @a _cfg to be a control flow graph generated from disambiguated Yul.
 	/// If @a _functionName is empty, the stack too deep errors of the main entry point are reported instead.
-	static std::vector<StackTooDeep> reportStackTooDeep(CFG const& _cfg, YulName _functionName, bool _simulateFunctionsWithJumps);
+	static std::vector<StackTooDeep> reportStackTooDeep(
+		CFG const& _cfg,
+		YulName _functionName,
+		bool _simulateFunctionsWithJumps,
+		size_t _reachableStackDepth
+	);
 
 private:
-	StackLayoutGenerator(StackLayout& _context, CFG::FunctionInfo const* _functionInfo, bool _simulateFunctionsWithJumps);
+	StackLayoutGenerator(
+		StackLayout& _context,
+		CFG::FunctionInfo const* _functionInfo,
+		bool _simulateFunctionsWithJumps,
+		size_t _reachableStackDepth
+	);
 
 	/// @returns the optimal entry stack layout, s.t. @a _operation can be applied to it and
 	/// the result can be transformed to @a _exitStack with minimal stack shuffling.
@@ -100,7 +114,7 @@ private:
 
 	/// Calculates the ideal stack layout, s.t. both @a _stack1 and @a _stack2 can be achieved with minimal
 	/// stack shuffling when starting from the returned layout.
-	static Stack combineStack(Stack const& _stack1, Stack const& _stack2);
+	static Stack combineStack(Stack const& _stack1, Stack const& _stack2, size_t _reachableStackDepth);
 
 	/// Walks through the CFG and reports any stack too deep errors that would occur when generating code for it
 	/// without countermeasures.
@@ -109,7 +123,7 @@ private:
 	/// @returns a copy of @a _stack stripped of all duplicates and slots that can be freely generated.
 	/// Attempts to create a layout that requires a minimal amount of operations to reconstruct the original
 	/// stack @a _stack.
-	static Stack compressStack(Stack _stack);
+	static Stack compressStack(Stack _stack, size_t _reachableStackDepth);
 
 	//// Fills in junk when entering branches that do not need a clean stack in case the result is cheaper.
 	void fillInJunk(CFG::BasicBlock const& _block, CFG::FunctionInfo const* _functionInfo = nullptr);
@@ -118,6 +132,7 @@ private:
 	CFG::FunctionInfo const* m_currentFunctionInfo = nullptr;
 	/// True if it simulates functions with jumps. False otherwise. True for legacy bytecode
 	bool m_simulateFunctionsWithJumps = true;
+	size_t const m_reachableStackDepth{};
 };
 
 }

--- a/libyul/optimiser/StackCompressor.cpp
+++ b/libyul/optimiser/StackCompressor.cpp
@@ -249,6 +249,7 @@ std::tuple<bool, Block> StackCompressor::run(
 	);
 	bool usesOptimizedCodeGenerator = false;
 	bool simulateFunctionsWithJumps = true;
+	size_t reachableStackDepth = 16;
 	if (auto evmDialect = dynamic_cast<EVMDialect const*>(_object.dialect()))
 	{
 		usesOptimizedCodeGenerator =
@@ -256,6 +257,7 @@ std::tuple<bool, Block> StackCompressor::run(
 			evmDialect->evmVersion().canOverchargeGasForCall() &&
 			evmDialect->providesObjectAccess();
 		simulateFunctionsWithJumps = !evmDialect->eofVersion().has_value();
+		reachableStackDepth = evmDialect->reachableStackDepth();
 	}
 	bool allowMSizeOptimization = !MSizeFinder::containsMSize(*_object.dialect(), _object.code()->root());
 	Block astRoot = std::get<Block>(ASTCopier{}(_object.code()->root()));
@@ -270,7 +272,7 @@ std::tuple<bool, Block> StackCompressor::run(
 		eliminateVariablesOptimizedCodegen(
 			*_object.dialect(),
 			astRoot,
-			StackLayoutGenerator::reportStackTooDeep(*cfg, simulateFunctionsWithJumps),
+			StackLayoutGenerator::reportStackTooDeep(*cfg, simulateFunctionsWithJumps, reachableStackDepth),
 			allowMSizeOptimization
 		);
 	}

--- a/libyul/optimiser/StackLimitEvader.cpp
+++ b/libyul/optimiser/StackLimitEvader.cpp
@@ -141,7 +141,7 @@ Block StackLimitEvader::run(
 			_object.summarizeStructure()
 		);
 		std::unique_ptr<CFG> cfg = ControlFlowGraphBuilder::build(analysisInfo, *evmDialect, astRoot);
-		run(_context, astRoot, StackLayoutGenerator::reportStackTooDeep(*cfg, !evmDialect->eofVersion().has_value()));
+		run(_context, astRoot, StackLayoutGenerator::reportStackTooDeep(*cfg, !evmDialect->eofVersion().has_value(), evmDialect->reachableStackDepth()));
 	}
 	else
 	{

--- a/libyul/optimiser/StackLimitEvader.cpp
+++ b/libyul/optimiser/StackLimitEvader.cpp
@@ -145,7 +145,7 @@ Block StackLimitEvader::run(
 			_object.summarizeStructure()
 		);
 		std::unique_ptr<CFG> cfg = ControlFlowGraphBuilder::build(analysisInfo, *evmDialect, astRoot);
-		run(_context, astRoot, StackLayoutGenerator::reportStackTooDeep(*cfg, !evmDialect->eofVersion().has_value(), evmDialect->reachableStackDepth()));
+		run(_context, astRoot, StackLayoutGenerator::reportStackTooDeep(*cfg, *evmDialect));
 	}
 	else
 	{

--- a/libyul/optimiser/StackLimitEvader.cpp
+++ b/libyul/optimiser/StackLimitEvader.cpp
@@ -132,6 +132,10 @@ Block StackLimitEvader::run(
 		evmDialect && evmDialect->providesObjectAccess(),
 		"StackLimitEvader can only be run on objects using the EVMDialect with object access."
 	);
+	yulAssert(
+		!evmDialect->eofVersion().has_value(),
+		"StackLimitEvader does not support EOF."
+	);
 	auto astRoot = std::get<Block>(ASTCopier{}(_object.code()->root()));
 	if (evmDialect && evmDialect->evmVersion().canOverchargeGasForCall())
 	{
@@ -159,6 +163,15 @@ void StackLimitEvader::run(
 	std::map<YulName, std::vector<StackLayoutGenerator::StackTooDeep>> const& _stackTooDeepErrors
 )
 {
+	auto const* evmDialect = dynamic_cast<EVMDialect const*>(&_context.dialect);
+	yulAssert(
+		evmDialect && evmDialect->providesObjectAccess(),
+		"StackLimitEvader can only be run on objects using the EVMDialect with object access."
+	);
+	yulAssert(
+		!evmDialect->eofVersion().has_value(),
+		"StackLimitEvader does not support EOF."
+	);
 	std::map<YulName, std::vector<YulName>> unreachableVariables;
 	for (auto&& [function, stackTooDeepErrors]: _stackTooDeepErrors)
 	{
@@ -182,6 +195,10 @@ void StackLimitEvader::run(
 	yulAssert(
 		evmDialect && evmDialect->providesObjectAccess(),
 		"StackLimitEvader can only be run on objects using the EVMDialect with object access."
+	);
+	yulAssert(
+		!evmDialect->eofVersion().has_value(),
+		"StackLimitEvader does not support EOF."
 	);
 
 	std::vector<FunctionCall*> memoryGuardCalls = findFunctionCalls(_astRoot, "memoryguard", *evmDialect);

--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -163,25 +163,29 @@ void OptimiserSuite::run(
 		}
 		if (usesOptimizedCodeGenerator)
 		{
+			if (!evmDialect->eofVersion().has_value())
 			{
-				PROFILER_PROBE("StackCompressor", probe);
-				_object.setCode(std::make_shared<AST>(dialect, std::move(astRoot)));
-				astRoot = std::get<1>(StackCompressor::run(
-					_object,
-					_optimizeStackAllocation,
-					stackCompressorMaxIterations
-				));
-			}
-			if (evmDialect->providesObjectAccess())
-			{
-				PROFILER_PROBE("StackLimitEvader", probe);
-				_object.setCode(std::make_shared<AST>(dialect, std::move(astRoot)));
-				astRoot = StackLimitEvader::run(suite.m_context, _object);
+				{
+					PROFILER_PROBE("StackCompressor", probe);
+					_object.setCode(std::make_shared<AST>(dialect, std::move(astRoot)));
+					astRoot = std::get<1>(StackCompressor::run(
+						_object,
+						_optimizeStackAllocation,
+						stackCompressorMaxIterations
+					));
+				}
+				if (evmDialect->providesObjectAccess())
+				{
+					PROFILER_PROBE("StackLimitEvader", probe);
+					_object.setCode(std::make_shared<AST>(dialect, std::move(astRoot)));
+					astRoot = StackLimitEvader::run(suite.m_context, _object);
+				}
 			}
 		}
 		else if (evmDialect->providesObjectAccess() && _optimizeStackAllocation)
 		{
 			PROFILER_PROBE("StackLimitEvader", probe);
+			yulAssert(!evmDialect->eofVersion().has_value(), "");
 			_object.setCode(std::make_shared<AST>(dialect, std::move(astRoot)));
 			astRoot = StackLimitEvader::run(suite.m_context, _object);
 		}

--- a/test/libyul/StackLayoutGeneratorTest.cpp
+++ b/test/libyul/StackLayoutGeneratorTest.cpp
@@ -233,10 +233,14 @@ TestCase::TestResult StackLayoutGeneratorTest::run(std::ostream& _stream, std::s
 	);
 
 	bool simulateFunctionsWithJumps = true;
+	size_t reachableStackDepth = 16;
 	if (auto const* evmDialect = dynamic_cast<EVMDialect const*>(&yulStack.dialect()))
+	{
 		simulateFunctionsWithJumps = !evmDialect->eofVersion().has_value();
+		reachableStackDepth = evmDialect->reachableStackDepth();
+	}
 
-	StackLayout stackLayout = StackLayoutGenerator::run(*cfg, simulateFunctionsWithJumps);
+	StackLayout stackLayout = StackLayoutGenerator::run(*cfg, simulateFunctionsWithJumps, reachableStackDepth);
 
 	output << "digraph CFG {\nnodesep=0.7;\nnode[shape=box];\n\n";
 	StackLayoutPrinter printer{output, stackLayout, yulStack.dialect()};

--- a/test/libyul/StackLayoutGeneratorTest.cpp
+++ b/test/libyul/StackLayoutGeneratorTest.cpp
@@ -234,10 +234,8 @@ TestCase::TestResult StackLayoutGeneratorTest::run(std::ostream& _stream, std::s
 
 	auto const* evmDialect = dynamic_cast<EVMDialect const*>(&yulStack.dialect());
 	solAssert(evmDialect, "StackLayoutGenerator can only be run on EVM dialects.");
-	bool simulateFunctionsWithJumps = !evmDialect->eofVersion().has_value();
-	size_t reachableStackDepth = evmDialect->reachableStackDepth();
 
-	StackLayout stackLayout = StackLayoutGenerator::run(*cfg, simulateFunctionsWithJumps, reachableStackDepth);
+	StackLayout stackLayout = StackLayoutGenerator::run(*cfg, *evmDialect);
 
 	output << "digraph CFG {\nnodesep=0.7;\nnode[shape=box];\n\n";
 	StackLayoutPrinter printer{output, stackLayout, yulStack.dialect()};

--- a/test/libyul/StackLayoutGeneratorTest.cpp
+++ b/test/libyul/StackLayoutGeneratorTest.cpp
@@ -232,13 +232,10 @@ TestCase::TestResult StackLayoutGeneratorTest::run(std::ostream& _stream, std::s
 		yulStack.parserResult()->code()->root()
 	);
 
-	bool simulateFunctionsWithJumps = true;
-	size_t reachableStackDepth = 16;
-	if (auto const* evmDialect = dynamic_cast<EVMDialect const*>(&yulStack.dialect()))
-	{
-		simulateFunctionsWithJumps = !evmDialect->eofVersion().has_value();
-		reachableStackDepth = evmDialect->reachableStackDepth();
-	}
+	auto const* evmDialect = dynamic_cast<EVMDialect const*>(&yulStack.dialect());
+	solAssert(evmDialect, "StackLayoutGenerator can only be run on EVM dialects.");
+	bool simulateFunctionsWithJumps = !evmDialect->eofVersion().has_value();
+	size_t reachableStackDepth = evmDialect->reachableStackDepth();
 
 	StackLayout stackLayout = StackLayoutGenerator::run(*cfg, simulateFunctionsWithJumps, reachableStackDepth);
 

--- a/test/libyul/StackShufflingTest.cpp
+++ b/test/libyul/StackShufflingTest.cpp
@@ -174,7 +174,8 @@ TestCase::TestResult StackShufflingTest::run(std::ostream& _stream, std::string 
 		[&](){ // pop
 			output << stackToString(m_sourceStack, dialect) << std::endl;
 			output << "POP" << std::endl;
-		}
+		},
+		16u // TODO: make it a test setting
     );
 
 	output << stackToString(m_sourceStack, dialect) << std::endl;

--- a/test/libyul/StackShufflingTest.cpp
+++ b/test/libyul/StackShufflingTest.cpp
@@ -24,6 +24,7 @@
 
 #include <liblangutil/Scanner.h>
 #include <libsolutil/AnsiColorized.h>
+#include <libsolutil/StringUtils.h>
 
 using namespace solidity::test;
 using namespace solidity::util;
@@ -136,8 +137,18 @@ bool StackShufflingTest::parse(std::string const& _source)
 StackShufflingTest::StackShufflingTest(std::string const& _filename):
 	TestCase(_filename)
 {
+	processSettings();
 	m_source = m_reader.source();
 	m_expectation = m_reader.simpleExpectations();
+}
+
+void StackShufflingTest::processSettings()
+{
+	std::string depthString = m_reader.stringSetting("maximumStackDepth", "16");
+	std::optional<unsigned> depth = toUnsignedInt(depthString);
+	if (!depth.has_value())
+		BOOST_THROW_EXCEPTION(std::runtime_error{"Invalid maximum stack depth: \"" + depthString + "\""});
+	m_maximumStackDepth = *depth;
 }
 
 TestCase::TestResult StackShufflingTest::run(std::ostream& _stream, std::string const& _linePrefix, bool _formatted)
@@ -150,16 +161,19 @@ TestCase::TestResult StackShufflingTest::run(std::ostream& _stream, std::string 
 	}
 
 	std::ostringstream output;
+	size_t operations = 0;
 	createStackLayout(
 		m_sourceStack,
 		m_targetStack,
 		[&](unsigned _swapDepth) // swap
 		{
+			++operations;
 			output << stackToString(m_sourceStack, dialect) << std::endl;
 			output << "SWAP" << _swapDepth << std::endl;
 		},
 		[&](StackSlot const& _slot) // dupOrPush
 		{
+			++operations;
 			output << stackToString(m_sourceStack, dialect) << std::endl;
 			if (canBeFreelyGenerated(_slot))
 				output << "PUSH " << stackSlotToString(_slot, dialect) << std::endl;
@@ -172,13 +186,15 @@ TestCase::TestResult StackShufflingTest::run(std::ostream& _stream, std::string 
 			}
 		},
 		[&](){ // pop
+			++operations;
 			output << stackToString(m_sourceStack, dialect) << std::endl;
 			output << "POP" << std::endl;
 		},
-		16u // TODO: make it a test setting
+		m_maximumStackDepth
     );
 
 	output << stackToString(m_sourceStack, dialect) << std::endl;
+	output << operations << " operations" << std::endl;
 	m_obtainedResult = output.str();
 
 	return checkResult(_stream, _linePrefix, _formatted);

--- a/test/libyul/StackShufflingTest.h
+++ b/test/libyul/StackShufflingTest.h
@@ -37,8 +37,10 @@ public:
 	explicit StackShufflingTest(std::string const& _filename);
 	TestResult run(std::ostream& _stream, std::string const& _linePrefix = "", bool const _formatted = false) override;
 private:
+	void processSettings();
 	bool parse(std::string const& _source);
 
+	size_t m_maximumStackDepth{};
 	Stack m_sourceStack;
 	Stack m_targetStack;
 	std::map<YulName, yul::FunctionCall> m_functions;

--- a/test/libyul/evmCodeTransform/eof_dup256.yul
+++ b/test/libyul/evmCodeTransform/eof_dup256.yul
@@ -1,0 +1,2595 @@
+object "main" {
+    code {
+        let v0 := calldataload(0)
+        let v1 := calldataload(1)
+        let v2 := calldataload(2)
+        let v3 := calldataload(3)
+        let v4 := calldataload(4)
+        let v5 := calldataload(5)
+        let v6 := calldataload(6)
+        let v7 := calldataload(7)
+        let v8 := calldataload(8)
+        let v9 := calldataload(9)
+        let v10 := calldataload(10)
+        let v11 := calldataload(11)
+        let v12 := calldataload(12)
+        let v13 := calldataload(13)
+        let v14 := calldataload(14)
+        let v15 := calldataload(15)
+        let v16 := calldataload(16)
+        let v17 := calldataload(17)
+        let v18 := calldataload(18)
+        let v19 := calldataload(19)
+        let v20 := calldataload(20)
+        let v21 := calldataload(21)
+        let v22 := calldataload(22)
+        let v23 := calldataload(23)
+        let v24 := calldataload(24)
+        let v25 := calldataload(25)
+        let v26 := calldataload(26)
+        let v27 := calldataload(27)
+        let v28 := calldataload(28)
+        let v29 := calldataload(29)
+        let v30 := calldataload(30)
+        let v31 := calldataload(31)
+        let v32 := calldataload(32)
+        let v33 := calldataload(33)
+        let v34 := calldataload(34)
+        let v35 := calldataload(35)
+        let v36 := calldataload(36)
+        let v37 := calldataload(37)
+        let v38 := calldataload(38)
+        let v39 := calldataload(39)
+        let v40 := calldataload(40)
+        let v41 := calldataload(41)
+        let v42 := calldataload(42)
+        let v43 := calldataload(43)
+        let v44 := calldataload(44)
+        let v45 := calldataload(45)
+        let v46 := calldataload(46)
+        let v47 := calldataload(47)
+        let v48 := calldataload(48)
+        let v49 := calldataload(49)
+        let v50 := calldataload(50)
+        let v51 := calldataload(51)
+        let v52 := calldataload(52)
+        let v53 := calldataload(53)
+        let v54 := calldataload(54)
+        let v55 := calldataload(55)
+        let v56 := calldataload(56)
+        let v57 := calldataload(57)
+        let v58 := calldataload(58)
+        let v59 := calldataload(59)
+        let v60 := calldataload(60)
+        let v61 := calldataload(61)
+        let v62 := calldataload(62)
+        let v63 := calldataload(63)
+        let v64 := calldataload(64)
+        let v65 := calldataload(65)
+        let v66 := calldataload(66)
+        let v67 := calldataload(67)
+        let v68 := calldataload(68)
+        let v69 := calldataload(69)
+        let v70 := calldataload(70)
+        let v71 := calldataload(71)
+        let v72 := calldataload(72)
+        let v73 := calldataload(73)
+        let v74 := calldataload(74)
+        let v75 := calldataload(75)
+        let v76 := calldataload(76)
+        let v77 := calldataload(77)
+        let v78 := calldataload(78)
+        let v79 := calldataload(79)
+        let v80 := calldataload(80)
+        let v81 := calldataload(81)
+        let v82 := calldataload(82)
+        let v83 := calldataload(83)
+        let v84 := calldataload(84)
+        let v85 := calldataload(85)
+        let v86 := calldataload(86)
+        let v87 := calldataload(87)
+        let v88 := calldataload(88)
+        let v89 := calldataload(89)
+        let v90 := calldataload(90)
+        let v91 := calldataload(91)
+        let v92 := calldataload(92)
+        let v93 := calldataload(93)
+        let v94 := calldataload(94)
+        let v95 := calldataload(95)
+        let v96 := calldataload(96)
+        let v97 := calldataload(97)
+        let v98 := calldataload(98)
+        let v99 := calldataload(99)
+        let v100 := calldataload(100)
+        let v101 := calldataload(101)
+        let v102 := calldataload(102)
+        let v103 := calldataload(103)
+        let v104 := calldataload(104)
+        let v105 := calldataload(105)
+        let v106 := calldataload(106)
+        let v107 := calldataload(107)
+        let v108 := calldataload(108)
+        let v109 := calldataload(109)
+        let v110 := calldataload(110)
+        let v111 := calldataload(111)
+        let v112 := calldataload(112)
+        let v113 := calldataload(113)
+        let v114 := calldataload(114)
+        let v115 := calldataload(115)
+        let v116 := calldataload(116)
+        let v117 := calldataload(117)
+        let v118 := calldataload(118)
+        let v119 := calldataload(119)
+        let v120 := calldataload(120)
+        let v121 := calldataload(121)
+        let v122 := calldataload(122)
+        let v123 := calldataload(123)
+        let v124 := calldataload(124)
+        let v125 := calldataload(125)
+        let v126 := calldataload(126)
+        let v127 := calldataload(127)
+        let v128 := calldataload(128)
+        let v129 := calldataload(129)
+        let v130 := calldataload(130)
+        let v131 := calldataload(131)
+        let v132 := calldataload(132)
+        let v133 := calldataload(133)
+        let v134 := calldataload(134)
+        let v135 := calldataload(135)
+        let v136 := calldataload(136)
+        let v137 := calldataload(137)
+        let v138 := calldataload(138)
+        let v139 := calldataload(139)
+        let v140 := calldataload(140)
+        let v141 := calldataload(141)
+        let v142 := calldataload(142)
+        let v143 := calldataload(143)
+        let v144 := calldataload(144)
+        let v145 := calldataload(145)
+        let v146 := calldataload(146)
+        let v147 := calldataload(147)
+        let v148 := calldataload(148)
+        let v149 := calldataload(149)
+        let v150 := calldataload(150)
+        let v151 := calldataload(151)
+        let v152 := calldataload(152)
+        let v153 := calldataload(153)
+        let v154 := calldataload(154)
+        let v155 := calldataload(155)
+        let v156 := calldataload(156)
+        let v157 := calldataload(157)
+        let v158 := calldataload(158)
+        let v159 := calldataload(159)
+        let v160 := calldataload(160)
+        let v161 := calldataload(161)
+        let v162 := calldataload(162)
+        let v163 := calldataload(163)
+        let v164 := calldataload(164)
+        let v165 := calldataload(165)
+        let v166 := calldataload(166)
+        let v167 := calldataload(167)
+        let v168 := calldataload(168)
+        let v169 := calldataload(169)
+        let v170 := calldataload(170)
+        let v171 := calldataload(171)
+        let v172 := calldataload(172)
+        let v173 := calldataload(173)
+        let v174 := calldataload(174)
+        let v175 := calldataload(175)
+        let v176 := calldataload(176)
+        let v177 := calldataload(177)
+        let v178 := calldataload(178)
+        let v179 := calldataload(179)
+        let v180 := calldataload(180)
+        let v181 := calldataload(181)
+        let v182 := calldataload(182)
+        let v183 := calldataload(183)
+        let v184 := calldataload(184)
+        let v185 := calldataload(185)
+        let v186 := calldataload(186)
+        let v187 := calldataload(187)
+        let v188 := calldataload(188)
+        let v189 := calldataload(189)
+        let v190 := calldataload(190)
+        let v191 := calldataload(191)
+        let v192 := calldataload(192)
+        let v193 := calldataload(193)
+        let v194 := calldataload(194)
+        let v195 := calldataload(195)
+        let v196 := calldataload(196)
+        let v197 := calldataload(197)
+        let v198 := calldataload(198)
+        let v199 := calldataload(199)
+        let v200 := calldataload(200)
+        let v201 := calldataload(201)
+        let v202 := calldataload(202)
+        let v203 := calldataload(203)
+        let v204 := calldataload(204)
+        let v205 := calldataload(205)
+        let v206 := calldataload(206)
+        let v207 := calldataload(207)
+        let v208 := calldataload(208)
+        let v209 := calldataload(209)
+        let v210 := calldataload(210)
+        let v211 := calldataload(211)
+        let v212 := calldataload(212)
+        let v213 := calldataload(213)
+        let v214 := calldataload(214)
+        let v215 := calldataload(215)
+        let v216 := calldataload(216)
+        let v217 := calldataload(217)
+        let v218 := calldataload(218)
+        let v219 := calldataload(219)
+        let v220 := calldataload(220)
+        let v221 := calldataload(221)
+        let v222 := calldataload(222)
+        let v223 := calldataload(223)
+        let v224 := calldataload(224)
+        let v225 := calldataload(225)
+        let v226 := calldataload(226)
+        let v227 := calldataload(227)
+        let v228 := calldataload(228)
+        let v229 := calldataload(229)
+        let v230 := calldataload(230)
+        let v231 := calldataload(231)
+        let v232 := calldataload(232)
+        let v233 := calldataload(233)
+        let v234 := calldataload(234)
+        let v235 := calldataload(235)
+        let v236 := calldataload(236)
+        let v237 := calldataload(237)
+        let v238 := calldataload(238)
+        let v239 := calldataload(239)
+        let v240 := calldataload(240)
+        let v241 := calldataload(241)
+        let v242 := calldataload(242)
+        let v243 := calldataload(243)
+        let v244 := calldataload(244)
+        let v245 := calldataload(245)
+        let v246 := calldataload(246)
+        let v247 := calldataload(247)
+        let v248 := calldataload(248)
+        let v249 := calldataload(249)
+        let v250 := calldataload(250)
+        let v251 := calldataload(251)
+        let v252 := calldataload(252)
+        let v253 := calldataload(253)
+        let v254 := calldataload(254)
+        let v255 := calldataload(255)
+        // The conditional jump splits basic blocks and prevents us from moving the resulting dupn{256} further up.
+        // At the time of writing, the current code transform would do that and turn it into a less-deep dup otherwise.
+        if calldataload(256) { revert(0,0) }
+        sstore(256, v0)
+        sstore(255, v255)
+        sstore(254, v254)
+        sstore(253, v253)
+        sstore(252, v252)
+        sstore(251, v251)
+        sstore(250, v250)
+        sstore(249, v249)
+        sstore(248, v248)
+        sstore(247, v247)
+        sstore(246, v246)
+        sstore(245, v245)
+        sstore(244, v244)
+        sstore(243, v243)
+        sstore(242, v242)
+        sstore(241, v241)
+        sstore(240, v240)
+        sstore(239, v239)
+        sstore(238, v238)
+        sstore(237, v237)
+        sstore(236, v236)
+        sstore(235, v235)
+        sstore(234, v234)
+        sstore(233, v233)
+        sstore(232, v232)
+        sstore(231, v231)
+        sstore(230, v230)
+        sstore(229, v229)
+        sstore(228, v228)
+        sstore(227, v227)
+        sstore(226, v226)
+        sstore(225, v225)
+        sstore(224, v224)
+        sstore(223, v223)
+        sstore(222, v222)
+        sstore(221, v221)
+        sstore(220, v220)
+        sstore(219, v219)
+        sstore(218, v218)
+        sstore(217, v217)
+        sstore(216, v216)
+        sstore(215, v215)
+        sstore(214, v214)
+        sstore(213, v213)
+        sstore(212, v212)
+        sstore(211, v211)
+        sstore(210, v210)
+        sstore(209, v209)
+        sstore(208, v208)
+        sstore(207, v207)
+        sstore(206, v206)
+        sstore(205, v205)
+        sstore(204, v204)
+        sstore(203, v203)
+        sstore(202, v202)
+        sstore(201, v201)
+        sstore(200, v200)
+        sstore(199, v199)
+        sstore(198, v198)
+        sstore(197, v197)
+        sstore(196, v196)
+        sstore(195, v195)
+        sstore(194, v194)
+        sstore(193, v193)
+        sstore(192, v192)
+        sstore(191, v191)
+        sstore(190, v190)
+        sstore(189, v189)
+        sstore(188, v188)
+        sstore(187, v187)
+        sstore(186, v186)
+        sstore(185, v185)
+        sstore(184, v184)
+        sstore(183, v183)
+        sstore(182, v182)
+        sstore(181, v181)
+        sstore(180, v180)
+        sstore(179, v179)
+        sstore(178, v178)
+        sstore(177, v177)
+        sstore(176, v176)
+        sstore(175, v175)
+        sstore(174, v174)
+        sstore(173, v173)
+        sstore(172, v172)
+        sstore(171, v171)
+        sstore(170, v170)
+        sstore(169, v169)
+        sstore(168, v168)
+        sstore(167, v167)
+        sstore(166, v166)
+        sstore(165, v165)
+        sstore(164, v164)
+        sstore(163, v163)
+        sstore(162, v162)
+        sstore(161, v161)
+        sstore(160, v160)
+        sstore(159, v159)
+        sstore(158, v158)
+        sstore(157, v157)
+        sstore(156, v156)
+        sstore(155, v155)
+        sstore(154, v154)
+        sstore(153, v153)
+        sstore(152, v152)
+        sstore(151, v151)
+        sstore(150, v150)
+        sstore(149, v149)
+        sstore(148, v148)
+        sstore(147, v147)
+        sstore(146, v146)
+        sstore(145, v145)
+        sstore(144, v144)
+        sstore(143, v143)
+        sstore(142, v142)
+        sstore(141, v141)
+        sstore(140, v140)
+        sstore(139, v139)
+        sstore(138, v138)
+        sstore(137, v137)
+        sstore(136, v136)
+        sstore(135, v135)
+        sstore(134, v134)
+        sstore(133, v133)
+        sstore(132, v132)
+        sstore(131, v131)
+        sstore(130, v130)
+        sstore(129, v129)
+        sstore(128, v128)
+        sstore(127, v127)
+        sstore(126, v126)
+        sstore(125, v125)
+        sstore(124, v124)
+        sstore(123, v123)
+        sstore(122, v122)
+        sstore(121, v121)
+        sstore(120, v120)
+        sstore(119, v119)
+        sstore(118, v118)
+        sstore(117, v117)
+        sstore(116, v116)
+        sstore(115, v115)
+        sstore(114, v114)
+        sstore(113, v113)
+        sstore(112, v112)
+        sstore(111, v111)
+        sstore(110, v110)
+        sstore(109, v109)
+        sstore(108, v108)
+        sstore(107, v107)
+        sstore(106, v106)
+        sstore(105, v105)
+        sstore(104, v104)
+        sstore(103, v103)
+        sstore(102, v102)
+        sstore(101, v101)
+        sstore(100, v100)
+        sstore(99, v99)
+        sstore(98, v98)
+        sstore(97, v97)
+        sstore(96, v96)
+        sstore(95, v95)
+        sstore(94, v94)
+        sstore(93, v93)
+        sstore(92, v92)
+        sstore(91, v91)
+        sstore(90, v90)
+        sstore(89, v89)
+        sstore(88, v88)
+        sstore(87, v87)
+        sstore(86, v86)
+        sstore(85, v85)
+        sstore(84, v84)
+        sstore(83, v83)
+        sstore(82, v82)
+        sstore(81, v81)
+        sstore(80, v80)
+        sstore(79, v79)
+        sstore(78, v78)
+        sstore(77, v77)
+        sstore(76, v76)
+        sstore(75, v75)
+        sstore(74, v74)
+        sstore(73, v73)
+        sstore(72, v72)
+        sstore(71, v71)
+        sstore(70, v70)
+        sstore(69, v69)
+        sstore(68, v68)
+        sstore(67, v67)
+        sstore(66, v66)
+        sstore(65, v65)
+        sstore(64, v64)
+        sstore(63, v63)
+        sstore(62, v62)
+        sstore(61, v61)
+        sstore(60, v60)
+        sstore(59, v59)
+        sstore(58, v58)
+        sstore(57, v57)
+        sstore(56, v56)
+        sstore(55, v55)
+        sstore(54, v54)
+        sstore(53, v53)
+        sstore(52, v52)
+        sstore(51, v51)
+        sstore(50, v50)
+        sstore(49, v49)
+        sstore(48, v48)
+        sstore(47, v47)
+        sstore(46, v46)
+        sstore(45, v45)
+        sstore(44, v44)
+        sstore(43, v43)
+        sstore(42, v42)
+        sstore(41, v41)
+        sstore(40, v40)
+        sstore(39, v39)
+        sstore(38, v38)
+        sstore(37, v37)
+        sstore(36, v36)
+        sstore(35, v35)
+        sstore(34, v34)
+        sstore(33, v33)
+        sstore(32, v32)
+        sstore(31, v31)
+        sstore(30, v30)
+        sstore(29, v29)
+        sstore(28, v28)
+        sstore(27, v27)
+        sstore(26, v26)
+        sstore(25, v25)
+        sstore(24, v24)
+        sstore(23, v23)
+        sstore(22, v22)
+        sstore(21, v21)
+        sstore(20, v20)
+        sstore(19, v19)
+        sstore(18, v18)
+        sstore(17, v17)
+        sstore(16, v16)
+        sstore(15, v15)
+        sstore(14, v14)
+        sstore(13, v13)
+        sstore(12, v12)
+        sstore(11, v11)
+        sstore(10, v10)
+        sstore(9, v9)
+        sstore(8, v8)
+        sstore(7, v7)
+        sstore(6, v6)
+        sstore(5, v5)
+        sstore(4, v4)
+        sstore(3, v3)
+        sstore(2, v2)
+        sstore(1, v1)
+        sstore(0, v0)
+    }
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// stackOptimization: true
+// ----
+//     /* "":58:59   */
+//   0x00
+//     /* "":45:60   */
+//   calldataload
+//     /* "":92:93   */
+//   0x01
+//     /* "":79:94   */
+//   calldataload
+//     /* "":126:127   */
+//   0x02
+//     /* "":113:128   */
+//   calldataload
+//     /* "":160:161   */
+//   0x03
+//     /* "":147:162   */
+//   calldataload
+//     /* "":194:195   */
+//   0x04
+//     /* "":181:196   */
+//   calldataload
+//     /* "":228:229   */
+//   0x05
+//     /* "":215:230   */
+//   calldataload
+//     /* "":262:263   */
+//   0x06
+//     /* "":249:264   */
+//   calldataload
+//     /* "":296:297   */
+//   0x07
+//     /* "":283:298   */
+//   calldataload
+//     /* "":330:331   */
+//   0x08
+//     /* "":317:332   */
+//   calldataload
+//     /* "":364:365   */
+//   0x09
+//     /* "":351:366   */
+//   calldataload
+//     /* "":399:401   */
+//   0x0a
+//     /* "":386:402   */
+//   calldataload
+//     /* "":435:437   */
+//   0x0b
+//     /* "":422:438   */
+//   calldataload
+//     /* "":471:473   */
+//   0x0c
+//     /* "":458:474   */
+//   calldataload
+//     /* "":507:509   */
+//   0x0d
+//     /* "":494:510   */
+//   calldataload
+//     /* "":543:545   */
+//   0x0e
+//     /* "":530:546   */
+//   calldataload
+//     /* "":579:581   */
+//   0x0f
+//     /* "":566:582   */
+//   calldataload
+//     /* "":615:617   */
+//   0x10
+//     /* "":602:618   */
+//   calldataload
+//     /* "":651:653   */
+//   0x11
+//     /* "":638:654   */
+//   calldataload
+//     /* "":687:689   */
+//   0x12
+//     /* "":674:690   */
+//   calldataload
+//     /* "":723:725   */
+//   0x13
+//     /* "":710:726   */
+//   calldataload
+//     /* "":759:761   */
+//   0x14
+//     /* "":746:762   */
+//   calldataload
+//     /* "":795:797   */
+//   0x15
+//     /* "":782:798   */
+//   calldataload
+//     /* "":831:833   */
+//   0x16
+//     /* "":818:834   */
+//   calldataload
+//     /* "":867:869   */
+//   0x17
+//     /* "":854:870   */
+//   calldataload
+//     /* "":903:905   */
+//   0x18
+//     /* "":890:906   */
+//   calldataload
+//     /* "":939:941   */
+//   0x19
+//     /* "":926:942   */
+//   calldataload
+//     /* "":975:977   */
+//   0x1a
+//     /* "":962:978   */
+//   calldataload
+//     /* "":1011:1013   */
+//   0x1b
+//     /* "":998:1014   */
+//   calldataload
+//     /* "":1047:1049   */
+//   0x1c
+//     /* "":1034:1050   */
+//   calldataload
+//     /* "":1083:1085   */
+//   0x1d
+//     /* "":1070:1086   */
+//   calldataload
+//     /* "":1119:1121   */
+//   0x1e
+//     /* "":1106:1122   */
+//   calldataload
+//     /* "":1155:1157   */
+//   0x1f
+//     /* "":1142:1158   */
+//   calldataload
+//     /* "":1191:1193   */
+//   0x20
+//     /* "":1178:1194   */
+//   calldataload
+//     /* "":1227:1229   */
+//   0x21
+//     /* "":1214:1230   */
+//   calldataload
+//     /* "":1263:1265   */
+//   0x22
+//     /* "":1250:1266   */
+//   calldataload
+//     /* "":1299:1301   */
+//   0x23
+//     /* "":1286:1302   */
+//   calldataload
+//     /* "":1335:1337   */
+//   0x24
+//     /* "":1322:1338   */
+//   calldataload
+//     /* "":1371:1373   */
+//   0x25
+//     /* "":1358:1374   */
+//   calldataload
+//     /* "":1407:1409   */
+//   0x26
+//     /* "":1394:1410   */
+//   calldataload
+//     /* "":1443:1445   */
+//   0x27
+//     /* "":1430:1446   */
+//   calldataload
+//     /* "":1479:1481   */
+//   0x28
+//     /* "":1466:1482   */
+//   calldataload
+//     /* "":1515:1517   */
+//   0x29
+//     /* "":1502:1518   */
+//   calldataload
+//     /* "":1551:1553   */
+//   0x2a
+//     /* "":1538:1554   */
+//   calldataload
+//     /* "":1587:1589   */
+//   0x2b
+//     /* "":1574:1590   */
+//   calldataload
+//     /* "":1623:1625   */
+//   0x2c
+//     /* "":1610:1626   */
+//   calldataload
+//     /* "":1659:1661   */
+//   0x2d
+//     /* "":1646:1662   */
+//   calldataload
+//     /* "":1695:1697   */
+//   0x2e
+//     /* "":1682:1698   */
+//   calldataload
+//     /* "":1731:1733   */
+//   0x2f
+//     /* "":1718:1734   */
+//   calldataload
+//     /* "":1767:1769   */
+//   0x30
+//     /* "":1754:1770   */
+//   calldataload
+//     /* "":1803:1805   */
+//   0x31
+//     /* "":1790:1806   */
+//   calldataload
+//     /* "":1839:1841   */
+//   0x32
+//     /* "":1826:1842   */
+//   calldataload
+//     /* "":1875:1877   */
+//   0x33
+//     /* "":1862:1878   */
+//   calldataload
+//     /* "":1911:1913   */
+//   0x34
+//     /* "":1898:1914   */
+//   calldataload
+//     /* "":1947:1949   */
+//   0x35
+//     /* "":1934:1950   */
+//   calldataload
+//     /* "":1983:1985   */
+//   0x36
+//     /* "":1970:1986   */
+//   calldataload
+//     /* "":2019:2021   */
+//   0x37
+//     /* "":2006:2022   */
+//   calldataload
+//     /* "":2055:2057   */
+//   0x38
+//     /* "":2042:2058   */
+//   calldataload
+//     /* "":2091:2093   */
+//   0x39
+//     /* "":2078:2094   */
+//   calldataload
+//     /* "":2127:2129   */
+//   0x3a
+//     /* "":2114:2130   */
+//   calldataload
+//     /* "":2163:2165   */
+//   0x3b
+//     /* "":2150:2166   */
+//   calldataload
+//     /* "":2199:2201   */
+//   0x3c
+//     /* "":2186:2202   */
+//   calldataload
+//     /* "":2235:2237   */
+//   0x3d
+//     /* "":2222:2238   */
+//   calldataload
+//     /* "":2271:2273   */
+//   0x3e
+//     /* "":2258:2274   */
+//   calldataload
+//     /* "":2307:2309   */
+//   0x3f
+//     /* "":2294:2310   */
+//   calldataload
+//     /* "":2343:2345   */
+//   0x40
+//     /* "":2330:2346   */
+//   calldataload
+//     /* "":2379:2381   */
+//   0x41
+//     /* "":2366:2382   */
+//   calldataload
+//     /* "":2415:2417   */
+//   0x42
+//     /* "":2402:2418   */
+//   calldataload
+//     /* "":2451:2453   */
+//   0x43
+//     /* "":2438:2454   */
+//   calldataload
+//     /* "":2487:2489   */
+//   0x44
+//     /* "":2474:2490   */
+//   calldataload
+//     /* "":2523:2525   */
+//   0x45
+//     /* "":2510:2526   */
+//   calldataload
+//     /* "":2559:2561   */
+//   0x46
+//     /* "":2546:2562   */
+//   calldataload
+//     /* "":2595:2597   */
+//   0x47
+//     /* "":2582:2598   */
+//   calldataload
+//     /* "":2631:2633   */
+//   0x48
+//     /* "":2618:2634   */
+//   calldataload
+//     /* "":2667:2669   */
+//   0x49
+//     /* "":2654:2670   */
+//   calldataload
+//     /* "":2703:2705   */
+//   0x4a
+//     /* "":2690:2706   */
+//   calldataload
+//     /* "":2739:2741   */
+//   0x4b
+//     /* "":2726:2742   */
+//   calldataload
+//     /* "":2775:2777   */
+//   0x4c
+//     /* "":2762:2778   */
+//   calldataload
+//     /* "":2811:2813   */
+//   0x4d
+//     /* "":2798:2814   */
+//   calldataload
+//     /* "":2847:2849   */
+//   0x4e
+//     /* "":2834:2850   */
+//   calldataload
+//     /* "":2883:2885   */
+//   0x4f
+//     /* "":2870:2886   */
+//   calldataload
+//     /* "":2919:2921   */
+//   0x50
+//     /* "":2906:2922   */
+//   calldataload
+//     /* "":2955:2957   */
+//   0x51
+//     /* "":2942:2958   */
+//   calldataload
+//     /* "":2991:2993   */
+//   0x52
+//     /* "":2978:2994   */
+//   calldataload
+//     /* "":3027:3029   */
+//   0x53
+//     /* "":3014:3030   */
+//   calldataload
+//     /* "":3063:3065   */
+//   0x54
+//     /* "":3050:3066   */
+//   calldataload
+//     /* "":3099:3101   */
+//   0x55
+//     /* "":3086:3102   */
+//   calldataload
+//     /* "":3135:3137   */
+//   0x56
+//     /* "":3122:3138   */
+//   calldataload
+//     /* "":3171:3173   */
+//   0x57
+//     /* "":3158:3174   */
+//   calldataload
+//     /* "":3207:3209   */
+//   0x58
+//     /* "":3194:3210   */
+//   calldataload
+//     /* "":3243:3245   */
+//   0x59
+//     /* "":3230:3246   */
+//   calldataload
+//     /* "":3279:3281   */
+//   0x5a
+//     /* "":3266:3282   */
+//   calldataload
+//     /* "":3315:3317   */
+//   0x5b
+//     /* "":3302:3318   */
+//   calldataload
+//     /* "":3351:3353   */
+//   0x5c
+//     /* "":3338:3354   */
+//   calldataload
+//     /* "":3387:3389   */
+//   0x5d
+//     /* "":3374:3390   */
+//   calldataload
+//     /* "":3423:3425   */
+//   0x5e
+//     /* "":3410:3426   */
+//   calldataload
+//     /* "":3459:3461   */
+//   0x5f
+//     /* "":3446:3462   */
+//   calldataload
+//     /* "":3495:3497   */
+//   0x60
+//     /* "":3482:3498   */
+//   calldataload
+//     /* "":3531:3533   */
+//   0x61
+//     /* "":3518:3534   */
+//   calldataload
+//     /* "":3567:3569   */
+//   0x62
+//     /* "":3554:3570   */
+//   calldataload
+//     /* "":3603:3605   */
+//   0x63
+//     /* "":3590:3606   */
+//   calldataload
+//     /* "":3640:3643   */
+//   0x64
+//     /* "":3627:3644   */
+//   calldataload
+//     /* "":3678:3681   */
+//   0x65
+//     /* "":3665:3682   */
+//   calldataload
+//     /* "":3716:3719   */
+//   0x66
+//     /* "":3703:3720   */
+//   calldataload
+//     /* "":3754:3757   */
+//   0x67
+//     /* "":3741:3758   */
+//   calldataload
+//     /* "":3792:3795   */
+//   0x68
+//     /* "":3779:3796   */
+//   calldataload
+//     /* "":3830:3833   */
+//   0x69
+//     /* "":3817:3834   */
+//   calldataload
+//     /* "":3868:3871   */
+//   0x6a
+//     /* "":3855:3872   */
+//   calldataload
+//     /* "":3906:3909   */
+//   0x6b
+//     /* "":3893:3910   */
+//   calldataload
+//     /* "":3944:3947   */
+//   0x6c
+//     /* "":3931:3948   */
+//   calldataload
+//     /* "":3982:3985   */
+//   0x6d
+//     /* "":3969:3986   */
+//   calldataload
+//     /* "":4020:4023   */
+//   0x6e
+//     /* "":4007:4024   */
+//   calldataload
+//     /* "":4058:4061   */
+//   0x6f
+//     /* "":4045:4062   */
+//   calldataload
+//     /* "":4096:4099   */
+//   0x70
+//     /* "":4083:4100   */
+//   calldataload
+//     /* "":4134:4137   */
+//   0x71
+//     /* "":4121:4138   */
+//   calldataload
+//     /* "":4172:4175   */
+//   0x72
+//     /* "":4159:4176   */
+//   calldataload
+//     /* "":4210:4213   */
+//   0x73
+//     /* "":4197:4214   */
+//   calldataload
+//     /* "":4248:4251   */
+//   0x74
+//     /* "":4235:4252   */
+//   calldataload
+//     /* "":4286:4289   */
+//   0x75
+//     /* "":4273:4290   */
+//   calldataload
+//     /* "":4324:4327   */
+//   0x76
+//     /* "":4311:4328   */
+//   calldataload
+//     /* "":4362:4365   */
+//   0x77
+//     /* "":4349:4366   */
+//   calldataload
+//     /* "":4400:4403   */
+//   0x78
+//     /* "":4387:4404   */
+//   calldataload
+//     /* "":4438:4441   */
+//   0x79
+//     /* "":4425:4442   */
+//   calldataload
+//     /* "":4476:4479   */
+//   0x7a
+//     /* "":4463:4480   */
+//   calldataload
+//     /* "":4514:4517   */
+//   0x7b
+//     /* "":4501:4518   */
+//   calldataload
+//     /* "":4552:4555   */
+//   0x7c
+//     /* "":4539:4556   */
+//   calldataload
+//     /* "":4590:4593   */
+//   0x7d
+//     /* "":4577:4594   */
+//   calldataload
+//     /* "":4628:4631   */
+//   0x7e
+//     /* "":4615:4632   */
+//   calldataload
+//     /* "":4666:4669   */
+//   0x7f
+//     /* "":4653:4670   */
+//   calldataload
+//     /* "":4704:4707   */
+//   0x80
+//     /* "":4691:4708   */
+//   calldataload
+//     /* "":4742:4745   */
+//   0x81
+//     /* "":4729:4746   */
+//   calldataload
+//     /* "":4780:4783   */
+//   0x82
+//     /* "":4767:4784   */
+//   calldataload
+//     /* "":4818:4821   */
+//   0x83
+//     /* "":4805:4822   */
+//   calldataload
+//     /* "":4856:4859   */
+//   0x84
+//     /* "":4843:4860   */
+//   calldataload
+//     /* "":4894:4897   */
+//   0x85
+//     /* "":4881:4898   */
+//   calldataload
+//     /* "":4932:4935   */
+//   0x86
+//     /* "":4919:4936   */
+//   calldataload
+//     /* "":4970:4973   */
+//   0x87
+//     /* "":4957:4974   */
+//   calldataload
+//     /* "":5008:5011   */
+//   0x88
+//     /* "":4995:5012   */
+//   calldataload
+//     /* "":5046:5049   */
+//   0x89
+//     /* "":5033:5050   */
+//   calldataload
+//     /* "":5084:5087   */
+//   0x8a
+//     /* "":5071:5088   */
+//   calldataload
+//     /* "":5122:5125   */
+//   0x8b
+//     /* "":5109:5126   */
+//   calldataload
+//     /* "":5160:5163   */
+//   0x8c
+//     /* "":5147:5164   */
+//   calldataload
+//     /* "":5198:5201   */
+//   0x8d
+//     /* "":5185:5202   */
+//   calldataload
+//     /* "":5236:5239   */
+//   0x8e
+//     /* "":5223:5240   */
+//   calldataload
+//     /* "":5274:5277   */
+//   0x8f
+//     /* "":5261:5278   */
+//   calldataload
+//     /* "":5312:5315   */
+//   0x90
+//     /* "":5299:5316   */
+//   calldataload
+//     /* "":5350:5353   */
+//   0x91
+//     /* "":5337:5354   */
+//   calldataload
+//     /* "":5388:5391   */
+//   0x92
+//     /* "":5375:5392   */
+//   calldataload
+//     /* "":5426:5429   */
+//   0x93
+//     /* "":5413:5430   */
+//   calldataload
+//     /* "":5464:5467   */
+//   0x94
+//     /* "":5451:5468   */
+//   calldataload
+//     /* "":5502:5505   */
+//   0x95
+//     /* "":5489:5506   */
+//   calldataload
+//     /* "":5540:5543   */
+//   0x96
+//     /* "":5527:5544   */
+//   calldataload
+//     /* "":5578:5581   */
+//   0x97
+//     /* "":5565:5582   */
+//   calldataload
+//     /* "":5616:5619   */
+//   0x98
+//     /* "":5603:5620   */
+//   calldataload
+//     /* "":5654:5657   */
+//   0x99
+//     /* "":5641:5658   */
+//   calldataload
+//     /* "":5692:5695   */
+//   0x9a
+//     /* "":5679:5696   */
+//   calldataload
+//     /* "":5730:5733   */
+//   0x9b
+//     /* "":5717:5734   */
+//   calldataload
+//     /* "":5768:5771   */
+//   0x9c
+//     /* "":5755:5772   */
+//   calldataload
+//     /* "":5806:5809   */
+//   0x9d
+//     /* "":5793:5810   */
+//   calldataload
+//     /* "":5844:5847   */
+//   0x9e
+//     /* "":5831:5848   */
+//   calldataload
+//     /* "":5882:5885   */
+//   0x9f
+//     /* "":5869:5886   */
+//   calldataload
+//     /* "":5920:5923   */
+//   0xa0
+//     /* "":5907:5924   */
+//   calldataload
+//     /* "":5958:5961   */
+//   0xa1
+//     /* "":5945:5962   */
+//   calldataload
+//     /* "":5996:5999   */
+//   0xa2
+//     /* "":5983:6000   */
+//   calldataload
+//     /* "":6034:6037   */
+//   0xa3
+//     /* "":6021:6038   */
+//   calldataload
+//     /* "":6072:6075   */
+//   0xa4
+//     /* "":6059:6076   */
+//   calldataload
+//     /* "":6110:6113   */
+//   0xa5
+//     /* "":6097:6114   */
+//   calldataload
+//     /* "":6148:6151   */
+//   0xa6
+//     /* "":6135:6152   */
+//   calldataload
+//     /* "":6186:6189   */
+//   0xa7
+//     /* "":6173:6190   */
+//   calldataload
+//     /* "":6224:6227   */
+//   0xa8
+//     /* "":6211:6228   */
+//   calldataload
+//     /* "":6262:6265   */
+//   0xa9
+//     /* "":6249:6266   */
+//   calldataload
+//     /* "":6300:6303   */
+//   0xaa
+//     /* "":6287:6304   */
+//   calldataload
+//     /* "":6338:6341   */
+//   0xab
+//     /* "":6325:6342   */
+//   calldataload
+//     /* "":6376:6379   */
+//   0xac
+//     /* "":6363:6380   */
+//   calldataload
+//     /* "":6414:6417   */
+//   0xad
+//     /* "":6401:6418   */
+//   calldataload
+//     /* "":6452:6455   */
+//   0xae
+//     /* "":6439:6456   */
+//   calldataload
+//     /* "":6490:6493   */
+//   0xaf
+//     /* "":6477:6494   */
+//   calldataload
+//     /* "":6528:6531   */
+//   0xb0
+//     /* "":6515:6532   */
+//   calldataload
+//     /* "":6566:6569   */
+//   0xb1
+//     /* "":6553:6570   */
+//   calldataload
+//     /* "":6604:6607   */
+//   0xb2
+//     /* "":6591:6608   */
+//   calldataload
+//     /* "":6642:6645   */
+//   0xb3
+//     /* "":6629:6646   */
+//   calldataload
+//     /* "":6680:6683   */
+//   0xb4
+//     /* "":6667:6684   */
+//   calldataload
+//     /* "":6718:6721   */
+//   0xb5
+//     /* "":6705:6722   */
+//   calldataload
+//     /* "":6756:6759   */
+//   0xb6
+//     /* "":6743:6760   */
+//   calldataload
+//     /* "":6794:6797   */
+//   0xb7
+//     /* "":6781:6798   */
+//   calldataload
+//     /* "":6832:6835   */
+//   0xb8
+//     /* "":6819:6836   */
+//   calldataload
+//     /* "":6870:6873   */
+//   0xb9
+//     /* "":6857:6874   */
+//   calldataload
+//     /* "":6908:6911   */
+//   0xba
+//     /* "":6895:6912   */
+//   calldataload
+//     /* "":6946:6949   */
+//   0xbb
+//     /* "":6933:6950   */
+//   calldataload
+//     /* "":6984:6987   */
+//   0xbc
+//     /* "":6971:6988   */
+//   calldataload
+//     /* "":7022:7025   */
+//   0xbd
+//     /* "":7009:7026   */
+//   calldataload
+//     /* "":7060:7063   */
+//   0xbe
+//     /* "":7047:7064   */
+//   calldataload
+//     /* "":7098:7101   */
+//   0xbf
+//     /* "":7085:7102   */
+//   calldataload
+//     /* "":7136:7139   */
+//   0xc0
+//     /* "":7123:7140   */
+//   calldataload
+//     /* "":7174:7177   */
+//   0xc1
+//     /* "":7161:7178   */
+//   calldataload
+//     /* "":7212:7215   */
+//   0xc2
+//     /* "":7199:7216   */
+//   calldataload
+//     /* "":7250:7253   */
+//   0xc3
+//     /* "":7237:7254   */
+//   calldataload
+//     /* "":7288:7291   */
+//   0xc4
+//     /* "":7275:7292   */
+//   calldataload
+//     /* "":7326:7329   */
+//   0xc5
+//     /* "":7313:7330   */
+//   calldataload
+//     /* "":7364:7367   */
+//   0xc6
+//     /* "":7351:7368   */
+//   calldataload
+//     /* "":7402:7405   */
+//   0xc7
+//     /* "":7389:7406   */
+//   calldataload
+//     /* "":7440:7443   */
+//   0xc8
+//     /* "":7427:7444   */
+//   calldataload
+//     /* "":7478:7481   */
+//   0xc9
+//     /* "":7465:7482   */
+//   calldataload
+//     /* "":7516:7519   */
+//   0xca
+//     /* "":7503:7520   */
+//   calldataload
+//     /* "":7554:7557   */
+//   0xcb
+//     /* "":7541:7558   */
+//   calldataload
+//     /* "":7592:7595   */
+//   0xcc
+//     /* "":7579:7596   */
+//   calldataload
+//     /* "":7630:7633   */
+//   0xcd
+//     /* "":7617:7634   */
+//   calldataload
+//     /* "":7668:7671   */
+//   0xce
+//     /* "":7655:7672   */
+//   calldataload
+//     /* "":7706:7709   */
+//   0xcf
+//     /* "":7693:7710   */
+//   calldataload
+//     /* "":7744:7747   */
+//   0xd0
+//     /* "":7731:7748   */
+//   calldataload
+//     /* "":7782:7785   */
+//   0xd1
+//     /* "":7769:7786   */
+//   calldataload
+//     /* "":7820:7823   */
+//   0xd2
+//     /* "":7807:7824   */
+//   calldataload
+//     /* "":7858:7861   */
+//   0xd3
+//     /* "":7845:7862   */
+//   calldataload
+//     /* "":7896:7899   */
+//   0xd4
+//     /* "":7883:7900   */
+//   calldataload
+//     /* "":7934:7937   */
+//   0xd5
+//     /* "":7921:7938   */
+//   calldataload
+//     /* "":7972:7975   */
+//   0xd6
+//     /* "":7959:7976   */
+//   calldataload
+//     /* "":8010:8013   */
+//   0xd7
+//     /* "":7997:8014   */
+//   calldataload
+//     /* "":8048:8051   */
+//   0xd8
+//     /* "":8035:8052   */
+//   calldataload
+//     /* "":8086:8089   */
+//   0xd9
+//     /* "":8073:8090   */
+//   calldataload
+//     /* "":8124:8127   */
+//   0xda
+//     /* "":8111:8128   */
+//   calldataload
+//     /* "":8162:8165   */
+//   0xdb
+//     /* "":8149:8166   */
+//   calldataload
+//     /* "":8200:8203   */
+//   0xdc
+//     /* "":8187:8204   */
+//   calldataload
+//     /* "":8238:8241   */
+//   0xdd
+//     /* "":8225:8242   */
+//   calldataload
+//     /* "":8276:8279   */
+//   0xde
+//     /* "":8263:8280   */
+//   calldataload
+//     /* "":8314:8317   */
+//   0xdf
+//     /* "":8301:8318   */
+//   calldataload
+//     /* "":8352:8355   */
+//   0xe0
+//     /* "":8339:8356   */
+//   calldataload
+//     /* "":8390:8393   */
+//   0xe1
+//     /* "":8377:8394   */
+//   calldataload
+//     /* "":8428:8431   */
+//   0xe2
+//     /* "":8415:8432   */
+//   calldataload
+//     /* "":8466:8469   */
+//   0xe3
+//     /* "":8453:8470   */
+//   calldataload
+//     /* "":8504:8507   */
+//   0xe4
+//     /* "":8491:8508   */
+//   calldataload
+//     /* "":8542:8545   */
+//   0xe5
+//     /* "":8529:8546   */
+//   calldataload
+//     /* "":8580:8583   */
+//   0xe6
+//     /* "":8567:8584   */
+//   calldataload
+//     /* "":8618:8621   */
+//   0xe7
+//     /* "":8605:8622   */
+//   calldataload
+//     /* "":8656:8659   */
+//   0xe8
+//     /* "":8643:8660   */
+//   calldataload
+//     /* "":8694:8697   */
+//   0xe9
+//     /* "":8681:8698   */
+//   calldataload
+//     /* "":8732:8735   */
+//   0xea
+//     /* "":8719:8736   */
+//   calldataload
+//     /* "":8770:8773   */
+//   0xeb
+//     /* "":8757:8774   */
+//   calldataload
+//     /* "":8808:8811   */
+//   0xec
+//     /* "":8795:8812   */
+//   calldataload
+//     /* "":8846:8849   */
+//   0xed
+//     /* "":8833:8850   */
+//   calldataload
+//     /* "":8884:8887   */
+//   0xee
+//     /* "":8871:8888   */
+//   calldataload
+//     /* "":8922:8925   */
+//   0xef
+//     /* "":8909:8926   */
+//   calldataload
+//     /* "":8960:8963   */
+//   0xf0
+//     /* "":8947:8964   */
+//   calldataload
+//     /* "":8998:9001   */
+//   0xf1
+//     /* "":8985:9002   */
+//   calldataload
+//     /* "":9036:9039   */
+//   0xf2
+//     /* "":9023:9040   */
+//   calldataload
+//     /* "":9074:9077   */
+//   0xf3
+//     /* "":9061:9078   */
+//   calldataload
+//     /* "":9112:9115   */
+//   0xf4
+//     /* "":9099:9116   */
+//   calldataload
+//     /* "":9150:9153   */
+//   0xf5
+//     /* "":9137:9154   */
+//   calldataload
+//     /* "":9188:9191   */
+//   0xf6
+//     /* "":9175:9192   */
+//   calldataload
+//     /* "":9226:9229   */
+//   0xf7
+//     /* "":9213:9230   */
+//   calldataload
+//     /* "":9264:9267   */
+//   0xf8
+//     /* "":9251:9268   */
+//   calldataload
+//     /* "":9302:9305   */
+//   0xf9
+//     /* "":9289:9306   */
+//   calldataload
+//     /* "":9340:9343   */
+//   0xfa
+//     /* "":9327:9344   */
+//   calldataload
+//     /* "":9378:9381   */
+//   0xfb
+//     /* "":9365:9382   */
+//   calldataload
+//     /* "":9416:9419   */
+//   0xfc
+//     /* "":9403:9420   */
+//   calldataload
+//     /* "":9454:9457   */
+//   0xfd
+//     /* "":9441:9458   */
+//   calldataload
+//     /* "":9492:9495   */
+//   0xfe
+//     /* "":9479:9496   */
+//   calldataload
+//     /* "":9530:9533   */
+//   0xff
+//     /* "":9517:9534   */
+//   calldataload
+//     /* "":9795:9798   */
+//   0x0100
+//     /* "":9782:9799   */
+//   calldataload
+//     /* "":9779:9815   */
+//   rjumpi{tag_1}
+//     /* "":25:16281   */
+// tag_2:
+//     /* "":9824:9839   */
+//   dupn{256}
+//     /* "":9831:9834   */
+//   0x0100
+//     /* "":9824:9839   */
+//   sstore
+//     /* "":9855:9858   */
+//   0xff
+//     /* "":9848:9865   */
+//   sstore
+//     /* "":9881:9884   */
+//   0xfe
+//     /* "":9874:9891   */
+//   sstore
+//     /* "":9907:9910   */
+//   0xfd
+//     /* "":9900:9917   */
+//   sstore
+//     /* "":9933:9936   */
+//   0xfc
+//     /* "":9926:9943   */
+//   sstore
+//     /* "":9959:9962   */
+//   0xfb
+//     /* "":9952:9969   */
+//   sstore
+//     /* "":9985:9988   */
+//   0xfa
+//     /* "":9978:9995   */
+//   sstore
+//     /* "":10011:10014   */
+//   0xf9
+//     /* "":10004:10021   */
+//   sstore
+//     /* "":10037:10040   */
+//   0xf8
+//     /* "":10030:10047   */
+//   sstore
+//     /* "":10063:10066   */
+//   0xf7
+//     /* "":10056:10073   */
+//   sstore
+//     /* "":10089:10092   */
+//   0xf6
+//     /* "":10082:10099   */
+//   sstore
+//     /* "":10115:10118   */
+//   0xf5
+//     /* "":10108:10125   */
+//   sstore
+//     /* "":10141:10144   */
+//   0xf4
+//     /* "":10134:10151   */
+//   sstore
+//     /* "":10167:10170   */
+//   0xf3
+//     /* "":10160:10177   */
+//   sstore
+//     /* "":10193:10196   */
+//   0xf2
+//     /* "":10186:10203   */
+//   sstore
+//     /* "":10219:10222   */
+//   0xf1
+//     /* "":10212:10229   */
+//   sstore
+//     /* "":10245:10248   */
+//   0xf0
+//     /* "":10238:10255   */
+//   sstore
+//     /* "":10271:10274   */
+//   0xef
+//     /* "":10264:10281   */
+//   sstore
+//     /* "":10297:10300   */
+//   0xee
+//     /* "":10290:10307   */
+//   sstore
+//     /* "":10323:10326   */
+//   0xed
+//     /* "":10316:10333   */
+//   sstore
+//     /* "":10349:10352   */
+//   0xec
+//     /* "":10342:10359   */
+//   sstore
+//     /* "":10375:10378   */
+//   0xeb
+//     /* "":10368:10385   */
+//   sstore
+//     /* "":10401:10404   */
+//   0xea
+//     /* "":10394:10411   */
+//   sstore
+//     /* "":10427:10430   */
+//   0xe9
+//     /* "":10420:10437   */
+//   sstore
+//     /* "":10453:10456   */
+//   0xe8
+//     /* "":10446:10463   */
+//   sstore
+//     /* "":10479:10482   */
+//   0xe7
+//     /* "":10472:10489   */
+//   sstore
+//     /* "":10505:10508   */
+//   0xe6
+//     /* "":10498:10515   */
+//   sstore
+//     /* "":10531:10534   */
+//   0xe5
+//     /* "":10524:10541   */
+//   sstore
+//     /* "":10557:10560   */
+//   0xe4
+//     /* "":10550:10567   */
+//   sstore
+//     /* "":10583:10586   */
+//   0xe3
+//     /* "":10576:10593   */
+//   sstore
+//     /* "":10609:10612   */
+//   0xe2
+//     /* "":10602:10619   */
+//   sstore
+//     /* "":10635:10638   */
+//   0xe1
+//     /* "":10628:10645   */
+//   sstore
+//     /* "":10661:10664   */
+//   0xe0
+//     /* "":10654:10671   */
+//   sstore
+//     /* "":10687:10690   */
+//   0xdf
+//     /* "":10680:10697   */
+//   sstore
+//     /* "":10713:10716   */
+//   0xde
+//     /* "":10706:10723   */
+//   sstore
+//     /* "":10739:10742   */
+//   0xdd
+//     /* "":10732:10749   */
+//   sstore
+//     /* "":10765:10768   */
+//   0xdc
+//     /* "":10758:10775   */
+//   sstore
+//     /* "":10791:10794   */
+//   0xdb
+//     /* "":10784:10801   */
+//   sstore
+//     /* "":10817:10820   */
+//   0xda
+//     /* "":10810:10827   */
+//   sstore
+//     /* "":10843:10846   */
+//   0xd9
+//     /* "":10836:10853   */
+//   sstore
+//     /* "":10869:10872   */
+//   0xd8
+//     /* "":10862:10879   */
+//   sstore
+//     /* "":10895:10898   */
+//   0xd7
+//     /* "":10888:10905   */
+//   sstore
+//     /* "":10921:10924   */
+//   0xd6
+//     /* "":10914:10931   */
+//   sstore
+//     /* "":10947:10950   */
+//   0xd5
+//     /* "":10940:10957   */
+//   sstore
+//     /* "":10973:10976   */
+//   0xd4
+//     /* "":10966:10983   */
+//   sstore
+//     /* "":10999:11002   */
+//   0xd3
+//     /* "":10992:11009   */
+//   sstore
+//     /* "":11025:11028   */
+//   0xd2
+//     /* "":11018:11035   */
+//   sstore
+//     /* "":11051:11054   */
+//   0xd1
+//     /* "":11044:11061   */
+//   sstore
+//     /* "":11077:11080   */
+//   0xd0
+//     /* "":11070:11087   */
+//   sstore
+//     /* "":11103:11106   */
+//   0xcf
+//     /* "":11096:11113   */
+//   sstore
+//     /* "":11129:11132   */
+//   0xce
+//     /* "":11122:11139   */
+//   sstore
+//     /* "":11155:11158   */
+//   0xcd
+//     /* "":11148:11165   */
+//   sstore
+//     /* "":11181:11184   */
+//   0xcc
+//     /* "":11174:11191   */
+//   sstore
+//     /* "":11207:11210   */
+//   0xcb
+//     /* "":11200:11217   */
+//   sstore
+//     /* "":11233:11236   */
+//   0xca
+//     /* "":11226:11243   */
+//   sstore
+//     /* "":11259:11262   */
+//   0xc9
+//     /* "":11252:11269   */
+//   sstore
+//     /* "":11285:11288   */
+//   0xc8
+//     /* "":11278:11295   */
+//   sstore
+//     /* "":11311:11314   */
+//   0xc7
+//     /* "":11304:11321   */
+//   sstore
+//     /* "":11337:11340   */
+//   0xc6
+//     /* "":11330:11347   */
+//   sstore
+//     /* "":11363:11366   */
+//   0xc5
+//     /* "":11356:11373   */
+//   sstore
+//     /* "":11389:11392   */
+//   0xc4
+//     /* "":11382:11399   */
+//   sstore
+//     /* "":11415:11418   */
+//   0xc3
+//     /* "":11408:11425   */
+//   sstore
+//     /* "":11441:11444   */
+//   0xc2
+//     /* "":11434:11451   */
+//   sstore
+//     /* "":11467:11470   */
+//   0xc1
+//     /* "":11460:11477   */
+//   sstore
+//     /* "":11493:11496   */
+//   0xc0
+//     /* "":11486:11503   */
+//   sstore
+//     /* "":11519:11522   */
+//   0xbf
+//     /* "":11512:11529   */
+//   sstore
+//     /* "":11545:11548   */
+//   0xbe
+//     /* "":11538:11555   */
+//   sstore
+//     /* "":11571:11574   */
+//   0xbd
+//     /* "":11564:11581   */
+//   sstore
+//     /* "":11597:11600   */
+//   0xbc
+//     /* "":11590:11607   */
+//   sstore
+//     /* "":11623:11626   */
+//   0xbb
+//     /* "":11616:11633   */
+//   sstore
+//     /* "":11649:11652   */
+//   0xba
+//     /* "":11642:11659   */
+//   sstore
+//     /* "":11675:11678   */
+//   0xb9
+//     /* "":11668:11685   */
+//   sstore
+//     /* "":11701:11704   */
+//   0xb8
+//     /* "":11694:11711   */
+//   sstore
+//     /* "":11727:11730   */
+//   0xb7
+//     /* "":11720:11737   */
+//   sstore
+//     /* "":11753:11756   */
+//   0xb6
+//     /* "":11746:11763   */
+//   sstore
+//     /* "":11779:11782   */
+//   0xb5
+//     /* "":11772:11789   */
+//   sstore
+//     /* "":11805:11808   */
+//   0xb4
+//     /* "":11798:11815   */
+//   sstore
+//     /* "":11831:11834   */
+//   0xb3
+//     /* "":11824:11841   */
+//   sstore
+//     /* "":11857:11860   */
+//   0xb2
+//     /* "":11850:11867   */
+//   sstore
+//     /* "":11883:11886   */
+//   0xb1
+//     /* "":11876:11893   */
+//   sstore
+//     /* "":11909:11912   */
+//   0xb0
+//     /* "":11902:11919   */
+//   sstore
+//     /* "":11935:11938   */
+//   0xaf
+//     /* "":11928:11945   */
+//   sstore
+//     /* "":11961:11964   */
+//   0xae
+//     /* "":11954:11971   */
+//   sstore
+//     /* "":11987:11990   */
+//   0xad
+//     /* "":11980:11997   */
+//   sstore
+//     /* "":12013:12016   */
+//   0xac
+//     /* "":12006:12023   */
+//   sstore
+//     /* "":12039:12042   */
+//   0xab
+//     /* "":12032:12049   */
+//   sstore
+//     /* "":12065:12068   */
+//   0xaa
+//     /* "":12058:12075   */
+//   sstore
+//     /* "":12091:12094   */
+//   0xa9
+//     /* "":12084:12101   */
+//   sstore
+//     /* "":12117:12120   */
+//   0xa8
+//     /* "":12110:12127   */
+//   sstore
+//     /* "":12143:12146   */
+//   0xa7
+//     /* "":12136:12153   */
+//   sstore
+//     /* "":12169:12172   */
+//   0xa6
+//     /* "":12162:12179   */
+//   sstore
+//     /* "":12195:12198   */
+//   0xa5
+//     /* "":12188:12205   */
+//   sstore
+//     /* "":12221:12224   */
+//   0xa4
+//     /* "":12214:12231   */
+//   sstore
+//     /* "":12247:12250   */
+//   0xa3
+//     /* "":12240:12257   */
+//   sstore
+//     /* "":12273:12276   */
+//   0xa2
+//     /* "":12266:12283   */
+//   sstore
+//     /* "":12299:12302   */
+//   0xa1
+//     /* "":12292:12309   */
+//   sstore
+//     /* "":12325:12328   */
+//   0xa0
+//     /* "":12318:12335   */
+//   sstore
+//     /* "":12351:12354   */
+//   0x9f
+//     /* "":12344:12361   */
+//   sstore
+//     /* "":12377:12380   */
+//   0x9e
+//     /* "":12370:12387   */
+//   sstore
+//     /* "":12403:12406   */
+//   0x9d
+//     /* "":12396:12413   */
+//   sstore
+//     /* "":12429:12432   */
+//   0x9c
+//     /* "":12422:12439   */
+//   sstore
+//     /* "":12455:12458   */
+//   0x9b
+//     /* "":12448:12465   */
+//   sstore
+//     /* "":12481:12484   */
+//   0x9a
+//     /* "":12474:12491   */
+//   sstore
+//     /* "":12507:12510   */
+//   0x99
+//     /* "":12500:12517   */
+//   sstore
+//     /* "":12533:12536   */
+//   0x98
+//     /* "":12526:12543   */
+//   sstore
+//     /* "":12559:12562   */
+//   0x97
+//     /* "":12552:12569   */
+//   sstore
+//     /* "":12585:12588   */
+//   0x96
+//     /* "":12578:12595   */
+//   sstore
+//     /* "":12611:12614   */
+//   0x95
+//     /* "":12604:12621   */
+//   sstore
+//     /* "":12637:12640   */
+//   0x94
+//     /* "":12630:12647   */
+//   sstore
+//     /* "":12663:12666   */
+//   0x93
+//     /* "":12656:12673   */
+//   sstore
+//     /* "":12689:12692   */
+//   0x92
+//     /* "":12682:12699   */
+//   sstore
+//     /* "":12715:12718   */
+//   0x91
+//     /* "":12708:12725   */
+//   sstore
+//     /* "":12741:12744   */
+//   0x90
+//     /* "":12734:12751   */
+//   sstore
+//     /* "":12767:12770   */
+//   0x8f
+//     /* "":12760:12777   */
+//   sstore
+//     /* "":12793:12796   */
+//   0x8e
+//     /* "":12786:12803   */
+//   sstore
+//     /* "":12819:12822   */
+//   0x8d
+//     /* "":12812:12829   */
+//   sstore
+//     /* "":12845:12848   */
+//   0x8c
+//     /* "":12838:12855   */
+//   sstore
+//     /* "":12871:12874   */
+//   0x8b
+//     /* "":12864:12881   */
+//   sstore
+//     /* "":12897:12900   */
+//   0x8a
+//     /* "":12890:12907   */
+//   sstore
+//     /* "":12923:12926   */
+//   0x89
+//     /* "":12916:12933   */
+//   sstore
+//     /* "":12949:12952   */
+//   0x88
+//     /* "":12942:12959   */
+//   sstore
+//     /* "":12975:12978   */
+//   0x87
+//     /* "":12968:12985   */
+//   sstore
+//     /* "":13001:13004   */
+//   0x86
+//     /* "":12994:13011   */
+//   sstore
+//     /* "":13027:13030   */
+//   0x85
+//     /* "":13020:13037   */
+//   sstore
+//     /* "":13053:13056   */
+//   0x84
+//     /* "":13046:13063   */
+//   sstore
+//     /* "":13079:13082   */
+//   0x83
+//     /* "":13072:13089   */
+//   sstore
+//     /* "":13105:13108   */
+//   0x82
+//     /* "":13098:13115   */
+//   sstore
+//     /* "":13131:13134   */
+//   0x81
+//     /* "":13124:13141   */
+//   sstore
+//     /* "":13157:13160   */
+//   0x80
+//     /* "":13150:13167   */
+//   sstore
+//     /* "":13183:13186   */
+//   0x7f
+//     /* "":13176:13193   */
+//   sstore
+//     /* "":13209:13212   */
+//   0x7e
+//     /* "":13202:13219   */
+//   sstore
+//     /* "":13235:13238   */
+//   0x7d
+//     /* "":13228:13245   */
+//   sstore
+//     /* "":13261:13264   */
+//   0x7c
+//     /* "":13254:13271   */
+//   sstore
+//     /* "":13287:13290   */
+//   0x7b
+//     /* "":13280:13297   */
+//   sstore
+//     /* "":13313:13316   */
+//   0x7a
+//     /* "":13306:13323   */
+//   sstore
+//     /* "":13339:13342   */
+//   0x79
+//     /* "":13332:13349   */
+//   sstore
+//     /* "":13365:13368   */
+//   0x78
+//     /* "":13358:13375   */
+//   sstore
+//     /* "":13391:13394   */
+//   0x77
+//     /* "":13384:13401   */
+//   sstore
+//     /* "":13417:13420   */
+//   0x76
+//     /* "":13410:13427   */
+//   sstore
+//     /* "":13443:13446   */
+//   0x75
+//     /* "":13436:13453   */
+//   sstore
+//     /* "":13469:13472   */
+//   0x74
+//     /* "":13462:13479   */
+//   sstore
+//     /* "":13495:13498   */
+//   0x73
+//     /* "":13488:13505   */
+//   sstore
+//     /* "":13521:13524   */
+//   0x72
+//     /* "":13514:13531   */
+//   sstore
+//     /* "":13547:13550   */
+//   0x71
+//     /* "":13540:13557   */
+//   sstore
+//     /* "":13573:13576   */
+//   0x70
+//     /* "":13566:13583   */
+//   sstore
+//     /* "":13599:13602   */
+//   0x6f
+//     /* "":13592:13609   */
+//   sstore
+//     /* "":13625:13628   */
+//   0x6e
+//     /* "":13618:13635   */
+//   sstore
+//     /* "":13651:13654   */
+//   0x6d
+//     /* "":13644:13661   */
+//   sstore
+//     /* "":13677:13680   */
+//   0x6c
+//     /* "":13670:13687   */
+//   sstore
+//     /* "":13703:13706   */
+//   0x6b
+//     /* "":13696:13713   */
+//   sstore
+//     /* "":13729:13732   */
+//   0x6a
+//     /* "":13722:13739   */
+//   sstore
+//     /* "":13755:13758   */
+//   0x69
+//     /* "":13748:13765   */
+//   sstore
+//     /* "":13781:13784   */
+//   0x68
+//     /* "":13774:13791   */
+//   sstore
+//     /* "":13807:13810   */
+//   0x67
+//     /* "":13800:13817   */
+//   sstore
+//     /* "":13833:13836   */
+//   0x66
+//     /* "":13826:13843   */
+//   sstore
+//     /* "":13859:13862   */
+//   0x65
+//     /* "":13852:13869   */
+//   sstore
+//     /* "":13885:13888   */
+//   0x64
+//     /* "":13878:13895   */
+//   sstore
+//     /* "":13911:13913   */
+//   0x63
+//     /* "":13904:13919   */
+//   sstore
+//     /* "":13935:13937   */
+//   0x62
+//     /* "":13928:13943   */
+//   sstore
+//     /* "":13959:13961   */
+//   0x61
+//     /* "":13952:13967   */
+//   sstore
+//     /* "":13983:13985   */
+//   0x60
+//     /* "":13976:13991   */
+//   sstore
+//     /* "":14007:14009   */
+//   0x5f
+//     /* "":14000:14015   */
+//   sstore
+//     /* "":14031:14033   */
+//   0x5e
+//     /* "":14024:14039   */
+//   sstore
+//     /* "":14055:14057   */
+//   0x5d
+//     /* "":14048:14063   */
+//   sstore
+//     /* "":14079:14081   */
+//   0x5c
+//     /* "":14072:14087   */
+//   sstore
+//     /* "":14103:14105   */
+//   0x5b
+//     /* "":14096:14111   */
+//   sstore
+//     /* "":14127:14129   */
+//   0x5a
+//     /* "":14120:14135   */
+//   sstore
+//     /* "":14151:14153   */
+//   0x59
+//     /* "":14144:14159   */
+//   sstore
+//     /* "":14175:14177   */
+//   0x58
+//     /* "":14168:14183   */
+//   sstore
+//     /* "":14199:14201   */
+//   0x57
+//     /* "":14192:14207   */
+//   sstore
+//     /* "":14223:14225   */
+//   0x56
+//     /* "":14216:14231   */
+//   sstore
+//     /* "":14247:14249   */
+//   0x55
+//     /* "":14240:14255   */
+//   sstore
+//     /* "":14271:14273   */
+//   0x54
+//     /* "":14264:14279   */
+//   sstore
+//     /* "":14295:14297   */
+//   0x53
+//     /* "":14288:14303   */
+//   sstore
+//     /* "":14319:14321   */
+//   0x52
+//     /* "":14312:14327   */
+//   sstore
+//     /* "":14343:14345   */
+//   0x51
+//     /* "":14336:14351   */
+//   sstore
+//     /* "":14367:14369   */
+//   0x50
+//     /* "":14360:14375   */
+//   sstore
+//     /* "":14391:14393   */
+//   0x4f
+//     /* "":14384:14399   */
+//   sstore
+//     /* "":14415:14417   */
+//   0x4e
+//     /* "":14408:14423   */
+//   sstore
+//     /* "":14439:14441   */
+//   0x4d
+//     /* "":14432:14447   */
+//   sstore
+//     /* "":14463:14465   */
+//   0x4c
+//     /* "":14456:14471   */
+//   sstore
+//     /* "":14487:14489   */
+//   0x4b
+//     /* "":14480:14495   */
+//   sstore
+//     /* "":14511:14513   */
+//   0x4a
+//     /* "":14504:14519   */
+//   sstore
+//     /* "":14535:14537   */
+//   0x49
+//     /* "":14528:14543   */
+//   sstore
+//     /* "":14559:14561   */
+//   0x48
+//     /* "":14552:14567   */
+//   sstore
+//     /* "":14583:14585   */
+//   0x47
+//     /* "":14576:14591   */
+//   sstore
+//     /* "":14607:14609   */
+//   0x46
+//     /* "":14600:14615   */
+//   sstore
+//     /* "":14631:14633   */
+//   0x45
+//     /* "":14624:14639   */
+//   sstore
+//     /* "":14655:14657   */
+//   0x44
+//     /* "":14648:14663   */
+//   sstore
+//     /* "":14679:14681   */
+//   0x43
+//     /* "":14672:14687   */
+//   sstore
+//     /* "":14703:14705   */
+//   0x42
+//     /* "":14696:14711   */
+//   sstore
+//     /* "":14727:14729   */
+//   0x41
+//     /* "":14720:14735   */
+//   sstore
+//     /* "":14751:14753   */
+//   0x40
+//     /* "":14744:14759   */
+//   sstore
+//     /* "":14775:14777   */
+//   0x3f
+//     /* "":14768:14783   */
+//   sstore
+//     /* "":14799:14801   */
+//   0x3e
+//     /* "":14792:14807   */
+//   sstore
+//     /* "":14823:14825   */
+//   0x3d
+//     /* "":14816:14831   */
+//   sstore
+//     /* "":14847:14849   */
+//   0x3c
+//     /* "":14840:14855   */
+//   sstore
+//     /* "":14871:14873   */
+//   0x3b
+//     /* "":14864:14879   */
+//   sstore
+//     /* "":14895:14897   */
+//   0x3a
+//     /* "":14888:14903   */
+//   sstore
+//     /* "":14919:14921   */
+//   0x39
+//     /* "":14912:14927   */
+//   sstore
+//     /* "":14943:14945   */
+//   0x38
+//     /* "":14936:14951   */
+//   sstore
+//     /* "":14967:14969   */
+//   0x37
+//     /* "":14960:14975   */
+//   sstore
+//     /* "":14991:14993   */
+//   0x36
+//     /* "":14984:14999   */
+//   sstore
+//     /* "":15015:15017   */
+//   0x35
+//     /* "":15008:15023   */
+//   sstore
+//     /* "":15039:15041   */
+//   0x34
+//     /* "":15032:15047   */
+//   sstore
+//     /* "":15063:15065   */
+//   0x33
+//     /* "":15056:15071   */
+//   sstore
+//     /* "":15087:15089   */
+//   0x32
+//     /* "":15080:15095   */
+//   sstore
+//     /* "":15111:15113   */
+//   0x31
+//     /* "":15104:15119   */
+//   sstore
+//     /* "":15135:15137   */
+//   0x30
+//     /* "":15128:15143   */
+//   sstore
+//     /* "":15159:15161   */
+//   0x2f
+//     /* "":15152:15167   */
+//   sstore
+//     /* "":15183:15185   */
+//   0x2e
+//     /* "":15176:15191   */
+//   sstore
+//     /* "":15207:15209   */
+//   0x2d
+//     /* "":15200:15215   */
+//   sstore
+//     /* "":15231:15233   */
+//   0x2c
+//     /* "":15224:15239   */
+//   sstore
+//     /* "":15255:15257   */
+//   0x2b
+//     /* "":15248:15263   */
+//   sstore
+//     /* "":15279:15281   */
+//   0x2a
+//     /* "":15272:15287   */
+//   sstore
+//     /* "":15303:15305   */
+//   0x29
+//     /* "":15296:15311   */
+//   sstore
+//     /* "":15327:15329   */
+//   0x28
+//     /* "":15320:15335   */
+//   sstore
+//     /* "":15351:15353   */
+//   0x27
+//     /* "":15344:15359   */
+//   sstore
+//     /* "":15375:15377   */
+//   0x26
+//     /* "":15368:15383   */
+//   sstore
+//     /* "":15399:15401   */
+//   0x25
+//     /* "":15392:15407   */
+//   sstore
+//     /* "":15423:15425   */
+//   0x24
+//     /* "":15416:15431   */
+//   sstore
+//     /* "":15447:15449   */
+//   0x23
+//     /* "":15440:15455   */
+//   sstore
+//     /* "":15471:15473   */
+//   0x22
+//     /* "":15464:15479   */
+//   sstore
+//     /* "":15495:15497   */
+//   0x21
+//     /* "":15488:15503   */
+//   sstore
+//     /* "":15519:15521   */
+//   0x20
+//     /* "":15512:15527   */
+//   sstore
+//     /* "":15543:15545   */
+//   0x1f
+//     /* "":15536:15551   */
+//   sstore
+//     /* "":15567:15569   */
+//   0x1e
+//     /* "":15560:15575   */
+//   sstore
+//     /* "":15591:15593   */
+//   0x1d
+//     /* "":15584:15599   */
+//   sstore
+//     /* "":15615:15617   */
+//   0x1c
+//     /* "":15608:15623   */
+//   sstore
+//     /* "":15639:15641   */
+//   0x1b
+//     /* "":15632:15647   */
+//   sstore
+//     /* "":15663:15665   */
+//   0x1a
+//     /* "":15656:15671   */
+//   sstore
+//     /* "":15687:15689   */
+//   0x19
+//     /* "":15680:15695   */
+//   sstore
+//     /* "":15711:15713   */
+//   0x18
+//     /* "":15704:15719   */
+//   sstore
+//     /* "":15735:15737   */
+//   0x17
+//     /* "":15728:15743   */
+//   sstore
+//     /* "":15759:15761   */
+//   0x16
+//     /* "":15752:15767   */
+//   sstore
+//     /* "":15783:15785   */
+//   0x15
+//     /* "":15776:15791   */
+//   sstore
+//     /* "":15807:15809   */
+//   0x14
+//     /* "":15800:15815   */
+//   sstore
+//     /* "":15831:15833   */
+//   0x13
+//     /* "":15824:15839   */
+//   sstore
+//     /* "":15855:15857   */
+//   0x12
+//     /* "":15848:15863   */
+//   sstore
+//     /* "":15879:15881   */
+//   0x11
+//     /* "":15872:15887   */
+//   sstore
+//     /* "":15903:15905   */
+//   0x10
+//     /* "":15896:15911   */
+//   sstore
+//     /* "":15927:15929   */
+//   0x0f
+//     /* "":15920:15935   */
+//   sstore
+//     /* "":15951:15953   */
+//   0x0e
+//     /* "":15944:15959   */
+//   sstore
+//     /* "":15975:15977   */
+//   0x0d
+//     /* "":15968:15983   */
+//   sstore
+//     /* "":15999:16001   */
+//   0x0c
+//     /* "":15992:16007   */
+//   sstore
+//     /* "":16023:16025   */
+//   0x0b
+//     /* "":16016:16031   */
+//   sstore
+//     /* "":16047:16049   */
+//   0x0a
+//     /* "":16040:16055   */
+//   sstore
+//     /* "":16071:16072   */
+//   0x09
+//     /* "":16064:16077   */
+//   sstore
+//     /* "":16093:16094   */
+//   0x08
+//     /* "":16086:16099   */
+//   sstore
+//     /* "":16115:16116   */
+//   0x07
+//     /* "":16108:16121   */
+//   sstore
+//     /* "":16137:16138   */
+//   0x06
+//     /* "":16130:16143   */
+//   sstore
+//     /* "":16159:16160   */
+//   0x05
+//     /* "":16152:16165   */
+//   sstore
+//     /* "":16181:16182   */
+//   0x04
+//     /* "":16174:16187   */
+//   sstore
+//     /* "":16203:16204   */
+//   0x03
+//     /* "":16196:16209   */
+//   sstore
+//     /* "":16225:16226   */
+//   0x02
+//     /* "":16218:16231   */
+//   sstore
+//     /* "":16247:16248   */
+//   0x01
+//     /* "":16240:16253   */
+//   sstore
+//     /* "":16269:16270   */
+//   0x00
+//     /* "":16262:16275   */
+//   sstore
+//     /* "":25:16281   */
+//   stop
+//     /* "":9800:9815   */
+// tag_1:
+//     /* "":9811:9812   */
+//   0x00
+//     /* "":9802:9813   */
+//   dup1
+//   revert

--- a/test/libyul/evmCodeTransform/eof_swap17.yul
+++ b/test/libyul/evmCodeTransform/eof_swap17.yul
@@ -1,0 +1,229 @@
+object "main" {
+	code {
+        // v17 is 17 slots deep in stack - all values in between are still needed - no way to avoid a swapn{17}.
+        // Running this without EOF, as expected, throws stack-too-deep.
+        function f(v00, v01, v02, v03, v04, v05, v06, v07, v08, v09, v10, v11, v12, v13, v14, v15, v16, v17) {
+            sstore(17, v17)
+            sstore(16, v16)
+            sstore(15, v15)
+            sstore(14, v14)
+            sstore(13, v13)
+            sstore(12, v12)
+            sstore(11, v11)
+            sstore(10, v10)
+            sstore(9, v09)
+            sstore(8, v08)
+            sstore(7, v07)
+            sstore(6, v06)
+            sstore(5, v05)
+            sstore(4, v04)
+            sstore(3, v03)
+            sstore(2, v02)
+            sstore(1, v01)
+            sstore(0, v00)
+        }
+        f(
+            calldataload(0),
+            calldataload(1),
+            calldataload(2),
+            calldataload(3),
+            calldataload(4),
+            calldataload(5),
+            calldataload(6),
+            calldataload(7),
+            calldataload(8),
+            calldataload(9),
+            calldataload(10),
+            calldataload(11),
+            calldataload(12),
+            calldataload(13),
+            calldataload(14),
+            calldataload(15),
+            calldataload(16),
+            calldataload(17)
+        )
+	}
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// stackOptimization: true
+// ----
+//     /* "":1361:1363   */
+//   0x11
+//     /* "":1348:1364   */
+//   calldataload
+//     /* "":1331:1333   */
+//   0x10
+//     /* "":1318:1334   */
+//   calldataload
+//     /* "":1301:1303   */
+//   0x0f
+//     /* "":1288:1304   */
+//   calldataload
+//     /* "":1271:1273   */
+//   0x0e
+//     /* "":1258:1274   */
+//   calldataload
+//     /* "":1241:1243   */
+//   0x0d
+//     /* "":1228:1244   */
+//   calldataload
+//     /* "":1211:1213   */
+//   0x0c
+//     /* "":1198:1214   */
+//   calldataload
+//     /* "":1181:1183   */
+//   0x0b
+//     /* "":1168:1184   */
+//   calldataload
+//     /* "":1151:1153   */
+//   0x0a
+//     /* "":1138:1154   */
+//   calldataload
+//     /* "":1122:1123   */
+//   0x09
+//     /* "":1109:1124   */
+//   calldataload
+//     /* "":1093:1094   */
+//   0x08
+//     /* "":1080:1095   */
+//   calldataload
+//     /* "":1064:1065   */
+//   0x07
+//     /* "":1051:1066   */
+//   calldataload
+//     /* "":1035:1036   */
+//   0x06
+//     /* "":1022:1037   */
+//   calldataload
+//     /* "":1006:1007   */
+//   0x05
+//     /* "":993:1008   */
+//   calldataload
+//     /* "":977:978   */
+//   0x04
+//     /* "":964:979   */
+//   calldataload
+//     /* "":948:949   */
+//   0x03
+//     /* "":935:950   */
+//   calldataload
+//     /* "":919:920   */
+//   0x02
+//     /* "":906:921   */
+//   calldataload
+//     /* "":890:891   */
+//   0x01
+//     /* "":877:892   */
+//   calldataload
+//     /* "":861:862   */
+//   0x00
+//     /* "":848:863   */
+//   calldataload
+//     /* "":833:1374   */
+//   callf{code_section_1}
+//     /* "":22:1377   */
+//   stop
+//
+// code_section_1: assembly {
+//         /* "":218:824   */
+//       swapn{17}
+//       swap16
+//       swap1
+//       swap16
+//       swap15
+//       swap2
+//       swap15
+//       swap14
+//       swap3
+//       swap14
+//       swap13
+//       swap4
+//       swap13
+//       swap12
+//       swap5
+//       swap12
+//       swap11
+//       swap6
+//       swap11
+//       swap10
+//       swap7
+//       swap10
+//       swap9
+//       swap8
+//       swap9
+//         /* "":340:342   */
+//       0x11
+//         /* "":333:348   */
+//       sstore
+//         /* "":368:370   */
+//       0x10
+//         /* "":361:376   */
+//       sstore
+//         /* "":396:398   */
+//       0x0f
+//         /* "":389:404   */
+//       sstore
+//         /* "":424:426   */
+//       0x0e
+//         /* "":417:432   */
+//       sstore
+//         /* "":452:454   */
+//       0x0d
+//         /* "":445:460   */
+//       sstore
+//         /* "":480:482   */
+//       0x0c
+//         /* "":473:488   */
+//       sstore
+//         /* "":508:510   */
+//       0x0b
+//         /* "":501:516   */
+//       sstore
+//         /* "":536:538   */
+//       0x0a
+//         /* "":529:544   */
+//       sstore
+//         /* "":564:565   */
+//       0x09
+//         /* "":557:571   */
+//       sstore
+//         /* "":591:592   */
+//       0x08
+//         /* "":584:598   */
+//       sstore
+//         /* "":618:619   */
+//       0x07
+//         /* "":611:625   */
+//       sstore
+//         /* "":645:646   */
+//       0x06
+//         /* "":638:652   */
+//       sstore
+//         /* "":672:673   */
+//       0x05
+//         /* "":665:679   */
+//       sstore
+//         /* "":699:700   */
+//       0x04
+//         /* "":692:706   */
+//       sstore
+//         /* "":726:727   */
+//       0x03
+//         /* "":719:733   */
+//       sstore
+//         /* "":753:754   */
+//       0x02
+//         /* "":746:760   */
+//       sstore
+//         /* "":780:781   */
+//       0x01
+//         /* "":773:787   */
+//       sstore
+//         /* "":807:808   */
+//       0x00
+//         /* "":800:814   */
+//       sstore
+//         /* "":218:824   */
+//       retf
+// }

--- a/test/libyul/evmCodeTransform/eof_swap256.yul
+++ b/test/libyul/evmCodeTransform/eof_swap256.yul
@@ -1,0 +1,2839 @@
+object "main" {
+    code {
+        // Triggers a swapn{256}. Generating one more variable results in a stack-too-deep.
+        // Note that this relies on not running the optimizer here. With optimizer this code
+        // can become entirely swap-free.
+        let v0 := calldataload(0)
+        let v1 := calldataload(1)
+        let v2 := calldataload(2)
+        let v3 := calldataload(3)
+        let v4 := calldataload(4)
+        let v5 := calldataload(5)
+        let v6 := calldataload(6)
+        let v7 := calldataload(7)
+        let v8 := calldataload(8)
+        let v9 := calldataload(9)
+        let v10 := calldataload(10)
+        let v11 := calldataload(11)
+        let v12 := calldataload(12)
+        let v13 := calldataload(13)
+        let v14 := calldataload(14)
+        let v15 := calldataload(15)
+        let v16 := calldataload(16)
+        let v17 := calldataload(17)
+        let v18 := calldataload(18)
+        let v19 := calldataload(19)
+        let v20 := calldataload(20)
+        let v21 := calldataload(21)
+        let v22 := calldataload(22)
+        let v23 := calldataload(23)
+        let v24 := calldataload(24)
+        let v25 := calldataload(25)
+        let v26 := calldataload(26)
+        let v27 := calldataload(27)
+        let v28 := calldataload(28)
+        let v29 := calldataload(29)
+        let v30 := calldataload(30)
+        let v31 := calldataload(31)
+        let v32 := calldataload(32)
+        let v33 := calldataload(33)
+        let v34 := calldataload(34)
+        let v35 := calldataload(35)
+        let v36 := calldataload(36)
+        let v37 := calldataload(37)
+        let v38 := calldataload(38)
+        let v39 := calldataload(39)
+        let v40 := calldataload(40)
+        let v41 := calldataload(41)
+        let v42 := calldataload(42)
+        let v43 := calldataload(43)
+        let v44 := calldataload(44)
+        let v45 := calldataload(45)
+        let v46 := calldataload(46)
+        let v47 := calldataload(47)
+        let v48 := calldataload(48)
+        let v49 := calldataload(49)
+        let v50 := calldataload(50)
+        let v51 := calldataload(51)
+        let v52 := calldataload(52)
+        let v53 := calldataload(53)
+        let v54 := calldataload(54)
+        let v55 := calldataload(55)
+        let v56 := calldataload(56)
+        let v57 := calldataload(57)
+        let v58 := calldataload(58)
+        let v59 := calldataload(59)
+        let v60 := calldataload(60)
+        let v61 := calldataload(61)
+        let v62 := calldataload(62)
+        let v63 := calldataload(63)
+        let v64 := calldataload(64)
+        let v65 := calldataload(65)
+        let v66 := calldataload(66)
+        let v67 := calldataload(67)
+        let v68 := calldataload(68)
+        let v69 := calldataload(69)
+        let v70 := calldataload(70)
+        let v71 := calldataload(71)
+        let v72 := calldataload(72)
+        let v73 := calldataload(73)
+        let v74 := calldataload(74)
+        let v75 := calldataload(75)
+        let v76 := calldataload(76)
+        let v77 := calldataload(77)
+        let v78 := calldataload(78)
+        let v79 := calldataload(79)
+        let v80 := calldataload(80)
+        let v81 := calldataload(81)
+        let v82 := calldataload(82)
+        let v83 := calldataload(83)
+        let v84 := calldataload(84)
+        let v85 := calldataload(85)
+        let v86 := calldataload(86)
+        let v87 := calldataload(87)
+        let v88 := calldataload(88)
+        let v89 := calldataload(89)
+        let v90 := calldataload(90)
+        let v91 := calldataload(91)
+        let v92 := calldataload(92)
+        let v93 := calldataload(93)
+        let v94 := calldataload(94)
+        let v95 := calldataload(95)
+        let v96 := calldataload(96)
+        let v97 := calldataload(97)
+        let v98 := calldataload(98)
+        let v99 := calldataload(99)
+        let v100 := calldataload(100)
+        let v101 := calldataload(101)
+        let v102 := calldataload(102)
+        let v103 := calldataload(103)
+        let v104 := calldataload(104)
+        let v105 := calldataload(105)
+        let v106 := calldataload(106)
+        let v107 := calldataload(107)
+        let v108 := calldataload(108)
+        let v109 := calldataload(109)
+        let v110 := calldataload(110)
+        let v111 := calldataload(111)
+        let v112 := calldataload(112)
+        let v113 := calldataload(113)
+        let v114 := calldataload(114)
+        let v115 := calldataload(115)
+        let v116 := calldataload(116)
+        let v117 := calldataload(117)
+        let v118 := calldataload(118)
+        let v119 := calldataload(119)
+        let v120 := calldataload(120)
+        let v121 := calldataload(121)
+        let v122 := calldataload(122)
+        let v123 := calldataload(123)
+        let v124 := calldataload(124)
+        let v125 := calldataload(125)
+        let v126 := calldataload(126)
+        let v127 := calldataload(127)
+        let v128 := calldataload(128)
+        let v129 := calldataload(129)
+        let v130 := calldataload(130)
+        let v131 := calldataload(131)
+        let v132 := calldataload(132)
+        let v133 := calldataload(133)
+        let v134 := calldataload(134)
+        let v135 := calldataload(135)
+        let v136 := calldataload(136)
+        let v137 := calldataload(137)
+        let v138 := calldataload(138)
+        let v139 := calldataload(139)
+        let v140 := calldataload(140)
+        let v141 := calldataload(141)
+        let v142 := calldataload(142)
+        let v143 := calldataload(143)
+        let v144 := calldataload(144)
+        let v145 := calldataload(145)
+        let v146 := calldataload(146)
+        let v147 := calldataload(147)
+        let v148 := calldataload(148)
+        let v149 := calldataload(149)
+        let v150 := calldataload(150)
+        let v151 := calldataload(151)
+        let v152 := calldataload(152)
+        let v153 := calldataload(153)
+        let v154 := calldataload(154)
+        let v155 := calldataload(155)
+        let v156 := calldataload(156)
+        let v157 := calldataload(157)
+        let v158 := calldataload(158)
+        let v159 := calldataload(159)
+        let v160 := calldataload(160)
+        let v161 := calldataload(161)
+        let v162 := calldataload(162)
+        let v163 := calldataload(163)
+        let v164 := calldataload(164)
+        let v165 := calldataload(165)
+        let v166 := calldataload(166)
+        let v167 := calldataload(167)
+        let v168 := calldataload(168)
+        let v169 := calldataload(169)
+        let v170 := calldataload(170)
+        let v171 := calldataload(171)
+        let v172 := calldataload(172)
+        let v173 := calldataload(173)
+        let v174 := calldataload(174)
+        let v175 := calldataload(175)
+        let v176 := calldataload(176)
+        let v177 := calldataload(177)
+        let v178 := calldataload(178)
+        let v179 := calldataload(179)
+        let v180 := calldataload(180)
+        let v181 := calldataload(181)
+        let v182 := calldataload(182)
+        let v183 := calldataload(183)
+        let v184 := calldataload(184)
+        let v185 := calldataload(185)
+        let v186 := calldataload(186)
+        let v187 := calldataload(187)
+        let v188 := calldataload(188)
+        let v189 := calldataload(189)
+        let v190 := calldataload(190)
+        let v191 := calldataload(191)
+        let v192 := calldataload(192)
+        let v193 := calldataload(193)
+        let v194 := calldataload(194)
+        let v195 := calldataload(195)
+        let v196 := calldataload(196)
+        let v197 := calldataload(197)
+        let v198 := calldataload(198)
+        let v199 := calldataload(199)
+        let v200 := calldataload(200)
+        let v201 := calldataload(201)
+        let v202 := calldataload(202)
+        let v203 := calldataload(203)
+        let v204 := calldataload(204)
+        let v205 := calldataload(205)
+        let v206 := calldataload(206)
+        let v207 := calldataload(207)
+        let v208 := calldataload(208)
+        let v209 := calldataload(209)
+        let v210 := calldataload(210)
+        let v211 := calldataload(211)
+        let v212 := calldataload(212)
+        let v213 := calldataload(213)
+        let v214 := calldataload(214)
+        let v215 := calldataload(215)
+        let v216 := calldataload(216)
+        let v217 := calldataload(217)
+        let v218 := calldataload(218)
+        let v219 := calldataload(219)
+        let v220 := calldataload(220)
+        let v221 := calldataload(221)
+        let v222 := calldataload(222)
+        let v223 := calldataload(223)
+        let v224 := calldataload(224)
+        let v225 := calldataload(225)
+        let v226 := calldataload(226)
+        let v227 := calldataload(227)
+        let v228 := calldataload(228)
+        let v229 := calldataload(229)
+        let v230 := calldataload(230)
+        let v231 := calldataload(231)
+        let v232 := calldataload(232)
+        let v233 := calldataload(233)
+        let v234 := calldataload(234)
+        let v235 := calldataload(235)
+        let v236 := calldataload(236)
+        let v237 := calldataload(237)
+        let v238 := calldataload(238)
+        let v239 := calldataload(239)
+        let v240 := calldataload(240)
+        let v241 := calldataload(241)
+        let v242 := calldataload(242)
+        let v243 := calldataload(243)
+        let v244 := calldataload(244)
+        let v245 := calldataload(245)
+        let v246 := calldataload(246)
+        let v247 := calldataload(247)
+        let v248 := calldataload(248)
+        let v249 := calldataload(249)
+        let v250 := calldataload(250)
+        let v251 := calldataload(251)
+        let v252 := calldataload(252)
+        let v253 := calldataload(253)
+        let v254 := calldataload(254)
+        let v255 := calldataload(255)
+        let v256 := calldataload(256)
+        sstore(0, v0)
+        sstore(1, v1)
+        sstore(2, v2)
+        sstore(3, v3)
+        sstore(4, v4)
+        sstore(5, v5)
+        sstore(6, v6)
+        sstore(7, v7)
+        sstore(8, v8)
+        sstore(9, v9)
+        sstore(10, v10)
+        sstore(11, v11)
+        sstore(12, v12)
+        sstore(13, v13)
+        sstore(14, v14)
+        sstore(15, v15)
+        sstore(16, v16)
+        sstore(17, v17)
+        sstore(18, v18)
+        sstore(19, v19)
+        sstore(20, v20)
+        sstore(21, v21)
+        sstore(22, v22)
+        sstore(23, v23)
+        sstore(24, v24)
+        sstore(25, v25)
+        sstore(26, v26)
+        sstore(27, v27)
+        sstore(28, v28)
+        sstore(29, v29)
+        sstore(30, v30)
+        sstore(31, v31)
+        sstore(32, v32)
+        sstore(33, v33)
+        sstore(34, v34)
+        sstore(35, v35)
+        sstore(36, v36)
+        sstore(37, v37)
+        sstore(38, v38)
+        sstore(39, v39)
+        sstore(40, v40)
+        sstore(41, v41)
+        sstore(42, v42)
+        sstore(43, v43)
+        sstore(44, v44)
+        sstore(45, v45)
+        sstore(46, v46)
+        sstore(47, v47)
+        sstore(48, v48)
+        sstore(49, v49)
+        sstore(50, v50)
+        sstore(51, v51)
+        sstore(52, v52)
+        sstore(53, v53)
+        sstore(54, v54)
+        sstore(55, v55)
+        sstore(56, v56)
+        sstore(57, v57)
+        sstore(58, v58)
+        sstore(59, v59)
+        sstore(60, v60)
+        sstore(61, v61)
+        sstore(62, v62)
+        sstore(63, v63)
+        sstore(64, v64)
+        sstore(65, v65)
+        sstore(66, v66)
+        sstore(67, v67)
+        sstore(68, v68)
+        sstore(69, v69)
+        sstore(70, v70)
+        sstore(71, v71)
+        sstore(72, v72)
+        sstore(73, v73)
+        sstore(74, v74)
+        sstore(75, v75)
+        sstore(76, v76)
+        sstore(77, v77)
+        sstore(78, v78)
+        sstore(79, v79)
+        sstore(80, v80)
+        sstore(81, v81)
+        sstore(82, v82)
+        sstore(83, v83)
+        sstore(84, v84)
+        sstore(85, v85)
+        sstore(86, v86)
+        sstore(87, v87)
+        sstore(88, v88)
+        sstore(89, v89)
+        sstore(90, v90)
+        sstore(91, v91)
+        sstore(92, v92)
+        sstore(93, v93)
+        sstore(94, v94)
+        sstore(95, v95)
+        sstore(96, v96)
+        sstore(97, v97)
+        sstore(98, v98)
+        sstore(99, v99)
+        sstore(100, v100)
+        sstore(101, v101)
+        sstore(102, v102)
+        sstore(103, v103)
+        sstore(104, v104)
+        sstore(105, v105)
+        sstore(106, v106)
+        sstore(107, v107)
+        sstore(108, v108)
+        sstore(109, v109)
+        sstore(110, v110)
+        sstore(111, v111)
+        sstore(112, v112)
+        sstore(113, v113)
+        sstore(114, v114)
+        sstore(115, v115)
+        sstore(116, v116)
+        sstore(117, v117)
+        sstore(118, v118)
+        sstore(119, v119)
+        sstore(120, v120)
+        sstore(121, v121)
+        sstore(122, v122)
+        sstore(123, v123)
+        sstore(124, v124)
+        sstore(125, v125)
+        sstore(126, v126)
+        sstore(127, v127)
+        sstore(128, v128)
+        sstore(129, v129)
+        sstore(130, v130)
+        sstore(131, v131)
+        sstore(132, v132)
+        sstore(133, v133)
+        sstore(134, v134)
+        sstore(135, v135)
+        sstore(136, v136)
+        sstore(137, v137)
+        sstore(138, v138)
+        sstore(139, v139)
+        sstore(140, v140)
+        sstore(141, v141)
+        sstore(142, v142)
+        sstore(143, v143)
+        sstore(144, v144)
+        sstore(145, v145)
+        sstore(146, v146)
+        sstore(147, v147)
+        sstore(148, v148)
+        sstore(149, v149)
+        sstore(150, v150)
+        sstore(151, v151)
+        sstore(152, v152)
+        sstore(153, v153)
+        sstore(154, v154)
+        sstore(155, v155)
+        sstore(156, v156)
+        sstore(157, v157)
+        sstore(158, v158)
+        sstore(159, v159)
+        sstore(160, v160)
+        sstore(161, v161)
+        sstore(162, v162)
+        sstore(163, v163)
+        sstore(164, v164)
+        sstore(165, v165)
+        sstore(166, v166)
+        sstore(167, v167)
+        sstore(168, v168)
+        sstore(169, v169)
+        sstore(170, v170)
+        sstore(171, v171)
+        sstore(172, v172)
+        sstore(173, v173)
+        sstore(174, v174)
+        sstore(175, v175)
+        sstore(176, v176)
+        sstore(177, v177)
+        sstore(178, v178)
+        sstore(179, v179)
+        sstore(180, v180)
+        sstore(181, v181)
+        sstore(182, v182)
+        sstore(183, v183)
+        sstore(184, v184)
+        sstore(185, v185)
+        sstore(186, v186)
+        sstore(187, v187)
+        sstore(188, v188)
+        sstore(189, v189)
+        sstore(190, v190)
+        sstore(191, v191)
+        sstore(192, v192)
+        sstore(193, v193)
+        sstore(194, v194)
+        sstore(195, v195)
+        sstore(196, v196)
+        sstore(197, v197)
+        sstore(198, v198)
+        sstore(199, v199)
+        sstore(200, v200)
+        sstore(201, v201)
+        sstore(202, v202)
+        sstore(203, v203)
+        sstore(204, v204)
+        sstore(205, v205)
+        sstore(206, v206)
+        sstore(207, v207)
+        sstore(208, v208)
+        sstore(209, v209)
+        sstore(210, v210)
+        sstore(211, v211)
+        sstore(212, v212)
+        sstore(213, v213)
+        sstore(214, v214)
+        sstore(215, v215)
+        sstore(216, v216)
+        sstore(217, v217)
+        sstore(218, v218)
+        sstore(219, v219)
+        sstore(220, v220)
+        sstore(221, v221)
+        sstore(222, v222)
+        sstore(223, v223)
+        sstore(224, v224)
+        sstore(225, v225)
+        sstore(226, v226)
+        sstore(227, v227)
+        sstore(228, v228)
+        sstore(229, v229)
+        sstore(230, v230)
+        sstore(231, v231)
+        sstore(232, v232)
+        sstore(233, v233)
+        sstore(234, v234)
+        sstore(235, v235)
+        sstore(236, v236)
+        sstore(237, v237)
+        sstore(238, v238)
+        sstore(239, v239)
+        sstore(240, v240)
+        sstore(241, v241)
+        sstore(242, v242)
+        sstore(243, v243)
+        sstore(244, v244)
+        sstore(245, v245)
+        sstore(246, v246)
+        sstore(247, v247)
+        sstore(248, v248)
+        sstore(249, v249)
+        sstore(250, v250)
+        sstore(251, v251)
+        sstore(252, v252)
+        sstore(253, v253)
+        sstore(254, v254)
+        sstore(255, v255)
+        sstore(256, v256)
+    }
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// stackOptimization: true
+// ----
+//     /* "":285:286   */
+//   0x00
+//     /* "":272:287   */
+//   calldataload
+//     /* "":319:320   */
+//   0x01
+//     /* "":306:321   */
+//   calldataload
+//     /* "":353:354   */
+//   0x02
+//     /* "":340:355   */
+//   calldataload
+//     /* "":387:388   */
+//   0x03
+//     /* "":374:389   */
+//   calldataload
+//     /* "":421:422   */
+//   0x04
+//     /* "":408:423   */
+//   calldataload
+//     /* "":455:456   */
+//   0x05
+//     /* "":442:457   */
+//   calldataload
+//     /* "":489:490   */
+//   0x06
+//     /* "":476:491   */
+//   calldataload
+//     /* "":523:524   */
+//   0x07
+//     /* "":510:525   */
+//   calldataload
+//     /* "":557:558   */
+//   0x08
+//     /* "":544:559   */
+//   calldataload
+//     /* "":591:592   */
+//   0x09
+//     /* "":578:593   */
+//   calldataload
+//     /* "":626:628   */
+//   0x0a
+//     /* "":613:629   */
+//   calldataload
+//     /* "":662:664   */
+//   0x0b
+//     /* "":649:665   */
+//   calldataload
+//     /* "":698:700   */
+//   0x0c
+//     /* "":685:701   */
+//   calldataload
+//     /* "":734:736   */
+//   0x0d
+//     /* "":721:737   */
+//   calldataload
+//     /* "":770:772   */
+//   0x0e
+//     /* "":757:773   */
+//   calldataload
+//     /* "":806:808   */
+//   0x0f
+//     /* "":793:809   */
+//   calldataload
+//     /* "":842:844   */
+//   0x10
+//     /* "":829:845   */
+//   calldataload
+//     /* "":878:880   */
+//   0x11
+//     /* "":865:881   */
+//   calldataload
+//     /* "":914:916   */
+//   0x12
+//     /* "":901:917   */
+//   calldataload
+//     /* "":950:952   */
+//   0x13
+//     /* "":937:953   */
+//   calldataload
+//     /* "":986:988   */
+//   0x14
+//     /* "":973:989   */
+//   calldataload
+//     /* "":1022:1024   */
+//   0x15
+//     /* "":1009:1025   */
+//   calldataload
+//     /* "":1058:1060   */
+//   0x16
+//     /* "":1045:1061   */
+//   calldataload
+//     /* "":1094:1096   */
+//   0x17
+//     /* "":1081:1097   */
+//   calldataload
+//     /* "":1130:1132   */
+//   0x18
+//     /* "":1117:1133   */
+//   calldataload
+//     /* "":1166:1168   */
+//   0x19
+//     /* "":1153:1169   */
+//   calldataload
+//     /* "":1202:1204   */
+//   0x1a
+//     /* "":1189:1205   */
+//   calldataload
+//     /* "":1238:1240   */
+//   0x1b
+//     /* "":1225:1241   */
+//   calldataload
+//     /* "":1274:1276   */
+//   0x1c
+//     /* "":1261:1277   */
+//   calldataload
+//     /* "":1310:1312   */
+//   0x1d
+//     /* "":1297:1313   */
+//   calldataload
+//     /* "":1346:1348   */
+//   0x1e
+//     /* "":1333:1349   */
+//   calldataload
+//     /* "":1382:1384   */
+//   0x1f
+//     /* "":1369:1385   */
+//   calldataload
+//     /* "":1418:1420   */
+//   0x20
+//     /* "":1405:1421   */
+//   calldataload
+//     /* "":1454:1456   */
+//   0x21
+//     /* "":1441:1457   */
+//   calldataload
+//     /* "":1490:1492   */
+//   0x22
+//     /* "":1477:1493   */
+//   calldataload
+//     /* "":1526:1528   */
+//   0x23
+//     /* "":1513:1529   */
+//   calldataload
+//     /* "":1562:1564   */
+//   0x24
+//     /* "":1549:1565   */
+//   calldataload
+//     /* "":1598:1600   */
+//   0x25
+//     /* "":1585:1601   */
+//   calldataload
+//     /* "":1634:1636   */
+//   0x26
+//     /* "":1621:1637   */
+//   calldataload
+//     /* "":1670:1672   */
+//   0x27
+//     /* "":1657:1673   */
+//   calldataload
+//     /* "":1706:1708   */
+//   0x28
+//     /* "":1693:1709   */
+//   calldataload
+//     /* "":1742:1744   */
+//   0x29
+//     /* "":1729:1745   */
+//   calldataload
+//     /* "":1778:1780   */
+//   0x2a
+//     /* "":1765:1781   */
+//   calldataload
+//     /* "":1814:1816   */
+//   0x2b
+//     /* "":1801:1817   */
+//   calldataload
+//     /* "":1850:1852   */
+//   0x2c
+//     /* "":1837:1853   */
+//   calldataload
+//     /* "":1886:1888   */
+//   0x2d
+//     /* "":1873:1889   */
+//   calldataload
+//     /* "":1922:1924   */
+//   0x2e
+//     /* "":1909:1925   */
+//   calldataload
+//     /* "":1958:1960   */
+//   0x2f
+//     /* "":1945:1961   */
+//   calldataload
+//     /* "":1994:1996   */
+//   0x30
+//     /* "":1981:1997   */
+//   calldataload
+//     /* "":2030:2032   */
+//   0x31
+//     /* "":2017:2033   */
+//   calldataload
+//     /* "":2066:2068   */
+//   0x32
+//     /* "":2053:2069   */
+//   calldataload
+//     /* "":2102:2104   */
+//   0x33
+//     /* "":2089:2105   */
+//   calldataload
+//     /* "":2138:2140   */
+//   0x34
+//     /* "":2125:2141   */
+//   calldataload
+//     /* "":2174:2176   */
+//   0x35
+//     /* "":2161:2177   */
+//   calldataload
+//     /* "":2210:2212   */
+//   0x36
+//     /* "":2197:2213   */
+//   calldataload
+//     /* "":2246:2248   */
+//   0x37
+//     /* "":2233:2249   */
+//   calldataload
+//     /* "":2282:2284   */
+//   0x38
+//     /* "":2269:2285   */
+//   calldataload
+//     /* "":2318:2320   */
+//   0x39
+//     /* "":2305:2321   */
+//   calldataload
+//     /* "":2354:2356   */
+//   0x3a
+//     /* "":2341:2357   */
+//   calldataload
+//     /* "":2390:2392   */
+//   0x3b
+//     /* "":2377:2393   */
+//   calldataload
+//     /* "":2426:2428   */
+//   0x3c
+//     /* "":2413:2429   */
+//   calldataload
+//     /* "":2462:2464   */
+//   0x3d
+//     /* "":2449:2465   */
+//   calldataload
+//     /* "":2498:2500   */
+//   0x3e
+//     /* "":2485:2501   */
+//   calldataload
+//     /* "":2534:2536   */
+//   0x3f
+//     /* "":2521:2537   */
+//   calldataload
+//     /* "":2570:2572   */
+//   0x40
+//     /* "":2557:2573   */
+//   calldataload
+//     /* "":2606:2608   */
+//   0x41
+//     /* "":2593:2609   */
+//   calldataload
+//     /* "":2642:2644   */
+//   0x42
+//     /* "":2629:2645   */
+//   calldataload
+//     /* "":2678:2680   */
+//   0x43
+//     /* "":2665:2681   */
+//   calldataload
+//     /* "":2714:2716   */
+//   0x44
+//     /* "":2701:2717   */
+//   calldataload
+//     /* "":2750:2752   */
+//   0x45
+//     /* "":2737:2753   */
+//   calldataload
+//     /* "":2786:2788   */
+//   0x46
+//     /* "":2773:2789   */
+//   calldataload
+//     /* "":2822:2824   */
+//   0x47
+//     /* "":2809:2825   */
+//   calldataload
+//     /* "":2858:2860   */
+//   0x48
+//     /* "":2845:2861   */
+//   calldataload
+//     /* "":2894:2896   */
+//   0x49
+//     /* "":2881:2897   */
+//   calldataload
+//     /* "":2930:2932   */
+//   0x4a
+//     /* "":2917:2933   */
+//   calldataload
+//     /* "":2966:2968   */
+//   0x4b
+//     /* "":2953:2969   */
+//   calldataload
+//     /* "":3002:3004   */
+//   0x4c
+//     /* "":2989:3005   */
+//   calldataload
+//     /* "":3038:3040   */
+//   0x4d
+//     /* "":3025:3041   */
+//   calldataload
+//     /* "":3074:3076   */
+//   0x4e
+//     /* "":3061:3077   */
+//   calldataload
+//     /* "":3110:3112   */
+//   0x4f
+//     /* "":3097:3113   */
+//   calldataload
+//     /* "":3146:3148   */
+//   0x50
+//     /* "":3133:3149   */
+//   calldataload
+//     /* "":3182:3184   */
+//   0x51
+//     /* "":3169:3185   */
+//   calldataload
+//     /* "":3218:3220   */
+//   0x52
+//     /* "":3205:3221   */
+//   calldataload
+//     /* "":3254:3256   */
+//   0x53
+//     /* "":3241:3257   */
+//   calldataload
+//     /* "":3290:3292   */
+//   0x54
+//     /* "":3277:3293   */
+//   calldataload
+//     /* "":3326:3328   */
+//   0x55
+//     /* "":3313:3329   */
+//   calldataload
+//     /* "":3362:3364   */
+//   0x56
+//     /* "":3349:3365   */
+//   calldataload
+//     /* "":3398:3400   */
+//   0x57
+//     /* "":3385:3401   */
+//   calldataload
+//     /* "":3434:3436   */
+//   0x58
+//     /* "":3421:3437   */
+//   calldataload
+//     /* "":3470:3472   */
+//   0x59
+//     /* "":3457:3473   */
+//   calldataload
+//     /* "":3506:3508   */
+//   0x5a
+//     /* "":3493:3509   */
+//   calldataload
+//     /* "":3542:3544   */
+//   0x5b
+//     /* "":3529:3545   */
+//   calldataload
+//     /* "":3578:3580   */
+//   0x5c
+//     /* "":3565:3581   */
+//   calldataload
+//     /* "":3614:3616   */
+//   0x5d
+//     /* "":3601:3617   */
+//   calldataload
+//     /* "":3650:3652   */
+//   0x5e
+//     /* "":3637:3653   */
+//   calldataload
+//     /* "":3686:3688   */
+//   0x5f
+//     /* "":3673:3689   */
+//   calldataload
+//     /* "":3722:3724   */
+//   0x60
+//     /* "":3709:3725   */
+//   calldataload
+//     /* "":3758:3760   */
+//   0x61
+//     /* "":3745:3761   */
+//   calldataload
+//     /* "":3794:3796   */
+//   0x62
+//     /* "":3781:3797   */
+//   calldataload
+//     /* "":3830:3832   */
+//   0x63
+//     /* "":3817:3833   */
+//   calldataload
+//     /* "":3867:3870   */
+//   0x64
+//     /* "":3854:3871   */
+//   calldataload
+//     /* "":3905:3908   */
+//   0x65
+//     /* "":3892:3909   */
+//   calldataload
+//     /* "":3943:3946   */
+//   0x66
+//     /* "":3930:3947   */
+//   calldataload
+//     /* "":3981:3984   */
+//   0x67
+//     /* "":3968:3985   */
+//   calldataload
+//     /* "":4019:4022   */
+//   0x68
+//     /* "":4006:4023   */
+//   calldataload
+//     /* "":4057:4060   */
+//   0x69
+//     /* "":4044:4061   */
+//   calldataload
+//     /* "":4095:4098   */
+//   0x6a
+//     /* "":4082:4099   */
+//   calldataload
+//     /* "":4133:4136   */
+//   0x6b
+//     /* "":4120:4137   */
+//   calldataload
+//     /* "":4171:4174   */
+//   0x6c
+//     /* "":4158:4175   */
+//   calldataload
+//     /* "":4209:4212   */
+//   0x6d
+//     /* "":4196:4213   */
+//   calldataload
+//     /* "":4247:4250   */
+//   0x6e
+//     /* "":4234:4251   */
+//   calldataload
+//     /* "":4285:4288   */
+//   0x6f
+//     /* "":4272:4289   */
+//   calldataload
+//     /* "":4323:4326   */
+//   0x70
+//     /* "":4310:4327   */
+//   calldataload
+//     /* "":4361:4364   */
+//   0x71
+//     /* "":4348:4365   */
+//   calldataload
+//     /* "":4399:4402   */
+//   0x72
+//     /* "":4386:4403   */
+//   calldataload
+//     /* "":4437:4440   */
+//   0x73
+//     /* "":4424:4441   */
+//   calldataload
+//     /* "":4475:4478   */
+//   0x74
+//     /* "":4462:4479   */
+//   calldataload
+//     /* "":4513:4516   */
+//   0x75
+//     /* "":4500:4517   */
+//   calldataload
+//     /* "":4551:4554   */
+//   0x76
+//     /* "":4538:4555   */
+//   calldataload
+//     /* "":4589:4592   */
+//   0x77
+//     /* "":4576:4593   */
+//   calldataload
+//     /* "":4627:4630   */
+//   0x78
+//     /* "":4614:4631   */
+//   calldataload
+//     /* "":4665:4668   */
+//   0x79
+//     /* "":4652:4669   */
+//   calldataload
+//     /* "":4703:4706   */
+//   0x7a
+//     /* "":4690:4707   */
+//   calldataload
+//     /* "":4741:4744   */
+//   0x7b
+//     /* "":4728:4745   */
+//   calldataload
+//     /* "":4779:4782   */
+//   0x7c
+//     /* "":4766:4783   */
+//   calldataload
+//     /* "":4817:4820   */
+//   0x7d
+//     /* "":4804:4821   */
+//   calldataload
+//     /* "":4855:4858   */
+//   0x7e
+//     /* "":4842:4859   */
+//   calldataload
+//     /* "":4893:4896   */
+//   0x7f
+//     /* "":4880:4897   */
+//   calldataload
+//     /* "":4931:4934   */
+//   0x80
+//     /* "":4918:4935   */
+//   calldataload
+//     /* "":4969:4972   */
+//   0x81
+//     /* "":4956:4973   */
+//   calldataload
+//     /* "":4994:5011   */
+//   swap2
+//     /* "":5007:5010   */
+//   0x82
+//     /* "":4994:5011   */
+//   calldataload
+//     /* "":5032:5049   */
+//   swap4
+//     /* "":5045:5048   */
+//   0x83
+//     /* "":5032:5049   */
+//   calldataload
+//     /* "":5070:5087   */
+//   swap6
+//     /* "":5083:5086   */
+//   0x84
+//     /* "":5070:5087   */
+//   calldataload
+//     /* "":5108:5125   */
+//   swap8
+//     /* "":5121:5124   */
+//   0x85
+//     /* "":5108:5125   */
+//   calldataload
+//     /* "":5146:5163   */
+//   swap10
+//     /* "":5159:5162   */
+//   0x86
+//     /* "":5146:5163   */
+//   calldataload
+//     /* "":5184:5201   */
+//   swap12
+//     /* "":5197:5200   */
+//   0x87
+//     /* "":5184:5201   */
+//   calldataload
+//     /* "":5222:5239   */
+//   swap14
+//     /* "":5235:5238   */
+//   0x88
+//     /* "":5222:5239   */
+//   calldataload
+//     /* "":5260:5277   */
+//   swap16
+//     /* "":5273:5276   */
+//   0x89
+//     /* "":5260:5277   */
+//   calldataload
+//     /* "":5298:5315   */
+//   swapn{18}
+//     /* "":5311:5314   */
+//   0x8a
+//     /* "":5298:5315   */
+//   calldataload
+//     /* "":5336:5353   */
+//   swapn{20}
+//     /* "":5349:5352   */
+//   0x8b
+//     /* "":5336:5353   */
+//   calldataload
+//     /* "":5374:5391   */
+//   swapn{22}
+//     /* "":5387:5390   */
+//   0x8c
+//     /* "":5374:5391   */
+//   calldataload
+//     /* "":5412:5429   */
+//   swapn{24}
+//     /* "":5425:5428   */
+//   0x8d
+//     /* "":5412:5429   */
+//   calldataload
+//     /* "":5450:5467   */
+//   swapn{26}
+//     /* "":5463:5466   */
+//   0x8e
+//     /* "":5450:5467   */
+//   calldataload
+//     /* "":5488:5505   */
+//   swapn{28}
+//     /* "":5501:5504   */
+//   0x8f
+//     /* "":5488:5505   */
+//   calldataload
+//     /* "":5526:5543   */
+//   swapn{30}
+//     /* "":5539:5542   */
+//   0x90
+//     /* "":5526:5543   */
+//   calldataload
+//     /* "":5564:5581   */
+//   swapn{32}
+//     /* "":5577:5580   */
+//   0x91
+//     /* "":5564:5581   */
+//   calldataload
+//     /* "":5602:5619   */
+//   swapn{34}
+//     /* "":5615:5618   */
+//   0x92
+//     /* "":5602:5619   */
+//   calldataload
+//     /* "":5640:5657   */
+//   swapn{36}
+//     /* "":5653:5656   */
+//   0x93
+//     /* "":5640:5657   */
+//   calldataload
+//     /* "":5678:5695   */
+//   swapn{38}
+//     /* "":5691:5694   */
+//   0x94
+//     /* "":5678:5695   */
+//   calldataload
+//     /* "":5716:5733   */
+//   swapn{40}
+//     /* "":5729:5732   */
+//   0x95
+//     /* "":5716:5733   */
+//   calldataload
+//     /* "":5754:5771   */
+//   swapn{42}
+//     /* "":5767:5770   */
+//   0x96
+//     /* "":5754:5771   */
+//   calldataload
+//     /* "":5792:5809   */
+//   swapn{44}
+//     /* "":5805:5808   */
+//   0x97
+//     /* "":5792:5809   */
+//   calldataload
+//     /* "":5830:5847   */
+//   swapn{46}
+//     /* "":5843:5846   */
+//   0x98
+//     /* "":5830:5847   */
+//   calldataload
+//     /* "":5868:5885   */
+//   swapn{48}
+//     /* "":5881:5884   */
+//   0x99
+//     /* "":5868:5885   */
+//   calldataload
+//     /* "":5906:5923   */
+//   swapn{50}
+//     /* "":5919:5922   */
+//   0x9a
+//     /* "":5906:5923   */
+//   calldataload
+//     /* "":5944:5961   */
+//   swapn{52}
+//     /* "":5957:5960   */
+//   0x9b
+//     /* "":5944:5961   */
+//   calldataload
+//     /* "":5982:5999   */
+//   swapn{54}
+//     /* "":5995:5998   */
+//   0x9c
+//     /* "":5982:5999   */
+//   calldataload
+//     /* "":6020:6037   */
+//   swapn{56}
+//     /* "":6033:6036   */
+//   0x9d
+//     /* "":6020:6037   */
+//   calldataload
+//     /* "":6058:6075   */
+//   swapn{58}
+//     /* "":6071:6074   */
+//   0x9e
+//     /* "":6058:6075   */
+//   calldataload
+//     /* "":6096:6113   */
+//   swapn{60}
+//     /* "":6109:6112   */
+//   0x9f
+//     /* "":6096:6113   */
+//   calldataload
+//     /* "":6134:6151   */
+//   swapn{62}
+//     /* "":6147:6150   */
+//   0xa0
+//     /* "":6134:6151   */
+//   calldataload
+//     /* "":6172:6189   */
+//   swapn{64}
+//     /* "":6185:6188   */
+//   0xa1
+//     /* "":6172:6189   */
+//   calldataload
+//     /* "":6210:6227   */
+//   swapn{66}
+//     /* "":6223:6226   */
+//   0xa2
+//     /* "":6210:6227   */
+//   calldataload
+//     /* "":6248:6265   */
+//   swapn{68}
+//     /* "":6261:6264   */
+//   0xa3
+//     /* "":6248:6265   */
+//   calldataload
+//     /* "":6286:6303   */
+//   swapn{70}
+//     /* "":6299:6302   */
+//   0xa4
+//     /* "":6286:6303   */
+//   calldataload
+//     /* "":6324:6341   */
+//   swapn{72}
+//     /* "":6337:6340   */
+//   0xa5
+//     /* "":6324:6341   */
+//   calldataload
+//     /* "":6362:6379   */
+//   swapn{74}
+//     /* "":6375:6378   */
+//   0xa6
+//     /* "":6362:6379   */
+//   calldataload
+//     /* "":6400:6417   */
+//   swapn{76}
+//     /* "":6413:6416   */
+//   0xa7
+//     /* "":6400:6417   */
+//   calldataload
+//     /* "":6438:6455   */
+//   swapn{78}
+//     /* "":6451:6454   */
+//   0xa8
+//     /* "":6438:6455   */
+//   calldataload
+//     /* "":6476:6493   */
+//   swapn{80}
+//     /* "":6489:6492   */
+//   0xa9
+//     /* "":6476:6493   */
+//   calldataload
+//     /* "":6514:6531   */
+//   swapn{82}
+//     /* "":6527:6530   */
+//   0xaa
+//     /* "":6514:6531   */
+//   calldataload
+//     /* "":6552:6569   */
+//   swapn{84}
+//     /* "":6565:6568   */
+//   0xab
+//     /* "":6552:6569   */
+//   calldataload
+//     /* "":6590:6607   */
+//   swapn{86}
+//     /* "":6603:6606   */
+//   0xac
+//     /* "":6590:6607   */
+//   calldataload
+//     /* "":6628:6645   */
+//   swapn{88}
+//     /* "":6641:6644   */
+//   0xad
+//     /* "":6628:6645   */
+//   calldataload
+//     /* "":6666:6683   */
+//   swapn{90}
+//     /* "":6679:6682   */
+//   0xae
+//     /* "":6666:6683   */
+//   calldataload
+//     /* "":6704:6721   */
+//   swapn{92}
+//     /* "":6717:6720   */
+//   0xaf
+//     /* "":6704:6721   */
+//   calldataload
+//     /* "":6742:6759   */
+//   swapn{94}
+//     /* "":6755:6758   */
+//   0xb0
+//     /* "":6742:6759   */
+//   calldataload
+//     /* "":6780:6797   */
+//   swapn{96}
+//     /* "":6793:6796   */
+//   0xb1
+//     /* "":6780:6797   */
+//   calldataload
+//     /* "":6818:6835   */
+//   swapn{98}
+//     /* "":6831:6834   */
+//   0xb2
+//     /* "":6818:6835   */
+//   calldataload
+//     /* "":6856:6873   */
+//   swapn{100}
+//     /* "":6869:6872   */
+//   0xb3
+//     /* "":6856:6873   */
+//   calldataload
+//     /* "":6894:6911   */
+//   swapn{102}
+//     /* "":6907:6910   */
+//   0xb4
+//     /* "":6894:6911   */
+//   calldataload
+//     /* "":6932:6949   */
+//   swapn{104}
+//     /* "":6945:6948   */
+//   0xb5
+//     /* "":6932:6949   */
+//   calldataload
+//     /* "":6970:6987   */
+//   swapn{106}
+//     /* "":6983:6986   */
+//   0xb6
+//     /* "":6970:6987   */
+//   calldataload
+//     /* "":7008:7025   */
+//   swapn{108}
+//     /* "":7021:7024   */
+//   0xb7
+//     /* "":7008:7025   */
+//   calldataload
+//     /* "":7046:7063   */
+//   swapn{110}
+//     /* "":7059:7062   */
+//   0xb8
+//     /* "":7046:7063   */
+//   calldataload
+//     /* "":7084:7101   */
+//   swapn{112}
+//     /* "":7097:7100   */
+//   0xb9
+//     /* "":7084:7101   */
+//   calldataload
+//     /* "":7122:7139   */
+//   swapn{114}
+//     /* "":7135:7138   */
+//   0xba
+//     /* "":7122:7139   */
+//   calldataload
+//     /* "":7160:7177   */
+//   swapn{116}
+//     /* "":7173:7176   */
+//   0xbb
+//     /* "":7160:7177   */
+//   calldataload
+//     /* "":7198:7215   */
+//   swapn{118}
+//     /* "":7211:7214   */
+//   0xbc
+//     /* "":7198:7215   */
+//   calldataload
+//     /* "":7236:7253   */
+//   swapn{120}
+//     /* "":7249:7252   */
+//   0xbd
+//     /* "":7236:7253   */
+//   calldataload
+//     /* "":7274:7291   */
+//   swapn{122}
+//     /* "":7287:7290   */
+//   0xbe
+//     /* "":7274:7291   */
+//   calldataload
+//     /* "":7312:7329   */
+//   swapn{124}
+//     /* "":7325:7328   */
+//   0xbf
+//     /* "":7312:7329   */
+//   calldataload
+//     /* "":7350:7367   */
+//   swapn{126}
+//     /* "":7363:7366   */
+//   0xc0
+//     /* "":7350:7367   */
+//   calldataload
+//     /* "":7388:7405   */
+//   swapn{128}
+//     /* "":7401:7404   */
+//   0xc1
+//     /* "":7388:7405   */
+//   calldataload
+//     /* "":7426:7443   */
+//   swapn{130}
+//     /* "":7439:7442   */
+//   0xc2
+//     /* "":7426:7443   */
+//   calldataload
+//     /* "":7464:7481   */
+//   swapn{132}
+//     /* "":7477:7480   */
+//   0xc3
+//     /* "":7464:7481   */
+//   calldataload
+//     /* "":7502:7519   */
+//   swapn{134}
+//     /* "":7515:7518   */
+//   0xc4
+//     /* "":7502:7519   */
+//   calldataload
+//     /* "":7540:7557   */
+//   swapn{136}
+//     /* "":7553:7556   */
+//   0xc5
+//     /* "":7540:7557   */
+//   calldataload
+//     /* "":7578:7595   */
+//   swapn{138}
+//     /* "":7591:7594   */
+//   0xc6
+//     /* "":7578:7595   */
+//   calldataload
+//     /* "":7616:7633   */
+//   swapn{140}
+//     /* "":7629:7632   */
+//   0xc7
+//     /* "":7616:7633   */
+//   calldataload
+//     /* "":7654:7671   */
+//   swapn{142}
+//     /* "":7667:7670   */
+//   0xc8
+//     /* "":7654:7671   */
+//   calldataload
+//     /* "":7692:7709   */
+//   swapn{144}
+//     /* "":7705:7708   */
+//   0xc9
+//     /* "":7692:7709   */
+//   calldataload
+//     /* "":7730:7747   */
+//   swapn{146}
+//     /* "":7743:7746   */
+//   0xca
+//     /* "":7730:7747   */
+//   calldataload
+//     /* "":7768:7785   */
+//   swapn{148}
+//     /* "":7781:7784   */
+//   0xcb
+//     /* "":7768:7785   */
+//   calldataload
+//     /* "":7806:7823   */
+//   swapn{150}
+//     /* "":7819:7822   */
+//   0xcc
+//     /* "":7806:7823   */
+//   calldataload
+//     /* "":7844:7861   */
+//   swapn{152}
+//     /* "":7857:7860   */
+//   0xcd
+//     /* "":7844:7861   */
+//   calldataload
+//     /* "":7882:7899   */
+//   swapn{154}
+//     /* "":7895:7898   */
+//   0xce
+//     /* "":7882:7899   */
+//   calldataload
+//     /* "":7920:7937   */
+//   swapn{156}
+//     /* "":7933:7936   */
+//   0xcf
+//     /* "":7920:7937   */
+//   calldataload
+//     /* "":7958:7975   */
+//   swapn{158}
+//     /* "":7971:7974   */
+//   0xd0
+//     /* "":7958:7975   */
+//   calldataload
+//     /* "":7996:8013   */
+//   swapn{160}
+//     /* "":8009:8012   */
+//   0xd1
+//     /* "":7996:8013   */
+//   calldataload
+//     /* "":8034:8051   */
+//   swapn{162}
+//     /* "":8047:8050   */
+//   0xd2
+//     /* "":8034:8051   */
+//   calldataload
+//     /* "":8072:8089   */
+//   swapn{164}
+//     /* "":8085:8088   */
+//   0xd3
+//     /* "":8072:8089   */
+//   calldataload
+//     /* "":8110:8127   */
+//   swapn{166}
+//     /* "":8123:8126   */
+//   0xd4
+//     /* "":8110:8127   */
+//   calldataload
+//     /* "":8148:8165   */
+//   swapn{168}
+//     /* "":8161:8164   */
+//   0xd5
+//     /* "":8148:8165   */
+//   calldataload
+//     /* "":8186:8203   */
+//   swapn{170}
+//     /* "":8199:8202   */
+//   0xd6
+//     /* "":8186:8203   */
+//   calldataload
+//     /* "":8224:8241   */
+//   swapn{172}
+//     /* "":8237:8240   */
+//   0xd7
+//     /* "":8224:8241   */
+//   calldataload
+//     /* "":8262:8279   */
+//   swapn{174}
+//     /* "":8275:8278   */
+//   0xd8
+//     /* "":8262:8279   */
+//   calldataload
+//     /* "":8300:8317   */
+//   swapn{176}
+//     /* "":8313:8316   */
+//   0xd9
+//     /* "":8300:8317   */
+//   calldataload
+//     /* "":8338:8355   */
+//   swapn{178}
+//     /* "":8351:8354   */
+//   0xda
+//     /* "":8338:8355   */
+//   calldataload
+//     /* "":8376:8393   */
+//   swapn{180}
+//     /* "":8389:8392   */
+//   0xdb
+//     /* "":8376:8393   */
+//   calldataload
+//     /* "":8414:8431   */
+//   swapn{182}
+//     /* "":8427:8430   */
+//   0xdc
+//     /* "":8414:8431   */
+//   calldataload
+//     /* "":8452:8469   */
+//   swapn{184}
+//     /* "":8465:8468   */
+//   0xdd
+//     /* "":8452:8469   */
+//   calldataload
+//     /* "":8490:8507   */
+//   swapn{186}
+//     /* "":8503:8506   */
+//   0xde
+//     /* "":8490:8507   */
+//   calldataload
+//     /* "":8528:8545   */
+//   swapn{188}
+//     /* "":8541:8544   */
+//   0xdf
+//     /* "":8528:8545   */
+//   calldataload
+//     /* "":8566:8583   */
+//   swapn{190}
+//     /* "":8579:8582   */
+//   0xe0
+//     /* "":8566:8583   */
+//   calldataload
+//     /* "":8604:8621   */
+//   swapn{192}
+//     /* "":8617:8620   */
+//   0xe1
+//     /* "":8604:8621   */
+//   calldataload
+//     /* "":8642:8659   */
+//   swapn{194}
+//     /* "":8655:8658   */
+//   0xe2
+//     /* "":8642:8659   */
+//   calldataload
+//     /* "":8680:8697   */
+//   swapn{196}
+//     /* "":8693:8696   */
+//   0xe3
+//     /* "":8680:8697   */
+//   calldataload
+//     /* "":8718:8735   */
+//   swapn{198}
+//     /* "":8731:8734   */
+//   0xe4
+//     /* "":8718:8735   */
+//   calldataload
+//     /* "":8756:8773   */
+//   swapn{200}
+//     /* "":8769:8772   */
+//   0xe5
+//     /* "":8756:8773   */
+//   calldataload
+//     /* "":8794:8811   */
+//   swapn{202}
+//     /* "":8807:8810   */
+//   0xe6
+//     /* "":8794:8811   */
+//   calldataload
+//     /* "":8832:8849   */
+//   swapn{204}
+//     /* "":8845:8848   */
+//   0xe7
+//     /* "":8832:8849   */
+//   calldataload
+//     /* "":8870:8887   */
+//   swapn{206}
+//     /* "":8883:8886   */
+//   0xe8
+//     /* "":8870:8887   */
+//   calldataload
+//     /* "":8908:8925   */
+//   swapn{208}
+//     /* "":8921:8924   */
+//   0xe9
+//     /* "":8908:8925   */
+//   calldataload
+//     /* "":8946:8963   */
+//   swapn{210}
+//     /* "":8959:8962   */
+//   0xea
+//     /* "":8946:8963   */
+//   calldataload
+//     /* "":8984:9001   */
+//   swapn{212}
+//     /* "":8997:9000   */
+//   0xeb
+//     /* "":8984:9001   */
+//   calldataload
+//     /* "":9022:9039   */
+//   swapn{214}
+//     /* "":9035:9038   */
+//   0xec
+//     /* "":9022:9039   */
+//   calldataload
+//     /* "":9060:9077   */
+//   swapn{216}
+//     /* "":9073:9076   */
+//   0xed
+//     /* "":9060:9077   */
+//   calldataload
+//     /* "":9098:9115   */
+//   swapn{218}
+//     /* "":9111:9114   */
+//   0xee
+//     /* "":9098:9115   */
+//   calldataload
+//     /* "":9136:9153   */
+//   swapn{220}
+//     /* "":9149:9152   */
+//   0xef
+//     /* "":9136:9153   */
+//   calldataload
+//     /* "":9174:9191   */
+//   swapn{222}
+//     /* "":9187:9190   */
+//   0xf0
+//     /* "":9174:9191   */
+//   calldataload
+//     /* "":9212:9229   */
+//   swapn{224}
+//     /* "":9225:9228   */
+//   0xf1
+//     /* "":9212:9229   */
+//   calldataload
+//     /* "":9250:9267   */
+//   swapn{226}
+//     /* "":9263:9266   */
+//   0xf2
+//     /* "":9250:9267   */
+//   calldataload
+//     /* "":9288:9305   */
+//   swapn{228}
+//     /* "":9301:9304   */
+//   0xf3
+//     /* "":9288:9305   */
+//   calldataload
+//     /* "":9326:9343   */
+//   swapn{230}
+//     /* "":9339:9342   */
+//   0xf4
+//     /* "":9326:9343   */
+//   calldataload
+//     /* "":9364:9381   */
+//   swapn{232}
+//     /* "":9377:9380   */
+//   0xf5
+//     /* "":9364:9381   */
+//   calldataload
+//     /* "":9402:9419   */
+//   swapn{234}
+//     /* "":9415:9418   */
+//   0xf6
+//     /* "":9402:9419   */
+//   calldataload
+//     /* "":9440:9457   */
+//   swapn{236}
+//     /* "":9453:9456   */
+//   0xf7
+//     /* "":9440:9457   */
+//   calldataload
+//     /* "":9478:9495   */
+//   swapn{238}
+//     /* "":9491:9494   */
+//   0xf8
+//     /* "":9478:9495   */
+//   calldataload
+//     /* "":9516:9533   */
+//   swapn{240}
+//     /* "":9529:9532   */
+//   0xf9
+//     /* "":9516:9533   */
+//   calldataload
+//     /* "":9554:9571   */
+//   swapn{242}
+//     /* "":9567:9570   */
+//   0xfa
+//     /* "":9554:9571   */
+//   calldataload
+//     /* "":9592:9609   */
+//   swapn{244}
+//     /* "":9605:9608   */
+//   0xfb
+//     /* "":9592:9609   */
+//   calldataload
+//     /* "":9630:9647   */
+//   swapn{246}
+//     /* "":9643:9646   */
+//   0xfc
+//     /* "":9630:9647   */
+//   calldataload
+//     /* "":9668:9685   */
+//   swapn{248}
+//     /* "":9681:9684   */
+//   0xfd
+//     /* "":9668:9685   */
+//   calldataload
+//     /* "":9706:9723   */
+//   swapn{250}
+//     /* "":9719:9722   */
+//   0xfe
+//     /* "":9706:9723   */
+//   calldataload
+//     /* "":9744:9761   */
+//   swapn{252}
+//     /* "":9757:9760   */
+//   0xff
+//     /* "":9744:9761   */
+//   calldataload
+//     /* "":9782:9799   */
+//   swapn{254}
+//     /* "":9795:9798   */
+//   0x0100
+//     /* "":9782:9799   */
+//   calldataload
+//     /* "":9808:9821   */
+//   swapn{256}
+//     /* "":9815:9816   */
+//   0x00
+//     /* "":9808:9821   */
+//   sstore
+//     /* "":9837:9838   */
+//   0x01
+//     /* "":9830:9843   */
+//   sstore
+//     /* "":9859:9860   */
+//   0x02
+//     /* "":9852:9865   */
+//   sstore
+//     /* "":9881:9882   */
+//   0x03
+//     /* "":9874:9887   */
+//   sstore
+//     /* "":9903:9904   */
+//   0x04
+//     /* "":9896:9909   */
+//   sstore
+//     /* "":9925:9926   */
+//   0x05
+//     /* "":9918:9931   */
+//   sstore
+//     /* "":9947:9948   */
+//   0x06
+//     /* "":9940:9953   */
+//   sstore
+//     /* "":9969:9970   */
+//   0x07
+//     /* "":9962:9975   */
+//   sstore
+//     /* "":9991:9992   */
+//   0x08
+//     /* "":9984:9997   */
+//   sstore
+//     /* "":10013:10014   */
+//   0x09
+//     /* "":10006:10019   */
+//   sstore
+//     /* "":10035:10037   */
+//   0x0a
+//     /* "":10028:10043   */
+//   sstore
+//     /* "":10059:10061   */
+//   0x0b
+//     /* "":10052:10067   */
+//   sstore
+//     /* "":10083:10085   */
+//   0x0c
+//     /* "":10076:10091   */
+//   sstore
+//     /* "":10107:10109   */
+//   0x0d
+//     /* "":10100:10115   */
+//   sstore
+//     /* "":10131:10133   */
+//   0x0e
+//     /* "":10124:10139   */
+//   sstore
+//     /* "":10155:10157   */
+//   0x0f
+//     /* "":10148:10163   */
+//   sstore
+//     /* "":10179:10181   */
+//   0x10
+//     /* "":10172:10187   */
+//   sstore
+//     /* "":10203:10205   */
+//   0x11
+//     /* "":10196:10211   */
+//   sstore
+//     /* "":10227:10229   */
+//   0x12
+//     /* "":10220:10235   */
+//   sstore
+//     /* "":10251:10253   */
+//   0x13
+//     /* "":10244:10259   */
+//   sstore
+//     /* "":10275:10277   */
+//   0x14
+//     /* "":10268:10283   */
+//   sstore
+//     /* "":10299:10301   */
+//   0x15
+//     /* "":10292:10307   */
+//   sstore
+//     /* "":10323:10325   */
+//   0x16
+//     /* "":10316:10331   */
+//   sstore
+//     /* "":10347:10349   */
+//   0x17
+//     /* "":10340:10355   */
+//   sstore
+//     /* "":10371:10373   */
+//   0x18
+//     /* "":10364:10379   */
+//   sstore
+//     /* "":10395:10397   */
+//   0x19
+//     /* "":10388:10403   */
+//   sstore
+//     /* "":10419:10421   */
+//   0x1a
+//     /* "":10412:10427   */
+//   sstore
+//     /* "":10443:10445   */
+//   0x1b
+//     /* "":10436:10451   */
+//   sstore
+//     /* "":10467:10469   */
+//   0x1c
+//     /* "":10460:10475   */
+//   sstore
+//     /* "":10491:10493   */
+//   0x1d
+//     /* "":10484:10499   */
+//   sstore
+//     /* "":10515:10517   */
+//   0x1e
+//     /* "":10508:10523   */
+//   sstore
+//     /* "":10539:10541   */
+//   0x1f
+//     /* "":10532:10547   */
+//   sstore
+//     /* "":10563:10565   */
+//   0x20
+//     /* "":10556:10571   */
+//   sstore
+//     /* "":10587:10589   */
+//   0x21
+//     /* "":10580:10595   */
+//   sstore
+//     /* "":10611:10613   */
+//   0x22
+//     /* "":10604:10619   */
+//   sstore
+//     /* "":10635:10637   */
+//   0x23
+//     /* "":10628:10643   */
+//   sstore
+//     /* "":10659:10661   */
+//   0x24
+//     /* "":10652:10667   */
+//   sstore
+//     /* "":10683:10685   */
+//   0x25
+//     /* "":10676:10691   */
+//   sstore
+//     /* "":10707:10709   */
+//   0x26
+//     /* "":10700:10715   */
+//   sstore
+//     /* "":10731:10733   */
+//   0x27
+//     /* "":10724:10739   */
+//   sstore
+//     /* "":10755:10757   */
+//   0x28
+//     /* "":10748:10763   */
+//   sstore
+//     /* "":10779:10781   */
+//   0x29
+//     /* "":10772:10787   */
+//   sstore
+//     /* "":10803:10805   */
+//   0x2a
+//     /* "":10796:10811   */
+//   sstore
+//     /* "":10827:10829   */
+//   0x2b
+//     /* "":10820:10835   */
+//   sstore
+//     /* "":10851:10853   */
+//   0x2c
+//     /* "":10844:10859   */
+//   sstore
+//     /* "":10875:10877   */
+//   0x2d
+//     /* "":10868:10883   */
+//   sstore
+//     /* "":10899:10901   */
+//   0x2e
+//     /* "":10892:10907   */
+//   sstore
+//     /* "":10923:10925   */
+//   0x2f
+//     /* "":10916:10931   */
+//   sstore
+//     /* "":10947:10949   */
+//   0x30
+//     /* "":10940:10955   */
+//   sstore
+//     /* "":10971:10973   */
+//   0x31
+//     /* "":10964:10979   */
+//   sstore
+//     /* "":10995:10997   */
+//   0x32
+//     /* "":10988:11003   */
+//   sstore
+//     /* "":11019:11021   */
+//   0x33
+//     /* "":11012:11027   */
+//   sstore
+//     /* "":11043:11045   */
+//   0x34
+//     /* "":11036:11051   */
+//   sstore
+//     /* "":11067:11069   */
+//   0x35
+//     /* "":11060:11075   */
+//   sstore
+//     /* "":11091:11093   */
+//   0x36
+//     /* "":11084:11099   */
+//   sstore
+//     /* "":11115:11117   */
+//   0x37
+//     /* "":11108:11123   */
+//   sstore
+//     /* "":11139:11141   */
+//   0x38
+//     /* "":11132:11147   */
+//   sstore
+//     /* "":11163:11165   */
+//   0x39
+//     /* "":11156:11171   */
+//   sstore
+//     /* "":11187:11189   */
+//   0x3a
+//     /* "":11180:11195   */
+//   sstore
+//     /* "":11211:11213   */
+//   0x3b
+//     /* "":11204:11219   */
+//   sstore
+//     /* "":11235:11237   */
+//   0x3c
+//     /* "":11228:11243   */
+//   sstore
+//     /* "":11259:11261   */
+//   0x3d
+//     /* "":11252:11267   */
+//   sstore
+//     /* "":11283:11285   */
+//   0x3e
+//     /* "":11276:11291   */
+//   sstore
+//     /* "":11307:11309   */
+//   0x3f
+//     /* "":11300:11315   */
+//   sstore
+//     /* "":11331:11333   */
+//   0x40
+//     /* "":11324:11339   */
+//   sstore
+//     /* "":11355:11357   */
+//   0x41
+//     /* "":11348:11363   */
+//   sstore
+//     /* "":11379:11381   */
+//   0x42
+//     /* "":11372:11387   */
+//   sstore
+//     /* "":11403:11405   */
+//   0x43
+//     /* "":11396:11411   */
+//   sstore
+//     /* "":11427:11429   */
+//   0x44
+//     /* "":11420:11435   */
+//   sstore
+//     /* "":11451:11453   */
+//   0x45
+//     /* "":11444:11459   */
+//   sstore
+//     /* "":11475:11477   */
+//   0x46
+//     /* "":11468:11483   */
+//   sstore
+//     /* "":11499:11501   */
+//   0x47
+//     /* "":11492:11507   */
+//   sstore
+//     /* "":11523:11525   */
+//   0x48
+//     /* "":11516:11531   */
+//   sstore
+//     /* "":11547:11549   */
+//   0x49
+//     /* "":11540:11555   */
+//   sstore
+//     /* "":11571:11573   */
+//   0x4a
+//     /* "":11564:11579   */
+//   sstore
+//     /* "":11595:11597   */
+//   0x4b
+//     /* "":11588:11603   */
+//   sstore
+//     /* "":11619:11621   */
+//   0x4c
+//     /* "":11612:11627   */
+//   sstore
+//     /* "":11643:11645   */
+//   0x4d
+//     /* "":11636:11651   */
+//   sstore
+//     /* "":11667:11669   */
+//   0x4e
+//     /* "":11660:11675   */
+//   sstore
+//     /* "":11691:11693   */
+//   0x4f
+//     /* "":11684:11699   */
+//   sstore
+//     /* "":11715:11717   */
+//   0x50
+//     /* "":11708:11723   */
+//   sstore
+//     /* "":11739:11741   */
+//   0x51
+//     /* "":11732:11747   */
+//   sstore
+//     /* "":11763:11765   */
+//   0x52
+//     /* "":11756:11771   */
+//   sstore
+//     /* "":11787:11789   */
+//   0x53
+//     /* "":11780:11795   */
+//   sstore
+//     /* "":11811:11813   */
+//   0x54
+//     /* "":11804:11819   */
+//   sstore
+//     /* "":11835:11837   */
+//   0x55
+//     /* "":11828:11843   */
+//   sstore
+//     /* "":11859:11861   */
+//   0x56
+//     /* "":11852:11867   */
+//   sstore
+//     /* "":11883:11885   */
+//   0x57
+//     /* "":11876:11891   */
+//   sstore
+//     /* "":11907:11909   */
+//   0x58
+//     /* "":11900:11915   */
+//   sstore
+//     /* "":11931:11933   */
+//   0x59
+//     /* "":11924:11939   */
+//   sstore
+//     /* "":11955:11957   */
+//   0x5a
+//     /* "":11948:11963   */
+//   sstore
+//     /* "":11979:11981   */
+//   0x5b
+//     /* "":11972:11987   */
+//   sstore
+//     /* "":12003:12005   */
+//   0x5c
+//     /* "":11996:12011   */
+//   sstore
+//     /* "":12027:12029   */
+//   0x5d
+//     /* "":12020:12035   */
+//   sstore
+//     /* "":12051:12053   */
+//   0x5e
+//     /* "":12044:12059   */
+//   sstore
+//     /* "":12075:12077   */
+//   0x5f
+//     /* "":12068:12083   */
+//   sstore
+//     /* "":12099:12101   */
+//   0x60
+//     /* "":12092:12107   */
+//   sstore
+//     /* "":12123:12125   */
+//   0x61
+//     /* "":12116:12131   */
+//   sstore
+//     /* "":12147:12149   */
+//   0x62
+//     /* "":12140:12155   */
+//   sstore
+//     /* "":12171:12173   */
+//   0x63
+//     /* "":12164:12179   */
+//   sstore
+//     /* "":12195:12198   */
+//   0x64
+//     /* "":12188:12205   */
+//   sstore
+//     /* "":12221:12224   */
+//   0x65
+//     /* "":12214:12231   */
+//   sstore
+//     /* "":12247:12250   */
+//   0x66
+//     /* "":12240:12257   */
+//   sstore
+//     /* "":12273:12276   */
+//   0x67
+//     /* "":12266:12283   */
+//   sstore
+//     /* "":12299:12302   */
+//   0x68
+//     /* "":12292:12309   */
+//   sstore
+//     /* "":12325:12328   */
+//   0x69
+//     /* "":12318:12335   */
+//   sstore
+//     /* "":12351:12354   */
+//   0x6a
+//     /* "":12344:12361   */
+//   sstore
+//     /* "":12377:12380   */
+//   0x6b
+//     /* "":12370:12387   */
+//   sstore
+//     /* "":12403:12406   */
+//   0x6c
+//     /* "":12396:12413   */
+//   sstore
+//     /* "":12429:12432   */
+//   0x6d
+//     /* "":12422:12439   */
+//   sstore
+//     /* "":12455:12458   */
+//   0x6e
+//     /* "":12448:12465   */
+//   sstore
+//     /* "":12481:12484   */
+//   0x6f
+//     /* "":12474:12491   */
+//   sstore
+//     /* "":12507:12510   */
+//   0x70
+//     /* "":12500:12517   */
+//   sstore
+//     /* "":12533:12536   */
+//   0x71
+//     /* "":12526:12543   */
+//   sstore
+//     /* "":12559:12562   */
+//   0x72
+//     /* "":12552:12569   */
+//   sstore
+//     /* "":12585:12588   */
+//   0x73
+//     /* "":12578:12595   */
+//   sstore
+//     /* "":12611:12614   */
+//   0x74
+//     /* "":12604:12621   */
+//   sstore
+//     /* "":12637:12640   */
+//   0x75
+//     /* "":12630:12647   */
+//   sstore
+//     /* "":12663:12666   */
+//   0x76
+//     /* "":12656:12673   */
+//   sstore
+//     /* "":12689:12692   */
+//   0x77
+//     /* "":12682:12699   */
+//   sstore
+//     /* "":12715:12718   */
+//   0x78
+//     /* "":12708:12725   */
+//   sstore
+//     /* "":12741:12744   */
+//   0x79
+//     /* "":12734:12751   */
+//   sstore
+//     /* "":12767:12770   */
+//   0x7a
+//     /* "":12760:12777   */
+//   sstore
+//     /* "":12793:12796   */
+//   0x7b
+//     /* "":12786:12803   */
+//   sstore
+//     /* "":12819:12822   */
+//   0x7c
+//     /* "":12812:12829   */
+//   sstore
+//     /* "":12845:12848   */
+//   0x7d
+//     /* "":12838:12855   */
+//   sstore
+//     /* "":12871:12874   */
+//   0x7e
+//     /* "":12864:12881   */
+//   sstore
+//     /* "":12897:12900   */
+//   0x7f
+//     /* "":12890:12907   */
+//   sstore
+//     /* "":12923:12926   */
+//   0x80
+//     /* "":12916:12933   */
+//   sstore
+//     /* "":12949:12952   */
+//   0x81
+//     /* "":12942:12959   */
+//   sstore
+//     /* "":12975:12978   */
+//   0x82
+//     /* "":12968:12985   */
+//   sstore
+//     /* "":13001:13004   */
+//   0x83
+//     /* "":12994:13011   */
+//   sstore
+//     /* "":13027:13030   */
+//   0x84
+//     /* "":13020:13037   */
+//   sstore
+//     /* "":13053:13056   */
+//   0x85
+//     /* "":13046:13063   */
+//   sstore
+//     /* "":13079:13082   */
+//   0x86
+//     /* "":13072:13089   */
+//   sstore
+//     /* "":13105:13108   */
+//   0x87
+//     /* "":13098:13115   */
+//   sstore
+//     /* "":13131:13134   */
+//   0x88
+//     /* "":13124:13141   */
+//   sstore
+//     /* "":13157:13160   */
+//   0x89
+//     /* "":13150:13167   */
+//   sstore
+//     /* "":13183:13186   */
+//   0x8a
+//     /* "":13176:13193   */
+//   sstore
+//     /* "":13209:13212   */
+//   0x8b
+//     /* "":13202:13219   */
+//   sstore
+//     /* "":13235:13238   */
+//   0x8c
+//     /* "":13228:13245   */
+//   sstore
+//     /* "":13261:13264   */
+//   0x8d
+//     /* "":13254:13271   */
+//   sstore
+//     /* "":13287:13290   */
+//   0x8e
+//     /* "":13280:13297   */
+//   sstore
+//     /* "":13313:13316   */
+//   0x8f
+//     /* "":13306:13323   */
+//   sstore
+//     /* "":13339:13342   */
+//   0x90
+//     /* "":13332:13349   */
+//   sstore
+//     /* "":13365:13368   */
+//   0x91
+//     /* "":13358:13375   */
+//   sstore
+//     /* "":13391:13394   */
+//   0x92
+//     /* "":13384:13401   */
+//   sstore
+//     /* "":13417:13420   */
+//   0x93
+//     /* "":13410:13427   */
+//   sstore
+//     /* "":13443:13446   */
+//   0x94
+//     /* "":13436:13453   */
+//   sstore
+//     /* "":13469:13472   */
+//   0x95
+//     /* "":13462:13479   */
+//   sstore
+//     /* "":13495:13498   */
+//   0x96
+//     /* "":13488:13505   */
+//   sstore
+//     /* "":13521:13524   */
+//   0x97
+//     /* "":13514:13531   */
+//   sstore
+//     /* "":13547:13550   */
+//   0x98
+//     /* "":13540:13557   */
+//   sstore
+//     /* "":13573:13576   */
+//   0x99
+//     /* "":13566:13583   */
+//   sstore
+//     /* "":13599:13602   */
+//   0x9a
+//     /* "":13592:13609   */
+//   sstore
+//     /* "":13625:13628   */
+//   0x9b
+//     /* "":13618:13635   */
+//   sstore
+//     /* "":13651:13654   */
+//   0x9c
+//     /* "":13644:13661   */
+//   sstore
+//     /* "":13677:13680   */
+//   0x9d
+//     /* "":13670:13687   */
+//   sstore
+//     /* "":13703:13706   */
+//   0x9e
+//     /* "":13696:13713   */
+//   sstore
+//     /* "":13729:13732   */
+//   0x9f
+//     /* "":13722:13739   */
+//   sstore
+//     /* "":13755:13758   */
+//   0xa0
+//     /* "":13748:13765   */
+//   sstore
+//     /* "":13781:13784   */
+//   0xa1
+//     /* "":13774:13791   */
+//   sstore
+//     /* "":13807:13810   */
+//   0xa2
+//     /* "":13800:13817   */
+//   sstore
+//     /* "":13833:13836   */
+//   0xa3
+//     /* "":13826:13843   */
+//   sstore
+//     /* "":13859:13862   */
+//   0xa4
+//     /* "":13852:13869   */
+//   sstore
+//     /* "":13885:13888   */
+//   0xa5
+//     /* "":13878:13895   */
+//   sstore
+//     /* "":13911:13914   */
+//   0xa6
+//     /* "":13904:13921   */
+//   sstore
+//     /* "":13937:13940   */
+//   0xa7
+//     /* "":13930:13947   */
+//   sstore
+//     /* "":13963:13966   */
+//   0xa8
+//     /* "":13956:13973   */
+//   sstore
+//     /* "":13989:13992   */
+//   0xa9
+//     /* "":13982:13999   */
+//   sstore
+//     /* "":14015:14018   */
+//   0xaa
+//     /* "":14008:14025   */
+//   sstore
+//     /* "":14041:14044   */
+//   0xab
+//     /* "":14034:14051   */
+//   sstore
+//     /* "":14067:14070   */
+//   0xac
+//     /* "":14060:14077   */
+//   sstore
+//     /* "":14093:14096   */
+//   0xad
+//     /* "":14086:14103   */
+//   sstore
+//     /* "":14119:14122   */
+//   0xae
+//     /* "":14112:14129   */
+//   sstore
+//     /* "":14145:14148   */
+//   0xaf
+//     /* "":14138:14155   */
+//   sstore
+//     /* "":14171:14174   */
+//   0xb0
+//     /* "":14164:14181   */
+//   sstore
+//     /* "":14197:14200   */
+//   0xb1
+//     /* "":14190:14207   */
+//   sstore
+//     /* "":14223:14226   */
+//   0xb2
+//     /* "":14216:14233   */
+//   sstore
+//     /* "":14249:14252   */
+//   0xb3
+//     /* "":14242:14259   */
+//   sstore
+//     /* "":14275:14278   */
+//   0xb4
+//     /* "":14268:14285   */
+//   sstore
+//     /* "":14301:14304   */
+//   0xb5
+//     /* "":14294:14311   */
+//   sstore
+//     /* "":14327:14330   */
+//   0xb6
+//     /* "":14320:14337   */
+//   sstore
+//     /* "":14353:14356   */
+//   0xb7
+//     /* "":14346:14363   */
+//   sstore
+//     /* "":14379:14382   */
+//   0xb8
+//     /* "":14372:14389   */
+//   sstore
+//     /* "":14405:14408   */
+//   0xb9
+//     /* "":14398:14415   */
+//   sstore
+//     /* "":14431:14434   */
+//   0xba
+//     /* "":14424:14441   */
+//   sstore
+//     /* "":14457:14460   */
+//   0xbb
+//     /* "":14450:14467   */
+//   sstore
+//     /* "":14483:14486   */
+//   0xbc
+//     /* "":14476:14493   */
+//   sstore
+//     /* "":14509:14512   */
+//   0xbd
+//     /* "":14502:14519   */
+//   sstore
+//     /* "":14535:14538   */
+//   0xbe
+//     /* "":14528:14545   */
+//   sstore
+//     /* "":14561:14564   */
+//   0xbf
+//     /* "":14554:14571   */
+//   sstore
+//     /* "":14587:14590   */
+//   0xc0
+//     /* "":14580:14597   */
+//   sstore
+//     /* "":14613:14616   */
+//   0xc1
+//     /* "":14606:14623   */
+//   sstore
+//     /* "":14639:14642   */
+//   0xc2
+//     /* "":14632:14649   */
+//   sstore
+//     /* "":14665:14668   */
+//   0xc3
+//     /* "":14658:14675   */
+//   sstore
+//     /* "":14691:14694   */
+//   0xc4
+//     /* "":14684:14701   */
+//   sstore
+//     /* "":14717:14720   */
+//   0xc5
+//     /* "":14710:14727   */
+//   sstore
+//     /* "":14743:14746   */
+//   0xc6
+//     /* "":14736:14753   */
+//   sstore
+//     /* "":14769:14772   */
+//   0xc7
+//     /* "":14762:14779   */
+//   sstore
+//     /* "":14795:14798   */
+//   0xc8
+//     /* "":14788:14805   */
+//   sstore
+//     /* "":14821:14824   */
+//   0xc9
+//     /* "":14814:14831   */
+//   sstore
+//     /* "":14847:14850   */
+//   0xca
+//     /* "":14840:14857   */
+//   sstore
+//     /* "":14873:14876   */
+//   0xcb
+//     /* "":14866:14883   */
+//   sstore
+//     /* "":14899:14902   */
+//   0xcc
+//     /* "":14892:14909   */
+//   sstore
+//     /* "":14925:14928   */
+//   0xcd
+//     /* "":14918:14935   */
+//   sstore
+//     /* "":14951:14954   */
+//   0xce
+//     /* "":14944:14961   */
+//   sstore
+//     /* "":14977:14980   */
+//   0xcf
+//     /* "":14970:14987   */
+//   sstore
+//     /* "":15003:15006   */
+//   0xd0
+//     /* "":14996:15013   */
+//   sstore
+//     /* "":15029:15032   */
+//   0xd1
+//     /* "":15022:15039   */
+//   sstore
+//     /* "":15055:15058   */
+//   0xd2
+//     /* "":15048:15065   */
+//   sstore
+//     /* "":15081:15084   */
+//   0xd3
+//     /* "":15074:15091   */
+//   sstore
+//     /* "":15107:15110   */
+//   0xd4
+//     /* "":15100:15117   */
+//   sstore
+//     /* "":15133:15136   */
+//   0xd5
+//     /* "":15126:15143   */
+//   sstore
+//     /* "":15159:15162   */
+//   0xd6
+//     /* "":15152:15169   */
+//   sstore
+//     /* "":15185:15188   */
+//   0xd7
+//     /* "":15178:15195   */
+//   sstore
+//     /* "":15211:15214   */
+//   0xd8
+//     /* "":15204:15221   */
+//   sstore
+//     /* "":15237:15240   */
+//   0xd9
+//     /* "":15230:15247   */
+//   sstore
+//     /* "":15263:15266   */
+//   0xda
+//     /* "":15256:15273   */
+//   sstore
+//     /* "":15289:15292   */
+//   0xdb
+//     /* "":15282:15299   */
+//   sstore
+//     /* "":15315:15318   */
+//   0xdc
+//     /* "":15308:15325   */
+//   sstore
+//     /* "":15341:15344   */
+//   0xdd
+//     /* "":15334:15351   */
+//   sstore
+//     /* "":15367:15370   */
+//   0xde
+//     /* "":15360:15377   */
+//   sstore
+//     /* "":15393:15396   */
+//   0xdf
+//     /* "":15386:15403   */
+//   sstore
+//     /* "":15419:15422   */
+//   0xe0
+//     /* "":15412:15429   */
+//   sstore
+//     /* "":15445:15448   */
+//   0xe1
+//     /* "":15438:15455   */
+//   sstore
+//     /* "":15471:15474   */
+//   0xe2
+//     /* "":15464:15481   */
+//   sstore
+//     /* "":15497:15500   */
+//   0xe3
+//     /* "":15490:15507   */
+//   sstore
+//     /* "":15523:15526   */
+//   0xe4
+//     /* "":15516:15533   */
+//   sstore
+//     /* "":15549:15552   */
+//   0xe5
+//     /* "":15542:15559   */
+//   sstore
+//     /* "":15575:15578   */
+//   0xe6
+//     /* "":15568:15585   */
+//   sstore
+//     /* "":15601:15604   */
+//   0xe7
+//     /* "":15594:15611   */
+//   sstore
+//     /* "":15627:15630   */
+//   0xe8
+//     /* "":15620:15637   */
+//   sstore
+//     /* "":15653:15656   */
+//   0xe9
+//     /* "":15646:15663   */
+//   sstore
+//     /* "":15679:15682   */
+//   0xea
+//     /* "":15672:15689   */
+//   sstore
+//     /* "":15705:15708   */
+//   0xeb
+//     /* "":15698:15715   */
+//   sstore
+//     /* "":15731:15734   */
+//   0xec
+//     /* "":15724:15741   */
+//   sstore
+//     /* "":15757:15760   */
+//   0xed
+//     /* "":15750:15767   */
+//   sstore
+//     /* "":15783:15786   */
+//   0xee
+//     /* "":15776:15793   */
+//   sstore
+//     /* "":15809:15812   */
+//   0xef
+//     /* "":15802:15819   */
+//   sstore
+//     /* "":15835:15838   */
+//   0xf0
+//     /* "":15828:15845   */
+//   sstore
+//     /* "":15861:15864   */
+//   0xf1
+//     /* "":15854:15871   */
+//   sstore
+//     /* "":15887:15890   */
+//   0xf2
+//     /* "":15880:15897   */
+//   sstore
+//     /* "":15913:15916   */
+//   0xf3
+//     /* "":15906:15923   */
+//   sstore
+//     /* "":15939:15942   */
+//   0xf4
+//     /* "":15932:15949   */
+//   sstore
+//     /* "":15965:15968   */
+//   0xf5
+//     /* "":15958:15975   */
+//   sstore
+//     /* "":15991:15994   */
+//   0xf6
+//     /* "":15984:16001   */
+//   sstore
+//     /* "":16017:16020   */
+//   0xf7
+//     /* "":16010:16027   */
+//   sstore
+//     /* "":16043:16046   */
+//   0xf8
+//     /* "":16036:16053   */
+//   sstore
+//     /* "":16069:16072   */
+//   0xf9
+//     /* "":16062:16079   */
+//   sstore
+//     /* "":16095:16098   */
+//   0xfa
+//     /* "":16088:16105   */
+//   sstore
+//     /* "":16121:16124   */
+//   0xfb
+//     /* "":16114:16131   */
+//   sstore
+//     /* "":16147:16150   */
+//   0xfc
+//     /* "":16140:16157   */
+//   sstore
+//     /* "":16173:16176   */
+//   0xfd
+//     /* "":16166:16183   */
+//   sstore
+//     /* "":16199:16202   */
+//   0xfe
+//     /* "":16192:16209   */
+//   sstore
+//     /* "":16225:16228   */
+//   0xff
+//     /* "":16218:16235   */
+//   sstore
+//     /* "":16251:16254   */
+//   0x0100
+//     /* "":16244:16261   */
+//   sstore
+//     /* "":25:16267   */
+//   stop

--- a/test/libyul/yulOptimizerTests/fakeStackLimitEvader/connected.yul
+++ b/test/libyul/yulOptimizerTests/fakeStackLimitEvader/connected.yul
@@ -20,6 +20,8 @@
 	sstore(0, f())
 	let x, y := g()
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: fakeStackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/fakeStackLimitEvader/function_arg.yul
+++ b/test/libyul/yulOptimizerTests/fakeStackLimitEvader/function_arg.yul
@@ -7,6 +7,8 @@
 	}
 	sstore(1, h(32))
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: fakeStackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/fakeStackLimitEvader/multi_variable_declaration_without_value.yul
+++ b/test/libyul/yulOptimizerTests/fakeStackLimitEvader/multi_variable_declaration_without_value.yul
@@ -7,6 +7,8 @@
     let z, $w
   }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: fakeStackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/fakeStackLimitEvader/outer_block.yul
+++ b/test/libyul/yulOptimizerTests/fakeStackLimitEvader/outer_block.yul
@@ -3,6 +3,8 @@
     let $x := 42
     sstore(42, $x)
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: fakeStackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/fakeStackLimitEvader/return_leave.yul
+++ b/test/libyul/yulOptimizerTests/fakeStackLimitEvader/return_leave.yul
@@ -14,6 +14,8 @@
     }
 
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: fakeStackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/fakeStackLimitEvader/return_one.yul
+++ b/test/libyul/yulOptimizerTests/fakeStackLimitEvader/return_one.yul
@@ -12,6 +12,8 @@
     }
 
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: fakeStackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/fakeStackLimitEvader/return_one_with_args.yul
+++ b/test/libyul/yulOptimizerTests/fakeStackLimitEvader/return_one_with_args.yul
@@ -12,6 +12,8 @@
     }
 
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: fakeStackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/fakeStackLimitEvader/same_variable_in_lhs_and_rhs.yul
+++ b/test/libyul/yulOptimizerTests/fakeStackLimitEvader/same_variable_in_lhs_and_rhs.yul
@@ -5,6 +5,8 @@
     let $z := 42
     $z := f($z)
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: fakeStackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/fakeStackLimitEvader/stub.yul
+++ b/test/libyul/yulOptimizerTests/fakeStackLimitEvader/stub.yul
@@ -23,6 +23,8 @@
     g(0)
     h(1, 2, 3, 4)
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: fakeStackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/stackCompressor/noInline.yul
+++ b/test/libyul/yulOptimizerTests/stackCompressor/noInline.yul
@@ -2,6 +2,8 @@
   let x := 8
   function f() { let y := 9 }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: stackCompressor
 //

--- a/test/libyul/yulOptimizerTests/stackLimitEvader/cycle.yul
+++ b/test/libyul/yulOptimizerTests/stackLimitEvader/cycle.yul
@@ -44,6 +44,8 @@
         sstore(23, g(sload(42)))
     }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: stackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/stackLimitEvader/cycle_after.yul
+++ b/test/libyul/yulOptimizerTests/stackLimitEvader/cycle_after.yul
@@ -44,6 +44,8 @@
         v := h()
     }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: stackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/stackLimitEvader/cycle_after_2.yul
+++ b/test/libyul/yulOptimizerTests/stackLimitEvader/cycle_after_2.yul
@@ -47,6 +47,8 @@
         v := h()
     }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: stackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/stackLimitEvader/cycle_before.yul
+++ b/test/libyul/yulOptimizerTests/stackLimitEvader/cycle_before.yul
@@ -49,6 +49,8 @@
         sstore(mul(1,4), a1)
     }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: stackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/stackLimitEvader/cycle_before_2.yul
+++ b/test/libyul/yulOptimizerTests/stackLimitEvader/cycle_before_2.yul
@@ -52,6 +52,8 @@
         sstore(mul(1,4), a1)
     }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: stackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/stackLimitEvader/cycle_before_after.yul
+++ b/test/libyul/yulOptimizerTests/stackLimitEvader/cycle_before_after.yul
@@ -53,6 +53,8 @@
         v := h()
     }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: stackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/stackLimitEvader/function_arg.yul
+++ b/test/libyul/yulOptimizerTests/stackLimitEvader/function_arg.yul
@@ -40,6 +40,8 @@
 	sstore(mul(1,4), a1)
     }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: stackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/stackLimitEvader/stub.yul
+++ b/test/libyul/yulOptimizerTests/stackLimitEvader/stub.yul
@@ -45,6 +45,8 @@
 	sstore(mul(1,4), a1)
     }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: stackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/stackLimitEvader/too_many_args_14.yul
+++ b/test/libyul/yulOptimizerTests/stackLimitEvader/too_many_args_14.yul
@@ -15,6 +15,8 @@
     }
 
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: stackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/stackLimitEvader/too_many_args_15.yul
+++ b/test/libyul/yulOptimizerTests/stackLimitEvader/too_many_args_15.yul
@@ -17,6 +17,8 @@
     }
 
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: stackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/stackLimitEvader/too_many_args_16.yul
+++ b/test/libyul/yulOptimizerTests/stackLimitEvader/too_many_args_16.yul
@@ -17,6 +17,8 @@
     }
 
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: stackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/stackLimitEvader/too_many_returns_15.yul
+++ b/test/libyul/yulOptimizerTests/stackLimitEvader/too_many_returns_15.yul
@@ -13,6 +13,8 @@
     }
 
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: stackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/stackLimitEvader/too_many_returns_16.yul
+++ b/test/libyul/yulOptimizerTests/stackLimitEvader/too_many_returns_16.yul
@@ -13,6 +13,8 @@
     }
 
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: stackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/stackLimitEvader/tree.yul
+++ b/test/libyul/yulOptimizerTests/stackLimitEvader/tree.yul
@@ -164,6 +164,8 @@
         v := sload(mul(42,8))
     }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: stackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/stackLimitEvader/verbatim_many_arguments.yul
+++ b/test/libyul/yulOptimizerTests/stackLimitEvader/verbatim_many_arguments.yul
@@ -24,6 +24,8 @@
         verbatim_20i_0o("test", a_1, a_2, a_3, a_4, a_5, a_6, a_7, a_8, a_9, a_10, a_11, a_12, a_13, a_14, a_15, a_16, a_17, a_18, a_19, a_20)
     }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: stackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/stackLimitEvader/verbatim_many_arguments_and_returns.yul
+++ b/test/libyul/yulOptimizerTests/stackLimitEvader/verbatim_many_arguments_and_returns.yul
@@ -45,6 +45,8 @@
 
     }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: stackLimitEvader
 //

--- a/test/libyul/yulOptimizerTests/stackLimitEvader/verbatim_many_returns.yul
+++ b/test/libyul/yulOptimizerTests/stackLimitEvader/verbatim_many_returns.yul
@@ -7,6 +7,8 @@
         sstore(a18, 20)
     }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // step: stackLimitEvader
 //

--- a/test/libyul/yulStackShuffling/pop_early_to_avoid_swap17.stack
+++ b/test/libyul/yulStackShuffling/pop_early_to_avoid_swap17.stack
@@ -1,0 +1,12 @@
+// We avoid a SWAP17 here by first removing duplicates on stack.
+[ junk v00 v01 v02 v03 v04 v05 v06 v07 v08 v09 v10 v11 v12 v13 v14 junk deep ]
+[ deep v00 v01 v02 v03 v04 v05 v06 v07 v08 v09 v10 v11 v12 v13 v14 junk ]
+// ----
+// [ junk v00 v01 v02 v03 v04 v05 v06 v07 v08 v09 v10 v11 v12 v13 v14 junk deep ]
+// SWAP1
+// [ junk v00 v01 v02 v03 v04 v05 v06 v07 v08 v09 v10 v11 v12 v13 v14 deep junk ]
+// POP
+// [ junk v00 v01 v02 v03 v04 v05 v06 v07 v08 v09 v10 v11 v12 v13 v14 deep ]
+// SWAP16
+// [ deep v00 v01 v02 v03 v04 v05 v06 v07 v08 v09 v10 v11 v12 v13 v14 junk ]
+// 3 operations

--- a/test/libyul/yulStackShuffling/swap17.stack
+++ b/test/libyul/yulStackShuffling/swap17.stack
@@ -1,0 +1,13 @@
+// With a SWAP17 at our disposal, we do not need to first remove duplicates from stack
+// as seen in pop_early_to_avoid_swap17.stack.
+[ junk v00 v01 v02 v03 v04 v05 v06 v07 v08 v09 v10 v11 v12 v13 v14 junk deep ]
+[ deep v00 v01 v02 v03 v04 v05 v06 v07 v08 v09 v10 v11 v12 v13 v14 junk ]
+// ====
+// maximumStackDepth: 256
+// ----
+// [ junk v00 v01 v02 v03 v04 v05 v06 v07 v08 v09 v10 v11 v12 v13 v14 junk deep ]
+// SWAP17
+// [ deep v00 v01 v02 v03 v04 v05 v06 v07 v08 v09 v10 v11 v12 v13 v14 junk junk ]
+// POP
+// [ deep v00 v01 v02 v03 v04 v05 v06 v07 v08 v09 v10 v11 v12 v13 v14 junk ]
+// 2 operations

--- a/test/libyul/yulStackShuffling/swap_cycle.stack
+++ b/test/libyul/yulStackShuffling/swap_cycle.stack
@@ -20,3 +20,4 @@
 // [ v1 v0 v2 v3 v4 v5 v6 v7 v9 v10 v11 v12 v13 v14 v15 v16 RET JUNK ]
 // PUSH JUNK
 // [ v1 v0 v2 v3 v4 v5 v6 v7 v9 v10 v11 v12 v13 v14 v15 v16 RET JUNK JUNK ]
+// 9 operations


### PR DESCRIPTION
I didn't think through the actual limit cases properly, so we'd need to double-check. Annoying to test `SWAP257`, though...
I'm marking it as ready for a first review regardless.
~~Depends on https://github.com/ethereum/solidity/pull/15845~~ (merged)

FYI: I'd be happy to remove the ``swapn{256}`` and ``dupn{256}`` tests here, shrinking the PR by a few thousand lines :-).