### PR TITLE
Better safeguard against incompatible builtin handles between dialects

### DIFF
--- a/liblangutil/EVMVersion.h
+++ b/liblangutil/EVMVersion.h
@@ -27,7 +27,6 @@
 #include <cstdint>
 #include <optional>
 #include <string>
-#include <vector>
 
 
 namespace solidity::evmasm
@@ -50,23 +49,23 @@ public:
 
 	static EVMVersion current() { return {currentVersion}; }
 
-	static EVMVersion homestead() { return {Version::Homestead}; }
-	static EVMVersion tangerineWhistle() { return {Version::TangerineWhistle}; }
-	static EVMVersion spuriousDragon() { return {Version::SpuriousDragon}; }
-	static EVMVersion byzantium() { return {Version::Byzantium}; }
-	static EVMVersion constantinople() { return {Version::Constantinople}; }
-	static EVMVersion petersburg() { return {Version::Petersburg}; }
-	static EVMVersion istanbul() { return {Version::Istanbul}; }
-	static EVMVersion berlin() { return {Version::Berlin}; }
-	static EVMVersion london() { return {Version::London}; }
-	static EVMVersion paris() { return {Version::Paris}; }
-	static EVMVersion shanghai() { return {Version::Shanghai}; }
-	static EVMVersion cancun() { return {Version::Cancun}; }
-	static EVMVersion prague() { return {Version::Prague}; }
-	static EVMVersion osaka() { return {Version::Osaka}; }
+	static EVMVersion constexpr homestead() { return {Version::Homestead}; }
+	static EVMVersion constexpr tangerineWhistle() { return {Version::TangerineWhistle}; }
+	static EVMVersion constexpr spuriousDragon() { return {Version::SpuriousDragon}; }
+	static EVMVersion constexpr byzantium() { return {Version::Byzantium}; }
+	static EVMVersion constexpr constantinople() { return {Version::Constantinople}; }
+	static EVMVersion constexpr petersburg() { return {Version::Petersburg}; }
+	static EVMVersion constexpr istanbul() { return {Version::Istanbul}; }
+	static EVMVersion constexpr berlin() { return {Version::Berlin}; }
+	static EVMVersion constexpr london() { return {Version::London}; }
+	static EVMVersion constexpr paris() { return {Version::Paris}; }
+	static EVMVersion constexpr shanghai() { return {Version::Shanghai}; }
+	static EVMVersion constexpr cancun() { return {Version::Cancun}; }
+	static EVMVersion constexpr prague() { return {Version::Prague}; }
+	static EVMVersion constexpr osaka() { return {Version::Osaka}; }
 
-	static std::vector<EVMVersion> allVersions() {
-		return {
+	static auto constexpr allVersions() {
+		return std::array{
 			homestead(),
 			tangerineWhistle(),
 			spuriousDragon(),
@@ -172,7 +171,7 @@ private:
 	};
 	static auto constexpr currentVersion = Version::Prague;
 
-	EVMVersion(Version _version): m_version(_version) {}
+	constexpr EVMVersion(Version _version): m_version(_version) {}
 
 	Version m_version = currentVersion;
 };

--- a/liblangutil/EVMVersion.h
+++ b/liblangutil/EVMVersion.h
@@ -23,6 +23,7 @@
 
 #include <libsolutil/Assertions.h>
 
+#include <array>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -80,6 +81,14 @@ public:
 			cancun(),
 			prague(),
 			osaka(),
+		};
+	}
+
+	static auto constexpr allEOFVersions()
+	{
+		return std::array{
+			std::optional<uint8_t>(),
+			std::make_optional<uint8_t>(1)
 		};
 	}
 

