### PR TITLE
Pin hardhat to last 2.x.x version in gp2 and pool-together external tests

### DIFF
--- a/test/externalTests/gp2.sh
+++ b/test/externalTests/gp2.sh
@@ -66,7 +66,8 @@ function gp2_test
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")" "$config_var"
     force_hardhat_unlimited_contract_size "$config_file" "$config_var"
     yarn
-    yarn add hardhat
+    # Hardhat 3.0+ breaks the test suite
+    yarn add hardhat@2.26.3
 
     # Ignore bench directory which fails to compile with current hardhat and ethers versions.
     # bench/trace/gas.ts:123:19 - error TS2339: Property 'equals' does not exist on type 'Uint8Array'.

--- a/test/externalTests/pool-together.sh
+++ b/test/externalTests/pool-together.sh
@@ -66,7 +66,8 @@ function pool_together_test
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")" "$config_var"
     yarn install
-    yarn add hardhat
+    # Hardhat 3.0+ breaks the test suite
+    yarn add hardhat@2.26.3
 
     # These come with already compiled artifacts. We want them recompiled with latest compiler.
     rm -r node_modules/@pooltogether/yield-source-interface/artifacts/


### PR DESCRIPTION
Hardhat 3.0.0 introduces breaking changes, and getting gp2 and pool together to be compatible would be significant work for repositories that have been archived 2/3 years ago. Pinning hardhat to the latest 2.x.x. version is therefore the optimal course of action.