### PR TITLE
update to boost 1.70.0 for non-windows builds

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,9 @@ Bugfixes:
 * Assembler: Fix not using a fixed-width type for IDs being assigned to subassemblies nested more than one level away, resulting in inconsistent `--asm-json` output between target architectures.
 * Yul Optimizer: Fix edge case in which invalid Yul code is produced by ExpressionSimplifier due to expressions being substituted that contain out-of-scope variables.
 
+Build System:
+* Update to boost 1.70.0 for non-windows builds.
+
 ### 0.8.30 (2025-05-07)
 
 Compiler Features:

--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -42,17 +42,9 @@ if (WIN32)
 else()
 	# Boost 1.65 is the first to also provide boost::get for rvalue-references (#5787).
 	# Boost 1.67 moved container_hash into is own module.
+	# Boost 1.69 boost::system is header-only and no longer needs to be fetched as component
 	# Boost 1.70 comes with its own BoostConfig.cmake and is the new (non-deprecated) behavior
-	find_package(Boost 1.70.0 QUIET COMPONENTS ${BOOST_COMPONENTS})
-	if (NOT ${Boost_FOUND})
-		# If the boost version is < 1.70.0, there is no boost config delivered with it, revert to old behavior
-		# todo drop this once cmake minimum version >= 3.30 is reached
-		if(POLICY CMP0167)
-			cmake_policy(SET CMP0167 OLD)
-		endif()
-		list(APPEND BOOST_COMPONENTS system)
-		find_package(Boost 1.67.0 QUIET REQUIRED COMPONENTS ${BOOST_COMPONENTS})
-	endif()
+	find_package(Boost 1.70.0 QUIET REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 endif()
 
 # If cmake is older than boost and boost is older than 1.70,

--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -327,7 +327,7 @@ The following are dependencies for all builds of Solidity:
 | Windows, 3.13+ otherwise)         |                                                       |
 +-----------------------------------+-------------------------------------------------------+
 | `Boost`_ (version 1.77+ on        | C++ libraries.                                        |
-| Windows, 1.67+ otherwise)         |                                                       |
+| Windows, 1.70+ otherwise)         |                                                       |
 +-----------------------------------+-------------------------------------------------------+
 | `Git`_                            | Command-line tool for retrieving source code.         |
 +-----------------------------------+-------------------------------------------------------+


### PR DESCRIPTION
This somewhat simplifies the CMake setup. See also https://github.com/ethereum/solidity/pull/16163#issuecomment-3190781810.