### PR TITLE
Add deprecation warnings for `send()`, `transfer()`, ABI coder v1, contract comparisons, virtual modifiers and `memory-safe-assembly` comment

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,11 @@ Language Features:
 Compiler Features:
 * ethdebug: Experimental support for instructions and source locations under EOF.
 * EVM: Set default EVM Version to `osaka`.
+* DocString Parser: Warn about deprecation of inline assembly special comment `memory-safe-assembly`.
+* Syntax Checker: Warn about deprecation of ABI coder v1.
+* Syntax Checker: Warn about deprecation of virtual modifiers.
+* Type Checker: Warn about deprecation of `send` and `transfer` functions on instances of `address`.
+* Type Checker: Warn about deprecation of comparisons between variables of contract types.
 
 Bugfixes:
 * Assembler: Fix not using a fixed-width type for IDs being assigned to subassemblies nested more than one level away, resulting in inconsistent `--asm-json` output between target architectures.

--- a/docs/assembly.rst
+++ b/docs/assembly.rst
@@ -381,8 +381,9 @@ of Solidity, you can use a special comment to annotate an assembly block as memo
         ...
     }
 
-Note that we will disallow the annotation via comment in a future breaking release; so, if you are not concerned with
-backward-compatibility with older compiler versions, prefer using the dialect string.
+.. warning::
+    The ``memory-safe-assembly`` special comment is deprecated and scheduled for removal.
+    In new code targeting recent compilers, use the assembly block annotation.
 
 Advanced Safe Use of Memory
 ---------------------------

--- a/docs/cheatsheet.rst
+++ b/docs/cheatsheet.rst
@@ -53,8 +53,8 @@ Members of ``address``
 - ``<address>.staticcall(bytes memory) returns (bool, bytes memory)``: issue low-level ``STATICCALL`` with the given payload,
   returns success condition and return data
 - ``<address payable>.send(uint256 amount) returns (bool)``: send given amount of Wei to :ref:`address`,
-  returns ``false`` on failure
-- ``<address payable>.transfer(uint256 amount)``: send given amount of Wei to :ref:`address`, throws on failure
+  returns ``false`` on failure (deprecated)
+- ``<address payable>.transfer(uint256 amount)``: send given amount of Wei to :ref:`address`, throws on failure (deprecated)
 
 .. index:: blockhash, blobhash, block, block;basefee, block;blobbasefee, block;chainid, block;coinbase, block;difficulty, block;gaslimit, block;number, block;prevrandao, block;timestamp
 .. index:: gasleft, msg;data, msg;sender, msg;sig, msg;value, tx;gasprice, tx;origin

--- a/docs/contracts/functions.rst
+++ b/docs/contracts/functions.rst
@@ -311,6 +311,10 @@ will consume more gas than the 2300 gas stipend:
 - Sending Ether
 
 .. warning::
+    ``send()`` and ``transfer()`` are deprecated and scheduled for removal.
+    See the section on :ref:`send <send-address-member>` and :ref:`transfer <balance-transfer-address-members>` for more information.
+
+.. warning::
     When Ether is sent directly to a contract (without a function call, i.e. sender uses ``send`` or ``transfer``)
     but the receiving contract does not define a receive Ether function or a payable fallback function,
     an exception will be thrown, sending back the Ether (this was different
@@ -318,7 +322,6 @@ will consume more gas than the 2300 gas stipend:
     you have to implement a receive Ether function (using payable fallback functions for receiving Ether is
     not recommended, since the fallback is invoked and would not fail for interface confusions
     on the part of the sender).
-
 
 .. warning::
     A contract without a receive Ether function can receive Ether as a
@@ -440,6 +443,7 @@ operations as long as there is enough gas passed on to it.
 
             // If someone sends Ether to that contract,
             // the transfer will fail, i.e. this returns false here.
+            // This will report a warning (deprecation)
             return testPayable.send(2 ether);
         }
 

--- a/docs/contracts/inheritance.rst
+++ b/docs/contracts/inheritance.rst
@@ -377,8 +377,8 @@ of the variable:
 
 .. _modifier-overriding:
 
-Modifier Overriding
-===================
+Modifier Overriding (deprecated)
+================================
 
 Function modifiers can override each other. This works in the same way as
 :ref:`function overriding <function-overriding>` (except that there is no overloading for modifiers). The
@@ -392,6 +392,7 @@ and the ``override`` keyword must be used in the overriding modifier:
 
     contract Base
     {
+        // This will report a warning (deprecation)
         modifier foo() virtual {_;}
     }
 
@@ -411,11 +412,13 @@ explicitly:
 
     contract Base1
     {
+        // This will report a warning (deprecation)
         modifier foo() virtual {_;}
     }
 
     contract Base2
     {
+        // This will report a warning (deprecation)
         modifier foo() virtual {_;}
     }
 
@@ -424,6 +427,8 @@ explicitly:
         modifier foo() override(Base1, Base2) {_;}
     }
 
+.. warning::
+    ``virtual`` modifiers are deprecated and scheduled for removal.
 
 
 .. index:: ! constructor

--- a/docs/control-structures.rst
+++ b/docs/control-structures.rst
@@ -692,16 +692,16 @@ and ``assert`` for internal error checking.
     :force:
 
     // SPDX-License-Identifier: GPL-3.0
-    pragma solidity >=0.5.0 <0.9.0;
+    pragma solidity >=0.6.2 <0.9.0;
 
     contract Sharer {
         function sendHalf(address payable addr) public payable returns (uint balance) {
             require(msg.value % 2 == 0, "Even value required.");
             uint balanceBeforeTransfer = address(this).balance;
-            addr.transfer(msg.value / 2);
-            // Since transfer throws an exception on failure and
-            // cannot call back here, there should be no way for us to
-            // still have half of the Ether.
+            (bool success, ) = addr.call{value: msg.value / 2}("");
+            require(success);
+            // Since require will stop execution and revert if success is false,
+            // there should be no way for us to still have half of the Ether.
             assert(address(this).balance == balanceBeforeTransfer - msg.value / 2);
             return address(this).balance;
         }
@@ -775,7 +775,8 @@ together with ``revert`` and the equivalent ``require``:
             if (msg.sender != owner)
                 revert Unauthorized();
 
-            payable(msg.sender).transfer(address(this).balance);
+            (bool success, ) = payable(msg.sender).call{value: address(this).balance}("");
+            require(success);
         }
     }
 

--- a/docs/examples/blind-auction.rst
+++ b/docs/examples/blind-auction.rst
@@ -118,13 +118,14 @@ to receive their Ether - contracts cannot activate themselves.
             if (amount > 0) {
                 // It is important to set this to zero because the recipient
                 // can call this function again as part of the receiving call
-                // before `send` returns.
+                // before `call` returns.
                 pendingReturns[msg.sender] = 0;
 
                 // msg.sender is not of type `address payable` and must be
                 // explicitly converted using `payable(msg.sender)` in order
-                // use the member function `send()`.
-                if (!payable(msg.sender).send(amount)) {
+                // use the member function `call()`.
+                (bool success, ) = payable(msg.sender).call{value: amount}("");
+                if (!success) {
                     // No need to call throw here, just reset the amount owing
                     pendingReturns[msg.sender] = amount;
                     return false;
@@ -160,7 +161,8 @@ to receive their Ether - contracts cannot activate themselves.
             emit AuctionEnded(highestBidder, highestBid);
 
             // 3. Interaction
-            beneficiary.transfer(highestBid);
+            (bool success, ) = beneficiary.call{value: highestBid}("");
+            require(success);
         }
     }
 
@@ -310,7 +312,8 @@ invalid bids.
                 // the same deposit.
                 bidToCheck.blindedBid = bytes32(0);
             }
-            payable(msg.sender).transfer(refund);
+            (bool success, ) = payable(msg.sender).call{value: refund}("");
+            require(success);
         }
 
         /// Withdraw a bid that was overbid.
@@ -319,11 +322,12 @@ invalid bids.
             if (amount > 0) {
                 // It is important to set this to zero because the recipient
                 // can call this function again as part of the receiving call
-                // before `transfer` returns (see the remark above about
+                // before `call` returns (see the remark above about
                 // conditions -> effects -> interaction).
                 pendingReturns[msg.sender] = 0;
 
-                payable(msg.sender).transfer(amount);
+                (bool success, ) = payable(msg.sender).call{value: amount}("");
+                require(success);
             }
         }
 
@@ -336,7 +340,8 @@ invalid bids.
             if (ended) revert AuctionEndAlreadyCalled();
             emit AuctionEnded(highestBidder, highestBid);
             ended = true;
-            beneficiary.transfer(highestBid);
+            (bool success, ) = beneficiary.call{value: highestBid}("");
+            require(success);
         }
 
         // This is an "internal" function which means that it

--- a/docs/examples/micropayment.rst
+++ b/docs/examples/micropayment.rst
@@ -185,7 +185,8 @@ The full contract
             // this recreates the message that was signed on the client
             bytes32 message = prefixed(keccak256(abi.encodePacked(msg.sender, amount, nonce, this)));
             require(recoverSigner(message, signature) == owner);
-            payable(msg.sender).transfer(amount);
+            (bool success, ) = payable(msg.sender).call{value: amount}("");
+            require(success);
         }
 
         /// freeze the contract and reclaim the leftover funds.
@@ -195,7 +196,8 @@ The full contract
         {
             require(msg.sender == owner);
             freeze();
-            payable(msg.sender).transfer(address(this).balance);
+            (bool success, ) = payable(msg.sender).call{value: address(this).balance}("");
+            require(success);
         }
 
         /// signature methods.
@@ -406,9 +408,11 @@ The full contract
             require(msg.sender == recipient);
             require(isValidSignature(amount, signature));
 
-            recipient.transfer(amount);
+            (bool success, ) = recipient.call{value: amount}("");
+            require(success);
             freeze();
-            sender.transfer(address(this).balance);
+            (success, ) = sender.call{value: address(this).balance}("");
+            require(success);
         }
 
         /// the sender can extend the expiration at any time
@@ -430,7 +434,8 @@ The full contract
         {
             require(block.timestamp >= expiration);
             freeze();
-            sender.transfer(address(this).balance);
+            (bool success, ) = sender.call{value: address(this).balance}("");
+            require(success);
         }
 
         function isValidSignature(uint256 amount, bytes memory signature)

--- a/docs/examples/safe-remote.rst
+++ b/docs/examples/safe-remote.rst
@@ -93,11 +93,12 @@ you can use state machine-like constructs inside a contract.
         {
             emit Aborted();
             state = State.Inactive;
-            // We use transfer here directly. It is
+            // We use call here directly. It is
             // reentrancy-safe, because it is the
             // last call in this function and we
             // already changed the state.
-            seller.transfer(address(this).balance);
+            (bool success, ) = seller.call{value: address(this).balance}("");
+            require(success);
         }
 
         /// Confirm the purchase as buyer.
@@ -124,11 +125,12 @@ you can use state machine-like constructs inside a contract.
         {
             emit ItemReceived();
             // It is important to change the state first because
-            // otherwise, the contracts called using `send` below
+            // otherwise, the contracts called using `call` below
             // can call in again here.
             state = State.Release;
 
-            buyer.transfer(value);
+            (bool success, ) = buyer.call{value: value}("");
+            require(success);
         }
 
         /// This function refunds the seller, i.e.
@@ -140,10 +142,11 @@ you can use state machine-like constructs inside a contract.
         {
             emit SellerRefunded();
             // It is important to change the state first because
-            // otherwise, the contracts called using `send` below
+            // otherwise, the contracts called using `call` below
             // can call in again here.
             state = State.Inactive;
 
-            seller.transfer(3 * value);
+            (bool success, ) = seller.call{value: 3 * value}("");
+            require(success);
         }
     }

--- a/docs/layout-of-source-files.rst
+++ b/docs/layout-of-source-files.rst
@@ -103,9 +103,13 @@ select between the two implementations of the ABI encoder and decoder.
 The new ABI coder (v2) is able to encode and decode arbitrarily nested
 arrays and structs. Apart from supporting more types, it involves more extensive
 validation and safety checks, which may result in higher gas costs, but also heightened
-security. It is considered
-non-experimental as of Solidity 0.6.0 and it is enabled by default starting
+security.
+It is considered non-experimental as of Solidity 0.6.0 and it is enabled by default starting
 with Solidity 0.8.0. The old ABI coder can still be selected using ``pragma abicoder v1;``.
+
+.. warning::
+  The ABI coder v1 is deprecated and scheduled for removal.
+  Use ABI coder v2 instead.
 
 The set of types supported by the new encoder is a strict superset of
 the ones supported by the old one. Contracts that use it can interact with ones

