### PR TITLE
workflow: added github workflow automated linux-arm64 builds via native arm runners

### DIFF
--- a/.github/workflows/build-linux-arm64-solc.yml
+++ b/.github/workflows/build-linux-arm64-solc.yml
@@ -1,0 +1,83 @@
+name: Build Solidity ARM64 Binary
+run-name: Build solc-linux-arm64-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || 'develop' }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Solidity version to build (e.g., v0.8.24)'
+        required: false
+        default: 'v0.8.24'
+        type: string
+  # push:
+  #   branches: [ develop ]
+  # pull_request:
+  #   branches: [ develop ]
+
+jobs:
+  build-arm64:
+    runs-on: ubuntu-24.04-arm  # Native ARM runner
+    
+    steps:
+      - name: Determine version to build
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="develop"
+          fi
+          echo "Building version: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          
+          # Extract clean version for filename (remove 'v' prefix if present)
+          CLEAN_VERSION=$(echo "$VERSION" | sed 's/^v//')
+          echo "clean_version=$CLEAN_VERSION" >> $GITHUB_OUTPUT
+          
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.version.outputs.version }}
+          
+      # No QEMU needed - we're on native ARM!
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        
+      - name: Apply cross-compilation patches
+        run: |
+          echo "Patching missing includes for cross-compilation..."
+          sed -i '/#include <string>/a #include <cstdint>' liblangutil/Token.h
+          
+      - name: Build ARM64 binary
+        run: |
+          # Build directly on ARM - no platform specification needed
+          docker build \
+            -t solc-arm64:latest \
+            -f scripts/Dockerfile \
+            .
+            
+      - name: Extract and rename binary
+        run: |
+          # Create container and extract binary
+          docker create --name temp-container solc-arm64:latest
+          docker cp temp-container:/usr/bin/solc ./solc-temp
+          docker rm temp-container
+          
+          # Rename binary with version
+          BINARY_NAME="solc-linux-arm64-v${{ steps.version.outputs.clean_version }}"
+          mv ./solc-temp "./$BINARY_NAME"
+          
+          # Make it executable
+          chmod +x "./$BINARY_NAME"
+          
+          # Display file info
+          echo "Binary created: $BINARY_NAME"
+          ls -la "./$BINARY_NAME"
+          file "./$BINARY_NAME"
+          
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: solc-linux-arm64-v${{ steps.version.outputs.clean_version }}
+          path: solc-linux-arm64-v${{ steps.version.outputs.clean_version }}

--- a/.github/workflows/build-qemu-linux-arm64-solc.yml
+++ b/.github/workflows/build-qemu-linux-arm64-solc.yml
@@ -1,0 +1,85 @@
+name: Build Solidity ARM64 Binary (QEMU + x86 runners)
+run-name: Build solc-linux-arm64-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || 'develop' }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Solidity version to build (e.g., v0.8.24)'
+        required: false
+        default: 'v0.8.24'
+        type: string
+  # push:
+  #   branches: [ develop ]
+  # pull_request:
+  #   branches: [ develop ]
+
+jobs:
+  build-arm64:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Determine version to build
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="develop"
+          fi
+          echo "Building version: $VERSION"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          
+          # Extract clean version for filename (remove 'v' prefix if present)
+          CLEAN_VERSION=$(echo "$VERSION" | sed 's/^v//')
+          echo "clean_version=$CLEAN_VERSION" >> $GITHUB_OUTPUT
+          
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.version.outputs.version }}
+          
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        
+      - name: Apply cross-compilation patches
+        run: |
+          echo "Patching missing includes for cross-compilation..."
+          sed -i '/#include <string>/a #include <cstdint>' liblangutil/Token.h
+          
+      - name: Build ARM64 binary
+        run: |
+          docker buildx build \
+            --platform linux/arm64 \
+            --load \
+            -t solc-arm64:latest \
+            -f scripts/Dockerfile \
+            .
+            
+      - name: Extract and rename binary
+        run: |
+          # Create container and extract binary
+          docker create --name temp-container solc-arm64:latest
+          docker cp temp-container:/usr/bin/solc ./solc-temp
+          docker rm temp-container
+          
+          # Rename binary with version
+          BINARY_NAME="solc-linux-arm64-v${{ steps.version.outputs.clean_version }}"
+          mv ./solc-temp "./$BINARY_NAME"
+          
+          # Make it executable
+          chmod +x "./$BINARY_NAME"
+          
+          # Display file info
+          echo "Binary created: $BINARY_NAME"
+          ls -la "./$BINARY_NAME"
+          file "./$BINARY_NAME"
+          
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: solc-linux-arm64-v${{ steps.version.outputs.clean_version }}
+          path: solc-linux-arm64-v${{ steps.version.outputs.clean_version }}


### PR DESCRIPTION
## Rationale
There has been a demand for verifiable linux-arm64 builds for some time ( #11351 ) so I decided to create a Github workflow where you can specify the version string (e.g. v0.8.24) and it will build the binary and upload it as an artifact. Currently the workflow is configured to only manually run, but if feel free to modify this to e.g. build the latest version at every new release. I added one workflow that uses arm-native runners (fast) and a slow runner that uses qemu+x86 runners. I had to dynamically include `cstdint` library to fix the runner's build step.