### PR TITLE
Migrate to ghcr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,25 +9,25 @@ version: 2.1
 parameters:
   ubuntu-2004-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2004-26
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:1f387a77be889f65a2a25986a5c5eccc88cec23fabe6aeaf351790751145c81e"
+    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu2004-26
+    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:1f387a77be889f65a2a25986a5c5eccc88cec23fabe6aeaf351790751145c81e"
   ubuntu-2404-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2404-6
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:c0412c53e59ce0c96bde4c08e7332ea12e4cadba9bbac829621947897fa21272"
+    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu2404-6
+    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:c0412c53e59ce0c96bde4c08e7332ea12e4cadba9bbac829621947897fa21272"
   ubuntu-2404-clang-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu2404.clang-7
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:7466ed23590cf14e60da884894723bcdab064742f017dcfcce015999b4f9143b"
+    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu2404.clang-7
+    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:7466ed23590cf14e60da884894723bcdab064742f017dcfcce015999b4f9143b"
   ubuntu-clang-ossfuzz-docker-image:
     type: string
-    # solbuildpackpusher/solidity-buildpack-deps:ubuntu.clang.ossfuzz-12
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:c7088af5082bf764244a6251ecf3dd29d280d2cd2cd071f011f7f32e0326f426"
+    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu.clang.ossfuzz-12
+    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:c7088af5082bf764244a6251ecf3dd29d280d2cd2cd071f011f7f32e0326f426"
   emscripten-docker-image:
     type: string
     # NOTE: Please remember to update the `scripts/build_emscripten.sh` whenever the hash of this image changes.
-    # solbuildpackpusher/solidity-buildpack-deps:emscripten-21
-    default: "solbuildpackpusher/solidity-buildpack-deps@sha256:fc53d68a4680ffa7d5f70164e13a903478964f15bcc07434d74833a05f4fbc19"
+    # ghcr.io/argotorg/solidity-buildpack-deps:emscripten-21
+    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:fc53d68a4680ffa7d5f70164e13a903478964f15bcc07434d74833a05f4fbc19"
   evm-version:
     type: string
     default: prague

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1866,7 +1866,7 @@ jobs:
           command: scripts/docker_deploy_manual.sh develop "file://$PWD" --no-push
       - run:
           name: Smoke test
-          command: docker run --pull=never ethereum/solc:build-alpine --version
+          command: docker run --pull=never ghcr.io/argotorg/solc:build-alpine --version
       - matrix_notify_failure_unless_pr
 
 workflows:

--- a/.github/workflows/buildpack-deps.yml
+++ b/.github/workflows/buildpack-deps.yml
@@ -16,8 +16,7 @@ jobs:
   buildpack-deps:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      DOCKER_REPOSITORY: solbuildpackpusher/solidity-buildpack-deps
+      DOCKER_REPOSITORY: ghcr.io/argotorg/solidity-buildpack-deps
       IMAGE_NAME: buildpack-deps
 
     runs-on: ubuntu-latest
@@ -32,11 +31,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upgrade ${{ env.IMAGE_NAME }}-${{ matrix.image_variant }}
         run: |
-          echo ${DOCKERHUB_TOKEN} | docker login -u solbuildpackpusher --password-stdin
           scripts/ci/docker_upgrade.sh ${{ env.IMAGE_NAME }} ${{ matrix.image_variant }} ${{ env.DOCKER_REPOSITORY }}
-          docker logout
 
       - name: comment PR
         if: "env.DOCKER_IMAGE"

--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -71,7 +71,7 @@ Please refer to the solc-js repository for instructions.
 Docker
 ======
 
-Docker images of Solidity builds are available using the ``solc`` image from the ``ethereum`` organization.
+Docker images of Solidity builds are available using the `solc <https://github.com/argotorg/solidity/pkgs/container/solc>`_ image from the argotorg organization on ghcr.io.
 Use the ``stable`` tag for the latest released version, and ``nightly`` for potentially unstable changes in the ``develop`` branch.
 
 The Docker image runs the compiler executable so that you can pass all compiler arguments to it.
@@ -80,11 +80,11 @@ and runs it in a new container, passing the ``--help`` argument.
 
 .. code-block:: bash
 
-    docker run ethereum/solc:stable --help
+    docker run ghcr.io/argotorg/solc:stable --help
 
 .. note::
 
-    Specific compiler versions are supported as the Docker image tag such as ``ethereum/solc:0.8.23``.
+    Specific compiler versions are supported as the Docker image tag such as ``ghcr.io/argotorg/solc:0.8.23``.
     We will be passing the ``stable`` tag here instead of specific version tag to ensure that users get
     the latest version by default and avoid the issue of an out-of-date version.
 
