### PR TITLE
Fix AttributeError in `insert_node_before`

### DIFF
--- a/docs/ext/remix_code_links.py
+++ b/docs/ext/remix_code_links.py
@@ -14,7 +14,7 @@ def insert_node_before(child, new_sibling):
 
     for position, node in enumerate(child.parent.children):
         if node == child:
-            child.parent.insert(position, new_sibling)
+            child.parent.children.insert(position, new_sibling)
             break
 
 


### PR DESCRIPTION
This PR fixes a bug in `insert_node_before` where `child.parent.insert(position, new_sibling)` was incorrectly used.  
Since `docutils.nodes.Element` does not have an `insert` method, the correct approach is to insert the new sibling into the `children` list instead.

### Changes
- Replaced `child.parent.insert(position, new_sibling)` with `child.parent.children.insert(position, new_sibling)`, ensuring proper insertion of nodes.
