### PR TITLE
re-enable full prb-math preset matrix

### DIFF
--- a/test/externalTests/prb-math.py
+++ b/test/externalTests/prb-math.py
@@ -52,16 +52,13 @@ test_config = TestConfig(
     name="PRBMath",
     repo_url="https://github.com/PaulRBerg/prb-math.git",
     ref="<latest-release>",
-    compile_only_presets=[
-        # pylint: disable=line-too-long
-        # SettingsPreset.IR_NO_OPTIMIZE,       # Error: Yul exception:Variable expr_15699_address is 2 slot(s) too deep inside the stack. Stack too deep.
-        # SettingsPreset.IR_OPTIMIZE_EVM_ONLY, # Error: Yul exception:Variable expr_15699_address is 2 slot(s) too deep inside the stack. Stack too deep.
-    ],
     settings_presets=[
         SettingsPreset.LEGACY_NO_OPTIMIZE,
         SettingsPreset.LEGACY_OPTIMIZE_EVM_ONLY,
         SettingsPreset.LEGACY_OPTIMIZE_EVM_YUL,
+        SettingsPreset.IR_NO_OPTIMIZE,
         SettingsPreset.IR_OPTIMIZE_EVM_YUL,
+        SettingsPreset.IR_OPTIMIZE_EVM_ONLY,
     ],
 )
 


### PR DESCRIPTION
seems like we no longer run into stack-to-deep under the latest release in any of the presets