### PR TITLE
Update ConsenSys StandardToken.sol reference link to current GitHub location

### DIFF
--- a/test/externalTests/solc-js/DAO/Token.sol
+++ b/test/externalTests/solc-js/DAO/Token.sol
@@ -23,7 +23,7 @@ corresponding approval process. Tokens need to be created by a derived
 contract (e.g. TokenCreation.sol).
 
 Thank you ConsenSys, this contract originated from:
-https://github.com/ConsenSys/Tokens/blob/master/Token_Contracts/contracts/Standard_Token.sol
+https://github.com/ConsenSys/Token-Factory/blob/master/contracts/StandardToken.sol
 Which is itself based on the Ethereum standardized contract APIs:
 https://github.com/ethereum/wiki/wiki/Standardized_Contract_APIs
 */


### PR DESCRIPTION
Replaced the outdated ConsenSys Standard_Token.sol GitHub URL in the Token.sol file header with the current valid link:
https://github.com/ConsenSys/Token-Factory/blob/master/contracts/StandardToken.sol
This ensures that future readers and developers are directed to the correct source for the standard token contract reference.