### PR TITLE
Pass `count` into `re.sub()` as a named argument in `isolate_tests.py` to fix the deprecation warning

### DIFF
--- a/scripts/wasm-rebuild/docker-scripts/isolate_tests.py
+++ b/scripts/wasm-rebuild/docker-scripts/isolate_tests.py
@@ -46,7 +46,7 @@ def extract_and_write(f, path):
 def write_cases(f, tests):
     cleaned_filename = f.replace(".","_").replace("-","_").replace(" ","_").lower()
     for test in tests:
-        remainder = re.sub(r'^ {4}', '', test, 0, re.MULTILINE)
+        remainder = re.sub(r'^ {4}', '', test, count=0, flags=re.MULTILINE)
         source_code_hash = hashlib.sha256(test).hexdigest()
         with open(f'test_{source_code_hash}_{cleaned_filename}.sol', 'w', encoding='utf8') as _f:
             _f.write(remainder)


### PR DESCRIPTION
# PR Summary
This small PR resolves the regex library warnings showing in Python3.11:
```python
DeprecationWarning: 'count' is passed as positional argument
```