### PR TITLE
Correct Chinese translation URL

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -89,7 +89,7 @@ The English version stands as a reference.
 You can switch between languages by clicking on the flyout menu in the bottom-left corner
 and selecting the preferred language.
 
-* `Chinese <https://docs.soliditylang.org/zh/latest/>`_
+* `Chinese <https://docs.soliditylang.org/zh-cn/latest/>`_
 * `French <https://docs.soliditylang.org/fr/latest/>`_
 * `Indonesian <https://github.com/solidity-docs/id-indonesian>`_
 * `Japanese <https://github.com/solidity-docs/ja-japanese>`_


### PR DESCRIPTION
The https://docs.soliditylang.org/zh/latest/ URL is invalid and returns a "page not found" error. The correct URL is https://docs.soliditylang.org/zh-cn/latest/