### PR TITLE
Yul Disambiguator: Don't check for builtins when translating identifiers

### DIFF
--- a/libyul/optimiser/Disambiguator.cpp
+++ b/libyul/optimiser/Disambiguator.cpp
@@ -30,15 +30,15 @@ using namespace solidity;
 using namespace solidity::yul;
 using namespace solidity::util;
 
-YulName Disambiguator::translateIdentifier(YulName _originalName)
+YulName Disambiguator::translateIdentifier(YulName const _originalName)
 {
-	if (m_dialect.findBuiltin(_originalName.str()) || m_externallyUsedIdentifiers.count(_originalName))
+	if (m_externallyUsedIdentifiers.contains(_originalName))
 		return _originalName;
 
 	assertThrow(!m_scopes.empty() && m_scopes.back(), OptimizerException, "");
 	Scope::Identifier const* id = m_scopes.back()->lookup(_originalName);
 	assertThrow(id, OptimizerException, "");
-	if (!m_translations.count(id))
+	if (!m_translations.contains(id))
 		m_translations[id] = m_nameDispenser.newName(_originalName);
 	return m_translations.at(id);
 }

--- a/libyul/optimiser/Disambiguator.h
+++ b/libyul/optimiser/Disambiguator.h
@@ -56,7 +56,7 @@ protected:
 	void leaveScope(Block const& _block) override;
 	void enterFunction(FunctionDefinition const& _function) override;
 	void leaveFunction(FunctionDefinition const& _function) override;
-	YulName translateIdentifier(YulName _name) override;
+	YulName translateIdentifier(YulName _originalName) override;
 
 	void enterScopeInternal(Scope& _scope);
 	void leaveScopeInternal(Scope& _scope);


### PR DESCRIPTION
Builtins are stored via `BuiltinHandle`