### PR TITLE
fix: correct fromHex function documentation

### DIFF
--- a/libsolutil/CommonData.h
+++ b/libsolutil/CommonData.h
@@ -453,7 +453,7 @@ int fromHex(char _i, WhenError _throw);
 
 /// Converts a (printable) ASCII hex string into the corresponding byte stream.
 /// @example fromHex("41626261") == asBytes("Abba")
-/// If _throw = ThrowType::DontThrow, it replaces bad hex characters with 0's, otherwise it will throw an exception.
+/// If _throw = WhenError::DontThrow, it returns an empty bytes array on any validation error, otherwise it will throw an exception.
 bytes fromHex(std::string const& _s, WhenError _throw = WhenError::DontThrow);
 /// Converts byte array to a string containing the same (binary) data. Unless
 /// the byte array happens to contain ASCII data, this won't be printable.


### PR DESCRIPTION
Fix incorrect documentation for fromHex function:

**Why it was wrong:**
- Referenced non-existent type "ThrowType::DontThrow" instead of "WhenError::DontThrow"
- Claimed function "replaces bad hex characters with 0's" which never happened

**Why it's now correct:**
- Uses correct enum type "WhenError::DontThrow"
- Accurately describes behavior: "returns an empty bytes array on any validation error"
- Documentation now matches actual implementation and test expectations