### PR TITLE
Exclude dependency docs from source tarball

### DIFF
--- a/scripts/create_source_tarball.sh
+++ b/scripts/create_source_tarball.sh
@@ -43,6 +43,11 @@ git checkout-index --all --prefix="$SOLDIR"
 # shellcheck disable=SC2016
 SOLDIR="$SOLDIR" git submodule foreach 'git checkout-index --all --prefix="${SOLDIR}/${sm_path}/"'
 
+# Documentation is pretty heavy and not necessary to build the compiler.
+# Especially nlohmann-json has several huge images, which blow up the size of the compressed tarball.
+# shellcheck disable=SC2016
+SOLDIR="$SOLDIR" git submodule foreach 'rm -rf "${SOLDIR}/${sm_path}/"doc/; rm -rf "${SOLDIR}/${sm_path}/"docs/'
+
 # Include the commit hash and prerelease suffix in the tarball
 echo "$commit_hash" > "${SOLDIR}/commit_hash.txt"
 [[ -e prerelease.txt ]] && cp prerelease.txt "${SOLDIR}/"


### PR DESCRIPTION
Follow-up to #16256.

During the prerelease we discovered that `create_source_tarball.sh` packages nlohmann-json docs as a part of our source. And it includes a bunch of unnecessary things, especially big images and rendered versions of the docs. For example:

- https://github.com/nlohmann/json/blob/v3.11.3/docs/avatars.png (1.6 MB)
- https://github.com/nlohmann/json/blob/v3.11.3/docs/json.gif (1.6 MB)
- https://github.com/nlohmann/json/blob/v3.11.3/docs/usages/macos.png (1.2 MB)
- https://github.com/ericniebler/range-v3/tree/0.12.0/doc (`gh-pages/` is 15 MB)
    - I see that it actually does not end up in the archive. I think we skip recursive submodules but it's probably not even intentional. If it was a fixed part of `range-v3` we'd have it in there as well.

Excluding `doc/` and `docs/` from these submodules shaves off almost half of the size of the source tarball (12.3 MB -> 7.3 MB).

These things are essentially dead weight as I would not expect anyone to look for them in our archive (they'd more likely go the source repo or to their docs webpage) and they do not the affect compiler build.