### PR TITLE
Grammar & Clarity Fixes in external test scripts (Reopened)

### DIFF
--- a/test/externalTests/brink.sh
+++ b/test/externalTests/brink.sh
@@ -61,7 +61,7 @@ function brink_test
     setup_solc "$DIR" "$BINARY_TYPE" "$BINARY_PATH"
     download_project "$repo" "$ref" "$DIR"
 
-    # TODO: Remove this when Brink merges https://github.com/brinktrade/brink-core/pull/52
+    # TODO: Remove this once Brink merges PR #52 (https://github.com/brinktrade/brink-core/pull/52).
     sed -i "s|\(function isValidSignature(bytes \)calldata\( _data, bytes \)calldata\( _signature)\)|\1memory\2memory\3|g" src/Test/MockEIP1271Validator.sol
 
     neutralize_package_lock

--- a/test/externalTests/elementfi.sh
+++ b/test/externalTests/elementfi.sh
@@ -93,8 +93,8 @@ function elementfi_test
     sed -i 's|it(\("should prevent withdrawal of Principal Tokens and Interest Tokens before the tranche expires "\)|it.skip(\1|g' test/trancheTest.ts
     sed -i 's|it(\("should prevent withdrawal of more Principal Tokens and Interest Tokens than the user has"\)|it.skip(\1|g' test/trancheTest.ts
 
-    # This test file is very flaky. There's one particular cases that fails randomly (see
-    # https://github.com/element-fi/elf-contracts/issues/240) but some others also depends on an external
+    # This test file is very flaky. There's one particular case that fails randomly (see
+    # https://github.com/element-fi/elf-contracts/issues/240) but some others also depend on an external
     # service which makes tests time out when that service is down.
     # "ProviderError: Too Many Requests error received from eth-mainnet.alchemyapi.io"
     rm test/mockERC20YearnVaultTest.ts


### PR DESCRIPTION
File: test/externalTests/brink_test.sh
Before: "Remove this when Brink merges"
After: "Remove once Brink merges PR https://github.com/ethereum/solidity/pull/52"
Fixed grammar in flaky test comment

File: test/externalTests/elementfi_test.sh
Before: "one particular cases" → "one particular case"
Before: "depends" → "depend"