### PR TITLE
external tests: pin gnosis to v1.4.1

### DIFF
--- a/test/externalTests/gnosis.sh
+++ b/test/externalTests/gnosis.sh
@@ -37,7 +37,7 @@ function test_fn { npm test; }
 function gnosis_safe_test
 {
     local repo="https://github.com/safe-global/safe-contracts.git"
-    local ref="<latest-release>"
+    local ref="v1.4.1"
     local config_file="hardhat.config.ts"
     local config_var=userConfig
 


### PR DESCRIPTION
it fails with a type error in OZ for v1.5.0