### PR TITLE
fix: make parameter name fallback null-safe in Predicate::formatSummaryCall

### DIFF
--- a/libsolidity/formal/Predicate.cpp
+++ b/libsolidity/formal/Predicate.cpp
@@ -303,7 +303,13 @@ std::string Predicate::formatSummaryCall(
 			functionArgs.emplace_back(*functionArgsCex.at(i));
 		else {
 			paramNameInsteadOfValue = true;
-			functionArgs.emplace_back(params[i]->name());
+			if (params.at(i))
+			{
+				auto const& paramName = params.at(i)->name();
+				functionArgs.emplace_back(paramName.empty() ? ("param_" + std::to_string(i)) : paramName);
+			}
+			else
+				functionArgs.emplace_back("param_" + std::to_string(i));
 		}
 
 	std::string fName = fun->isConstructor() ? "constructor" :


### PR DESCRIPTION
Reason: Formatting function calls in counterexamples could dereference a null parameter pointer when a parameter is absent and no concrete value is available, leading to undefined behavior.

Change: Guard against null params.at(i) and use a safe fallback: prefer the parameter’s actual name when available, otherwise use the placeholder param_<i>. The existing “counterexample incomplete” note remains unchanged.

Goal: Eliminate potential UB and make counterexample formatting robust. This aligns with existing null checks in nearby code (e.g., CHC.cpp, RenameSymbol.cpp) and follows existing placeholder naming (param_) used elsewhere. Tests pass.