### PR TITLE
yulrun: Move dialect check of parse step after analyze

### DIFF
--- a/test/tools/yulrun.cpp
+++ b/test/tools/yulrun.cpp
@@ -63,11 +63,11 @@ std::pair<std::shared_ptr<AST const>, std::shared_ptr<AsmAnalysisInfo>> parse(st
 		solidity::frontend::OptimiserSettings::none(),
 		DebugInfoSelection::Default()
 	);
-	auto const* evmDialect = dynamic_cast<EVMDialect const*>(&stack.dialect());
-	// TODO: Add EOF support
-	solUnimplementedAssert(evmDialect && !evmDialect->eofVersion(), "No EOF support for yulrun yet.");
 	if (stack.parseAndAnalyze("--INPUT--", _source))
 	{
+		auto const* evmDialect = dynamic_cast<EVMDialect const*>(&stack.dialect());
+		// TODO: Add EOF support
+		solUnimplementedAssert(evmDialect && !evmDialect->eofVersion(), "No EOF support for yulrun yet.");
 		yulAssert(!Error::hasErrorsWarningsOrInfos(stack.errors()), "Parsed successfully but had errors.");
 		return make_pair(stack.parserResult()->code(), stack.parserResult()->analysisInfo);
 	}


### PR DESCRIPTION
The yul stack only has a dialect set when it is past the analysis stage.

Fixes #16104.