### PR TITLE
Replace temporary std::string with std::string_view in _yulname literal

### DIFF
--- a/libyul/YulString.h
+++ b/libyul/YulString.h
@@ -165,7 +165,7 @@ private:
 
 inline YulString operator "" _yulname(char const* _string, std::size_t _size)
 {
-	return YulString(std::string(_string, _size));
+	return YulString(std::string_view(_string, _size));
 }
 
 }


### PR DESCRIPTION
Replace temporary std::string with std::string_view in _yulname literal to avoid unnecessary allocations and copies