--- a/liblangutil/EVMVersion.h
+++ b/liblangutil/EVMVersion.h
@@ -28,8 +28,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/operators.hpp>
-
 
 namespace solidity::evmasm
 {
@@ -44,12 +42,12 @@ namespace solidity::langutil
  * A version specifier of the EVM we want to compile to.
  * Defaults to the latest version deployed on Ethereum Mainnet at the time of compiler release.
  */
-class EVMVersion:
-	boost::less_than_comparable<EVMVersion>,
-	boost::equality_comparable<EVMVersion>
+class EVMVersion
 {
 public:
 	EVMVersion() = default;
+
+	static EVMVersion current() { return {currentVersion}; }
 
 	static EVMVersion homestead() { return {Version::Homestead}; }
 	static EVMVersion tangerineWhistle() { return {Version::TangerineWhistle}; }
@@ -96,11 +94,10 @@ public:
 	static EVMVersion firstWithEOF() { return {Version::Osaka}; }
 
 	bool isExperimental() const {
-		return *this > EVMVersion{};
+		return m_version > currentVersion;
 	}
 
-	bool operator==(EVMVersion const& _other) const { return m_version == _other.m_version; }
-	bool operator<(EVMVersion const& _other) const { return m_version < _other.m_version; }
+	auto operator<=>(EVMVersion const&) const = default;
 
 	std::string name() const
 	{
@@ -164,10 +161,11 @@ private:
 		Prague,
 		Osaka,
 	};
+	static auto constexpr currentVersion = Version::Prague;
 
 	EVMVersion(Version _version): m_version(_version) {}
 
-	Version m_version = Version::Prague;
+	Version m_version = currentVersion;
 };
 
 }

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -58,6 +58,8 @@ add_library(yul
 	backends/evm/ControlFlowGraphBuilder.h
 	backends/evm/EthAssemblyAdapter.cpp
 	backends/evm/EthAssemblyAdapter.h
+	backends/evm/EVMBuiltins.cpp
+	backends/evm/EVMBuiltins.h
 	backends/evm/EVMCodeTransform.cpp
 	backends/evm/EVMCodeTransform.h
 	backends/evm/EVMDialect.cpp

--- a/libyul/backends/evm/EVMBuiltins.cpp
+++ b/libyul/backends/evm/EVMBuiltins.cpp
@@ -1,0 +1,419 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libyul/backends/evm/EVMBuiltins.h>
+
+#include <libyul/AST.h>
+#include <libyul/Object.h>
+#include <libyul/Utilities.h>
+
+#include <libevmasm/AssemblyItem.h>
+
+#include <libsolutil/StringUtils.h>
+
+#include <range/v3/algorithm/all_of.hpp>
+
+using namespace solidity;
+using namespace solidity::yul;
+
+namespace
+{
+
+BuiltinFunctionForEVM createFunction(
+	std::string const& _name,
+	size_t _params,
+	size_t _returns,
+	SideEffects _sideEffects,
+	ControlFlowSideEffects _controlFlowSideEffects,
+	std::vector<std::optional<LiteralKind>> _literalArguments,
+	std::function<void(FunctionCall const&, AbstractAssembly&, BuiltinContext&)> _generateCode
+)
+{
+	yulAssert(_literalArguments.size() == _params || _literalArguments.empty(), "");
+
+	BuiltinFunctionForEVM f;
+	f.name = _name;
+	f.numParameters = _params;
+	f.numReturns = _returns;
+	f.sideEffects = _sideEffects;
+	f.controlFlowSideEffects = _controlFlowSideEffects;
+	f.literalArguments = std::move(_literalArguments);
+	f.isMSize = false;
+	f.instruction = {};
+	f.generateCode = std::move(_generateCode);
+	return f;
+}
+
+BuiltinFunctionForEVM instructionBuiltin(evmasm::Instruction const& _instruction, langutil::EVMVersion const& _evmVersion)
+{
+	evmasm::InstructionInfo const info = evmasm::instructionInfo(_instruction, _evmVersion);
+	BuiltinFunctionForEVM f;
+	f.name = util::toLower(info.name);
+	f.numParameters = static_cast<size_t>(info.args);
+	f.numReturns = static_cast<size_t>(info.ret);
+	f.sideEffects = EVMBuiltins::sideEffectsOfInstruction(_instruction);
+	f.controlFlowSideEffects = ControlFlowSideEffects::fromInstruction(_instruction);
+	f.isMSize = _instruction == evmasm::Instruction::MSIZE;
+	f.literalArguments.clear();
+	f.instruction = _instruction;
+	f.generateCode = [_instruction](
+		FunctionCall const&,
+		AbstractAssembly& _assembly,
+		BuiltinContext&
+	)
+	{
+		_assembly.appendInstruction(_instruction);
+	};
+	return f;
+}
+
+BuiltinFunctionForEVM linkersymbolBuiltin()
+{
+	return createFunction(
+		"linkersymbol",
+		1,
+		1,
+		SideEffects{},
+		ControlFlowSideEffects{},
+		{LiteralKind::String},
+		[](FunctionCall const& _call, AbstractAssembly& _assembly, BuiltinContext&) {
+			yulAssert(_call.arguments.size() == 1, "");
+			Expression const& arg = _call.arguments.front();
+			_assembly.appendLinkerSymbol(formatLiteral(std::get<Literal>(arg)));
+		}
+	);
+}
+
+BuiltinFunctionForEVM memoryguardBuiltin()
+{
+	return createFunction(
+		"memoryguard",
+		1,
+		1,
+		SideEffects{},
+		ControlFlowSideEffects{},
+		{LiteralKind::Number},
+		[](FunctionCall const& _call, AbstractAssembly& _assembly, BuiltinContext&) {
+			yulAssert(_call.arguments.size() == 1, "");
+			Literal const* literal = std::get_if<Literal>(&_call.arguments.front());
+			yulAssert(literal, "");
+			_assembly.appendConstant(literal->value.value());
+		}
+	);
+}
+
+BuiltinFunctionForEVM datasizeBuiltin()
+{
+	return createFunction(
+		"datasize",
+		1,
+		1,
+		SideEffects{},
+		ControlFlowSideEffects{},
+		{LiteralKind::String},
+		[](FunctionCall const& _call, AbstractAssembly& _assembly, BuiltinContext& _context) {
+			yulAssert(_context.currentObject, "No object available.");
+			yulAssert(_call.arguments.size() == 1, "");
+			Expression const& arg = _call.arguments.front();
+			YulName const dataName (formatLiteral(std::get<Literal>(arg)));
+			if (_context.currentObject->name == dataName.str())
+				_assembly.appendAssemblySize();
+			else
+			{
+				std::vector<size_t> subIdPath =
+					_context.subIDs.count(dataName.str()) == 0 ?
+						_context.currentObject->pathToSubObject(dataName.str()) :
+						std::vector<size_t>{_context.subIDs.at(dataName.str())};
+				yulAssert(!subIdPath.empty(), "Could not find assembly object <" + dataName.str() + ">.");
+				_assembly.appendDataSize(subIdPath);
+			}
+		}
+	);
+}
+
+BuiltinFunctionForEVM dataoffsetBuiltin()
+{
+	return createFunction("dataoffset", 1, 1, SideEffects{}, ControlFlowSideEffects{}, {LiteralKind::String}, [](
+		FunctionCall const& _call,
+		AbstractAssembly& _assembly,
+		BuiltinContext& _context
+	) {
+		yulAssert(_context.currentObject, "No object available.");
+		yulAssert(_call.arguments.size() == 1, "");
+		Expression const& arg = _call.arguments.front();
+		YulName const dataName (formatLiteral(std::get<Literal>(arg)));
+		if (_context.currentObject->name == dataName.str())
+			_assembly.appendConstant(0);
+		else
+		{
+			std::vector<size_t> subIdPath =
+				_context.subIDs.count(dataName.str()) == 0 ?
+					_context.currentObject->pathToSubObject(dataName.str()) :
+					std::vector<size_t>{_context.subIDs.at(dataName.str())};
+			yulAssert(!subIdPath.empty(), "Could not find assembly object <" + dataName.str() + ">.");
+			_assembly.appendDataOffset(subIdPath);
+		}
+	});
+}
+
+BuiltinFunctionForEVM datacopyBuiltin()
+{
+	return createFunction(
+		"datacopy",
+		3,
+		0,
+		EVMBuiltins::sideEffectsOfInstruction(evmasm::Instruction::CODECOPY),
+		ControlFlowSideEffects::fromInstruction(evmasm::Instruction::CODECOPY),
+		{},
+		[](
+			FunctionCall const&,
+			AbstractAssembly& _assembly,
+			BuiltinContext&
+		) {
+			_assembly.appendInstruction(evmasm::Instruction::CODECOPY);
+		}
+	);
+}
+
+BuiltinFunctionForEVM setimmutableBuiltin()
+{
+	return createFunction(
+		"setimmutable",
+		3,
+		0,
+		SideEffects{
+			false,               // movable
+			false,               // movableApartFromEffects
+			false,               // canBeRemoved
+			false,               // canBeRemovedIfNotMSize
+			true,                // cannotLoop
+			SideEffects::None,   // otherState
+			SideEffects::None,   // storage
+			SideEffects::Write,  // memory
+			SideEffects::None    // transientStorage
+		},
+		ControlFlowSideEffects{},
+		{std::nullopt, LiteralKind::String, std::nullopt},
+		[](
+			FunctionCall const& _call,
+			AbstractAssembly& _assembly,
+			BuiltinContext&
+		) {
+			yulAssert(_call.arguments.size() == 3, "");
+			auto const identifier = (formatLiteral(std::get<Literal>(_call.arguments[1])));
+			_assembly.appendImmutableAssignment(identifier);
+		}
+	);
+}
+
+BuiltinFunctionForEVM loadimmutableBuiltin()
+{
+	return createFunction(
+		"loadimmutable",
+		1,
+		1,
+		SideEffects{},
+		ControlFlowSideEffects{},
+		{LiteralKind::String},
+		[](
+			FunctionCall const& _call,
+			AbstractAssembly& _assembly,
+			BuiltinContext&
+		) {
+			yulAssert(_call.arguments.size() == 1, "");
+			_assembly.appendImmutable(formatLiteral(std::get<Literal>(_call.arguments.front())));
+		}
+	);
+}
+
+BuiltinFunctionForEVM auxdataloadnBuiltin()
+{
+	return createFunction(
+		"auxdataloadn",
+		1,
+		1,
+		EVMBuiltins::sideEffectsOfInstruction(evmasm::Instruction::DATALOADN),
+		ControlFlowSideEffects::fromInstruction(evmasm::Instruction::DATALOADN),
+		{LiteralKind::Number},
+		[](
+			FunctionCall const& _call,
+			AbstractAssembly& _assembly,
+			BuiltinContext&
+		) {
+			yulAssert(_call.arguments.size() == 1);
+			Literal const* literal = std::get_if<Literal>(&_call.arguments.front());
+			yulAssert(literal, "");
+			yulAssert(literal->value.value() <= std::numeric_limits<uint16_t>::max());
+			_assembly.appendAuxDataLoadN(static_cast<uint16_t>(literal->value.value()));
+		}
+	);
+}
+
+BuiltinFunctionForEVM eofcreateBuiltin()
+{
+	return createFunction(
+		"eofcreate",
+		5,
+		1,
+		EVMBuiltins::sideEffectsOfInstruction(evmasm::Instruction::EOFCREATE),
+		ControlFlowSideEffects::fromInstruction(evmasm::Instruction::EOFCREATE),
+		{LiteralKind::String, std::nullopt, std::nullopt, std::nullopt, std::nullopt},
+		[](
+			FunctionCall const& _call,
+			AbstractAssembly& _assembly,
+			BuiltinContext& context
+		) {
+			yulAssert(_call.arguments.size() == 5);
+			Literal const* literal = std::get_if<Literal>(&_call.arguments.front());
+			auto const formattedLiteral = formatLiteral(*literal);
+			yulAssert(!util::contains(formattedLiteral, '.'));
+			auto const* containerID = util::valueOrNullptr(context.subIDs, formattedLiteral);
+			yulAssert(containerID != nullptr);
+			yulAssert(*containerID <= std::numeric_limits<AbstractAssembly::ContainerID>::max());
+			_assembly.appendEOFCreate(static_cast<AbstractAssembly::ContainerID>(*containerID));
+		}
+	);
+}
+
+BuiltinFunctionForEVM returncontractBuiltin()
+{
+	return createFunction(
+		"returncontract",
+		3,
+		0,
+		EVMBuiltins::sideEffectsOfInstruction(evmasm::Instruction::RETURNCONTRACT),
+		ControlFlowSideEffects::fromInstruction(evmasm::Instruction::RETURNCONTRACT),
+		{LiteralKind::String, std::nullopt, std::nullopt},
+		[](
+			FunctionCall const& _call,
+			AbstractAssembly& _assembly,
+			BuiltinContext& context
+		) {
+			yulAssert(_call.arguments.size() == 3);
+			Literal const* literal = std::get_if<Literal>(&_call.arguments.front());
+			yulAssert(literal);
+			auto const formattedLiteral = formatLiteral(*literal);
+			yulAssert(!util::contains(formattedLiteral, '.'));
+			auto const* containerID = util::valueOrNullptr(context.subIDs, formattedLiteral);
+			yulAssert(containerID != nullptr);
+			yulAssert(*containerID <= std::numeric_limits<AbstractAssembly::ContainerID>::max());
+			_assembly.appendReturnContract(static_cast<AbstractAssembly::ContainerID>(*containerID));
+		}
+	);
+}
+
+}
+
+EVMBuiltins::EVMBuiltins()
+{
+	for (auto const& [name, opcode]: evmasm::c_instructions)
+	{
+		if (
+			opcode == evmasm::Instruction::SWAPN ||
+			opcode == evmasm::Instruction::DUPN ||
+			evmasm::SemanticInformation::isSwapInstruction(opcode) ||
+			evmasm::SemanticInformation::isDupInstruction(opcode)
+		)
+			continue;
+
+		// difficulty was replaced by prevrandao after london
+		if (opcode == evmasm::Instruction::PREVRANDAO && name == "DIFFICULTY")
+			m_scopesAndFunctions.emplace_back(instruction, instructionBuiltin(opcode, langutil::EVMVersion::london()));
+		else
+			m_scopesAndFunctions.emplace_back(instruction, instructionBuiltin(opcode, langutil::EVMVersion::current()));
+
+		// these are replaced by 'proper' builtin functions
+		if (
+			opcode == evmasm::Instruction::DATALOADN ||
+			opcode == evmasm::Instruction::EOFCREATE ||
+			opcode == evmasm::Instruction::RETURNCONTRACT
+		)
+			std::get<0>(m_scopesAndFunctions.back()) |= replaced;
+	}
+
+	m_scopesAndFunctions.emplace_back(objectAccess, linkersymbolBuiltin());
+	m_scopesAndFunctions.emplace_back(objectAccess, memoryguardBuiltin());
+
+	m_scopesAndFunctions.emplace_back(objectAccess | requiresNonEOF, datasizeBuiltin());
+	m_scopesAndFunctions.emplace_back(objectAccess | requiresNonEOF, dataoffsetBuiltin());
+	m_scopesAndFunctions.emplace_back(objectAccess | requiresNonEOF, datacopyBuiltin());
+	m_scopesAndFunctions.emplace_back(objectAccess | requiresNonEOF, setimmutableBuiltin());
+	m_scopesAndFunctions.emplace_back(objectAccess | requiresNonEOF, loadimmutableBuiltin());
+
+	m_scopesAndFunctions.emplace_back(objectAccess | requiresEOF, auxdataloadnBuiltin());
+	m_scopesAndFunctions.emplace_back(objectAccess | requiresEOF, eofcreateBuiltin());
+	m_scopesAndFunctions.emplace_back(objectAccess | requiresEOF, returncontractBuiltin());
+
+	static size_t constexpr verbatimPrefixLength = std::char_traits<char>::length("verbatim_");
+	for (auto const& [scope, builtin]: m_scopesAndFunctions)
+	{
+		yulAssert(
+			builtin.name.substr(0, verbatimPrefixLength) != "verbatim_",
+			"Builtin functions besides verbatim should not start with the verbatim_ prefix."
+		);
+		yulAssert(!(scope.requiresEOF() && scope.requiresNonEOF()), "Mutually exclusive scopes");
+	}
+}
+
+BuiltinFunctionForEVM EVMBuiltins::createVerbatimFunction(size_t const _arguments, size_t const _returnVariables)
+{
+	BuiltinFunctionForEVM builtinFunction = createFunction(
+		"verbatim_" + std::to_string(_arguments) + "i_" + std::to_string(_returnVariables) + "o",
+		1 + _arguments,
+		_returnVariables,
+		SideEffects::worst(),
+		ControlFlowSideEffects::worst(), // Worst control flow side effects because verbatim can do anything.
+		std::vector<std::optional<LiteralKind>>{LiteralKind::String} + std::vector<std::optional<LiteralKind>>(_arguments),
+		[=](
+			FunctionCall const& _call,
+			AbstractAssembly& _assembly,
+			BuiltinContext&
+		) {
+			yulAssert(_call.arguments.size() == (1 + _arguments), "");
+			Expression const& bytecode = _call.arguments.front();
+
+			_assembly.appendVerbatim(
+				util::asBytes(formatLiteral(std::get<Literal>(bytecode))),
+				_arguments,
+				_returnVariables
+			);
+		}
+	);
+	builtinFunction.isMSize = true;
+	return builtinFunction;
+}
+
+SideEffects EVMBuiltins::sideEffectsOfInstruction(evmasm::Instruction _instruction)
+{
+	auto translate = [](evmasm::SemanticInformation::Effect _e) -> SideEffects::Effect
+	{
+		return static_cast<SideEffects::Effect>(_e);
+	};
+
+	return SideEffects{
+		evmasm::SemanticInformation::movable(_instruction),
+		evmasm::SemanticInformation::movableApartFromEffects(_instruction),
+		evmasm::SemanticInformation::canBeRemoved(_instruction),
+		evmasm::SemanticInformation::canBeRemovedIfNoMSize(_instruction),
+		true, // cannotLoop
+		translate(evmasm::SemanticInformation::otherState(_instruction)),
+		translate(evmasm::SemanticInformation::storage(_instruction)),
+		translate(evmasm::SemanticInformation::memory(_instruction)),
+		translate(evmasm::SemanticInformation::transientStorage(_instruction)),
+	};
+}

--- a/libyul/backends/evm/EVMBuiltins.h
+++ b/libyul/backends/evm/EVMBuiltins.h
@@ -1,0 +1,120 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libyul/backends/evm/AbstractAssembly.h>
+
+#include <libyul/Dialect.h>
+#include <libyul/Scope.h>
+
+#include <bitset>
+#include <cstddef>
+#include <map>
+#include <optional>
+#include <tuple>
+#include <vector>
+
+namespace solidity::yul
+{
+
+class Object;
+
+/// Context used during code generation.
+struct BuiltinContext
+{
+	Object const* currentObject = nullptr;
+	/// Mapping from named objects to abstract assembly sub IDs.
+	std::map<std::string, AbstractAssembly::SubID> subIDs;
+
+	std::map<Scope::Function const*, AbstractAssembly::FunctionID> functionIDs;
+};
+
+struct BuiltinFunctionForEVM: public BuiltinFunction
+{
+	std::optional<evmasm::Instruction> instruction;
+	/// Function to generate code for the given function call and append it to the abstract
+	/// assembly. Expects all non-literal arguments of the call to be on stack in reverse order
+	/// (i.e. right-most argument pushed first).
+	/// Expects the caller to set the source location.
+	std::function<void(FunctionCall const&, AbstractAssembly&, BuiltinContext&)> generateCode;
+};
+
+/// Collection of all possible EVM builtin functions.
+/// Each builtin can have one (or multiple) scopes, which define whether, e.g., it requires object access.
+/// Using this class as single source of truth for builtin functions makes sure that these are consistent over
+/// EVM dialects. If the order were to depend on the EVM dialect - which can easily happen using conditionals -,
+/// different dialects' builtin handles become inherently incompatible.
+class EVMBuiltins
+{
+	static std::size_t constexpr instructionBit = 0;
+	static std::size_t constexpr replacedInstructionBit = 1;
+	static std::size_t constexpr objectAccessBit = 2;
+	static std::size_t constexpr requiresEOFBit = 3;
+	static std::size_t constexpr requiresNonEOFBit = 4;
+
+public:
+	struct Scopes
+	{
+		/// whether the corresponding evm builtin function is an instruction builtin
+		bool instruction() const { return value.test(instructionBit); }
+		/// whether the corresponding evm builtin has been replaced by another builtin, ie, should be skipped
+		bool replaced() const { return value.test(replacedInstructionBit); }
+		/// if true, the evm builtin function is only valid when object access is given
+		bool requiresObjectAccess() const { return value.test(objectAccessBit); }
+		/// if true, the evm builtin function is only valid if EOF is enabled
+		bool requiresEOF() const { return value.test(requiresEOFBit); }
+		/// if true, the evm builtin function is only valid if EOF is not enabled
+		bool requiresNonEOF() const { return value.test(requiresNonEOFBit); }
+
+		Scopes operator|(Scopes const& _other) const
+		{
+			Scopes result = *this;
+			result |= _other;
+			return result;
+		}
+
+		Scopes& operator|=(Scopes const& _other)
+		{
+			value |= _other.value;
+			return *this;
+		}
+
+		std::bitset<5> value;
+	};
+
+	EVMBuiltins();
+
+	std::vector<std::tuple<Scopes, BuiltinFunctionForEVM>> const& functions() const { return m_scopesAndFunctions; }
+
+	/// Creates a verbatim builtin function. These are not part of the usual builtin functions collection and
+	/// must be cached in the dialect creating them.
+	static BuiltinFunctionForEVM createVerbatimFunction(size_t _arguments, size_t _returnVariables);
+	static SideEffects sideEffectsOfInstruction(evmasm::Instruction _instruction);
+
+private:
+	static Scopes constexpr instruction{1 << instructionBit};
+	static Scopes constexpr replaced{1 << replacedInstructionBit};
+	static Scopes constexpr objectAccess{1 << objectAccessBit};
+	static Scopes constexpr requiresEOF{1 << requiresEOFBit};
+	static Scopes constexpr requiresNonEOF{1 << requiresNonEOFBit};
+
+	std::vector<std::tuple<Scopes, BuiltinFunctionForEVM>> m_scopesAndFunctions;
+};
+
+}

--- a/libyul/backends/evm/EVMDialect.h
+++ b/libyul/backends/evm/EVMDialect.h
@@ -125,7 +125,7 @@ protected:
 	langutil::EVMVersion const m_evmVersion;
 	std::optional<uint8_t> m_eofVersion;
 	std::unordered_map<std::string_view, BuiltinHandle> m_builtinFunctionsByName;
-	std::vector<std::optional<BuiltinFunctionForEVM>> m_functions;
+	std::vector<BuiltinFunctionForEVM const*> m_functions;
 	std::array<std::unique_ptr<BuiltinFunctionForEVM>, verbatimIDOffset> mutable m_verbatimFunctions{};
 	std::set<std::string, std::less<>> m_reserved;
 

--- a/libyul/backends/evm/EVMDialect.h
+++ b/libyul/backends/evm/EVMDialect.h
@@ -45,6 +45,10 @@ class Object;
  * Yul dialect for EVM as a backend.
  * The main difference is that the builtin functions take an AbstractAssembly for the
  * code generation.
+ *
+ * Builtins are defined so that their handles stay compatible over different dialect flavors - be it with/without
+ * object access, with/without EOF, different versions. It may be, of course, that these builtins are no longer defined.
+ * The ones that _are_ defined, though, remain under the same handle.
  */
 class EVMDialect: public Dialect
 {
@@ -81,6 +85,8 @@ public:
 	AuxiliaryBuiltinHandles const& auxiliaryBuiltinHandles() const { return m_auxiliaryBuiltinHandles; }
 
 	static EVMDialect const& strictAssemblyForEVM(langutil::EVMVersion _evmVersion, std::optional<uint8_t> _eofVersion);
+	/// Builtins with and without object access are compatible, i.e., builtin handles without object access are not
+	/// invalidated and still point to the same function.
 	static EVMDialect const& strictAssemblyForEVMObjects(langutil::EVMVersion _evmVersion, std::optional<uint8_t> _eofVersion);
 
 	langutil::EVMVersion evmVersion() const { return m_evmVersion; }
@@ -91,6 +97,8 @@ public:
 
 	static size_t constexpr verbatimMaxInputSlots = 100;
 	static size_t constexpr verbatimMaxOutputSlots = 100;
+
+	std::set<std::string_view> builtinFunctionNames() const;
 
 protected:
 	static bool constexpr isVerbatimHandle(BuiltinHandle const& _handle) { return _handle.id < verbatimIDOffset; }

--- a/libyul/backends/evm/NoOutputAssembly.h
+++ b/libyul/backends/evm/NoOutputAssembly.h
@@ -114,6 +114,9 @@ public:
 	explicit NoOutputEVMDialect(EVMDialect const& _copyFrom);
 
 	BuiltinFunctionForEVM const& builtin(BuiltinHandle const& _handle) const override;
+
+private:
+	static std::vector<BuiltinFunctionForEVM> defineNoOutputBuiltins();
 };
 
 

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -596,7 +596,7 @@ General Information)").c_str(),
 	auto const annotateEVMVersion = [](EVMVersion const& _version) {
 		return _version.name() + (_version.isExperimental() ? " (experimental)" : "");
 	};
