### PR TITLE
CircleCI slimming [WIP]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1889,7 +1889,6 @@ workflows:
 
       # build-only
       - b_docs: *requires_nothing
-      - b_ubu_ossfuzz: *requires_nothing
       - b_ubu_2204: *requires_nothing
       - b_ubu_2204_clang: *requires_nothing
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,25 @@ commands:
               echo "ccache not available, skipping configuration"
             fi
 
+  finalize_ccache:
+    parameters:
+      os:
+        type: string
+    steps:
+      - run:
+          name: Show ccache stats
+          command: |
+            if command -v ccache &> /dev/null; then
+              echo "ccache final stats:"
+              ccache --show-stats
+            else
+              echo "ccache not available"
+            fi
+      - save_cache:
+          key: ccache-v1-<<parameters.os>>-{{ arch }}-{{ .Branch }}-{{ checksum "/tmp/all-cmake-files.txt" }}
+          paths:
+            - ~/.ccache
+
   setup_prerelease_commit_hash:
     steps:
       - run:
@@ -255,15 +274,8 @@ commands:
       - run:
           name: Build
           command: scripts/ci/build.sh
-      - run:
-          name: Show ccache stats
-          command: |
-            echo "ccache final stats:"
-            ccache --show-stats
-      - save_cache:
-          key: ccache-v1-<<parameters.os>>-{{ arch }}-{{ .Branch }}-{{ checksum "/tmp/all-cmake-files.txt" }}
-          paths:
-            - ~/.ccache
+      - finalize_ccache:
+          os: <<parameters.os>>
 
   run_build_ossfuzz:
     steps:
@@ -1290,10 +1302,14 @@ jobs:
       MAKEFLAGS: -j 10
     steps:
       - checkout
+      - setup_ccache:
+          os: ems
       - run:
           name: Build
           command: |
             scripts/ci/build_emscripten.sh
+      - finalize_ccache:
+          os: ems
       - store_artifacts:
           path: upload/soljson.js
           destination: soljson.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,6 +186,52 @@ commands:
   # --------------------------------------------------------------------------
   # Build Commands
 
+  setup_ccache:
+    parameters:
+      os:
+        type: string
+        default: "undefined"
+    steps:
+      - run:
+          name: Create CMake files checksum
+          command: |
+            find . -name "CMakeLists.txt" -exec cat {} \; > /tmp/all-cmake-files.txt
+      - restore_cache:
+          keys:
+            - ccache-v1-<<parameters.os>>-{{ arch }}-{{ .Branch }}-{{ checksum "/tmp/all-cmake-files.txt" }}
+            - ccache-v1-<<parameters.os>>-{{ arch }}-{{ .Branch }}-
+            - ccache-v1-<<parameters.os>>-{{ arch }}-
+      - run:
+          name: Install and configure ccache
+          command: |
+            # Install ccache if not present (cmake will use it, via EthCcache)
+            if ! command -v ccache &> /dev/null; then
+              if command -v brew &> /dev/null; then
+                brew install ccache
+              elif command -v apt &> /dev/null; then
+                sudo apt update
+                sudo apt install -y ccache
+              elif command -v pacman &> /dev/null; then
+                # ArchLinux
+                sudo pacman --noconfirm -S ccache
+              else
+                echo "Warning: Unknown package manager, ccache may not be available"
+              fi
+            fi
+
+            # Configure ccache settings (only if ccache is available)
+            if command -v ccache &> /dev/null; then
+              ccache --set-config max_size=2G
+              ccache --set-config cache_dir=$HOME/.ccache
+              ccache --zero-stats
+
+              # Show initial stats
+              echo "ccache initial stats:"
+              ccache --show-stats
+            else
+              echo "ccache not available, skipping configuration"
+            fi
+
   setup_prerelease_commit_hash:
     steps:
       - run:
@@ -199,10 +245,25 @@ commands:
             echo -n "$CIRCLE_SHA1" > commit_hash.txt
 
   run_build:
+    parameters:
+      os:
+        type: string
+        default: "undefined"
     steps:
+      - setup_ccache:
+          os: <<parameters.os>>
       - run:
           name: Build
           command: scripts/ci/build.sh
+      - run:
+          name: Show ccache stats
+          command: |
+            echo "ccache final stats:"
+            ccache --show-stats
+      - save_cache:
+          key: ccache-v1-<<parameters.os>>-{{ arch }}-{{ .Branch }}-{{ checksum "/tmp/all-cmake-files.txt" }}
+          paths:
+            - ~/.ccache
 
   run_build_ossfuzz:
     steps:
