### PR TITLE
Docs: Quickstart test run + --via-ir optimizer example

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -113,6 +113,24 @@ Solidity includes different types of tests, most of them bundled into the
 `Boost C++ Test Framework <https://www.boost.org/doc/libs/release/libs/test/doc/html/index.html>`_ application ``soltest``.
 Running ``build/test/soltest`` or its wrapper ``scripts/soltest.sh`` is sufficient for most changes.
 
+.. tip::
+
+   **Quickstart: build & run tests once**
+
+   If you just want to verify your environment (for example on GitHub Codespaces), run:
+
+   .. code-block:: bash
+
+      ./scripts/tests.sh
+
+   This runs the Python script tests and other basic checks. To sanity-check only the Boost test runner:
+
+   .. code-block:: bash
+
+      ./scripts/soltest.sh
+      # or directly after a full C++ build:
+      build/test/soltest
+
 The ``./scripts/tests.sh`` script executes most Solidity tests automatically,
 including those bundled into the `Boost C++ Test Framework <https://www.boost.org/doc/libs/release/libs/test/doc/html/index.html>`_
 application ``soltest`` (or its wrapper ``scripts/soltest.sh``), as well as command-line tests and

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -33,6 +33,29 @@ This parameter has effects on the following (this might change in the future):
 - the size of the binary search in the function dispatch routine
 - the way constants like large numbers or strings are stored
 
+.. rubric:: Using ``--via-ir`` with the optimizer (example)
+
+You can compile via the Yul IR pipeline and still use optimizer flags. The following
+uses a small run count which tends to favor smaller bytecode:
+
+.. code-block:: solidity
+
+   // SPDX-License-Identifier: MIT
+   pragma solidity ^0.8.25;
+
+   contract Inc {
+       function add1(uint256 x) external pure returns (uint256) {
+           return x + 1;
+       }
+   }
+
+Compile:
+
+.. code-block:: bash
+
+   solc --via-ir --optimize --optimize-runs=1 Inc.sol --bin --asm
+
+
 .. index:: allowed paths, --allow-paths, base path, --base-path, include paths, --include-path
 
 Base Path and Import Remapping


### PR DESCRIPTION
This PR adds two small, newcomer-friendly docs improvements:

Contributing: a “Quickstart: build & run tests once” snippet so first-time contributors can verify their environment quickly.

Using the compiler: a minimal example showing solc --via-ir used with --optimize and --optimize-runs.

Files changed

docs/contributing.rst — quickstart test run block

docs/using-the-compiler.rst — --via-ir + optimizer example (--optimize-runs=1)

Why
New contributors often look for a single command to build & run tests, and many are unsure how --via-ir interacts with optimizer flags. These short, concrete snippets reduce setup friction and align with current usage.

Verification

Built docs locally with:

./docs/docs.sh
✅ Passed (no warnings/errors).

Scope
Docs-only. No changes to compiler code or behavior.