### PR TITLE
Move ssa pipeline things into own subdirectory

### DIFF
--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -42,8 +42,6 @@ add_library(yul
 	ScopeFiller.h
 	Utilities.cpp
 	Utilities.h
-	YulControlFlowGraphExporter.h
-	YulControlFlowGraphExporter.cpp
 	YulName.h
 	YulString.h
 	backends/evm/AbstractAssembly.h
@@ -51,8 +49,6 @@ add_library(yul
 	backends/evm/AsmCodeGen.h
 	backends/evm/ConstantOptimiser.cpp
 	backends/evm/ConstantOptimiser.h
-	backends/evm/ControlFlow.cpp
-	backends/evm/ControlFlow.h
 	backends/evm/ControlFlowGraph.h
 	backends/evm/ControlFlowGraphBuilder.cpp
 	backends/evm/ControlFlowGraphBuilder.h
@@ -72,21 +68,25 @@ add_library(yul
 	backends/evm/NoOutputAssembly.cpp
 	backends/evm/OptimizedEVMCodeTransform.cpp
 	backends/evm/OptimizedEVMCodeTransform.h
-	backends/evm/SSACFGLiveness.cpp
-	backends/evm/SSACFGLiveness.h
-	backends/evm/SSACFGLoopNestingForest.cpp
-	backends/evm/SSACFGLoopNestingForest.h
-	backends/evm/SSACFGTopologicalSort.cpp
-	backends/evm/SSACFGTopologicalSort.h
-	backends/evm/SSAControlFlowGraph.cpp
-	backends/evm/SSAControlFlowGraph.h
-	backends/evm/SSAControlFlowGraphBuilder.cpp
-	backends/evm/SSAControlFlowGraphBuilder.h
 	backends/evm/StackHelpers.h
 	backends/evm/StackLayoutGenerator.cpp
 	backends/evm/StackLayoutGenerator.h
 	backends/evm/VariableReferenceCounter.h
 	backends/evm/VariableReferenceCounter.cpp
+	backends/evm/ssa/ControlFlow.cpp
+	backends/evm/ssa/ControlFlow.h
+	backends/evm/ssa/LivenessAnalysis.cpp
+	backends/evm/ssa/LivenessAnalysis.h
+	backends/evm/ssa/SSACFGLoopNestingForest.cpp
+	backends/evm/ssa/SSACFGLoopNestingForest.h
+	backends/evm/ssa/SSACFGTopologicalSort.cpp
+	backends/evm/ssa/SSACFGTopologicalSort.h
+	backends/evm/ssa/SSACFG.cpp
+	backends/evm/ssa/SSACFG.h
+	backends/evm/ssa/SSACFGBuilder.cpp
+	backends/evm/ssa/SSACFGBuilder.h
+	backends/evm/ssa/SSACFGJsonExporter.h
+	backends/evm/ssa/SSACFGJsonExporter.cpp
 	optimiser/ASTCopier.cpp
 	optimiser/ASTCopier.h
 	optimiser/ASTWalker.cpp

--- a/libyul/YulStack.cpp
+++ b/libyul/YulStack.cpp
@@ -20,7 +20,8 @@
 
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmAnalysisInfo.h>
-#include <libyul/backends/evm/SSAControlFlowGraphBuilder.h>
+#include <libyul/backends/evm/ssa/SSACFGBuilder.h>
+#include <libyul/backends/evm/ssa/SSACFGJsonExporter.h>
 #include <libyul/backends/evm/EthAssemblyAdapter.h>
 #include <libyul/backends/evm/EVMCodeTransform.h>
 #include <libyul/backends/evm/EVMDialect.h>
@@ -28,7 +29,6 @@
 #include <libyul/ObjectParser.h>
 #include <libyul/optimiser/Semantics.h>
 #include <libyul/optimiser/Suite.h>
-#include <libyul/YulControlFlowGraphExporter.h>
 #include <libevmasm/Assembly.h>
 #include <libevmasm/Ethdebug.h>
 #include <liblangutil/Scanner.h>
@@ -398,14 +398,14 @@ Json YulStack::cfgJson() const
 		// operations to the control flow graphs
 		bool constexpr keepLiteralAssignments = true;
 		// NOTE: The block Ids are reset for each object
-		std::unique_ptr<ControlFlow> controlFlow = SSAControlFlowGraphBuilder::build(
+		std::unique_ptr<ssa::ControlFlow> controlFlow = ssa::SSACFGBuilder::build(
 			*_object.analysisInfo,
 			languageToDialect(m_language, m_evmVersion, m_eofVersion),
 			_object.code()->root(),
 			keepLiteralAssignments
 		);
-		std::unique_ptr<ControlFlowLiveness> liveness = std::make_unique<ControlFlowLiveness>(*controlFlow);
-		YulControlFlowGraphExporter exporter(*controlFlow, liveness.get());
+		std::unique_ptr<ssa::ControlFlowLiveness> liveness = std::make_unique<ssa::ControlFlowLiveness>(*controlFlow);
+		ssa::SSACFGJsonExporter exporter(*controlFlow, liveness.get());
 		return exporter.run();
 	};
 

--- a/libyul/backends/evm/ssa/ControlFlow.cpp
+++ b/libyul/backends/evm/ssa/ControlFlow.cpp
@@ -16,15 +16,16 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
-#include <libyul/backends/evm/ControlFlow.h>
+#include <libyul/backends/evm/ssa/ControlFlow.h>
+
 #include <range/v3/range/conversion.hpp>
 
-using namespace solidity::yul;
+using namespace solidity::yul::ssa;
 
 ControlFlowLiveness::ControlFlowLiveness(ControlFlow const& _controlFlow):
 	controlFlow(_controlFlow),
-	mainLiveness(std::make_unique<SSACFGLiveness>(*_controlFlow.mainGraph)),
-	functionLiveness(_controlFlow.functionGraphs | ranges::views::transform([](auto const& _cfg) { return std::make_unique<SSACFGLiveness>(*_cfg); }) | ranges::to<std::vector>)
+	mainLiveness(std::make_unique<LivenessAnalysis>(*_controlFlow.mainGraph)),
+	functionLiveness(_controlFlow.functionGraphs | ranges::views::transform([](auto const& _cfg) { return std::make_unique<LivenessAnalysis>(*_cfg); }) | ranges::to<std::vector>)
 { }
 
 std::string ControlFlowLiveness::toDot() const

--- a/libyul/backends/evm/ssa/ControlFlow.h
+++ b/libyul/backends/evm/ssa/ControlFlow.h
@@ -18,12 +18,13 @@
 
 #pragma once
 
+#include <libyul/backends/evm/ssa/LivenessAnalysis.h>
+#include <libyul/backends/evm/ssa/SSACFG.h>
+
 #include <libyul/AST.h>
 #include <libyul/Scope.h>
-#include <libyul/backends/evm/SSACFGLiveness.h>
-#include <libyul/backends/evm/SSAControlFlowGraph.h>
 
-namespace solidity::yul
+namespace solidity::yul::ssa
 {
 
 struct ControlFlow;
@@ -32,8 +33,8 @@ struct ControlFlowLiveness{
 	explicit ControlFlowLiveness(ControlFlow const& _controlFlow);
 
 	std::reference_wrapper<ControlFlow const> controlFlow;
-	std::unique_ptr<SSACFGLiveness> mainLiveness;
-	std::vector<std::unique_ptr<SSACFGLiveness>> functionLiveness;
+	std::unique_ptr<LivenessAnalysis> mainLiveness;
+	std::vector<std::unique_ptr<LivenessAnalysis>> functionLiveness;
 
 	std::string toDot() const;
 };

--- a/libyul/backends/evm/ssa/LivenessAnalysis.cpp
+++ b/libyul/backends/evm/ssa/LivenessAnalysis.cpp
@@ -16,7 +16,7 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
-#include <libyul/backends/evm/SSACFGLiveness.h>
+#include <libyul/backends/evm/ssa/LivenessAnalysis.h>
 
 #include <libsolutil/Visitor.h>
 
@@ -24,7 +24,7 @@
 #include <range/v3/view/filter.hpp>
 #include <range/v3/view/reverse.hpp>
 
-using namespace solidity::yul;
+using namespace solidity::yul::ssa;
 
 namespace
 {
@@ -37,7 +37,7 @@ constexpr auto literalsFilter(SSACFG const& _cfg)
 }
 }
 
-std::set<SSACFG::ValueId> SSACFGLiveness::blockExitValues(SSACFG::BlockId const& _blockId) const
+std::set<SSACFG::ValueId> LivenessAnalysis::blockExitValues(SSACFG::BlockId const& _blockId) const
 {
 	std::set<SSACFG::ValueId> result;
 	util::GenericVisitor exitVisitor {
@@ -60,7 +60,7 @@ std::set<SSACFG::ValueId> SSACFGLiveness::blockExitValues(SSACFG::BlockId const&
 	return result;
 }
 
-SSACFGLiveness::SSACFGLiveness(SSACFG const& _cfg):
+LivenessAnalysis::LivenessAnalysis(SSACFG const& _cfg):
 	m_cfg(_cfg),
 	m_topologicalSort(_cfg),
 	m_loopNestingForest(m_topologicalSort),
@@ -75,7 +75,7 @@ SSACFGLiveness::SSACFGLiveness(SSACFG const& _cfg):
 	fillOperationsLiveOut();
 }
 
-void SSACFGLiveness::runDagDfs()
+void LivenessAnalysis::runDagDfs()
 {
 	// SSA Book, Algorithm 9.2
 	for (auto const blockIdValue: m_topologicalSort.postOrder())
@@ -137,7 +137,7 @@ void SSACFGLiveness::runDagDfs()
 	}
 }
 
-void SSACFGLiveness::runLoopTreeDfs(size_t const _loopHeader)
+void LivenessAnalysis::runLoopTreeDfs(size_t const _loopHeader)
 {
 	// SSA Book, Algorithm 9.3
 	if (m_loopNestingForest.loopNodes().count(_loopHeader) > 0)
@@ -161,7 +161,7 @@ void SSACFGLiveness::runLoopTreeDfs(size_t const _loopHeader)
 	}
 }
 
-void SSACFGLiveness::fillOperationsLiveOut()
+void LivenessAnalysis::fillOperationsLiveOut()
 {
 	for (size_t blockIdValue = 0; blockIdValue < m_cfg.numBlocks(); ++blockIdValue)
 	{

--- a/libyul/backends/evm/ssa/LivenessAnalysis.h
+++ b/libyul/backends/evm/ssa/LivenessAnalysis.h
@@ -18,25 +18,25 @@
 
 #pragma once
 
-#include <libyul/backends/evm/SSACFGLoopNestingForest.h>
-#include <libyul/backends/evm/SSACFGTopologicalSort.h>
-#include <libyul/backends/evm/SSAControlFlowGraph.h>
+#include <libyul/backends/evm/ssa/SSACFGTopologicalSort.h>
+#include <libyul/backends/evm/ssa/SSACFG.h>
+#include <libyul/backends/evm/ssa/SSACFGLoopNestingForest.h>
 
 #include <cstddef>
 #include <set>
 #include <vector>
 
-namespace solidity::yul
+namespace solidity::yul::ssa
 {
 
 /// Performs liveness analysis on a reducible SSA CFG following Algorithm 9.1 in [1].
 ///
 /// [1] Rastello, Fabrice, and Florent Bouchez Tichadou, eds. SSA-based Compiler Design. Springer, 2022.
-class SSACFGLiveness
+class LivenessAnalysis
 {
 public:
 	using LivenessData = std::set<SSACFG::ValueId>;
-	explicit SSACFGLiveness(SSACFG const& _cfg);
+	explicit LivenessAnalysis(SSACFG const& _cfg);
 
 	LivenessData const& liveIn(SSACFG::BlockId _blockId) const { return m_liveIns[_blockId.value]; }
 	LivenessData const& liveOut(SSACFG::BlockId _blockId) const { return m_liveOuts[_blockId.value]; }

--- a/libyul/backends/evm/ssa/SSACFG.cpp
+++ b/libyul/backends/evm/ssa/SSACFG.cpp
@@ -16,9 +16,9 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
-#include <libyul/backends/evm/SSAControlFlowGraph.h>
+#include <libyul/backends/evm/ssa/SSACFG.h>
 
-#include <libyul/backends/evm/SSACFGLiveness.h>
+#include <libyul/backends/evm/ssa/LivenessAnalysis.h>
 
 #include <libsolutil/StringUtils.h>
 #include <libsolutil/Visitor.h>
@@ -33,18 +33,19 @@
 using namespace solidity;
 using namespace solidity::util;
 using namespace solidity::yul;
+using namespace solidity::yul::ssa;
 
 namespace
 {
 class SSACFGPrinter
 {
 public:
-	SSACFGPrinter(SSACFG const& _cfg, SSACFG::BlockId _blockId, SSACFGLiveness const* _liveness):
+	SSACFGPrinter(SSACFG const& _cfg, SSACFG::BlockId _blockId, LivenessAnalysis const* _liveness):
 		m_cfg(_cfg), m_functionIndex(0), m_liveness(_liveness)
 	{
 		printBlock(_blockId);
 	}
-	SSACFGPrinter(SSACFG const& _cfg, size_t _functionIndex, Scope::Function const& _function, SSACFGLiveness const* _liveness):
+	SSACFGPrinter(SSACFG const& _cfg, size_t _functionIndex, Scope::Function const& _function, LivenessAnalysis const* _liveness):
 		m_cfg(_cfg), m_functionIndex(_functionIndex), m_liveness(_liveness)
 	{
 		printFunction(_function);
@@ -291,7 +292,7 @@ private:
 
 	SSACFG const& m_cfg;
 	size_t m_functionIndex;
-	SSACFGLiveness const* m_liveness;
+	LivenessAnalysis const* m_liveness;
 	std::stringstream m_result{};
 };
 }
@@ -299,7 +300,7 @@ private:
 std::string SSACFG::toDot(
 	bool _includeDiGraphDefinition,
 	std::optional<size_t> _functionIndex,
-	SSACFGLiveness const* _liveness
+	LivenessAnalysis const* _liveness
 ) const
 {
 	std::ostringstream output;

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -35,9 +35,9 @@
 #include <list>
 #include <vector>
 
-namespace solidity::yul
+namespace solidity::yul::ssa
 {
-class SSACFGLiveness;
+class LivenessAnalysis;
 
 class SSACFG
 {
@@ -227,7 +227,7 @@ public:
 	std::string toDot(
 		bool _includeDiGraphDefinition=true,
 		std::optional<size_t> _functionIndex=std::nullopt,
-		SSACFGLiveness const* _liveness=nullptr
+		LivenessAnalysis const* _liveness=nullptr
 	) const;
 private:
 	std::deque<ValueInfo> m_valueInfos;

--- a/libyul/backends/evm/ssa/SSACFGBuilder.h
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.h
@@ -29,17 +29,17 @@
 */
 #pragma once
 
+#include <libyul/backends/evm/ssa/ControlFlow.h>
 #include <libyul/ControlFlowSideEffectsCollector.h>
-#include <libyul/backends/evm/ControlFlow.h>
-#include <libyul/backends/evm/SSAControlFlowGraph.h>
+#include <libyul/backends/evm/ssa/SSACFG.h>
 #include <stack>
 
-namespace solidity::yul
+namespace solidity::yul::ssa
 {
 
-class SSAControlFlowGraphBuilder
+class SSACFGBuilder
 {
-	SSAControlFlowGraphBuilder(
+	SSACFGBuilder(
 		ControlFlow& _controlFlow,
 		SSACFG& _graph,
 		AsmAnalysisInfo const& _analysisInfo,
@@ -48,8 +48,8 @@ class SSAControlFlowGraphBuilder
 		bool _keepLiteralAssignments
 	);
 public:
-	SSAControlFlowGraphBuilder(SSAControlFlowGraphBuilder const&) = delete;
-	SSAControlFlowGraphBuilder& operator=(SSAControlFlowGraphBuilder const&) = delete;
+	SSACFGBuilder(SSACFGBuilder const&) = delete;
+	SSACFGBuilder& operator=(SSACFGBuilder const&) = delete;
 	static std::unique_ptr<ControlFlow> build(
 		AsmAnalysisInfo const& _analysisInfo,
 		Dialect const& _dialect,

--- a/libyul/backends/evm/ssa/SSACFGJsonExporter.h
+++ b/libyul/backends/evm/ssa/SSACFGJsonExporter.h
@@ -18,26 +18,28 @@
 
 #pragma once
 
-#include <libyul/backends/evm/ControlFlow.h>
+#include <libyul/backends/evm/ssa/ControlFlow.h>
 #include <libsolutil/JSON.h>
 #include <libsolutil/Visitor.h>
 
-using namespace solidity;
-using namespace yul;
+namespace solidity::yul::ssa
+{
 
-class YulControlFlowGraphExporter
+class SSACFGJsonExporter
 {
 public:
-	YulControlFlowGraphExporter(ControlFlow const& _controlFlow, ControlFlowLiveness const* _liveness=nullptr);
+	SSACFGJsonExporter(ControlFlow const& _controlFlow, ControlFlowLiveness const* _liveness=nullptr);
 	Json run();
-	Json exportBlock(SSACFG const& _cfg, SSACFG::BlockId _blockId, SSACFGLiveness const* _liveness);
-	Json exportFunction(SSACFG const& _cfg, SSACFGLiveness const* _liveness);
+	Json exportBlock(SSACFG const& _cfg, SSACFG::BlockId _blockId, LivenessAnalysis const* _liveness);
+	Json exportFunction(SSACFG const& _cfg, LivenessAnalysis const* _liveness);
 	std::string varToString(SSACFG const& _cfg, SSACFG::ValueId _var);
 
 private:
 	ControlFlow const& m_controlFlow;
 	ControlFlowLiveness const* m_liveness;
-	Json toJson(SSACFG const& _cfg, SSACFG::BlockId _blockId, SSACFGLiveness const* _liveness);
+	Json toJson(SSACFG const& _cfg, SSACFG::BlockId _blockId, LivenessAnalysis const* _liveness);
 	Json toJson(Json& _ret, SSACFG const& _cfg, SSACFG::Operation const& _operation);
 	Json toJson(SSACFG const& _cfg, std::vector<SSACFG::ValueId> const& _values);
 };
+
+}

--- a/libyul/backends/evm/ssa/SSACFGLoopNestingForest.cpp
+++ b/libyul/backends/evm/ssa/SSACFGLoopNestingForest.cpp
@@ -16,9 +16,9 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
-#include <libyul/backends/evm/SSACFGLoopNestingForest.h>
+#include <libyul/backends/evm/ssa/SSACFGLoopNestingForest.h>
 
-using namespace solidity::yul;
+using namespace solidity::yul::ssa;
 
 SSACFGLoopNestingForest::SSACFGLoopNestingForest(ForwardSSACFGTopologicalSort const& _sort):
 	m_sort(_sort),

--- a/libyul/backends/evm/ssa/SSACFGLoopNestingForest.h
+++ b/libyul/backends/evm/ssa/SSACFGLoopNestingForest.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
-#include <libyul/backends/evm/SSACFGTopologicalSort.h>
-#include <libyul/backends/evm/SSAControlFlowGraph.h>
+#include <libyul/backends/evm/ssa/SSACFGTopologicalSort.h>
+#include <libyul/backends/evm/ssa/SSACFG.h>
 
 #include <libsolutil/DisjointSet.h>
 
@@ -27,7 +27,7 @@
 #include <set>
 #include <vector>
 
-namespace solidity::yul
+namespace solidity::yul::ssa
 {
 
 /// Constructs a loop nesting forest for an SSACFG using Tarjan's algorithm [1].

--- a/libyul/backends/evm/ssa/SSACFGTopologicalSort.cpp
+++ b/libyul/backends/evm/ssa/SSACFGTopologicalSort.cpp
@@ -16,9 +16,9 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
-#include <libyul/backends/evm/SSACFGTopologicalSort.h>
+#include <libyul/backends/evm/ssa/SSACFGTopologicalSort.h>
 
-using namespace solidity::yul;
+using namespace solidity::yul::ssa;
 
 ForwardSSACFGTopologicalSort::ForwardSSACFGTopologicalSort(SSACFG const& _cfg):
 	m_cfg(_cfg),

--- a/libyul/backends/evm/ssa/SSACFGTopologicalSort.h
+++ b/libyul/backends/evm/ssa/SSACFGTopologicalSort.h
@@ -18,13 +18,13 @@
 
 #pragma once
 
-#include <libyul/backends/evm/SSAControlFlowGraph.h>
+#include <libyul/backends/evm/ssa/SSACFG.h>
 
 #include <cstddef>
 #include <set>
 #include <vector>
 
-namespace solidity::yul
+namespace solidity::yul::ssa
 {
 
 /// Performs a topological sort on the forward CFG (no back/cross edges)

--- a/test/libyul/SSAControlFlowGraphTest.cpp
+++ b/test/libyul/SSAControlFlowGraphTest.cpp
@@ -20,7 +20,7 @@
 #include <test/libyul/Common.h>
 #include <test/Common.h>
 
-#include <libyul/backends/evm/SSAControlFlowGraphBuilder.h>
+#include <libyul/backends/evm/ssa/SSACFGBuilder.h>
 #include <libyul/backends/evm/StackHelpers.h>
 
 #include <libyul/AsmAnalysis.h>
@@ -70,13 +70,13 @@ TestCase::TestResult SSAControlFlowGraphTest::run(std::ostream& _stream, std::st
 		return TestResult::FatalError;
 	}
 
-	std::unique_ptr<ControlFlow> controlFlow = SSAControlFlowGraphBuilder::build(
+	std::unique_ptr<ssa::ControlFlow> controlFlow = ssa::SSACFGBuilder::build(
 		*yulStack.parserResult()->analysisInfo,
 		yulStack.dialect(),
 		yulStack.parserResult()->code()->root(),
 		true
 	);
-	ControlFlowLiveness liveness(*controlFlow);
+	ssa::ControlFlowLiveness liveness(*controlFlow);
 	m_obtainedResult = controlFlow->toDot(&liveness);
 
 	auto result = checkResult(_stream, _linePrefix, _formatted);


### PR DESCRIPTION
PR includes the following refactorings: 

- `libyul/YulControlFlowGraphExporter` -> `libyul/backends/evm/ssa/SSACFGJsonExporter`
- `libyul/backends/evm/SSAControlFlowGraph` -> `libyul/backends/evm/ssa/SSACFG`
- `libyul/backends/evm/SSAControlFlowGraphBuilder` -> `libyul/backends/evm/ssa/SSACFGBuilder`
- `libyul/backends/evm/SSACFGLiveness` -> `libyul/backends/evm/ssa/LivenessAnalysis`
- moving directories of `SSACFGLoopNestingForest`, `SSACFGTopologicalSort`, and `ControlFlow` into the `ssa` subdirectory.
- all of the above live in their own `solidity::yul::ssa` namespace