### PR TITLE
Get rid of `assertThrow()` in soltest

### DIFF
--- a/test/Common.cpp
+++ b/test/Common.cpp
@@ -129,22 +129,22 @@ void CommonOptions::addOptions()
 
 void CommonOptions::validate() const
 {
-	assertThrow(
+	solRequire(
 		!testPath.empty(),
 		ConfigException,
 		"No test path specified. The --testpath argument must not be empty when given."
 	);
-	assertThrow(
+	solRequire(
 		fs::exists(testPath),
 		ConfigException,
 		"Invalid test path specified."
 	);
-	assertThrow(
+	solRequire(
 		batches > 0,
 		ConfigException,
 		"Batches needs to be at least 1."
 	);
-	assertThrow(
+	solRequire(
 		selectedBatch < batches,
 		ConfigException,
 		"Selected batch has to be less than number of batches."
@@ -162,7 +162,7 @@ void CommonOptions::validate() const
 		std::cout << std::endl << "DO NOT COMMIT THE UPDATED EXPECTATIONS." << std::endl << std::endl;
 	}
 
-	assertThrow(!eofVersion().has_value() || evmVersion().supportsEOF(), ConfigException, "EOF is unavailable before Osaka fork.");
+	solRequire(!eofVersion().has_value() || evmVersion().supportsEOF(), ConfigException, "EOF is unavailable before Osaka fork.");
 }
 
 bool CommonOptions::parse(int argc, char const* const* argv)

--- a/test/tools/IsolTestOptions.cpp
+++ b/test/tools/IsolTestOptions.cpp
@@ -92,7 +92,7 @@ void IsolTestOptions::validate() const
 	CommonOptions::validate();
 	static std::string filterString{"[a-zA-Z0-9_/*]*"};
 	static std::regex filterExpression{filterString};
-	assertThrow(
+	solRequire(
 		regex_match(testFilter, filterExpression),
 		ConfigException,
 		"Invalid test unit filter - can only contain '" + filterString + ": " + testFilter


### PR DESCRIPTION
A tiny bit of cleanup extracted from #15905. I removed a couple of `assertThrow()`s from the code I was touching and then noticed that there aren't that many left in tests overall so I can just do them all.

For context, `assertThrow()` is a weird legacy macro that is named as if it was an assert but instead of reporting an ICE, throws the user-supplied exception, which makes it a validation (when used properly). And of course it's often abused for things that are not validations. There's no reason to use it at all and it should eventually be replaced by the more self-explanatory `solAssert()`/`solRequire()`/`solUnimplemented()`, depending on what it's actually used for.