### PR TITLE
Replace string comparisons with empty() method

### DIFF
--- a/libsolidity/parsing/DocStringParser.cpp
+++ b/libsolidity/parsing/DocStringParser.cpp
@@ -163,7 +163,7 @@ DocStringParser::iter DocStringParser::parseDocTag(iter _pos, iter _end, std::st
 {
 	// TODO: need to check for @(start of a tag) between here and the end of line
 	// for all cases.
-	if (!m_lastTag || _tag != "")
+	if (!m_lastTag || !_tag.empty())
 	{
 		if (_tag == "param")
 			return parseDocTagParam(_pos, _end);

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -217,7 +217,7 @@ void Parser::parsePragmaVersion(SourceLocation const& _location, std::vector<Tok
 
 ASTPointer<StructuredDocumentation> Parser::parseStructuredDocumentation()
 {
-	if (m_scanner->currentCommentLiteral() != "")
+	if (!m_scanner->currentCommentLiteral().empty())
 	{
 		ASTNodeFactory nodeFactory{*this};
 		nodeFactory.setLocation(m_scanner->currentCommentLocation());
@@ -1445,7 +1445,7 @@ ASTPointer<Statement> Parser::parseStatement(bool _allowUnchecked)
 	RecursionGuard recursionGuard(*this);
 	ASTPointer<ASTString> docString;
 	ASTPointer<Statement> statement;
-	if (m_scanner->currentCommentLiteral() != "")
+	if (!m_scanner->currentCommentLiteral().empty())
 		docString = std::make_shared<ASTString>(m_scanner->currentCommentLiteral());
 	switch (m_scanner->currentToken())
 	{


### PR DESCRIPTION
Replace inefficient string comparisons with empty string ("") with the more idiomatic and efficient empty() method. This improves code readability and follows C++ best practices.