### PR TITLE
Nightly foundry for prb math and docs build dependencies`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1236,6 +1236,11 @@ jobs:
       - checkout
       - setup_prerelease_commit_hash
       - run:
+          name: Install build system dependencies
+          command: |
+            apt-get update
+            apt-get install --quiet=2 --no-install-recommends python3-dev libcairo2-dev pkg-config
+      - run:
           name: Build documentation
           command: docs/docs.sh
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -839,9 +839,7 @@ defaults:
       project: prb-math
       binary_type: native
       image: cimg/rust:1.74.0-node
-      resource_class: medium
-      # TODO: Use nightly Foundry builds after https://github.com/PaulRBerg/prb-math/issues/248 is fixed
-      foundry_version: "v0.3.0"
+      resource_class: large # Tests run out of memory on a smaller machine
 
   - job_native_test_ext_elementfi: &job_native_test_ext_elementfi
       <<: *requires_b_ubu_static

--- a/test/externalTests/prb-math.py
+++ b/test/externalTests/prb-math.py
@@ -51,7 +51,7 @@ class PRBMathRunner(FoundryRunner):
 test_config = TestConfig(
     name="PRBMath",
     repo_url="https://github.com/PaulRBerg/prb-math.git",
-    ref="<latest-release>",
+    ref="main",
     settings_presets=[
         SettingsPreset.LEGACY_NO_OPTIMIZE,
         SettingsPreset.LEGACY_OPTIMIZE_EVM_ONLY,


### PR DESCRIPTION
This PR does two things:
1. switch to the nightly foundry version for prb-math and switch prb-math itself to the trunk version so that we can actually use the nightly foundry.
2. install python3-dev, libcairo2-dev, and pkg-config into the container before building the docs