### PR TITLE
Add Cyfrin's glossary to Resources in the docs

### DIFF
--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -15,6 +15,7 @@ General Resources
 * `awesome-solidity <https://github.com/bkrem/awesome-solidity>`_
 * `Solidity by Example <https://solidity-by-example.org/>`_
 * `Solidity documentation community translations <https://github.com/solidity-docs>`_
+* `Solidity and Smart Contract Glossary <https://www.cyfrin.io/glossary>`_
 
 Integrated (Ethereum) Development Environments
 ==============================================


### PR DESCRIPTION
We have a glossary with many of the terms taught in Cyfrin Updraft.

https://www.cyfrin.io/glossary

Figured it would be a good resource to add!

(Note: It's different from what's in https://github.com/ethereum/solidity/pull/15339)