### PR TITLE
docs: fix typos in comments across multiple files (`assignmed`, `captital`, `runds`)

### DIFF
--- a/libyul/backends/evm/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/StackLayoutGenerator.cpp
@@ -308,7 +308,7 @@ Stack StackLayoutGenerator::propagateStackThroughOperation(Stack _exitStack, CFG
 	// generated on the fly), s.t. shuffling the `stack + _operation.output` to _exitLayout is cheap.
 	Stack stack = createIdealLayout(_operation.output, _exitStack, generateSlotOnTheFly, reachableStackDepth());
 
-	// Make sure the resulting previous slots do not overlap with any assignmed variables.
+	// Make sure the resulting previous slots do not overlap with any assigned variables.
 	if (auto const* assignment = std::get_if<CFG::Assignment>(&_operation.operation))
 		for (auto& stackSlot: stack)
 			if (auto const* varSlot = std::get_if<VariableSlot>(&stackSlot))

--- a/test/compilationTests/corion/provider.sol
+++ b/test/compilationTests/corion/provider.sol
@@ -185,7 +185,7 @@ contract provider is module, safeMath, announcementTypes {
     }
     function setRightForInterest(uint256 oldValue, uint256 newValue, bool priv) internal {
         /*
-            It checks if the provider has enough connected captital to be able to get from the token emission.
+            It checks if the provider has enough connected capital to be able to get from the token emission.
             In case the provider is not able to get the share from the token emission then the connected capital will not count to the value of the globalFunds, to the current schelling round.
 
             @oldValue       old

--- a/test/compilationTests/corion/schelling.sol
+++ b/test/compilationTests/corion/schelling.sol
@@ -256,7 +256,7 @@ contract schelling is module, announcementTypes, schellingVars {
             @_moduleHandler         Address of ModuleHandler.
             @_db                    Address of the database.
             @_forReplace            This address will be replaced with the old one or not.
-            @_icoExpansionAddress   This address can turn schelling runds during ICO.
+            @_icoExpansionAddress   This address can turn schelling funds during ICO.
         */
         db = schellingDB(_db);
         super.registerModuleHandler(_moduleHandler);


### PR DESCRIPTION
Fixed minor typos in comments for clarity and correctness:

- Corrected "assignmed" to "assignment" in StackLayoutGenerator.cpp.
- Fixed "captital" to "capital" in provider.sol.
- Corrected "runds" to "funds" in schelling.sol.

These changes improve the readability of the codebase without affecting functionality.