### PR TITLE
Add nullptr checking for rename logging

### DIFF
--- a/libsolidity/lsp/RenameSymbol.cpp
+++ b/libsolidity/lsp/RenameSymbol.cpp
@@ -65,7 +65,8 @@ void RenameSymbol::operator()(MessageID _id, Json const& _args)
 		.translateLineColumnToPosition(lineColumn);
 	solAssert(cursorBytePosition.has_value(), "Expected source pos");
 
-	extractNameAndDeclaration(*sourceNode, *cursorBytePosition);
+	if (sourceNode != nullptr)
+		extractNameAndDeclaration(*sourceNode, *cursorBytePosition);
 
 	// Find all source units using this symbol
 	for (auto const& [name, content]: fileRepository().sourceUnits())
@@ -156,7 +157,8 @@ void RenameSymbol::extractNameAndDeclaration(ASTNode const& _node, int _cursorBy
 	else
 		solAssert(false, "Unexpected ASTNODE id: " + std::to_string(_node.id()));
 
-	lspDebug(fmt::format("Goal: rename '{}', loc: {}-{}", m_symbolName, m_declarationToRename->nameLocation().start, m_declarationToRename->nameLocation().end));
+	if (m_declarationToRename != nullptr)
+		lspDebug(fmt::format("Goal: rename '{}', loc: {}-{}", m_symbolName, m_declarationToRename->nameLocation().start, m_declarationToRename->nameLocation().end));
 }
 
 void RenameSymbol::extractNameAndDeclaration(ImportDirective const& _importDirective, int _cursorBytePosition)


### PR DESCRIPTION
There is a segmentation fault during a rename when the position is not pointing to a valid symbol. Add a checking to avoid that.

POC:

```solidity
function id(uint x) pure returns (uint) {
    return x;
}

function zero(uint) pure returns (uint) {
    return 0;
}

contract C {
    function f(uint z) pure external returns(uint) {
        return z.id();
    }

    function g(uint z) pure external returns (uint) {
        return z.zero();
    }

    using {id, zero} for uint;
}
```

```json
{
  "jsonrpc": "2.0",
  "id": 3,
  "method": "textDocument/rename",
  "params": {
    "textDocument": {
      "uri": "file:///tmp/export/input_2/workspace/main.sol"
    },
    "position": {
      "line": 10,
      "character": 20
    },
    "newName": "pure"
  }
}

```