--- a/docs/security-considerations.rst
+++ b/docs/security-considerations.rst
@@ -65,6 +65,7 @@ To give an example, the following code contains a bug (it is just a snippet and 
         mapping(address => uint) shares;
         /// Withdraw your share.
         function withdraw() public {
+        // This will report a warning (deprecation)
             if (payable(msg.sender).send(shares[msg.sender]))
                 shares[msg.sender] = 0;
         }
@@ -76,7 +77,7 @@ Ether transfer can always include code execution,
 so the recipient could be a contract that calls back into ``withdraw``.
 This would let it get multiple refunds and, basically, retrieve all the Ether in the contract.
 In particular, the following contract will allow an attacker to refund multiple times
-as it uses ``call`` which forwards all remaining gas by default:
+as it uses ``call`` which does not limit the amount of gas that is forwarded by default:
 
 .. code-block:: solidity
 
@@ -100,7 +101,7 @@ To avoid reentrancy, you can use the Checks-Effects-Interactions pattern as demo
 .. code-block:: solidity
 
     // SPDX-License-Identifier: GPL-3.0
-    pragma solidity >=0.6.0 <0.9.0;
+    pragma solidity >=0.6.2 <0.9.0;
 
     contract Fund {
         /// @dev Mapping of ether shares of the contract.
@@ -109,7 +110,8 @@ To avoid reentrancy, you can use the Checks-Effects-Interactions pattern as demo
         function withdraw() public {
             uint share = shares[msg.sender];
             shares[msg.sender] = 0;
-            payable(msg.sender).transfer(share);
+            (bool success, ) = payable(msg.sender).call{value: share}("");
+            require(success);
         }
     }
 
@@ -158,8 +160,9 @@ Sending and Receiving Ether
   (for example in the "details" section in Remix).
 
 - There is a way to forward more gas to the receiving contract using ``addr.call{value: x}("")``.
-  This is essentially the same as ``addr.transfer(x)``, only that it forwards all remaining gas
-  and opens up the ability for the recipient to perform more expensive actions
+  This is essentially the same as ``addr.transfer(x)``, only that it forwards all remaining gas,
+  subject to additional limits imposed by some EVM versions (such as the `63/64th rule <https://eips.ethereum.org/EIPS/eip-150>`_
+  introduced by ``tangerineWhistle``), and opens up the ability for the recipient to perform more expensive actions
   (and it returns a failure code instead of automatically propagating the error).
   This might include calling back into the sending contract or other state changes you might not have thought of.
   So it allows for great flexibility for honest users but also for malicious actors.
@@ -255,6 +258,7 @@ Let's say you have a wallet contract like this:
         function transferTo(address payable dest, uint amount) public {
             // THE BUG IS RIGHT HERE, you must use msg.sender instead of tx.origin
             require(tx.origin == owner);
+            // This will report a warning (deprecation)
             dest.transfer(amount);
         }
     }

--- a/docs/types/reference-types.rst
+++ b/docs/types/reference-types.rst
@@ -680,7 +680,7 @@ shown in the following example:
 .. code-block:: solidity
 
     // SPDX-License-Identifier: GPL-3.0
-    pragma solidity >=0.6.0 <0.9.0;
+    pragma solidity >=0.6.2 <0.9.0;
 
     // Defines a new type with two fields.
     // Declaring a struct outside of a contract allows
@@ -729,8 +729,8 @@ shown in the following example:
                 return false;
             uint amount = c.amount;
             c.amount = 0;
-            c.beneficiary.transfer(amount);
-            return true;
+            (bool success, ) = c.beneficiary.call{value: amount}("");
+            return success;
         }
     }
 

--- a/docs/types/value-types.rst
+++ b/docs/types/value-types.rst
@@ -242,118 +242,148 @@ Members of Addresses
 
 For a quick reference of all members of address, see :ref:`address_related`.
 
+.. _balance-transfer-address-members:
+
 * ``balance`` and ``transfer``
 
-It is possible to query the balance of an address using the property ``balance``
-and to send Ether (in units of wei) to a payable address using the ``transfer`` function:
+    It is possible to query the balance of an address using the property ``balance``
+    and to send Ether (in units of wei) to a payable address using the ``transfer`` function:
 
-.. code-block:: solidity
-    :force:
+    .. code-block:: solidity
+        :force:
 
-    address payable x = payable(0x123);
-    address myAddress = address(this);
-    if (x.balance < 10 && myAddress.balance >= 10) x.transfer(10);
+        address payable x = payable(0x123);
+        address myAddress = address(this);
+        if (x.balance < 10 && myAddress.balance >= 10) x.transfer(10);
 
-The ``transfer`` function fails if the balance of the current contract is not large enough
-or if the Ether transfer is rejected by the receiving account. The ``transfer`` function
-reverts on failure.
+    The ``transfer`` function fails if the balance of the current contract is not large enough
+    or if the Ether transfer is rejected by the receiving account. The ``transfer`` function
+    reverts on failure.
 
-.. note::
-    If ``x`` is a contract address, its code (more specifically: its :ref:`receive-ether-function`, if present, or otherwise its :ref:`fallback-function`, if present) will be executed together with the ``transfer`` call (this is a feature of the EVM and cannot be prevented). If that execution runs out of gas or fails in any way, the Ether transfer will be reverted and the current contract will stop with an exception.
+    .. note::
+        If ``x`` is a contract address, its code (more specifically: its :ref:`receive-ether-function`, if present, or otherwise its :ref:`fallback-function`, if present) will be executed together with the ``transfer`` call (this is a feature of the EVM and cannot be prevented). If that execution runs out of gas or fails in any way, the Ether transfer will be reverted and the current contract will stop with an exception.
+
+    .. warning::
+        ``transfer`` is deprecated and scheduled for removal.
+        Simple ether transfers can still be performed using the :ref:`call function <address_call_functions>`
+        with with an optionally provided maximum amount of gas and empty payload, i.e., ``call{value: <amount>}("")``.
+        By default this forwards all the remaining gas, subject to additional limits imposed by some EVM versions
+        (such as the `63/64th rule <https://eips.ethereum.org/EIPS/eip-150>`_ introduced by ``tangerineWhistle``).
+        As with any external call, the ``gas`` call option can be used to set a lower limit.
+
+        While it is possible to recreate the functionality by explicitly setting the limit to the value of the stipend (2300 gas),
+        this value no longer holds its original meaning due to changing opcode costs.
+        It is recommended to use different means to protect against reentrancy.
+
+.. _send-address-member:
 
 * ``send``
 
-``send`` is the low-level counterpart of ``transfer``. If the execution fails, the current contract will not stop with an exception, but ``send`` will return ``false``.
+    ``send`` is the low-level counterpart of ``transfer``. If the execution fails, the current contract will not stop with an exception, but ``send`` will return ``false``.
 
-.. warning::
-    There are some dangers in using ``send``: The transfer fails if the call stack depth is at 1024
-    (this can always be forced by the caller) and it also fails if the recipient runs out of gas. So in order
-    to make safe Ether transfers, always check the return value of ``send``, use ``transfer`` or even better:
-    use a pattern where the recipient withdraws the Ether.
+    .. warning::
+        There are some dangers in using ``send``: The transfer fails if the call stack depth is at 1024
+        (this can always be forced by the caller) and it also fails if the recipient runs out of gas. So in order
+        to make safe Ether transfers, always check the return value of ``send``, use ``transfer`` or even better:
+        use a pattern where the recipient withdraws the Ether.
+
+    .. warning::
+        ``send`` is deprecated and scheduled for removal.
+        Simple ether transfers can still be performed using the :ref:`call function <address_call_functions>`
+        with with an optionally provided maximum amount of gas and empty payload, i.e., ``call{value: <amount>}("")``.
+        By default this forwards all the remaining gas, subject to additional limits imposed by some EVM versions
+        (such as the `63/64th rule <https://eips.ethereum.org/EIPS/eip-150>`_ introduced by ``tangerineWhistle``).
+        As with any external call, the ``gas`` call option can be used to set a lower limit.
+
+        While it is possible to recreate the functionality by explicitly setting the limit to the value of the stipend (2300 gas),
+        this value no longer holds its original meaning due to changing opcode costs.
+        It is recommended to use different means to protect against reentrancy.
+
+.. _address_call_functions:
 
 * ``call``, ``delegatecall`` and ``staticcall``
 
-In order to interface with contracts that do not adhere to the ABI,
-or to get more direct control over the encoding,
-the functions ``call``, ``delegatecall`` and ``staticcall`` are provided.
-They all take a single ``bytes memory`` parameter and
-return the success condition (as a ``bool``) and the returned data
-(``bytes memory``).
-The functions ``abi.encode``, ``abi.encodePacked``, ``abi.encodeWithSelector``
-and ``abi.encodeWithSignature`` can be used to encode structured data.
+    In order to interface with contracts that do not adhere to the ABI,
+    or to get more direct control over the encoding,
+    the functions ``call``, ``delegatecall`` and ``staticcall`` are provided.
+    They all take a single ``bytes memory`` parameter and
+    return the success condition (as a ``bool``) and the returned data
+    (``bytes memory``).
+    The functions ``abi.encode``, ``abi.encodePacked``, ``abi.encodeWithSelector``
+    and ``abi.encodeWithSignature`` can be used to encode structured data.
 
-Example:
+    Example:
 
-.. code-block:: solidity
+    .. code-block:: solidity
 
-    bytes memory payload = abi.encodeWithSignature("register(string)", "MyName");
-    (bool success, bytes memory returnData) = address(nameReg).call(payload);
-    require(success);
+        bytes memory payload = abi.encodeWithSignature("register(string)", "MyName");
+        (bool success, bytes memory returnData) = address(nameReg).call(payload);
+        require(success);
 
-.. warning::
-    All these functions are low-level functions and should be used with care.
-    Specifically, any unknown contract might be malicious and if you call it, you
-    hand over control to that contract which could in turn call back into
-    your contract, so be prepared for changes to your state variables
-    when the call returns. The regular way to interact with other contracts
-    is to call a function on a contract object (``x.f()``).
+    .. warning::
+        All these functions are low-level functions and should be used with care.
+        Specifically, any unknown contract might be malicious and if you call it, you
+        hand over control to that contract which could in turn call back into
+        your contract, so be prepared for changes to your state variables
+        when the call returns. The regular way to interact with other contracts
+        is to call a function on a contract object (``x.f()``).
 
-.. note::
-    Previous versions of Solidity allowed these functions to receive
-    arbitrary arguments and would also handle a first argument of type
-    ``bytes4`` differently. These edge cases were removed in version 0.5.0.
+    .. note::
+        Previous versions of Solidity allowed these functions to receive
+        arbitrary arguments and would also handle a first argument of type
+        ``bytes4`` differently. These edge cases were removed in version 0.5.0.
 
-It is possible to adjust the supplied gas with the ``gas`` modifier:
+    It is possible to adjust the supplied gas with the ``gas`` modifier:
 
-.. code-block:: solidity
+    .. code-block:: solidity
 
-    address(nameReg).call{gas: 1000000}(abi.encodeWithSignature("register(string)", "MyName"));
+        address(nameReg).call{gas: 1000000}(abi.encodeWithSignature("register(string)", "MyName"));
 
-Similarly, the supplied Ether value can be controlled too:
+    Similarly, the supplied Ether value can be controlled too:
 
-.. code-block:: solidity
+    .. code-block:: solidity
 
-    address(nameReg).call{value: 1 ether}(abi.encodeWithSignature("register(string)", "MyName"));
+        address(nameReg).call{value: 1 ether}(abi.encodeWithSignature("register(string)", "MyName"));
 
-Lastly, these modifiers can be combined. Their order does not matter:
+    Lastly, these modifiers can be combined. Their order does not matter:
 
-.. code-block:: solidity
+    .. code-block:: solidity
 
-    address(nameReg).call{gas: 1000000, value: 1 ether}(abi.encodeWithSignature("register(string)", "MyName"));
+        address(nameReg).call{gas: 1000000, value: 1 ether}(abi.encodeWithSignature("register(string)", "MyName"));
 
-In a similar way, the function ``delegatecall`` can be used: the difference is that only the code of the given address is used, all other aspects (storage, balance, ...) are taken from the current contract. The purpose of ``delegatecall`` is to use library code which is stored in another contract. The user has to ensure that the layout of storage in both contracts is suitable for delegatecall to be used.
+    In a similar way, the function ``delegatecall`` can be used: the difference is that only the code of the given address is used, all other aspects (storage, balance, ...) are taken from the current contract. The purpose of ``delegatecall`` is to use library code which is stored in another contract. The user has to ensure that the layout of storage in both contracts is suitable for delegatecall to be used.
 
-.. note::
-    Prior to homestead, only a limited variant called ``callcode`` was available that did not provide access to the original ``msg.sender`` and ``msg.value`` values. This function was removed in version 0.5.0.
+    .. note::
+        Prior to homestead, only a limited variant called ``callcode`` was available that did not provide access to the original ``msg.sender`` and ``msg.value`` values. This function was removed in version 0.5.0.
 
-Since byzantium ``staticcall`` can be used as well. This is basically the same as ``call``, but will revert if the called function modifies the state in any way.
+    Since byzantium ``staticcall`` can be used as well. This is basically the same as ``call``, but will revert if the called function modifies the state in any way.
 
