### PR TITLE
docs: fix unnecessary `uint160(bytes20(b))` casting

### DIFF
--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -229,7 +229,7 @@ Operators:
     To reduce conversion ambiguity, starting with version 0.4.24, the compiler will force you to make the truncation explicit in the conversion.
     Take for example the 32-byte value ``0x111122223333444455556666777788889999AAAABBBBCCCCDDDDEEEEFFFFCCCC``.
 
-    You can use ``address(uint160(bytes20(b)))``, which results in ``0x111122223333444455556666777788889999aAaa``,
+    You can use ``address(bytes20(b))``, which results in ``0x111122223333444455556666777788889999aAaa``,
     or you can use ``address(uint160(uint256(b)))``, which results in ``0x777788889999AaAAbBbbCcccddDdeeeEfFFfCcCc``.
 
 .. note::


### PR DESCRIPTION
Fixes: https://github.com/ethereum/solidity/issues/16129.