### PR TITLE
Fix custom cleanup sequence missing from metadata when other optimizer settings have default values

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ Compiler Features:
 
 Bugfixes:
  * General: Fix internal compiler error when requesting IR AST outputs for interfaces and abstract contracts.
+ * Metadata: Fix custom cleanup sequence missing from metadata when other optimizer settings have default values.
  * SMTChecker: Fix internal compiler error when analyzing overflowing expressions or bitwise negation of unsigned types involving constants.
  * SMTChecker: Fix reporting on targets that are safe in the context of one contract but unsafe in the context of another contract.
  * SMTChecker: Fix SMT logic error when analyzing cross-contract getter call with BMC.

--- a/libsolidity/interface/OptimiserSettings.h
+++ b/libsolidity/interface/OptimiserSettings.h
@@ -111,27 +111,8 @@ struct OptimiserSettings
 		util::unreachable();
 	}
 
-	bool operator==(OptimiserSettings const& _other) const
-	{
-		return
-			runOrderLiterals == _other.runOrderLiterals &&
-			runInliner == _other.runInliner &&
-			runJumpdestRemover == _other.runJumpdestRemover &&
-			runPeephole == _other.runPeephole &&
-			runDeduplicate == _other.runDeduplicate &&
-			runCSE == _other.runCSE &&
-			runConstantOptimiser == _other.runConstantOptimiser &&
-			simpleCounterForLoopUncheckedIncrement == _other.simpleCounterForLoopUncheckedIncrement &&
-			optimizeStackAllocation == _other.optimizeStackAllocation &&
-			runYulOptimiser == _other.runYulOptimiser &&
-			yulOptimiserSteps == _other.yulOptimiserSteps &&
-			expectedExecutionsPerDeployment == _other.expectedExecutionsPerDeployment;
-	}
-
-	bool operator!=(OptimiserSettings const& _other) const
-	{
-		return !(*this == _other);
-	}
+	bool operator==(OptimiserSettings const& _other) const = default;
+	bool operator!=(OptimiserSettings const& _other) const = default;
 
 	/// Move literals to the right of commutative binary operators during code generation.
 	/// This helps exploiting associativity.

--- a/test/libsolidity/Metadata.cpp
+++ b/test/libsolidity/Metadata.cpp
@@ -443,7 +443,7 @@ BOOST_AUTO_TEST_CASE(metadata_revert_strings)
 
 BOOST_AUTO_TEST_CASE(metadata_optimiser_sequence)
 {
-	char const* sourceCode = R"(
+	std::string const sourceCode = R"(
 		pragma solidity >=0.0;
 		contract C {
 		}
@@ -455,28 +455,34 @@ BOOST_AUTO_TEST_CASE(metadata_optimiser_sequence)
 		{"", ""},
 		{"", "fDn"},
 		{"dhfoDgvulfnTUtnIf", "" },
-		{"dhfoDgvulfnTUtnIf", "fDn"}
+		{"dhfoDgvulfnTUtnIf", "fDn"},
+		// test that a custom cleanup step sequence does not lead to default standard optimiser settings in metadata
+		{OptimiserSettings::DefaultYulOptimiserSteps, "D"},
+		// test that a custom optimizer sequence does not lead to default standard optimiser settings in metadata
+		{"dhfoDgvulfnTUtnIf", OptimiserSettings::DefaultYulOptimiserCleanupSteps}
 	};
 
 	std::vector<OptimiserSettings> settingsToTest;
 	for (auto const& [optimizerSequence, optimizerCleanupSequence]: sequences)
 	{
-		settingsToTest.emplace_back(OptimiserSettings::minimal());
-		settingsToTest.back().runYulOptimiser = true;
-		settingsToTest.back().yulOptimiserSteps = optimizerSequence;
-		settingsToTest.back().yulOptimiserCleanupSteps = optimizerCleanupSequence;
+		for (auto const& preset: {
+			OptimiserSettings::none(),
+			OptimiserSettings::minimal(),
+			OptimiserSettings::standard(),
+			OptimiserSettings::full(),
+		})
+		{
+			settingsToTest.emplace_back(preset);
+			settingsToTest.back().runYulOptimiser = true;
+			settingsToTest.back().yulOptimiserSteps = optimizerSequence;
+			settingsToTest.back().yulOptimiserCleanupSteps = optimizerCleanupSequence;
+		}
 	}
 
