### PR TITLE
Bump boost, gcc, clang for non-windows builds and add CI job with these versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,6 @@ parameters:
     type: string
     # solbuildpackpusher/solidity-buildpack-deps:ubuntu2004-26
     default: "solbuildpackpusher/solidity-buildpack-deps@sha256:1f387a77be889f65a2a25986a5c5eccc88cec23fabe6aeaf351790751145c81e"
-  ubuntu-2204-docker-image:
-    type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2204-2
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:877fcc2589779f8245770711d10db92eda97d338dae76b6a9f27dde1a41b3aa0"
   ubuntu-2404-docker-image:
     type: string
     # solbuildpackpusher/solidity-buildpack-deps:ubuntu2404-3
@@ -573,42 +569,6 @@ defaults:
         MAKEFLAGS: -j 10
         CPUs: 10
 
-  - base_ubuntu2204: &base_ubuntu2204
-      docker:
-        - image: << pipeline.parameters.ubuntu-2204-docker-image >>
-      environment: &base_ubuntu2204_env
-        TERM: xterm
-        CC: gcc
-        CXX: g++
-        MAKEFLAGS: -j 3
-        CPUs: 3
-
-  - base_ubuntu2204_large: &base_ubuntu2204_large
-      <<: *base_ubuntu2204
-      resource_class: large
-      environment: &base_ubuntu2204_large_env
-        <<: *base_ubuntu2204_env
-        MAKEFLAGS: -j 5
-        CPUs: 5
-
-  - base_ubuntu2204_clang: &base_ubuntu2204_clang
-      docker:
-        - image: << pipeline.parameters.ubuntu-2204-docker-image >>
-      environment: &base_ubuntu2204_clang_env
-        TERM: xterm
-        CC: clang
-        CXX: clang++
-        MAKEFLAGS: -j 3
-        CPUs: 3
-
-  - base_ubuntu2204_clang_large: &base_ubuntu2204_clang_large
-      <<: *base_ubuntu2204_clang
-      resource_class: large
-      environment: &base_ubuntu2204_clang_large_env
-        <<: *base_ubuntu2204_clang_env
-        MAKEFLAGS: -j 5
-        CPUs: 5
-
   - base_ubuntu2404: &base_ubuntu2404
       docker:
         - image: << pipeline.parameters.ubuntu-2404-docker-image >>
@@ -1148,8 +1108,6 @@ jobs:
       EVM: << pipeline.parameters.evm-version >>
       EOF_VERSION: 0
       OPTIMIZE: 0
-      # Skip semantic tests due to evmone compatibility issues with Ubuntu 22.04
-      SOLTEST_FLAGS: --no-semantic-tests --no-smt
     steps:
       - soltest
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,19 @@ commands:
             fi
             echo -n "$CIRCLE_SHA1" > commit_hash.txt
 
+  install_and_check_minimum_requirements:
+    parameters:
+      compiler:
+        description: "Compiler to check: gcc or clang"
+        type: enum
+        enum:
+          - gcc
+          - clang
+    steps:
+      - run:
+          name: Install and check minimum requirements
+          command: scripts/ci/install_and_check_minimum_requirements.sh "--<< parameters.compiler >>"
+
   run_build:
     steps:
       - run:
@@ -1103,22 +1116,42 @@ jobs:
             - solc/solc-static-linux
       - matrix_notify_failure_unless_pr
 
-  b_ubu_2204:
-    <<: *base_ubuntu2204_large
+  b_ubu_min_req:
+    <<: *base_ubuntu2404_large
     steps:
       - checkout
+      - install_and_check_minimum_requirements:
+          compiler: gcc
       - run_build
+      - store_artifacts_solc
+      - persist_executables_to_workspace
       - matrix_notify_failure_unless_pr
+      - build
 
-  b_ubu_2204_clang:
-    <<: *base_ubuntu2204_clang_large
+  b_ubu_min_req_clang:
+    <<: *base_ubuntu2404_clang_large
     environment:
-      <<: *base_ubuntu2204_clang_large_env
+      <<: *base_ubuntu2404_clang_large_env
       MAKEFLAGS: -j 10
     steps:
       - checkout
+      - install_and_check_minimum_requirements:
+          compiler: clang
       - run_build
       - matrix_notify_failure_unless_pr
