### PR TITLE
Remove unused solidity::util namespace import from libsolc.cpp

### DIFF
--- a/libsolc/libsolc.cpp
+++ b/libsolc/libsolc.cpp
@@ -33,7 +33,6 @@
 #include "license.h"
 
 using namespace solidity;
-using namespace solidity::util;
 
 using solidity::frontend::ReadCallback;
 using solidity::frontend::StandardCompiler;


### PR DESCRIPTION
Drop the redundant using namespace solidity::util; directive from libsolc/libsolc.cpp
Keep the public API module free of unused dependencies and silence unnecessary compiler warnings