### PR TITLE
Warn when the storage layout base is near the end of storage (2^64 slots or less)

### DIFF
--- a/libsolidity/analysis/PostTypeContractLevelChecker.h
+++ b/libsolidity/analysis/PostTypeContractLevelChecker.h
@@ -52,6 +52,8 @@ private:
 
 	void checkStorageLayoutSpecifier(ContractDefinition const& _contract);
 
+	void warnStorageLayoutBaseNearStorageEnd(ContractDefinition const& _contract);
+
 	langutil::ErrorReporter& m_errorReporter;
 };
 

--- a/test/libsolidity/syntaxTests/largeTypes/max_size_array_with_transient_state_variables.sol
+++ b/test/libsolidity/syntaxTests/largeTypes/max_size_array_with_transient_state_variables.sol
@@ -5,4 +5,5 @@ contract C {
 // ====
 // EVMVersion: >=cancun
 // ----
+// Warning 3495: (0-60): This contract is very close to the end of storage. This limits its future upgradability.
 // Warning 7325: (17-33): Type uint256[115792089237316195423570985008687907853269984665640564039457584007913129639935] covers a large part of storage and thus makes collisions likely. Either use mappings or dynamic arrays and allow their size to be increased only in small quantities per transaction.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/contract_at_storage_end.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/contract_at_storage_end.sol
@@ -1,3 +1,4 @@
 contract C layout at 2**256 - 1 {
 }
 // ----
+// Warning 3495: (11-31): This contract is very close to the end of storage. This limits its future upgradability.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/contract_at_storage_end_with_transient_state_variables.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/contract_at_storage_end_with_transient_state_variables.sol
@@ -6,3 +6,4 @@ contract C layout at 2**256 - 1 {
 // ====
 // EVMVersion: >=cancun
 // ----
+// Warning 3495: (11-31): This contract is very close to the end of storage. This limits its future upgradability.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/intermediate_operation_out_of_range.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/intermediate_operation_out_of_range.sol
@@ -1,3 +1,4 @@
 contract A layout at (2**256 + 1) * 2  - 2**256 - 3 {}
 contract B layout at (2**2 - 2**3) * (2**5 - 2**8) {}
 // ----
+// Warning 3495: (11-51): This contract is very close to the end of storage. This limits its future upgradability.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specification_max_value.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specification_max_value.sol
@@ -1,2 +1,3 @@
 contract C layout at 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF {}
 // ----
+// Warning 3495: (11-87): This contract is very close to the end of storage. This limits its future upgradability.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/warning_near_the_storage_end.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/warning_near_the_storage_end.sol
@@ -4,3 +4,5 @@ contract C layout at 2**256 - 2**65 {
     uint[2**63] y;
 }
 // ----
+// Warning 3495: (11-35): This contract is very close to the end of storage. This limits its future upgradability.
+// Warning 3495: (50-74): This contract is very close to the end of storage. This limits its future upgradability.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/warning_near_the_storage_end.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/warning_near_the_storage_end.sol
@@ -1,0 +1,6 @@
+contract A layout at 2**256 - 2**64 {}
+contract C layout at 2**256 - 2**65 {
+    uint[2**63] x;
+    uint[2**63] y;
+}
+// ----


### PR DESCRIPTION
part of #15727.
- [x] Depends on #15668.