### PR TITLE
SMTChecker: Ignore errors that might occur during constant evaluation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,7 @@ Compiler Features:
 
 Bugfixes:
  * General: Fix internal compiler error when requesting IR AST outputs for interfaces and abstract contracts.
+ * SMTChecker: Fix internal compiler error when analyzing overflowing expressions or bitwise negation of unsigned types involving constants.
  * SMTChecker: Fix reporting on targets that are safe in the context of one contract but unsafe in the context of another contract.
  * SMTChecker: Fix SMT logic error when analyzing cross-contract getter call with BMC.
  * SMTChecker: Fix SMT logic error when contract deployment involves string literal to fixed bytes conversion.

--- a/libsolidity/analysis/ConstantEvaluator.cpp
+++ b/libsolidity/analysis/ConstantEvaluator.cpp
@@ -269,6 +269,20 @@ std::optional<TypedRational> ConstantEvaluator::evaluate(
 	return ConstantEvaluator{_errorReporter}.evaluate(_expr);
 }
 
+std::optional<TypedRational> ConstantEvaluator::tryEvaluate(Expression const& _expr)
+{
+	ErrorList errorList;
+	ErrorReporter errorReporter(errorList);
+	try
+	{
+		return ConstantEvaluator{errorReporter}.evaluate(_expr);
+	}
+	catch (FatalError const&)
+	{
+		return std::nullopt;
+	}
+}
+
 
 std::optional<TypedRational> ConstantEvaluator::evaluate(ASTNode const& _node)
 {

--- a/libsolidity/analysis/ConstantEvaluator.h
+++ b/libsolidity/analysis/ConstantEvaluator.h
@@ -57,6 +57,10 @@ public:
 		Expression const& _expr
 	);
 
+	/// Works the same as `evaluate` but swallows any errors that might occur in the evaluation and simply returns
+	/// `std::nullopt` instead.
+	static std::optional<TypedRational> tryEvaluate(Expression const& _expr);
+
 	/// Performs arbitrary-precision evaluation of a binary operator. Returns nullopt on cases like
 	/// division by zero or e.g. bit operators applied to fractional values.
 	static std::optional<rational> evaluateBinaryOperator(Token _operator, rational const& _left, rational const&  _right);

--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -3124,13 +3124,8 @@ RationalNumberType const* SMTEncoder::isConstant(Expression const& _expr)
 	if (auto type = dynamic_cast<RationalNumberType const*>(_expr.annotation().type))
 		return type;
 
-	// _expr may not be constant evaluable.
-	// In that case we ignore any warnings emitted by the constant evaluator,
-	// as it will return nullptr in case of failure.
-	ErrorList l;
-	ErrorReporter e(l);
-	if (auto t = ConstantEvaluator::evaluate(e, _expr))
-		return TypeProvider::rationalNumber(t->value);
+	if (auto typedRational = ConstantEvaluator::tryEvaluate(_expr))
+		return TypeProvider::rationalNumber(typedRational->value);
 
 	return nullptr;
 }

--- a/test/libsolidity/smtCheckerTests/operators/constant_evaluation_add.sol
+++ b/test/libsolidity/smtCheckerTests/operators/constant_evaluation_add.sol
@@ -1,0 +1,11 @@
+contract C {
+    uint8 constant N = 255;
+
+    function f() public pure returns (uint8) {
+        return N + 1;
+    }
+}
+// ====
+// SMTEngine: chc
+// ----
+// Warning 4984: (104-109): CHC: Overflow (resulting value larger than 255) happens here.\nCounterexample:\nN = 255\n = 0\n\nTransaction trace:\nC.constructor()\nState: N = 255\nC.f()

--- a/test/libsolidity/smtCheckerTests/operators/constant_evaluation_bitwise_not.sol
+++ b/test/libsolidity/smtCheckerTests/operators/constant_evaluation_bitwise_not.sol
@@ -1,0 +1,9 @@
+contract C {
+    uint256 constant largeConstant = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+    function test() public pure returns (uint256) {
+        return ~largeConstant;
+    }
+}
+// ====
+// SMTEngine: chc
+// ----

--- a/test/libsolidity/smtCheckerTests/operators/constant_evaluation_sub.sol
+++ b/test/libsolidity/smtCheckerTests/operators/constant_evaluation_sub.sol
@@ -1,0 +1,11 @@
+contract C {
+    uint256 public constant B = 1;
+
+    function f() public pure returns (uint256) {
+        return B - 112;
+    }
+}
+// ====
+// SMTEngine: chc
+// ----
+// Warning 3944: (113-120): CHC: Underflow (resulting value less than 0) happens here.\nCounterexample:\nB = 1\n = 0\n\nTransaction trace:\nC.constructor()\nState: B = 1\nC.f()


### PR DESCRIPTION
Previously, if a fatal error would occur during constant evaluation in the model checker, it would throw an exception which the model checker would let escape and crash the compiler.

We introduce a new API to `ConstantEvaluator` that swallows any errors use it from the model checker.
This allows model checker to continue, treating any expression where an error would occur simply as not constant.

Fixes #15600 #15601 #15722.

Resolves point 3 of [@cameel 's analysis](https://github.com/ethereum/solidity/issues/15709#issuecomment-2628622966) in #15709.