### PR TITLE
Report errors only for contracts that directly inherit from one with a specified storage layout

### DIFF
--- a/test/cmdlineTests/storage_layout_already_defined_in_ancestor/err
+++ b/test/cmdlineTests/storage_layout_already_defined_in_ancestor/err
@@ -1,20 +1,9 @@
-Error: Storage layout can only be specified in the most derived contract.
- --> <stdin>:5:1:
+Error: Cannot inherit from a contract with a custom storage layout.
+ --> <stdin>:5:15:
   |
 5 | contract B is A {}
-  | ^^^^^^^^^^^^^^^^^^
-Note: Storage layout was already specified here.
- --> <stdin>:4:12:
-  |
-4 | contract A layout at 0x1234 {}
-  |            ^^^^^^^^^^^^^^^^
-
-Error: Storage layout can only be specified in the most derived contract.
- --> <stdin>:6:1:
-  |
-6 | contract C layout at 0x1234 is B {}
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Note: Storage layout was already specified here.
+  |               ^
+Note: Custom storage layout defined here:
  --> <stdin>:4:12:
   |
 4 | contract A layout at 0x1234 {}

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_already_specified_in_ancestor_contract.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_already_specified_in_ancestor_contract.sol
@@ -4,5 +4,4 @@ contract B is A {}
 
 contract C is B layout at 0xABCD {}
 // ----
-// TypeError 8894: (32-50): Storage layout can only be specified in the most derived contract.
-// TypeError 8894: (52-87): Storage layout can only be specified in the most derived contract.
+// TypeError 8894: (46-47): Cannot inherit from a contract with a custom storage layout.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specified_by_ancestor_contract_module.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specified_by_ancestor_contract_module.sol
@@ -1,0 +1,13 @@
+==== Source: C ====
+import "M" as M;
+import "N" as N;
+
+contract C is M.A, N.A layout at 0xABCD {}
+==== Source: M ====
+contract A layout at 0x1234 {}
+
+==== Source: N ====
+contract A {}
+
+// ----
+// TypeError 8894: (C:49-52): Cannot inherit from a contract with a custom storage layout.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specified_by_ancestor_contract_multiple_inheritance.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specified_by_ancestor_contract_multiple_inheritance.sol
@@ -1,0 +1,16 @@
+contract A layout at 1 {}
+contract B is A layout at 2 {}
+
+contract C1 is B {}
+contract C2 is A, B {}
+contract C3 is B {}
+
+contract D1 is C1 {}
+contract D2 is C2 {}
+contract D3 is C3 {}
+// ----
+// TypeError 8894: (40-41): Cannot inherit from a contract with a custom storage layout.
+// TypeError 8894: (73-74): Cannot inherit from a contract with a custom storage layout.
+// TypeError 8894: (93-94): Cannot inherit from a contract with a custom storage layout.
+// TypeError 8894: (96-97): Cannot inherit from a contract with a custom storage layout.
+// TypeError 8894: (116-117): Cannot inherit from a contract with a custom storage layout.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specified_by_first_ancestor_contract.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specified_by_first_ancestor_contract.sol
@@ -3,6 +3,4 @@ contract B is A {}
 contract C is B {}
 contract D is C {}
 // ----
-// TypeError 8894: (27-45): Storage layout can only be specified in the most derived contract.
-// TypeError 8894: (46-64): Storage layout can only be specified in the most derived contract.
-// TypeError 8894: (65-83): Storage layout can only be specified in the most derived contract.
+// TypeError 8894: (41-42): Cannot inherit from a contract with a custom storage layout.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specified_by_last_ancestor_contract.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specified_by_last_ancestor_contract.sol
@@ -3,4 +3,4 @@ contract B is A {}
 contract C is B layout at 42 {}
 contract D is C {}
 // ----
-// TypeError 8894: (65-83): Storage layout can only be specified in the most derived contract.
+// TypeError 8894: (79-80): Cannot inherit from a contract with a custom storage layout.


### PR DESCRIPTION
Suggested in https://github.com/ethereum/solidity/pull/15528#discussion_r1967472244