### PR TITLE
assign zero value to not explicitly initialized variables during ssa cfg construction

### DIFF
--- a/libyul/backends/evm/SSAControlFlowGraphBuilder.cpp
+++ b/libyul/backends/evm/SSAControlFlowGraphBuilder.cpp
@@ -273,11 +273,6 @@ void SSAControlFlowGraphBuilder::operator()(Assignment const& _assignment)
 
 void SSAControlFlowGraphBuilder::operator()(VariableDeclaration const& _variableDeclaration)
 {
-	// if we have no value (like in `let a` without right-hand side), we can just skip this. the variable(s) will be
-	// added when first needed
-	if (!_variableDeclaration.value)
-		return;
-
 	assign(
 		_variableDeclaration.variables | ranges::views::transform([&](auto& _var) { return std::ref(lookupVariable(_var.name)); }) | ranges::to<std::vector>,
 		_variableDeclaration.value.get()

--- a/test/libyul/yulSSAControlFlowGraph/default_initialized_variable.yul
+++ b/test/libyul/yulSSAControlFlowGraph/default_initialized_variable.yul
@@ -1,0 +1,42 @@
+{
+    let x
+    if mload(42) {
+        x := 5
+    }
+    sstore(x, x)
+}
+// ----
+// digraph SSACFG {
+// nodesep=0.7;
+// graph[fontname="DejaVu Sans"]
+// node[shape=box,fontname="DejaVu Sans"];
+//
+// Entry0 [label="Entry"];
+// Entry0 -> Block0_0;
+// Block0_0 [label="\
+// Block 0; (0, max 2)\nLiveIn: \l\
+// LiveOut: v1\l\nv1 := 0\l\
+// v3 := mload(42)\l\
+// "];
+// Block0_0 -> Block0_0Exit;
+// Block0_0Exit [label="{ If v3 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_0Exit:0 -> Block0_2 [style="solid"];
+// Block0_0Exit:1 -> Block0_1 [style="solid"];
+// Block0_1 [label="\
+// Block 1; (1, max 2)\nLiveIn: \l\
+// LiveOut: v5\l\nv5 := 5\l\
+// "];
+// Block0_1 -> Block0_1Exit [arrowhead=none];
+// Block0_1Exit [label="Jump" shape=oval];
+// Block0_1Exit -> Block0_2 [style="solid"];
+// Block0_2 [label="\
+// Block 2; (2, max 2)\nLiveIn: v6\l\
+// LiveOut: \l\nv6 := φ(\l\
+// 	Block 0 => v1,\l\
+// 	Block 1 => v5\l\
+// )\l\
+// sstore(v6, v6)\l\
+// "];
+// Block0_2Exit [label="MainExit"];
+// Block0_2 -> Block0_2Exit;
+// }


### PR DESCRIPTION
Without this, we can end up in situations where no phi function is introduced for variables that are not explicitly initialized but referenced later (as in the added test)