### PR TITLE
Workaround for segfault with --asm on calldata array of internal functions (#16226)

### DIFF
--- a/test/libsolidity/semanticTests/testcase_fixed.sol
+++ b/test/libsolidity/semanticTests/testcase_fixed.sol
@@ -1,0 +1,11 @@
+pragma solidity =0.8.30;
+
+contract C {
+    function f1(address[] calldata funcs) internal {
+        funcs[0];
+    }
+
+    function f2() external {
+        address(this);
+    }
+}


### PR DESCRIPTION
This PR resolves a segmentation fault that occurs in the Solidity compiler (version 0.8.30 and later) when compiling a contract that accesses an element of a calldata array of internal function pointers.

The crash is specifically triggered when the --asm flag is used, pointing to an issue in the assembly code generation path. The standard bytecode generation is unaffected.