### PR TITLE
Use a read-only GitHub token when retrieving PR information

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,8 +142,8 @@ commands:
             FOUNDRY_REPO="foundry-rs/foundry"
             FOUNDRY_VERSION="<< parameters.version >>"
             # Make authenticated requests when the Github token is available
-            if [[ -n "$GITHUB_ACCESS_TOKEN" ]]; then
-              EXTRA_HEADERS=(--header 'Authorization: Bearer '"${GITHUB_ACCESS_TOKEN}")
+            if [[ -n "$GITHUB_READ_TOKEN" ]]; then
+              EXTRA_HEADERS=(--header 'Authorization: Bearer '"${GITHUB_READ_TOKEN}")
             fi
             FOUNDRY_RELEASE_SHA=$(curl \
               --silent \
@@ -1418,8 +1418,8 @@ jobs:
           name: Retrieve EDR latest release tag
           command: |
             # Make authenticated requests when the Github token is available
-            if [[ -n "$GITHUB_ACCESS_TOKEN" ]]; then
-              EXTRA_HEADERS=(--header "Authorization: Bearer ${GITHUB_ACCESS_TOKEN}")
+            if [[ -n "$GITHUB_READ_TOKEN" ]]; then
+              EXTRA_HEADERS=(--header "Authorization: Bearer ${GITHUB_READ_TOKEN}")
             fi
             EDR_LATEST_RELEASE_TAG=$(
               curl \

--- a/scripts/common/rest_api_helpers.py
+++ b/scripts/common/rest_api_helpers.py
@@ -84,10 +84,13 @@ class Github:
         self.debug_requests = debug_requests
 
     def pull_request(self, pr_id: int) -> dict:
+        # GITHUB_READ_TOKEN should be a PAT with read-only permissions
+        # This is used by CircleCI and local scripts to avoid GitHub API rate limits
+        headers = {'Authorization': f'Bearer {environ.get("GITHUB_READ_TOKEN")}'} if 'GITHUB_READ_TOKEN' in environ else {}
         return query_api(
             f'{self.BASE_URL}/repos/{self.project_slug}/pulls/{pr_id}',
             {},
-            {},
+            headers,
             self.debug_requests
         )
 


### PR DESCRIPTION
Note, this token is used by CircleCI and it is not the same as the default GITHUB_TOKEN available for github actions. This should avoid GitHub API rate limits when downloading benchmarks artifacts from PRs.

The token was already added to our circleci config and the previous one will be removed after merge.