### PR TITLE
Yul: NoOutputAssembly assigns functions instead of appending

### DIFF
--- a/libyul/backends/evm/NoOutputAssembly.cpp
+++ b/libyul/backends/evm/NoOutputAssembly.cpp
@@ -212,13 +212,13 @@ NoOutputEVMDialect::NoOutputEVMDialect(EVMDialect const& _copyFrom):
 	// them in one go, later reference pointers to this static vector
 	static std::vector<BuiltinFunctionForEVM> noOutputBuiltins = defineNoOutputBuiltins();
 
-	m_functions.reserve(m_functions.size());
+	yulAssert(m_functions.size() == noOutputBuiltins.size(), "Function count mismatch.");
 	for (auto const& [index, builtinFunction]: m_functions | ranges::views::enumerate)
 	{
 		if (builtinFunction)
-			m_functions.emplace_back(&noOutputBuiltins[index]);
+			m_functions[index] = &noOutputBuiltins[index];
 		else
-			m_functions.emplace_back(nullptr);
+			m_functions[index] = nullptr;
 	}
 }
 


### PR DESCRIPTION
There was an implementation error in that the functions were already part of the dialect (via the parent constructor) and the no output versions were appended instead of overwritten. This causes the vector to be re-allocated and therefore could invalidate pointers to its elements while looping over it.

Introduced in https://github.com/ethereum/solidity/pull/15961, discovered here https://app.circleci.com/pipelines/github/ethereum/solidity/40009/workflows/9d961d8e-2275-438b-82ee-311147bdba51