### PR TITLE
chore: Remove redundant post-loop invalidation in DataFlowAnalyzer::operator()(Switch&

### DIFF
--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -147,7 +147,6 @@ void DataFlowAnalyzer::operator()(Switch& _switch)
 		clearKnowledgeIfInvalidated(_case.body);
 	}
 	for (auto& _case: _switch.cases)
-		clearKnowledgeIfInvalidated(_case.body);
 	clearValues(assignedVariables);
 }
 


### PR DESCRIPTION
Delete the extra clearKnowledgeIfInvalidated(_case.body) loop after processing all cases.
Per-case invalidation already applies the necessary clears, and joinKnowledge does not reintroduce knowledge, so the second pass is redundant.
Keeps behavior unchanged while reducing unnecessary work.