### PR TITLE
Fix typos in test file names and macro parameters

### DIFF
--- a/test/libsolidity/util/TestFileParserTests.cpp
+++ b/test/libsolidity/util/TestFileParserTests.cpp
@@ -798,7 +798,7 @@ BOOST_AUTO_TEST_CASE(call_arguments_tuple_invalid_empty)
 	BOOST_REQUIRE_THROW(parse(source), TestParserError);
 }
 
-BOOST_AUTO_TEST_CASE(call_arguments_tuple_invalid_parantheses)
+BOOST_AUTO_TEST_CASE(call_arguments_tuple_invalid_parentheses)
 {
 	char const* source = R"(
 		// f((uint8,() -> FAILURE

--- a/test/tools/ossfuzz/protoToAbiV2.cpp
+++ b/test/tools/ossfuzz/protoToAbiV2.cpp
@@ -5,7 +5,7 @@
 
 /// Convenience macros
 /// Returns a valid Solidity integer width w such that 8 <= w <= 256.
-#define INTWIDTH(z, n, _ununsed) BOOST_PP_MUL(BOOST_PP_ADD(n, 1), 8)
+#define INTWIDTH(z, n, _unused) BOOST_PP_MUL(BOOST_PP_ADD(n, 1), 8)
 /// Using declaration that aliases long boost multiprecision types with
 /// s(u)<width> where <width> is a valid Solidity integer width and "s"
 /// stands for "signed" and "u" for "unsigned".


### PR DESCRIPTION
This PR fixes two typos:

1. Corrects the spelling of "parentheses" in test case name from "parantheses" to "parentheses" in test/libsolidity/util/TestFileParserTests.cpp

2. Fixes the typo in macro parameter name from "_ununsed" to "_unused" in test/tools/ossfuzz/protoToAbiV2.cpp

These changes improve code readability and consistency without affecting functionality.