+
+  t_ubu_min_req_soltest:
+    <<: *base_ubuntu2404_large
+    parallelism: 20
+    environment:
+      <<: *base_ubuntu2404_large_env
+      EVM: << pipeline.parameters.evm-version >>
+      EOF_VERSION: 0
+      OPTIMIZE: 0
+      # Skip semantic tests due to evmone compatibility issues with Ubuntu 22.04
+      SOLTEST_FLAGS: --no-semantic-tests --no-smt
+    steps:
+      - soltest
 
   b_ubu_ossfuzz: &b_ubu_ossfuzz
     <<: *base_ubuntu_clang_large
@@ -1893,8 +1926,14 @@ workflows:
       # build-only
       - b_docs: *requires_nothing
       - b_ubu_ossfuzz: *requires_nothing
-      - b_ubu_2204: *requires_nothing
-      - b_ubu_2204_clang: *requires_nothing
+
+      # build and test with minimum supported versions of dependencies
+      - b_ubu_min_req_clang: *requires_nothing
+      - b_ubu_min_req: *requires_nothing
+      - t_ubu_min_req_soltest:
+          <<: *on_all_tags_and_branches
+          requires:
+            - b_ubu_min_req
 
       # OS/X build and tests
       - b_osx: *requires_nothing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ parameters:
   emscripten-docker-image:
     type: string
     # NOTE: Please remember to update the `scripts/build_emscripten.sh` whenever the hash of this image changes.
-    # solbuildpackpusher/solidity-buildpack-deps:emscripten-20
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:98f963ed799a0d206ef8e7b5475f847e0dea53b7fdea9618bbc6106a62730bd2"
+    # solbuildpackpusher/solidity-buildpack-deps:emscripten-21
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:fc53d68a4680ffa7d5f70164e13a903478964f15bcc07434d74833a05f4fbc19"
   evm-version:
     type: string
     default: prague

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,7 +10,7 @@ Bugfixes:
 * Yul Optimizer: Fix edge case in which invalid Yul code is produced by ExpressionSimplifier due to expressions being substituted that contain out-of-scope variables.
 
 Build System:
-* Update to boost 1.70.0 for non-windows builds.
+* Update minimum version requirements of Boost to 1.83.0 for non-windows builds and of GCC and Clang to 13.3 and 18.1.3, respectively. Fixes infinite recursion on `boost::rational` comparison affecting compiler binaries built with GCC<14.0 and Boost<1.75.
 
 ### 0.8.30 (2025-05-07)
 

--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -44,7 +44,9 @@ else()
 	# Boost 1.67 moved container_hash into is own module.
 	# Boost 1.69 boost::system is header-only and no longer needs to be fetched as component
 	# Boost 1.70 comes with its own BoostConfig.cmake and is the new (non-deprecated) behavior
-	find_package(Boost 1.70.0 QUIET REQUIRED COMPONENTS ${BOOST_COMPONENTS})
+	# Boost 1.75 fixes infinite recursion on `boost::rational` comparison with GCC<14.0 under C++20
+	# Boost 1.83 is the version that comes with Ubuntu 24.04.
+	find_package(Boost 1.83.0 QUIET REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 endif()
 
 # If cmake is older than boost and boost is older than 1.70,

--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -320,6 +320,8 @@ Prerequisites - All Operating Systems
 
 The following are dependencies for all builds of Solidity:
 
+.. Note: This has to be kept in sync with `scripts/ci/install_and_check_minimum_requirements.sh`.
+
 +-----------------------------------+-------------------------------------------------------+
 | Software                          | Notes                                                 |
 +===================================+=======================================================+
@@ -327,7 +329,7 @@ The following are dependencies for all builds of Solidity:
 | Windows, 3.13+ otherwise)         |                                                       |
 +-----------------------------------+-------------------------------------------------------+
 | `Boost`_ (version 1.77+ on        | C++ libraries.                                        |
-| Windows, 1.70+ otherwise)         |                                                       |
+| Windows, 1.83+ otherwise)         |                                                       |
 +-----------------------------------+-------------------------------------------------------+
 | `Git`_                            | Command-line tool for retrieving source code.         |
 +-----------------------------------+-------------------------------------------------------+
@@ -372,8 +374,10 @@ Minimum Compiler Versions
 
 The following C++ compilers and their minimum versions can build the Solidity codebase:
 
