### PR TITLE
Disallow non-default `expectedExecutionsPerDeployment` in evmasm tests when only a creation object is present

### DIFF
--- a/test/libevmasm/EVMAssemblyTest.h
+++ b/test/libevmasm/EVMAssemblyTest.h
@@ -75,6 +75,7 @@ private:
 	AssemblyFormat m_assemblyFormat{};
 	std::string m_selectedOutputs;
 	evmasm::Assembly::OptimiserSettings m_optimizerSettings;
+	bool m_usingDefaultExpectedExecutionsPerDeployment{};
 };
 
 }


### PR DESCRIPTION
~Depends on #16021.~ Merged.

This adds an extra check to prevent confusion like in https://github.com/ethereum/solidity/pull/16012#issuecomment-2824630511. `expectedExecutionsPerDeployment` only affects runtime assemblies, but the top-level assembly is a creation one so if you have only one, it will seem like the setting is not working. This PR makes the test case throw an exception in that situation to make it obvious. It is not likely to be intentional.

I did not include it in #16021, because I'm not yet 100% convinced we want this. There are some downsides:
- It would be better off as a warning, but soltest does not have support for that. I can only throw.
    - I guess I could just print to stdout...
- This error means that the JSON import cannot be tested in full generality. This corner case will trigger an error while `--import-asm-json` would just accept it.
- It does not detect when the setting is specified in the test, only when it has a non-default value.

Still, these seem minor enough that we're probably better off with this check than without it.