### PR TITLE
Remove deprecated whitespace in literal operator declaration

### DIFF
--- a/liblangutil/Exceptions.h
+++ b/liblangutil/Exceptions.h
@@ -163,7 +163,7 @@ struct ErrorId
 	bool operator!=(ErrorId const& _rhs) const { return !(*this == _rhs); }
 	bool operator<(ErrorId const& _rhs) const { return error < _rhs.error; }
 };
-constexpr ErrorId operator"" _error(unsigned long long _error) { return ErrorId{ _error }; }
+constexpr ErrorId operator""_error(unsigned long long _error) { return ErrorId{ _error }; }
 
 class Error: virtual public util::Exception
 {

--- a/libyul/YulString.h
+++ b/libyul/YulString.h
@@ -163,7 +163,7 @@ private:
 	YulStringRepository::Handle m_handle{ 0, YulStringRepository::emptyHash() };
 };
 
-inline YulString operator "" _yulname(char const* _string, std::size_t _size)
+inline YulString operator""_yulname(char const* _string, std::size_t _size)
 {
 	return YulString(std::string_view(_string, _size));
 }


### PR DESCRIPTION
This should fix the issues we are currently having in CI: https://app.circleci.com/pipelines/github/ethereum/solidity/39752/workflows/b911322a-7204-47c5-a2c7-0e24ba30afe1/jobs/1841317

```
#11 11.62 /solidity/liblangutil/Exceptions.h:166:30: error: identifier '_error' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
#11 11.62   166 | constexpr ErrorId operator"" _error(unsigned long long _error) { return ErrorId{ _error }; }
#11 11.62       |                   ~~~~~~~~~~~^~~~~~
#11 11.62       |                   operator""_error
```

See https://reviews.llvm.org/D153156 and https://github.com/llvm/llvm-project/pull/111027

And about the deprecation: https://cplusplus.github.io/CWG/issues/2521.html

Not sure if we need to maintain compatibility with old GCC, but if so, we may need to add some preprocessor directives like in:
https://github.com/apache/arrow-nanoarrow/pull/661#issuecomment-2412663957

