### PR TITLE
Subassembly syntax for plain EVM assembly tests

### DIFF
--- a/test/libevmasm/PlainAssemblyParser.h
+++ b/test/libevmasm/PlainAssemblyParser.h
@@ -37,12 +37,18 @@ namespace solidity::evmasm::test
 /// - A non-empty line represents a single assembly item.
 /// - The name of the item is the first thing on the line and may consist of one or more tokens.
 /// - One or more arguments follow the name.
+/// - Indentation determines assembly nesting level (4 spaces per level).
+/// - A new subassembly starts with '.sub' and contains all subsequent lines at a higher nesting level.
+///     The first line at the same or lower nesting level ends the subassembly.
+/// - Subassemblies can be nested to arbitrary depth.
+/// - The code of an assembly must be specified before its subassemblies.
 ///
 /// Supported items:
 /// - All instruction names.
 /// - PUSH <hex value>
 /// - PUSH [tag] <tagID>
 /// - tag <tagID>
+/// - .sub
 class PlainAssemblyParser
 {
 public:
@@ -57,9 +63,14 @@ protected:
 		size_t position;        ///< Position of the first character of the token within m_line.
 	};
 
+	Json parseAssembly(size_t _nestingLevel);
+	size_t parseNestingLevel() const;
+
 	Token const& currentToken() const;
 	Token const& nextToken() const;
 	bool hasMoreTokens() const { return m_tokenIndex + 1 < m_lineTokens.size(); }
+
+	std::string_view indentation() const;
 
 	bool advanceToken();
 	std::string_view expectArgument();

--- a/test/libevmasm/PlainAssemblyParser.h
+++ b/test/libevmasm/PlainAssemblyParser.h
@@ -20,6 +20,7 @@
 
 #include <libsolutil/JSON.h>
 
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -63,17 +64,18 @@ protected:
 	bool advanceToken();
 	std::string_view expectArgument();
 	void expectNoMoreArguments();
-	void advanceLine(std::string_view _line);
+	bool advanceLine();
 
 	static std::vector<Token> tokenizeLine(std::string_view _line);
 	std::string formatError(std::string_view _message) const;
 
 private:
-	std::string m_sourceName;        ///< Name of the file the source comes from.
-	size_t m_lineNumber = 0;         ///< The number of the current line within the source, 1-based.
-	std::string m_line;              ///< The current line, unparsed.
-	std::vector<Token> m_lineTokens; ///< Decomposition of the current line into tokens (does not include comments).
-	size_t m_tokenIndex = 0;         ///< Points at a token within m_lineTokens.
+	std::istringstream m_sourceStream; ///< The source code being parsed.
+	std::string m_sourceName;          ///< Name of the file the source comes from.
+	size_t m_lineNumber = 0;           ///< The number of the current line within the source, 1-based.
+	std::optional<std::string> m_line; ///< The current line, unparsed.
+	std::vector<Token> m_lineTokens;   ///< Decomposition of the current line into tokens (does not include comments).
+	size_t m_tokenIndex = 0;           ///< Points at a token within m_lineTokens.
 };
 
 }

--- a/test/libevmasm/PlainAssemblyParser.h
+++ b/test/libevmasm/PlainAssemblyParser.h
@@ -48,6 +48,8 @@ namespace solidity::evmasm::test
 /// - PUSH <hex value>
 /// - PUSH [tag] <tagID>
 /// - tag <tagID>
