### PR TITLE
Update units-and-global-variables.rst

### DIFF
--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -73,7 +73,7 @@ or are general-use utility functions.
 Block and Transaction Properties
 --------------------------------
 
-- ``blockhash(uint blockNumber) returns (bytes32)``: hash of the given block when ``blocknumber`` is one of the 256 most recent blocks; otherwise returns zero
+- ``blockhash(uint blockNumber) returns (bytes32)``: hash of the given block when ``blockNumber`` is one of the 256 most recent blocks; otherwise returns zero
 - ``blobhash(uint index) returns (bytes32)``: versioned hash of the ``index``-th blob associated with the current transaction.
   A versioned hash consists of a single byte representing the version (currently ``0x01``), followed by the last 31 bytes
   of the SHA256 hash of the KZG commitment (`EIP-4844 <https://eips.ethereum.org/EIPS/eip-4844>`_).


### PR DESCRIPTION
docs(units-and-global-variables): fix casing of blockNumber in blockhash description