### PR TITLE
eof: Enable jumpdest remover optimiser for EOF.

### DIFF
--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -832,8 +832,8 @@ std::map<u256, u256> const& Assembly::optimiseInternal(
 				m_evmVersion
 			}.optimise();
 		}
-		// TODO: verify this for EOF.
-		if (_settings.runJumpdestRemover && !m_eofVersion.has_value())
+
+		if (_settings.runJumpdestRemover)
 		{
 			for (auto& codeSection: m_codeSections)
 			{

--- a/test/libyul/objectCompiler/eof/functions.yul
+++ b/test/libyul/objectCompiler/eof/functions.yul
@@ -42,8 +42,6 @@ object "a" {
 //   calldataload
 //     /* "source":91:128   */
 //   rjumpi{tag_1}
-//     /* "source":22:386   */
-// tag_2:
 //     /* "source":151:153   */
 //   0x20
 //     /* "source":148:149   */
@@ -58,8 +56,6 @@ object "a" {
 // code_section_1: assembly {
 //         /* "source":217:294   */
 //       rjumpi{tag_3}
-//         /* "source":203:324   */
-//     tag_4:
 //         /* "source":312:314   */
 //       0x63
 //         /* "source":173:324   */
@@ -81,4 +77,4 @@ object "a" {
 // }
 // Bytecode: ef000101000c020003001400090003040000000080000201010001008000025f35e300015f52602035e1000460205ff3e50002e100036063e46005e45f80fd
 // Opcodes: 0xEF STOP ADD ADD STOP 0xC MUL STOP SUB STOP EQ STOP MULMOD STOP SUB DIV STOP STOP STOP STOP DUP1 STOP MUL ADD ADD STOP ADD STOP DUP1 STOP MUL PUSH0 CALLDATALOAD CALLF 0x1 PUSH0 MSTORE PUSH1 0x20 CALLDATALOAD RJUMPI 0x4 PUSH1 0x20 PUSH0 RETURN JUMPF 0x2 RJUMPI 0x3 PUSH1 0x63 RETF PUSH1 0x5 RETF PUSH0 DUP1 REVERT
-// SourceMappings: 74:1:0:-:0;61:15;56:21::i;53:1::-;46:32;107:2;94:16;91:37;22:364;151:2;148:1;141:13;111:17;113:13::i217:77:0:-:0;203:121;312:2;173:151::o;234:60::-;257:1;275:5::o376:1:0:-:0;366:12;
+// SourceMappings: 74:1:0:-:0;61:15;56:21::i;53:1::-;46:32;107:2;94:16;91:37;151:2;148:1;141:13;111:17;113:13::i217:77:0:-:0;312:2;173:151::o;234:60::-;257:1;275:5::o376:1:0:-:0;366:12;

--- a/test/libyul/objectCompiler/eof/verbatim_bug.yul
+++ b/test/libyul/objectCompiler/eof/verbatim_bug.yul
@@ -44,8 +44,6 @@ object "a" {
 //     /* "source":133:225   */
 //   eq
 //   rjumpi{tag_1}
-//     /* "source":108:406   */
-// tag_2:
 //     /* "source":238:263   */
 //   dup1
 //     /* "source":243:247   */
@@ -53,8 +51,6 @@ object "a" {
 //     /* "source":238:263   */
 //   eq
 //   rjumpi{tag_3}
-//     /* "source":108:406   */
-// tag_4:
 //     /* "source":276:368   */
 //   dup1
 //     /* "source":281:285   */
@@ -62,8 +58,6 @@ object "a" {
 //     /* "source":276:368   */
 //   eq
 //   rjumpi{tag_5}
-//     /* "source":108:406   */
-// tag_6:
 //     /* "source":386:390   */
 //   0x03
 //     /* "source":381:406   */


### PR DESCRIPTION
This PR enables jumpdest remover for EOF. The name is of the optimiser is a little misleading b/c it removes used tags. 