### PR TITLE
Language Server: Fix hover crashes on invalid parameters

### DIFF
--- a/libsolidity/lsp/DocumentHoverHandler.cpp
+++ b/libsolidity/lsp/DocumentHoverHandler.cpp
@@ -59,6 +59,11 @@ void DocumentHoverHandler::operator()(MessageID _id, Json const& _args)
 {
 	auto const [sourceUnitName, lineColumn] = HandlerBase(*this).extractSourceUnitNameAndLineColumn(_args);
 	auto const [sourceNode, sourceOffset] = m_server.astNodeAndOffsetAtSourceLocation(sourceUnitName, lineColumn);
+	if (!sourceNode)
+	{
+		client().reply(_id, Json());
+		return;
+	}
 
 	MarkdownBuilder markdown;
 	auto rangeToHighlight = toRange(sourceNode->location());


### PR DESCRIPTION
When `textDocument/hover` gets an out-of-range request, `sourceNode` will be a `nullptr`, which leads to a crash in `toRange()` (Line 64).

https://github.com/ethereum/solidity/blob/7a4ddb27b5d522f322da3133b6ef28fff9057347/libsolidity/lsp/DocumentHoverHandler.cpp#L61-L65