### PR TITLE
Remove the hard dependency on `boost::system` compatibility library to fix builds with Boost 1.89.0

### DIFF
--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -29,7 +29,7 @@ if (WIN32)
 	option(Boost_USE_STATIC_RUNTIME "Link Boost against static C++ runtime libraries" ON)
 endif()
 
-set(BOOST_COMPONENTS "filesystem;unit_test_framework;program_options;system")
+set(BOOST_COMPONENTS "filesystem;unit_test_framework;program_options")
 
 # CMake >= 3.30 should not use the vendored boost
 if(POLICY CMP0167)
@@ -50,6 +50,7 @@ else()
 		if(POLICY CMP0167)
 			cmake_policy(SET CMP0167 OLD)
 		endif()
+		list(APPEND BOOST_COMPONENTS system)
 		find_package(Boost 1.67.0 QUIET REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 	endif()
 endif()

--- a/libsolutil/CMakeLists.txt
+++ b/libsolutil/CMakeLists.txt
@@ -47,7 +47,7 @@ set(sources
 )
 
 add_library(solutil ${sources})
-target_link_libraries(solutil PUBLIC Boost::boost Boost::filesystem Boost::system range-v3 fmt::fmt-header-only nlohmann_json::nlohmann_json)
+target_link_libraries(solutil PUBLIC Boost::boost Boost::filesystem ${Boost_SYSTEM_LIBRARY} range-v3 fmt::fmt-header-only nlohmann_json::nlohmann_json)
 target_include_directories(solutil PUBLIC "${PROJECT_SOURCE_DIR}")
 add_dependencies(solutil solidity_BuildInfo.h)
 

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -5,10 +5,10 @@ add_executable(yulrun yulrun.cpp)
 target_link_libraries(yulrun PRIVATE yulInterpreter libsolc evmasm Boost::boost Boost::program_options)
 
 add_executable(solfuzzer afl_fuzzer.cpp fuzzer_common.cpp)
-target_link_libraries(solfuzzer PRIVATE libsolc evmasm Boost::boost Boost::program_options Boost::system)
+target_link_libraries(solfuzzer PRIVATE libsolc evmasm Boost::boost Boost::program_options ${Boost_SYSTEM_LIBRARY})
 
 add_executable(yulopti yulopti.cpp)
-target_link_libraries(yulopti PRIVATE solidity Boost::boost Boost::program_options Boost::system)
+target_link_libraries(yulopti PRIVATE solidity Boost::boost Boost::program_options ${Boost_SYSTEM_LIBRARY})
 
 add_executable(isoltest
 	isoltest.cpp


### PR DESCRIPTION
Boost.System has been header-only since Boost 1.69[^1] and will be dropping the compatibility stub library in Boost 1.89 (boostorg/system@7a495bb).

Since the `system` component is only needed for Boost < 1.69, it can be added to `BOOST_COMPONENTS` in the fallback find_package.

[^1]: https://www.boost.org/doc/libs/1_69_0/libs/system/doc/html/system.html#changes_in_boost_1_69