### PR TITLE
Fix docs for python 3.13

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,9 @@
 sphinx_rtd_theme>=0.5.2
 
 pygments-lexer-solidity>=0.7.0
-sphinx-a4doc>=1.6.0
+sphinx-a4doc>=1.6.0; python_version < '3.13'
+# todo remove this once there is a version > 1.6.0
+sphinx-a4doc @ git+https://github.com/taminomara/sphinx-a4doc@f63d3b2; python_version >= '3.13'
 
 # Sphinx 2.1.0 is the oldest version that accepts a lexer class in add_lexer()
 sphinx>=2.1.0, <6.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,8 @@
 # Older versions of sphinx-rtd-theme do not work with never docutils but have a bug in the dependency
 # which could result in it being installed anyway and the style (especially bullet points) being broken.
 # See https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
-sphinx_rtd_theme>=0.5.2
+# theme >=3.0.0 removes the display_version option in favor of version_selector and language_selector
+sphinx_rtd_theme>=0.5.2, <3.0.0
 
 pygments-lexer-solidity>=0.7.0
 sphinx-a4doc>=1.6.0; python_version < '3.13'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,4 +9,4 @@ sphinx-a4doc>=1.6.0; python_version < '3.13'
 sphinx-a4doc @ git+https://github.com/taminomara/sphinx-a4doc@f63d3b2; python_version >= '3.13'
 
 # Sphinx 2.1.0 is the oldest version that accepts a lexer class in add_lexer()
-sphinx>=2.1.0, <6.0
+sphinx>=2.1.0, <9.0


### PR DESCRIPTION
sphinx-a4doc needs an unreleased version and newer sphinx version to function under python 3.13. 

See https://github.com/ethereum/solidity/issues/15811#issuecomment-2695125539