### PR TITLE
CI: Update cimg/node to 20.19 for gp2 and pool together

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -823,7 +823,7 @@ defaults:
       # NOTE: test suite disabled due to dependence on a specific version of Hardhat
       # which does not support shanghai EVM.
       compile_only: 1
-      image: cimg/node:18.16
+      image: cimg/node:20.19
 
   - job_native_test_ext_uniswap: &job_native_test_ext_uniswap
       <<: *requires_b_ubu_static
@@ -876,7 +876,7 @@ defaults:
       binary_type: native
       # NOTE: test suite disabled due to constant failures.
       compile_only: 1
-      image: cimg/node:18.16
+      image: cimg/node:20.19
 
   - job_b_ubu_asan_clang: &job_b_ubu_asan_clang
       <<: *on_all_tags_and_branches


### PR DESCRIPTION
Requirement of the micro-eth-signer dependency.