+/// - PUSH [$] <subassemblyID>
+/// - PUSH #[$] <subassemblyID>
 /// - .sub
 class PlainAssemblyParser
 {

--- a/test/libevmasm/evmAssemblyTests/isoltestTesting/empty.asm
+++ b/test/libevmasm/evmAssemblyTests/isoltestTesting/empty.asm
@@ -1,0 +1,10 @@
+// ====
+// outputs: InputAssemblyJSON,Assembly,Bytecode,Opcodes,SourceMappings
+// ----
+// InputAssemblyJSON: {
+//     ".code": []
+// }
+// Assembly:
+// Bytecode:
+// Opcodes:
+// SourceMappings:

--- a/test/libevmasm/evmAssemblyTests/isoltestTesting/pushsize.asm
+++ b/test/libevmasm/evmAssemblyTests/isoltestTesting/pushsize.asm
@@ -1,0 +1,33 @@
+PUSHSIZE
+
+.sub
+    PUSHSIZE
+// ====
+// outputs: InputAssemblyJSON,Assembly,Bytecode,Opcodes,SourceMappings
+// ----
+// InputAssemblyJSON: {
+//     ".code": [
+//         {
+//             "name": "PUSHSIZE"
+//         }
+//     ],
+//     ".data": {
+//         "0": {
+//             ".code": [
+//                 {
+//                     "name": "PUSHSIZE"
+//                 }
+//             ]
+//         }
+//     }
+// }
+// Assembly:
+//   bytecodeSize
+// stop
+//
+// sub_0: assembly {
+//       bytecodeSize
+// }
+// Bytecode: 6003fe
+// Opcodes: PUSH1 0x3 INVALID
+// SourceMappings: :::-:0

--- a/test/libevmasm/evmAssemblyTests/isoltestTesting/pushsubsize.asm
+++ b/test/libevmasm/evmAssemblyTests/isoltestTesting/pushsubsize.asm
@@ -1,0 +1,72 @@
+PUSH [$] 0x0000
+PUSH #[$] 0x0000
+
+.sub
+    PUSH [$] 0x0
+    PUSH #[$] 0x2
+
+    .sub
+    .sub
+    .sub
+// ====
+// outputs: InputAssemblyJSON,Assembly,Bytecode,Opcodes,SourceMappings
+// ----
+// InputAssemblyJSON: {
+//     ".code": [
+//         {
+//             "name": "PUSH [$]",
+//             "value": "0000"
+//         },
+//         {
+//             "name": "PUSH #[$]",
+//             "value": "0000"
+//         }
+//     ],
+//     ".data": {
+//         "0": {
+//             ".code": [
+//                 {
+//                     "name": "PUSH [$]",
+//                     "value": "0"
+//                 },
+//                 {
+//                     "name": "PUSH #[$]",
+//                     "value": "2"
+//                 }
+//             ],
+//             ".data": {
+//                 "0": {
+//                     ".code": []
+//                 },
+//                 "1": {
+//                     ".code": []
+//                 },
+//                 "2": {
+//                     ".code": []
+//                 }
+//             }
+//         }
+//     }
+// }
+// Assembly:
+//   dataOffset(sub_0)
+//   dataSize(sub_0)
+// stop
+//
+// sub_0: assembly {
+//       dataOffset(sub_0)
+//       dataSize(sub_2)
+//     stop
+//
+//     sub_0: assembly {
+//     }
+//
+//     sub_1: assembly {
+//     }
+//
+//     sub_2: assembly {
+//     }
+// }
+// Bytecode: 60056005fe60056000fe
+// Opcodes: PUSH1 0x5 PUSH1 0x5 INVALID PUSH1 0x5 PUSH1 0x0 INVALID
+// SourceMappings: :::-:0;

--- a/test/libevmasm/evmAssemblyTests/isoltestTesting/subassemblies.asm
+++ b/test/libevmasm/evmAssemblyTests/isoltestTesting/subassemblies.asm
@@ -1,0 +1,69 @@
+PUSH 0x2
+DUP1
+ADD
+
+.sub
+    PUSH 0x42
+    DUP1
+    MUL
+
+.sub
+    STOP
+// ====
+// outputs: InputAssemblyJSON,Assembly,Bytecode,Opcodes,SourceMappings
+// ----
+// InputAssemblyJSON: {
+//     ".code": [
+//         {
+//             "name": "PUSH",
+//             "value": "2"
+//         },
+//         {
+//             "name": "DUP1"
+//         },
+//         {
+//             "name": "ADD"
+//         }
+//     ],
+//     ".data": {
+//         "0": {
+//             ".code": [
+//                 {
+//                     "name": "PUSH",
+//                     "value": "42"
+//                 },
+//                 {
+//                     "name": "DUP1"
+//                 },
+//                 {
+//                     "name": "MUL"
+//                 }
+//             ]
+//         },
+//         "1": {
+//             ".code": [
+//                 {
+//                     "name": "STOP"
+//                 }
+//             ]
+//         }
+//     }
+// }
+// Assembly:
+//   0x02
+//   dup1
+//   add
+// stop
+//
+// sub_0: assembly {
+//       0x42
+//       dup1
+//       mul
+// }
+//
+// sub_1: assembly {
+//       stop
+// }
+// Bytecode: 60028001fe
+// Opcodes: PUSH1 0x2 DUP1 ADD INVALID
+// SourceMappings: :::-:0;;

--- a/test/libevmasm/evmAssemblyTests/isoltestTesting/subassemblies_empty.asm
+++ b/test/libevmasm/evmAssemblyTests/isoltestTesting/subassemblies_empty.asm
@@ -1,0 +1,34 @@
+.sub
+.sub
+.sub
+// ====
+// outputs: InputAssemblyJSON,Assembly,Bytecode,Opcodes,SourceMappings
+// ----
+// InputAssemblyJSON: {
+//     ".code": [],
+//     ".data": {
+//         "0": {
+//             ".code": []
+//         },
+//         "1": {
+//             ".code": []
+//         },
+//         "2": {
+//             ".code": []
+//         }
+//     }
+// }
+// Assembly:
+// stop
+//
+// sub_0: assembly {
+// }
+//
+// sub_1: assembly {
+// }
+//
+// sub_2: assembly {
+// }
+// Bytecode: fe
+// Opcodes: INVALID
+// SourceMappings:

--- a/test/libevmasm/evmAssemblyTests/isoltestTesting/subassemblies_nested.asm
+++ b/test/libevmasm/evmAssemblyTests/isoltestTesting/subassemblies_nested.asm
@@ -1,0 +1,171 @@
+TIMESTAMP
+TIMESTAMP
+
+.sub
+    TIMESTAMP
+
+    .sub
+        TIMESTAMP
+    .sub
+        TIMESTAMP
+        .sub
+            TIMESTAMP
+            .sub
+                TIMESTAMP
+    .sub
+        TIMESTAMP
+.sub
+    NUMBER
+    SLOAD
+    .sub
+        NUMBER
+        MLOAD
+        .sub
+            NUMBER
+            TLOAD
+
+// ====
+// outputs: InputAssemblyJSON,Assembly,Bytecode,Opcodes,SourceMappings
+// ----
+// InputAssemblyJSON: {
+//     ".code": [
+//         {
+//             "name": "TIMESTAMP"
+//         },
+//         {
+//             "name": "TIMESTAMP"
+//         }
+//     ],
+//     ".data": {
+//         "0": {
+//             ".code": [
+//                 {
+//                     "name": "TIMESTAMP"
+//                 }
+//             ],
+//             ".data": {
+//                 "0": {
+//                     ".code": [
+//                         {
+//                             "name": "TIMESTAMP"
+//                         }
+//                     ]
+//                 },
+//                 "1": {
+//                     ".code": [
+//                         {
+//                             "name": "TIMESTAMP"
+//                         }
+//                     ],
+//                     ".data": {
+//                         "0": {
+//                             ".code": [
+//                                 {
+//                                     "name": "TIMESTAMP"
+//                                 }
+//                             ],
+//                             ".data": {
+//                                 "0": {
+//                                     ".code": [
+//                                         {
+//                                             "name": "TIMESTAMP"
+//                                         }
+//                                     ]
+//                                 }
+//                             }
+//                         }
+//                     }
+//                 },
+//                 "2": {
+//                     ".code": [
+//                         {
+//                             "name": "TIMESTAMP"
+//                         }
+//                     ]
+//                 }
+//             }
+//         },
+//         "1": {
+//             ".code": [
+//                 {
+//                     "name": "NUMBER"
+//                 },
+//                 {
+//                     "name": "SLOAD"
+//                 }
+//             ],
+//             ".data": {
+//                 "0": {
+//                     ".code": [
+//                         {
+//                             "name": "NUMBER"
+//                         },
+//                         {
+//                             "name": "MLOAD"
+//                         }
+//                     ],
+//                     ".data": {
+//                         "0": {
+//                             ".code": [
+//                                 {
+//                                     "name": "NUMBER"
+//                                 },
+//                                 {
+//                                     "name": "TLOAD"
+//                                 }
+//                             ]
+//                         }
+//                     }
+//                 }
+//             }
+//         }
+//     }
+// }
+// Assembly:
+//   timestamp
+//   timestamp
+// stop
+//
+// sub_0: assembly {
+//       timestamp
+//     stop
+//
+//     sub_0: assembly {
+//           timestamp
+//     }
+//
+//     sub_1: assembly {
+//           timestamp
+//         stop
+//
+//         sub_0: assembly {
+//               timestamp
+//             stop
+//
+//             sub_0: assembly {
+//                   timestamp
+//             }
+//         }
+//     }
+//
+//     sub_2: assembly {
+//           timestamp
+//     }
+// }
+//
+// sub_1: assembly {
+//       sload(number)
+//     stop
+//
+//     sub_0: assembly {
+//           mload(number)
+//         stop
+//
+//         sub_0: assembly {
+//               tload(number)
+//         }
+//     }
+// }
+// Bytecode: 4242fe
+// Opcodes: TIMESTAMP TIMESTAMP INVALID
+// SourceMappings: :::-:0;


### PR DESCRIPTION
Follow-up to #16012.

Adds support for plain assembly tests that contain more than one assembly. This resolves the limitation I mentioned in https://github.com/ethereum/solidity/pull/16012#issuecomment-2825295845 and therefore will allow proper testing of the constant optimizer in #15935.