### PR TITLE
Remove unused m_resolveCache member from ControlFlowRevertPruner

### DIFF
--- a/libsolidity/analysis/ControlFlowRevertPruner.h
+++ b/libsolidity/analysis/ControlFlowRevertPruner.h
@@ -57,10 +57,5 @@ private:
 	/// function/contract pairs mapped to their according revert state
 	std::map<CFG::FunctionContractTuple, RevertState> m_functions;
 
-	std::map<
-		std::tuple<FunctionCall const*, ContractDefinition const*>,
-		FunctionDefinition const*
-	> m_resolveCache;
-
 };
 }


### PR DESCRIPTION
Remove unused m_resolveCache member that was leftover from incomplete
function resolution caching optimization. The cache was never used and
doesn't match the current architecture where function resolution happens
during CFG construction.