### PR TITLE
Fix spelling issues in a few code comments

### DIFF
--- a/libsmtutil/SMTPortfolio.cpp
+++ b/libsmtutil/SMTPortfolio.cpp
@@ -78,7 +78,7 @@ void SMTPortfolio::addAssertion(Expression const& _expr)
  * Ideally all solvers answer the query and agree on what the answer is
  * (all say SAT or all say UNSAT).
  *
- * The actual logic as as follows:
+ * The actual logic as follows:
  * 1) If at least one solver answers the query, all the non-answer results are ignored.
  *   Here SAT/UNSAT is preferred over UNKNOWN since it's an actual answer, and over ERROR
  *   because one buggy solver/integration shouldn't break the portfolio.

--- a/libsolidity/analysis/TypeChecker.h
+++ b/libsolidity/analysis/TypeChecker.h
@@ -54,7 +54,7 @@ public:
 	{}
 
 	/// Performs type checking on the given source and all of its sub-nodes.
-	/// @returns true iff all checks passed. Note even if all checks passed, errors() can still contain warnings
+	/// @returns true if all checks passed. Note even if all checks passed, errors() can still contain warnings
 	bool checkTypeRequirements(SourceUnit const& _source);
 
 	static bool typeSupportedByOldABIEncoder(Type const& _type, bool _isLibraryCall);

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -1646,7 +1646,7 @@ BoolResult ArrayType::isImplicitlyConvertibleTo(Type const& _convertTo) const
 	}
 	else
 	{
-		// Conversion to storage pointer or to memory, we de not copy element-for-element here, so
+		// Conversion to storage pointer or to memory, we do not copy element-for-element here, so
 		// require that the base type is the same, not only convertible.
 		// This disallows assignment of nested dynamic arrays from storage to memory for now.
 		if (


### PR DESCRIPTION
as as - as   `repetition`
iff - if  `fix typo`
we de not - we do not `fix typo`