### PR TITLE
eof: Enable `eofcreate` inline assembly

### DIFF
--- a/libsolidity/analysis/ReferencesResolver.cpp
+++ b/libsolidity/analysis/ReferencesResolver.cpp
@@ -329,7 +329,7 @@ void ReferencesResolver::operator()(yul::Identifier const& _identifier)
 		return;
 	}
 
-	static std::set<std::string> suffixes{"slot", "offset", "length", "address", "selector"};
+	static std::set<std::string> suffixes{"slot", "offset", "length", "address", "selector", "objectName"};
 	std::string suffix;
 	for (std::string const& s: suffixes)
 		if (boost::algorithm::ends_with(_identifier.name.str(), "." + s))

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -815,7 +815,7 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 			if (!identifierInfo.suffix.empty())
 			{
 				std::string const& suffix = identifierInfo.suffix;
-				solAssert((std::set<std::string>{"offset", "slot", "length", "selector", "address"}).count(suffix), "");
+				solAssert((std::set<std::string>{"offset", "slot", "length", "selector", "address", "objectName"}).count(suffix), "");
 				if (!var->isConstant() && (var->isStateVariable() || var->type()->dataStoredIn(DataLocation::Storage)))
 				{
 					if (suffix != "slot" && suffix != "offset")
@@ -896,9 +896,36 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 				return false;
 			}
 		}
+		else if (dynamic_cast<ContractDefinition const*>(declaration) && !identifierInfo.suffix.empty())
+		{
+			if (identifierInfo.suffix != "objectName" || !m_eofVersion.has_value())
+			{
+				m_errorReporter.typeError(
+					1342_error,
+					nativeLocationOf(_identifier),
+					"\".objectName\" suffix is supported only for contract name identifier when compiling to EOF."
+				);
+				return false;
+			}
+		}
 		else if (!identifierInfo.suffix.empty())
 		{
-			m_errorReporter.typeError(7944_error, nativeLocationOf(_identifier), "The suffixes \".offset\", \".slot\" and \".length\" can only be used with variables.");
+			if (m_eofVersion.has_value())
+			{
+				m_errorReporter.typeError(
+					9479_error,
+					nativeLocationOf(_identifier),
+					"The suffixes \".offset\", \".slot\" and \".length\" can only be used with variables or the suffix \"objectName\" can be used with a contract name identifier."
+				);
+			}
+			else
+			{
+				m_errorReporter.typeError(
+					7944_error,
+					nativeLocationOf(_identifier),
+					"The suffixes \".offset\", \".slot\" and \".length\" can only be used with variables."
+				);
+			}
 			return false;
 		}
 		else if (_context == yul::IdentifierContext::LValue)
