### PR TITLE
feat: remove unused fmt include from SemanticTokensBuilder.h and add pragma once

### DIFF
--- a/libsolidity/lsp/SemanticTokensBuilder.h
+++ b/libsolidity/lsp/SemanticTokensBuilder.h
@@ -15,11 +15,10 @@
 	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
 */
 // SPDX-License-Identifier: GPL-3.0
+#pragma once
 #include <libsolidity/ast/AST.h>
 #include <libsolidity/ast/ASTVisitor.h>
 #include <libsolutil/JSON.h>
-
-#include <fmt/format.h>
 
 namespace solidity::langutil
 {


### PR DESCRIPTION
Drop #include <fmt/format.h> from SemanticTokensBuilder.h since the header does not use fmt.
Keep fmt usage in SemanticTokensBuilder.cpp only.
Add #pragma once to the header to follow the project’s preprocessor guideline.
This reduces header coupling and compile times and aligns with other LSP headers.