### PR TITLE
Fix spelling errors in a few code comments in libsolidity and SMTChecker

### DIFF
--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -367,7 +367,7 @@ private:
 	/// modifier is applied twice, the position of the variable needs to be restored
 	/// after the nested modifier is left.
 	std::map<Declaration const*, std::vector<unsigned>> m_localVariables;
-	/// The contract currently being compiled. Virtual function lookup starts from this contarct.
+	/// The contract currently being compiled. Virtual function lookup starts from this contract.
 	ContractDefinition const* m_mostDerivedContract = nullptr;
 	/// Whether to use checked arithmetic.
 	Arithmetic m_arithmetic = Arithmetic::Checked;

--- a/libsolidity/formal/BMC.cpp
+++ b/libsolidity/formal/BMC.cpp
@@ -459,7 +459,7 @@ bool BMC::visit(ForStatement const& _node)
 			_node.condition()->accept(*this);
 			forCondition = expr(*_node.condition());
 		}
-		// asseert that the loop is complete
+		// assert that the loop is complete
 		m_context.addAssertion(!forCondition || broke || !forConditionOnPreviousIterations);
 		mergeVariables(
 			broke || !forConditionOnPreviousIterations,

--- a/libsolidity/formal/SMTEncoder.h
+++ b/libsolidity/formal/SMTEncoder.h
@@ -508,7 +508,7 @@ protected:
 	ContractDefinition const* m_currentContract = nullptr;
 
 	/// Stores the free functions and internal library functions.
-	/// Those need to be encoded repeatedely for every analyzed contract.
+	/// Those need to be encoded repeatedly for every analyzed contract.
 	std::set<FunctionDefinition const*, ASTNode::CompareByID> m_freeFunctions;
 
 	/// Stores the context of the encoding.


### PR DESCRIPTION
contarct - contract
asseert - assert
repeatedely - repeatedly