### PR TITLE
chore: remove duplicate word (`file`) from `PYTHONPATH` comment in several Python scripts

### DIFF
--- a/test/scripts/test_bytecodecompare_prepare_report.py
+++ b/test/scripts/test_bytecodecompare_prepare_report.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 
 from unittest_helpers import FIXTURE_DIR, LIBSOLIDITY_TEST_DIR, load_fixture, load_libsolidity_test_case
 
-# NOTE: This test file file only works with scripts/ added to PYTHONPATH so pylint can't find the imports
+# NOTE: This test file only works with scripts/ added to PYTHONPATH so pylint can't find the imports
 # pragma pylint: disable=import-error
 from bytecodecompare.prepare_report import ExecutionArchitecture, CompilerInterface, FileReport, ContractReport
 from bytecodecompare.prepare_report import SettingsPreset, SMTUse, Statistics

--- a/test/scripts/test_externalTests_benchmark_diff.py
+++ b/test/scripts/test_externalTests_benchmark_diff.py
@@ -6,7 +6,7 @@ import unittest
 
 from unittest_helpers import FIXTURE_DIR, load_fixture
 
-# NOTE: This test file file only works with scripts/ added to PYTHONPATH so pylint can't find the imports
+# NOTE: This test file only works with scripts/ added to PYTHONPATH so pylint can't find the imports
 # pragma pylint: disable=import-error
 from externalTests.benchmark_diff import BenchmarkDiffer, DifferenceStyle, DiffTableSet, DiffTableFormatter, OutputFormat
 # pragma pylint: enable=import-error

--- a/test/scripts/test_externalTests_benchmark_downloader.py
+++ b/test/scripts/test_externalTests_benchmark_downloader.py
@@ -6,7 +6,7 @@ from unittest.mock import call, Mock, patch
 import os
 import requests
 
-# NOTE: This test file file only works with scripts/ added to PYTHONPATH so pylint can't find the imports
+# NOTE: This test file only works with scripts/ added to PYTHONPATH so pylint can't find the imports
 # pragma pylint: disable=import-error
 from externalTests.download_benchmarks import download_benchmarks
 # pragma pylint: enable=import-error

--- a/test/scripts/test_externalTests_parse_eth_gas_report.py
+++ b/test/scripts/test_externalTests_parse_eth_gas_report.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 
 from unittest_helpers import FIXTURE_DIR, load_fixture
 
-# NOTE: This test file file only works with scripts/ added to PYTHONPATH so pylint can't find the imports
+# NOTE: This test file only works with scripts/ added to PYTHONPATH so pylint can't find the imports
 # pragma pylint: disable=import-error
 from externalTests.parse_eth_gas_report import parse_report, ReportParsingError, ReportValidationError
 # pragma pylint: enable=import-error

--- a/test/scripts/test_gas_diff_stats.py
+++ b/test/scripts/test_gas_diff_stats.py
@@ -3,7 +3,7 @@
 import unittest
 from textwrap import dedent
 
-# NOTE: This test file file only works with scripts/ added to PYTHONPATH so pylint can't find the imports
+# NOTE: This test file only works with scripts/ added to PYTHONPATH so pylint can't find the imports
 # pragma pylint: disable=import-error
 from gas_diff_stats import collect_statistics
 # pragma pylint: enable=import-error

--- a/test/scripts/test_isolate_tests.py
+++ b/test/scripts/test_isolate_tests.py
@@ -6,7 +6,7 @@ from textwrap import dedent, indent
 
 from unittest_helpers import FIXTURE_DIR, load_fixture
 
-# NOTE: This test file file only works with scripts/ added to PYTHONPATH so pylint can't find the imports
+# NOTE: This test file only works with scripts/ added to PYTHONPATH so pylint can't find the imports
 # pragma pylint: disable=import-error
 from isolate_tests import extract_solidity_docs_cases, extract_yul_docs_cases
 # pragma pylint: enable=import-error


### PR DESCRIPTION
remove redundant word in comment