### PR TITLE
[docs] Update the link to Consensys best practices in `security-considerations.rst`

### DIFF
--- a/docs/security-considerations.rst
+++ b/docs/security-considerations.rst
@@ -32,7 +32,7 @@ please help us extend this section (especially, some examples would not hurt)!
 
 NOTE: In addition to the list below, you can find more security recommendations and best practices
 `in Guy Lando's knowledge list <https://github.com/guylando/KnowledgeLists/blob/master/EthereumSmartContracts.md>`_ and
-`the Consensys GitHub repo <https://consensys.github.io/smart-contract-best-practices/>`_.
+`the Smart Contract Security Field Guide <https://scsfg.io/>`_.
 
 ********
 Pitfalls


### PR DESCRIPTION
The Consensys link is no longer maintained and points towards the SCSFG