### PR TITLE
Prerelease logic cleanup

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,26 +1,26 @@
 #!/usr/bin/env bash
 set -e
 
-ROOTDIR="$(dirname "$0")/.."
+ROOTDIR=$(dirname "$0")/..
 BUILDDIR="${ROOTDIR}/build"
 
-if [[ $# -eq 0 ]]; then
+if (( $# == 0 )); then
     BUILD_TYPE=Release
 else
     BUILD_TYPE="$1"
 fi
 
-if [[ "$(git tag --points-at HEAD 2>/dev/null)" == v* ]]; then
-	touch "${ROOTDIR}/prerelease.txt"
+if [[ $(git tag --points-at HEAD 2> /dev/null) == v* ]]; then
+    touch "${ROOTDIR}/prerelease.txt"
 fi
 
-mkdir -p "${BUILDDIR}"
-cd "${BUILDDIR}"
+mkdir -p "$BUILDDIR"
+cd "$BUILDDIR"
 
 cmake .. -DCMAKE_BUILD_TYPE="$BUILD_TYPE" "${@:2}"
 make -j2
 
-if [[ "${CI}" == "" ]]; then
-	echo "Installing ..."
-	sudo make install
+if [[ $CI == "" ]]; then
+    echo "Installing ..."
+    sudo make install
 fi

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -9,27 +9,23 @@ prerelease_source="${1:-ci}"
 
 cd "${ROOTDIR}"
 
-# shellcheck disable=SC2166
-if [ "$CIRCLE_BRANCH" = release -o -n "$CIRCLE_TAG" -o -n "$FORCE_RELEASE" ]
-then
-    echo -n >prerelease.txt
+if [[ $CIRCLE_BRANCH == release || -n $CIRCLE_TAG || -n $FORCE_RELEASE ]]; then
+    echo -n > prerelease.txt
 else
     # Use last commit date rather than build date to avoid ending up with builds for
     # different platforms having different version strings (and therefore producing different bytecode)
     # if the CI is triggered just before midnight.
-    TZ=UTC git show --quiet --date="format-local:%Y.%-m.%-d" --format="${prerelease_source}.%cd" >prerelease.txt
+    TZ=UTC git show --quiet --date="format-local:%Y.%-m.%-d" --format="${prerelease_source}.%cd" > prerelease.txt
 fi
 
-if [ -n "$CIRCLE_SHA1" ]
-then
-    echo -n "$CIRCLE_SHA1" >commit_hash.txt
+if [[ -n $CIRCLE_SHA1 ]]; then
+    echo -n "$CIRCLE_SHA1" > commit_hash.txt
 fi
 
 mkdir -p build
 cd build
 
-# shellcheck disable=SC2166
-[ -n "$COVERAGE" -a "$CIRCLE_BRANCH" != release -a -z "$CIRCLE_TAG" ] && CMAKE_OPTIONS="$CMAKE_OPTIONS -DCOVERAGE=ON"
+[[ -n $COVERAGE && $CIRCLE_BRANCH != release && -z $CIRCLE_TAG ]] && CMAKE_OPTIONS="$CMAKE_OPTIONS -DCOVERAGE=ON"
 
 # shellcheck disable=SC2086
 cmake .. -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}" $CMAKE_OPTIONS

--- a/scripts/ci/build_emscripten.sh
+++ b/scripts/ci/build_emscripten.sh
@@ -45,19 +45,16 @@ function build() {
 
     cd "${ROOT_DIR}"
 
-    # shellcheck disable=SC2166
-    if [[ "$CIRCLE_BRANCH" = release || -n "$CIRCLE_TAG" || -n "$FORCE_RELEASE" || "$(git tag --points-at HEAD 2>/dev/null)" == v* ]]
-    then
-        echo -n >prerelease.txt
+    if [[ $CIRCLE_BRANCH == release || -n $CIRCLE_TAG || -n $FORCE_RELEASE || $(git tag --points-at HEAD 2> /dev/null) == v* ]]; then
+        echo -n > prerelease.txt
     else
         # Use last commit date rather than build date to avoid ending up with builds for
         # different platforms having different version strings (and therefore producing different bytecode)
         # if the CI is triggered just before midnight.
-        TZ=UTC git show --quiet --date="format-local:%Y.%-m.%-d" --format="${prerelease_source}.%cd" >prerelease.txt
+        TZ=UTC git show --quiet --date="format-local:%Y.%-m.%-d" --format="${prerelease_source}.%cd" > prerelease.txt
     fi
-    if [ -n "$CIRCLE_SHA1" ]
-    then
-        echo -n "$CIRCLE_SHA1" >commit_hash.txt
+    if [[ -n $CIRCLE_SHA1 ]]; then
+        echo -n "$CIRCLE_SHA1" > commit_hash.txt
     fi
 
     # Disable warnings for unqualified `move()` calls, introduced and enabled by

--- a/scripts/create_source_tarball.sh
+++ b/scripts/create_source_tarball.sh
@@ -1,39 +1,41 @@
-#!/usr/bin/env sh
-#
-
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
 REPO_ROOT="$(dirname "$0")"/..
-(
-    cd "$REPO_ROOT"
-    version=$(scripts/get_version.sh)
-    commithash=$(git rev-parse --short=8 HEAD)
-    commitdate=$(git show --format=%ci HEAD | head -n 1 | cut - -b1-10 | sed -e 's/-0?/./' | sed -e 's/-0?/./')
+cd "$REPO_ROOT"
+version=$(scripts/get_version.sh)
+commit_hash=$(git rev-parse --short=8 HEAD)
+commit_date=$(git show --format=%ci HEAD | head -n 1 | cut - -b1-10 | sed -e 's/-0?/./' | sed -e 's/-0?/./')
 
-    # file exists and has zero size -> not a prerelease
-    if [ -e prerelease.txt ] && [ ! -s prerelease.txt ]
-    then
-        versionstring="$version"
-    else
-        versionstring="$version-nightly-$commitdate-$commithash"
-    fi
+# File exists and has zero size -> not a prerelease
+if [[ -e prerelease.txt && ! -s prerelease.txt ]]; then
+    version_string="$version"
+else
+    version_string="${version}-nightly-${commit_date}-${commit_hash}"
+fi
 
-    TEMPDIR=$(mktemp -d)
-    SOLDIR="$TEMPDIR/solidity_$versionstring/"
-    mkdir "$SOLDIR"
-    # Ensure that submodules are initialized.
-    git submodule update --init --recursive
-    # Store the current source
-    git checkout-index -a --prefix="$SOLDIR"
-    # shellcheck disable=SC2016
-    SOLDIR="$SOLDIR" git submodule foreach 'git checkout-index -a --prefix="$SOLDIR/$sm_path/"'
-    # Store the commit hash
-    echo "$commithash" > "$SOLDIR/commit_hash.txt"
-    if [ -e prerelease.txt ] && [ ! -s prerelease.txt ]
-    then
-        cp prerelease.txt "$SOLDIR/"
-    fi
-    mkdir -p "$REPO_ROOT/upload"
-    tar --owner 0 --group 0 -czf "$REPO_ROOT/upload/solidity_$versionstring.tar.gz" -C "$TEMPDIR" "solidity_$versionstring"
-    rm -r "$TEMPDIR"
-)
+TEMPDIR=$(mktemp -d -t "solc-src-tarball-XXXXXX")
+SOLDIR="${TEMPDIR}/solidity_${version_string}/"
+mkdir "$SOLDIR"
+
+# Ensure that submodules are initialized.
+git submodule update --init --recursive
+# Store the current source
+git checkout-index --all --prefix="$SOLDIR"
+# shellcheck disable=SC2016
+SOLDIR="$SOLDIR" git submodule foreach 'git checkout-index --all --prefix="${SOLDIR}/${sm_path}/"'
+
+# Include the commit hash and prerelease suffix in the tarball
+echo "$commit_hash" > "${SOLDIR}/commit_hash.txt"
+[[ -e prerelease.txt && ! -s prerelease.txt ]] && cp prerelease.txt "${SOLDIR}/"
+
+mkdir -p "$REPO_ROOT/upload"
+tar \
+    --owner 0 \
+    --group 0 \
+    --create \
+    --gzip \
+    --file "${REPO_ROOT}/upload/solidity_${version_string}.tar.gz" \
+    --directory "$TEMPDIR" \
+    "solidity_${version_string}"
+rm -r "$TEMPDIR"


### PR DESCRIPTION
Just a bunch of refactors extracted from the upcoming PR that actually updates the logic.

The changes either have zero effect on behavior or only affect it in trivial ways, like giving the temporary dir a recognizable prefix or enabling Bash error handling.