### PR TITLE
ossfuzz and Yul interpreter use ast over block

### DIFF
--- a/test/libyul/YulInterpreterTest.cpp
+++ b/test/libyul/YulInterpreterTest.cpp
@@ -80,8 +80,7 @@ std::string YulInterpreterTest::interpret(std::shared_ptr<Object const> const& _
 	{
 		Interpreter::run(
 			state,
-			*_object->dialect(),
-			_object->code()->root(),
+			*_object->code(),
 			/*disableExternalCalls=*/ !m_simulateExternalCallsToSelf,
 			/*disableMemoryTracing=*/ false
 		);

--- a/test/tools/ossfuzz/strictasm_diff_ossfuzz.cpp
+++ b/test/tools/ossfuzz/strictasm_diff_ossfuzz.cpp
@@ -90,8 +90,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 	// TODO: Add EOF support
 	yulFuzzerUtil::TerminationReason termReason = yulFuzzerUtil::interpret(
 		os1,
-		stack.parserResult()->code()->root(),
-		EVMDialect::strictAssemblyForEVMObjects(langutil::EVMVersion(), std::nullopt),
+		*stack.parserResult()->code(),
 		/*disableMemoryTracing=*/true
 	);
 	if (yulFuzzerUtil::resourceLimitsExceeded(termReason))
@@ -100,8 +99,7 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* _data, size_t _size)
 	stack.optimize();
 	termReason = yulFuzzerUtil::interpret(
 		os2,
-		stack.parserResult()->code()->root(),
-		EVMDialect::strictAssemblyForEVMObjects(langutil::EVMVersion(), std::nullopt),
+		*stack.parserResult()->code(),
 		/*disableMemoryTracing=*/true
 	);
 

--- a/test/tools/ossfuzz/yulFuzzerCommon.cpp
+++ b/test/tools/ossfuzz/yulFuzzerCommon.cpp
@@ -23,8 +23,7 @@ using namespace solidity::yul::test::yul_fuzzer;
 
 yulFuzzerUtil::TerminationReason yulFuzzerUtil::interpret(
 	std::ostream& _os,
-	yul::Block const& _astRoot,
-	Dialect const& _dialect,
+	AST const& _ast,
 	bool _disableMemoryTracing,
 	bool _outputStorageOnly,
 	size_t _maxSteps,
@@ -52,7 +51,7 @@ yulFuzzerUtil::TerminationReason yulFuzzerUtil::interpret(
 	TerminationReason reason = TerminationReason::None;
 	try
 	{
-		Interpreter::run(state, _dialect, _astRoot, true, _disableMemoryTracing);
+		Interpreter::run(state, _ast, true, _disableMemoryTracing);
 	}
 	catch (StepLimitReached const&)
 	{

--- a/test/tools/ossfuzz/yulFuzzerCommon.h
+++ b/test/tools/ossfuzz/yulFuzzerCommon.h
@@ -40,8 +40,7 @@ struct yulFuzzerUtil
 	/// eliminator.
 	static TerminationReason interpret(
 		std::ostream& _os,
-		yul::Block const& _astRoot,
-		Dialect const& _dialect,
+		AST const& _ast,
 		bool _disableMemoryTracing = false,
 		bool _outputStorageOnly = false,
 		size_t _maxSteps = maxSteps,

--- a/test/tools/ossfuzz/yulProto_diff_ossfuzz.cpp
+++ b/test/tools/ossfuzz/yulProto_diff_ossfuzz.cpp
@@ -90,8 +90,7 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 	// TODO: Add EOF support
 	yulFuzzerUtil::TerminationReason termReason = yulFuzzerUtil::interpret(
 		os1,
-		stack.parserResult()->code()->root(),
-		EVMDialect::strictAssemblyForEVMObjects(version, std::nullopt),
+		*stack.parserResult()->code(),
 		/*disableMemoryTracing=*/true
 	);
 
@@ -106,8 +105,7 @@ DEFINE_PROTO_FUZZER(Program const& _input)
 	// TODO: Add EOF support
 	termReason = yulFuzzerUtil::interpret(
 		os2,
-		*astRoot,
-		EVMDialect::strictAssemblyForEVMObjects(version, std::nullopt),
+		*optimizerTest.optimizedObject()->code(),
 		true
 	);
 	if (yulFuzzerUtil::resourceLimitsExceeded(termReason))

--- a/test/tools/yulInterpreter/Inspector.cpp
+++ b/test/tools/yulInterpreter/Inspector.cpp
@@ -31,9 +31,9 @@ using namespace solidity::yul::test;
 namespace
 {
 
-void printVariable(YulString const& _name, u256 const& _value)
+void printVariable(std::string_view const _name, u256 const& _value)
 {
-	std::cout << "\t" << _name.str() << " = " << _value.str();
+	std::cout << "\t" << _name << " = " << _value.str();
 
 	if (_value != 0)
 		std::cout << " (" << toCompactHexWithPrefix(_value) << ")";
@@ -46,17 +46,16 @@ void printVariable(YulString const& _name, u256 const& _value)
 void InspectedInterpreter::run(
 	std::shared_ptr<Inspector> _inspector,
 	InterpreterState& _state,
-	Dialect const& _dialect,
-	Block const& _ast,
+	AST const& _ast,
 	bool _disableExternalCalls,
 	bool _disableMemoryTrace
 )
 {
 	Scope scope;
-	InspectedInterpreter{_inspector, _state, _dialect, scope, _disableExternalCalls, _disableMemoryTrace}(_ast);
+	InspectedInterpreter{_inspector, _state, _ast.dialect(), scope, _disableExternalCalls, _disableMemoryTrace}(_ast.root());
 }
 
-Inspector::NodeAction Inspector::queryUser(langutil::DebugData const& _data, std::map<YulString, u256> const& _variables)
+Inspector::NodeAction Inspector::queryUser(langutil::DebugData const& _data, std::map<YulName, u256> const& _variables)
 {
 	if (m_stepMode == NodeAction::RunNode)
 	{
@@ -99,7 +98,7 @@ Inspector::NodeAction Inspector::queryUser(langutil::DebugData const& _data, std
 		else if (input == "variables" || input == "v")
 		{
 			for (auto &&[yulStr, val]: _variables)
-				printVariable(yulStr, val);
+				printVariable(yulStr.str(), val);
 			std::cout << std::endl;
 		}
 		else if (
@@ -120,7 +119,7 @@ Inspector::NodeAction Inspector::queryUser(langutil::DebugData const& _data, std
 			for (auto &&[yulStr, val]: _variables)
 				if (yulStr.str() == varname)
 				{
-					printVariable(yulStr, val);
+					printVariable(varname, val);
 					found = true;
 					break;
 				}

--- a/test/tools/yulInterpreter/Inspector.h
+++ b/test/tools/yulInterpreter/Inspector.h
@@ -103,8 +103,7 @@ public:
 	static void run(
 		std::shared_ptr<Inspector> _inspector,
 		InterpreterState& _state,
-		Dialect const& _dialect,
-		Block const& _ast,
+		AST const& _ast,
 		bool _disableExternalCalls,
 		bool _disableMemoryTracing
 	);

--- a/test/tools/yulInterpreter/Interpreter.cpp
+++ b/test/tools/yulInterpreter/Interpreter.cpp
@@ -109,14 +109,13 @@ void InterpreterState::dumpTraceAndState(std::ostream& _out, bool _disableMemory
 
 void Interpreter::run(
 	InterpreterState& _state,
-	Dialect const& _dialect,
-	Block const& _ast,
+	AST const& _ast,
 	bool _disableExternalCalls,
 	bool _disableMemoryTrace
 )
 {
 	Scope scope;
-	Interpreter{_state, _dialect, scope, _disableExternalCalls, _disableMemoryTrace}(_ast);
+	Interpreter{_state, _ast.dialect(), scope, _disableExternalCalls, _disableMemoryTrace}(_ast.root());
 }
 
 void Interpreter::operator()(ExpressionStatement const& _expressionStatement)

--- a/test/tools/yulInterpreter/Interpreter.h
+++ b/test/tools/yulInterpreter/Interpreter.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <libyul/ASTForward.h>
+#include <libyul/backends/evm/EVMDialect.h>
 #include <libyul/optimiser/ASTWalker.h>
 
 #include <libevmasm/Instruction.h>
@@ -162,8 +163,7 @@ public:
 	/// activated e.g., Redundant store eliminator, Equal store eliminator.
 	static void run(
 		InterpreterState& _state,
-		Dialect const& _dialect,
-		Block const& _ast,
+		AST const& _ast,
 		bool _disableExternalCalls,
 		bool _disableMemoryTracing
 	);

--- a/test/tools/yulrun.cpp
+++ b/test/tools/yulrun.cpp
@@ -63,6 +63,9 @@ std::pair<std::shared_ptr<AST const>, std::shared_ptr<AsmAnalysisInfo>> parse(st
 		solidity::frontend::OptimiserSettings::none(),
 		DebugInfoSelection::Default()
 	);
+	auto const* evmDialect = dynamic_cast<EVMDialect const*>(&stack.dialect());
+	// TODO: Add EOF support
+	solUnimplementedAssert(evmDialect && !evmDialect->eofVersion(), "No EOF support for yulrun yet.");
 	if (stack.parseAndAnalyze("--INPUT--", _source))
 	{
 		yulAssert(!Error::hasErrorsWarningsOrInfos(stack.errors()), "Parsed successfully but had errors.");
@@ -87,13 +90,10 @@ void interpret(std::string const& _source, bool _inspect, bool _disableExternalC
 	state.maxTraceSize = 10000;
 	try
 	{
-		Dialect const& dialect(EVMDialect::strictAssemblyForEVMObjects(langutil::EVMVersion{}, std::nullopt));
-
 		if (_inspect)
-			InspectedInterpreter::run(std::make_shared<Inspector>(_source, state), state, dialect, ast->root(), _disableExternalCalls, /*disableMemoryTracing=*/false);
-
+			InspectedInterpreter::run(std::make_shared<Inspector>(_source, state), state, *ast, _disableExternalCalls, /*disableMemoryTracing=*/false);
 		else
-			Interpreter::run(state, dialect, ast->root(), _disableExternalCalls, /*disableMemoryTracing=*/false);
+			Interpreter::run(state, *ast, _disableExternalCalls, /*disableMemoryTracing=*/false);
 	}
 	catch (InterpreterTerminatedGeneric const&)
 	{


### PR DESCRIPTION
Changing the interface of the Yul interpreter to use an instance of AST over individual block and dialect. With numeric IDs, the AST will also contain the labels, so this makes the overall interface leaner.
On that note I realized that yul interpreter tests are parsed potentially with eof (in CI, for ex.) but are interpreted without.