### PR TITLE
Fix grammar issues in events documentation

### DIFF
--- a/docs/contracts/events.rst
+++ b/docs/contracts/events.rst
@@ -15,7 +15,7 @@ arguments to be stored in the transaction's log - a special data structure
 in the blockchain. These logs are associated with the address of the contract that emitted them,
 are incorporated into the blockchain, and stay there as long as a block is
 accessible (forever as of now, but this might
-change in the future). The Log and its event data is not accessible from within
+change in the future). The Log and its event data are not accessible from within
 contracts (not even from the contract that created them).
 
 It is possible to request a Merkle proof for logs, so if


### PR DESCRIPTION
Incorrect:
"The Log and its event data is not accessible from within contracts"
Corrected:
"The log and its event data are not accessible from within contracts"
Reason: "Log and its event data" is a compound subject, making it plural. Therefore, "is" should be changed to "are" for proper subject-verb agreement.