-- `GCC <https://gcc.gnu.org>`_, version 11+
-- `Clang <https://clang.llvm.org/>`_, version 14+
+.. Note: Minimum versions for GCC and Clang are based on availability in Ubuntu 24.04.
+
+- `GCC <https://gcc.gnu.org>`_, version 13.3+
+- `Clang <https://clang.llvm.org/>`_, version 18.1.3+
 - `MSVC <https://visualstudio.microsoft.com/vs/>`_, version 2019+
 
 Prerequisites - macOS

--- a/scripts/ci/install_and_check_minimum_requirements.sh
+++ b/scripts/ci/install_and_check_minimum_requirements.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# minimum boost version
+BOOST_VERSION=1.83
+
+# minimum cmake version
+CMAKE_MAJOR=3
+CMAKE_MINOR=13
+CMAKE_PATCH=0
+CMAKE_FULL_VERSION="${CMAKE_MAJOR}.${CMAKE_MINOR}.${CMAKE_PATCH}"
+
+# minimum gcc/clang versions
+GCC_VERSION=13.3.0
+CLANG_VERSION=18.1.3
+
+# which compiler version to check in this script
+check_gcc=false
+check_clang=false
+
+while (( $# > 0 )); do
+    case "$1" in
+        --gcc)
+            check_gcc=true
+            shift
+            ;;
+        --clang)
+            check_clang=true
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [--gcc] [--clang]"
+            exit 1
+            ;;
+    esac
+done
+
+echo "-- Removing boost and CMake from the system"
+sudo apt-get --quiet=2 remove --purge 'libboost*'
+sudo apt-get --quiet=2 remove --purge cmake
+
+echo "-- Installing Boost ${BOOST_VERSION}"
+sudo apt-get --quiet=2 update
+sudo apt-get --quiet=2 install libboost${BOOST_VERSION}-all-dev
+installed_boost_version=$(dpkg-query --showformat='${Version}' --show libboost${BOOST_VERSION}-all-dev 2>/dev/null || echo "none")
+if [[ $installed_boost_version != ${BOOST_VERSION}* ]]; then
+    echo "Error: installed version of boost is $installed_boost_version, expected $BOOST_VERSION"
+    exit 1
+fi
+
+echo "-- Installing CMake ${CMAKE_FULL_VERSION}"
+wget "https://cmake.org/files/v${CMAKE_MAJOR}.${CMAKE_MINOR}/cmake-${CMAKE_FULL_VERSION}-Linux-x86_64.tar.gz"
+tar --extract --gzip --file "cmake-${CMAKE_FULL_VERSION}-Linux-x86_64.tar.gz"
+sudo mv "cmake-${CMAKE_FULL_VERSION}-Linux-x86_64" "/opt/cmake-${CMAKE_FULL_VERSION}"
+sudo ln --symbolic "/opt/cmake-${CMAKE_FULL_VERSION}/bin/"* /usr/local/bin/
+echo "-- Installed $(cmake --version)"
+
+if [[ "$check_gcc" == true ]]; then
+    installed_gcc_version=$(gcc -dumpfullversion -dumpversion || echo "none")
+    if [[ "$installed_gcc_version" != "$GCC_VERSION" ]]; then
+        echo "Error: installed version of gcc is $installed_gcc_version, expected $GCC_VERSION"
+        exit 1
+    fi
+    echo "-- gcc version check passed: $installed_gcc_version"
+fi
+
+if [[ "$check_clang" == true ]]; then
+    installed_clang_version=$(clang -dumpfullversion -dumpversion || echo "none")
+    if [[ "$installed_clang_version" != "$CLANG_VERSION" ]]; then
+        echo "Error: installed version of clang is $installed_clang_version, expected $CLANG_VERSION"
+        exit 1
+    fi
+    echo "-- clang version check passed: $installed_clang_version"
+fi

--- a/scripts/ci/install_and_check_minimum_requirements.sh
+++ b/scripts/ci/install_and_check_minimum_requirements.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# These versions must be kept in sync with the docs in `docs/installing-solidity.rst#building-from-source`.
+
 # minimum boost version
 BOOST_VERSION=1.83
 


### PR DESCRIPTION
Use explicit .operator==() calls to avoid infinite recursion in rational-to-integer comparisons caused by symmetric operator overload resolution bug.

Fixes #16084.

We might potentially want to add a CI job as outlined in https://github.com/ethereum/solidity/issues/15136 to this PR. Or do it separately.

Adds a CI job that tests on 22.04 which falls into the gcc/boost version category that is problematic. The shipped glibc is too old for current evmone releases, therefore it skips smt and semantic tests.