### PR TITLE
Switch to `lts` version of node.js in `t_native_test_ext_ens` to fix the failing external ENS test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -779,7 +779,7 @@ defaults:
       name: t_native_test_ext_ens
       project: ens
       binary_type: native
-      image: cimg/node:18.16
+      image: cimg/node:lts
 
   - job_native_compile_ext_trident: &job_native_compile_ext_trident
       <<: *requires_b_ubu_static


### PR DESCRIPTION
Set node cimg to lts as it's one of the recommended approach form hardhat's docs. https://hardhat.org/hardhat-runner/docs/reference/stability-guarantees#node.js-versions-support