### PR TITLE
Fix inconsistent negative subassembly indices between different sizeof(size_t)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Compiler Features:
 * ethdebug: Experimental support for instructions and source locations under EOF.
 
 Bugfixes:
+* Assembler: Fix not using a fixed-width type for IDs being assigned to subassemblies nested more than one level away, resulting in inconsistent `--asm-json` output between target architectures.
 
 ### 0.8.30 (2025-05-07)
 

--- a/libevmasm/AssemblyItem.h
+++ b/libevmasm/AssemblyItem.h
@@ -24,6 +24,7 @@
 
 #include <libevmasm/Instruction.h>
 #include <libevmasm/Exceptions.h>
+#include <libevmasm/SubAssemblyID.h>
 #include <liblangutil/DebugData.h>
 #include <liblangutil/Exceptions.h>
 #include <libsolutil/Common.h>
@@ -171,14 +172,14 @@ public:
 	AssemblyItem pushTag() const { solAssert(m_type == PushTag || m_type == Tag || m_type == RelativeJump || m_type == ConditionalRelativeJump); return AssemblyItem(PushTag, data()); }
 	/// Converts the tag to a subassembly tag. This has to be called in order to move a tag across assemblies.
 	/// @param _subId the identifier of the subassembly the tag is taken from.
-	AssemblyItem toSubAssemblyTag(size_t _subId) const;
+	AssemblyItem toSubAssemblyTag(SubAssemblyID _subId) const;
 	/// @returns splits the data of the push tag into sub assembly id and actual tag id.
 	/// The sub assembly id of non-foreign push tags is -1.
-	std::pair<size_t, size_t> splitForeignPushTag() const;
+	std::pair<SubAssemblyID, size_t> splitForeignPushTag() const;
 	/// @returns relative jump target tag ID. Asserts that it is not foreign tag.
 	size_t relativeJumpTagID() const;
 	/// Sets sub-assembly part and tag for a push tag.
-	void setPushTagSubIdAndTag(size_t _subId, size_t _tag);
+	void setPushTagSubIdAndTag(SubAssemblyID _subId, size_t _tag);
 
 	AssemblyItemType type() const { return m_type; }
 	u256 const& data() const { solAssert(m_type != Operation && m_data != nullptr); return *m_data; }