-	std::vector<EVMVersion> allEVMVersions = EVMVersion::allVersions();
+	static auto constexpr allEVMVersions = EVMVersion::allVersions();
 	std::string annotatedEVMVersions = util::joinHumanReadable(
 		allEVMVersions | ranges::views::transform(annotateEVMVersion),
 		", ",

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -149,6 +149,7 @@ set(libyul_sources
     libyul/ControlFlowSideEffectsTest.h
     libyul/EVMCodeTransformTest.cpp
     libyul/EVMCodeTransformTest.h
+    libyul/EVMDialectCompatibility.cpp
     libyul/FunctionSideEffects.cpp
     libyul/FunctionSideEffects.h
     libyul/Inliner.cpp

--- a/test/libyul/EVMDialectCompatibility.cpp
+++ b/test/libyul/EVMDialectCompatibility.cpp
@@ -1,0 +1,167 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libyul/backends/evm/EVMDialect.h>
+
+#include <libsolidity/util/SoltestErrors.h>
+
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/data/monomorphic.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <range/v3/view/zip.hpp>
+#include <range/v3/range_concepts.hpp>
+
+#include <fmt/format.h>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace bdata = boost::unit_test::data;
+
+using namespace solidity;
+using namespace solidity::yul;
+
+namespace
+{
+
+struct EVMDialectConfigurationToTest
+{
+	EVMDialect const& dialect() const
+	{
+		return objectAccess ? EVMDialect::strictAssemblyForEVMObjects(evmVersion, eofVersion) : EVMDialect::strictAssemblyForEVM(evmVersion, eofVersion);
+	}
+
+	friend std::ostream& operator<<(std::ostream& _out, EVMDialectConfigurationToTest const& _config)
+	{
+		_out << fmt::format(
+			"EVMConfigurationToTest[{}, eof={}, objectAccess={}]",
+			_config.evmVersion.name(),
+			_config.eofVersion.has_value() ? std::to_string(*_config.eofVersion) : "null",
+			_config.objectAccess
+		);
+		return _out;
+	}
+
+	langutil::EVMVersion evmVersion;
+	std::optional<uint8_t> eofVersion;
+	bool objectAccess;
+};
+
+template<ranges::range EVMVersionCollection>
+std::vector<EVMDialectConfigurationToTest> generateConfigs(EVMVersionCollection const& _evmVersions, std::vector<bool> const& _objectAccess = {false, true})
+{
+	std::vector<EVMDialectConfigurationToTest> configs;
+	for (bool const objectAccess: _objectAccess)
+		for (auto const& eofVersion: langutil::EVMVersion::allEOFVersions())
+			for (auto const& evmVersion: _evmVersions)
+				if (!eofVersion || evmVersion.supportsEOF())
+					configs.push_back(EVMDialectConfigurationToTest{evmVersion, eofVersion, objectAccess});
+
+	return configs;
+}
+}
+
+BOOST_AUTO_TEST_SUITE(EVMDialectCompatibility)
+
+/// Test for both current and latest (source) EVM dialect that for all other (target) dialects and all builtins in the
+/// source dialect, if the builtin exists for both source and target, they have the same handle.
+/// Note: The comparison is packed into a single BOOST_REQUIRE to avoid massive amounts of output on cout.
+BOOST_DATA_TEST_CASE(
+	builtin_function_handle_compatibility,
+	bdata::monomorphic::grid(
+		bdata::make(generateConfigs(std::array{langutil::EVMVersion::current(), langutil::EVMVersion::allVersions().back()})),
+		bdata::make(generateConfigs(langutil::EVMVersion::allVersions()))
+	),
+	sourceDialectConfiguration,
+	evmDialectConfigurationToTest
+)
+{
+	auto const& sourceDialect = sourceDialectConfiguration.dialect();
+	auto const& dialectToTestAgainst = evmDialectConfigurationToTest.dialect();
+
+	std::set<std::string_view> const builtinNames = sourceDialect.builtinFunctionNames();
+	std::vector<BuiltinHandle> sourceHandles;
+	sourceHandles.reserve(builtinNames.size());
+	std::vector<std::optional<BuiltinHandle>> testHandles;
+	testHandles.reserve(builtinNames.size());
+
+	for (auto const& builtinFunctionName: builtinNames)
+	{
+		std::optional<BuiltinHandle> sourceHandle = sourceDialect.findBuiltin(builtinFunctionName);
+		soltestAssert(sourceHandle.has_value());
+		sourceHandles.push_back(*sourceHandle);
+		testHandles.push_back(dialectToTestAgainst.findBuiltin(builtinFunctionName));
+	}
+
+	BOOST_REQUIRE([&]() -> boost::test_tools::predicate_result
+	{
+		boost::test_tools::predicate_result result{true};
+		for (auto const& [name, sourceBuiltin, testBuiltin]: ranges::views::zip(builtinNames, sourceHandles, testHandles))
+			if (testBuiltin && sourceBuiltin != *testBuiltin)
+			{
+				result = false;
+				result.message() << fmt::format("Builtin \"{}\" had a mismatch of builtin handles: {} =/= {}.", name, sourceBuiltin.id, testBuiltin->id);
+			}
+		return result;
+	}());
+}
+
+/// Test that for all inline-dialects the corresponding object dialect contains all inline-dialect builtins and they
+/// have the same handle.
+BOOST_DATA_TEST_CASE(
+	builtin_inline_to_object_compatibility,
+	bdata::make(generateConfigs(langutil::EVMVersion::allVersions(), {false})),
+	configToTest
+)
+{
+	auto const& dialect = EVMDialect::strictAssemblyForEVM(configToTest.evmVersion, configToTest.eofVersion);
+	auto const& dialectForObjects = EVMDialect::strictAssemblyForEVMObjects(configToTest.evmVersion, configToTest.eofVersion);
+
+	std::set<std::string_view> const inlineBuiltinNames = dialect.builtinFunctionNames();
+
+	std::vector<BuiltinHandle> inlineHandles;
+	inlineHandles.reserve(inlineBuiltinNames.size());
+	std::vector<std::optional<BuiltinHandle>> objectHandles;
+	objectHandles.reserve(inlineBuiltinNames.size());
+
+	for (auto const& builtinFunctionName: inlineBuiltinNames)
+	{
+		std::optional<BuiltinHandle> handle = dialect.findBuiltin(builtinFunctionName);
+		soltestAssert(handle.has_value());
+		inlineHandles.push_back(*handle);
+		objectHandles.push_back(dialectForObjects.findBuiltin(builtinFunctionName));
+	}
+
+	BOOST_REQUIRE([&]() -> boost::test_tools::predicate_result
+	{
+		boost::test_tools::predicate_result result{true};
+		for (auto const& [name, inlineHandle, objectHandle]: ranges::views::zip(inlineBuiltinNames, inlineHandles, objectHandles))
+			if (!objectHandle || inlineHandle != *objectHandle)
+			{
+				result = false;
+				result.message()
+					<< fmt::format("Builtin \"{}\" had a mismatch of builtin handles: {} != ", name, inlineHandle.id)
+					<< (objectHandle.has_value() ? std::to_string(objectHandle->id) : "null");
+			}
+		return result;
+	}());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/tools/fuzzer_common.cpp
+++ b/test/tools/fuzzer_common.cpp
@@ -39,7 +39,7 @@ using namespace solidity::frontend;
 using namespace solidity::langutil;
 using namespace solidity::util;
 
-static std::vector<EVMVersion> s_evmVersions = EVMVersion::allVersions();
+static auto constexpr s_evmVersions = EVMVersion::allVersions();
 
 void FuzzerUtil::testCompilerJsonInterface(std::string const& _input, bool _optimize, bool _quiet)
 {


### PR DESCRIPTION
Inspired from the remarks by @cameel in https://github.com/ethereum/solidity/pull/15952#discussion_r2003884305, I have refactored `EVMDialect` a bit so that there is a class for generating the builtin vector that will automatically insert blanks if conditions aren't met and not give direct access to the underlying raw datastructure.
Also, I have added a unit test which takes the default dialect (without EOF) as well as the latest dialect with EOF and tests whether the populated builtin functions with their handles contained in the respective dialects are preserved when compared to all other dialects with and without object access.
