### PR TITLE
Update GitHub Actions in CI Workflow

### DIFF
--- a/.github/workflows/buildpack-deps.yml
+++ b/.github/workflows/buildpack-deps.yml
@@ -26,7 +26,7 @@ jobs:
         image_variant: [emscripten, ubuntu.clang.ossfuzz, ubuntu2004, ubuntu2204, ubuntu2404, ubuntu2404.clang]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0