### PR TITLE
replace 404 reference Natspec.cpp

### DIFF
--- a/libsolidity/interface/Natspec.cpp
+++ b/libsolidity/interface/Natspec.cpp
@@ -19,7 +19,7 @@
  * @author Lefteris <lefteris@ethdev.com>
  * @date 2014
  * Takes the parsed AST and produces the Natspec documentation:
- * https://github.com/ethereum/wiki/wiki/Ethereum-Natural-Specification-Format
+ * https://docs.soliditylang.org/en/latest/natspec-format.html
  *
  * Can generally deal with JSON files
  */


### PR DESCRIPTION
Hi, I fixed broken link in the documentation and replaced them with working ones:

https://github.com/ethereum/wiki/wiki/Ethereum-Natural-Specification-Format - old link
https://docs.soliditylang.org/en/latest/natspec-format.html - new link