### PR TITLE
Polishing up any minor spelling errors in contracts inside `compilationTests/`

### DIFF
--- a/test/compilationTests/corion/premium.sol
+++ b/test/compilationTests/corion/premium.sol
@@ -229,7 +229,7 @@ contract premium is module, safeMath {
     function transfer(address to, uint256 amount, bytes calldata extraData) isReady external returns (bool success) {
         /*
             Launch a transaction where we transfer from a given address to another one.
-            After thetransaction the approvedCorionPremiumToken function of the receiver’s address is going to be called with the given data.
+            After the transaction the approvedCorionPremiumToken function of the receiver’s address is going to be called with the given data.
 
             @to         For who?
             @amount     Amount

--- a/test/compilationTests/corion/publisher.sol
+++ b/test/compilationTests/corion/publisher.sol
@@ -205,8 +205,8 @@ contract publisher is announcementTypes, module, safeMath {
             If announcement is opposable, anyone owning a token can oppose it
             Opposition is automatically with the total amount of tokens
             If the quantity of his tokens changes, the purport of his opposition changes automatically
-            The prime time is the windup  of the announcement, because this is the moment when the number of tokens in opposition are counted.
-            One address is entitled to be in oppositon only once. An opposition cannot be withdrawn.
+            The prime time is the windup of the announcement, because this is the moment when the number of tokens in opposition are counted.
+            One address is entitled to be in opposition only once. An opposition cannot be withdrawn.
             Running announcements can be opposed only.
 
             @id     Announcement identification


### PR DESCRIPTION
hey team ! i found errors
thetransaction - the transaction` fix error`
windup__of `deleted double space `
oppositon - opposition `fix error`