### PR TITLE
fix: reorder accept methods in UserDefinedValueTypeDefinition

### DIFF
--- a/libsolidity/ast/AST_accept.h
+++ b/libsolidity/ast/AST_accept.h
@@ -174,7 +174,7 @@ void EnumValue::accept(ASTConstVisitor& _visitor) const
 	_visitor.endVisit(*this);
 }
 
-void UserDefinedValueTypeDefinition::accept(ASTConstVisitor& _visitor) const
+void UserDefinedValueTypeDefinition::accept(ASTVisitor& _visitor)
 {
 	if (_visitor.visit(*this))
 	{
@@ -184,7 +184,7 @@ void UserDefinedValueTypeDefinition::accept(ASTConstVisitor& _visitor) const
 	_visitor.endVisit(*this);
 }
 
-void UserDefinedValueTypeDefinition::accept(ASTVisitor& _visitor)
+void UserDefinedValueTypeDefinition::accept(ASTConstVisitor& _visitor) const
 {
 	if (_visitor.visit(*this))
 	{


### PR DESCRIPTION
Fix inconsistent order of accept method declarations in UserDefinedValueTypeDefinition. 

The const version was declared before the non-const version, breaking the established pattern used by all other AST node classes. 