### PR TITLE
Update GitHub Actions Stale Workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v6
+      - uses: actions/stale@v9
         with:
           debug-only: false
           days-before-issue-stale: ${{ env.BEFORE_ISSUE_STALE }}


### PR DESCRIPTION
Changes Made:
Updated from actions/stale@v6 to actions/stale@v9
This update brings the latest version of the stale action, which includes several improvements from v9.1.0 release: https://github.com/actions/stale/releases/tag/v9.1.0