-	{
-		// test that a custom cleanup step sequence does not lead to default standard optimiser settings in metadata
-		settingsToTest.emplace_back(OptimiserSettings::standard());
-		settingsToTest.back().yulOptimiserCleanupSteps = "D";
-	}
-
-	auto check = [sourceCode](OptimiserSettings const& _optimizerSettings)
+	auto generateMetadataJson = [](std::string const& _source, OptimiserSettings const& _optimizerSettings) -> Json
 	{
 		CompilerStack compilerStack;
-		compilerStack.setSources({{"", sourceCode}});
+		compilerStack.setSources({{"", _source}});
 		compilerStack.setEVMVersion(solidity::test::CommonOptions::get().evmVersion());
 		compilerStack.setOptimiserSettings(_optimizerSettings);
 
@@ -486,17 +492,33 @@ BOOST_AUTO_TEST_CASE(metadata_optimiser_sequence)
 		Json metadata;
 		BOOST_REQUIRE(util::jsonParseStrict(serialisedMetadata, metadata));
 		BOOST_CHECK(solidity::test::isValidMetadata(metadata));
-		BOOST_CHECK(metadata["settings"]["optimizer"].contains("details"));
-		BOOST_CHECK(metadata["settings"]["optimizer"]["details"].contains("yulDetails"));
-		BOOST_CHECK(metadata["settings"]["optimizer"]["details"]["yulDetails"].contains("optimizerSteps"));
+		return metadata;
+	};
 
-		std::string const metadataOptimizerSteps = metadata["settings"]["optimizer"]["details"]["yulDetails"]["optimizerSteps"].get<std::string>();
+	auto checkCustomSettings = [generateMetadataJson, sourceCode](OptimiserSettings const& _optimizerSettings)
+	{
+		auto const metadataJson = generateMetadataJson(sourceCode, _optimizerSettings);
+		BOOST_CHECK(metadataJson["settings"]["optimizer"].contains("details"));
+		BOOST_CHECK(metadataJson["settings"]["optimizer"]["details"].contains("yulDetails"));
+		BOOST_CHECK(metadataJson["settings"]["optimizer"]["details"]["yulDetails"].contains("optimizerSteps"));
+
+		std::string const metadataOptimizerSteps = metadataJson["settings"]["optimizer"]["details"]["yulDetails"]["optimizerSteps"].get<std::string>();
 		std::string const expectedMetadataOptimiserSteps = _optimizerSettings.yulOptimiserSteps + ":" + _optimizerSettings.yulOptimiserCleanupSteps;
 		BOOST_CHECK_EQUAL(metadataOptimizerSteps, expectedMetadataOptimiserSteps);
 	};
 
 	for (auto const& optimizerSettings: settingsToTest)
-		check(optimizerSettings);
+		checkCustomSettings(optimizerSettings);
+
+	for (auto const& preset: {OptimiserSettings::minimal(), OptimiserSettings::standard(), OptimiserSettings::full()})
+	{
+		auto const metadataJson = generateMetadataJson(sourceCode, preset);
+		Json expectedOptimizerMetadata = {
+			{"enabled", preset != OptimiserSettings::minimal()},
+			{"runs", preset.expectedExecutionsPerDeployment}
+		};
+		BOOST_CHECK(metadataJson["settings"]["optimizer"] == expectedOptimizerMetadata);
+	}
 }
 
 BOOST_AUTO_TEST_CASE(metadata_license_missing)


### PR DESCRIPTION
Extracted from PR #15834, see https://github.com/ethereum/solidity/pull/15834#discussion_r1954436008.

The previous implementation did not make use of the `yulOptimiserCleanupSteps`. As @cameel suspected, providing a custom cleanup sequence under the default optimization sequence previously simply yielded a `"optimizer": "enabled":true, "runs": 200}` which potentially (or: most likely) doesn't reproduce the original compilation results.

I think it is a bit mitigated by there not being a specific field for the cleanup sequence in the standard-json input but one would rather have to reproduce the entire default optimization sequence, add a colon, and then modify the cleanup sequence.