-All three functions ``call``, ``delegatecall`` and ``staticcall`` are very low-level functions and should only be used as a *last resort* as they break the type-safety of Solidity.
+    All three functions ``call``, ``delegatecall`` and ``staticcall`` are very low-level functions and should only be used as a *last resort* as they break the type-safety of Solidity.
 
-The ``gas`` option is available on all three methods, while the ``value`` option is only available
-on ``call``.
+    The ``gas`` option is available on all three methods, while the ``value`` option is only available
+    on ``call``.
 
-.. note::
-    It is best to avoid relying on hardcoded gas values in your smart contract code,
-    regardless of whether state is read from or written to, as this can have many pitfalls.
-    Also, access to gas might change in the future.
+    .. note::
+        It is best to avoid relying on hardcoded gas values in your smart contract code,
+        regardless of whether state is read from or written to, as this can have many pitfalls.
+        Also, access to gas might change in the future.
 
 * ``code`` and ``codehash``
 
-You can query the deployed code for any smart contract. Use ``.code`` to get the EVM bytecode as a
-``bytes memory``, which might be empty. Use ``.codehash`` to get the Keccak-256 hash of that code
-(as a ``bytes32``). Note that ``addr.codehash`` is cheaper than using ``keccak256(addr.code)``.
+    You can query the deployed code for any smart contract. Use ``.code`` to get the EVM bytecode as a
+    ``bytes memory``, which might be empty. Use ``.codehash`` to get the Keccak-256 hash of that code
+    (as a ``bytes32``). Note that ``addr.codehash`` is cheaper than using ``keccak256(addr.code)``.
 
-.. warning::
-    The output of ``addr.codehash`` may be ``0`` if the account associated with ``addr`` is empty or non-existent
-    (i.e., it has no code, zero balance, and zero nonce as defined by `EIP-161 <https://eips.ethereum.org/EIPS/eip-161>`_).
-    If the account has no code but a non-zero balance or nonce, then ``addr.codehash`` will output the Keccak-256 hash of empty data
-    (i.e., ``keccak256("")`` which is equal to ``c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470``), as defined by
-    `EIP-1052 <https://eips.ethereum.org/EIPS/eip-1052>`_.
+    .. warning::
+        The output of ``addr.codehash`` may be ``0`` if the account associated with ``addr`` is empty or non-existent
+        (i.e., it has no code, zero balance, and zero nonce as defined by `EIP-161 <https://eips.ethereum.org/EIPS/eip-161>`_).
+        If the account has no code but a non-zero balance or nonce, then ``addr.codehash`` will output the Keccak-256 hash of empty data
+        (i.e., ``keccak256("")`` which is equal to ``c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470``), as defined by
+        `EIP-1052 <https://eips.ethereum.org/EIPS/eip-1052>`_.
 
-.. note::
-    All contracts can be converted to ``address`` type, so it is possible to query the balance of the
-    current contract using ``address(this).balance``.
+    .. note::
+        All contracts can be converted to ``address`` type, so it is possible to query the balance of the
+        current contract using ``address(this).balance``.
 
 .. index:: ! contract type, ! type; contract
 

--- a/docs/units-and-global-variables.rst
+++ b/docs/units-and-global-variables.rst
@@ -252,6 +252,7 @@ Mathematical and Cryptographic Functions
 
 Members of Address Types
 ------------------------
+These members are explained in more detail in the section on :ref:`members of address <members-of-addresses>`.
 
 ``<address>.balance`` (``uint256``)
     balance of the :ref:`address` in Wei
@@ -268,14 +269,21 @@ Members of Address Types
 ``<address payable>.send(uint256 amount) returns (bool)``
     send given amount of Wei to :ref:`address`, returns ``false`` on failure, forwards 2300 gas stipend, not adjustable
 
+.. warning::
+    ``send()`` and ``transfer()`` are deprecated and scheduled for removal.
+    See the section on :ref:`send <send-address-member>` and :ref:`transfer <balance-transfer-address-members>` for more information.
+
 ``<address>.call(bytes memory) returns (bool, bytes memory)``
-    issue low-level ``CALL`` with the given payload, returns success condition and return data, forwards all available gas, adjustable
+    issue low-level ``CALL`` with the given payload, returns success condition and return data,
+    forwards all available gas (subject to additional limits imposed by some EVM versions), adjustable
 
 ``<address>.delegatecall(bytes memory) returns (bool, bytes memory)``
-    issue low-level ``DELEGATECALL`` with the given payload, returns success condition and return data, forwards all available gas, adjustable
+    issue low-level ``DELEGATECALL`` with the given payload, returns success condition and return data,
+    forwards all available gas (subject to additional limits imposed by some EVM versions), adjustable
 
 ``<address>.staticcall(bytes memory) returns (bool, bytes memory)``
-    issue low-level ``STATICCALL`` with the given payload, returns success condition and return data, forwards all available gas, adjustable
+    issue low-level ``STATICCALL`` with the given payload, returns success condition and return data,
+    forwards all available gas (subject to additional limits imposed by some EVM versions), adjustable
 
 For more information, see the section on :ref:`address`.
 

--- a/libsolidity/analysis/DocStringTagParser.cpp
+++ b/libsolidity/analysis/DocStringTagParser.cpp
@@ -206,11 +206,18 @@ bool DocStringTagParser::visit(InlineAssembly const& _assembly)
 							m_errorReporter.warning(
 								8544_error,
 								_assembly.location(),
-								"Inline assembly marked as memory safe using both a NatSpec tag and an assembly flag. "
-								"If you are not concerned with backwards compatibility, only use the assembly flag, "
+								"Inline assembly marked as memory safe using both a NatSpec tag and an assembly block annotation. "
+								"If you are not concerned with backwards compatibility, only use the assembly block annotation, "
 								"otherwise only use the NatSpec tag."
 							);
 						_assembly.annotation().markedMemorySafe = true;
+						m_errorReporter.warning(
+							2424_error,
+							_assembly.location(),
+							"Natspec memory-safe-assembly special comment for inline assembly is deprecated and "
+							"scheduled for removal. "
+							"Use the memory-safe block annotation instead."
+						);
 					}
 					else
 						m_errorReporter.warning(

--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -149,6 +149,16 @@ bool SyntaxChecker::visit(PragmaDirective const& _pragma)
 			);
 		else
 			m_sourceUnit->annotation().useABICoderV2 = (_pragma.literals()[1] == "v2");
+
+		if (
+			_pragma.literals().size() > 1 &&
+			_pragma.literals()[1] == "v1"
+		)
+			m_errorReporter.warning(
+				9511_error,
+				_pragma.location(),
+				"ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead."
+			);
 	}
 	else if (_pragma.literals()[0] == "solidity")
 	{
@@ -184,6 +194,14 @@ void SyntaxChecker::endVisit(ModifierDefinition const& _modifier)
 {
 	if (_modifier.isImplemented() && !m_placeholderFound)
 		m_errorReporter.syntaxError(2883_error, _modifier.body().location(), "Modifier body does not contain '_'.");
+
+	if (_modifier.markedVirtual())
+		m_errorReporter.warning(
+			8429_error,
+			_modifier.location(),
+			"Virtual modifiers are deprecated and scheduled for removal."
+		);
+
 	m_placeholderFound = false;
 }
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1829,6 +1829,16 @@ void TypeChecker::endVisit(BinaryOperation const& _operation)
 				)
 			);
 	}
+	if (
+		TokenTraits::isCompareOp(_operation.getOperator()) &&
+		commonType->category() == Type::Category::Contract
+	)
+		m_errorReporter.warning(
+			9170_error,
+			_operation.location(),
+			"Comparison of variables of contract type is deprecated and scheduled for removal. "
+			"Use an explicit cast to address type and compare the addresses instead."
+		);
 }
 
 Type const* TypeChecker::typeCheckTypeConversionAndRetrieveReturnType(
@@ -3212,6 +3222,19 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 				if (contractType && contractType->isSuper())
 					requiredLookup = VirtualLookup::Super;
 			}
+
+		if (
+			funType->kind() == FunctionType::Kind::Send ||
+			funType->kind() == FunctionType::Kind::Transfer
+		)
+			m_errorReporter.warning(
+				9207_error,
+				_memberAccess.location(),
+				fmt::format(
+					"'{}' is deprecated and scheduled for removal. Use 'call{{value: <amount>}}(\"\")' instead.",
+					funType->kind() == FunctionType::Kind::Send ? "send" : "transfer"
+				)
+			);
 	}
 
 	annotation.requiredLookup = requiredLookup;

--- a/test/cmdlineTests/model_checker_targets_all_all_engines/err
+++ b/test/cmdlineTests/model_checker_targets_all_all_engines/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: CHC: Underflow (resulting value less than 0) happens here.
 Counterexample:
 arr = []

--- a/test/cmdlineTests/model_checker_targets_all_bmc/err
+++ b/test/cmdlineTests/model_checker_targets_all_bmc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: BMC: Condition is always true.
  --> input.sol:6:11:
   |

--- a/test/cmdlineTests/model_checker_targets_all_chc/err
+++ b/test/cmdlineTests/model_checker_targets_all_chc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: CHC: Underflow (resulting value less than 0) happens here.
 Counterexample:
 arr = []

--- a/test/cmdlineTests/model_checker_targets_assert_bmc/err
+++ b/test/cmdlineTests/model_checker_targets_assert_bmc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: BMC: Assertion violation happens here.
   --> input.sol:11:3:
    |

--- a/test/cmdlineTests/model_checker_targets_assert_chc/err
+++ b/test/cmdlineTests/model_checker_targets_assert_chc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: CHC: Assertion violation happens here.
 Counterexample:
 arr = []

--- a/test/cmdlineTests/model_checker_targets_balance_bmc/err
+++ b/test/cmdlineTests/model_checker_targets_balance_bmc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: BMC: Insufficient funds happens here.
   --> input.sol:10:3:
    |

--- a/test/cmdlineTests/model_checker_targets_constant_condition_bmc/err
+++ b/test/cmdlineTests/model_checker_targets_constant_condition_bmc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: BMC: Condition is always true.
  --> input.sol:6:11:
   |

--- a/test/cmdlineTests/model_checker_targets_constant_condition_chc/err
+++ b/test/cmdlineTests/model_checker_targets_constant_condition_chc/err
@@ -3,5 +3,3 @@ Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <a
    |
 11 | 		a.transfer(x);
    | 		^^^^^^^^^^
-
-Info: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/cmdlineTests/model_checker_targets_default_all_engines/err
+++ b/test/cmdlineTests/model_checker_targets_default_all_engines/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: CHC: Division by zero happens here.
 Counterexample:
 arr = []

--- a/test/cmdlineTests/model_checker_targets_default_bmc/err
+++ b/test/cmdlineTests/model_checker_targets_default_bmc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: BMC: Condition is always true.
  --> input.sol:6:11:
   |

--- a/test/cmdlineTests/model_checker_targets_default_chc/err
+++ b/test/cmdlineTests/model_checker_targets_default_chc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: CHC: Division by zero happens here.
 Counterexample:
 arr = []

--- a/test/cmdlineTests/model_checker_targets_div_by_zero_bmc/err
+++ b/test/cmdlineTests/model_checker_targets_div_by_zero_bmc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: BMC: Division by zero happens here.
  --> input.sol:9:3:
   |

--- a/test/cmdlineTests/model_checker_targets_div_by_zero_chc/err
+++ b/test/cmdlineTests/model_checker_targets_div_by_zero_chc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: CHC: Division by zero happens here.
 Counterexample:
 arr = []

--- a/test/cmdlineTests/model_checker_targets_out_of_bounds_bmc/err
+++ b/test/cmdlineTests/model_checker_targets_out_of_bounds_bmc/err
@@ -3,5 +3,3 @@ Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <a
    |
 11 | 		a.transfer(x);
    | 		^^^^^^^^^^
-
-Info: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/cmdlineTests/model_checker_targets_out_of_bounds_chc/err
+++ b/test/cmdlineTests/model_checker_targets_out_of_bounds_chc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: CHC: Out of bounds access happens here.
 Counterexample:
 arr = []

--- a/test/cmdlineTests/model_checker_targets_overflow_bmc/err
+++ b/test/cmdlineTests/model_checker_targets_overflow_bmc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: BMC: Overflow (resulting value larger than 2**256 - 1) happens here.
  --> input.sol:8:3:
   |

--- a/test/cmdlineTests/model_checker_targets_overflow_chc/err
+++ b/test/cmdlineTests/model_checker_targets_overflow_chc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: CHC: Overflow (resulting value larger than 2**256 - 1) happens here.
 Counterexample:
 arr = []

--- a/test/cmdlineTests/model_checker_targets_pop_empty_bmc/err
+++ b/test/cmdlineTests/model_checker_targets_pop_empty_bmc/err
@@ -3,5 +3,3 @@ Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <a
    |
 11 | 		a.transfer(x);
    | 		^^^^^^^^^^
-
-Info: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/cmdlineTests/model_checker_targets_pop_empty_chc/err
+++ b/test/cmdlineTests/model_checker_targets_pop_empty_chc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: CHC: Empty array "pop" happens here.
 Counterexample:
 arr = []

