### PR TITLE
 Update sphinx-a4doc URL format in requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,7 @@ sphinx_rtd_theme>=0.5.2, <3.0.0
 pygments-lexer-solidity>=0.7.0
 sphinx-a4doc>=1.6.0; python_version < '3.13'
 # todo remove this once there is a version > 1.6.0
-sphinx-a4doc @ git+https://github.com/taminomara/sphinx-a4doc@f63d3b2; python_version >= '3.13'
+sphinx-a4doc @ git+https://github.com/taminomara/sphinx-a4doc/commit/f63d3b2; python_version >= '3.13'
 
 # Sphinx 2.1.0 is the oldest version that accepts a lexer class in add_lexer()
 sphinx>=2.1.0, <9.0


### PR DESCRIPTION
# Update sphinx-a4doc URL format in requirements.txt

### File: docs/requirements.txt
Changed the sphinx-a4doc URL format:
- Old: `sphinx-a4doc @ git+https://github.com/taminomara/sphinx-a4doc@f63d3b2; python_version >= '3.13'`
+ New: `sphinx-a4doc @ git+https://github.com/taminomara/sphinx-a4doc/commit/f63d3b2; python_version >= '3.13'`

