### PR TITLE
Only build documentation if files under docs folder changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@
 #     - ubu: ubuntu
 #     - ems: Emscripten
 version: 2.1
+
+
 parameters:
   ubuntu-2004-docker-image:
     type: string
@@ -35,9 +37,17 @@ parameters:
   evm-version:
     type: string
     default: prague
+  # Path filtering parameters
+  run-main-workflow:
+    type: boolean
+    default: true
+  run-docs-workflow:
+    type: boolean
+    default: false
 
 orbs:
   win: circleci/windows@2.2.0
+  path-filtering: circleci/path-filtering@2.0.1
 
 commands:
   matrix_notify_unless_pr:
@@ -1872,7 +1882,23 @@ jobs:
 workflows:
   version: 2
 
+  setup:
+    jobs:
+      - path-filtering/filter:
+          name: filter-docs
+          mapping: |
+            docs/.* run-docs-workflow true run-main-workflow false
+          # FIXME: << pipeline.git.base_revision >> seems to be empty sometimes so for now we are using the develop branch as base
+          base-revision: develop
+          config-path: .circleci/config.yml
+
+  docs:
+    when: << pipeline.parameters.run-docs-workflow >>
+    jobs:
+      - b_docs: *requires_nothing
+
   main:
+    when: << pipeline.parameters.run-main-workflow >>
     jobs:
       # basic checks
       - chk_spelling: *requires_nothing
@@ -1887,8 +1913,6 @@ workflows:
       - t_ubu_pyscripts: *requires_nothing
       - t_win_pyscripts: *requires_nothing
 
-      # build-only
-      - b_docs: *requires_nothing
       - b_ubu_ossfuzz: *requires_nothing
       - b_ubu_2204: *requires_nothing
       - b_ubu_2204_clang: *requires_nothing


### PR DESCRIPTION
This PR addresses one suggestion from: https://github.com/ethereum/solidity/pull/16125.

I've added a dynamic configuration in our CircleCI setup to run documentation builds only when files in the docs folder are modified (reference: https://circleci.com/docs/dynamic-config/#use-dynamic-configuration).

Note that workflow reruns may fail due to how CircleCI's dynamic setups work:

```
A pipeline can only be continued once. A pipeline cannot be continued with another setup configuration.
Workflow reruns will fail as part of this restriction. Rather than rerun a setup workflow you can trigger a new pipeline.
```

To be able to do that, I enabled the following option in the project CircleCI configuration: `Project settings > Advanced -> Dynamic config using setup workflows`