### PR TITLE
Always copy `prerelease.txt` to the source tarball

### DIFF
--- a/scripts/create_source_tarball.sh
+++ b/scripts/create_source_tarball.sh
@@ -45,7 +45,7 @@ SOLDIR="$SOLDIR" git submodule foreach 'git checkout-index --all --prefix="${SOL
 
 # Include the commit hash and prerelease suffix in the tarball
 echo "$commit_hash" > "${SOLDIR}/commit_hash.txt"
-[[ -e prerelease.txt && ! -s prerelease.txt ]] && cp prerelease.txt "${SOLDIR}/"
+[[ -e prerelease.txt ]] && cp prerelease.txt "${SOLDIR}/"
 
 mkdir -p "$REPO_ROOT/upload"
 tar \


### PR DESCRIPTION
One crucial bit missing from #16246. The `prerelease.txt` file is only copied to the source tarball when it's empty (i.e. when doing a full release). For nightlies it's not as important, though we should still do it. It's much more important for tagged prereleases though.