### PR TITLE
add "--break-system-packages" to pip install on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ commands:
             if [[ "<< parameters.packages >>" != "" ]]
             then
               echo "Installing additional packages..."
-              python3 -m pip install --user << parameters.packages >>
+              python3 -m pip install --user --break-system-packages << parameters.packages >>
             fi
 
   install_foundry:


### PR DESCRIPTION
`pip install` or even `pip install --user` on its own does not work anymore on recent ubuntu and python versions to prevent breaking system packages (PEP 0668)