@@ -923,7 +950,7 @@ bool TypeChecker::visit(InlineAssembly const& _inlineAssembly)
 			}
 			else if (auto contract = dynamic_cast<ContractDefinition const*>(declaration))
 			{
-				if (!contract->isLibrary())
+				if (!contract->isLibrary() && identifierInfo.suffix != "objectName")
 				{
 					m_errorReporter.typeError(4977_error, nativeLocationOf(_identifier), "Expected a library.");
 					return false;

--- a/libsolidity/analysis/ViewPureChecker.cpp
+++ b/libsolidity/analysis/ViewPureChecker.cpp
@@ -68,8 +68,11 @@ public:
 	{
 		if (yul::EVMDialect const* dialect = dynamic_cast<decltype(dialect)>(&m_dialect))
 			if (yul::BuiltinFunctionForEVM const* builtin = resolveBuiltinFunctionForEVM(_funCall.functionName, *dialect))
+			{
+				solAssert(builtin->instruction.has_value());
 				if (builtin->instruction)
 					checkInstruction(nativeLocationOf(_funCall), *builtin->instruction);
+			}
 
 		for (auto const& arg: _funCall.arguments)
 			std::visit(*this, arg);

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -105,11 +105,27 @@ private:
 	yul::Expression translateReference(yul::Identifier const& _identifier)
 	{
 		auto const& reference = m_references.at(&_identifier);
+		std::string value;
+
+		if (auto const contractDefinition = dynamic_cast<ContractDefinition const*>(reference.declaration))
+		{
+			// Already verified in TypeChecker
+			solAssert(reference.suffix == "objectName");
+			solAssert(m_context.eofVersion().has_value());
+
+			// Add sub-object as it's referenced from this context
+			m_context.addSubObject(contractDefinition);
+			return yul::Literal{
+				_identifier.debugData,
+				yul::LiteralKind::String,
+				yul::LiteralValue{IRNames::creationObject(*contractDefinition)}
+			};
+		}
+
 		auto const varDecl = dynamic_cast<VariableDeclaration const*>(reference.declaration);
 		solUnimplementedAssert(varDecl);
 		std::string const& suffix = reference.suffix;
 
-		std::string value;
 		if (suffix.empty() && varDecl->isLocalVariable())
 		{
 			auto const& var = m_context.localVariable(*varDecl);

--- a/libyul/AsmAnalysis.cpp
+++ b/libyul/AsmAnalysis.cpp
@@ -790,12 +790,12 @@ bool AsmAnalyzer::validateInstructions(evmasm::Instruction _instr, SourceLocatio
 	yulAssert(m_evmVersion.hasBitwiseShifting() == m_evmVersion.hasCreate2(), "");
 
 	// These instructions are disabled in the dialect.
+	// EOFCREATE instruction is enabled to run ViewPureChecker validation.
 	yulAssert(
 		_instr != evmasm::Instruction::JUMP &&
 		_instr != evmasm::Instruction::JUMPI &&
 		_instr != evmasm::Instruction::JUMPDEST &&
 		_instr != evmasm::Instruction::DATALOADN &&
-		_instr != evmasm::Instruction::EOFCREATE &&
 		_instr != evmasm::Instruction::RETURNCONTRACT &&
 		_instr != evmasm::Instruction::RJUMP &&
 		_instr != evmasm::Instruction::RJUMPI &&
@@ -863,7 +863,8 @@ bool AsmAnalyzer::validateInstructions(evmasm::Instruction _instr, SourceLocatio
 	else if (!m_eofVersion.has_value() && (
 		_instr == evmasm::Instruction::EXTCALL ||
 		_instr == evmasm::Instruction::EXTDELEGATECALL ||
-		_instr == evmasm::Instruction::EXTSTATICCALL
+		_instr == evmasm::Instruction::EXTSTATICCALL ||
+		_instr == evmasm::Instruction::EOFCREATE
 	))
 	{
 		m_errorReporter.typeError(

--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -435,7 +435,7 @@ std::vector<std::optional<BuiltinFunctionForEVM>> createBuiltins(langutil::EVMVe
 			1,
 			EVMDialect::sideEffectsOfInstruction(evmasm::Instruction::EOFCREATE),
 			ControlFlowSideEffects::fromInstruction(evmasm::Instruction::EOFCREATE),
-			// TODO: Personaly I don't like this solution but cannot find any better way to prevent 9114 error in asm analysis.
+			// TODO: Personally I don't like this solution but cannot find any better way to prevent 9114 error in asm analysis.
 			{_objectAccess ? LiteralKind::String : std::optional<LiteralKind>{}, std::nullopt, std::nullopt, std::nullopt, std::nullopt},
 			[](
 				FunctionCall const& _call,

--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -405,29 +405,6 @@ std::vector<std::optional<BuiltinFunctionForEVM>> createBuiltins(langutil::EVMVe
 			));
 
 			builtins.emplace_back(createFunction(
-				"eofcreate",
-				5,
-				1,
-				EVMDialect::sideEffectsOfInstruction(evmasm::Instruction::EOFCREATE),
-				ControlFlowSideEffects::fromInstruction(evmasm::Instruction::EOFCREATE),
-				{LiteralKind::String, std::nullopt, std::nullopt, std::nullopt, std::nullopt},
-				[](
-					FunctionCall const& _call,
-					AbstractAssembly& _assembly,
-					BuiltinContext& context
-				) {
-					yulAssert(_call.arguments.size() == 5);
-					Literal const* literal = std::get_if<Literal>(&_call.arguments.front());
-					auto const formattedLiteral = formatLiteral(*literal);
-					yulAssert(!util::contains(formattedLiteral, '.'));
-					auto const* containerID = valueOrNullptr(context.subIDs, formattedLiteral);
-					yulAssert(containerID != nullptr);
-					yulAssert(*containerID <= std::numeric_limits<AbstractAssembly::ContainerID>::max());
-					_assembly.appendEOFCreate(static_cast<AbstractAssembly::ContainerID>(*containerID));
-				}
-				));
-
-			builtins.emplace_back(createFunction(
 				"returncontract",
 				3,
 				0,
@@ -451,6 +428,31 @@ std::vector<std::optional<BuiltinFunctionForEVM>> createBuiltins(langutil::EVMVe
 				}
 			));
 		}
+
+		builtins.emplace_back(createFunction(
+			"eofcreate",
+			5,
+			1,
+			EVMDialect::sideEffectsOfInstruction(evmasm::Instruction::EOFCREATE),
+			ControlFlowSideEffects::fromInstruction(evmasm::Instruction::EOFCREATE),
+			// TODO: Personaly I don't like this solution but cannot find any better way to prevent 9114 error in asm analysis.
+			{_objectAccess ? LiteralKind::String : std::optional<LiteralKind>{}, std::nullopt, std::nullopt, std::nullopt, std::nullopt},
+			[](
+				FunctionCall const& _call,
+				AbstractAssembly& _assembly,
+				BuiltinContext& context
+			) {
+				yulAssert(_call.arguments.size() == 5);
+				Literal const* literal = std::get_if<Literal>(&_call.arguments.front());
+				auto const formattedLiteral = formatLiteral(*literal);
+				yulAssert(!util::contains(formattedLiteral, '.'));
+				auto const* containerID = valueOrNullptr(context.subIDs, formattedLiteral);
+				yulAssert(containerID != nullptr);
+				yulAssert(*containerID <= std::numeric_limits<AbstractAssembly::ContainerID>::max());
+				_assembly.appendEOFCreate(static_cast<AbstractAssembly::ContainerID>(*containerID));
+			}
+		));
+		(*builtins.back()).instruction = evmasm::Instruction::EOFCREATE;
 	}
 	yulAssert(
 		ranges::all_of(builtins, [](std::optional<BuiltinFunctionForEVM> const& _builtinFunction){

--- a/test/libsolidity/semanticTests/inlineAssembly/objectName.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/objectName.sol
@@ -1,0 +1,28 @@
+contract B
+{
+    function f() public returns (uint ret){
+        ret = 123;
+    }
+}
+
+contract C {
+    B b;
+
+    function f() public {
+        B t;
+        assembly {
+            t := eofcreate(B.objectName, 0, 0, 0, 0)
+        }
+
+        b = t;
+    }
+
+    function run_B_f() public returns (uint) {
+        return b.f();
+    }
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// f()
+// run_B_f() -> 123

--- a/test/libsolidity/semanticTests/inlineAssembly/objectNameLibrary.sol
+++ b/test/libsolidity/semanticTests/inlineAssembly/objectNameLibrary.sol
@@ -1,0 +1,34 @@
+library Lib {
+    struct S {
+        uint v;
+    }
+    function add(uint a, uint b) external pure returns(uint ret) {
+        ret = a + b;
+    }
+}
+
+interface ILib {
+    function add(uint a, uint b) external pure returns (uint);
+}
+
+contract C {
+    address addr;
+
+    function create_lib() public {
+        address l;
+        assembly {
+            l := eofcreate(Lib.objectName, 0, 0, 0, 0)
+
+        }
+        addr = l;
+    }
+
+    function add() public returns(uint){
+        return ILib(addr).add(5, 7);
+    }
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// create_lib()
+// add() -> 12

--- a/test/libsolidity/syntaxTests/inlineAssembly/eof/storage_reference_on_function.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/eof/storage_reference_on_function.sol
@@ -1,0 +1,11 @@
+contract C {
+    function f() pure public {
+        assembly {
+            let x := f.slot
+        }
+    }
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// TypeError 9479: (84-90): The suffixes ".offset", ".slot" and ".length" can only be used with variables or the suffix "objectName" can be used with a contract name identifier.

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/eof/eof_builtins_disallowed.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/eof/eof_builtins_disallowed.sol
@@ -10,6 +10,6 @@ contract C {
 // ====
 // bytecodeFormat: legacy
 // ----
-// DeclarationError 7223: (75-84): Builtin function "eofcreate" is only available in EOF.
+// TypeError 4328: (75-84): The "eofcreate" instruction is only available in EOF.
 // DeclarationError 7223: (114-128): Builtin function "returncontract" is only available in EOF.
 // DeclarationError 7223: (149-161): Builtin function "auxdataloadn" is only available in EOF.

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalid/eof/eof_builtins_disallowed_in_inline_assembly.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalid/eof/eof_builtins_disallowed_in_inline_assembly.sol
@@ -2,7 +2,6 @@
 contract C {
     function f() view public {
         assembly {
-            eofcreate("a", 0, 0, 0, 0)
             returncontract("a", 0)
             auxdataloadn(0)
         }
@@ -11,6 +10,5 @@ contract C {
 // ====
 // bytecodeFormat: >=EOFv1
 // ----
-// DeclarationError 4619: (186-195): Function "eofcreate" not found.
-// DeclarationError 4619: (225-239): Function "returncontract" not found.
-// DeclarationError 4619: (260-272): Function "auxdataloadn" not found.
+// DeclarationError 4619: (186-200): Function "returncontract" not found.
+// DeclarationError 4619: (221-233): Function "auxdataloadn" not found.

--- a/test/libsolidity/syntaxTests/inlineAssembly/invalidContractDefinitionSuffix.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/invalidContractDefinitionSuffix.sol
@@ -1,0 +1,14 @@
+contract B {}
+
+contract C {
+    function f() public {
+        B b;
+        assembly {
+            b := eofcreate(B.objectId, 0, 0, 0, 0)
+        }
+    }
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// DeclarationError 8198: (113-123): Identifier "B.objectId" not found.

--- a/test/libsolidity/syntaxTests/inlineAssembly/objectName.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/objectName.sol
@@ -1,0 +1,12 @@
+contract B {}
+
+contract C {
+    function f() public {
+        B b;
+        assembly {
+            b := eofcreate(B.objectName, 0, 0, 0, 0)
+        }
+    }
+}
+// ====
+// bytecodeFormat: >=EOFv1

--- a/test/libsolidity/syntaxTests/inlineAssembly/objectNameAsVariableSuffix.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/objectNameAsVariableSuffix.sol
@@ -1,0 +1,15 @@
+contract C {
+    uint s;
+    function f() public {
+        uint b;
+        assembly {
+            b := s.objectName
+            b := b.objectName
+        }
+    }
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// TypeError 4656: (103-115): State variables only support ".slot" and ".offset".
+// TypeError 3622: (133-145): The suffix ".objectName" is not supported by this variable or type.

--- a/test/libsolidity/syntaxTests/inlineAssembly/objectNameInLegacy.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/objectNameInLegacy.sol
@@ -1,0 +1,16 @@
+contract B {}
+
+contract C {
+    function f() public {
+        B b;
+        assembly {
+            b := eofcreate(B.objectName, 0, 0, 0, 0)
+        }
+    }
+}
+// ====
+// bytecodeFormat: legacy
+// ----
+// TypeError 4328: (103-112): The "eofcreate" instruction is only available in EOF.
+// TypeError 1342: (113-125): ".objectName" suffix is supported only for contract name identifier when compiling to EOF.
+// DeclarationError 8678: (98-138): Variable count for assignment to "b" does not match number of values (1 vs. 0)

--- a/test/libsolidity/syntaxTests/inlineAssembly/objectNameInPureOrView.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/objectNameInPureOrView.sol
@@ -1,0 +1,23 @@
+contract B {}
+
+contract C {
+    function f() public view {
+        B b;
+        assembly {
+            b := eofcreate(B.objectName, 0, 0, 0, 0)
+        }
+    }
+
+    function g() public pure {
+        B b;
+        assembly {
+            b := eofcreate(B.objectName, 0, 0, 0, 0)
+        }
+    }
+
+}
+// ====
+// bytecodeFormat: >=EOFv1
+// ----
+// TypeError 8961: (108-143): Function cannot be declared as view because this expression (potentially) modifies the state.
+// TypeError 8961: (241-276): Function cannot be declared as pure because this expression (potentially) modifies the state.

--- a/test/libsolidity/syntaxTests/inlineAssembly/objectNameLibrary.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/objectNameLibrary.sol
@@ -1,0 +1,11 @@
+library Lib {}
+
+contract C {
+    function f() public {
+        assembly {
+            pop(eofcreate(Lib.objectName, 0, 0, 0, 0))
+        }
+    }
+}
+// ====
+// bytecodeFormat: >=EOFv1

--- a/test/libsolidity/syntaxTests/inlineAssembly/storage_reference_on_function.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/storage_reference_on_function.sol
@@ -5,5 +5,7 @@ contract C {
         }
     }
 }
+// ====
+// bytecodeFormat: legacy
 // ----
 // TypeError 7944: (84-90): The suffixes ".offset", ".slot" and ".length" can only be used with variables.

--- a/test/libsolidity/syntaxTests/viewPureChecker/eof/inline_assembly_instructions_allowed.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/eof/inline_assembly_instructions_allowed.sol
@@ -1,3 +1,5 @@
+contract B {}
+
 contract C {
     function f() public {
         assembly {
@@ -71,6 +73,8 @@ contract C {
             pop(tload(0))
             tstore(0, 0)
 
+            pop(eofcreate(B.objectName, 0, 0, 0, 0))
+
             // NOTE: msize() is allowed only with optimizer disabled
             //pop(msize())
         }
@@ -79,8 +83,8 @@ contract C {
 // ====
 // bytecodeFormat: >=EOFv1
 // ----
-// Warning 2394: (1970-1976): Transient storage as defined by EIP-1153 can break the composability of smart contracts: Since transient storage is cleared only at the end of the transaction and not at the end of the outermost call frame to the contract within a transaction, your contract may unintentionally misbehave when invoked multiple times in a complex transaction. To avoid this, be sure to clear all transient storage at the end of any call to your contract. The use of transient storage for reentrancy guards that are cleared at the end of the call is safe.
-// Warning 5740: (89-1400): Unreachable code.
-// Warning 5740: (1413-1425): Unreachable code.
-// Warning 5740: (1438-1447): Unreachable code.
-// Warning 5740: (1460-1982): Unreachable code.
+// Warning 2394: (1985-1991): Transient storage as defined by EIP-1153 can break the composability of smart contracts: Since transient storage is cleared only at the end of the transaction and not at the end of the outermost call frame to the contract within a transaction, your contract may unintentionally misbehave when invoked multiple times in a complex transaction. To avoid this, be sure to clear all transient storage at the end of any call to your contract. The use of transient storage for reentrancy guards that are cleared at the end of the call is safe.
+// Warning 5740: (104-1415): Unreachable code.
+// Warning 5740: (1428-1440): Unreachable code.
+// Warning 5740: (1453-1462): Unreachable code.
+// Warning 5740: (1475-2051): Unreachable code.

--- a/test/libsolidity/syntaxTests/viewPureChecker/eof/inline_assembly_instructions_disallowed.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/eof/inline_assembly_instructions_disallowed.sol
@@ -6,7 +6,6 @@ contract C {
             memoryguard(0)
             verbatim_1i_1o(hex"600202", 0)
 
-            pop(eofcreate("a", 0, 0, 0, 0))
             returncontract("a", 0, 0, 0)
             pop(auxdataloadn(0))
 
@@ -17,12 +16,10 @@ contract C {
 // ====
 // bytecodeFormat: >=EOFv1
 // ----
-// SyntaxError 6553: (184-449): The msize instruction cannot be used when the Yul optimizer is activated because it can change its semantics. Either disable the Yul optimizer or do not use the instruction.
+// SyntaxError 6553: (184-405): The msize instruction cannot be used when the Yul optimizer is activated because it can change its semantics. Either disable the Yul optimizer or do not use the instruction.
 // DeclarationError 4619: (207-219): Function "linkersymbol" not found.
 // DeclarationError 4619: (237-248): Function "memoryguard" not found.
 // DeclarationError 4619: (264-278): Function "verbatim_1i_1o" not found.
-// DeclarationError 4619: (312-321): Function "eofcreate" not found.
-// TypeError 3950: (312-338): Expected expression to evaluate to one value, but got 0 values instead.
-// DeclarationError 4619: (352-366): Function "returncontract" not found.
-// DeclarationError 4619: (397-409): Function "auxdataloadn" not found.
-// TypeError 3950: (397-412): Expected expression to evaluate to one value, but got 0 values instead.
+// DeclarationError 4619: (308-322): Function "returncontract" not found.
+// DeclarationError 4619: (353-365): Function "auxdataloadn" not found.
+// TypeError 3950: (353-368): Expected expression to evaluate to one value, but got 0 values instead.

--- a/test/libsolidity/syntaxTests/viewPureChecker/eof/inline_assembly_instructions_disallowed_pure.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/eof/inline_assembly_instructions_disallowed_pure.sol
@@ -1,3 +1,5 @@
+contract B {}
+
 contract C {
     function f() public pure {
         assembly {
@@ -30,6 +32,7 @@ contract C {
             pop(chainid())
             pop(basefee())
             pop(prevrandao())
+            pop(eofcreate(B.objectName, 0, 0, 0, 0))
 
             // This one is disallowed too but the error suppresses other errors.
             //pop(msize())
@@ -39,33 +42,34 @@ contract C {
 // ====
 // bytecodeFormat: >=EOFv1
 // ----
-// Warning 2394: (781-787): Transient storage as defined by EIP-1153 can break the composability of smart contracts: Since transient storage is cleared only at the end of the transaction and not at the end of the outermost call frame to the contract within a transaction, your contract may unintentionally misbehave when invoked multiple times in a complex transaction. To avoid this, be sure to clear all transient storage at the end of any call to your contract. The use of transient storage for reentrancy guards that are cleared at the end of the call is safe.
-// TypeError 2527: (79-87): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 8961: (101-113): Function cannot be declared as pure because this expression (potentially) modifies the state.
-// TypeError 2527: (130-139): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (157-167): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (185-193): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (211-222): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 8961: (240-259): Function cannot be declared as pure because this expression (potentially) modifies the state.
-// TypeError 2527: (277-299): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 8961: (317-341): Function cannot be declared as pure because this expression (potentially) modifies the state.
-// TypeError 8961: (355-365): Function cannot be declared as pure because this expression (potentially) modifies the state.
-// TypeError 8961: (378-391): Function cannot be declared as pure because this expression (potentially) modifies the state.
-// TypeError 8961: (404-420): Function cannot be declared as pure because this expression (potentially) modifies the state.
-// TypeError 8961: (433-452): Function cannot be declared as pure because this expression (potentially) modifies the state.
-// TypeError 8961: (465-487): Function cannot be declared as pure because this expression (potentially) modifies the state.
-// TypeError 2527: (504-512): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (530-540): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (558-570): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (588-598): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (616-627): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (645-653): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (671-681): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (699-710): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (728-741): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (759-767): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 8961: (781-793): Function cannot be declared as pure because this expression (potentially) modifies the state.
-// TypeError 2527: (810-823): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (841-850): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (868-877): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
-// TypeError 2527: (895-907): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// Warning 2394: (796-802): Transient storage as defined by EIP-1153 can break the composability of smart contracts: Since transient storage is cleared only at the end of the transaction and not at the end of the outermost call frame to the contract within a transaction, your contract may unintentionally misbehave when invoked multiple times in a complex transaction. To avoid this, be sure to clear all transient storage at the end of any call to your contract. The use of transient storage for reentrancy guards that are cleared at the end of the call is safe.
+// TypeError 2527: (94-102): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 8961: (116-128): Function cannot be declared as pure because this expression (potentially) modifies the state.
+// TypeError 2527: (145-154): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (172-182): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (200-208): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (226-237): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 8961: (255-274): Function cannot be declared as pure because this expression (potentially) modifies the state.
+// TypeError 2527: (292-314): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 8961: (332-356): Function cannot be declared as pure because this expression (potentially) modifies the state.
+// TypeError 8961: (370-380): Function cannot be declared as pure because this expression (potentially) modifies the state.
+// TypeError 8961: (393-406): Function cannot be declared as pure because this expression (potentially) modifies the state.
+// TypeError 8961: (419-435): Function cannot be declared as pure because this expression (potentially) modifies the state.
+// TypeError 8961: (448-467): Function cannot be declared as pure because this expression (potentially) modifies the state.
+// TypeError 8961: (480-502): Function cannot be declared as pure because this expression (potentially) modifies the state.
+// TypeError 2527: (519-527): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (545-555): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (573-585): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (603-613): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (631-642): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (660-668): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (686-696): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (714-725): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (743-756): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (774-782): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 8961: (796-808): Function cannot be declared as pure because this expression (potentially) modifies the state.
+// TypeError 2527: (825-838): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (856-865): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (883-892): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (910-922): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 8961: (940-975): Function cannot be declared as pure because this expression (potentially) modifies the state.

--- a/test/libsolidity/syntaxTests/viewPureChecker/eof/inline_assembly_instructions_disallowed_view.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/eof/inline_assembly_instructions_disallowed_view.sol
@@ -1,3 +1,5 @@
+contract B {}
+
 contract C {
     function f() public view {
         assembly {
@@ -9,6 +11,7 @@ contract C {
             log2(0, 1, 2, 3)
             log3(0, 1, 2, 3, 4)
             log4(0, 1, 2, 3, 4, 5)
+            pop(eofcreate(B.objectName, 0, 0, 0, 0))
 
             // This one is disallowed too but the error suppresses other errors.
             //pop(msize())
@@ -18,11 +21,12 @@ contract C {
 // ====
 // bytecodeFormat: >=EOFv1
 // ----
-// TypeError 8961: (75-87): Function cannot be declared as view because this expression (potentially) modifies the state.
-// TypeError 8961: (104-123): Function cannot be declared as view because this expression (potentially) modifies the state.
-// TypeError 8961: (141-165): Function cannot be declared as view because this expression (potentially) modifies the state.
-// TypeError 8961: (179-189): Function cannot be declared as view because this expression (potentially) modifies the state.
-// TypeError 8961: (202-215): Function cannot be declared as view because this expression (potentially) modifies the state.
-// TypeError 8961: (228-244): Function cannot be declared as view because this expression (potentially) modifies the state.
-// TypeError 8961: (257-276): Function cannot be declared as view because this expression (potentially) modifies the state.
-// TypeError 8961: (289-311): Function cannot be declared as view because this expression (potentially) modifies the state.
+// TypeError 8961: (90-102): Function cannot be declared as view because this expression (potentially) modifies the state.
+// TypeError 8961: (119-138): Function cannot be declared as view because this expression (potentially) modifies the state.
+// TypeError 8961: (156-180): Function cannot be declared as view because this expression (potentially) modifies the state.
+// TypeError 8961: (194-204): Function cannot be declared as view because this expression (potentially) modifies the state.
+// TypeError 8961: (217-230): Function cannot be declared as view because this expression (potentially) modifies the state.
+// TypeError 8961: (243-259): Function cannot be declared as view because this expression (potentially) modifies the state.
+// TypeError 8961: (272-291): Function cannot be declared as view because this expression (potentially) modifies the state.
+// TypeError 8961: (304-326): Function cannot be declared as view because this expression (potentially) modifies the state.
+// TypeError 8961: (343-378): Function cannot be declared as view because this expression (potentially) modifies the state.

--- a/test/libyul/yulSyntaxTests/eof/eof_identifiers_not_defined_in_legacy.yul
+++ b/test/libyul/yulSyntaxTests/eof/eof_identifiers_not_defined_in_legacy.yul
@@ -19,7 +19,7 @@
 // ----
 // DeclarationError 7223: (6-18): Builtin function "auxdataloadn" is only available in EOF.
 // DeclarationError 4619: (26-35): Function "dataloadn" not found.
-// DeclarationError 7223: (43-52): Builtin function "eofcreate" is only available in EOF.
+// TypeError 4328: (43-52): The "eofcreate" instruction is only available in EOF.
 // DeclarationError 7223: (77-91): Builtin function "returncontract" is only available in EOF.
 // DeclarationError 4619: (110-115): Function "rjump" not found.
 // DeclarationError 4619: (122-128): Function "rjumpi" not found.


### PR DESCRIPTION
This PR contains:
- Add `objectName` suffix of a contract name in inline assembly which maps to object name in yul.
- Enable `eofcreate` in inline assembly to make eof style of contract creation possible.
- Add and update semantic and syntaxt tests.

TODOs:
1. How to make `objectName` unavailable for the contract name inside which we are using this suffix.
2. ~~Should it work for libraries?~~ Edit: It looks that it can. Test added.
