### PR TITLE
Update resources.rst - Added link to Aderyn VS Code Extension

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -78,6 +78,9 @@ Editor Integrations
 
 * Visual Studio Code (VS Code)
 
+    * `Aderyn Visual Studio Code extension <https://marketplace.visualstudio.com/items?itemName=Cyfrin.aderyn>`_
+        Solidity Smart contract analyzer designed to help find vulnerabilities. It supports projects built with Hardhat, Foundry, or any custom framework.
+
     * `Ethereum Remix Visual Studio Code extension <https://github.com/ethereum/remix-vscode>`_
         Ethereum Remix extension pack for VS Code
         💡 Note: As per the official repository, this extension has been removed from the VSCODE marketplace and will be replaced by a dedicated stand-alone desktop application.
@@ -107,7 +110,7 @@ Solidity Tools
     Tool to generate Solidity interface source from a given ABI JSON.
 
 * `Aderyn <https://github.com/Cyfrin/aderyn>`_
-    Rust-based solidity smart contract static analyzer designed to help find vulnerabilities in Solidity code bases. Comes with `VS Code Extension <https://marketplace.visualstudio.com/items?itemName=Cyfrin.aderyn>` for easy use.
+    Command Line Tool that helps find vulnerabilities in Solidity smart contracts. It supports projects built with Hardhat, Foundry, or any custom framework.
 
 * `Doxity <https://github.com/DigixGlobal/doxity>`_
     Documentation Generator for Solidity.

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -107,7 +107,7 @@ Solidity Tools
     Tool to generate Solidity interface source from a given ABI JSON.
 
 * `Aderyn <https://github.com/Cyfrin/aderyn>`_
-    Rust-based solidity smart contract static analyzer designed to help find vulnerabilities in Solidity code bases.
+    Rust-based solidity smart contract static analyzer designed to help find vulnerabilities in Solidity code bases. Comes with `VS Code Extension <https://marketplace.visualstudio.com/items?itemName=Cyfrin.aderyn>` for easy use.
 
 * `Doxity <https://github.com/DigixGlobal/doxity>`_
     Documentation Generator for Solidity.


### PR DESCRIPTION
GM!
Aderyn Maintainer here!

We recently launched a VS Code extension to make it easy to use Aderyn. So I thought I'll include that link in the resources section

Especially if someone is using Solidity for first time, they don't want to be bogged with installing any of these tools manually. So a vscode extension that would take care of everything under the hood in our opinion would make life  easy :) 

That's why I want to add this link.

I am not sure the formatting in rst doc for links  is correct though, so please adjust before merge if needed.

https://marketplace.visualstudio.com/items?itemName=Cyfrin.aderyn

Thank you.