### PR TITLE
Testing: Fix unused variable warning in SMTCheckerTests on other platforms than Windows/Linux/Macos

### DIFF
--- a/test/libsolidity/SMTCheckerTest.cpp
+++ b/test/libsolidity/SMTCheckerTest.cpp
@@ -131,6 +131,10 @@ SMTCheckerTest::SMTCheckerTest(std::string const& _filename):
 #elif __linux__
 		if (os == "linux")
 			m_shouldRun = false;
+#else
+		// On other operating systems this setting is ignored (as we don't test other operating systems in CI),
+		// but we need to prevent an unused-variable warning.
+		(void)os;
 #endif
 	}
 


### PR DESCRIPTION
Resolves #15679.

The `SMTCheckerTest` setting `SMTIgnoreOS`, which disables a test on the specified platforms, is ignored on other platforms than Windows/Linux/Macos. That's fine, because we do not have other operating systems in CI.
However, the current code was causing an unused-variable warning on other platforms, which we need to silence explicitly.