### PR TITLE
[SMTChecker] Fix comparison of `CHCVerificationTarget` for proper `std::set` ordering

### DIFF
--- a/libsolidity/formal/CHC.h
+++ b/libsolidity/formal/CHC.h
@@ -74,18 +74,10 @@ public:
 
 		friend bool operator<(CHCVerificationTarget const& _a, CHCVerificationTarget const& _b)
 		{
-			return _a.errorId < _b.errorId;
-		}
-	};
-
-	struct SafeTargetsCompare
-	{
-		bool operator()(CHCVerificationTarget const & _lhs, CHCVerificationTarget const & _rhs) const
-		{
-			if (_lhs.errorNode->id() == _rhs.errorNode->id())
-				return _lhs.type  < _rhs.type;
+			if (_a.errorNode->id() == _b.errorNode->id())
+				return _a.type < _b.type;
 			else
-				return _lhs.errorNode->id() == _rhs.errorNode->id();
+				return _a.errorNode->id() < _b.errorNode->id();
 		}
 	};
 
@@ -96,7 +88,7 @@ public:
 		std::string message;
 	};
 
-	std::map<ASTNode const*, std::set<CHCVerificationTarget, SafeTargetsCompare>, smt::EncodingContext::IdCompare> const& safeTargets() const { return m_safeTargets; }
+	std::map<ASTNode const*, std::set<CHCVerificationTarget>, smt::EncodingContext::IdCompare> const& safeTargets() const { return m_safeTargets; }
 	std::map<ASTNode const*, std::map<VerificationTargetType, ReportTargetInfo>, smt::EncodingContext::IdCompare> const& unsafeTargets() const { return m_unsafeTargets; }
 
 	/// This is used if the Horn solver is not directly linked into this binary.
@@ -434,7 +426,7 @@ private:
 	std::map<unsigned, CHCVerificationTarget> m_verificationTargets;
 
 	/// Targets proved safe.
-	std::map<ASTNode const*, std::set<CHCVerificationTarget, SafeTargetsCompare>, smt::EncodingContext::IdCompare> m_safeTargets;
+	std::map<ASTNode const*, std::set<CHCVerificationTarget>, smt::EncodingContext::IdCompare> m_safeTargets;
 	/// Targets proved unsafe.
 	std::map<ASTNode const*, std::map<VerificationTargetType, ReportTargetInfo>, smt::EncodingContext::IdCompare> m_unsafeTargets;
 	/// Targets not proved.


### PR DESCRIPTION
## What was changed
- Moved comparison logic from `SafeTargetsCompare` struct to `CHCVerificationTarget::operator<`
- Removed the `SafeTargetsCompare` struct completely
- Fixed a bug where `==` was used instead of `<` in the comparison operator
- Updated `std::set<CHCVerificationTarget, SafeTargetsCompare>` to use default `std::set<CHCVerificationTarget>`