### PR TITLE
AssemblyItem gets an optional instruction

### DIFF
--- a/libevmasm/AssemblyItem.h
+++ b/libevmasm/AssemblyItem.h
@@ -105,7 +105,6 @@ public:
 
 	explicit AssemblyItem(bytes _verbatimData, size_t _arguments, size_t _returnVariables):
 		m_type(VerbatimBytecode),
-		m_instruction{},
 		m_verbatimBytecode{{_arguments, _returnVariables, std::move(_verbatimData)}},
 		m_debugData{langutil::DebugData::create()}
 	{}
@@ -195,7 +194,7 @@ public:
 	/// @returns true if the item has m_instruction properly set.
 	bool hasInstruction() const
 	{
-		return
+		bool const shouldHaveInstruction =
 			m_type == Operation ||
 			m_type == EOFCreate ||
 			m_type == ReturnContract ||
@@ -206,12 +205,14 @@ public:
 			m_type == RetF ||
 			m_type == SwapN ||
 			m_type == DupN;
+		solAssert(shouldHaveInstruction == m_instruction.has_value());
+		return shouldHaveInstruction;
 	}
 	/// @returns the instruction of this item (only valid if hasInstruction returns true)
 	Instruction instruction() const
 	{
 		solAssert(hasInstruction());
-		return m_instruction;
+		return *m_instruction;
 	}
 
 	/// @returns true if the type and data of the items are equal.
@@ -323,7 +324,7 @@ private:
 	size_t opcodeCount() const noexcept;
 
 	AssemblyItemType m_type;
-	Instruction m_instruction; ///< Only valid if m_type == Operation
+	std::optional<Instruction> m_instruction; ///< Only valid for item types that represent a specific opcode
 	std::shared_ptr<u256> m_data; ///< Only valid if m_type != Operation
 	std::optional<FunctionSignature> m_functionSignature; ///< Only valid if m_type == CallF or JumpF
 	/// If m_type == VerbatimBytecode, this holds number of arguments, number of


### PR DESCRIPTION
I have also sharpened the `hasInstruction` function to check if there is actually something inside of `m_instruction`. Previously it could happen that it returns `true` while the instruction was still undefined / null:

https://github.com/ethereum/solidity/blob/340ae32d5c27c87ce51ca0b484f7566f1951c4a0/libevmasm/AssemblyItem.h#L89-L97

Setting the `AssemblyItemType` to, e.g., `SwapN` leaves `m_instruction` undefined but still yields `hasInstruction() -> true`. This is why I think an optional better and more reliably reflects the intended behavior than default-initializing the class member.

Fixes #15933.