@@ -341,9 +402,14 @@ commands:
       - matrix_notify_failure_unless_pr
 
   build:
+    parameters:
+      os:
+        type: string
+        default: "undefined"
     steps:
       - checkout
-      - run_build
+      - run_build:
+          os: << parameters.os >>
       - store_artifacts_solc
       - store_artifacts_yul_phaser
       - persist_executables_to_workspace
@@ -1034,7 +1100,8 @@ jobs:
     # Enough other jobs depend on it that it's worth it though.
     <<: *base_ubuntu2404_xlarge
     steps:
-      - build
+      - build:
+          os: ubu
 
   # x64 ASAN build, for testing for memory related bugs
   b_ubu_asan: &b_ubu_asan
@@ -1051,7 +1118,8 @@ jobs:
       # Set the number of jobs to two instead of the default three, so that we do not run out of memory
       MAKEFLAGS: -j 2
     steps:
-      - build
+      - build:
+          os: ubu_asan
 
   b_ubu_clang: &b_ubu_clang
     <<: *base_ubuntu2404_clang_large
@@ -1059,7 +1127,8 @@ jobs:
       <<: *base_ubuntu2404_clang_large_env
       MAKEFLAGS: -j 10
     steps:
-      - build
+      - build:
+          os: ubu_clang
 
   b_ubu_san_clang:
     # This runs a bit faster on large and xlarge but on nightly efficiency matters more.
@@ -1072,7 +1141,8 @@ jobs:
       # NOTE: Disabled pedantic builds to avoid false positives, see b_ubu_asan for a more detailed explanation.
       CMAKE_OPTIONS: -DPEDANTIC=OFF << parameters.cmake_options >>
     steps:
-      - build
+      - build:
+          os: ubu_san_clang
 
   b_ubu_force_release: &b_ubu_force_release
     <<: *b_ubu
@@ -1091,7 +1161,8 @@ jobs:
       CMAKE_OPTIONS: -DCMAKE_BUILD_TYPE=Release -DSOLC_LINK_STATIC=ON
     steps:
       - checkout
-      - run_build
+      - run_build:
+          os: ubu
       - run:
           name: strip binary
           command: strip build/solc/solc
@@ -1109,7 +1180,8 @@ jobs:
     <<: *base_ubuntu2204_large
     steps:
       - checkout
-      - run_build
+      - run_build:
+          os: ubu_2204
       - matrix_notify_failure_unless_pr
 
   b_ubu_2204_clang:
@@ -1119,7 +1191,8 @@ jobs:
       MAKEFLAGS: -j 10
     steps:
       - checkout
-      - run_build
+      - run_build:
+          os: ubu_2204_clang
       - matrix_notify_failure_unless_pr
 
   b_ubu_ossfuzz: &b_ubu_ossfuzz
@@ -1157,7 +1230,8 @@ jobs:
           command: |
             pacman --noconfirm -Syu --noprogressbar --needed base-devel boost cmake git openssh tar
       - checkout
-      - run_build
+      - run_build:
+          os: archlinux
       - store_artifacts_solc
       - persist_executables_to_workspace
       - matrix_notify_failure_unless_pr
@@ -1172,7 +1246,8 @@ jobs:
     steps:
       - checkout
       - install_dependencies_osx
-      - run_build
+      - run_build:
+          os: mac
       - store_artifacts_solc
       - store_artifacts_yul_phaser
       - persist_executables_to_workspace_osx

--- a/scripts/ci/build_emscripten.sh
+++ b/scripts/ci/build_emscripten.sh
@@ -74,6 +74,8 @@ function build() {
         -DBoost_USE_STATIC_LIBS=1 \
         -DBoost_USE_STATIC_RUNTIME=1 \
         -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS}" \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
         -DTESTS=0 \
     ..
     make soljson


### PR DESCRIPTION
- [x] only run b_ubu_ossfuzz during nightly fuzz run (~24m Large)
- [ ] only run chk_antlr_grammar when the grammar changes (~11m Small)
- [ ] use ccache for solc builds
- [ ] docs-only PRs should only run a build-docs github action (big savings for many PRs)
- [ ] skip archlinux build & test for PRs, unless a cmake file changes (~17m Large)
- [ ] only run tests on linux for most commits, and full ci on PR approval or manual 'run-full-ci' github label? (big savings)
- [ ] move ossfuzz nightly job to a "scheduled pipeline", and run it half as often? (24m Large, 67m Small)
- [ ] investigate b_alpine_docker (44m Medium)
       >   # Always build from scratch to use current packages.
       >   # This job is only meant to run nightly so build time is not an issue.
       >   docker_layer_caching: false