--- a/test/cmdlineTests/model_checker_targets_underflow_bmc/err
+++ b/test/cmdlineTests/model_checker_targets_underflow_bmc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: BMC: Underflow (resulting value less than 0) happens here.
  --> input.sol:7:3:
   |

--- a/test/cmdlineTests/model_checker_targets_underflow_chc/err
+++ b/test/cmdlineTests/model_checker_targets_underflow_chc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: CHC: Underflow (resulting value less than 0) happens here.
 Counterexample:
 arr = []

--- a/test/cmdlineTests/model_checker_targets_underflow_overflow_assert_bmc/err
+++ b/test/cmdlineTests/model_checker_targets_underflow_overflow_assert_bmc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: BMC: Underflow (resulting value less than 0) happens here.
  --> input.sol:7:3:
   |

--- a/test/cmdlineTests/model_checker_targets_underflow_overflow_assert_chc/err
+++ b/test/cmdlineTests/model_checker_targets_underflow_overflow_assert_chc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: CHC: Underflow (resulting value less than 0) happens here.
 Counterexample:
 arr = []

--- a/test/cmdlineTests/model_checker_targets_underflow_overflow_bmc/err
+++ b/test/cmdlineTests/model_checker_targets_underflow_overflow_bmc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: BMC: Underflow (resulting value less than 0) happens here.
  --> input.sol:7:3:
   |

--- a/test/cmdlineTests/model_checker_targets_underflow_overflow_chc/err
+++ b/test/cmdlineTests/model_checker_targets_underflow_overflow_chc/err
@@ -1,3 +1,9 @@
+Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+  --> input.sol:10:3:
+   |
+10 | 		a.transfer(x);
+   | 		^^^^^^^^^^
+
 Warning: CHC: Underflow (resulting value less than 0) happens here.
 Counterexample:
 arr = []

--- a/test/cmdlineTests/standard_model_checker_targets_assert_bmc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_assert_bmc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "4661",
             "formattedMessage": "Warning: BMC: Assertion violation happens here.
   --> A:12:7:

--- a/test/cmdlineTests/standard_model_checker_targets_assert_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_assert_chc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "6328",
             "formattedMessage": "Warning: CHC: Assertion violation happens here.
 Counterexample:

--- a/test/cmdlineTests/standard_model_checker_targets_balance_bmc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_balance_bmc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "1236",
             "formattedMessage": "Warning: BMC: Insufficient funds happens here.
   --> A:11:7:

--- a/test/cmdlineTests/standard_model_checker_targets_balance_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_balance_chc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "1391",
             "formattedMessage": "Info: CHC: 1 verification condition(s) proved safe! Enable the model checker option \"show proved safe\" to see all of them.
 

--- a/test/cmdlineTests/standard_model_checker_targets_constantCondition_bmc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_constantCondition_bmc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "6838",
             "formattedMessage": "Warning: BMC: Condition is always true.
  --> A:7:15:

