### PR TITLE
Fix input file name display in benchmark_contract function

### DIFF
--- a/test/benchmarks/local.sh
+++ b/test/benchmarks/local.sh
@@ -50,6 +50,9 @@ function benchmark_contract {
     local pipeline="$1"
     local input_path="$2"
 
+    local input_file
+    input_file=$(basename "$input_path")
+
     local solc_command=("${solc}" --optimize --bin --color "${input_path}")
     [[ $pipeline == ir ]] && solc_command+=(--via-ir)
     local time_file="${output_dir}/time-and-status-${pipeline}.txt"


### PR DESCRIPTION
Previously, the benchmark_contract function used the input_file variable, which was not defined within the function scope, leading to incorrect or empty file names in the benchmark output table.
This commit ensures that input_file is correctly set to the basename of the input path inside the function, so the results table now accurately displays the contract file name for each benchmarked contract.