### PR TITLE
Refactor Dockerfile: Add Optimizations for Building Dependencies in Dockerfile

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -5,8 +5,16 @@ MAINTAINER chriseth <chris@ethereum.org>
 #Establish working directory as solidity
 WORKDIR /solidity
 
-# Build dependencies
-RUN apk update && apk add boost-dev boost-static build-base cmake git clang
+# Build dependencies 
+RUN apk update && \
+    apk add --no-cache --no-install-recommends \
+        boost-dev \
+        boost-static \
+        build-base \
+        cmake \
+        git \
+        clang && \
+    rm -rf /var/cache/apk/*
 
 #Copy working directory on travis to the image
 COPY / $WORKDIR


### PR DESCRIPTION
**Adding optimization for Building Dependencies**

- Use --no-cache and --no-install-recommends to reduce image size
  Clean up package cache after install
  
**Effect:**
- Easier to maintain and update
- More consistent with Docker community standards
- Slightly smaller and cleaner image