### PR TITLE
Bump evmone version to `0.16.0` in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,16 +13,16 @@ parameters:
     default: "solbuildpackpusher/solidity-buildpack-deps@sha256:1f387a77be889f65a2a25986a5c5eccc88cec23fabe6aeaf351790751145c81e"
   ubuntu-2404-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2404-3
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:ef6a91d7f1434c67fb9e05c6136d80f71c0ad9198479e1a88e3437680993cda4"
+    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2404-6
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:c0412c53e59ce0c96bde4c08e7332ea12e4cadba9bbac829621947897fa21272"
   ubuntu-2404-clang-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2404.clang-4
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:97fb2d1bc002b3624161f539a1d29543c0e6c6f4d9a61f611b9b60e99e18f377"
+    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2404.clang-7
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:7466ed23590cf14e60da884894723bcdab064742f017dcfcce015999b4f9143b"
   ubuntu-clang-ossfuzz-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu.clang.ossfuzz-10
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:bd55d9a3b13c88608709ec442188c414d30f4c49f23dc2ce8b76bf8c90603fc7"
+    # solbuildpackpusher/solidity-buildpack-deps:ubuntu.clang.ossfuzz-12
+    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:c7088af5082bf764244a6251ecf3dd29d280d2cd2cd071f011f7f32e0326f426"
   emscripten-docker-image:
     type: string
     # NOTE: Please remember to update the `scripts/build_emscripten.sh` whenever the hash of this image changes.

--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -108,10 +108,10 @@ then
   rm -rf "$z3_dir"
 
   # evmone
-  evmone_version="0.13.0"
+  evmone_version="0.16.0"
   evmone_package="evmone-${evmone_version}-darwin-arm64.tar.gz"
   wget "https://github.com/ipsilon/evmone/releases/download/v${evmone_version}/${evmone_package}"
-  validate_checksum "$evmone_package" 49fe6cc35e0e13c48ca2f29a6b85a47f7b25dcd427e14254000d3bc29cddf2a6
+  validate_checksum "$evmone_package" d26bcf7ada6c712b669ee70cbd8b534f80dadb6207fa15e15d1517d2b6823aa8
   sudo tar xzpf "$evmone_package" -C /usr/local
   rm "$evmone_package"
 fi

--- a/.circleci/soltest_all.sh
+++ b/.circleci/soltest_all.sh
@@ -40,7 +40,8 @@ IFS=" " read -ra EVM_VALUES <<< "${1:-${DEFAULT_EVM_VALUES[@]}}"
 
 DEFAULT_EVM=prague
 OPTIMIZE_VALUES=(0 1)
-EOF_VERSIONS=(0 1)
+# TODO: EOF is marked as experimental in evmone. Reenable when proper handling for that is added here.
+EOF_VERSIONS=(0)
 
 # Run for ABI encoder v1, without SMTChecker tests.
 EVM="${DEFAULT_EVM}" \

--- a/scripts/install_evmone.ps1
+++ b/scripts/install_evmone.ps1
@@ -3,6 +3,6 @@ $ErrorActionPreference = "Stop"
 # Needed for Invoke-WebRequest to work via CI.
 $progressPreference = "silentlyContinue"
 
-Invoke-WebRequest -URI "https://github.com/ipsilon/evmone/releases/download/v0.13.0/evmone-0.13.0-windows-amd64.zip" -OutFile "evmone.zip"
+Invoke-WebRequest -URI "https://github.com/ipsilon/evmone/releases/download/v0.16.0/evmone-0.16.0-windows-amd64.zip" -OutFile "evmone.zip"
 tar -xf evmone.zip "bin/evmone.dll"
 mv bin/evmone.dll deps/

--- a/test/Common.h
+++ b/test/Common.h
@@ -39,13 +39,13 @@ namespace solidity::test
 
 #ifdef _WIN32
 static constexpr auto evmoneFilename = "evmone.dll";
-static constexpr auto evmoneDownloadLink = "https://github.com/ipsilon/evmone/releases/download/v0.13.0/evmone-0.13.0-windows-amd64.zip";
+static constexpr auto evmoneDownloadLink = "https://github.com/ipsilon/evmone/releases/download/v0.16.0/evmone-0.16.0-windows-amd64.zip";
 #elif defined(__APPLE__)
 static constexpr auto evmoneFilename = "libevmone.dylib";
-static constexpr auto evmoneDownloadLink = "https://github.com/ipsilon/evmone/releases/download/v0.13.0/evmone-0.13.0-darwin-arm64.tar.gz";
+static constexpr auto evmoneDownloadLink = "https://github.com/ipsilon/evmone/releases/download/v0.16.0/evmone-0.16.0-darwin-arm64.tar.gz";
 #else
 static constexpr auto evmoneFilename = "libevmone.so";
-static constexpr auto evmoneDownloadLink = "https://github.com/ipsilon/evmone/releases/download/v0.13.0/evmone-0.13.0-linux-x86_64.tar.gz";
+static constexpr auto evmoneDownloadLink = "https://github.com/ipsilon/evmone/releases/download/v0.16.0/evmone-0.16.0-linux-x86_64.tar.gz";
 #endif
 
 struct ConfigException: public util::Exception {};


### PR DESCRIPTION
closes #16230. 
depends on #16239.