### PR TITLE
docs, scripts: Fix inheritance explanation and help text typo

### DIFF
--- a/docs/contracts/inheritance.rst
+++ b/docs/contracts/inheritance.rst
@@ -229,7 +229,7 @@ The way around this is to use ``super``:
 If ``Final`` calls a function of ``super``, it does not simply
 call this function on one of its base contracts.  Rather, it
 calls this function on the next base contract in the final
-inheritance graph, so it will call ``Base1.emitEvent()`` (note that
+inheritance graph, so it will call ``Base2.emitEvent()`` (note that
 the final inheritance sequence is -- starting with the most
 derived contract: Final, Base2, Base1, Emittable, Owned).
 The actual function that is called when using super is

--- a/scripts/externalTests/benchmark_diff.py
+++ b/scripts/externalTests/benchmark_diff.py
@@ -350,7 +350,7 @@ def process_commandline() -> CommandLineOptions:
         choices=[m.value for m in DiffMode],
         help=(
             "Diff mode: "
-            f"'{DiffMode.IN_PLACE.value}' preserves input JSON structure and replace values with differences; "
+            f"'{DiffMode.IN_PLACE.value}' preserves input JSON structure and replaces values with differences; "
             f"'{DiffMode.TABLE.value}' creates a table assuming 3-level project/preset/attribute structure."
         )
     )


### PR DESCRIPTION
docs/contracts/inheritance.rst:

- The text incorrectly stated that a `super` call in a contract defined as `Final is Base1, Base2` would invoke the function in `Base1`.
- According to Solidity's C3 linearization rules (right-to-left), the next contract in the inheritance graph is `Base2`. The change corrects the text to state that `Base2.emitEvent()` is called, resolving a logical contradiction in the documentation.



scripts/externalTests/benchmark_diff.py: 

- The verb `replace` was changed to `replaces` to agree with its singular subject, improving the clarity of the script's usage instructions.
