### PR TITLE
Do not add extcodesize check when `revertStrings` is set to debug

### DIFF
--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -2851,8 +2851,7 @@ void ExpressionCompiler::appendExternalFunctionCall(
 		// code, the call will return empty data and the ABI decoder will revert.
 		if (
 			encodedHeadSize == 0 ||
-			!haveReturndatacopy ||
-			m_context.revertStrings() >= RevertStrings::Debug
+			!haveReturndatacopy
 		)
 		{
 			m_context << Instruction::DUP1 << Instruction::EXTCODESIZE << Instruction::ISZERO;

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -2724,8 +2724,7 @@ void IRGeneratorForStatements::appendExternalFunctionCall(
 		!eof &&
 		(
 			encodedHeadSize == 0 ||
-			!m_context.evmVersion().supportsReturndata() ||
-			m_context.revertStrings() >= RevertStrings::Debug
+			!m_context.evmVersion().supportsReturndata()
 		);
 	templ("checkExtcodesize", checkExtcodesize);
 


### PR DESCRIPTION
If `revertStrings` option is set to `debug` or higher, then the compiler always adds the `extcodesize` check even if the function has a return value.

I believe it's a bug because it's unnatural for the compiler to change its logic just because a debug option is provided.