### PR TITLE
Grammar and typo fixes in code comments

### DIFF
--- a/libyul/optimiser/SSATransform.h
+++ b/libyul/optimiser/SSATransform.h
@@ -67,7 +67,7 @@ class NameDispenser;
  * The current value mapping is cleared for a variable a at the end of each block
  * in which it was assigned. We compensate that by appending a declaration
  * of the form of "let a_1 := a" right after the location where control flow joins so
- * variable references can use the SSA variable. The only exception to this rule are
+ * variable references can use the SSA variable. The only exception to this rule is
  * for loop conditions, as we cannot insert a variable declaration there.
  *
  * After this stage, UnusedAssignmentEliminator is recommended to remove the unnecessary

--- a/scripts/docker/buildpack-deps/emscripten.jam
+++ b/scripts/docker/buildpack-deps/emscripten.jam
@@ -25,7 +25,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 #
-# Boost.Build support for Emscipten.
+# Boost.Build support for Emscripten.
 #
 # @todo add support for dynamic linking
 # @todo add support for --js-library, --pre-js, and --post-js options


### PR DESCRIPTION
In SSATransform.h:

Old: "The only exception to this rule are"
New: "The only exception to this rule is"
Reason: Corrects subject-verb agreement.
In emscripten.jam:

Old: "Boost.Build support for Emscipten."
New: "Boost.Build support for Emscripten."
Reason: Fixes the typo in "Emscripten."