### PR TITLE
Fix typos in code comments: `toanother`, `an`, `inte`, `axiliary`, `heighht`

### DIFF
--- a/docs/metadata.rst
+++ b/docs/metadata.rst
@@ -66,7 +66,7 @@ explanatory purposes.
           },
           "events": {
             "Transfer(address,address,uint256)": {
-              "details": "Emitted when `value` tokens are moved from one account (`from`) toanother (`to`).",
+              "details": "Emitted when `value` tokens are moved from one account (`from`) to another (`to`).",
               "params": {
                 "from": "The sender address",
                 "to": "The receiver address",

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -287,7 +287,7 @@ Input Description
           // NOTE: The state of the optimizer is fully determined by the 'details' dict and this setting
           // only affects its defaults - when enabled, all components default to being enabled.
           // The opposite is not true - there are several components that always default to being
-          // enabled an can only be explicitly disabled via 'details'.
+          // enabled and can only be explicitly disabled via 'details'.
           // WARNING: Before version 0.8.6 omitting this setting was not equivalent to setting
           // it to false and would result in all components being disabled instead.
           // WARNING: Enabling optimizations for EVMAssembly input is allowed but not necessary under normal

--- a/libevmasm/ControlFlowGraph.h
+++ b/libevmasm/ControlFlowGraph.h
@@ -68,7 +68,7 @@ struct BasicBlock
 {
 	/// Start index into assembly item list.
 	unsigned begin = 0;
-	/// End index (excluded) inte assembly item list.
+	/// End index (excluded) into assembly item list.
 	unsigned end = 0;
 	/// Tags pushed inside this block, with multiplicity.
 	std::vector<BlockId> pushedTags;

--- a/libevmasm/Instruction.h
+++ b/libevmasm/Instruction.h
@@ -193,7 +193,7 @@ enum class Instruction: uint8_t
 	DUPN = 0xe6,              ///< copies a value at the stack depth given as immediate argument to the top of the stack
 	SWAPN = 0xe7,             ///< swaps the highest value with a value at a stack depth given as immediate argument
 	EOFCREATE = 0xec,         ///< create a new account with associated container code.
-	RETURNCONTRACT = 0xee,    ///< return container to be deployed with axiliary data filled in.
+	RETURNCONTRACT = 0xee,    ///< return container to be deployed with auxiliary data filled in.
 	CREATE = 0xf0,            ///< create a new account with associated code
 	CALL,                     ///< message-call into an account
 	CALLCODE,                 ///< message-call with another account's code only

--- a/libevmasm/KnownState.h
+++ b/libevmasm/KnownState.h
@@ -121,7 +121,7 @@ public:
 	unsigned sequenceNumber() const { return m_sequenceNumber; }
 
 	/// Replaces the state by the intersection with _other, i.e. only equal knowledge is retained.
-	/// If the stack heighht is different, the smaller one is used and the stack is compared
+	/// If the stack height is different, the smaller one is used and the stack is compared
 	/// relatively.
 	/// @param _combineSequenceNumbers if true, sets the sequence number to the maximum of both
 	void reduceToCommonKnowledge(KnownState const& _other, bool _combineSequenceNumbers);


### PR DESCRIPTION
docs/metadata.rst
  toanother -> to another
docs/using-the-compiler.rst
  an -> and
libevmasm/ControlFlowGraph.h
  inte -> into
libevmasm/Instruction.h
  axiliary -> auxiliary
libevmasm/KnownState.h
  heighht -> height