### PR TITLE
Fix reversed conditions in `ObjectOptimizer::calculateCacheKey()`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -29,6 +29,7 @@ Bugfixes:
  * Standard JSON Interface: Fix ``generatedSources`` and ``sourceMap`` being generated internally even when not requested.
  * TypeChecker: Fix supurious compilation errors due to incorrect computation of contract storage size which erroneously included transient storage variables.
  * Yul: Fix internal compiler error when a code generation error should be reported instead.
+ * Yul Optimizer: Fix failing debug assertion due to dereferencing of an empty ``optional`` value.
 
 
 Build system:

--- a/libyul/ObjectOptimizer.cpp
+++ b/libyul/ObjectOptimizer.cpp
@@ -154,9 +154,10 @@ std::optional<h256> ObjectOptimizer::calculateCacheKey(
 	rawKey += keccak256(asmPrinter(_ast)).asBytes();
 	rawKey += keccak256(_debugData.formatUseSrcComment()).asBytes();
 	rawKey += h256(u256(_settings.language)).asBytes();
-	rawKey += FixedHash<1>(static_cast<uint8_t>(_settings.optimizeStackAllocation ? 1 : 0)).asBytes();
+	static_assert(static_cast<uint8_t>(static_cast<bool>(2)) == 1);
+	rawKey += FixedHash<1>(static_cast<uint8_t>(_settings.optimizeStackAllocation)).asBytes();
 	rawKey += h256(u256(_settings.expectedExecutionsPerDeployment)).asBytes();
-	rawKey += FixedHash<1>(static_cast<uint8_t>(_isCreation ? 1 : 0)).asBytes();
+	rawKey += FixedHash<1>(static_cast<uint8_t>(_isCreation)).asBytes();
 	rawKey += keccak256(_settings.evmVersion.name()).asBytes();
 	yulAssert(!_settings.eofVersion.has_value() || *_settings.eofVersion > 0);
 	rawKey += FixedHash<1>(static_cast<uint8_t>(_settings.eofVersion ? *_settings.eofVersion : 0)).asBytes();

--- a/libyul/ObjectOptimizer.cpp
+++ b/libyul/ObjectOptimizer.cpp
@@ -154,12 +154,12 @@ std::optional<h256> ObjectOptimizer::calculateCacheKey(
 	rawKey += keccak256(asmPrinter(_ast)).asBytes();
 	rawKey += keccak256(_debugData.formatUseSrcComment()).asBytes();
 	rawKey += h256(u256(_settings.language)).asBytes();
-	rawKey += FixedHash<1>(uint8_t(_settings.optimizeStackAllocation ? 0 : 1)).asBytes();
+	rawKey += FixedHash<1>(static_cast<uint8_t>(_settings.optimizeStackAllocation ? 1 : 0)).asBytes();
 	rawKey += h256(u256(_settings.expectedExecutionsPerDeployment)).asBytes();
-	rawKey += FixedHash<1>(uint8_t(_isCreation ? 0 : 1)).asBytes();
+	rawKey += FixedHash<1>(static_cast<uint8_t>(_isCreation ? 1 : 0)).asBytes();
 	rawKey += keccak256(_settings.evmVersion.name()).asBytes();
 	yulAssert(!_settings.eofVersion.has_value() || *_settings.eofVersion > 0);
-	rawKey += FixedHash<1>(uint8_t(_settings.eofVersion ? 0 : *_settings.eofVersion)).asBytes();
+	rawKey += FixedHash<1>(static_cast<uint8_t>(_settings.eofVersion ? *_settings.eofVersion : 0)).asBytes();
 	rawKey += keccak256(_settings.yulOptimiserSteps).asBytes();
 	rawKey += keccak256(_settings.yulOptimiserCleanupSteps).asBytes();
 


### PR DESCRIPTION
Fixes #15871.

The cache key calculation was using reversed values for boolean flags. This was unintended, but wasn't really breaking anything on its own since they can't be read back and it only matters that they are unique. Actual problems started in #15467, where a new entry was based on the incorrect condition, putting code dereferencing an `optional` in the wrong branch.

This started failing a debug assertion in STL, but fortunately does not seem like it could lead to broken output. If the value that ends up getting stored is zero, it will result in EOF and non-EOF compilation getting the same cache key, but it's currently not possible to mix them. If the value is some random garbage from memory, it will lead to identical objects getting different keys, bypassing the cache, but we haven't observed this kind of degradation in benchmarks so far.