### PR TITLE
docs: auto-detect user timezone for community call time

### DIFF
--- a/docs/_static/js/timezone.js
+++ b/docs/_static/js/timezone.js
@@ -1,0 +1,68 @@
+// docs/_static/js/timezone.js
+document.addEventListener("DOMContentLoaded", function() {
+  const element = document.getElementById("community-call-time");
+  if (!element) return;
+
+  // Base info
+  const zurichZone = "Europe/Zurich"; // covers CET/CEST
+  const targetWeekdayShort = "Wed";   // weekday short form returned by en-GB formatter
+  const targetHour = 15;              // 3 PM Zurich time
+
+  // Helper: find next Wednesday 15:00 in Zurich time
+  function nextCommunityCallUTC() {
+    const now = new Date();
+    let candidate = new Date(now);
+    candidate.setUTCMinutes(0, 0, 0, 0);
+
+    const maxHours = 14 * 24; // 14 days safety cap
+    for (let i = 0; i < maxHours; i++) {
+      const check = new Date(candidate.getTime() + i * 3600000);
+      let parts = [];
+      try {
+        parts = new Intl.DateTimeFormat("en-GB", {
+          timeZone: zurichZone,
+          weekday: "short",
+          hour: "2-digit",
+          hour12: false
+        }).formatToParts(check);
+      } catch (e) {
+        // Intl might throw in very old environments; fallback to continue loop
+        continue;
+      }
+
+      const weekdayPart = parts.find(p => p.type === "weekday");
+      const hourPart = parts.find(p => p.type === "hour");
+      const weekday = weekdayPart ? weekdayPart.value : null;
+      const hour = hourPart ? parseInt(hourPart.value, 10) : NaN;
+
+      if (weekday === targetWeekdayShort && hour === targetHour) return check;
+    }
+    // fallback: return "now" if not found (rare)
+    return now;
+  }
+
+  function formatForZone(date, zone, locale) {
+    try {
+      return new Intl.DateTimeFormat(locale || undefined, {
+        timeZone: zone,
+        weekday: "long",
+        day: "numeric",
+        month: "long",
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+        timeZoneName: "short"
+      }).format(date);
+    } catch (e) {
+      return date.toString();
+    }
+  }
+
+  const targetUTC = nextCommunityCallUTC();
+
+  const zurichTime = formatForZone(targetUTC, zurichZone, "en-GB");
+  const userTZ = Intl.DateTimeFormat().resolvedOptions().timeZone || "your timezone";
+  const localTime = formatForZone(targetUTC, userTZ);
+
+  element.textContent = `Community calls are held on ${zurichTime} — Your local time: ${localTime}`;
+});

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -218,7 +218,7 @@ html_static_path = ['_static']
 
 html_css_files = ["css/toggle.css"]
 
-html_js_files = ["js/constants.js", "js/initialize.js", "js/toggle.js"]
+html_js_files = ["js/constants.js", "js/initialize.js", "js/toggle.js", 'js/timezone.js']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -30,9 +30,12 @@ Team Calls
 If you have issues or pull requests to discuss, or are interested in hearing what
 the team and contributors are working on, you can join our public team call:
 
-- Wednesdays at 3PM CET/CEST.
-
 The call takes place on `Jitsi <https://meet.solidity.org>`_.
+
+.. raw:: html
+
+   <p id="community-call-time">Community calls are held on Wednesdays at 3PM CET/CEST.</p>
+
 
 How to Report Issues
 ====================


### PR DESCRIPTION
This PR improves documentation accessibility by auto-detecting the viewer's timezone and displaying the local equivalent of the Solidity community call (Wed 15:00 Europe/Zurich).

Changes:
- Added docs/_static/js/timezone.js
- Updated docs/conf.py to include the script
- Replaced hardcoded time line in docs/contributing.rst with an HTML placeholder

Uses the Intl API so CET/CEST (DST) is handled automatically.

Closes: argotorg/solidity#16234