### PR TITLE
Analyze the SSA CFG regarding which blocks are allowed to introduce junk slots 

### DIFF
--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -76,6 +76,8 @@ add_library(yul
 	backends/evm/ssa/BridgeFinder.h
 	backends/evm/ssa/ControlFlow.cpp
 	backends/evm/ssa/ControlFlow.h
+	backends/evm/ssa/JunkAdmittingBlocksFinder.cpp
+	backends/evm/ssa/JunkAdmittingBlocksFinder.h
 	backends/evm/ssa/LivenessAnalysis.cpp
 	backends/evm/ssa/LivenessAnalysis.h
 	backends/evm/ssa/SSACFGLoopNestingForest.cpp

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -73,6 +73,7 @@ add_library(yul
 	backends/evm/StackLayoutGenerator.h
 	backends/evm/VariableReferenceCounter.h
 	backends/evm/VariableReferenceCounter.cpp
+	backends/evm/ssa/BridgeFinder.h
 	backends/evm/ssa/ControlFlow.cpp
 	backends/evm/ssa/ControlFlow.h
 	backends/evm/ssa/LivenessAnalysis.cpp

--- a/libyul/backends/evm/ssa/BridgeFinder.h
+++ b/libyul/backends/evm/ssa/BridgeFinder.h
@@ -1,0 +1,129 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+
+#pragma once
+
+#include <libyul/backends/evm/ssa/SSACFG.h>
+
+#include <range/v3/view/concat.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace solidity::yul::ssa
+{
+/// Detect bridges according to Algorithm 1 of https://arxiv.org/pdf/2108.07346.pdf.
+///
+/// A bridge in an undirected graph is an edge whose removal increases the number of connected components. In control
+/// flow analysis, bridge vertices are critical articulation points where removing the vertex would disconnect
+/// reachable code from unreachable code. This implementation adapts the bridge-finding algorithm to directed control
+/// flow graphs by treating them as undirected, then validating edge directionality to identify vertices that gate
+/// access to subsequent blocks.
+///
+/// We use bridges to determine blocks in which it is fine to introduce junk slots on the stack at any point in time.
+class BridgeFinder
+{
+public:
+	explicit BridgeFinder(SSACFG const& _cfg):
+		m_cfg(_cfg),
+		m_bridgeVertex(_cfg.numBlocks()),
+		m_visited(_cfg.numBlocks()),
+		m_disc(_cfg.numBlocks()),
+		m_low(_cfg.numBlocks())
+	{
+		size_t time = 0;
+		dfs(time, _cfg.entry, std::nullopt);
+	}
+
+	bool bridgeVertex(SSACFG::BlockId const& _blockId) const
+	{
+		return m_bridgeVertex[_blockId.value];
+	}
+
+private:
+	void dfs(size_t& _time, SSACFG::BlockId const& _vertex, std::optional<SSACFG::BlockId> const& _parent)
+	{
+		m_visited[_vertex.value] = true;
+		m_disc[_vertex.value] = _time;
+		m_low[_vertex.value] = _time;
+		++_time;
+
+		auto const& currentBlock = m_cfg.block(_vertex);
+		currentBlock.forEachExit([&](SSACFG::BlockId const& _exit)
+		{
+			processNeighbor(_exit, _time, _vertex, currentBlock.entries, _parent);
+		});
+
+		for (SSACFG::BlockId const neighbor: currentBlock.entries)
+			processNeighbor(neighbor, _time, _vertex, currentBlock.entries, _parent);
+	}
+
+	void processNeighbor(
+		SSACFG::BlockId const& _neighbor,
+		size_t& _time,
+		SSACFG::BlockId const& _vertex,
+		std::set<SSACFG::BlockId> const& _vertexEntries,
+		std::optional<SSACFG::BlockId> const& _parent
+	)
+	{
+		if (_neighbor == _parent)
+			return;
+
+		if (!m_visited[_neighbor.value])
+		{
+			dfs(_time, _neighbor, _vertex);
+			m_low[_vertex.value] = std::min(m_low[_vertex.value], m_low[_neighbor.value]);
+			if (m_low[_neighbor.value] > m_disc[_vertex.value])
+			{
+				// vertex <-> neighbor is a bridge in the undirected graph
+				bool const edgeNeighborToVertex = _vertexEntries.contains(_neighbor);
+				bool const edgeVertexToNeighbor = m_cfg.block(_neighbor).entries.contains(_vertex);
+
+				// special case: if it's the entry itself, we mark it as bridge vertex (provided correct orientation),
+				// so that functions which do nothing but revert have their whole tree marked as such (sans loops)
+				if (!_parent)
+					m_bridgeVertex[_vertex.value] = edgeVertexToNeighbor;
+				// Since we are not really undirected, check if we don't have a cycle (u -> v and v -> u) and see,
+				// which edge really exists here.
+				// Then record the targeted vertex as bridge vertex.
+				if (edgeVertexToNeighbor && !edgeNeighborToVertex)
+					// bridge vertex -> neighbor
+					m_bridgeVertex[_neighbor.value] = true;
+				else if (edgeNeighborToVertex && !edgeVertexToNeighbor)
+					// bridge neighbor -> vertex
+					m_bridgeVertex[_vertex.value] = true;
+			}
+		}
+		else
+			m_low[_vertex.value] = std::min(m_low[_vertex.value], m_disc[_neighbor.value]);
+	}
+
+	SSACFG const& m_cfg;
+	// determines whether a vertex is a bridge vertex. optimizing for performance over space with u8.
+	std::vector<std::uint8_t> m_bridgeVertex;
+	// determines whether a vertex is visited. optimizing for performance over space with u8.
+	std::vector<std::uint8_t> m_visited;
+	// vertex discovery time
+	std::vector<std::size_t> m_disc;
+	// minimum discovery time of subtree - if m_low[child] > m_low[parent], we have a bridge
+	std::vector<std::size_t> m_low;
+};
+
+}

--- a/libyul/backends/evm/ssa/JunkAdmittingBlocksFinder.cpp
+++ b/libyul/backends/evm/ssa/JunkAdmittingBlocksFinder.cpp
@@ -1,0 +1,73 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libyul/backends/evm/ssa/JunkAdmittingBlocksFinder.h>
+
+#include <libyul/backends/evm/ssa/BridgeFinder.h>
+
+namespace solidity::yul::ssa
+{
+
+JunkAdmittingBlocksFinder::JunkAdmittingBlocksFinder(SSACFG const& _cfg, ForwardSSACFGTopologicalSort const& _topologicalSort):
+	m_blockAllowsJunk(_cfg.numBlocks(), false)
+{
+	// special case: only one block here, we mark it as junkable in case it's not a function return
+	if (_topologicalSort.preOrder().size() == 1)
+	{
+		SSACFG::BlockId const id {_topologicalSort.preOrder().front()};
+		m_blockAllowsJunk[id.value] = !_cfg.block(id).isFunctionReturnBlock();
+		return;
+	}
+
+	// Find all bridges, i.e., vertices, which upon removal increase the number of connected components.
+	// Translated to SSA CFGs this means:
+	//   - control flow that enters a bridge vertex never returns to a previously visited block
+	//   - there is no parallel path to a child of the vertex, ie, adding junk is fine in terms of stack balance
+	BridgeFinder const bridgeFinder(_cfg);
+
+	// of the bridge vertices, we have the exclude the ones that can lead to a function return
+	std::vector<SSACFG::BlockId> toVisit;
+	for (auto const blockIndex: _topologicalSort.preOrder())
+	{
+		SSACFG::BlockId const blockId {blockIndex};
+		m_blockAllowsJunk[blockIndex] = bridgeFinder.bridgeVertex(blockId) || _cfg.block(blockId).isTerminationBlock();
+		if (_cfg.block(blockId).isFunctionReturnBlock())
+			toVisit.emplace_back(SSACFG::BlockId{blockIndex});
+	}
+
+	std::vector<uint8_t> visited(_cfg.numBlocks(), false);
+	while (!toVisit.empty())
+	{
+		auto const blockId = toVisit.back();
+		auto const& block = _cfg.block(blockId);
+		toVisit.pop_back();
+
+		m_blockAllowsJunk[blockId.value] = false;
+		visited[blockId.value] = true;
+		for (auto const& entry: block.entries)
+			if (!visited[entry.value])
+				toVisit.emplace_back(entry);
+	}
+}
+
+bool JunkAdmittingBlocksFinder::allowsAdditionOfJunk(SSACFG::BlockId const& _blockId) const
+{
+	return m_blockAllowsJunk[_blockId.value];
+}
+
+}

--- a/libyul/backends/evm/ssa/JunkAdmittingBlocksFinder.h
+++ b/libyul/backends/evm/ssa/JunkAdmittingBlocksFinder.h
@@ -1,0 +1,46 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libyul/backends/evm/ssa/SSACFGTopologicalSort.h>
+#include <libyul/backends/evm/ssa/SSACFG.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace solidity::yul::ssa
+{
+
+/// Identifies blocks where stack balance constraints can be relaxed.
+/// These are blocks that inevitably terminate down the line (i.e., there is no path to a function return exit) and
+/// which are "bridge vertices". For a bridge, the graph decomposes into `G1` and `G2` with a singular edge `e=(v1->v2)`
+/// between them. Therefore, traversal into `G2` cannot escape back into `G1` and in particular there cannot be a
+/// parallel path into G2 that has relaxed constraints with respect to introducing junk. Consequently, there cannot be
+/// a situation in which a junk-bloated stack has to be unified with a slimmer stack layout stemming from another path
+/// into `G2`.
+class JunkAdmittingBlocksFinder
+{
+public:
+	explicit JunkAdmittingBlocksFinder(SSACFG const& _cfg, ForwardSSACFGTopologicalSort const& _topologicalSort);
+	bool allowsAdditionOfJunk(SSACFG::BlockId const& _blockId) const;
+private:
+	std::vector<std::uint8_t> m_blockAllowsJunk;
+};
+
+}


### PR DESCRIPTION
Adds an algorithm that identifies bridges in undirected graphs and uses that to subselect blocks in an SSA CFG in which we can safely introduce junk on the way.