### PR TITLE
[DO NOT MERGE] Remove source locations on Yul optimizer function deduplication for testing.

### DIFF
--- a/libyul/AST.h
+++ b/libyul/AST.h
@@ -155,9 +155,21 @@ template <class T> inline langutil::DebugData::ConstPtr debugDataOf(T const& _no
 }
 
 /// Extracts the debug data from a Yul node.
+template <class T> inline void setDebugData(T& _node, langutil::DebugData::ConstPtr _debugData)
+{
+	_node.debugData = std::move(_debugData);
+}
+
+/// Extracts the debug data from a Yul node.
 template <class... Args> inline langutil::DebugData::ConstPtr debugDataOf(std::variant<Args...> const& _node)
 {
 	return std::visit([](auto const& _arg) { return debugDataOf(_arg); }, _node);
+}
+
+/// Extracts the debug data from a Yul node.
+template <class... Args> inline void setDebugData(std::variant<Args...>& _node, langutil::DebugData::ConstPtr _debugData)
+{
+	return std::visit([&](auto& _arg) { setDebugData(_arg, _debugData); }, _node);
 }
 
 inline bool hasDefaultCase(Switch const& _switch)

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -178,6 +178,7 @@ add_library(yul
 	optimiser/Semantics.h
 	optimiser/SimplificationRules.cpp
 	optimiser/SimplificationRules.h
+	optimiser/SourceLocationRemover.h
 	optimiser/StackCompressor.cpp
 	optimiser/StackCompressor.h
 	optimiser/StackLimitEvader.cpp

--- a/libyul/optimiser/EquivalentFunctionCombiner.cpp
+++ b/libyul/optimiser/EquivalentFunctionCombiner.cpp
@@ -20,8 +20,10 @@
  */
 
 #include <libyul/optimiser/EquivalentFunctionCombiner.h>
+#include <libyul/optimiser/SourceLocationRemover.h>
 #include <libyul/AST.h>
 #include <libsolutil/CommonData.h>
+#include <range/v3/view/map.hpp>
 
 using namespace solidity;
 using namespace solidity::yul;
@@ -30,6 +32,15 @@ void EquivalentFunctionCombiner::run(OptimiserStepContext&, Block& _ast)
 {
 	EquivalentFunctionCombiner{EquivalentFunctionDetector::run(_ast)}(_ast);
 }
+
+void EquivalentFunctionCombiner::operator()(FunctionDefinition& _functionDefinition)
+{
+	for (auto* functionDefinition: m_duplicates | ranges::views::values)
+		if (&_functionDefinition == functionDefinition)
+			SourceLocationRemover{}(_functionDefinition);
+	ASTModifier::operator()(_functionDefinition);
+}
+
 
 void EquivalentFunctionCombiner::operator()(FunctionCall& _funCall)
 {

--- a/libyul/optimiser/EquivalentFunctionCombiner.h
+++ b/libyul/optimiser/EquivalentFunctionCombiner.h
@@ -44,6 +44,7 @@ public:
 
 	using ASTModifier::operator();
 	void operator()(FunctionCall& _funCall) override;
+	void operator()(FunctionDefinition& _funCall) override;
 
 private:
 	EquivalentFunctionCombiner(std::map<YulName, FunctionDefinition const*> _duplicates): m_duplicates(std::move(_duplicates)) {}

--- a/libyul/optimiser/SourceLocationRemover.h
+++ b/libyul/optimiser/SourceLocationRemover.h
@@ -1,0 +1,117 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+#pragma once
+
+#include <libyul/optimiser/ASTWalker.h>
+#include <liblangutil/DebugData.h>
+#include <libyul/AST.h>
+
+namespace solidity::yul
+{
+class SourceLocationRemover: public ASTModifier
+{
+public:
+	void operator()(Literal& _literal) override
+	{
+		resetDebugData(_literal);
+		ASTModifier::operator()(_literal);
+	}
+	void operator()(Identifier& _identifier) override
+	{
+		resetDebugData(_identifier);
+		ASTModifier::operator()(_identifier);
+	}
+	void operator()(FunctionCall& _funCall) override
+	{
+		resetDebugData(_funCall.functionName);
+		resetDebugData(_funCall);
+		ASTModifier::operator()(_funCall);
+	}
+	void operator()(ExpressionStatement& _statement) override
+	{
+		resetDebugData(_statement);
+		ASTModifier::operator()(_statement);
+	}
+	void operator()(Assignment& _assignment) override
+	{
+		resetDebugData(_assignment);
+		ASTModifier::operator()(_assignment);
+	}
+	void operator()(VariableDeclaration& _varDecl) override
+	{
+		resetDebugData(_varDecl);
+		ASTModifier::operator()(_varDecl);
+	}
+	void operator()(If& _if) override
+	{
+		resetDebugData(_if);
+		ASTModifier::operator()(_if);
+	}
+	void operator()(Switch& _switch) override
+	{
+		resetDebugData(_switch);
+		ASTModifier::operator()(_switch);
+	}
+	void operator()(FunctionDefinition& _functionDefinition) override
+	{
+		resetDebugData(_functionDefinition);
+		ASTModifier::operator()(_functionDefinition);
+	}
+	void operator()(ForLoop& _forLoop) override
+	{
+		resetDebugData(_forLoop);
+		ASTModifier::operator()(_forLoop);
+	}
+	void operator()(Break& _break) override
+	{
+		resetDebugData(_break);
+		ASTModifier::operator()(_break);
+	}
+	void operator()(Continue& _continue) override
+	{
+		resetDebugData(_continue);
+		ASTModifier::operator()(_continue);
+	}
+	void operator()(Leave& _leaveStatement) override
+	{
+		resetDebugData(_leaveStatement);
+		ASTModifier::operator()(_leaveStatement);
+	}
+	void operator()(Block& _block) override
+	{
+		resetDebugData(_block);
+		ASTModifier::operator()(_block);
+	}
+	void visit(Statement& _st) override
+	{
+		resetDebugData(_st);
+		ASTModifier::visit(_st);
+	}
+	void visit(Expression& _e) override
+	{
+		resetDebugData(_e);
+		ASTModifier::visit(_e);
+	}
+	template<typename T>
+	void resetDebugData(T& _node)
+	{
+		setDebugData(_node, {});
+	}
+
+};
+}


### PR DESCRIPTION
@veniger As we talked about, this is a quick and dirty branch that removes source locations whenever functions are deduplicated by the Yul optimizer.
I'm a bit sceptical, whether this is really what we want (and it may still actually be the libevmasm optimizer that's doing the deduplication in the relevant cases), but I'd be curious to hear, if this actually changes the cases you're struggling with - if not, it may be interesting to post the sources for such a case, s.t. we can look into it in more detail.

Although, weirdly, I just see in some tests that - while it actually just removes source locations - in fact seems to sometimes *add* some - I guess since we'll fall back to previous ones, I'll still need to look into that to avoid that.