### PR TITLE
Pin actions-comment-pull-request action to specific commit and update to the latest version

### DIFF
--- a/.github/workflows/buildpack-deps.yml
+++ b/.github/workflows/buildpack-deps.yml
@@ -29,7 +29,7 @@ jobs:
         image_variant: [emscripten, ubuntu.clang.ossfuzz, ubuntu2004, ubuntu2204, ubuntu2404, ubuntu2404.clang]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
@@ -41,6 +41,6 @@ jobs:
 
       - name: comment PR
         if: "env.DOCKER_IMAGE"
-        uses: thollander/actions-comment-pull-request@v3
+        uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:
           message: "`${{ env.DOCKER_IMAGE }} ${{ env.DOCKER_REPO_DIGEST }}`."

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v6
+      - uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0
         with:
           debug-only: false
           days-before-issue-stale: ${{ env.BEFORE_ISSUE_STALE }}


### PR DESCRIPTION
As suggested by https://github.com/argotorg/solidity/pull/16184#discussion_r2334805785. This PR pins the github action version to a specific commit.

The commit hashes can be checked here:
- https://github.com/thollander/actions-comment-pull-request/releases/tag/v3.0.1
- https://github.com/actions/stale/releases/tag/v10.0.0
- https://github.com/actions/checkout/releases/tag/v5.0.0