### PR TITLE
Name dependent CSE bug: Compare ASM only

### DIFF
--- a/test/cmdlineTests/~name_dependent_cse_bug/test.sh
+++ b/test/cmdlineTests/~name_dependent_cse_bug/test.sh
@@ -19,7 +19,7 @@ function assemble_with_variable_name {
     local variable_name="$2"
 
     sed -e "s|__placeholder__|${variable_name}|g" "$input_file" | msg_on_error --no-stderr \
-        "$SOLC" --strict-assembly - --optimize --debug-info none |
+        "$SOLC" --strict-assembly - --optimize --debug-info none --asm |
             stripCLIDecorations
 }
 


### PR DESCRIPTION
The method implemented in #15838 will lead to the replaced `_1` and `_2` being preserved, making the test fail as the pretty printed source is no longer identical for the two cases. This PR changes the test so that only ASM output is produced and subsequently compared which is invariant under the change in label.