--- a/libevmasm/BlockDeduplicator.cpp
+++ b/libevmasm/BlockDeduplicator.cpp
@@ -101,14 +101,14 @@ bool BlockDeduplicator::deduplicate()
 bool BlockDeduplicator::applyTagReplacement(
 	AssemblyItems& _items,
 	std::map<u256, u256> const& _replacements,
-	size_t _subId
+	SubAssemblyID _subId
 )
 {
 	bool changed = false;
 	for (AssemblyItem& item: _items)
 		if (item.type() == PushTag || item.type() == RelativeJump || item.type() == ConditionalRelativeJump)
 		{
-			size_t subId;
+			SubAssemblyID subId;
 			size_t tagId;
 			std::tie(subId, tagId) = item.splitForeignPushTag();
 			if (subId != _subId)

--- a/libevmasm/BlockDeduplicator.h
+++ b/libevmasm/BlockDeduplicator.h
@@ -24,9 +24,10 @@
 
 #pragma once
 
+#include <libevmasm/SubAssemblyID.h>
+
 #include <libsolutil/Common.h>
 #include <libsolutil/Numeric.h>
-
 
 #include <cstddef>
 #include <vector>
@@ -52,14 +53,14 @@ public:
 	/// @returns the tags that were replaced.
 	std::map<u256, u256> const& replacedTags() const { return m_replacedTags; }
 
-	/// Replaces all PushTag operations insied @a _items that match a key in
-	/// @a _replacements by the respective value. If @a _subID is not -1, only
+	/// Replaces all PushTag operations inside @a _items that match a key in
+	/// @a _replacements by the respective value. If @a _subID is not empty, only
 	/// apply the replacement for foreign tags from this sub id.
 	/// @returns true iff a replacement was performed.
 	static bool applyTagReplacement(
 		AssemblyItems& _items,
 		std::map<u256, u256> const& _replacements,
-		size_t _subID = size_t(-1)
+		SubAssemblyID _subID = {}
 	);
 
 private:

--- a/libevmasm/CMakeLists.txt
+++ b/libevmasm/CMakeLists.txt
@@ -44,6 +44,7 @@ set(sources
 	SimplificationRule.h
 	SimplificationRules.cpp
 	SimplificationRules.h
+	SubAssemblyID.h
 )
 
 add_library(evmasm ${sources})

--- a/libevmasm/EVMAssemblyStack.cpp
+++ b/libevmasm/EVMAssemblyStack.cpp
@@ -62,7 +62,7 @@ void EVMAssemblyStack::assemble()
 	m_sourceMapping = AssemblyItem::computeSourceMapping(m_evmAssembly->codeSections().front().items, sourceIndices());
 	if (m_evmAssembly->numSubs() > 0)
 	{
-		m_evmRuntimeAssembly = std::make_shared<evmasm::Assembly>(m_evmAssembly->sub(0));
+		m_evmRuntimeAssembly = std::make_shared<evmasm::Assembly>(m_evmAssembly->sub(SubAssemblyID{0}));
 		solAssert(m_evmRuntimeAssembly && !m_evmRuntimeAssembly->isCreation());
 		// TODO: Check for EOF
 		solAssert(m_evmRuntimeAssembly->codeSections().size() == 1);

--- a/libevmasm/Inliner.cpp
+++ b/libevmasm/Inliner.cpp
@@ -71,7 +71,7 @@ std::optional<size_t> getLocalTag(AssemblyItem const& _item)
 	if (_item.type() != PushTag && _item.type() != Tag)
 		return std::nullopt;
 	auto [subId, tag] = _item.splitForeignPushTag();
-	if (subId != std::numeric_limits<size_t>::max())
+	if (!subId.empty())
 		return std::nullopt;
 	return tag;
 }

--- a/libevmasm/JumpdestRemover.cpp
+++ b/libevmasm/JumpdestRemover.cpp
@@ -32,7 +32,7 @@ using namespace solidity::evmasm;
 
 bool JumpdestRemover::optimise(std::set<size_t> const& _tagsReferencedFromOutside)
 {
-	std::set<size_t> references{referencedTags(m_items, std::numeric_limits<size_t>::max())};
+	std::set<size_t> references{referencedTags(m_items, SubAssemblyID{})};
 	references.insert(_tagsReferencedFromOutside.begin(), _tagsReferencedFromOutside.end());
 
 	size_t initialSize = m_items.size();
@@ -45,7 +45,7 @@ bool JumpdestRemover::optimise(std::set<size_t> const& _tagsReferencedFromOutsid
 			if (_item.type() != Tag)
 				return false;
 			auto asmIdAndTag = _item.splitForeignPushTag();
-			assertThrow(asmIdAndTag.first == std::numeric_limits<size_t>::max(), OptimizerException, "Sub-assembly tag used as label.");
+			solAssert(asmIdAndTag.first.empty(), "Sub-assembly tag used as label.");
 			size_t tag = asmIdAndTag.second;
 			return !references.count(tag);
 		}
@@ -54,7 +54,7 @@ bool JumpdestRemover::optimise(std::set<size_t> const& _tagsReferencedFromOutsid
 	return m_items.size() != initialSize;
 }
 
-std::set<size_t> JumpdestRemover::referencedTags(AssemblyItems const& _items, size_t _subId)
+std::set<size_t> JumpdestRemover::referencedTags(AssemblyItems const& _items, SubAssemblyID _subId)
 {
 	std::set<size_t> ret;
 	for (auto const& item: _items)

--- a/libevmasm/JumpdestRemover.h
+++ b/libevmasm/JumpdestRemover.h
@@ -21,6 +21,8 @@
  */
 #pragma once
 
+#include <libevmasm/SubAssemblyID.h>
+
 #include <vector>
 #include <cstddef>
 #include <set>
@@ -39,7 +41,7 @@ public:
 
 	/// @returns a set of all tags from the given sub-assembly that are referenced
 	/// from the given list of items.
-	static std::set<size_t> referencedTags(AssemblyItems const& _items, size_t _subId);
+	static std::set<size_t> referencedTags(AssemblyItems const& _items, SubAssemblyID _subId);
 
 private:
 	AssemblyItems& m_items;

--- a/libevmasm/SubAssemblyID.h
+++ b/libevmasm/SubAssemblyID.h
@@ -1,0 +1,62 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libsolutil/Numeric.h>
+
+#include <liblangutil/Exceptions.h>
+
+#include <compare>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+namespace solidity::evmasm
+{
+
+/// Sub assembly ID representing class. Based on fixed-size 64-bit unsigned int.
+/// An empty / root state is reflected by a value that is set to max and can be queried via the `empty()` member
+/// function.
+struct SubAssemblyID
+{
+	using ValueType = uint64_t;
+	SubAssemblyID() = default;
+	SubAssemblyID(ValueType const _value): value(_value) {}
+	explicit SubAssemblyID(u256 const& _data)
+	{
+		solAssert(_data <= std::numeric_limits<ValueType>::max());
+		value = static_cast<ValueType>(_data);
+	}
+
+	size_t asIndex() const
+	{
+		if constexpr(sizeof(ValueType) > sizeof(size_t))
+		{
+			solAssert(value < std::numeric_limits<size_t>::max());
+			return static_cast<size_t>(value);
+		}
+		return value;
+	}
+	bool empty() const { return value == std::numeric_limits<ValueType>::max(); }
+	auto operator<=>(SubAssemblyID const&) const = default;
+
+	ValueType value = std::numeric_limits<ValueType>::max();
+};
+
+}

--- a/libsolidity/codegen/Compiler.h
+++ b/libsolidity/codegen/Compiler.h
@@ -70,7 +70,7 @@ public:
 private:
 	OptimiserSettings const m_optimiserSettings;
 	CompilerContext m_runtimeContext;
-	size_t m_runtimeSub = size_t(-1); ///< Identifier of the runtime sub-assembly, if present.
+	evmasm::SubAssemblyID m_runtimeSub{}; ///< Identifier of the runtime sub-assembly, if present.
 	CompilerContext m_context;
 };
 

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -75,7 +75,7 @@ public:
 		m_yulUtilFunctions(m_evmVersion, _eofVersion, m_revertStrings, m_yulFunctionCollector)
 	{
 		if (m_runtimeContext)
-			m_runtimeSub = size_t(m_asm->newSub(m_runtimeContext->m_asm).data());
+			m_runtimeSub = evmasm::SubAssemblyID{m_asm->newSub(m_runtimeContext->m_asm).data()};
 	}
 
 	langutil::EVMVersion const& evmVersion() const { return m_evmVersion; }
@@ -227,9 +227,9 @@ public:
 	/// on the stack. @returns the pushsub assembly item.
 	evmasm::AssemblyItem addSubroutine(evmasm::AssemblyPointer const& _assembly) { return m_asm->appendSubroutine(_assembly); }
 	/// Pushes the size of the subroutine.
-	void pushSubroutineSize(size_t _subRoutine) { m_asm->pushSubroutineSize(_subRoutine); }
+	void pushSubroutineSize(evmasm::SubAssemblyID _subRoutine) { m_asm->pushSubroutineSize(_subRoutine); }
 	/// Pushes the offset of the subroutine.
-	void pushSubroutineOffset(size_t _subRoutine) { m_asm->pushSubroutineOffset(_subRoutine); }
+	void pushSubroutineOffset(evmasm::SubAssemblyID _subRoutine) { m_asm->pushSubroutineOffset(_subRoutine); }
 	/// Pushes the size of the final program
 	void appendProgramSize() { m_asm->appendProgramSize(); }
 	/// Adds data to the data section, pushes a reference to the stack
@@ -289,7 +289,7 @@ public:
 	/// @returns the runtime context if in creation mode and runtime context is set, nullptr otherwise.
 	CompilerContext* runtimeContext() const { return m_runtimeContext; }
 	/// @returns the identifier of the runtime subroutine.
-	size_t runtimeSub() const { return m_runtimeSub; }
+	evmasm::SubAssemblyID runtimeSub() const { return m_runtimeSub; }
 
 	/// @returns a const reference to the underlying assembly.
 	evmasm::Assembly const& assembly() const { return *m_asm; }
@@ -376,7 +376,7 @@ private:
 	/// The runtime context if in Creation mode, this is used for generating tags that would be stored into the storage and then used at runtime.
 	CompilerContext *m_runtimeContext;
 	/// The index of the runtime subroutine.
-	size_t m_runtimeSub = std::numeric_limits<size_t>::max();
+	evmasm::SubAssemblyID m_runtimeSub{};
 	/// An index of low-level function labels by name.
 	std::map<std::string, evmasm::AssemblyItem> m_lowLevelFunctions;
 	/// Collector for yul functions.

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -108,7 +108,7 @@ void ContractCompiler::compileContract(
 	appendFunctionSelector(_contract);
 }
 
-size_t ContractCompiler::compileConstructor(
+SubAssemblyID ContractCompiler::compileConstructor(
 	ContractDefinition const& _contract,
 	std::map<ContractDefinition const*, std::shared_ptr<Compiler const>> const& _otherCompilers
 )
@@ -167,7 +167,7 @@ void ContractCompiler::appendInitAndConstructorCode(ContractDefinition const& _c
 	}
 }
 
-size_t ContractCompiler::packIntoContractCreator(ContractDefinition const& _contract)
+SubAssemblyID ContractCompiler::packIntoContractCreator(ContractDefinition const& _contract)
 {
 	solAssert(!!m_runtimeCompiler, "");
 	solAssert(!_contract.isLibrary(), "Tried to use contract creator or library.");
@@ -186,7 +186,7 @@ size_t ContractCompiler::packIntoContractCreator(ContractDefinition const& _cont
 	CompilerContext::LocationSetter locationSetter(m_context, _contract);
 	m_context << deployRoutine;
 
-	solAssert(m_context.runtimeSub() != std::numeric_limits<size_t>::max(), "Runtime sub not registered");
+	solAssert(!m_context.runtimeSub().empty(), "Runtime sub not registered");
 
 	ContractType contractType(_contract);
 	auto const& immutables = contractType.immutableVariables();
@@ -220,7 +220,7 @@ size_t ContractCompiler::packIntoContractCreator(ContractDefinition const& _cont
 	return m_context.runtimeSub();
 }
 
-size_t ContractCompiler::deployLibrary(ContractDefinition const& _contract)
+SubAssemblyID ContractCompiler::deployLibrary(ContractDefinition const& _contract)
 {
 	solAssert(!!m_runtimeCompiler, "");
 	solAssert(_contract.isLibrary(), "Tried to deploy contract as library.");
@@ -230,7 +230,7 @@ size_t ContractCompiler::deployLibrary(ContractDefinition const& _contract)
 
 	CompilerContext::LocationSetter locationSetter(m_context, _contract);
 
-	solAssert(m_context.runtimeSub() != std::numeric_limits<size_t>::max(), "Runtime sub not registered");
+	solAssert(!m_context.runtimeSub().empty(), "Runtime sub not registered");
 	m_context.pushSubroutineSize(m_context.runtimeSub());
 	m_context.pushSubroutineOffset(m_context.runtimeSub());
 	// This code replaces the address added by appendDeployTimeAddress().

--- a/libsolidity/codegen/ContractCompiler.h
+++ b/libsolidity/codegen/ContractCompiler.h
@@ -58,7 +58,7 @@ public:
 	);
 	/// Compiles the constructor part of the contract.
 	/// @returns the identifier of the runtime sub-assembly.
-	size_t compileConstructor(
+	evmasm::SubAssemblyID compileConstructor(
 		ContractDefinition const& _contract,
 		std::map<ContractDefinition const*, std::shared_ptr<Compiler const>> const& _otherCompilers
 	);
@@ -73,11 +73,11 @@ private:
 	/// Adds the code that is run at creation time. Should be run after exchanging the run-time context
 	/// with a new and initialized context. Adds the constructor code.
 	/// @returns the identifier of the runtime sub assembly
-	size_t packIntoContractCreator(ContractDefinition const& _contract);
+	evmasm::SubAssemblyID packIntoContractCreator(ContractDefinition const& _contract);
 	/// Appends code that deploys the given contract as a library.
 	/// Will also add code that modifies the contract in memory by injecting the current address
 	/// for the call protector.
-	size_t deployLibrary(ContractDefinition const& _contract);
+	evmasm::SubAssemblyID deployLibrary(ContractDefinition const& _contract);
 	/// Appends state variable initialisation and constructor code.
 	void appendInitAndConstructorCode(ContractDefinition const& _contract);
 	void appendBaseConstructor(FunctionDefinition const& _constructor);

--- a/libyul/CompilabilityChecker.cpp
+++ b/libyul/CompilabilityChecker.cpp
@@ -49,9 +49,9 @@ CompilabilityChecker::CompilabilityChecker(
 		BuiltinContext builtinContext;
 		builtinContext.currentObject = &_object;
 		if (!_object.name.empty())
-			builtinContext.subIDs[_object.name] = 1;
+			builtinContext.subIDs[_object.name] = {1};
 		for (auto const& subNode: _object.subObjects)
-			builtinContext.subIDs[subNode->name] = 1;
+			builtinContext.subIDs[subNode->name] = {1};
 		NoOutputAssembly assembly{evmDialect->evmVersion()};
 		CodeTransform transform(
 			assembly,

--- a/libyul/Object.cpp
+++ b/libyul/Object.cpp
@@ -169,7 +169,7 @@ Object::Structure Object::summarizeStructure() const
 	return structure;
 }
 
-std::vector<size_t> Object::pathToSubObject(std::string_view _qualifiedName) const
+std::vector<evmasm::SubAssemblyID> Object::pathToSubObject(std::string_view _qualifiedName) const
 {
 	yulAssert(_qualifiedName != name, "");
 	yulAssert(subIndexByName.count(name) == 0, "");
@@ -181,7 +181,7 @@ std::vector<size_t> Object::pathToSubObject(std::string_view _qualifiedName) con
 	std::vector<std::string> subObjectPathComponents;
 	boost::algorithm::split(subObjectPathComponents, _qualifiedName, boost::is_any_of("."));
 
-	std::vector<size_t> path;
+	std::vector<evmasm::SubAssemblyID> path;
 	Object const* object = this;
 	for (std::string const& currentSubObjectName: subObjectPathComponents)
 	{
@@ -193,8 +193,8 @@ std::vector<size_t> Object::pathToSubObject(std::string_view _qualifiedName) con
 		);
 		object = dynamic_cast<Object const*>(object->subObjects[subIndexIt->second].get());
 		yulAssert(object, "Assembly object <" + std::string(_qualifiedName) + "> not found or does not contain code.");
-		yulAssert(object->subId != std::numeric_limits<size_t>::max(), "");
-		path.push_back({object->subId});
+		yulAssert(!object->subId.empty());
+		path.emplace_back(object->subId);
 	}
 
 	return path;

--- a/libyul/Object.h
+++ b/libyul/Object.h
@@ -24,6 +24,8 @@
 #include <libyul/ASTForward.h>
 #include <libyul/AsmPrinter.h>
 
+#include <libevmasm/SubAssemblyID.h>
+
 #include <liblangutil/CharStreamProvider.h>
 #include <liblangutil/DebugInfoSelection.h>
 
@@ -135,14 +137,14 @@ public:
 	/// pathToSubObject("E2.F3.H4") == {1, 0, 2}
 	/// pathToSubObject("A1.E2") == {1}
 	/// The path must not lead to a @a Data object (will throw in that case).
-	std::vector<size_t> pathToSubObject(std::string_view _qualifiedName) const;
+	std::vector<evmasm::SubAssemblyID> pathToSubObject(std::string_view _qualifiedName) const;
 
 	std::shared_ptr<AST const> code() const;
 	void setCode(std::shared_ptr<AST const> const& _ast, std::shared_ptr<yul::AsmAnalysisInfo> = nullptr);
 	bool hasCode() const;
 
-	/// sub id for object if it is subobject of another object, max value if it is not subobject
-	size_t subId = std::numeric_limits<size_t>::max();
+	/// sub id for object if it is subobject of another object, max value / empty if it is not subobject
+	evmasm::SubAssemblyID subId{};
 
 	std::vector<std::shared_ptr<ObjectNode>> subObjects;
 	std::map<std::string, size_t, std::less<>> subIndexByName;

--- a/libyul/ObjectOptimizer.cpp
+++ b/libyul/ObjectOptimizer.cpp
@@ -56,7 +56,7 @@ Dialect const& yul::languageToDialect(Language _language, EVMVersion _version, s
 
 void ObjectOptimizer::optimize(Object& _object, Settings const& _settings)
 {
-	yulAssert(_object.subId == std::numeric_limits<size_t>::max(), "Not a top-level object.");
+	yulAssert(_object.subId.empty(), "Not a top-level object.");
 
 	optimize(_object, _settings, true /* _isCreation */);
 }

--- a/libyul/YulStack.cpp
+++ b/libyul/YulStack.cpp
@@ -330,15 +330,15 @@ YulStack::assembleEVMWithDeployed(std::optional<std::string_view> _deployName)
 
 		assembly.optimise(evmasm::Assembly::OptimiserSettings::translateSettings(m_optimiserSettings));
 
-		std::optional<size_t> subIndex;
+		std::optional<evmasm::SubAssemblyID> subIndex;
 
 		// Pick matching assembly if name was given
 		if (_deployName.has_value())
 		{
 			for (size_t i = 0; i < assembly.numSubs(); i++)
-				if (assembly.sub(i).name() == _deployName)
+				if (assembly.sub({i}).name() == _deployName)
 				{
-					subIndex = i;
+					subIndex = {i};
 					break;
 				}
 
@@ -346,7 +346,7 @@ YulStack::assembleEVMWithDeployed(std::optional<std::string_view> _deployName)
 		}
 		// Otherwise use heuristic: If there is a single sub-assembly, this is likely the object to be deployed.
 		else if (assembly.numSubs() == 1)
-			subIndex = 0;
+			subIndex = {0};
 
 		if (subIndex.has_value())
 		{

--- a/libyul/backends/evm/AbstractAssembly.h
+++ b/libyul/backends/evm/AbstractAssembly.h
@@ -25,6 +25,8 @@
 
 #include <libyul/ASTForward.h>
 
+#include <libevmasm/SubAssemblyID.h>
+
 #include <libsolutil/Common.h>
 #include <libsolutil/CommonData.h>
 #include <libsolutil/Numeric.h>
@@ -55,7 +57,7 @@ class AbstractAssembly
 {
 public:
 	using LabelID = size_t;
-	using SubID = size_t;
+	using SubID = evmasm::SubAssemblyID;
 	using ContainerID = uint8_t;
 	using FunctionID = uint16_t;
 	enum class JumpType { Ordinary, IntoFunction, OutOfFunction };

--- a/libyul/backends/evm/EVMBuiltins.cpp
+++ b/libyul/backends/evm/EVMBuiltins.cpp
@@ -135,10 +135,10 @@ BuiltinFunctionForEVM datasizeBuiltin()
 				_assembly.appendAssemblySize();
 			else
 			{
-				std::vector<size_t> subIdPath =
+				std::vector<AbstractAssembly::SubID> subIdPath =
 					_context.subIDs.count(dataName.str()) == 0 ?
 						_context.currentObject->pathToSubObject(dataName.str()) :
-						std::vector<size_t>{_context.subIDs.at(dataName.str())};
+						std::vector{_context.subIDs.at(dataName.str())};
 				yulAssert(!subIdPath.empty(), "Could not find assembly object <" + dataName.str() + ">.");
 				_assembly.appendDataSize(subIdPath);
 			}
@@ -161,10 +161,10 @@ BuiltinFunctionForEVM dataoffsetBuiltin()
 			_assembly.appendConstant(0);
 		else
 		{
-			std::vector<size_t> subIdPath =
+			std::vector<AbstractAssembly::SubID> subIdPath =
 				_context.subIDs.count(dataName.str()) == 0 ?
 					_context.currentObject->pathToSubObject(dataName.str()) :
-					std::vector<size_t>{_context.subIDs.at(dataName.str())};
+					std::vector{_context.subIDs.at(dataName.str())};
 			yulAssert(!subIdPath.empty(), "Could not find assembly object <" + dataName.str() + ">.");
 			_assembly.appendDataOffset(subIdPath);
 		}
@@ -284,8 +284,8 @@ BuiltinFunctionForEVM eofcreateBuiltin()
 			yulAssert(!util::contains(formattedLiteral, '.'));
 			auto const* containerID = util::valueOrNullptr(context.subIDs, formattedLiteral);
 			yulAssert(containerID != nullptr);
-			yulAssert(*containerID <= std::numeric_limits<AbstractAssembly::ContainerID>::max());
-			_assembly.appendEOFCreate(static_cast<AbstractAssembly::ContainerID>(*containerID));
+			yulAssert(containerID->value <= std::numeric_limits<AbstractAssembly::ContainerID>::max());
+			_assembly.appendEOFCreate(static_cast<AbstractAssembly::ContainerID>(containerID->value));
 		}
 	);
 }
@@ -311,8 +311,8 @@ BuiltinFunctionForEVM returncontractBuiltin()
 			yulAssert(!util::contains(formattedLiteral, '.'));
 			auto const* containerID = util::valueOrNullptr(context.subIDs, formattedLiteral);
 			yulAssert(containerID != nullptr);
-			yulAssert(*containerID <= std::numeric_limits<AbstractAssembly::ContainerID>::max());
-			_assembly.appendReturnContract(static_cast<AbstractAssembly::ContainerID>(*containerID));
+			yulAssert(containerID->value <= std::numeric_limits<AbstractAssembly::ContainerID>::max());
+			_assembly.appendReturnContract(static_cast<AbstractAssembly::ContainerID>(containerID->value));
 		}
 	);
 }

--- a/libyul/backends/evm/EthAssemblyAdapter.cpp
+++ b/libyul/backends/evm/EthAssemblyAdapter.cpp
@@ -142,7 +142,7 @@ std::pair<std::shared_ptr<AbstractAssembly>, AbstractAssembly::SubID> EthAssembl
 {
 	std::shared_ptr<evmasm::Assembly> assembly{std::make_shared<evmasm::Assembly>(m_assembly.evmVersion(), _creation, m_assembly.eofVersion(), std::move(_name))};
 	auto sub = m_assembly.newSub(assembly);
-	return {std::make_shared<EthAssemblyAdapter>(*assembly), static_cast<size_t>(sub.data())};
+	return {std::make_shared<EthAssemblyAdapter>(*assembly), SubID{sub.data()}};
 }
 
 AbstractAssembly::FunctionID EthAssemblyAdapter::registerFunction(uint8_t _args, uint8_t _rets, bool _nonReturning)
@@ -207,7 +207,7 @@ void EthAssemblyAdapter::appendDataSize(std::vector<AbstractAssembly::SubID> con
 AbstractAssembly::SubID EthAssemblyAdapter::appendData(bytes const& _data)
 {
 	evmasm::AssemblyItem pushData = m_assembly.newData(_data);
-	SubID subID = m_nextDataCounter++;
+	SubID const subID{m_nextDataCounter++};
 	m_dataHashBySubId[subID] = pushData.data();
 	return subID;
 }

--- a/libyul/backends/evm/EthAssemblyAdapter.h
+++ b/libyul/backends/evm/EthAssemblyAdapter.h
@@ -88,6 +88,6 @@ private:
 
 	evmasm::Assembly& m_assembly;
 	std::map<SubID, u256> m_dataHashBySubId;
-	size_t m_nextDataCounter = std::numeric_limits<size_t>::max() / 2;
+	SubID::ValueType m_nextDataCounter = std::numeric_limits<SubID::ValueType>::max() / 2;
 };
 }

--- a/libyul/backends/evm/NoOutputAssembly.cpp
+++ b/libyul/backends/evm/NoOutputAssembly.cpp
@@ -176,7 +176,7 @@ void NoOutputAssembly::appendDataSize(std::vector<AbstractAssembly::SubID> const
 
 AbstractAssembly::SubID NoOutputAssembly::appendData(bytes const&)
 {
-	return 1;
+	return {1};
 }
 
 

--- a/test/cmdlineTests/asm_json_subassembly_id_representation/args
+++ b/test/cmdlineTests/asm_json_subassembly_id_representation/args
@@ -1,0 +1,1 @@
+--asm-json --pretty-json --strict-assembly --json-indent 4

--- a/test/cmdlineTests/asm_json_subassembly_id_representation/input.yul
+++ b/test/cmdlineTests/asm_json_subassembly_id_representation/input.yul
@@ -1,0 +1,19 @@
+object "root" {
+    code {
+        // this produces non-zero PUSH #[$] assembly item values
+        mstore(42, datasize("sub1.sub1_2"))
+        mstore(42, datasize("sub2.sub2_2"))
+    }
+    object "sub1" {
+        code {}
+        object "sub1_2" {
+            code {}
+        }
+    }
+    object "sub2" {
+        code {}
+        object "sub2_2" {
+            code {}
+        }
+    }
+}

--- a/test/cmdlineTests/asm_json_subassembly_id_representation/output
+++ b/test/cmdlineTests/asm_json_subassembly_id_representation/output
@@ -1,0 +1,101 @@
+
+======= input.yul (EVM) =======
+
+EVM assembly:
+{
+    ".code": [
+        {
+            "begin": 60,
+            "end": 83,
+            "name": "PUSH #[$]",
+            "source": -1,
+            "value": "000000000000000000000000000000000000000000000000ffffffffffffffff"
+        },
+        {
+            "begin": 56,
+            "end": 58,
+            "name": "PUSH",
+            "source": -1,
+            "value": "2A"
+        },
+        {
+            "begin": 49,
+            "end": 84,
+            "name": "MSTORE",
+            "source": -1
+        },
+        {
+            "begin": 108,
+            "end": 131,
+            "name": "PUSH #[$]",
+            "source": -1,
+            "value": "000000000000000000000000000000000000000000000000fffffffffffffffe"
+        },
+        {
+            "begin": 104,
+            "end": 106,
+            "name": "PUSH",
+            "source": -1,
+            "value": "2A"
+        },
+        {
+            "begin": 97,
+            "end": 132,
+            "name": "MSTORE",
+            "source": -1
+        },
+        {
+            "begin": 25,
+            "end": 148,
+            "name": "STOP",
+            "source": -1
+        }
+    ],
+    ".data": {
+        "0": {
+            ".code": [
+                {
+                    "begin": 182,
+                    "end": 189,
+                    "name": "STOP",
+                    "source": -1
+                }
+            ],
+            ".data": {
+                "0": {
+                    ".code": [
+                        {
+                            "begin": 233,
+                            "end": 240,
+                            "name": "STOP",
+                            "source": -1
+                        }
+                    ]
+                }
+            }
+        },
+        "1": {
+            ".code": [
+                {
+                    "begin": 290,
+                    "end": 297,
+                    "name": "STOP",
+                    "source": -1
+                }
+            ],
+            ".data": {
+                "0": {
+                    ".code": [
+                        {
+                            "begin": 341,
+                            "end": 348,
+                            "name": "STOP",
+                            "source": -1
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "sourceList": []
+}

--- a/test/externalTests/solc-js/asm-json.js
+++ b/test/externalTests/solc-js/asm-json.js
@@ -1,0 +1,45 @@
+const tape = require('tape');
+const fs = require('fs');
+const solc = require('../index.js');
+
+tape('ASM Json output consistency', function (t) {
+    t.test('Nested structure', function(st) {
+        const testdir = 'test/';
+        const output = JSON.parse(solc.compile(JSON.stringify({
+            language: 'Solidity',
+            settings: {
+                viaIR: true,
+                outputSelection: {
+                    '*': {
+                        '*': ['evm.legacyAssembly']
+                    }
+                }
+            },
+            sources: {
+                C: {
+                    content: fs.readFileSync(testdir + 'code_access_runtime.sol', 'utf8')
+                }
+            }
+        })));
+        st.ok(output);
+
+        function containsAssemblyItem(assemblyJSON, assemblyItem) {
+            if (Array.isArray(assemblyJSON))
+                return assemblyJSON.some(item => containsAssemblyItem(item, assemblyItem));
+            else if (typeof assemblyJSON === 'object' && assemblyJSON !== null) {
+                if (assemblyJSON.name === assemblyItem.name && assemblyJSON.value === assemblyItem.value)
+                    return true;
+                return Object.values(assemblyJSON).some(value => containsAssemblyItem(value, assemblyItem));
+            }
+            return false;
+        }
+
+        // regression test that there is indeed a negative subassembly index in there
+        // and it is based on a 64 bit uint
+        const targetObject = {
+            "name": "PUSH #[$]",
+            "value": "000000000000000000000000000000000000000000000000ffffffffffffffff"
+        };
+        st.equal(containsAssemblyItem(output["contracts"]["C"]["C"]["evm"]["legacyAssembly"], targetObject), true)
+    });
+});

--- a/test/externalTests/solc-js/solc-js.sh
+++ b/test/externalTests/solc-js/solc-js.sh
@@ -48,6 +48,9 @@ function solcjs_test
     printLog "Copying contracts..."
     cp -Rf "$SOLCJS_INPUT_DIR/DAO" test/
 
+    printLog "Copying test with non-zero subassembly access"
+    cp -f "$TEST_DIR"/test/libsolidity/semanticTests/various/code_access_runtime.sol test/
+
     printLog "Copying SMTChecker tests..."
     # We do not copy all tests because that takes too long.
     cp -Rf "$TEST_DIR"/test/libsolidity/smtCheckerTests/external_calls test/smtCheckerTests/

--- a/test/libevmasm/Assembler.cpp
+++ b/test/libevmasm/Assembler.cpp
@@ -109,11 +109,11 @@ BOOST_AUTO_TEST_CASE(all_assembly_items, *boost::unit_test::precondition(nonEOF(
 	// PushSubSize
 	auto sub = _assembly.appendSubroutine(_subAsmPtr);
 	// PushSub
-	_assembly.pushSubroutineOffset(static_cast<size_t>(sub.data()));
+	_assembly.pushSubroutineOffset(SubAssemblyID(sub.data()));
 	// PushSubSize
 	auto verbatim_sub = _assembly.appendSubroutine(_verbatimAsmPtr);
 	// PushSub
-	_assembly.pushSubroutineOffset(static_cast<size_t>(verbatim_sub.data()));
+	_assembly.pushSubroutineOffset(SubAssemblyID(verbatim_sub.data()));
 	// PushDeployTimeAddress
 	_assembly.append(PushDeployTimeAddress);
 	// AssignImmutable.
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE(immutable, *boost::unit_test::precondition(nonEOF()))
 	_assembly.appendImmutableAssignment("someOtherImmutable");
 
 	auto sub = _assembly.appendSubroutine(_subAsmPtr);
-	_assembly.pushSubroutineOffset(static_cast<size_t>(sub.data()));
+	_assembly.pushSubroutineOffset(SubAssemblyID(sub.data()));
 
 	checkCompilation(_assembly);
 
@@ -418,11 +418,11 @@ BOOST_AUTO_TEST_CASE(subobject_encode_decode)
 	assembly.appendSubroutine(subAsmPtr);
 	subAsmPtr->appendSubroutine(subSubAsmPtr);
 
-	BOOST_CHECK(assembly.encodeSubPath({0}) == 0);
-	BOOST_REQUIRE_THROW(assembly.encodeSubPath({1}), solidity::evmasm::AssemblyException);
-	BOOST_REQUIRE_THROW(assembly.decodeSubPath(1), solidity::evmasm::AssemblyException);
+	BOOST_CHECK(assembly.encodeSubPath({SubAssemblyID{0}}).value == 0);
+	BOOST_REQUIRE_THROW(assembly.encodeSubPath({SubAssemblyID{1}}), solidity::langutil::InternalCompilerError);
+	BOOST_REQUIRE_THROW(assembly.decodeSubPath(SubAssemblyID{1}), solidity::evmasm::AssemblyException);
 
-	std::vector<size_t> subPath{0, 0};
+	std::vector<SubAssemblyID> subPath{{0}, {0}};
 	BOOST_CHECK(assembly.decodeSubPath(assembly.encodeSubPath(subPath)) == subPath);
 }
 

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -1546,7 +1546,7 @@ BOOST_AUTO_TEST_CASE(jumpdest_removal_subassemblies, *boost::unit_test::precondi
 	sub->append(t4.pushTag());
 	sub->append(Instruction::JUMP);
 
-	size_t subId = static_cast<size_t>(main.appendSubroutine(sub).data());
+	SubAssemblyID subId{main.appendSubroutine(sub).data()};
 	main.append(t1.toSubAssemblyTag(subId));
 	main.append(t1.toSubAssemblyTag(subId));
 	main.append(u256(8));

--- a/test/libevmasm/evmAssemblyTests/isoltestTesting/nontrivial_subassembly_ids.asm
+++ b/test/libevmasm/evmAssemblyTests/isoltestTesting/nontrivial_subassembly_ids.asm
@@ -1,0 +1,61 @@
+// sub_0 and children
+PUSH #[$] 0x0000
+// negative indices for nested subobjects in DFS order
+PUSH #[$] 0x000000000000000000000000000000000000000000000000ffffffffffffffff
+PUSH #[$] 0x000000000000000000000000000000000000000000000000fffffffffffffffe
+PUSH #[$] 0x000000000000000000000000000000000000000000000000fffffffffffffffd
+PUSH #[$] 0x000000000000000000000000000000000000000000000000fffffffffffffffc
+// sub_1 and children
+PUSH #[$] 0x0001
+PUSH #[$] 0x000000000000000000000000000000000000000000000000fffffffffffffffb
+
+.sub
+    // referencing sub_0.sub_0 from inside sub_0
+    PUSH #[$] 0x0000
+    // referencing sub_0.sub_0.sub_0 from inside sub_0
+    PUSH #[$] 0x000000000000000000000000000000000000000000000000ffffffffffffffff
+    .sub
+        .sub
+    .sub
+    .sub
+.sub
+    .sub
+// ----
+// Assembly:
+//   dataSize(sub_0)
+//   dataSize(sub_0.sub_0)
+//   dataSize(sub_0.sub_0.sub_0)
+//   dataSize(sub_0.sub_1)
+//   dataSize(sub_0.sub_2)
+//   dataSize(sub_1)
+//   dataSize(sub_1.sub_0)
+// stop
+//
+// sub_0: assembly {
+//       dataSize(sub_0)
+//       dataSize(sub_0.sub_0)
+//     stop
+//
+//     sub_0: assembly {
+//         stop
+//
+//         sub_0: assembly {
+//         }
+//     }
+//
+//     sub_1: assembly {
+//     }
+//
+//     sub_2: assembly {
+//     }
+// }
+//
+// sub_1: assembly {
+//     stop
+//
+//     sub_0: assembly {
+//     }
+// }
+// Bytecode: 6005600160006000600060016000fe
+// Opcodes: PUSH1 0x5 PUSH1 0x1 PUSH1 0x0 PUSH1 0x0 PUSH1 0x0 PUSH1 0x1 PUSH1 0x0 INVALID
+// SourceMappings: :::-:0;;;;;;


### PR DESCRIPTION
When computing object ids for referencing subassemblies, these ids are currently determined as negative DFS enumeration based on `size_t`: 

https://github.com/ethereum/solidity/blob/a65229279d769a7b2936aef2aa802d77abbdc343/libevmasm/Assembly.cpp#L1825

This PR changes this to `uint64_t`, so that assembly text - in particular `PUSH #[$]` instructions - is consistent over different type sizes of `size_t`.

Since these indices are stored in a map and later referenced for exporting and importing, as well as (currently) `numeric_limits<size_t>::max()` is used to indicate the root object or an empty state which is used in, eg, various asserts, I found it helpful to wrap the `uint64_t` into a struct so that these places become apparent and dealing with the sizes is explicit. This caused a whole avalanche of changes, as such object ids (or more generally: `SubAssemblyID`s) are used in many places. In particular, also `yul::Object::subId`s are subject to the type.

We were lacking a cmdline test that has non-zero `PUSH #[$]`es, so I added one. Since emscripten builds do not execute them, we have no direct regression test by this but I have added one to the `solc-js` tests. While doing that I realized that it is currently not possible (to me at least :P) to request ASM json output via standard json interface if the language is Yul.

Fixes #15953