--- a/test/cmdlineTests/standard_model_checker_targets_constantCondition_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_constantCondition_chc/output.json
@@ -1,4 +1,25 @@
 {
+    "errors": [
+        {
+            "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        }
+    ],
     "sources": {
         "A": {
             "id": 0

--- a/test/cmdlineTests/standard_model_checker_targets_default_all_engines/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_default_all_engines/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "4281",
             "formattedMessage": "Warning: CHC: Division by zero happens here.
 Counterexample:

--- a/test/cmdlineTests/standard_model_checker_targets_default_bmc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_default_bmc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "6838",
             "formattedMessage": "Warning: BMC: Condition is always true.
  --> A:7:15:

--- a/test/cmdlineTests/standard_model_checker_targets_default_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_default_chc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "4281",
             "formattedMessage": "Warning: CHC: Division by zero happens here.
 Counterexample:

--- a/test/cmdlineTests/standard_model_checker_targets_div_by_zero_bmc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_div_by_zero_bmc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "3046",
             "formattedMessage": "Warning: BMC: Division by zero happens here.
   --> A:10:7:

--- a/test/cmdlineTests/standard_model_checker_targets_div_by_zero_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_div_by_zero_chc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "4281",
             "formattedMessage": "Warning: CHC: Division by zero happens here.
 Counterexample:

--- a/test/cmdlineTests/standard_model_checker_targets_out_of_bounds_bmc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_out_of_bounds_bmc/output.json
@@ -1,4 +1,25 @@
 {
+    "errors": [
+        {
+            "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        }
+    ],
     "sources": {
         "A": {
             "id": 0

--- a/test/cmdlineTests/standard_model_checker_targets_out_of_bounds_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_out_of_bounds_chc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "6368",
             "formattedMessage": "Warning: CHC: Out of bounds access happens here.
 Counterexample:

--- a/test/cmdlineTests/standard_model_checker_targets_overflow_bmc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_overflow_bmc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "2661",
             "formattedMessage": "Warning: BMC: Overflow (resulting value larger than 2**256 - 1) happens here.
  --> A:9:7:

--- a/test/cmdlineTests/standard_model_checker_targets_overflow_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_overflow_chc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "4984",
             "formattedMessage": "Warning: CHC: Overflow (resulting value larger than 2**256 - 1) happens here.
 Counterexample:

--- a/test/cmdlineTests/standard_model_checker_targets_pop_empty_bmc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_pop_empty_bmc/output.json
@@ -1,4 +1,25 @@
 {
+    "errors": [
+        {
+            "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        }
+    ],
     "sources": {
         "A": {
             "id": 0

--- a/test/cmdlineTests/standard_model_checker_targets_pop_empty_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_pop_empty_chc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "2529",
             "formattedMessage": "Warning: CHC: Empty array \"pop\" happens here.
 Counterexample:

--- a/test/cmdlineTests/standard_model_checker_targets_underflow_bmc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_underflow_bmc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "4144",
             "formattedMessage": "Warning: BMC: Underflow (resulting value less than 0) happens here.
  --> A:8:7:

--- a/test/cmdlineTests/standard_model_checker_targets_underflow_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_underflow_chc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "3944",
             "formattedMessage": "Warning: CHC: Underflow (resulting value less than 0) happens here.
 Counterexample:

--- a/test/cmdlineTests/standard_model_checker_targets_underflow_overflow_assert_bmc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_underflow_overflow_assert_bmc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "4144",
             "formattedMessage": "Warning: BMC: Underflow (resulting value less than 0) happens here.
  --> A:8:7:

--- a/test/cmdlineTests/standard_model_checker_targets_underflow_overflow_assert_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_underflow_overflow_assert_chc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "3944",
             "formattedMessage": "Warning: CHC: Underflow (resulting value less than 0) happens here.
 Counterexample:

--- a/test/cmdlineTests/standard_model_checker_targets_underflow_overflow_bmc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_underflow_overflow_bmc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "4144",
             "formattedMessage": "Warning: BMC: Underflow (resulting value less than 0) happens here.
  --> A:8:7:

--- a/test/cmdlineTests/standard_model_checker_targets_underflow_overflow_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_underflow_overflow_chc/output.json
@@ -2,6 +2,25 @@
     "errors": [
         {
             "component": "general",
+            "errorCode": "9207",
+            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
+  --> A:11:7:
+   |
+11 | \t\t\t\t\t\ta.transfer(x);
+   | \t\t\t\t\t\t^^^^^^^^^^
+
+",
+            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
+            "severity": "warning",
+            "sourceLocation": {
+                "end": 234,
+                "file": "A",
+                "start": 224
+            },
+            "type": "Warning"
+        },
+        {
+            "component": "general",
             "errorCode": "3944",
             "formattedMessage": "Warning: CHC: Underflow (resulting value less than 0) happens here.
 Counterexample:

--- a/test/cmdlineTests/viair_abicoder_v1/err
+++ b/test/cmdlineTests/viair_abicoder_v1/err
@@ -1,3 +1,9 @@
+Warning (9511): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
+ --> input.sol:3:1:
+  |
+3 | pragma abicoder v1;
+  | ^^^^^^^^^^^^^^^^^^^
+
 Warning (2066): Contract requests the ABI coder v1, which is incompatible with the IR. Using ABI coder v2 instead.
  --> input.sol:4:1:
   |

--- a/test/libsolidity/smtCheckerTests/blockchain_state/balance_spend.sol
+++ b/test/libsolidity/smtCheckerTests/blockchain_state/balance_spend.sol
@@ -18,5 +18,6 @@ contract C {
 // SMTEngine: all
 // SMTIgnoreCex: yes
 // ----
+// Warning 9207: (175-186): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
 // Warning 6328: (280-314): CHC: Assertion violation happens here.
 // Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/blockchain_state/balance_spend_2.sol
+++ b/test/libsolidity/smtCheckerTests/blockchain_state/balance_spend_2.sol
@@ -17,6 +17,7 @@ contract C {
 // SMTIgnoreCex: yes
 // SMTIgnoreOS: macos
 // ----
+// Warning 9207: (141-152): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
 // Warning 8656: (141-156): CHC: Insufficient funds happens here.
 // Warning 6328: (193-226): CHC: Assertion violation happens here.
 // Warning 6328: (245-279): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/blockchain_state/decreasing_balance.sol
+++ b/test/libsolidity/smtCheckerTests/blockchain_state/decreasing_balance.sol
@@ -18,4 +18,5 @@ contract C {
 // ====
 // SMTEngine: all
 // ----
+// Warning 9207: (160-170): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/blockchain_state/free_function_2.sol
+++ b/test/libsolidity/smtCheckerTests/blockchain_state/free_function_2.sol
@@ -19,5 +19,6 @@ contract C {
 // SMTEngine: all
 // SMTIgnoreCex: yes
 // ----
-// Warning 6328: (258-274): CHC: Assertion violation happens here.
+// Warning 9207: (33-43): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+// Warning 6328: (258-274): CHC: Assertion violation happens here.\nCounterexample:\nx = 0\na = 0x7e1e\nb1 = 38\nb2 = 37\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.f(0x7e1e){ msg.value: 17 }\n    l(0x7e1e) -- internal call
 // Info 1391: CHC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/blockchain_state/library_internal_2.sol
+++ b/test/libsolidity/smtCheckerTests/blockchain_state/library_internal_2.sol
@@ -22,5 +22,6 @@ contract C {
 // SMTEngine: all
 // SMTIgnoreCex: yes
 // ----
-// Warning 6328: (315-331): CHC: Assertion violation happens here.
+// Warning 9207: (87-97): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+// Warning 6328: (315-331): CHC: Assertion violation happens here.\nCounterexample:\nx = 0\na = 0x7e1e\nb1 = 38\nb2 = 37\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.f(0x7e1e){ msg.value: 17 }\n    L.l(0x7e1e) -- internal call
 // Info 1391: CHC: 4 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/blockchain_state/library_public_2.sol
+++ b/test/libsolidity/smtCheckerTests/blockchain_state/library_public_2.sol
@@ -20,7 +20,8 @@ contract C {
 // SMTEngine: all
 // SMTIgnoreCex: yes
 // ----
+// Warning 9207: (54-64): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
 // Warning 4588: (238-243): Assertion checker does not yet implement this type of function call.
-// Warning 8656: (54-67): CHC: Insufficient funds happens here.
-// Warning 6328: (282-298): CHC: Assertion violation happens here.
-// Warning 6328: (317-331): CHC: Assertion violation happens here.
+// Warning 8656: (54-67): CHC: Insufficient funds happens here.\nCounterexample:\n\na = 0x0\n\nTransaction trace:\nL.constructor()\nL.l(0x0)
+// Warning 6328: (282-298): CHC: Assertion violation happens here.\nCounterexample:\nx = 0\na = 0x0\nb1 = 15923\nb2 = 15924\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.f(0x0){ msg.value: 15923 }
+// Warning 6328: (317-331): CHC: Assertion violation happens here.\nCounterexample:\nx = 1\na = 0x0\nb1 = 15923\nb2 = 15924\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.f(0x0){ msg.value: 15923 }

--- a/test/libsolidity/smtCheckerTests/blockchain_state/transfer_1.sol
+++ b/test/libsolidity/smtCheckerTests/blockchain_state/transfer_1.sol
@@ -11,5 +11,6 @@ contract C {
 // SMTEngine: all
 // SMTIgnoreCex: yes
 // ----
-// Warning 6328: (166-201): CHC: Assertion violation happens here.
+// Warning 9207: (96-106): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+// Warning 6328: (166-201): CHC: Assertion violation happens here.\nCounterexample:\n\na = 0x0\n\nTransaction trace:\nC.constructor()\nC.f(0x0)
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/blockchain_state/transfer_2.sol
+++ b/test/libsolidity/smtCheckerTests/blockchain_state/transfer_2.sol
@@ -11,4 +11,6 @@ contract C {
 // ====
 // SMTEngine: chc
 // ----
+// Warning 9207: (133-151): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+// Warning 9207: (167-185): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/blockchain_state/transfer_3.sol
+++ b/test/libsolidity/smtCheckerTests/blockchain_state/transfer_3.sol
@@ -8,4 +8,5 @@ contract C {
 // ====
 // SMTEngine: all
 // ----
-// Warning 8656: (76-97): CHC: Insufficient funds happens here.
+// Warning 9207: (76-94): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+// Warning 8656: (76-97): CHC: Insufficient funds happens here.\nCounterexample:\nrecipient = 0x0\n\nTransaction trace:\nC.constructor()\nState: recipient = 0x0\nC.shouldFail()

--- a/test/libsolidity/smtCheckerTests/blockchain_state/transfer_4.sol
+++ b/test/libsolidity/smtCheckerTests/blockchain_state/transfer_4.sol
@@ -9,4 +9,5 @@ contract C {
 // ====
 // SMTEngine: all
 // ----
+// Warning 9207: (101-119): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/bmc_coverage/funds.sol
+++ b/test/libsolidity/smtCheckerTests/bmc_coverage/funds.sol
@@ -6,4 +6,5 @@ contract C {
 // ====
 // SMTEngine: bmc
 // ----
+// Warning 9207: (55-65): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
 // Warning 1236: (55-70): BMC: Insufficient funds happens here.

--- a/test/libsolidity/smtCheckerTests/deployment/deploy_trusted_addresses.sol
+++ b/test/libsolidity/smtCheckerTests/deployment/deploy_trusted_addresses.sol
@@ -16,4 +16,5 @@ contract C {
 // SMTEngine: all
 // SMTExtCalls: trusted
 // ----
+// Warning 9170: (107-115): Comparison of variables of contract type is deprecated and scheduled for removal. Use an explicit cast to address type and compare the addresses instead.
 // Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/deployment/deploy_untrusted_addresses.sol
+++ b/test/libsolidity/smtCheckerTests/deployment/deploy_untrusted_addresses.sol
@@ -15,8 +15,9 @@ contract C {
 // ====
 // SMTEngine: all
 // ----
+// Warning 9170: (107-115): Comparison of variables of contract type is deprecated and scheduled for removal. Use an explicit cast to address type and compare the addresses instead.
 // Warning 8729: (70-77): Contract deployment is only supported in the trusted mode for external calls with the CHC engine.
 // Warning 8729: (88-95): Contract deployment is only supported in the trusted mode for external calls with the CHC engine.
 // Warning 6328: (100-116): CHC: Assertion violation happens here.\nCounterexample:\n\nd1 = 0\nd2 = 0\n\nTransaction trace:\nC.constructor()\nC.f()
-// Warning 6328: (163-199): CHC: Assertion violation happens here.\nCounterexample:\n\nd1 = 21238\nd2 = 21238\n\nTransaction trace:\nC.constructor()\nC.f()
-// Warning 6328: (246-282): CHC: Assertion violation happens here.\nCounterexample:\n\nd1 = 21238\nd2 = 21238\n\nTransaction trace:\nC.constructor()\nC.f()
+// Warning 6328: (163-199): CHC: Assertion violation happens here.\nCounterexample:\n\nd1 = 11797\nd2 = 11797\n\nTransaction trace:\nC.constructor()\nC.f()
+// Warning 6328: (246-282): CHC: Assertion violation happens here.\nCounterexample:\n\nd1 = 8855\nd2 = 8855\n\nTransaction trace:\nC.constructor()\nC.f()

--- a/test/libsolidity/smtCheckerTests/functions/getters/array_of_structs_1.sol
+++ b/test/libsolidity/smtCheckerTests/functions/getters/array_of_structs_1.sol
@@ -15,4 +15,5 @@ contract D {
 // ====
 // SMTEngine: all
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/functions/getters/array_of_structs_2.sol
+++ b/test/libsolidity/smtCheckerTests/functions/getters/array_of_structs_2.sol
@@ -20,5 +20,6 @@ contract D {
 // SMTEngine: all
 // SMTIgnoreCex: no
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // Warning 6328: (267-281): CHC: Assertion violation happens here.\nCounterexample:\nitems = [{x: 42, y: 43}]\na = 42\nb = 43\n\nTransaction trace:\nD.constructor()\nState: items = []\nD.test()
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/functions/getters/array_of_structs_3.sol
+++ b/test/libsolidity/smtCheckerTests/functions/getters/array_of_structs_3.sol
@@ -21,5 +21,6 @@ contract D {
 // ====
 // SMTEngine: all
 // ----
-// Warning 6328: (322-336): CHC: Assertion violation happens here.
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
+// Warning 6328: (322-336): CHC: Assertion violation happens here.\nCounterexample:\nitems = [{x: 42, y: 43, arr: [0]}]\ntmp = [0]\na = 42\nb = 43\n\nTransaction trace:\nD.constructor()\nState: items = []\nD.test()
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/functions/getters/contract.sol
+++ b/test/libsolidity/smtCheckerTests/functions/getters/contract.sol
@@ -12,5 +12,6 @@ contract C {
 // ====
 // SMTEngine: all
 // ----
-// Warning 6328: (123-158): CHC: Assertion violation happens here.
+// Warning 9170: (97-103): Comparison of variables of contract type is deprecated and scheduled for removal. Use an explicit cast to address type and compare the addresses instead.
+// Warning 6328: (123-158): CHC: Assertion violation happens here.\nCounterexample:\nd = 0\ne = 0\n\nTransaction trace:\nC.constructor()\nState: d = 0\nC.f()
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/functions/getters/struct_4.sol
+++ b/test/libsolidity/smtCheckerTests/functions/getters/struct_4.sol
@@ -18,7 +18,8 @@ contract C {
 // ====
 // SMTEngine: all
 // ----
+// Warning 9170: (206-214): Comparison of variables of contract type is deprecated and scheduled for removal. Use an explicit cast to address type and compare the addresses instead.
 // Warning 2072: (146-183): Unused local variable.
 // Warning 8364: (187-193): Assertion checker does not yet implement type function () view external returns (contract D,function () external returns (uint256))
-// Warning 6328: (234-269): CHC: Assertion violation happens here.
+// Warning 6328: (234-269): CHC: Assertion violation happens here.\nCounterexample:\ns = {d: 0, f: 0}\nd = 0\nf = 0\n\nTransaction trace:\nC.constructor()\nState: s = {d: 0, f: 0}\nC.test()
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_abstract.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_abstract.sol
@@ -5,3 +5,4 @@ abstract contract A {
 // ====
 // SMTEngine: all
 // ----
+// Warning 8429: (51-72): Virtual modifiers are deprecated and scheduled for removal.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_1.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_1.sol
@@ -20,5 +20,6 @@ contract B is A {
 // ====
 // SMTEngine: all
 // ----
-// Warning 6328: (209-223): CHC: Assertion violation happens here.
+// Warning 8429: (64-93): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 6328: (209-223): CHC: Assertion violation happens here.\nCounterexample:\ns = 42\nx = 42\n\nTransaction trace:\nB.constructor()\nState: s = 0\nB.set(42)\nState: s = 42\nA.f()
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_2.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_2.sol
@@ -23,4 +23,6 @@ contract C is B {
 // ====
 // SMTEngine: all
 // ----
+// Warning 8429: (113-136): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (159-213): Virtual modifiers are deprecated and scheduled for removal.
 // Warning 6328: (66-75): CHC: Assertion violation happens here.\nCounterexample:\ns = false\n\nTransaction trace:\nB.constructor()\nState: s = false\nA.f()

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_3.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_3.sol
@@ -18,5 +18,7 @@ contract B is A {
 // ====
 // SMTEngine: all
 // ----
-// Warning 6328: (94-104): CHC: Assertion violation happens here.
+// Warning 8429: (125-148): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (171-238): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 6328: (94-104): CHC: Assertion violation happens here.\nCounterexample:\ns = true\nx = true\n\nTransaction trace:\nB.constructor()\nState: s = false\nA.f()
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_4.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_overriding_4.sol
@@ -36,6 +36,10 @@ contract D is B,C {
 // ====
 // SMTEngine: all
 // ----
+// Warning 8429: (262-294): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (317-367): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (390-440): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (465-520): Virtual modifiers are deprecated and scheduled for removal.
 // Warning 6328: (160-174): CHC: Assertion violation happens here.\nCounterexample:\nx = 1\n\nTransaction trace:\nB.constructor()\nState: x = 0\nA.f()
 // Warning 6328: (193-207): CHC: Assertion violation happens here.\nCounterexample:\nx = 2\n\nTransaction trace:\nC.constructor()\nState: x = 0\nA.f()
 // Warning 6328: (226-240): CHC: Assertion violation happens here.\nCounterexample:\nx = 3\n\nTransaction trace:\nD.constructor()\nState: x = 0\nA.f()

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_virtual_static_call_1.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_virtual_static_call_1.sol
@@ -10,3 +10,4 @@ contract C is A {
 // ====
 // SMTEngine: all
 // ----
+// Warning 8429: (17-52): Virtual modifiers are deprecated and scheduled for removal.

--- a/test/libsolidity/smtCheckerTests/modifiers/modifier_virtual_static_call_2.sol
+++ b/test/libsolidity/smtCheckerTests/modifiers/modifier_virtual_static_call_2.sol
@@ -20,5 +20,6 @@ contract C is A {
 // ====
 // SMTEngine: all
 // ----
-// Warning 6328: (83-98): CHC: Assertion violation happens here.
+// Warning 8429: (27-122): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 6328: (83-98): CHC: Assertion violation happens here.\nCounterexample:\nx = 0\n = 0\n\nTransaction trace:\nC.constructor()\nState: x = 0\nC.f()
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/types/address_transfer.sol
+++ b/test/libsolidity/smtCheckerTests/types/address_transfer.sol
@@ -11,5 +11,6 @@ contract C
 // ====
 // SMTEngine: all
 // ----
-// Warning 8656: (98-113): CHC: Insufficient funds happens here.
-// Warning 6328: (162-186): CHC: Assertion violation happens here.
+// Warning 9207: (98-108): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+// Warning 8656: (98-113): CHC: Insufficient funds happens here.\nCounterexample:\n\na = 0x51f0\nx = 100\n\nTransaction trace:\nC.constructor()\nC.f(0x51f0)
+// Warning 6328: (162-186): CHC: Assertion violation happens here.\nCounterexample:\n\na = 0x0\nx = 100\n\nTransaction trace:\nC.constructor()\nC.f(0x0)

--- a/test/libsolidity/smtCheckerTests/types/address_transfer_2.sol
+++ b/test/libsolidity/smtCheckerTests/types/address_transfer_2.sol
@@ -15,6 +15,8 @@ contract C
 // SMTEngine: all
 // SMTIgnoreCex: yes
 // ----
-// Warning 8656: (184-199): CHC: Insufficient funds happens here.
-// Warning 8656: (203-218): CHC: Insufficient funds happens here.
-// Warning 6328: (262-291): CHC: Assertion violation happens here.
+// Warning 9207: (184-194): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+// Warning 9207: (203-213): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+// Warning 8656: (184-199): CHC: Insufficient funds happens here.\nCounterexample:\n\nx = 100\na = 0x6532\nb = 0xffffffffffffffffffffffffffffffffffffed9d\n\nTransaction trace:\nC.constructor()\nC.f(100, 0x6532, 0xffffffffffffffffffffffffffffffffffffed9d)
+// Warning 8656: (203-218): CHC: Insufficient funds happens here.\nCounterexample:\n\nx = 100\na = 0x08c0\nb = 0x7992\n\nTransaction trace:\nC.constructor()\nC.f(100, 0x08c0, 0x7992)
+// Warning 6328: (262-291): CHC: Assertion violation happens here.\nCounterexample:\n\nx = 100\na = 0x08c1\nb = 0x08c0\n\nTransaction trace:\nC.constructor()\nC.f(100, 0x08c1, 0x08c0)

--- a/test/libsolidity/smtCheckerTests/types/address_transfer_3.sol
+++ b/test/libsolidity/smtCheckerTests/types/address_transfer_3.sol
@@ -13,4 +13,5 @@ contract C
 // ====
 // SMTEngine: all
 // ----
+// Warning 9207: (126-136): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/types/address_transfer_insufficient.sol
+++ b/test/libsolidity/smtCheckerTests/types/address_transfer_insufficient.sol
@@ -12,6 +12,8 @@ contract C
 // SMTEngine: all
 // SMTIgnoreCex: yes
 // ----
-// Warning 8656: (101-116): CHC: Insufficient funds happens here.
-// Warning 8656: (120-136): CHC: Insufficient funds happens here.
-// Warning 6328: (180-204): CHC: Assertion violation happens here.
+// Warning 9207: (101-111): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+// Warning 9207: (120-130): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+// Warning 8656: (101-116): CHC: Insufficient funds happens here.\nCounterexample:\n\na = 0x0\nb = 0x0\n\nTransaction trace:\nC.constructor()\nC.f(0x0, 0x0)
+// Warning 8656: (120-136): CHC: Insufficient funds happens here.\nCounterexample:\n\na = 0x0\nb = 0x0\n\nTransaction trace:\nC.constructor()\nC.f(0x0, 0x0)
+// Warning 6328: (180-204): CHC: Assertion violation happens here.\nCounterexample:\n\na = 0x0476\nb = 0x0476\n\nTransaction trace:\nC.constructor()\nC.f(0x0476, 0x0476)

--- a/test/libsolidity/smtCheckerTests/types/contract.sol
+++ b/test/libsolidity/smtCheckerTests/types/contract.sol
@@ -8,4 +8,5 @@ contract C
 // SMTEngine: all
 // SMTIgnoreCex: yes
 // ----
-// Warning 6328: (51-65): CHC: Assertion violation happens here.
+// Warning 9170: (58-64): Comparison of variables of contract type is deprecated and scheduled for removal. Use an explicit cast to address type and compare the addresses instead.
+// Warning 6328: (51-65): CHC: Assertion violation happens here.\nCounterexample:\n\nc = 0\nd = 1\n\nTransaction trace:\nC.constructor()\nC.f(0, 1)

--- a/test/libsolidity/smtCheckerTests/types/contract_2.sol
+++ b/test/libsolidity/smtCheckerTests/types/contract_2.sol
@@ -13,4 +13,5 @@ contract C
 // SMTEngine: all
 // SMTIgnoreCex: yes
 // ----
-// Warning 6328: (76-90): CHC: Assertion violation happens here.
+// Warning 9170: (83-89): Comparison of variables of contract type is deprecated and scheduled for removal. Use an explicit cast to address type and compare the addresses instead.
+// Warning 6328: (76-90): CHC: Assertion violation happens here.\nCounterexample:\n\nc = 0\nd = 1\n\nTransaction trace:\nC.constructor()\nC.f(0, 1)

--- a/test/libsolidity/smtCheckerTests/types/contract_3.sol
+++ b/test/libsolidity/smtCheckerTests/types/contract_3.sol
@@ -9,4 +9,7 @@ contract C
 // ====
 // SMTEngine: all
 // ----
+// Warning 9170: (64-70): Comparison of variables of contract type is deprecated and scheduled for removal. Use an explicit cast to address type and compare the addresses instead.
+// Warning 9170: (83-89): Comparison of variables of contract type is deprecated and scheduled for removal. Use an explicit cast to address type and compare the addresses instead.
+// Warning 9170: (101-107): Comparison of variables of contract type is deprecated and scheduled for removal. Use an explicit cast to address type and compare the addresses instead.
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/types/contract_address_conversion_2.sol
+++ b/test/libsolidity/smtCheckerTests/types/contract_address_conversion_2.sol
@@ -10,4 +10,5 @@ contract C
 // ====
 // SMTEngine: all
 // ----
+// Warning 9170: (121-127): Comparison of variables of contract type is deprecated and scheduled for removal. Use an explicit cast to address type and compare the addresses instead.
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/syntaxTests/abiEncoder/conflicting_settings.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/conflicting_settings.sol
@@ -2,3 +2,4 @@ pragma abicoder               v2;
 pragma abicoder v1;
 // ----
 // SyntaxError 3845: (34-53): ABI coder has already been selected for this source unit.
+// Warning 9511: (34-53): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.

--- a/test/libsolidity/syntaxTests/abiEncoder/conflicting_settings_reverse.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/conflicting_settings_reverse.sol
@@ -1,4 +1,5 @@
 pragma abicoder v1;
 pragma abicoder v2;
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // SyntaxError 3845: (20-39): ABI coder has already been selected for this source unit.

--- a/test/libsolidity/syntaxTests/abiEncoder/conflicting_settings_reverse_experimental.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/conflicting_settings_reverse_experimental.sol
@@ -1,4 +1,5 @@
 pragma abicoder v1;
 pragma experimental ABIEncoderV2;
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // SyntaxError 8273: (20-53): ABI coder v1 has already been selected through "pragma abicoder v1".

--- a/test/libsolidity/syntaxTests/abiEncoder/select_v1.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/select_v1.sol
@@ -1,2 +1,3 @@
 pragma abicoder v1;
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.

--- a/test/libsolidity/syntaxTests/abiEncoder/select_v1_quoted_string.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/select_v1_quoted_string.sol
@@ -1,2 +1,3 @@
 pragma abicoder "v1";
 // ----
+// Warning 9511: (0-21): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.

--- a/test/libsolidity/syntaxTests/abiEncoder/selected_twice.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/selected_twice.sol
@@ -1,4 +1,6 @@
 pragma abicoder v1;
 pragma abicoder v1;
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // SyntaxError 3845: (20-39): ABI coder has already been selected for this source unit.
+// Warning 9511: (20-39): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_accessing_public_state_variable_via_v1_type.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_accessing_public_state_variable_via_v1_type.sol
@@ -16,3 +16,4 @@ contract D {
 // ====
 // bytecodeFormat: legacy
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_accessing_public_state_variable_via_v2_type.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_accessing_public_state_variable_via_v2_type.sol
@@ -14,5 +14,6 @@ contract D {
     }
 }
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 7364: (222-260): Different number of components on the left hand side (1) than on the right hand side (2).
 // TypeError 9574: (222-260): Type uint256 is not implicitly convertible to expected type struct Item memory.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v1_library_function_accepting_storage_struct.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v1_library_function_accepting_storage_struct.sol
@@ -22,3 +22,4 @@ contract Test {
 // ====
 // bytecodeFormat: legacy
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_constructor_accepting_struct.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_constructor_accepting_struct.sol
@@ -18,4 +18,5 @@ contract Test {
     }
 }
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 2443: (B:91-100): The type of this parameter, struct C.Item memory, is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_contract_function_accepting_struct_via_named_argument.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_contract_function_accepting_struct_via_named_argument.sol
@@ -18,4 +18,5 @@ contract Test {
     }
 }
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 2443: (B:119-129): The type of this parameter, struct C.Item memory, is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_contract_function_pointer_accepting_struct.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_contract_function_pointer_accepting_struct.sol
@@ -20,4 +20,5 @@ contract Test {
     }
 }
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 2443: (B:166-175): The type of this parameter, struct C.Item memory, is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_contract_function_returning_dynamic_string_array.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_contract_function_returning_dynamic_string_array.sol
@@ -14,4 +14,5 @@ contract D {
     }
 }
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 2428: (B:85-105): The type of return parameter 1, string[] memory, is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_contract_function_returning_struct.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_contract_function_returning_struct.sol
@@ -18,4 +18,5 @@ contract Test {
     }
 }
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 2428: (B:90-112): The type of return parameter 1, struct C.Item memory, is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_contract_function_returning_struct_with_dynamic_array.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_contract_function_returning_struct_with_dynamic_array.sol
@@ -18,4 +18,5 @@ contract Test {
     }
 }
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 2428: (B:90-112): The type of return parameter 1, struct C.Item memory, is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_event_accepting_struct.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_event_accepting_struct.sol
@@ -17,4 +17,5 @@ contract Test {
     }
 }
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 2443: (B:94-104): The type of this parameter, struct L.Item memory, is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_library_attached_function_returning_struct.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_library_attached_function_returning_struct.sol
@@ -20,4 +20,5 @@ contract D {
     }
 }
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 2428: (B:106-117): The type of return parameter 1, struct L.Item memory, is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_library_function_accepting_storage_struct.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_library_function_accepting_storage_struct.sol
@@ -22,3 +22,4 @@ contract Test {
 // ====
 // bytecodeFormat: legacy
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_library_function_returning_struct.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_library_function_returning_struct.sol
@@ -18,4 +18,5 @@ contract Test {
     }
 }
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 2428: (B:90-97): The type of return parameter 1, struct L.Item memory, is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_modifier.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_call_to_v2_modifier.sol
@@ -28,3 +28,4 @@ contract C is B {
 // ====
 // bytecodeFormat: legacy
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_constructor_with_v2_modifier.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_constructor_with_v2_modifier.sol
@@ -35,3 +35,5 @@ contract D is C {
 // ====
 // bytecodeFormat: legacy
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
+// Warning 9511: (C:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_inheritance_from_contract_calling_v2_function.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_inheritance_from_contract_calling_v2_function.sol
@@ -26,3 +26,4 @@ contract C is B {}
 // ====
 // bytecodeFormat: legacy
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_inheritance_from_contract_defining_v2_event.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_inheritance_from_contract_defining_v2_event.sol
@@ -16,3 +16,4 @@ contract D is C {}
 // ====
 // bytecodeFormat: legacy
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_inheritance_from_contract_defining_v2_function_accepting_struct.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_inheritance_from_contract_defining_v2_function_accepting_struct.sol
@@ -14,4 +14,5 @@ import "A";
 
 contract D is C {}
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 6594: (B:33-51): Contract "D" does not use ABI coder v2 but wants to inherit from a contract which uses types that require it. Use "pragma abicoder v2;" for the inheriting contract as well to enable the feature.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_inheritance_from_contract_defining_v2_function_returning_struct.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_inheritance_from_contract_defining_v2_function_returning_struct.sol
@@ -14,4 +14,5 @@ import "A";
 
 contract D is C {}
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 6594: (B:33-51): Contract "D" does not use ABI coder v2 but wants to inherit from a contract which uses types that require it. Use "pragma abicoder v2;" for the inheriting contract as well to enable the feature.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_inheritance_from_contract_emitting_v2_event.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_inheritance_from_contract_emitting_v2_event.sol
@@ -22,3 +22,4 @@ contract D is C {}
 // ====
 // bytecodeFormat: legacy
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_modifier_overriding_v2_modifier.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_modifier_overriding_v2_modifier.sol
@@ -30,3 +30,5 @@ contract C is B {
 // ====
 // bytecodeFormat: legacy
 // ----
+// Warning 8429: (A:156-234): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.

--- a/test/libsolidity/syntaxTests/abiEncoder/v1_v2_v1_modifier_mix.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v1_v2_v1_modifier_mix.sol
@@ -55,3 +55,6 @@ contract X {
 // ====
 // bytecodeFormat: legacy
 // ----
+// Warning 9511: (V1A:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
+// Warning 9511: (V1B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
+// Warning 9511: (C:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.

--- a/test/libsolidity/syntaxTests/abiEncoder/v2_v1_v1_modifier_sandwich.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v2_v1_v1_modifier_sandwich.sol
@@ -29,4 +29,6 @@ contract C is B {
     {}
 }
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
+// Warning 9511: (C:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 2428: (B:80-102): The type of return parameter 1, struct Data memory, is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/abiEncoder/v2_v1_v2_modifier_sandwich.sol
+++ b/test/libsolidity/syntaxTests/abiEncoder/v2_v1_v2_modifier_sandwich.sol
@@ -30,4 +30,5 @@ contract C is B {
     {}
 }
 // ----
+// Warning 9511: (B:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 2428: (B:80-102): The type of return parameter 1, struct Data memory, is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/array/calldata_multi_dynamic_V1.sol
+++ b/test/libsolidity/syntaxTests/array/calldata_multi_dynamic_V1.sol
@@ -4,5 +4,6 @@ contract Test {
     function g(uint[][1] calldata) external { }
 }
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 4957: (51-68): This type is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.
 // TypeError 4957: (98-116): This type is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/constructor/nonabiv2_type.sol
+++ b/test/libsolidity/syntaxTests/constructor/nonabiv2_type.sol
@@ -3,4 +3,5 @@ contract C {
 	constructor(uint[][][] memory t) {}
 }
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 4957: (46-65): This type is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature. Alternatively, make the contract abstract and supply the constructor arguments from a derived contract.

--- a/test/libsolidity/syntaxTests/constructor/nonabiv2_type_abstract.sol
+++ b/test/libsolidity/syntaxTests/constructor/nonabiv2_type_abstract.sol
@@ -5,3 +5,4 @@ abstract contract C {
 // ====
 // bytecodeFormat: legacy
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.

--- a/test/libsolidity/syntaxTests/controlFlow/modifiers/implemented_without_placeholder.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/modifiers/implemented_without_placeholder.sol
@@ -6,3 +6,4 @@ abstract contract A {
 }
 // ----
 // SyntaxError 2883: (129-132): Modifier body does not contain '_'.
+// Warning 8429: (106-132): Virtual modifiers are deprecated and scheduled for removal.

--- a/test/libsolidity/syntaxTests/controlFlow/modifiers/modifier_different_functions.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/modifiers/modifier_different_functions.sol
@@ -9,4 +9,5 @@ contract A {
 	}
 }
 // ----
+// Warning 8429: (140-172): Virtual modifiers are deprecated and scheduled for removal.
 // TypeError 3464: (118-132): This variable is of storage pointer type and can be returned without prior assignment, which would lead to undefined behaviour.

--- a/test/libsolidity/syntaxTests/controlFlow/modifiers/modifier_override.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/modifiers/modifier_override.sol
@@ -13,5 +13,6 @@ contract B is A {
 	}
 }
 // ----
+// Warning 8429: (71-115): Virtual modifiers are deprecated and scheduled for removal.
 // Warning 5740: (65-69): Unreachable code.
 // TypeError 3464: (49-63): This variable is of storage pointer type and can be returned without prior assignment, which would lead to undefined behaviour.

--- a/test/libsolidity/syntaxTests/controlFlow/modifiers/non_implemented_modifier.sol
+++ b/test/libsolidity/syntaxTests/controlFlow/modifiers/non_implemented_modifier.sol
@@ -4,3 +4,5 @@ abstract contract A {
     }
     modifier mod() virtual;
 }
+// ----
+// Warning 8429: (106-129): Virtual modifiers are deprecated and scheduled for removal.

--- a/test/libsolidity/syntaxTests/conversion/implicit_conversion_of_super_in_comparison.sol
+++ b/test/libsolidity/syntaxTests/conversion/implicit_conversion_of_super_in_comparison.sol
@@ -21,7 +21,10 @@ contract C {
 // ----
 // TypeError 2271: (144-157): Built-in binary operator != cannot be applied to types type(contract super C) and contract C.
 // TypeError 2271: (167-180): Built-in binary operator != cannot be applied to types contract C and type(contract super C).
+// Warning 9170: (167-180): Comparison of variables of contract type is deprecated and scheduled for removal. Use an explicit cast to address type and compare the addresses instead.
 // TypeError 2271: (254-264): Built-in binary operator != cannot be applied to types type(contract super C) and contract C.
 // TypeError 2271: (274-284): Built-in binary operator != cannot be applied to types contract C and type(contract super C).
+// Warning 9170: (274-284): Comparison of variables of contract type is deprecated and scheduled for removal. Use an explicit cast to address type and compare the addresses instead.
 // TypeError 2271: (349-359): Built-in binary operator != cannot be applied to types type(contract super C) and contract D.
 // TypeError 2271: (369-379): Built-in binary operator != cannot be applied to types contract D and type(contract super C).
+// Warning 9170: (369-379): Comparison of variables of contract type is deprecated and scheduled for removal. Use an explicit cast to address type and compare the addresses instead.

--- a/test/libsolidity/syntaxTests/errors/no_structs_in_abiv1.sol
+++ b/test/libsolidity/syntaxTests/errors/no_structs_in_abiv1.sol
@@ -4,4 +4,5 @@ contract C {
     error MyError(S);
 }
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 3061: (70-71): This type is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/events/event_nested_array.sol
+++ b/test/libsolidity/syntaxTests/events/event_nested_array.sol
@@ -3,4 +3,5 @@ contract c {
     event E(uint[][]);
 }
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 3061: (45-53): This type is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/events/event_nested_array_in_struct.sol
+++ b/test/libsolidity/syntaxTests/events/event_nested_array_in_struct.sol
@@ -4,4 +4,5 @@ contract c {
     event E(S);
 }
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 3061: (81-82): This type is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/events/event_struct.sol
+++ b/test/libsolidity/syntaxTests/events/event_struct.sol
@@ -4,4 +4,5 @@ contract c {
     event E(S);
 }
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 3061: (71-72): This type is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/events/event_struct_indexed.sol
+++ b/test/libsolidity/syntaxTests/events/event_struct_indexed.sol
@@ -4,4 +4,5 @@ contract c {
     event E(S indexed);
 }
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 3061: (71-80): This type is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/getter/nested_structs.sol
+++ b/test/libsolidity/syntaxTests/getter/nested_structs.sol
@@ -9,4 +9,5 @@ contract C {
     mapping(uint256 => X) public m;
 }
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 2763: (108-138): The following types are only supported for getters in ABI coder v2: struct C.Y memory. Either remove "public" or use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/immutable/inheritance_virtual_modifiers.sol
+++ b/test/libsolidity/syntaxTests/immutable/inheritance_virtual_modifiers.sol
@@ -17,3 +17,5 @@ contract C is B {
         _; f(x);
     }
 }
+// ----
+// Warning 8429: (88-137): Virtual modifiers are deprecated and scheduled for removal.

--- a/test/libsolidity/syntaxTests/imports/inheritance_abi_encoder_mismatch_1.sol
+++ b/test/libsolidity/syntaxTests/imports/inheritance_abi_encoder_mismatch_1.sol
@@ -17,4 +17,5 @@ pragma abicoder v1;
 import "./B.sol";
 contract C is B { }
 // ----
+// Warning 9511: (C.sol:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 6594: (C.sol:38-57): Contract "C" does not use ABI coder v2 but wants to inherit from a contract which uses types that require it. Use "pragma abicoder v2;" for the inheriting contract as well to enable the feature.

--- a/test/libsolidity/syntaxTests/imports/inheritance_abi_encoder_mismatch_2.sol
+++ b/test/libsolidity/syntaxTests/imports/inheritance_abi_encoder_mismatch_2.sol
@@ -16,4 +16,6 @@ pragma abicoder v1;
 import "./B.sol";
 contract C is B { }
 // ----
+// Warning 9511: (B.sol:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
+// Warning 9511: (C.sol:0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 6594: (B.sol:38-57): Contract "B" does not use ABI coder v2 but wants to inherit from a contract which uses types that require it. Use "pragma abicoder v2;" for the inheriting contract as well to enable the feature.

--- a/test/libsolidity/syntaxTests/inheritance/dataLocation/modifier_parameter_data_location_change_illegal_internal.sol
+++ b/test/libsolidity/syntaxTests/inheritance/dataLocation/modifier_parameter_data_location_change_illegal_internal.sol
@@ -10,4 +10,5 @@ contract B is A {
     }
 }
 // ----
+// Warning 8429: (26-66): Virtual modifiers are deprecated and scheduled for removal.
 // TypeError 1078: (153-214): Override changes modifier signature.

--- a/test/libsolidity/syntaxTests/inheritance/override/modifier_ambiguous.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/modifier_ambiguous.sol
@@ -8,3 +8,5 @@ contract C is A, B {
     modifier f() override(A,B) { _; }
 }
 // ----
+// Warning 8429: (17-44): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (64-91): Virtual modifiers are deprecated and scheduled for removal.

--- a/test/libsolidity/syntaxTests/inheritance/override/modifier_ambiguous_fail.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/modifier_ambiguous_fail.sol
@@ -7,4 +7,6 @@ contract B {
 contract C is A, B {
 }
 // ----
+// Warning 8429: (17-44): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (64-91): Virtual modifiers are deprecated and scheduled for removal.
 // TypeError 6480: (94-116): Derived contract must override modifier "f". Two or more base classes define modifier with same name.

--- a/test/libsolidity/syntaxTests/inheritance/override/modifier_inherited_different_signature.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/modifier_inherited_different_signature.sol
@@ -7,4 +7,6 @@ contract B {
 contract C is A, B {
 }
 // ----
+// Warning 8429: (17-50): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (70-97): Virtual modifiers are deprecated and scheduled for removal.
 // TypeError 6480: (100-122): Derived contract must override modifier "f". Two or more base classes define modifier with same name.

--- a/test/libsolidity/syntaxTests/inheritance/override/modifier_inherited_different_signature_override.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/modifier_inherited_different_signature_override.sol
@@ -8,4 +8,7 @@ contract C is A, B {
     modifier f() virtual override(A, B) { _; }
 }
 // ----
+// Warning 8429: (17-50): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (70-97): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (125-167): Virtual modifiers are deprecated and scheduled for removal.
 // TypeError 1078: (125-167): Override changes modifier signature.

--- a/test/libsolidity/syntaxTests/inheritance/override/nonintermediate_common_base_and_unique_implementation_modifier.sol
+++ b/test/libsolidity/syntaxTests/inheritance/override/nonintermediate_common_base_and_unique_implementation_modifier.sol
@@ -16,4 +16,7 @@ contract B is IJ
 }
 contract C is A, B {}
 // ----
+// Warning 8429: (14-41): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (58-85): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (111-154): Virtual modifiers are deprecated and scheduled for removal.
 // TypeError 6480: (229-250): Derived contract must override modifier "f". Two or more base classes define modifier with same name.

--- a/test/libsolidity/syntaxTests/inheritance/virtual/modifier_virtual_err.sol
+++ b/test/libsolidity/syntaxTests/inheritance/virtual/modifier_virtual_err.sol
@@ -4,4 +4,5 @@ library test {
     }
 }
 // ----
+// Warning 8429: (19-38): Virtual modifiers are deprecated and scheduled for removal.
 // TypeError 3275: (19-38): Modifiers in a library cannot be virtual.

--- a/test/libsolidity/syntaxTests/inheritance/virtual/simple.sol
+++ b/test/libsolidity/syntaxTests/inheritance/virtual/simple.sol
@@ -5,3 +5,4 @@ contract C
 	modifier modi() virtual {_;}
 }
 // ----
+// Warning 8429: (83-111): Virtual modifiers are deprecated and scheduled for removal.

--- a/test/libsolidity/syntaxTests/inlineAssembly/memory_safe_dialect_string_and_comment.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/memory_safe_dialect_string_and_comment.sol
@@ -4,4 +4,5 @@ function f() pure {
     }
 }
 // ----
-// Warning 8544: (63-104): Inline assembly marked as memory safe using both a NatSpec tag and an assembly flag. If you are not concerned with backwards compatibility, only use the assembly flag, otherwise only use the NatSpec tag.
+// Warning 8544: (63-104): Inline assembly marked as memory safe using both a NatSpec tag and an assembly block annotation. If you are not concerned with backwards compatibility, only use the assembly block annotation, otherwise only use the NatSpec tag.
+// Warning 2424: (63-104): Natspec memory-safe-assembly special comment for inline assembly is deprecated and scheduled for removal. Use the memory-safe block annotation instead.

--- a/test/libsolidity/syntaxTests/inlineAssembly/natspec_multi.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/natspec_multi.sol
@@ -15,9 +15,11 @@ function f() pure {
 // Warning 6269: (189-200): Unexpected NatSpec tag "after" with value "bogus-value" in inline assembly.
 // Warning 6269: (189-200): Unexpected NatSpec tag "before" with value "bogus-value" in inline assembly.
 // Warning 8787: (189-200): Unexpected value for @solidity tag in inline assembly: a
+// Warning 2424: (189-200): Natspec memory-safe-assembly special comment for inline assembly is deprecated and scheduled for removal. Use the memory-safe block annotation instead.
 // Warning 8787: (189-200): Unexpected value for @solidity tag in inline assembly: b
 // Warning 8787: (189-200): Unexpected value for @solidity tag in inline assembly: c
 // Warning 8787: (189-200): Unexpected value for @solidity tag in inline assembly: d
+// Warning 2424: (289-300): Natspec memory-safe-assembly special comment for inline assembly is deprecated and scheduled for removal. Use the memory-safe block annotation instead.
 // Warning 8787: (289-300): Unexpected value for @solidity tag in inline assembly: a
 // Warning 4377: (289-300): Value for @solidity tag in inline assembly specified multiple times: a
 // Warning 4377: (289-300): Value for @solidity tag in inline assembly specified multiple times: memory-safe-assembly

--- a/test/libsolidity/syntaxTests/inlineAssembly/natspec_multi_swallowed.sol
+++ b/test/libsolidity/syntaxTests/inlineAssembly/natspec_multi_swallowed.sol
@@ -14,6 +14,7 @@ function f() pure {
 // ----
 // Warning 6269: (177-188): Unexpected NatSpec tag "after" with value "bogus-value" in inline assembly.
 // Warning 6269: (177-188): Unexpected NatSpec tag "before" with value "@solidity a   memory-safe-assembly b    c           d" in inline assembly.
+// Warning 2424: (277-288): Natspec memory-safe-assembly special comment for inline assembly is deprecated and scheduled for removal. Use the memory-safe block annotation instead.
 // Warning 8787: (277-288): Unexpected value for @solidity tag in inline assembly: a
 // Warning 4377: (277-288): Value for @solidity tag in inline assembly specified multiple times: a
 // Warning 4377: (277-288): Value for @solidity tag in inline assembly specified multiple times: memory-safe-assembly

--- a/test/libsolidity/syntaxTests/modifiers/definition_in_contract.sol
+++ b/test/libsolidity/syntaxTests/modifiers/definition_in_contract.sol
@@ -9,3 +9,6 @@ abstract contract A {
     modifier muv virtual;
 }
 // ----
+// Warning 8429: (39-65): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (117-143): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (148-169): Virtual modifiers are deprecated and scheduled for removal.

--- a/test/libsolidity/syntaxTests/modifiers/definition_in_contract_unimplemented.sol
+++ b/test/libsolidity/syntaxTests/modifiers/definition_in_contract_unimplemented.sol
@@ -3,5 +3,6 @@ contract C {
     modifier muv virtual;
 }
 // ----
+// Warning 8429: (34-55): Virtual modifiers are deprecated and scheduled for removal.
 // TypeError 3656: (0-57): Contract "C" should be marked as abstract.
 // TypeError 8063: (17-29): Modifiers without implementation must be marked virtual.

--- a/test/libsolidity/syntaxTests/modifiers/definition_in_interface.sol
+++ b/test/libsolidity/syntaxTests/modifiers/definition_in_interface.sol
@@ -5,6 +5,8 @@ interface I {
     modifier muv virtual;
 }
 // ----
+// Warning 8429: (57-83): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (88-109): Virtual modifiers are deprecated and scheduled for removal.
 // TypeError 6408: (18-35): Modifiers cannot be defined or declared in interfaces.
 // TypeError 6408: (40-52): Modifiers cannot be defined or declared in interfaces.
 // TypeError 8063: (40-52): Modifiers without implementation must be marked virtual.

--- a/test/libsolidity/syntaxTests/modifiers/definition_in_library.sol
+++ b/test/libsolidity/syntaxTests/modifiers/definition_in_library.sol
@@ -2,4 +2,5 @@ library L {
     modifier mv virtual { _; }
 }
 // ----
+// Warning 8429: (16-42): Virtual modifiers are deprecated and scheduled for removal.
 // TypeError 3275: (16-42): Modifiers in a library cannot be virtual.

--- a/test/libsolidity/syntaxTests/modifiers/definition_in_library_unimplemented.sol
+++ b/test/libsolidity/syntaxTests/modifiers/definition_in_library_unimplemented.sol
@@ -3,5 +3,6 @@ library L {
     modifier muv virtual;
 }
 // ----
+// Warning 8429: (33-54): Virtual modifiers are deprecated and scheduled for removal.
 // TypeError 8063: (16-28): Modifiers without implementation must be marked virtual.
 // TypeError 3275: (33-54): Modifiers in a library cannot be virtual.

--- a/test/libsolidity/syntaxTests/modifiers/empty_modifier_body.sol
+++ b/test/libsolidity/syntaxTests/modifiers/empty_modifier_body.sol
@@ -13,3 +13,5 @@ contract D is C {
 	}
 }
 // ----
+// Warning 8429: (22-51): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (134-153): Virtual modifiers are deprecated and scheduled for removal.

--- a/test/libsolidity/syntaxTests/modifiers/empty_modifier_err.sol
+++ b/test/libsolidity/syntaxTests/modifiers/empty_modifier_err.sol
@@ -5,6 +5,8 @@ contract C is B { }
 
 abstract contract D {modifier m;}
 // ----
+// Warning 8429: (12-31): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (55-74): Virtual modifiers are deprecated and scheduled for removal.
 // TypeError 3656: (0-32): Contract "A" should be marked as abstract.
 // TypeError 3656: (76-95): Contract "C" should be marked as abstract.
 // TypeError 8063: (118-129): Modifiers without implementation must be marked virtual.

--- a/test/libsolidity/syntaxTests/modifiers/legal_modifier_override.sol
+++ b/test/libsolidity/syntaxTests/modifiers/legal_modifier_override.sol
@@ -1,3 +1,4 @@
 contract A { modifier mod(uint a) virtual { _; } }
 contract B is A { modifier mod(uint a) override { _; } }
 // ----
+// Warning 8429: (13-48): Virtual modifiers are deprecated and scheduled for removal.

--- a/test/libsolidity/syntaxTests/modifiers/modifier_abstract_override.sol
+++ b/test/libsolidity/syntaxTests/modifiers/modifier_abstract_override.sol
@@ -8,4 +8,6 @@ contract C is B {
     function f() m public {}
 }
 // ----
+// Warning 8429: (17-44): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (78-108): Virtual modifiers are deprecated and scheduled for removal.
 // TypeError 4593: (78-108): Overriding an implemented modifier with an unimplemented modifier is not allowed.

--- a/test/libsolidity/syntaxTests/modifiers/multiple_inheritance_unimplemented_override.sol
+++ b/test/libsolidity/syntaxTests/modifiers/multiple_inheritance_unimplemented_override.sol
@@ -9,3 +9,5 @@ contract C is A, B {
     function f() m public {}
 }
 // ----
+// Warning 8429: (17-44): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (73-94): Virtual modifiers are deprecated and scheduled for removal.

--- a/test/libsolidity/syntaxTests/modifiers/unimplemented_function_and_modifier.sol
+++ b/test/libsolidity/syntaxTests/modifiers/unimplemented_function_and_modifier.sol
@@ -26,6 +26,7 @@ contract E is A {
   modifier mod() override { _;}
 }
 // ----
+// Warning 8429: (110-133): Virtual modifiers are deprecated and scheduled for removal.
 // TypeError 3656: (137-254): Contract "B" should be marked as abstract.
 // TypeError 3656: (256-344): Contract "C" should be marked as abstract.
 // TypeError 3656: (346-466): Contract "D" should be marked as abstract.

--- a/test/libsolidity/syntaxTests/modifiers/unimplemented_override_unimplemented.sol
+++ b/test/libsolidity/syntaxTests/modifiers/unimplemented_override_unimplemented.sol
@@ -9,3 +9,6 @@ abstract contract C is B {
     function f() m public {}
 }
 // ----
+// Warning 8429: (26-47): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (81-111): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (145-175): Virtual modifiers are deprecated and scheduled for removal.

--- a/test/libsolidity/syntaxTests/modifiers/use_unimplemented_from_base.sol
+++ b/test/libsolidity/syntaxTests/modifiers/use_unimplemented_from_base.sol
@@ -6,3 +6,5 @@ contract B is A {
     modifier m() virtual override { _; }
 }
 // ----
+// Warning 8429: (26-47): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (101-137): Virtual modifiers are deprecated and scheduled for removal.

--- a/test/libsolidity/syntaxTests/modifiers/use_unimplemented_on_overridden_func.sol
+++ b/test/libsolidity/syntaxTests/modifiers/use_unimplemented_on_overridden_func.sol
@@ -6,3 +6,4 @@ abstract contract B is A {
     function f() public override {}
 }
 // ----
+// Warning 8429: (26-47): Virtual modifiers are deprecated and scheduled for removal.

--- a/test/libsolidity/syntaxTests/modifiers/use_unimplemented_static.sol
+++ b/test/libsolidity/syntaxTests/modifiers/use_unimplemented_static.sol
@@ -9,4 +9,6 @@ contract C is A, B {
     function f() B.m public {}
 }
 // ----
+// Warning 8429: (17-44): Virtual modifiers are deprecated and scheduled for removal.
+// Warning 8429: (73-94): Virtual modifiers are deprecated and scheduled for removal.
 // TypeError 1835: (174-177): Cannot call unimplemented modifier. The modifier has no implementation in the referenced contract. Refer to it by its unqualified name if you want to call the implementation from the most derived contract.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/045_returning_multi_dimensional_arrays.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/045_returning_multi_dimensional_arrays.sol
@@ -3,4 +3,5 @@ contract C {
     function f() public pure returns (string[][] memory) {}
 }
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 4957: (71-88): This type is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/046_returning_multi_dimensional_static_arrays.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/046_returning_multi_dimensional_static_arrays.sol
@@ -3,4 +3,5 @@ contract C {
     function f() public pure returns (uint[][2] memory) {}
 }
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 4957: (71-87): This type is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/048_returning_arrays_in_structs_arrays.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/048_returning_arrays_in_structs_arrays.sol
@@ -4,4 +4,5 @@ contract C {
     function f() public pure returns (S memory x) {}
 }
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 4957: (100-110): This type is only supported in ABI coder v2. Use "pragma abicoder v2;" to enable the feature.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/346_unused_return_value_send.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/346_unused_return_value_send.sol
@@ -4,4 +4,5 @@ contract test {
     }
 }
 // ----
+// Warning 9207: (50-77): 'send' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
 // Warning 5878: (50-80): Failure condition of 'send' ignored. Consider using 'transfer' instead.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/405_address_checksum_type_deduction.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/405_address_checksum_type_deduction.sol
@@ -4,3 +4,4 @@ contract C {
     }
 }
 // ----
+// Warning 9207: (47-107): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/413_address_methods.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/413_address_methods.sol
@@ -10,3 +10,5 @@ contract C {
     }
 }
 // ----
+// Warning 9207: (227-236): 'send' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+// Warning 9207: (249-262): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/466_does_not_error_transfer_payable_fallback.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/466_does_not_error_transfer_payable_fallback.sol
@@ -13,3 +13,4 @@ contract B {
     }
 }
 // ----
+// Warning 9207: (227-246): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/535_address_overload_resolution.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/535_address_overload_resolution.sol
@@ -17,4 +17,5 @@ contract D {
     }
 }
 // ----
+// Warning 9207: (187-209): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
 // Warning 2018: (17-134): Function state mutability can be restricted to view

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/585_abi_decode_with_unsupported_types.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/585_abi_decode_with_unsupported_types.sol
@@ -6,4 +6,5 @@ contract C {
     }
 }
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 9611: (118-119): Decoding type struct C.s memory not supported.

--- a/test/libsolidity/syntaxTests/sizeLimits/bytecode_too_large_abiencoder_v1.sol
+++ b/test/libsolidity/syntaxTests/sizeLimits/bytecode_too_large_abiencoder_v1.sol
@@ -10,4 +10,5 @@ contract test {
 // EVMVersion: >=shanghai
 // bytecodeFormat: legacy
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // Warning 5574: (21-27154): Contract code size is 27205 bytes and exceeds 24576 bytes (a limit introduced in Spurious Dragon). This contract may not be deployable on Mainnet. Consider enabling the optimizer (with a low "runs" value!), turning off revert strings, or using libraries.

--- a/test/libsolidity/syntaxTests/specialFunctions/abi_encodePacked_nested_dynamic_array.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abi_encodePacked_nested_dynamic_array.sol
@@ -5,4 +5,5 @@ contract C {
     }
 }
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 9578: (89-119): Type not supported in packed mode.

--- a/test/libsolidity/syntaxTests/specialFunctions/abi_encode_nested_dynamic_array.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abi_encode_nested_dynamic_array.sol
@@ -5,4 +5,5 @@ contract C {
     }
 }
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 2056: (86-116): This type cannot be encoded.

--- a/test/libsolidity/syntaxTests/specialFunctions/abi_encode_structs.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abi_encode_structs.sol
@@ -12,6 +12,7 @@ contract C {
     }
 }
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 2056: (151-152): This type cannot be encoded.
 // TypeError 2056: (154-155): This type cannot be encoded.
 // TypeError 9578: (220-221): Type not supported in packed mode.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_nested_dynamic_array.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_nested_dynamic_array.sol
@@ -5,4 +5,5 @@ contract C {
     }
 }
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 9611: (92-101): Decoding type uint256[][3] memory not supported.

--- a/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_struct.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abidecode/abi_decode_struct.sol
@@ -9,4 +9,5 @@ contract C {
     }
 }
 // ----
+// Warning 9511: (0-19): ABI coder v1 is deprecated and scheduled for removal. Use ABI coder v2 instead.
 // TypeError 9611: (118-119): Decoding type struct S memory not supported.

--- a/test/libsolidity/syntaxTests/viewPureChecker/builtin_functions.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/builtin_functions.sol
@@ -21,4 +21,6 @@ contract C {
 // ====
 // bytecodeFormat: legacy
 // ----
+// Warning 9207: (47-69): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+// Warning 9207: (90-108): 'send' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
 // Warning 5159: (122-134): "selfdestruct" has been deprecated. Note that, starting from the Cancun hard fork, the underlying opcode no longer deletes the code and data associated with an account and only transfers its Ether to the beneficiary, unless executed in the same transaction in which the contract was created (see EIP-6780). Any use in newly deployed contracts is strongly discouraged even if the new behavior is taken into account. Future changes to the EVM might further reduce the functionality of the opcode.

--- a/test/libsolidity/syntaxTests/viewPureChecker/builtin_functions_view_fail.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/builtin_functions_view_fail.sol
@@ -20,6 +20,8 @@ contract C {
     }
 }
 // ----
+// Warning 9207: (52-74): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+// Warning 9207: (132-150): 'send' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
 // Warning 5159: (201-213): "selfdestruct" has been deprecated. Note that, starting from the Cancun hard fork, the underlying opcode no longer deletes the code and data associated with an account and only transfers its Ether to the beneficiary, unless executed in the same transaction in which the contract was created (see EIP-6780). Any use in newly deployed contracts is strongly discouraged even if the new behavior is taken into account. Future changes to the EVM might further reduce the functionality of the opcode.
 // TypeError 8961: (52-77): Function cannot be declared as view because this expression (potentially) modifies the state.
 // TypeError 8961: (132-153): Function cannot be declared as view because this expression (potentially) modifies the state.

--- a/test/libsolidity/syntaxTests/viewPureChecker/eof/builtin_functions.sol
+++ b/test/libsolidity/syntaxTests/viewPureChecker/eof/builtin_functions.sol
@@ -20,3 +20,5 @@ contract C {
 // ====
 // bytecodeFormat: >=EOFv1
 // ----
+// Warning 9207: (47-69): 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
+// Warning 9207: (90-108): 'send' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.


### PR DESCRIPTION
Partially solves #15795.
Deprecation warnings for:
 - comparison operators on contract type #11700.
 - `.send` and `.transfer` #7455.
 - ABI coder v1 #11323.
 - virtual modifiers #12483.
 - `/// @solidity memory-safe-assembly` natspec comment.