### PR TITLE
Document the EOF version setting in Standard JSON and metadata

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -134,6 +134,8 @@ explanatory purposes.
         },
         // Required for Solidity.
         "evmVersion": "london",
+        // Optional: Only present if not null.
+        "eofVersion": 1,
         // Required for Solidity: Addresses for libraries used.
         "libraries": {
           "MyLib": "0x123123..."

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -353,7 +353,7 @@ Input Description
             }
           }
         },
-        // Version of the EVM to compile for.
+        // Version of the EVM to compile for (optional).
         // Affects type checking and code generation. Can be homestead,
         // tangerineWhistle, spuriousDragon, byzantium, constantinople,
         // petersburg, istanbul, berlin, london, paris, shanghai, cancun (default), prague (experimental) or osaka (experimental).

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -358,6 +358,9 @@ Input Description
         // tangerineWhistle, spuriousDragon, byzantium, constantinople,
         // petersburg, istanbul, berlin, london, paris, shanghai, cancun (default), prague (experimental) or osaka (experimental).
         "evmVersion": "cancun",
+        // EVM Object Format version to compile for (optional, experimental).
+        // Currently the only valid value is 1. If not specified, legacy non-EOF bytecode will be generated.
+        "eofVersion": null,
         // Optional: Change compilation pipeline to go through the Yul intermediate representation.
         // This is false by default.
         "viaIR": true,


### PR DESCRIPTION
The feature is experimental, but we're advertising it in the release post, so we should at least tell people how to use it :)