### PR TITLE
chore: improve code readability and style in regressions.py and splitSources.py

### DIFF
--- a/scripts/regressions.py
+++ b/scripts/regressions.py
@@ -22,15 +22,15 @@ class PrintDotsThread:
         thread.start()
 
     def run(self):
-        """ Runs until the main Python thread exits. """
-        ## Print a newline at the very beginning.
+        """ Run indefinitely until the main Python thread exits. """
+        ## Print an initial newline at the very beginning.
         print("")
         while True:
             # Print dot
             print(".")
             time.sleep(self.interval)
 
-class regressor:
+class Regressor:
     _re_sanitizer_log = re.compile(r"""ERROR: (libFuzzer|UndefinedBehaviorSanitizer)""")
 
     def __init__(self, description, args):
@@ -87,7 +87,7 @@ class regressor:
                 False      -> Failure
         """
 
-        ## Log may contain non ASCII characters, so we simply stringify them
+        ## Log may contain non-ASCII characters, so we simply stringify them
         ## since they don't matter for regular expression matching
         with open(logfile, 'rb', encoding=None) as f:
             rawtext = str(f.read())
@@ -122,5 +122,5 @@ class regressor:
 
 if __name__ == '__main__':
     dotprinter = PrintDotsThread()
-    tool = regressor(DESCRIPTION, sys.argv[1:])
+    tool = Regressor(DESCRIPTION, sys.argv[1:])
     sys.exit(not tool.run())

--- a/scripts/splitSources.py
+++ b/scripts/splitSources.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # This script reads a syntaxTest file and writes all
-# sources into their own files. If one source-name specifies subdirectories
+# sources into separate files. If a source name specifies subdirectories,
 # those will be created too.
 
 # Usage: scripts/splitSources.py pathToTestfile
@@ -18,7 +18,7 @@ def uncaught_exception_hook(exc_type, exc_value, exc_traceback):
     # The script `scripts/ASTImportTest.sh` will interpret return code 3
     # as a critical error (because of the uncaught exception) and will
     # terminate further execution.
-    print("Unhandled exception: %s", "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)))
+    print("Unhandled exception: " + "".join(traceback.format_exception(exc_type, exc_value, exc_traceback)))
     sys.exit(3)
 
 
@@ -42,7 +42,7 @@ def writeSourceToFile(lines):
     with open(srcName, mode='a+', encoding='utf8', newline='') as f:
         for idx, line in enumerate(lines[1:]):
             # write to file
-            if line[:12] != "==== Source:":
+            if not line.startswith("==== Source:"):
                 f.write(line + '\n')
 
             # recursive call if there is another source


### PR DESCRIPTION
- Updated docstrings and comments for clarity and grammatical correctness.
- Fixed phrasing: "sources into their own files" → "sources into separate files".
- Improved uncaught exception handling print formatting in `splitSources.py`.
- Replaced manual string slicing with `startswith()` for better readability and Python best practices.
- Standardized class naming: `regressor` → `Regressor`.
- Improved comment wording for non-ASCII handling.
- Minor whitespace and indentation adjustments.
