### PR TITLE
Use /opt/boost as installation target for osx CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,7 +385,7 @@ commands:
           name: Installing dependencies / Restoring dependency cache
           command: |
             if [[ -f ~/osx-dependencies-cached ]]; then
-              echo "Dependency flag exists. Removing /usr/local/ and /opt/homebrew/. These directories will be restored from cache."
+              echo "Dependency flag exists. Removing /usr/local/, /opt/homebrew/, and /opt/boost. These directories will be restored from cache."
 
               # CircleCI is providing the circleci cli tools via some kind of symlink magic.
               # So we just save the original symlinks and restore them later.
@@ -404,6 +404,10 @@ commands:
               sudo rm -rf /usr/local/*
               sudo mkdir -p /usr/local/bin
               sudo chmod 777 /usr/{local,local/bin}
+
+              sudo rm -rf /opt/boost
+              sudo mkdir -p /opt/boost
+              sudo chmod 777 /opt/boost
 
               mv /tmp/circleci "${circleci_binary_path}"
               mv /tmp/circleci-agent "${circleci_agent_binary_path}"
@@ -425,6 +429,7 @@ commands:
             # Homebrew is installed in /usr/local on intel macs, but in /opt/homebrew on apple silicon.
             - /usr/local
             - /opt/homebrew
+            - /opt/boost
       - save_cache:
           key: osx-dependencies-cached-{{ arch }}-{{ checksum ".circleci/osx_install_dependencies.sh" }}
           paths:
@@ -1159,7 +1164,8 @@ jobs:
     environment:
       <<: *base_osx_env
       CMAKE_BUILD_TYPE: Release
-      CMAKE_OPTIONS: -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64;arm64
+      # boost root configured to the prefix used in `osx_install_dependencies.sh`
+      CMAKE_OPTIONS: -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64;arm64 -DBoost_ROOT=/opt/boost
     steps:
       - checkout
       - install_dependencies_osx

--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -69,7 +69,8 @@ then
   cd "$boost_dir"
   ./bootstrap.sh --with-toolset=clang --with-libraries=thread,system,filesystem,program_options,serialization,test
   # the default number of jobs that b2 is taking, is the number of detected available CPU threads.
-  sudo ./b2 -a address-model=64 architecture=arm+x86 install
+  # install boost to /opt/boost, to use it in CMake, specify Boost_ROOT
+  sudo ./b2 -a address-model=64 architecture=arm+x86 --prefix=/opt/boost install
   cd ..
   sudo rm -rf "$boost_dir"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,14 +70,6 @@ endif()
 
 find_package(Threads)
 
-if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin" AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-    if (CMAKE_VERSION VERSION_EQUAL "4.0.0" AND CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "15.0.0.15000040")
-        # for Apple clang 15 under cmake 4.0.0, disable pedantic warnings explicitly as it fails to treat boost properly as
-        # system library, warnings propagate
-        set(PEDANTIC OFF)
-    endif()
-endif()
-
 if(NOT PEDANTIC)
   message(WARNING "-- Pedantic build flags turned off. Warnings will not make compilation fail. This is NOT recommended in development builds.")
 endif()


### PR DESCRIPTION
This fixes the warnings we have seen earlier in #15982 so that the `PEDANTIC=OFF` switch can be removed again.