### PR TITLE
Document Node.js required version change for Solc-Js.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -38,6 +38,10 @@ Build system:
  * Linux release builds are fully static again and no longer depend on ``glibc``.
  * Switch from C++17 to C++20 as the target standard.
 
+
+Solc-Js:
+ * The wrapper now requires at least nodejs v12.
+
 ### 0.8.28 (2024-10-09)
 
 Language Features:


### PR DESCRIPTION
Depends on https://github.com/ethereum/solc-js/pull/756