@@ -95,7 +95,7 @@ local folder for input and output, and specify the contract to compile. For exam
 
     docker run \
         --volume "/tmp/some/local/path/:/sources/" \
-        ethereum/solc:stable \
+        ghcr.io/argotorg/solc:stable \
             /sources/Contract.sol \
             --abi \
             --bin \
@@ -108,7 +108,7 @@ self-contained (i.e. it does not refer to any external files that would have to 
 
 .. code-block:: bash
 
-    docker run ethereum/solc:stable --standard-json < input.json > output.json
+    docker run ghcr.io/argotorg/solc:stable --standard-json < input.json > output.json
 
 Linux Packages
 ==============

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,6 +1,4 @@
 FROM alpine AS build
-MAINTAINER chriseth <chris@ethereum.org>
-#Official solidity docker image
 
 #Establish working directory as solidity
 WORKDIR /solidity
@@ -8,8 +6,8 @@ WORKDIR /solidity
 # Build dependencies
 RUN apk update && apk add boost-dev boost-static build-base cmake git clang
 
-#Copy working directory on travis to the image
-COPY / $WORKDIR
+#Copy working directory to the image
+COPY . /solidity
 
 # Number of parallel jobs during build
 # or 0 for auto-computing (max(1, CPU_core_count * 2/3), a greedy value)
@@ -34,5 +32,7 @@ RUN make solc \
 RUN strip solc/solc
 
 FROM scratch
+LABEL org.opencontainers.image.source=https://github.com/argotorg/solidity
+LABEL maintainer="Solidity Team <solidity@argot.org>"
 COPY --from=build /solidity/solc/solc /usr/bin/solc
 ENTRYPOINT ["/usr/bin/solc"]

--- a/scripts/Dockerfile_alpine
+++ b/scripts/Dockerfile_alpine
@@ -1,5 +1,6 @@
 FROM alpine
-MAINTAINER chriseth <chris@ethereum.org>
+LABEL org.opencontainers.image.source=https://github.com/argotorg/solidity
+LABEL maintainer="Solidity Team <solidity@argot.org>"
 
 COPY upload/solc-static-linux /usr/local/bin/solc
 ENTRYPOINT ["/usr/local/bin/solc"]

--- a/scripts/build_emscripten.sh
+++ b/scripts/build_emscripten.sh
@@ -33,9 +33,9 @@ if (( $# != 0 )); then
     params="$(printf "%q " "${@}")"
 fi
 
-# solbuildpackpusher/solidity-buildpack-deps:emscripten-21
+# ghcr.io/argotorg/solidity-buildpack-deps:emscripten-21
 # NOTE: Without `safe.directory` git would assume it's not safe to operate on /root/project since it's owned by a different user.
 # See https://github.blog/2022-04-12-git-security-vulnerability-announced/
 docker run -v "$(pwd):/root/project" -w /root/project \
-    solbuildpackpusher/solidity-buildpack-deps@sha256:fc53d68a4680ffa7d5f70164e13a903478964f15bcc07434d74833a05f4fbc19 \
+    ghcr.io/argotorg/solidity-buildpack-deps@sha256:fc53d68a4680ffa7d5f70164e13a903478964f15bcc07434d74833a05f4fbc19 \
     /bin/bash -c "git config --global --add safe.directory /root/project && ./scripts/ci/build_emscripten.sh ${params}"

--- a/scripts/docker_deploy_manual.sh
+++ b/scripts/docker_deploy_manual.sh
@@ -6,7 +6,7 @@ REPO_ROOT="$(dirname "$0")/.."
 # shellcheck source=scripts/common.sh
 source "${REPO_ROOT}/scripts/common.sh"
 
-image="ethereum/solc"
+image="ghcr.io/argotorg/solc"
 
 if (( $# < 1 || $# > 3 )); then
     fail "Usage: $0 <tag/branch> [repo URL] [--no-push]"
@@ -22,7 +22,11 @@ else
     publish=true
 fi
 
-#docker login
+# NOTE: Login to GHCR before running this script with a PAT:
+# echo $GHCR_TOKEN | docker login ghcr.io -u USERNAME --password-stdin
+#
+# Create a classic PAT with write:packages scope only visiting the following url:
+# https://github.com/settings/tokens/new?scopes=write:packages
 
 DIR=$(mktemp -d)
 (


### PR DESCRIPTION
This PR migrates from dockerhub registry to ghcr.io. New images will be published to `ghcr.io/argotorg/solc` and `ghcr.io/argotorg/solidity-buildpack-deps`

`DOCKERHUB_TOKEN` should be removed from project secrets after merge.