### PR TITLE
SMTChecker: Fix reporting same target both as safe and unsafe

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,6 +13,7 @@ Compiler Features:
 
 Bugfixes:
  * General: Fix internal compiler error when requesting IR AST outputs for interfaces and abstract contracts.
+ * SMTChecker: Fix reporting on targets that are safe in the context of one contract but unsafe in the context of another contract.
  * SMTChecker: Fix SMT logic error when analyzing cross-contract getter call with BMC.
  * SMTChecker: Fix SMT logic error when contract deployment involves string literal to fixed bytes conversion.
  * SMTChecker: Fix SMT logic error when external call has extra effectless parentheses.

--- a/libsolidity/formal/CHC.cpp
+++ b/libsolidity/formal/CHC.cpp
@@ -2169,7 +2169,13 @@ void CHC::checkAndReportTarget(
 	}
 	else if (result == CheckResult::SATISFIABLE)
 	{
-		solAssert(!_satMsg.empty(), "");
+		solAssert(!_satMsg.empty());
+		if (auto it = m_safeTargets.find(_target.errorNode); it != m_safeTargets.end())
+		{
+			std::erase_if(it->second, [&](auto const& target) { return target.type == _target.type; });
+			if (it->second.empty())
+				m_safeTargets.erase(it);
+		}
 		auto cex = generateCounterexample(model, error().name);
 		if (cex)
 			m_unsafeTargets[_target.errorNode][_target.type] = {

--- a/test/libsolidity/smtCheckerTests/functions/free_function_multiple_contracts.sol
+++ b/test/libsolidity/smtCheckerTests/functions/free_function_multiple_contracts.sol
@@ -1,0 +1,20 @@
+function check(uint x) pure {
+	assert(x > 0);
+}
+
+contract C {
+	function a() public pure {
+		check(1);
+	}
+}
+
+contract D {
+	function b(uint x) public pure {
+		check(x);
+	}
+}
+// ====
+// SMTEngine: chc
+// SMTIgnoreCex: no
+// ----
+// Warning 6328: (31-44): CHC: Assertion violation happens here.\nCounterexample:\n\nx = 0\n\nTransaction trace:\nD.constructor()\nD.b(0)\n    check(0) -- internal call

--- a/test/libsolidity/smtCheckerTests/functions/internal_call_with_assertion_inheritance_1_fail.sol
+++ b/test/libsolidity/smtCheckerTests/functions/internal_call_with_assertion_inheritance_1_fail.sol
@@ -17,7 +17,7 @@ contract C is A {
 // ====
 // SMTEngine: all
 // ----
-// Warning 6328: (49-63): CHC: Assertion violation happens here.
-// Warning 6328: (115-129): CHC: Assertion violation happens here.
-// Warning 6328: (147-161): CHC: Assertion violation happens here.
-// Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 6328: (49-63): CHC: Assertion violation happens here.\nCounterexample:\nx = 1\n\nTransaction trace:\nC.constructor()
+// Warning 6328: (115-129): CHC: Assertion violation happens here.\nCounterexample:\nx = 0\n\nTransaction trace:\nC.constructor()
+// Warning 6328: (147-161): CHC: Assertion violation happens here.\nCounterexample:\nx = 0\n\nTransaction trace:\nC.constructor()
+// Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/functions/library_constant.sol
+++ b/test/libsolidity/smtCheckerTests/functions/library_constant.sol
@@ -19,6 +19,6 @@ contract C {
 // ====
 // SMTEngine: all
 // ----
-// Warning 6328: (103-122): CHC: Assertion violation happens here.
-// Warning 4984: (196-201): CHC: Overflow (resulting value larger than 2**256 - 1) happens here.
-// Info 1391: CHC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 6328: (103-122): CHC: Assertion violation happens here.\nCounterexample:\nTON = 1000\n\nTransaction trace:\nl1.constructor()\nState: TON = 1000\nl1.f1()
+// Warning 4984: (196-201): CHC: Overflow (resulting value larger than 2**256 - 1) happens here.\nCounterexample:\n\nx = 115792089237316195423570985008687907853269984665640564039457584007913129639935\n\nTransaction trace:\nC.constructor()\nC.f(115792089237316195423570985008687907853269984665640564039457584007913129639935)\n    l1.f2(115792089237316195423570985008687907853269984665640564039457584007913129639935, 1) -- internal call
+// Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/imports/import_library_2.sol
+++ b/test/libsolidity/smtCheckerTests/imports/import_library_2.sol
@@ -25,5 +25,4 @@ contract ERC20 {
 // ====
 // SMTEngine: all
 // ----
-// Warning 3944: (ERC20.sol:157-162): CHC: Underflow (resulting value less than 0) happens here.
-// Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 3944: (ERC20.sol:157-162): CHC: Underflow (resulting value less than 0) happens here.\nCounterexample:\n\namount = 1\n\nTransaction trace:\nERC20.constructor()\nERC20.transferFrom(1){ msg.sender: 0x2e15 }\n    SafeMath.sub(0, 1) -- internal call

--- a/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_1.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_1.sol
@@ -17,4 +17,3 @@ contract C is B {
 // SMTIgnoreCex: no
 // ----
 // Warning 6328: (52-66): CHC: Assertion violation happens here.\nCounterexample:\ny = 0, x = 1\n\nTransaction trace:\nC.constructor()\nState: y = 0, x = 0\nC.g()\n    B.f() -- internal call
-// Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_2.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_2.sol
@@ -24,4 +24,3 @@ contract C is B {
 // SMTIgnoreCex: no
 // ----
 // Warning 6328: (54-68): CHC: Assertion violation happens here.\nCounterexample:\ny = 0, z = 0, w = 0, a = 0, b = 0, x = 1\n\nTransaction trace:\nC.constructor()\nState: y = 0, z = 0, w = 0, a = 0, b = 0, x = 0\nC.g()\n    A.f() -- internal call
-// Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_3.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_3.sol
@@ -30,4 +30,4 @@ contract C is B {
 // SMTIgnoreCex: no
 // ----
 // Warning 6328: (64-78): CHC: Assertion violation happens here.\nCounterexample:\nx = 2\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.g()\n    B.f() -- internal call\n        A.f() -- internal call\n            C.v() -- internal call
-// Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_4.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_4.sol
@@ -37,4 +37,4 @@ contract C is B, A1 {
 // SMTIgnoreCex: no
 // ----
 // Warning 6328: (64-78): CHC: Assertion violation happens here.\nCounterexample:\nx = 2\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.g()\n    C.f() -- internal call\n        A1.f() -- internal call\n            B.f() -- internal call\n                A.f() -- internal call\n                    C.v() -- internal call
-// Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_5.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_5.sol
@@ -31,4 +31,4 @@ contract C is B {
 // SMTIgnoreCex: no
 // ----
 // Warning 6328: (97-111): CHC: Assertion violation happens here.\nCounterexample:\nx = 0\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.g()\n    B.f() -- internal call\n        A.f() -- internal call\n            C.v() -- internal call\n                A.v() -- internal call
-// Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_7.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_7.sol
@@ -24,4 +24,4 @@ contract C is A {
 // SMTIgnoreCex: no
 // ----
 // Warning 6328: (56-70): CHC: Assertion violation happens here.\nCounterexample:\nx = 2\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.g()\n    A.f() -- internal call\n        C.v() -- internal call
-// Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_9.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/base_contract_assertion_fail_9.sol
@@ -31,4 +31,3 @@ contract C is B {
 // ----
 // Warning 6328: (62-76): CHC: Assertion violation happens here.\nCounterexample:\nx = 2\n\nTransaction trace:\nC.constructor()\nState: x = 0\nB.f()\n    A.f() -- internal call\n        C.v() -- internal call
 // Warning 6328: (131-145): CHC: Assertion violation happens here.\nCounterexample:\nx = 0\n\nTransaction trace:\nA.constructor()\nState: x = 0\nA.f()\n    A.v() -- internal call
-// Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/inheritance/constructor_state_variable_init_diamond_middle.sol
+++ b/test/libsolidity/smtCheckerTests/inheritance/constructor_state_variable_init_diamond_middle.sol
@@ -25,6 +25,6 @@ contract D is B, C {
 // ====
 // SMTEngine: all
 // ----
-// Warning 6328: (134-148): CHC: Assertion violation happens here.
-// Warning 6328: (223-237): CHC: Assertion violation happens here.
-// Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 6328: (134-148): CHC: Assertion violation happens here.\nCounterexample:\nx = 2\n\nTransaction trace:\nD.constructor()
+// Warning 6328: (223-237): CHC: Assertion violation happens here.\nCounterexample:\nx = 3\n\nTransaction trace:\nD.constructor()
+// Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_4.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_4.sol
@@ -36,7 +36,7 @@ contract D is B,C {
 // ====
 // SMTEngine: all
 // ----
-// Warning 6328: (160-174): CHC: Assertion violation happens here.
-// Warning 6328: (193-207): CHC: Assertion violation happens here.
-// Warning 6328: (226-240): CHC: Assertion violation happens here.
-// Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 6328: (160-174): CHC: Assertion violation happens here.\nCounterexample:\nx = 1\n\nTransaction trace:\nB.constructor()\nState: x = 0\nA.f()
+// Warning 6328: (193-207): CHC: Assertion violation happens here.\nCounterexample:\nx = 2\n\nTransaction trace:\nC.constructor()\nState: x = 0\nA.f()
+// Warning 6328: (226-240): CHC: Assertion violation happens here.\nCounterexample:\nx = 3\n\nTransaction trace:\nD.constructor()\nState: x = 0\nA.f()
+// Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_two_invocations_2.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_two_invocations_2.sol
@@ -16,5 +16,5 @@ contract C
 // ====
 // SMTEngine: all
 // ----
-// Warning 6328: (76-90): CHC: Assertion violation happens here.
-// Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 6328: (76-90): CHC: Assertion violation happens here.\nCounterexample:\nx = 3\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.f()
+// Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/operators/assignment_chain_tuple_contract_3.sol
+++ b/test/libsolidity/smtCheckerTests/operators/assignment_chain_tuple_contract_3.sol
@@ -23,4 +23,4 @@ contract D is C {
 // ----
 // Warning 6328: (95-109): CHC: Assertion violation happens here.\nCounterexample:\ny = 3, x = 3\n\nTransaction trace:\nD.constructor()\nState: y = 3, x = 3\nC.f()
 // Warning 6328: (180-194): CHC: Assertion violation happens here.\nCounterexample:\nx = 2\n\nTransaction trace:\nC.constructor()\nState: x = 2\nC.g()
-// Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/special/msg_value_inheritance_2.sol
+++ b/test/libsolidity/smtCheckerTests/special/msg_value_inheritance_2.sol
@@ -14,6 +14,5 @@ contract C is A {
 // ====
 // SMTEngine: all
 // ----
-// Warning 6328: (60-74): CHC: Assertion violation happens here.
-// Warning 6328: (240-254): CHC: Assertion violation happens here.
-// Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 6328: (60-74): CHC: Assertion violation happens here.\nCounterexample:\nv = 0, x = 115792089237316195423570985008687907853269984665640564039457584007913129637498\n\nTransaction trace:\nC.constructor(){ msg.value: 115792089237316195423570985008687907853269984665640564039457584007913129637498 }
+// Warning 6328: (240-254): CHC: Assertion violation happens here.\nCounterexample:\nv = 115792089237316195423570985008687907853269984665640564039457584007913129637498, x = 115792089237316195423570985008687907853269984665640564039457584007913129637498\n\nTransaction trace:\nC.constructor(){ msg.value: 115792089237316195423570985008687907853269984665640564039457584007913129637498 }

--- a/test/libsolidity/smtCheckerTests/special/msg_value_inheritance_3.sol
+++ b/test/libsolidity/smtCheckerTests/special/msg_value_inheritance_3.sol
@@ -18,5 +18,5 @@ contract C is A, B {
 // ====
 // SMTEngine: all
 // ----
-// Warning 6328: (60-74): CHC: Assertion violation happens here.
-// Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.
+// Warning 6328: (60-74): CHC: Assertion violation happens here.\nCounterexample:\nx = 115792089237316195423570985008687907853269984665640564039457584007913129637498\n\nTransaction trace:\nC.constructor(){ msg.value: 115792089237316195423570985008687907853269984665640564039457584007913129637498 }
+// Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.


### PR DESCRIPTION
The same verification target can be analyzed in the context of different contracts.
If the target is safe in the context of one contract, but can be violated in the context of another contract, model checker may report it both safe and unsafe (depending on the order of the analyzed contracts).

Note that if one violation of a target has been detected, the same target is ignored later.
However, if it was first shown safe, that information would be kept and displayed to the user.

The proposed fix checks if an unsafe target has previously been shown safe, and if so, this information is deleted.

Resolves #15849.