### PR TITLE
Import/namespace and test extension handling cleanup in soltest

### DIFF
--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -43,9 +43,9 @@
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/map.hpp>
 
-#include <fstream>
 #include <limits>
 #include <iterator>
+#include <ostream>
 #include <stack>
 
 using namespace solidity;

--- a/test/Common.cpp
+++ b/test/Common.cpp
@@ -110,7 +110,7 @@ CommonOptions::CommonOptions(std::string _caption):
 void CommonOptions::addOptions()
 {
 	options.add_options()
-		("evm-version", po::value(&evmVersionString), "which EVM version to use")
+		("evm-version", po::value(&m_evmVersionString), "which EVM version to use")
 		// "eof-version" is declared as uint64_t, since uint8_t will be parsed as character by boost.
 		("eof-version", po::value<uint64_t>()->implicit_value(1u), "which EOF version to use")
 		("testpath", po::value<fs::path>(&this->testPath)->default_value(test::testPath()), "path to test files")
@@ -259,11 +259,11 @@ void CommonOptions::printSelectedOptions(std::ostream& _stream, std::string cons
 
 langutil::EVMVersion CommonOptions::evmVersion() const
 {
-	if (!evmVersionString.empty())
+	if (!m_evmVersionString.empty())
 	{
-		auto version = langutil::EVMVersion::fromString(evmVersionString);
+		auto version = langutil::EVMVersion::fromString(m_evmVersionString);
 		if (!version)
-			BOOST_THROW_EXCEPTION(std::runtime_error("Invalid EVM version: " + evmVersionString));
+			BOOST_THROW_EXCEPTION(std::runtime_error("Invalid EVM version: " + m_evmVersionString));
 		return *version;
 	}
 	else

--- a/test/Common.cpp
+++ b/test/Common.cpp
@@ -113,7 +113,7 @@ void CommonOptions::addOptions()
 		("evm-version", po::value(&evmVersionString), "which EVM version to use")
 		// "eof-version" is declared as uint64_t, since uint8_t will be parsed as character by boost.
 		("eof-version", po::value<uint64_t>()->implicit_value(1u), "which EOF version to use")
-		("testpath", po::value<fs::path>(&this->testPath)->default_value(solidity::test::testPath()), "path to test files")
+		("testpath", po::value<fs::path>(&this->testPath)->default_value(test::testPath()), "path to test files")
 		("vm", po::value<std::vector<fs::path>>(&vmPaths), "path to evmc library, can be supplied multiple times.")
 		("batches", po::value<size_t>(&this->batches)->default_value(1), "set number of batches to split the tests into")
 		("selected-batch", po::value<size_t>(&this->selectedBatch)->default_value(0), "zero-based number of batch to execute")
@@ -309,14 +309,14 @@ bool isValidSemanticTestPath(boost::filesystem::path const& _testPath)
 boost::unit_test::precondition::predicate_t nonEOF()
 {
 	return [](boost::unit_test::test_unit_id) {
-		return !solidity::test::CommonOptions::get().eofVersion().has_value();
+		return !CommonOptions::get().eofVersion().has_value();
 	};
 }
 
 boost::unit_test::precondition::predicate_t onEOF()
 {
 	return [](boost::unit_test::test_unit_id) {
-		return solidity::test::CommonOptions::get().eofVersion().has_value();
+		return CommonOptions::get().eofVersion().has_value();
 	};
 }
 
@@ -332,13 +332,13 @@ bool loadVMs(CommonOptions const& _options)
 	if (_options.disableSemanticTests)
 		return true;
 
-	bool evmSupported = solidity::test::EVMHost::checkVmPaths(_options.vmPaths);
+	bool evmSupported = EVMHost::checkVmPaths(_options.vmPaths);
 	if (!_options.disableSemanticTests && !evmSupported)
 	{
-		std::cerr << "Unable to find " << solidity::test::evmoneFilename;
+		std::cerr << "Unable to find " << evmoneFilename;
 		std::cerr << ". Please disable semantics tests with --no-semantic-tests or provide a path using --vm <path>." << std::endl;
 		std::cerr << "You can download it at" << std::endl;
-		std::cerr << solidity::test::evmoneDownloadLink << std::endl;
+		std::cerr << evmoneDownloadLink << std::endl;
 		return false;
 	}
 	return true;

--- a/test/Common.cpp
+++ b/test/Common.cpp
@@ -306,6 +306,17 @@ bool isValidSemanticTestPath(boost::filesystem::path const& _testPath)
 	return true;
 }
 
+std::set<std::string> testFileExtensions()
+{
+	return {
+		".sol",
+		".yul",
+		".asm",
+		".asmjson", // Not .json because JSON files that do not represent test cases exist in some test dirs.
+		".stack",
+	};
+}
+
 boost::unit_test::precondition::predicate_t nonEOF()
 {
 	return [](boost::unit_test::test_unit_id) {

--- a/test/Common.h
+++ b/test/Common.h
@@ -97,7 +97,7 @@ protected:
 	boost::program_options::options_description options;
 
 private:
-	std::string evmVersionString;
+	std::string m_evmVersionString;
 	std::optional<uint8_t> m_eofVersion;
 	static std::unique_ptr<CommonOptions const> m_singleton;
 };

--- a/test/Common.h
+++ b/test/Common.h
@@ -107,6 +107,9 @@ private:
 /// Note: @p _testPath can be relative but must include at least the `/test/libsolidity/semanticTests/` part
 bool isValidSemanticTestPath(boost::filesystem::path const& _testPath);
 
+/// Returns a list of file extensions allowed for test files.
+std::set<std::string> testFileExtensions();
+
 /// Helper that can be used to skip tests when the EVM version selected on the command line
 /// is older than @p _minEVMVersion.
 /// @return A predicate (function) that can be passed into @a boost::unit_test::precondition().

--- a/test/CommonSyntaxTest.cpp
+++ b/test/CommonSyntaxTest.cpp
@@ -30,8 +30,8 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/throw_exception.hpp>
 
-#include <fstream>
-#include <memory>
+#include <istream>
+#include <ostream>
 #include <stdexcept>
 
 using namespace solidity;
@@ -42,7 +42,6 @@ using namespace solidity::frontend;
 using namespace solidity::frontend::test;
 using namespace solidity::test;
 using namespace boost::unit_test;
-namespace fs = boost::filesystem;
 
 namespace
 {

--- a/test/CommonSyntaxTest.h
+++ b/test/CommonSyntaxTest.h
@@ -27,7 +27,6 @@
 #include <iosfwd>
 #include <string>
 #include <vector>
-#include <utility>
 
 namespace solidity::test
 {

--- a/test/ExecutionFramework.h
+++ b/test/ExecutionFramework.h
@@ -34,8 +34,6 @@
 #include <libsolutil/FunctionSelector.h>
 #include <libsolutil/ErrorCodes.h>
 
-#include <functional>
-
 #include <boost/rational.hpp>
 #include <boost/test/unit_test.hpp>
 

--- a/test/InteractiveTests.h
+++ b/test/InteractiveTests.h
@@ -19,10 +19,10 @@
 #pragma once
 
 #include <test/TestCase.h>
+
 #include <test/libsolidity/ABIJsonTest.h>
 #include <test/libsolidity/ASTJSONTest.h>
 #include <test/libsolidity/ASTPropertyTest.h>
-#include <libsolidity/FunctionDependencyGraphTest.h>
 #include <test/libsolidity/GasTest.h>
 #include <test/libsolidity/MemoryGuardTest.h>
 #include <test/libsolidity/NatspecJSONTest.h>
@@ -30,6 +30,7 @@
 #include <test/libsolidity/SyntaxTest.h>
 #include <test/libsolidity/SemanticTest.h>
 #include <test/libsolidity/SMTCheckerTest.h>
+
 #include <test/libyul/ControlFlowGraphTest.h>
 #include <test/libyul/SSAControlFlowGraphTest.h>
 #include <test/libyul/EVMCodeTransformTest.h>
@@ -43,6 +44,8 @@
 #include <test/libyul/SyntaxTest.h>
 
 #include <test/libevmasm/EVMAssemblyTest.h>
+
+#include <libsolidity/FunctionDependencyGraphTest.h>
 
 #include <boost/filesystem.hpp>
 

--- a/test/TestCase.cpp
+++ b/test/TestCase.cpp
@@ -31,6 +31,7 @@ using namespace solidity;
 using namespace solidity::frontend;
 using namespace solidity::frontend::test;
 using namespace solidity::util;
+using namespace solidity::test;
 
 void TestCase::printSettings(std::ostream& _stream, const std::string& _linePrefix, const bool)
 {
@@ -123,7 +124,7 @@ void EVMVersionRestrictedTestCase::processEVMVersionSetting()
 	if (!version)
 		BOOST_THROW_EXCEPTION(std::runtime_error{"Invalid EVM version: \"" + versionString + "\""});
 
-	langutil::EVMVersion evmVersion = solidity::test::CommonOptions::get().evmVersion();
+	langutil::EVMVersion evmVersion = CommonOptions::get().evmVersion();
 	bool comparisonResult;
 	if (comparator == ">")
 		comparisonResult = evmVersion > version;
@@ -146,9 +147,9 @@ void EVMVersionRestrictedTestCase::processEVMVersionSetting()
 
 void EVMVersionRestrictedTestCase::processBytecodeFormatSetting()
 {
-	std::optional<uint8_t> eofVersion = solidity::test::CommonOptions::get().eofVersion();
+	std::optional<uint8_t> eofVersion = CommonOptions::get().eofVersion();
 	// EOF only available since Osaka
-	solAssert(!eofVersion.has_value() || solidity::test::CommonOptions::get().evmVersion().supportsEOF());
+	solAssert(!eofVersion.has_value() || CommonOptions::get().evmVersion().supportsEOF());
 
 	std::string bytecodeFormatString = m_reader.stringSetting("bytecodeFormat", "legacy,>=EOFv1");
 	if (bytecodeFormatString == "legacy,>=EOFv1" || bytecodeFormatString == ">=EOFv1,legacy")

--- a/test/TestCase.cpp
+++ b/test/TestCase.cpp
@@ -51,9 +51,8 @@ void TestCase::printUpdatedSettings(std::ostream& _stream, std::string const& _l
 
 bool TestCase::isTestFilename(boost::filesystem::path const& _filename)
 {
-	std::string extension = _filename.extension().string();
-	// NOTE: .asmjson rather than .json because JSON files that do not represent test cases exist in some test dirs.
-	return (extension == ".sol" || extension == ".yul" || extension == ".asm" || extension == ".asmjson" || extension == ".stack") &&
+	return
+		testFileExtensions().contains(_filename.extension().string()) &&
 		!_filename.string().starts_with('~') &&
 		!_filename.string().starts_with('.');
 }

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -36,7 +36,6 @@
 #include <range/v3/algorithm/any_of.hpp>
 
 #include <string>
-#include <tuple>
 #include <memory>
 
 using namespace solidity::langutil;
@@ -319,7 +318,7 @@ BOOST_AUTO_TEST_CASE(cse_associativity2)
 
 BOOST_AUTO_TEST_CASE(cse_double_shift_right_overflow)
 {
-	if (solidity::test::CommonOptions::get().evmVersion().hasBitwiseShifting())
+	if (CommonOptions::get().evmVersion().hasBitwiseShifting())
 	{
 		AssemblyItems input{
 			Instruction::CALLVALUE,
@@ -334,7 +333,7 @@ BOOST_AUTO_TEST_CASE(cse_double_shift_right_overflow)
 
 BOOST_AUTO_TEST_CASE(cse_double_shift_left_overflow)
 {
-	if (solidity::test::CommonOptions::get().evmVersion().hasBitwiseShifting())
+	if (CommonOptions::get().evmVersion().hasBitwiseShifting())
 	{
 		AssemblyItems input{
 			Instruction::DUP1,
@@ -1001,7 +1000,7 @@ BOOST_AUTO_TEST_CASE(clear_unreachable_code)
 		AssemblyItem(PushTag, 1),
 		Instruction::JUMP
 	};
-	PeepholeOptimiser peepOpt(items, solidity::test::CommonOptions::get().evmVersion());
+	PeepholeOptimiser peepOpt(items, CommonOptions::get().evmVersion());
 	BOOST_REQUIRE(peepOpt.optimise());
 	BOOST_CHECK_EQUAL_COLLECTIONS(
 		items.begin(), items.end(),
@@ -1040,7 +1039,7 @@ BOOST_AUTO_TEST_CASE(clear_unreachable_code_eof, *boost::unit_test::precondition
 			Instruction::SSTORE,
 			blockTerminatingItem,
 		};
-		PeepholeOptimiser peepOpt(items, solidity::test::CommonOptions::get().evmVersion());
+		PeepholeOptimiser peepOpt(items, CommonOptions::get().evmVersion());
 		BOOST_REQUIRE(peepOpt.optimise());
 		BOOST_CHECK_EQUAL_COLLECTIONS(
 			items.begin(), items.end(),
@@ -1069,7 +1068,7 @@ BOOST_AUTO_TEST_CASE(is_zero_is_zero_rjumpi, *boost::unit_test::precondition(onE
 		AssemblyItem(Tag, 1),
 	};
 
-	PeepholeOptimiser peepOpt(items, solidity::test::CommonOptions::get().evmVersion());
+	PeepholeOptimiser peepOpt(items, CommonOptions::get().evmVersion());
 	BOOST_REQUIRE(peepOpt.optimise());
 	BOOST_CHECK_EQUAL_COLLECTIONS(
 		items.begin(), items.end(),
@@ -1100,7 +1099,7 @@ BOOST_AUTO_TEST_CASE(equal_is_zero_rjumpi, *boost::unit_test::precondition(onEOF
 		AssemblyItem(Tag, 1),
 	};
 
-	PeepholeOptimiser peepOpt(items, solidity::test::CommonOptions::get().evmVersion());
+	PeepholeOptimiser peepOpt(items, CommonOptions::get().evmVersion());
 	BOOST_REQUIRE(peepOpt.optimise());
 	BOOST_CHECK_EQUAL_COLLECTIONS(
 		items.begin(), items.end(),
@@ -1130,7 +1129,7 @@ BOOST_AUTO_TEST_CASE(double_rjump, *boost::unit_test::precondition(onEOF()))
 		AssemblyItem(Tag, 2),
 	};
 
-	PeepholeOptimiser peepOpt(items, solidity::test::CommonOptions::get().evmVersion());
+	PeepholeOptimiser peepOpt(items, CommonOptions::get().evmVersion());
 	BOOST_REQUIRE(peepOpt.optimise());
 	BOOST_CHECK_EQUAL_COLLECTIONS(
 		items.begin(), items.end(),
@@ -1153,7 +1152,7 @@ BOOST_AUTO_TEST_CASE(rjump_to_next, *boost::unit_test::precondition(onEOF()))
 		Instruction::SLOAD,
 	};
 
-	PeepholeOptimiser peepOpt(items, solidity::test::CommonOptions::get().evmVersion());
+	PeepholeOptimiser peepOpt(items, CommonOptions::get().evmVersion());
 	BOOST_REQUIRE(peepOpt.optimise());
 	BOOST_CHECK_EQUAL_COLLECTIONS(
 		items.begin(), items.end(),
@@ -1177,7 +1176,7 @@ BOOST_AUTO_TEST_CASE(rjumpi_to_next, *boost::unit_test::precondition(onEOF()))
 		Instruction::SLOAD,
 	};
 
-	PeepholeOptimiser peepOpt(items, solidity::test::CommonOptions::get().evmVersion());
+	PeepholeOptimiser peepOpt(items, CommonOptions::get().evmVersion());
 	BOOST_REQUIRE(peepOpt.optimise());
 	BOOST_CHECK_EQUAL_COLLECTIONS(
 		items.begin(), items.end(),
@@ -1205,7 +1204,7 @@ BOOST_AUTO_TEST_CASE(deduplicateNextTagBlockSize3)
 		u256(1),
 		Instruction::REVERT
 	};
-	PeepholeOptimiser peepOpt(items, solidity::test::CommonOptions::get().evmVersion());
+	PeepholeOptimiser peepOpt(items, CommonOptions::get().evmVersion());
 	BOOST_REQUIRE(peepOpt.optimise());
 	BOOST_CHECK_EQUAL_COLLECTIONS(
 		items.begin(), items.end(),
@@ -1230,7 +1229,7 @@ BOOST_AUTO_TEST_CASE(deduplicateNextTagBlockSize2)
 		u256(0),
 		Instruction::SELFDESTRUCT
 	};
-	PeepholeOptimiser peepOpt(items, solidity::test::CommonOptions::get().evmVersion());
+	PeepholeOptimiser peepOpt(items, CommonOptions::get().evmVersion());
 	BOOST_REQUIRE(peepOpt.optimise());
 	BOOST_CHECK_EQUAL_COLLECTIONS(
 		items.begin(), items.end(),
@@ -1252,7 +1251,7 @@ BOOST_AUTO_TEST_CASE(deduplicateNextTagBlockSize1)
 		AssemblyItem(Tag, 2),
 		Instruction::STOP
 	};
-	PeepholeOptimiser peepOpt(items, solidity::test::CommonOptions::get().evmVersion());
+	PeepholeOptimiser peepOpt(items, CommonOptions::get().evmVersion());
 	BOOST_REQUIRE(peepOpt.optimise());
 	BOOST_CHECK_EQUAL_COLLECTIONS(
 		items.begin(), items.end(),
@@ -1280,7 +1279,7 @@ BOOST_AUTO_TEST_CASE(peephole_double_push)
 	};
 
 	// `PUSH0 PUSH0` is cheaper than `DUP1 PUSH0`
-	if (solidity::test::CommonOptions::get().evmVersion() >= EVMVersion::shanghai())
+	if (CommonOptions::get().evmVersion() >= EVMVersion::shanghai())
 		expectation = {
 			u256(0),
 			u256(0),
@@ -1290,7 +1289,7 @@ BOOST_AUTO_TEST_CASE(peephole_double_push)
 			u256(5)
 		};
 
-	PeepholeOptimiser peepOpt(items, solidity::test::CommonOptions::get().evmVersion());
+	PeepholeOptimiser peepOpt(items, CommonOptions::get().evmVersion());
 	BOOST_REQUIRE(peepOpt.optimise());
 	BOOST_CHECK_EQUAL_COLLECTIONS(
 		items.begin(), items.end(),
@@ -1306,7 +1305,7 @@ BOOST_AUTO_TEST_CASE(peephole_pop_calldatasize)
 		Instruction::LT,
 		Instruction::POP
 	};
-	PeepholeOptimiser peepOpt(items, solidity::test::CommonOptions::get().evmVersion());
+	PeepholeOptimiser peepOpt(items, CommonOptions::get().evmVersion());
 	for (size_t i = 0; i < 3; i++)
 		BOOST_CHECK(peepOpt.optimise());
 	BOOST_CHECK(items.empty());
@@ -1339,7 +1338,7 @@ BOOST_AUTO_TEST_CASE(peephole_commutative_swap1)
 			u256(4),
 			u256(5)
 		};
-		PeepholeOptimiser peepOpt(items, solidity::test::CommonOptions::get().evmVersion());
+		PeepholeOptimiser peepOpt(items, CommonOptions::get().evmVersion());
 		BOOST_REQUIRE(peepOpt.optimise());
 		BOOST_CHECK_EQUAL_COLLECTIONS(
 			items.begin(), items.end(),
@@ -1377,7 +1376,7 @@ BOOST_AUTO_TEST_CASE(peephole_noncommutative_swap1)
 			u256(4),
 			u256(5)
 		};
-		PeepholeOptimiser peepOpt(items, solidity::test::CommonOptions::get().evmVersion());
+		PeepholeOptimiser peepOpt(items, CommonOptions::get().evmVersion());
 		BOOST_REQUIRE(!peepOpt.optimise());
 		BOOST_CHECK_EQUAL_COLLECTIONS(
 			items.begin(), items.end(),
@@ -1412,7 +1411,7 @@ BOOST_AUTO_TEST_CASE(peephole_swap_comparison)
 			u256(4),
 			u256(5)
 		};
-		PeepholeOptimiser peepOpt(items, solidity::test::CommonOptions::get().evmVersion());
+		PeepholeOptimiser peepOpt(items, CommonOptions::get().evmVersion());
 		BOOST_REQUIRE(peepOpt.optimise());
 		BOOST_CHECK_EQUAL_COLLECTIONS(
 			items.begin(), items.end(),
@@ -1438,7 +1437,7 @@ BOOST_AUTO_TEST_CASE(peephole_truthy_and)
 		AssemblyItem(PushTag, 1),
 		Instruction::JUMPI
 	};
-	PeepholeOptimiser peepOpt(items, solidity::test::CommonOptions::get().evmVersion());
+	PeepholeOptimiser peepOpt(items, CommonOptions::get().evmVersion());
 	BOOST_REQUIRE(peepOpt.optimise());
 	BOOST_CHECK_EQUAL_COLLECTIONS(
 		items.begin(), items.end(),
@@ -1471,7 +1470,7 @@ BOOST_AUTO_TEST_CASE(peephole_iszero_iszero_jumpi)
 		u256(0x20),
 		Instruction::RETURN
 	};
-	PeepholeOptimiser peepOpt(items, solidity::test::CommonOptions::get().evmVersion());
+	PeepholeOptimiser peepOpt(items, CommonOptions::get().evmVersion());
 	BOOST_REQUIRE(peepOpt.optimise());
 	BOOST_CHECK_EQUAL_COLLECTIONS(
 	  items.begin(), items.end(),
@@ -1513,7 +1512,7 @@ BOOST_AUTO_TEST_CASE(jumpdest_removal_subassemblies, *boost::unit_test::precondi
 	// tag unifications (due to block deduplication) is also
 	// visible at the super-assembly.
 
-	solAssert(!solidity::test::CommonOptions::get().eofVersion().has_value());
+	solAssert(!CommonOptions::get().eofVersion().has_value());
 	Assembly::OptimiserSettings settings;
 	settings.runInliner = false;
 	settings.runJumpdestRemover = true;
@@ -1728,7 +1727,7 @@ BOOST_AUTO_TEST_CASE(verbatim_knownstate)
 
 BOOST_AUTO_TEST_CASE(cse_remove_redundant_shift_masking)
 {
-	if (!solidity::test::CommonOptions::get().evmVersion().hasBitwiseShifting())
+	if (!CommonOptions::get().evmVersion().hasBitwiseShifting())
 		return;
 
 	for (unsigned i = 1; i < 256; i++)
@@ -1876,7 +1875,7 @@ BOOST_AUTO_TEST_CASE(cse_remove_unwanted_masking_of_address)
 
 BOOST_AUTO_TEST_CASE(cse_replace_too_large_shift)
 {
-	if (!solidity::test::CommonOptions::get().evmVersion().hasBitwiseShifting())
+	if (!CommonOptions::get().evmVersion().hasBitwiseShifting())
 		return;
 
 	checkCSE({

--- a/test/libsolidity/ABIJsonTest.cpp
+++ b/test/libsolidity/ABIJsonTest.cpp
@@ -26,12 +26,14 @@
 #include <libsolutil/JSON.h>
 #include <libsolutil/AnsiColorized.h>
 
-#include <fstream>
+#include <ostream>
+#include <string>
 
 using namespace solidity;
 using namespace solidity::util;
 using namespace solidity::frontend;
 using namespace solidity::frontend::test;
+using namespace solidity::test;
 
 ABIJsonTest::ABIJsonTest(std::string const& _filename):
 	TestCase(_filename)
@@ -48,8 +50,8 @@ TestCase::TestResult ABIJsonTest::run(std::ostream& _stream, std::string const& 
 		"",
 		"pragma solidity >=0.0;\n// SPDX-License-Identifier: GPL-3.0\n" + m_source
 	}});
-	compiler.setEVMVersion(solidity::test::CommonOptions::get().evmVersion());
-	compiler.setOptimiserSettings(solidity::test::CommonOptions::get().optimize);
+	compiler.setEVMVersion(CommonOptions::get().evmVersion());
+	compiler.setOptimiserSettings(CommonOptions::get().optimize);
 	if (!compiler.parseAndAnalyze())
 		BOOST_THROW_EXCEPTION(std::runtime_error("Parsing contract failed"));
 

--- a/test/libsolidity/ASTJSONTest.cpp
+++ b/test/libsolidity/ASTJSONTest.cpp
@@ -33,16 +33,15 @@
 #include <boost/throw_exception.hpp>
 
 #include <fstream>
-#include <memory>
 #include <stdexcept>
 
 using namespace solidity;
 using namespace solidity::langutil;
 using namespace solidity::frontend;
 using namespace solidity::frontend::test;
+using namespace solidity::test;
 using namespace solidity::util::formatting;
 using namespace solidity::util;
-namespace fs = boost::filesystem;
 using namespace boost::unit_test;
 using namespace std::string_literals;
 
@@ -79,7 +78,7 @@ void replaceVersionWithTag(std::string& _input)
 {
 	boost::algorithm::replace_all(
 		_input,
-		"\"" + solidity::test::CommonOptions::get().evmVersion().name() + "\"",
+		"\"" + CommonOptions::get().evmVersion().name() + "\"",
 		"%EVMVERSION%"
 	);
 }
@@ -89,7 +88,7 @@ void replaceTagWithVersion(std::string& _input)
 	boost::algorithm::replace_all(
 		_input,
 		"%EVMVERSION%",
-		"\"" + solidity::test::CommonOptions::get().evmVersion().name() + "\""
+		"\"" + CommonOptions::get().evmVersion().name() + "\""
 	);
 }
 
@@ -210,7 +209,7 @@ TestCase::TestResult ASTJSONTest::run(std::ostream& _stream, std::string const& 
 	{
 		c.reset();
 		c.setSources(sources);
-		c.setEVMVersion(solidity::test::CommonOptions::get().evmVersion());
+		c.setEVMVersion(CommonOptions::get().evmVersion());
 
 		if (!c.parseAndAnalyze(variant.stopAfter))
 		{

--- a/test/libsolidity/ASTPropertyTest.cpp
+++ b/test/libsolidity/ASTPropertyTest.cpp
@@ -36,6 +36,7 @@
 #include <queue>
 
 using namespace solidity::util;
+using namespace solidity::test;
 using namespace solidity::langutil;
 using namespace solidity::frontend;
 using namespace solidity::frontend::test;
@@ -191,8 +192,8 @@ TestCase::TestResult ASTPropertyTest::run(std::ostream& _stream, std::string con
 		"A",
 		"pragma solidity >=0.0;\n// SPDX-License-Identifier: GPL-3.0\n" + m_source
 	}});
-	compiler.setEVMVersion(solidity::test::CommonOptions::get().evmVersion());
-	compiler.setOptimiserSettings(solidity::test::CommonOptions::get().optimize);
+	compiler.setEVMVersion(CommonOptions::get().evmVersion());
+	compiler.setOptimiserSettings(CommonOptions::get().optimize);
 	if (!compiler.parseAndAnalyze())
 		BOOST_THROW_EXCEPTION(std::runtime_error(
 			"Parsing contract failed" +

--- a/test/libsolidity/GasTest.cpp
+++ b/test/libsolidity/GasTest.cpp
@@ -27,7 +27,9 @@
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/throw_exception.hpp>
-#include <fstream>
+
+#include <istream>
+#include <ostream>
 #include <stdexcept>
 
 using namespace solidity::langutil;

--- a/test/libsolidity/NatspecJSONTest.cpp
+++ b/test/libsolidity/NatspecJSONTest.cpp
@@ -27,8 +27,6 @@
 
 #include <fmt/format.h>
 
-#include <vector>
-
 using namespace solidity::frontend::test;
 using namespace solidity::util;
 using namespace std::string_literals;

--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -24,12 +24,12 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/throw_exception.hpp>
 
-#include <algorithm>
 #include <cctype>
-#include <fstream>
+#include <istream>
 #include <functional>
-#include <memory>
 #include <optional>
+#include <ostream>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -37,13 +37,13 @@
 using namespace solidity;
 using namespace solidity::yul;
 using namespace solidity::langutil;
+using namespace solidity::test;
 using namespace solidity::util;
 using namespace solidity::util::formatting;
 using namespace solidity::frontend::test;
 using namespace boost::algorithm;
 using namespace boost::unit_test;
 using namespace std::string_literals;
-namespace fs = boost::filesystem;
 
 std::ostream& solidity::frontend::test::operator<<(std::ostream& _output, RequiresYulOptimizer _requiresYulOptimizer)
 {
@@ -88,10 +88,10 @@ SemanticTest::SemanticTest(
 	);
 
 	m_runWithABIEncoderV1Only = m_reader.boolSetting("ABIEncoderV1Only", false);
-	if (m_runWithABIEncoderV1Only && !solidity::test::CommonOptions::get().useABIEncoderV1)
+	if (m_runWithABIEncoderV1Only && !CommonOptions::get().useABIEncoderV1)
 		m_shouldRun = false;
 
-	auto const eofEnabled = solidity::test::CommonOptions::get().eofVersion().has_value();
+	auto const eofEnabled = CommonOptions::get().eofVersion().has_value();
 	std::string compileViaYul = m_reader.stringSetting("compileViaYul", eofEnabled ? "true" : "also");
 
 	if (compileViaYul == "false" && eofEnabled)
@@ -326,14 +326,14 @@ TestCase::TestResult SemanticTest::run(std::ostream& _stream, std::string const&
 
 	if (m_testCaseWantsYulRun && result == TestResult::Success)
 	{
-		if (solidity::test::CommonOptions::get().optimize)
+		if (CommonOptions::get().optimize)
 			result = runTest(_stream, _linePrefix, _formatted, true /* _isYulRun */);
 		else
 			result = tryRunTestWithYulOptimizer(_stream, _linePrefix, _formatted);
 	}
 
 	if (result != TestResult::Success)
-		solidity::test::CommonOptions::get().printSelectedOptions(
+		CommonOptions::get().printSelectedOptions(
 			_stream,
 			_linePrefix,
 			{"evmVersion", "optimize", "useABIEncoderV1", "batch"}
@@ -364,7 +364,7 @@ TestCase::TestResult SemanticTest::runTest(
 	for (TestFunctionCall& test: m_tests)
 		test.reset();
 
-	std::map<std::string, solidity::test::Address> libraries;
+	std::map<std::string, Address> libraries;
 
 	bool constructed = false;
 
@@ -703,7 +703,7 @@ bool SemanticTest::deploy(
 	std::string const& _contractName,
 	u256 const& _value,
 	bytes const& _arguments,
-	std::map<std::string, solidity::test::Address> const& _libraries
+	std::map<std::string, Address> const& _libraries
 )
 {
 	auto output = compileAndRunWithoutCheck(m_sources.sources, _value, _contractName, _arguments, _libraries, m_sources.mainSourceFile);

--- a/test/libsolidity/SyntaxTest.cpp
+++ b/test/libsolidity/SyntaxTest.cpp
@@ -25,7 +25,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/throw_exception.hpp>
 #include <range/v3/algorithm/find_if.hpp>
-#include <fstream>
+
 #include <memory>
 #include <stdexcept>
 
@@ -35,8 +35,8 @@ using namespace solidity::util::formatting;
 using namespace solidity::langutil;
 using namespace solidity::frontend;
 using namespace solidity::frontend::test;
+using namespace solidity::test;
 using namespace boost::unit_test;
-namespace fs = boost::filesystem;
 
 SyntaxTest::SyntaxTest(
 	std::string const& _filename,
@@ -48,7 +48,7 @@ SyntaxTest::SyntaxTest(
 {
 	static std::set<std::string> const compileViaYulAllowedValues{"true", "false"};
 
-	auto const eofEnabled = solidity::test::CommonOptions::get().eofVersion().has_value();
+	auto const eofEnabled = CommonOptions::get().eofVersion().has_value();
 
 	m_compileViaYul = m_reader.stringSetting("compileViaYul", eofEnabled ? "true" : "false");
 	if (!util::contains(compileViaYulAllowedValues, m_compileViaYul))
@@ -133,8 +133,8 @@ void SyntaxTest::filterObtainedErrors()
 			if(m_sources.sources.count(sourceName) == 1)
 			{
 				int preambleSize =
-						static_cast<int>(compiler().charStream(sourceName).size()) -
-						static_cast<int>(m_sources.sources[sourceName].size());
+					static_cast<int>(compiler().charStream(sourceName).size()) -
+					static_cast<int>(m_sources.sources[sourceName].size());
 				solAssert(preambleSize >= 0, "");
 
 				// ignore the version & license pragma inserted by the testing tool when calculating locations.

--- a/test/libyul/Common.cpp
+++ b/test/libyul/Common.cpp
@@ -41,8 +41,6 @@
 
 #include <boost/test/unit_test.hpp>
 
-#include <variant>
-
 using namespace solidity;
 using namespace solidity::frontend;
 using namespace solidity::yul;

--- a/test/libyul/ObjectCompilerTest.cpp
+++ b/test/libyul/ObjectCompilerTest.cpp
@@ -42,9 +42,10 @@ using namespace solidity::yul;
 using namespace solidity::yul::test;
 using namespace solidity::frontend;
 using namespace solidity::frontend::test;
+using namespace solidity::test;
 
 ObjectCompilerTest::ObjectCompilerTest(std::string const& _filename):
-	solidity::frontend::test::EVMVersionRestrictedTestCase(_filename)
+	EVMVersionRestrictedTestCase(_filename)
 {
 	m_source = m_reader.source();
 	m_optimisationPreset = m_reader.enumSetting<OptimisationPreset>(
@@ -97,7 +98,7 @@ TestCase::TestResult ObjectCompilerTest::run(std::ostream& _stream, std::string 
 		{
 			m_obtainedResult += (!m_obtainedResult.empty() && m_obtainedResult.back() != '\n') ? "\n" : "";
 			m_obtainedResult += "Opcodes: " +
-				boost::trim_copy(evmasm::disassemble(obj.bytecode->bytecode, solidity::test::CommonOptions::get().evmVersion()));
+				boost::trim_copy(evmasm::disassemble(obj.bytecode->bytecode, CommonOptions::get().evmVersion()));
 		}
 		if (std::find(m_outputSetting.begin(), m_outputSetting.end(), "SourceMappings") != m_outputSetting.end())
 		{

--- a/test/libyul/YulOptimizerTest.cpp
+++ b/test/libyul/YulOptimizerTest.cpp
@@ -35,7 +35,7 @@
 #include <libsolutil/AnsiColorized.h>
 #include <libsolutil/StringUtils.h>
 
-#include <fstream>
+#include <ostream>
 
 using namespace solidity;
 using namespace solidity::util;

--- a/test/soltest.cpp
+++ b/test/soltest.cpp
@@ -49,6 +49,7 @@
 
 using namespace boost::unit_test;
 using namespace solidity::frontend::test;
+using namespace solidity::test;
 namespace fs = boost::filesystem;
 
 namespace
@@ -68,7 +69,7 @@ void removeTestSuite(std::string const& _name)
 class BoostBatcher: public test_tree_visitor
 {
 public:
-	BoostBatcher(solidity::test::Batcher& _batcher):
+	BoostBatcher(Batcher& _batcher):
 		m_batcher(_batcher)
 	{}
 
@@ -91,7 +92,7 @@ public:
 	}
 
 private:
-	solidity::test::Batcher& m_batcher;
+	Batcher& m_batcher;
 	std::vector<test_suite*> m_path;
 };
 
@@ -127,18 +128,18 @@ int registerTests(
 	boost::filesystem::path const& _path,
 	std::vector<std::string> const& _labels,
 	TestCase::TestCaseCreator _testCaseCreator,
-	solidity::test::Batcher& _batcher
+	Batcher& _batcher
 )
 {
 	int numTestsAdded = 0;
 	fs::path fullpath = _basepath / _path;
 	TestCase::Config config{
 		fullpath.string(),
-		solidity::test::CommonOptions::get().evmVersion(),
-		solidity::test::CommonOptions::get().eofVersion(),
-		solidity::test::CommonOptions::get().vmPaths,
-		solidity::test::CommonOptions::get().enforceGasTest,
-		solidity::test::CommonOptions::get().enforceGasTestMinValue,
+		CommonOptions::get().evmVersion(),
+		CommonOptions::get().eofVersion(),
+		CommonOptions::get().vmPaths,
+		CommonOptions::get().enforceGasTest,
+		CommonOptions::get().enforceGasTestMinValue,
 	};
 	if (fs::is_directory(fullpath))
 	{
@@ -148,7 +149,7 @@ int registerTests(
 			fs::directory_iterator()
 		))
 			if (
-				solidity::test::isValidSemanticTestPath(entry) &&
+				isValidSemanticTestPath(entry) &&
 				(fs::is_directory(entry.path()) || TestCase::isTestFilename(entry.path().filename()))
 			)
 				numTestsAdded += registerTests(
@@ -195,13 +196,13 @@ bool initializeOptions()
 {
 	auto const& suite = boost::unit_test::framework::master_test_suite();
 
-	auto options = std::make_unique<solidity::test::CommonOptions>();
+	auto options = std::make_unique<CommonOptions>();
 	bool shouldContinue = options->parse(suite.argc, suite.argv);
 	if (!shouldContinue)
 		return false;
 	options->validate();
 
-	solidity::test::CommonOptions::setSingleton(std::move(options));
+	CommonOptions::setSingleton(std::move(options));
 	return true;
 }
 
@@ -224,10 +225,10 @@ test_suite* init_unit_test_suite(int /*argc*/, char* /*argv*/[])
 		if (!shouldContinue)
 			exit(EXIT_SUCCESS);
 
-		if (!solidity::test::loadVMs(solidity::test::CommonOptions::get()))
+		if (!loadVMs(CommonOptions::get()))
 			exit(EXIT_FAILURE);
 
-		if (solidity::test::CommonOptions::get().disableSemanticTests)
+		if (CommonOptions::get().disableSemanticTests)
 			std::cout << std::endl << "--- SKIPPING ALL SEMANTICS TESTS ---" << std::endl << std::endl;
 
 		Batcher batcher(CommonOptions::get().selectedBatch, CommonOptions::get().batches);
@@ -241,12 +242,12 @@ test_suite* init_unit_test_suite(int /*argc*/, char* /*argv*/[])
 		// Include the interactive tests in the automatic tests as well
 		for (auto const& ts: g_interactiveTestsuites)
 		{
-			auto const& options = solidity::test::CommonOptions::get();
+			auto const& options = CommonOptions::get();
 
 			if (ts.smt && options.disableSMT)
 				continue;
 
-			if (ts.needsVM && solidity::test::CommonOptions::get().disableSemanticTests)
+			if (ts.needsVM && CommonOptions::get().disableSemanticTests)
 				continue;
 
 			//TODO
@@ -262,7 +263,7 @@ test_suite* init_unit_test_suite(int /*argc*/, char* /*argv*/[])
 			// > 0, std::string("no ") + ts.title + " tests found");
 		 }
 
-		if (solidity::test::CommonOptions::get().disableSemanticTests)
+		if (CommonOptions::get().disableSemanticTests)
 		{
 			for (auto suite: {
 				"ABIDecoderTest",

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -43,12 +43,9 @@ using namespace solidity::util;
 using namespace solidity::frontend;
 using namespace solidity::frontend::test;
 using namespace solidity::util::formatting;
+using namespace solidity::test;
 
-namespace po = boost::program_options;
 namespace fs = boost::filesystem;
-
-using TestCreator = TestCase::TestCaseCreator;
-using TestOptions = solidity::test::IsolTestOptions;
 
 struct TestStats
 {
@@ -80,7 +77,7 @@ public:
 
 	bool matches(fs::path const& _path, std::string const& _name) const
 	{
-		return std::regex_match(_name, m_filterExpression) && solidity::test::isValidSemanticTestPath(_path);
+		return std::regex_match(_name, m_filterExpression) && isValidSemanticTestPath(_path);
 	}
 
 private:
@@ -92,8 +89,8 @@ class TestTool
 {
 public:
 	TestTool(
-		TestCreator _testCaseCreator,
-		TestOptions const& _options,
+		TestCase::TestCaseCreator _testCaseCreator,
+		IsolTestOptions const& _options,
 		fs::path _path,
 		std::string _name
 	):
@@ -115,11 +112,11 @@ public:
 	Result process();
 
 	static TestStats processPath(
-		TestCreator _testCaseCreator,
-		TestOptions const& _options,
+		TestCase::TestCaseCreator _testCaseCreator,
+		IsolTestOptions const& _options,
 		fs::path const& _basepath,
 		fs::path const& _path,
-		solidity::test::Batcher& _batcher
+		Batcher& _batcher
 	);
 private:
 	enum class Request
@@ -132,8 +129,8 @@ private:
 	void updateTestCase();
 	Request handleResponse(bool _exception);
 
-	TestCreator m_testCaseCreator;
-	TestOptions const& m_options;
+	TestCase::TestCaseCreator m_testCaseCreator;
+	IsolTestOptions const& m_options;
 	TestFilter m_filter;
 	fs::path const m_path;
 	std::string const m_name;
@@ -253,11 +250,11 @@ TestTool::Request TestTool::handleResponse(bool _exception)
 }
 
 TestStats TestTool::processPath(
-	TestCreator _testCaseCreator,
-	TestOptions const& _options,
+	TestCase::TestCaseCreator _testCaseCreator,
+	IsolTestOptions const& _options,
 	fs::path const& _basepath,
 	fs::path const& _path,
-	solidity::test::Batcher& _batcher
+	Batcher& _batcher
 )
 {
 	std::queue<fs::path> paths;
@@ -362,12 +359,12 @@ void setupTerminal()
 }
 
 std::optional<TestStats> runTestSuite(
-	TestCreator _testCaseCreator,
-	TestOptions const& _options,
+	TestCase::TestCaseCreator _testCaseCreator,
+	IsolTestOptions const& _options,
 	fs::path const& _basePath,
 	fs::path const& _subdirectory,
 	std::string const& _name,
-	solidity::test::Batcher& _batcher
+	Batcher& _batcher
 )
 {
 	fs::path testPath{_basePath / _subdirectory};
@@ -429,7 +426,7 @@ int main(int argc, char const *argv[])
 
 		auto& options = dynamic_cast<IsolTestOptions const&>(CommonOptions::get());
 
-		if (!solidity::test::loadVMs(options))
+		if (!loadVMs(options))
 			return EXIT_FAILURE;
 
 		if (options.disableSemanticTests)
@@ -493,7 +490,7 @@ int main(int argc, char const *argv[])
 		std::cerr << exception.what() << std::endl;
 		return 2;
 	}
-	catch (solidity::test::ConfigException const& exception)
+	catch (ConfigException const& exception)
 	{
 		std::cerr << exception.what() << std::endl;
 		return 2;

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -25,8 +25,13 @@
 #include <test/InteractiveTests.h>
 #include <test/EVMHost.h>
 
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/filesystem.hpp>
+
+#include <fmt/format.h>
+
+#include <range/v3/algorithm/all_of.hpp>
 
 #include <cstdlib>
 #include <iostream>
@@ -65,14 +70,17 @@ struct TestStats
 class TestFilter
 {
 public:
-	explicit TestFilter(std::string _filter): m_filter(std::move(_filter))
+	explicit TestFilter(std::string _filter):
+		m_filter(std::move(_filter))
 	{
-		std::string filter{m_filter};
+		auto const startsWithDot = [](std::string const& _extension) { return boost::starts_with(_extension, "."); };
+		soltestAssert(ranges::all_of(testFileExtensions(), startsWithDot));
 
-		boost::replace_all(filter, "/", "\\/");
-		boost::replace_all(filter, "*", ".*");
-
-		m_filterExpression = std::regex{"(" + filter + "(\\.sol|\\.yul|\\.asm|\\.asmjson|\\.stack))"};
+		m_filterExpression = std::regex{fmt::format(
+			"({}({}))",
+			boost::replace_all_copy(boost::replace_all_copy(m_filter, "/", "\\/"), "*", ".*"),
+			boost::replace_all_copy(joinHumanReadable(testFileExtensions(), "|"), ".", "\\.")
+		)};
 	}
 
 	bool matches(fs::path const& _path, std::string const& _name) const


### PR DESCRIPTION
~Depends on #16012.~ Merged.

This is a bunch of refactors I extracted from #16012:
- We have lists of test file extensions hard-coded in two places, which is error-prone. The PR unifies them.
- Removal of unused imports in files where I spotted them.
- In some places we use the annoying, verbose `solidity::test::` prefix for `CommonOptions` and other things, in others we don't. Often we do both in the same file. This PR removes it.

It's a pure refactor, there are no functionality changes.