### PR TITLE
Add support for upcoming Boost 1.88.0

### DIFF
--- a/libsolidity/formal/ModelChecker.cpp
+++ b/libsolidity/formal/ModelChecker.cpp
@@ -18,7 +18,13 @@
 
 #include <libsolidity/formal/ModelChecker.h>
 
+#include <boost/version.hpp>
+#if (BOOST_VERSION < 108800)
 #include <boost/process.hpp>
+#else
+#define BOOST_PROCESS_VERSION 1
+#include <boost/process/v1/search_path.hpp>
+#endif
 
 #include <range/v3/algorithm/any_of.hpp>
 #include <range/v3/view.hpp>

--- a/libsolidity/interface/SMTSolverCommand.cpp
+++ b/libsolidity/interface/SMTSolverCommand.cpp
@@ -20,7 +20,16 @@
 #include <liblangutil/Exceptions.h>
 
 #include <boost/algorithm/string/join.hpp>
+#include <boost/version.hpp>
+#if (BOOST_VERSION < 108800)
 #include <boost/process.hpp>
+#else
+#define BOOST_PROCESS_VERSION 1
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/pipe.hpp>
+#include <boost/process/v1/search_path.hpp>
+#endif
 
 namespace solidity::frontend
 {

--- a/test/libyul/ControlFlowGraphTest.cpp
+++ b/test/libyul/ControlFlowGraphTest.cpp
@@ -29,7 +29,15 @@
 #include <libsolutil/Visitor.h>
 
 #ifdef ISOLTEST
+#include <boost/version.hpp>
+#if (BOOST_VERSION < 108800)
 #include <boost/process.hpp>
+#else
+#define BOOST_PROCESS_VERSION 1
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/pipe.hpp>
+#endif
 #endif
 
 using namespace solidity;

--- a/test/libyul/SSAControlFlowGraphTest.cpp
+++ b/test/libyul/SSAControlFlowGraphTest.cpp
@@ -28,7 +28,15 @@
 #include <libyul/YulStack.h>
 
 #ifdef ISOLTEST
+#include <boost/version.hpp>
+#if (BOOST_VERSION < 108800)
 #include <boost/process.hpp>
+#else
+#define BOOST_PROCESS_VERSION 1
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/pipe.hpp>
+#endif
 #endif
 
 using namespace solidity;

--- a/test/libyul/StackLayoutGeneratorTest.cpp
+++ b/test/libyul/StackLayoutGeneratorTest.cpp
@@ -33,7 +33,15 @@
 #include <range/v3/view/reverse.hpp>
 
 #ifdef ISOLTEST
+#include <boost/version.hpp>
+#if (BOOST_VERSION < 108800)
 #include <boost/process.hpp>
+#else
+#define BOOST_PROCESS_VERSION 1
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/pipe.hpp>
+#endif
 #endif
 
 using namespace solidity;


### PR DESCRIPTION
Boost.Process will make v2 the default in Boost 1.88.0[^1] which breaks compilation of prior code. For a simple fix, this commit updates to use the newer paths for v1 until the code is updated to use v2 API.

[^1]: https://github.com/boostorg/process/commit/2ccd97cd48c5468b0609a488b59253efaa381711

---

Seen while beta testing upcoming 1.88.0 in Homebrew (https://github.com/Homebrew/homebrew-core/pull/217231). Release date is planned for April 9th.