### PR TITLE
Optimize SSA CFG datastructure + construction

### DIFF
--- a/libsolutil/DisjointSet.cpp
+++ b/libsolutil/DisjointSet.cpp
@@ -24,7 +24,8 @@
 
 using namespace solidity::util;
 
-ContiguousDisjointSet::ContiguousDisjointSet(size_t const _numNodes):
+template<typename ValueType>
+ContiguousDisjointSet<ValueType>::ContiguousDisjointSet(size_t const _numNodes):
 	m_parents(_numNodes),
 	m_neighbors(_numNodes),
 	m_sizes(_numNodes, static_cast<value_type>(1)),
@@ -35,9 +36,11 @@ ContiguousDisjointSet::ContiguousDisjointSet(size_t const _numNodes):
 	std::iota(m_neighbors.begin(), m_neighbors.end(), 0);
 }
 
-size_t ContiguousDisjointSet::numSets() const { return m_numSets; }
+template<typename ValueType>
+size_t ContiguousDisjointSet<ValueType>::numSets() const { return m_numSets; }
 
-ContiguousDisjointSet::value_type ContiguousDisjointSet::find(value_type const _element) const
+template<typename ValueType>
+typename ContiguousDisjointSet<ValueType>::value_type ContiguousDisjointSet<ValueType>::find(value_type const _element) const
 {
 	solAssert(_element < m_parents.size());
 	// path halving
@@ -50,7 +53,8 @@ ContiguousDisjointSet::value_type ContiguousDisjointSet::find(value_type const _
 	return rootElement;
 }
 
-void ContiguousDisjointSet::merge(value_type const _x, value_type const _y, bool const _mergeBySize)
+template<typename ValueType>
+void ContiguousDisjointSet<ValueType>::merge(value_type const _x, value_type const _y, bool const _mergeBySize)
 {
 	auto xRoot = find(_x);
 	auto yRoot = find(_y);
@@ -69,17 +73,20 @@ void ContiguousDisjointSet::merge(value_type const _x, value_type const _y, bool
 	--m_numSets;
 }
 
-bool ContiguousDisjointSet::sameSubset(value_type const _x, value_type const _y) const
+template<typename ValueType>
+bool ContiguousDisjointSet<ValueType>::sameSubset(value_type const _x, value_type const _y) const
 {
 	return find(_x) == find(_y);
 }
 
-ContiguousDisjointSet::size_type ContiguousDisjointSet::sizeOfSubset(value_type const _x) const
+template<typename ValueType>
+typename  ContiguousDisjointSet<ValueType>::size_type ContiguousDisjointSet<ValueType>::sizeOfSubset(value_type const _x) const
 {
 	return m_sizes[find(_x)];
 }
 
-std::set<ContiguousDisjointSet::value_type> ContiguousDisjointSet::subset(value_type const _x) const
+template<typename ValueType>
+std::set<typename ContiguousDisjointSet<ValueType>::value_type> ContiguousDisjointSet<ValueType>::subset(value_type const _x) const
 {
 	solAssert(_x < m_parents.size());
 	std::set<value_type> result{_x};
@@ -92,7 +99,8 @@ std::set<ContiguousDisjointSet::value_type> ContiguousDisjointSet::subset(value_
 	return result;
 }
 
-std::vector<std::set<ContiguousDisjointSet::value_type>> ContiguousDisjointSet::subsets() const
+template<typename ValueType>
+std::vector<std::set<typename ContiguousDisjointSet<ValueType>::value_type>> ContiguousDisjointSet<ValueType>::subsets() const
 {
 	std::vector<std::set<value_type>> result;
 	std::vector<std::uint8_t> visited(m_parents.size(), false);
@@ -107,3 +115,5 @@ std::vector<std::set<ContiguousDisjointSet::value_type>> ContiguousDisjointSet::
 	}
 	return result;
 }
+
+template class solidity::util::ContiguousDisjointSet<std::uint32_t>;

--- a/libsolutil/DisjointSet.h
+++ b/libsolutil/DisjointSet.h
@@ -31,11 +31,12 @@ namespace solidity::util
 /// [1] https://en.wikipedia.org/wiki/Disjoint-set_data_structure
 /// [2] Tarjan, Robert E., and Jan Van Leeuwen. "Worst-case analysis of set union algorithms."
 ///     Journal of the ACM (JACM) 31.2 (1984): 245-281.
+template<typename ValueType>
 class ContiguousDisjointSet
 {
 public:
 	using size_type = size_t;
-	using value_type = size_t;
+	using value_type = ValueType;
 
 	/// Constructs a new disjoint set datastructure with `_numNodes` elements and each element in its own individual set
 	explicit ContiguousDisjointSet(size_t _numNodes);

--- a/libyul/YulStack.cpp
+++ b/libyul/YulStack.cpp
@@ -405,8 +405,7 @@ Json YulStack::cfgJson() const
 			keepLiteralAssignments
 		);
 		std::unique_ptr<ssa::ControlFlowLiveness> liveness = std::make_unique<ssa::ControlFlowLiveness>(*controlFlow);
-		ssa::SSACFGJsonExporter exporter(*controlFlow, liveness.get());
-		return exporter.run();
+		return ssa::json::exportControlFlow(*controlFlow, liveness.get());
 	};
 
 	std::function<Json(std::vector<std::shared_ptr<ObjectNode>>)> exportCFGFromSubObjects;

--- a/libyul/backends/evm/ssa/ControlFlow.cpp
+++ b/libyul/backends/evm/ssa/ControlFlow.cpp
@@ -24,8 +24,7 @@ using namespace solidity::yul::ssa;
 
 ControlFlowLiveness::ControlFlowLiveness(ControlFlow const& _controlFlow):
 	controlFlow(_controlFlow),
-	mainLiveness(std::make_unique<LivenessAnalysis>(*_controlFlow.mainGraph)),
-	functionLiveness(_controlFlow.functionGraphs | ranges::views::transform([](auto const& _cfg) { return std::make_unique<LivenessAnalysis>(*_cfg); }) | ranges::to<std::vector>)
+	cfgLiveness(_controlFlow.functionGraphs | ranges::views::transform([](auto const& _cfg) { return std::make_unique<LivenessAnalysis>(*_cfg); }) | ranges::to<std::vector>)
 { }
 
 std::string ControlFlowLiveness::toDot() const

--- a/libyul/backends/evm/ssa/LivenessAnalysis.h
+++ b/libyul/backends/evm/ssa/LivenessAnalysis.h
@@ -42,8 +42,7 @@ public:
 
 		LivenessData() = default;
 		template<std::input_iterator Iter, std::sentinel_for<Iter> Sentinel>
-		LivenessData(Iter begin, Sentinel end): m_liveCounts(begin, end) {
-		}
+		LivenessData(Iter begin, Sentinel end): m_liveCounts(begin, end) {}
 		explicit LivenessData(LiveCounts&& _liveCounts): m_liveCounts(std::move(_liveCounts)) {}
 
 		bool contains(Value const& _valueId) const;
@@ -113,7 +112,7 @@ public:
 
 private:
 	void runDagDfs();
-	void runLoopTreeDfs(std::size_t _loopHeader);
+	void runLoopTreeDfs(SSACFG::BlockId::ValueType _loopHeader);
 	void fillOperationsLiveOut();
 	LivenessData blockExitValues(SSACFG::BlockId const& _blockId) const;
 

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -51,15 +51,50 @@ public:
 
 	struct BlockId
 	{
-		size_t value = std::numeric_limits<size_t>::max();
-		auto operator<=>(BlockId const&) const = default;
-	};
-	struct ValueId
-	{
-		using ValueType = size_t;
+		using ValueType = std::uint32_t;
 		ValueType value = std::numeric_limits<ValueType>::max();
 		bool hasValue() const { return value != std::numeric_limits<ValueType>::max(); }
+		auto operator<=>(BlockId const&) const = default;
+	};
+	class ValueId
+	{
+	public:
+		enum class Kind: std::uint8_t
+		{
+			Literal,
+			Variable,
+			Phi,
+			Unreachable
+		};
+		using ValueType = std::uint32_t;
+
+		constexpr ValueId() = default;
+		constexpr ValueId(ValueType const _value, Kind const _kind): m_value(_value), m_kind(_kind) {}
+		constexpr ValueId(ValueId const&) = default;
+		constexpr ValueId(ValueId&&) = default;
+		constexpr ValueId& operator=(ValueId const&) = default;
+		constexpr ValueId& operator=(ValueId&&) = default;
+
+		static ValueId constexpr makeLiteral(ValueType const& _value) { return ValueId{_value, Kind::Literal}; }
+		static ValueId constexpr makeVariable(ValueType const& _value) { return ValueId{_value, Kind::Variable}; }
+		static ValueId constexpr makePhi(ValueType const& _value) { return ValueId{_value, Kind::Phi}; }
+		static ValueId constexpr makeUnreachable() { return ValueId{0u, Kind::Unreachable}; }
+
+		bool constexpr isLiteral() const noexcept { return m_kind == Kind::Literal; }
+		bool constexpr isVariable() const noexcept { return m_kind == Kind::Variable; }
+		bool constexpr isPhi() const noexcept { return m_kind == Kind::Phi; }
+		bool constexpr isUnreachable() const noexcept { return m_kind == Kind::Unreachable; }
+
+		bool constexpr hasValue() const { return m_value != std::numeric_limits<ValueType>::max(); }
+		ValueType constexpr value() const noexcept { return m_value; }
+		Kind constexpr kind() const noexcept { return m_kind; }
+		std::string str(SSACFG const& _cfg) const;
+
 		auto operator<=>(ValueId const&) const = default;
+
+	private:
+		ValueType m_value{std::numeric_limits<ValueType>::max()};
+		Kind m_kind{Kind::Unreachable};
 	};
 
 	struct BuiltinCall
@@ -158,7 +193,7 @@ public:
 	};
 	BlockId makeBlock(langutil::DebugData::ConstPtr _debugData)
 	{
-		BlockId blockId { m_blocks.size() };
+		BlockId blockId { static_cast<BlockId::ValueType>(m_blocks.size()) };
 		m_blocks.emplace_back(BasicBlock{std::move(_debugData), {}, {}, {}, BasicBlock::Terminated{}});
 		return blockId;
 	}
@@ -183,63 +218,47 @@ public:
 		std::vector<ValueId> arguments;
 	};
 	struct UnreachableValue {};
-	using ValueInfo = std::variant<UnreachableValue, VariableValue, LiteralValue, PhiValue>;
-	bool isLiteralValue(ValueId const _var) const
-	{
-		return std::holds_alternative<LiteralValue>(valueInfo(_var));
-	}
-	bool isPhiValue(ValueId const _var) const
-	{
-		return std::holds_alternative<PhiValue>(valueInfo(_var));
-	}
-	ValueInfo& valueInfo(ValueId const _var)
-	{
-		return m_valueInfos.at(_var.value);
-	}
-	ValueInfo const& valueInfo(ValueId const _var) const
-	{
-		return valueInfo(_var.value);
-	}
-	ValueInfo const& valueInfo(ValueId::ValueType const _var) const
-	{
-		return m_valueInfos.at(_var);
-	}
 	ValueId newPhi(BlockId const _definingBlock)
 	{
-		ValueId id { m_valueInfos.size() };
-		auto block = m_blocks.at(_definingBlock.value);
-		m_valueInfos.emplace_back(PhiValue{debugDataOf(block), _definingBlock, {}});
-		return id;
+		auto const& block = m_blocks.at(_definingBlock.value);
+		m_phis.emplace_back(PhiValue{debugDataOf(block), _definingBlock, std::vector<ValueId>{}});
+		auto const value = m_phis.size() - 1;
+		yulAssert(value < std::numeric_limits<ValueId::ValueType>::max());
+		return ValueId::makePhi(static_cast<ValueId::ValueType>(value));
 	}
 	ValueId newVariable(BlockId const _definingBlock)
 	{
-		ValueId id { m_valueInfos.size() };
-		auto block = m_blocks.at(_definingBlock.value);
-		m_valueInfos.emplace_back(VariableValue{debugDataOf(block), _definingBlock});
-		return id;
+		auto const& block = m_blocks.at(_definingBlock.value);
+		m_variables.emplace_back(VariableValue{debugDataOf(block), _definingBlock});
+		auto const value = m_variables.size() - 1;
+		yulAssert(value < std::numeric_limits<ValueId::ValueType>::max());
+		return ValueId::makeVariable(static_cast<ValueId::ValueType>(value));
 	}
+
 	ValueId unreachableValue()
 	{
 		if (!m_unreachableValue)
-		{
-			m_unreachableValue = ValueId { m_valueInfos.size() };
-			m_valueInfos.emplace_back(UnreachableValue{});
-		}
+			m_unreachableValue = ValueId::makeUnreachable();
 		return *m_unreachableValue;
 	}
+
 	ValueId newLiteral(langutil::DebugData::ConstPtr _debugData, u256 _value)
 	{
-		auto [it, inserted] = m_literals.emplace(_value, ValueId{m_valueInfos.size()});
-		if (inserted)
-			m_valueInfos.emplace_back(LiteralValue{std::move(_debugData), _value});
-		else
+		auto const it = m_literalMapping.find(_value);
+		if (it != m_literalMapping.end())
 		{
-			yulAssert(_value == it->first);
-			yulAssert(std::holds_alternative<LiteralValue>(m_valueInfos.at(it->second.value)));
-			yulAssert(std::get<LiteralValue>(m_valueInfos.at(it->second.value)).value == _value);
+			ValueId const& valueId = it->second;
+			yulAssert(valueId.hasValue() && m_literals[valueId.value()].value == _value);
+			return valueId;
 		}
-		yulAssert(it->second.value < m_valueInfos.size());
-		return it->second;
+
+
+		m_literals.emplace_back(LiteralValue{std::move(_debugData), std::move(_value)});
+		auto const value = m_literals.size() - 1;
+		yulAssert(value < std::numeric_limits<ValueId::ValueType>::max());
+		auto const literalId = ValueId::makeLiteral(static_cast<ValueId::ValueType>(value));
+		m_literalMapping.emplace(_value, literalId);
+		return literalId;
 	}
 
 	size_t phiArgumentIndex(BlockId const _source, BlockId const _target) const
@@ -255,9 +274,33 @@ public:
 		std::optional<size_t> _functionIndex=std::nullopt,
 		LivenessAnalysis const* _liveness=nullptr
 	) const;
+
+	PhiValue const& phiInfo(ValueId const& _valueId) const
+	{
+		yulAssert(_valueId.hasValue() && _valueId.isPhi());
+		return m_phis.at(_valueId.value());
+	}
+	PhiValue& phiInfo(ValueId const& _valueId)
+	{
+		yulAssert(_valueId.hasValue() && _valueId.isPhi());
+		return m_phis.at(_valueId.value());
+	}
+	LiteralValue const& literalInfo(ValueId const& _valueId) const
+	{
+		yulAssert(_valueId.hasValue() && _valueId.isLiteral());
+		return m_literals.at(_valueId.value());
+	}
+	VariableValue const& variableInfo(ValueId const& _valueId) const
+	{
+		yulAssert(_valueId.hasValue() && _valueId.isVariable());
+		return m_variables.at(_valueId.value());
+	}
+
 private:
-	std::deque<ValueInfo> m_valueInfos;
-	std::map<u256, ValueId> m_literals;
+	std::vector<LiteralValue> m_literals;
+	std::map<u256, ValueId> m_literalMapping;
+	std::vector<PhiValue> m_phis;
+	std::vector<VariableValue> m_variables;
 	std::optional<ValueId> m_unreachableValue;
 public:
 	langutil::DebugData::ConstPtr debugData;

--- a/libyul/backends/evm/ssa/SSACFGJsonExporter.h
+++ b/libyul/backends/evm/ssa/SSACFGJsonExporter.h
@@ -20,26 +20,10 @@
 
 #include <libyul/backends/evm/ssa/ControlFlow.h>
 #include <libsolutil/JSON.h>
-#include <libsolutil/Visitor.h>
 
-namespace solidity::yul::ssa
+namespace solidity::yul::ssa::json
 {
 
-class SSACFGJsonExporter
-{
-public:
-	SSACFGJsonExporter(ControlFlow const& _controlFlow, ControlFlowLiveness const* _liveness=nullptr);
-	Json run();
-	Json exportBlock(SSACFG const& _cfg, SSACFG::BlockId _blockId, LivenessAnalysis const* _liveness);
-	Json exportFunction(SSACFG const& _cfg, LivenessAnalysis const* _liveness);
-	std::string varToString(SSACFG const& _cfg, SSACFG::ValueId _var);
-
-private:
-	ControlFlow const& m_controlFlow;
-	ControlFlowLiveness const* m_liveness;
-	Json toJson(SSACFG const& _cfg, SSACFG::BlockId _blockId, LivenessAnalysis const* _liveness);
-	Json toJson(Json& _ret, SSACFG const& _cfg, SSACFG::Operation const& _operation);
-	Json toJson(SSACFG const& _cfg, std::vector<SSACFG::ValueId> const& _values);
-};
+Json exportControlFlow(ControlFlow const& _controlFlow, ControlFlowLiveness const* _liveness);
 
 }

--- a/libyul/backends/evm/ssa/SSACFGLoopNestingForest.h
+++ b/libyul/backends/evm/ssa/SSACFGLoopNestingForest.h
@@ -36,26 +36,28 @@ namespace solidity::yul::ssa
 ///     ACM Transactions on Programming Languages and Systems (TOPLAS) 21.2 (1999): 175-188.
 class SSACFGLoopNestingForest
 {
+	using BlockIdValue = SSACFG::BlockId::ValueType;
+
 public:
 	explicit SSACFGLoopNestingForest(ForwardSSACFGTopologicalSort const& _sort);
 
 	/// blocks which are not contained in a loop get assigned the loop parent numeric_limit<size_t>::max()
-	std::vector<size_t> const& loopParents() const { return m_loopParents; }
+	std::vector<BlockIdValue> const& loopParents() const { return m_loopParents; }
 	/// all loop nodes (entry blocks for loops), also nested ones
-	std::set<size_t> const& loopNodes() const { return m_loopNodes; }
+	std::set<BlockIdValue> const& loopNodes() const { return m_loopNodes; }
 	/// root loop nodes in the forest for outer-most loops
-	std::set<size_t> const& loopRootNodes() const { return m_loopRootNodes; }
+	std::set<BlockIdValue> const& loopRootNodes() const { return m_loopRootNodes; }
 private:
-	void findLoop(size_t _potentialHeader);
-	void collapse(std::set<size_t> const& _loopBody, size_t _loopHeader);
+	void findLoop(BlockIdValue _potentialHeader);
+	void collapse(std::set<BlockIdValue> const& _loopBody, BlockIdValue _loopHeader);
 
 	ForwardSSACFGTopologicalSort const& m_sort;
 	SSACFG const& m_cfg;
 
-	util::ContiguousDisjointSet m_vertexPartition;
-	std::vector<size_t> m_loopParents;
-	std::set<size_t> m_loopNodes;
-	std::set<size_t> m_loopRootNodes;
+	util::ContiguousDisjointSet<BlockIdValue> m_vertexPartition;
+	std::vector<BlockIdValue> m_loopParents;
+	std::set<BlockIdValue> m_loopNodes;
+	std::set<BlockIdValue> m_loopRootNodes;
 };
 
 }

--- a/libyul/backends/evm/ssa/SSACFGTopologicalSort.cpp
+++ b/libyul/backends/evm/ssa/SSACFGTopologicalSort.cpp
@@ -35,10 +35,10 @@ ForwardSSACFGTopologicalSort::ForwardSSACFGTopologicalSort(SSACFG const& _cfg):
 			m_backEdgeTargets.insert(v2);
 }
 
-void ForwardSSACFGTopologicalSort::dfs(size_t const _vertex) {
+void ForwardSSACFGTopologicalSort::dfs(SSACFG::BlockId::ValueType const _vertex) {
 	yulAssert(!m_explored[_vertex]);
 	m_explored[_vertex] = true;
-	m_blockWisePreOrder[_vertex] = m_preOrder.size();
+	m_blockWisePreOrder[_vertex] = static_cast<SSACFG::BlockId::ValueType>(m_preOrder.size());
 	m_blockWiseMaxSubtreePreOrder[_vertex] = m_blockWisePreOrder[_vertex];
 	m_preOrder.push_back(_vertex);
 
@@ -55,7 +55,7 @@ void ForwardSSACFGTopologicalSort::dfs(size_t const _vertex) {
 	m_postOrder.push_back(_vertex);
 }
 
-bool ForwardSSACFGTopologicalSort::ancestor(size_t const _block1, size_t const _block2) const {
+bool ForwardSSACFGTopologicalSort::ancestor(SSACFG::BlockId::ValueType const _block1, SSACFG::BlockId::ValueType const _block2) const {
 	yulAssert(_block1 < m_blockWisePreOrder.size());
 	yulAssert(_block2 < m_blockWisePreOrder.size());
 

--- a/libyul/backends/evm/ssa/SSACFGTopologicalSort.h
+++ b/libyul/backends/evm/ssa/SSACFGTopologicalSort.h
@@ -33,26 +33,26 @@ class ForwardSSACFGTopologicalSort
 public:
 	explicit ForwardSSACFGTopologicalSort(SSACFG const& _cfg);
 
-	std::vector<size_t> const& preOrder() const { return m_preOrder; }
-	std::vector<size_t> const& postOrder() const { return m_postOrder; }
-	std::set<size_t> const& backEdgeTargets() const { return m_backEdgeTargets; }
+	std::vector<SSACFG::BlockId::ValueType> const& preOrder() const { return m_preOrder; }
+	std::vector<SSACFG::BlockId::ValueType> const& postOrder() const { return m_postOrder; }
+	std::set<SSACFG::BlockId::ValueType> const& backEdgeTargets() const { return m_backEdgeTargets; }
 	SSACFG const& cfg() const { return m_cfg; }
 	bool backEdge(SSACFG::BlockId const& _block1, SSACFG::BlockId const& _block2) const;
-	size_t preOrderIndexOf(size_t _block) const { return m_blockWisePreOrder[_block]; }
-	size_t maxSubtreePreOrderIndexOf(size_t _block) const { return m_blockWiseMaxSubtreePreOrder[_block]; }
+	SSACFG::BlockId::ValueType preOrderIndexOf(SSACFG::BlockId::ValueType _block) const { return m_blockWisePreOrder[_block]; }
+	SSACFG::BlockId::ValueType maxSubtreePreOrderIndexOf(SSACFG::BlockId::ValueType _block) const { return m_blockWiseMaxSubtreePreOrder[_block]; }
 
 private:
-	void dfs(size_t _vertex);
+	void dfs(SSACFG::BlockId::ValueType _vertex);
 	/// Checks if block1 is an ancestor of block2, ie there's a path from block1 to block2 in the dfs tree
-	bool ancestor(size_t _block1, size_t _block2) const;
+	bool ancestor(SSACFG::BlockId::ValueType _block1, SSACFG::BlockId::ValueType _block2) const;
 
 	SSACFG const& m_cfg;
 	std::vector<char> m_explored{};
-	std::vector<size_t> m_postOrder{};
-	std::vector<size_t> m_preOrder{};
-	std::vector<size_t> m_blockWisePreOrder{};
-	std::vector<size_t> m_blockWiseMaxSubtreePreOrder{};
-	std::vector<std::tuple<size_t, size_t>> m_potentialBackEdges{};
-	std::set<size_t> m_backEdgeTargets{};
+	std::vector<SSACFG::BlockId::ValueType> m_postOrder{};
+	std::vector<SSACFG::BlockId::ValueType> m_preOrder{};
+	std::vector<SSACFG::BlockId::ValueType> m_blockWisePreOrder{};
+	std::vector<SSACFG::BlockId::ValueType> m_blockWiseMaxSubtreePreOrder{};
+	std::vector<std::tuple<SSACFG::BlockId::ValueType, SSACFG::BlockId::ValueType>> m_potentialBackEdges{};
+	std::set<SSACFG::BlockId::ValueType> m_backEdgeTargets{};
 };
 }

--- a/test/cmdlineTests/standard_yul_cfg_json_export/output.json
+++ b/test/cmdlineTests/standard_yul_cfg_json_export/output.json
@@ -7,7 +7,7 @@
                         "blocks": [
                             {
                                 "exit": {
-                                    "cond": "v2",
+                                    "cond": "v1",
                                     "targets": [
                                         "Block2",
                                         "Block1"
@@ -38,7 +38,7 @@
                                         "in": [],
                                         "op": "callvalue",
                                         "out": [
-                                            "v2"
+                                            "v1"
                                         ]
                                     }
                                 ],
@@ -63,7 +63,7 @@
                                         ],
                                         "op": "datasize",
                                         "out": [
-                                            "v4"
+                                            "v2"
                                         ]
                                     },
                                     {
@@ -73,13 +73,13 @@
                                         ],
                                         "op": "dataoffset",
                                         "out": [
-                                            "v5"
+                                            "v3"
                                         ]
                                     },
                                     {
                                         "in": [
-                                            "v4",
-                                            "v5",
+                                            "v2",
+                                            "v3",
                                             "v0"
                                         ],
                                         "op": "codecopy",
@@ -87,7 +87,7 @@
                                     },
                                     {
                                         "in": [
-                                            "v4",
+                                            "v2",
                                             "v0"
                                         ],
                                         "op": "return",
@@ -130,7 +130,7 @@
                                 "blocks": [
                                     {
                                         "exit": {
-                                            "cond": "v5",
+                                            "cond": "v3",
                                             "targets": [
                                                 "Block2",
                                                 "Block1"
@@ -161,26 +161,26 @@
                                                 "in": [],
                                                 "op": "calldatasize",
                                                 "out": [
-                                                    "v3"
+                                                    "v1"
                                                 ]
                                             },
                                             {
                                                 "in": [
                                                     "0x04",
-                                                    "v3"
+                                                    "v1"
                                                 ],
                                                 "op": "lt",
                                                 "out": [
-                                                    "v4"
+                                                    "v2"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v4"
+                                                    "v2"
                                                 ],
                                                 "op": "iszero",
                                                 "out": [
-                                                    "v5"
+                                                    "v3"
                                                 ]
                                             }
                                         ],
@@ -215,7 +215,7 @@
                                     },
                                     {
                                         "exit": {
-                                            "cond": "v11",
+                                            "cond": "v6",
                                             "targets": [
                                                 "Block4",
                                                 "Block3"
@@ -230,27 +230,27 @@
                                                 ],
                                                 "op": "calldataload",
                                                 "out": [
-                                                    "v7"
+                                                    "v4"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v7",
+                                                    "v4",
                                                     "0xe0"
                                                 ],
                                                 "op": "shr",
                                                 "out": [
-                                                    "v9"
+                                                    "v5"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v9",
+                                                    "v5",
                                                     "0x26121ff0"
                                                 ],
                                                 "op": "eq",
                                                 "out": [
-                                                    "v11"
+                                                    "v6"
                                                 ]
                                             }
                                         ],
@@ -280,7 +280,7 @@
                                     },
                                     {
                                         "exit": {
-                                            "cond": "v12",
+                                            "cond": "v7",
                                             "targets": [
                                                 "Block6",
                                                 "Block5"
@@ -293,7 +293,7 @@
                                                 "in": [],
                                                 "op": "callvalue",
                                                 "out": [
-                                                    "v12"
+                                                    "v7"
                                                 ]
                                             }
                                         ],
@@ -309,7 +309,7 @@
                                     },
                                     {
                                         "exit": {
-                                            "cond": "v17",
+                                            "cond": "v11",
                                             "targets": [
                                                 "Block9",
                                                 "Block8"
@@ -324,34 +324,34 @@
                                                 ],
                                                 "op": "not",
                                                 "out": [
-                                                    "v14"
+                                                    "v8"
                                                 ]
                                             },
                                             {
                                                 "in": [],
                                                 "op": "calldatasize",
                                                 "out": [
-                                                    "v15"
+                                                    "v9"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v14",
-                                                    "v15"
+                                                    "v8",
+                                                    "v9"
                                                 ],
                                                 "op": "add",
                                                 "out": [
-                                                    "v16"
+                                                    "v10"
                                                 ]
                                             },
                                             {
                                                 "in": [
                                                     "0x00",
-                                                    "v16"
+                                                    "v10"
                                                 ],
                                                 "op": "slt",
                                                 "out": [
-                                                    "v17"
+                                                    "v11"
                                                 ]
                                             }
                                         ],
@@ -454,7 +454,7 @@
                         "blocks": [
                             {
                                 "exit": {
-                                    "cond": "v2",
+                                    "cond": "v1",
                                     "targets": [
                                         "Block2",
                                         "Block1"
@@ -485,7 +485,7 @@
                                         "in": [],
                                         "op": "callvalue",
                                         "out": [
-                                            "v2"
+                                            "v1"
                                         ]
                                     }
                                 ],
@@ -510,7 +510,7 @@
                                         ],
                                         "op": "datasize",
                                         "out": [
-                                            "v4"
+                                            "v2"
                                         ]
                                     },
                                     {
@@ -520,13 +520,13 @@
                                         ],
                                         "op": "dataoffset",
                                         "out": [
-                                            "v5"
+                                            "v3"
                                         ]
                                     },
                                     {
                                         "in": [
-                                            "v4",
-                                            "v5",
+                                            "v2",
+                                            "v3",
                                             "v0"
                                         ],
                                         "op": "codecopy",
@@ -534,7 +534,7 @@
                                     },
                                     {
                                         "in": [
-                                            "v4",
+                                            "v2",
                                             "v0"
                                         ],
                                         "op": "return",
@@ -577,7 +577,7 @@
                                 "blocks": [
                                     {
                                         "exit": {
-                                            "cond": "v5",
+                                            "cond": "v3",
                                             "targets": [
                                                 "Block2",
                                                 "Block1"
@@ -608,26 +608,26 @@
                                                 "in": [],
                                                 "op": "calldatasize",
                                                 "out": [
-                                                    "v3"
+                                                    "v1"
                                                 ]
                                             },
                                             {
                                                 "in": [
                                                     "0x04",
-                                                    "v3"
+                                                    "v1"
                                                 ],
                                                 "op": "lt",
                                                 "out": [
-                                                    "v4"
+                                                    "v2"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v4"
+                                                    "v2"
                                                 ],
                                                 "op": "iszero",
                                                 "out": [
-                                                    "v5"
+                                                    "v3"
                                                 ]
                                             }
                                         ],
@@ -662,7 +662,7 @@
                                     },
                                     {
                                         "exit": {
-                                            "cond": "v11",
+                                            "cond": "v6",
                                             "targets": [
                                                 "Block4",
                                                 "Block3"
@@ -677,27 +677,27 @@
                                                 ],
                                                 "op": "calldataload",
                                                 "out": [
-                                                    "v7"
+                                                    "v4"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v7",
+                                                    "v4",
                                                     "0xe0"
                                                 ],
                                                 "op": "shr",
                                                 "out": [
-                                                    "v9"
+                                                    "v5"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v9",
+                                                    "v5",
                                                     "0x26121ff0"
                                                 ],
                                                 "op": "eq",
                                                 "out": [
-                                                    "v11"
+                                                    "v6"
                                                 ]
                                             }
                                         ],
@@ -727,7 +727,7 @@
                                     },
                                     {
                                         "exit": {
-                                            "cond": "v12",
+                                            "cond": "v7",
                                             "targets": [
                                                 "Block6",
                                                 "Block5"
@@ -740,7 +740,7 @@
                                                 "in": [],
                                                 "op": "callvalue",
                                                 "out": [
-                                                    "v12"
+                                                    "v7"
                                                 ]
                                             }
                                         ],
@@ -756,7 +756,7 @@
                                     },
                                     {
                                         "exit": {
-                                            "cond": "v17",
+                                            "cond": "v11",
                                             "targets": [
                                                 "Block9",
                                                 "Block8"
@@ -771,34 +771,34 @@
                                                 ],
                                                 "op": "not",
                                                 "out": [
-                                                    "v14"
+                                                    "v8"
                                                 ]
                                             },
                                             {
                                                 "in": [],
                                                 "op": "calldatasize",
                                                 "out": [
-                                                    "v15"
+                                                    "v9"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v14",
-                                                    "v15"
+                                                    "v8",
+                                                    "v9"
                                                 ],
                                                 "op": "add",
                                                 "out": [
-                                                    "v16"
+                                                    "v10"
                                                 ]
                                             },
                                             {
                                                 "in": [
                                                     "0x00",
-                                                    "v16"
+                                                    "v10"
                                                 ],
                                                 "op": "slt",
                                                 "out": [
-                                                    "v17"
+                                                    "v11"
                                                 ]
                                             }
                                         ],
@@ -835,7 +835,7 @@
                                     },
                                     {
                                         "exit": {
-                                            "cond": "v28",
+                                            "cond": "v16",
                                             "targets": [
                                                 "Block12",
                                                 "Block11"
@@ -851,47 +851,47 @@
                                                 ],
                                                 "op": "datasize",
                                                 "out": [
-                                                    "v18"
+                                                    "v12"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v18",
+                                                    "v12",
                                                     "v0"
                                                 ],
                                                 "op": "add",
                                                 "out": [
-                                                    "v24"
+                                                    "v13"
                                                 ]
                                             },
                                             {
                                                 "in": [
                                                     "v0",
-                                                    "v24"
+                                                    "v13"
                                                 ],
                                                 "op": "lt",
                                                 "out": [
-                                                    "v25"
+                                                    "v14"
                                                 ]
                                             },
                                             {
                                                 "in": [
                                                     "0xffffffffffffffff",
-                                                    "v24"
+                                                    "v13"
                                                 ],
                                                 "op": "gt",
                                                 "out": [
-                                                    "v27"
+                                                    "v15"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v25",
-                                                    "v27"
+                                                    "v14",
+                                                    "v15"
                                                 ],
                                                 "op": "or",
                                                 "out": [
-                                                    "v28"
+                                                    "v16"
                                                 ]
                                             }
                                         ],
@@ -901,8 +901,8 @@
                                             ],
                                             "out": [
                                                 "v0",
-                                                "v24",
-                                                "v18"
+                                                "v13",
+                                                "v12"
                                             ]
                                         },
                                         "type": "BuiltinCall"
@@ -930,7 +930,7 @@
                                     },
                                     {
                                         "exit": {
-                                            "cond": "v42",
+                                            "cond": "v21",
                                             "targets": [
                                                 "Block15",
                                                 "Block14"
@@ -946,13 +946,13 @@
                                                 ],
                                                 "op": "dataoffset",
                                                 "out": [
-                                                    "v35"
+                                                    "v18"
                                                 ]
                                             },
                                             {
                                                 "in": [
+                                                    "v12",
                                                     "v18",
-                                                    "v35",
                                                     "v0"
                                                 ],
                                                 "op": "datacopy",
@@ -961,42 +961,42 @@
                                             {
                                                 "in": [
                                                     "v0",
-                                                    "v24"
+                                                    "v13"
                                                 ],
                                                 "op": "sub",
                                                 "out": [
-                                                    "v40"
+                                                    "v19"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v40",
+                                                    "v19",
                                                     "v0",
                                                     "0x00"
                                                 ],
                                                 "op": "create",
                                                 "out": [
-                                                    "v41"
+                                                    "v20"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v41"
+                                                    "v20"
                                                 ],
                                                 "op": "iszero",
                                                 "out": [
-                                                    "v42"
+                                                    "v21"
                                                 ]
                                             }
                                         ],
                                         "liveness": {
                                             "in": [
                                                 "v0",
-                                                "v24",
-                                                "v18"
+                                                "v13",
+                                                "v12"
                                             ],
                                             "out": [
-                                                "v41"
+                                                "v20"
                                             ]
                                         },
                                         "type": "BuiltinCall"
@@ -1014,12 +1014,12 @@
                                                 ],
                                                 "op": "shl",
                                                 "out": [
-                                                    "v30"
+                                                    "v17"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v30",
+                                                    "v17",
                                                     "0x00"
                                                 ],
                                                 "op": "mstore",
@@ -1050,7 +1050,7 @@
                                     },
                                     {
                                         "exit": {
-                                            "cond": "v60",
+                                            "cond": "v32",
                                             "targets": [
                                                 "Block18",
                                                 "Block17"
@@ -1065,7 +1065,7 @@
                                                 ],
                                                 "op": "mload",
                                                 "out": [
-                                                    "v46"
+                                                    "v25"
                                                 ]
                                             },
                                             {
@@ -1075,13 +1075,13 @@
                                                 ],
                                                 "op": "shl",
                                                 "out": [
-                                                    "v49"
+                                                    "v26"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v49",
-                                                    "v46"
+                                                    "v26",
+                                                    "v25"
                                                 ],
                                                 "op": "mstore",
                                                 "out": []
@@ -1093,67 +1093,67 @@
                                                 ],
                                                 "op": "shl",
                                                 "out": [
-                                                    "v53"
+                                                    "v27"
                                                 ]
                                             },
                                             {
                                                 "in": [
                                                     "0x01",
-                                                    "v53"
+                                                    "v27"
                                                 ],
                                                 "op": "sub",
                                                 "out": [
-                                                    "v54"
+                                                    "v28"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v54",
-                                                    "v41"
+                                                    "v28",
+                                                    "v20"
                                                 ],
                                                 "op": "and",
                                                 "out": [
-                                                    "v57"
+                                                    "v29"
                                                 ]
                                             },
                                             {
                                                 "in": [],
                                                 "op": "gas",
                                                 "out": [
-                                                    "v58"
+                                                    "v30"
                                                 ]
                                             },
                                             {
                                                 "in": [
                                                     "0x20",
-                                                    "v46",
+                                                    "v25",
                                                     "0x04",
-                                                    "v46",
-                                                    "v57",
-                                                    "v58"
+                                                    "v25",
+                                                    "v29",
+                                                    "v30"
                                                 ],
                                                 "op": "staticcall",
                                                 "out": [
-                                                    "v59"
+                                                    "v31"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v59"
+                                                    "v31"
                                                 ],
                                                 "op": "iszero",
                                                 "out": [
-                                                    "v60"
+                                                    "v32"
                                                 ]
                                             }
                                         ],
                                         "liveness": {
                                             "in": [
-                                                "v41"
+                                                "v20"
                                             ],
                                             "out": [
-                                                "v46",
-                                                "v59"
+                                                "v25",
+                                                "v31"
                                             ]
                                         },
                                         "type": "BuiltinCall"
@@ -1170,21 +1170,21 @@
                                                 ],
                                                 "op": "mload",
                                                 "out": [
-                                                    "v43"
+                                                    "v22"
                                                 ]
                                             },
                                             {
                                                 "in": [],
                                                 "op": "returndatasize",
                                                 "out": [
-                                                    "v44"
+                                                    "v23"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v44",
+                                                    "v23",
                                                     "0x00",
-                                                    "v43"
+                                                    "v22"
                                                 ],
                                                 "op": "returndatacopy",
                                                 "out": []
@@ -1193,13 +1193,13 @@
                                                 "in": [],
                                                 "op": "returndatasize",
                                                 "out": [
-                                                    "v45"
+                                                    "v24"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v45",
-                                                    "v43"
+                                                    "v24",
+                                                    "v22"
                                                 ],
                                                 "op": "revert",
                                                 "out": []
@@ -1213,7 +1213,7 @@
                                     },
                                     {
                                         "exit": {
-                                            "cond": "v59",
+                                            "cond": "v31",
                                             "targets": [
                                                 "Block21",
                                                 "Block20"
@@ -1228,18 +1228,18 @@
                                                 ],
                                                 "op": "LiteralAssignment",
                                                 "out": [
-                                                    "v64"
+                                                    "v36"
                                                 ]
                                             }
                                         ],
                                         "liveness": {
                                             "in": [
-                                                "v46",
-                                                "v59"
+                                                "v25",
+                                                "v31"
                                             ],
                                             "out": [
-                                                "v64",
-                                                "v46"
+                                                "v36",
+                                                "v25"
                                             ]
                                         }
                                     },
@@ -1255,21 +1255,21 @@
                                                 ],
                                                 "op": "mload",
                                                 "out": [
-                                                    "v61"
+                                                    "v33"
                                                 ]
                                             },
                                             {
                                                 "in": [],
                                                 "op": "returndatasize",
                                                 "out": [
-                                                    "v62"
+                                                    "v34"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v62",
+                                                    "v34",
                                                     "0x00",
-                                                    "v61"
+                                                    "v33"
                                                 ],
                                                 "op": "returndatacopy",
                                                 "out": []
@@ -1278,13 +1278,13 @@
                                                 "in": [],
                                                 "op": "returndatasize",
                                                 "out": [
-                                                    "v63"
+                                                    "v35"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v63",
-                                                    "v61"
+                                                    "v35",
+                                                    "v33"
                                                 ],
                                                 "op": "revert",
                                                 "out": []
@@ -1308,12 +1308,12 @@
                                         "instructions": [
                                             {
                                                 "in": [
-                                                    "v64",
-                                                    "v95"
+                                                    "v36",
+                                                    "v52"
                                                 ],
                                                 "op": "PhiFunction",
                                                 "out": [
-                                                    "v97"
+                                                    "phi26"
                                                 ]
                                             },
                                             {
@@ -1322,13 +1322,13 @@
                                                 ],
                                                 "op": "mload",
                                                 "out": [
-                                                    "v96"
+                                                    "v53"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v97",
-                                                    "v96"
+                                                    "phi26",
+                                                    "v53"
                                                 ],
                                                 "op": "mstore",
                                                 "out": []
@@ -1336,7 +1336,7 @@
                                             {
                                                 "in": [
                                                     "0x20",
-                                                    "v96"
+                                                    "v53"
                                                 ],
                                                 "op": "return",
                                                 "out": []
@@ -1344,7 +1344,7 @@
                                         ],
                                         "liveness": {
                                             "in": [
-                                                "v97"
+                                                "phi26"
                                             ],
                                             "out": []
                                         },
@@ -1352,7 +1352,7 @@
                                     },
                                     {
                                         "exit": {
-                                            "cond": "v69",
+                                            "cond": "v39",
                                             "targets": [
                                                 "Block23",
                                                 "Block22"
@@ -1367,34 +1367,34 @@
                                                 ],
                                                 "op": "LiteralAssignment",
                                                 "out": [
-                                                    "v67"
+                                                    "v37"
                                                 ]
                                             },
                                             {
                                                 "in": [],
                                                 "op": "returndatasize",
                                                 "out": [
-                                                    "v68"
+                                                    "v38"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v68",
+                                                    "v38",
                                                     "0x20"
                                                 ],
                                                 "op": "gt",
                                                 "out": [
-                                                    "v69"
+                                                    "v39"
                                                 ]
                                             }
                                         ],
                                         "liveness": {
                                             "in": [
-                                                "v46"
+                                                "v25"
                                             ],
                                             "out": [
-                                                "v67",
-                                                "v46"
+                                                "v37",
+                                                "v25"
                                             ]
                                         },
                                         "type": "BuiltinCall"
@@ -1405,7 +1405,7 @@
                                             "Block22"
                                         ],
                                         "exit": {
-                                            "cond": "v82",
+                                            "cond": "v47",
                                             "targets": [
                                                 "Block25",
                                                 "Block24"
@@ -1416,12 +1416,12 @@
                                         "instructions": [
                                             {
                                                 "in": [
-                                                    "v67",
-                                                    "v70"
+                                                    "v37",
+                                                    "v40"
                                                 ],
                                                 "op": "PhiFunction",
                                                 "out": [
-                                                    "v73"
+                                                    "phi14"
                                                 ]
                                             },
                                             {
@@ -1430,79 +1430,79 @@
                                                 ],
                                                 "op": "not",
                                                 "out": [
-                                                    "v72"
+                                                    "v41"
                                                 ]
                                             },
                                             {
                                                 "in": [
                                                     "0x1f",
-                                                    "v73"
+                                                    "phi14"
                                                 ],
                                                 "op": "add",
                                                 "out": [
-                                                    "v74"
+                                                    "v42"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v72",
-                                                    "v74"
+                                                    "v41",
+                                                    "v42"
                                                 ],
                                                 "op": "and",
                                                 "out": [
-                                                    "v75"
+                                                    "v43"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v75",
-                                                    "v46"
+                                                    "v43",
+                                                    "v25"
                                                 ],
                                                 "op": "add",
                                                 "out": [
-                                                    "v79"
+                                                    "v44"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v46",
-                                                    "v79"
+                                                    "v25",
+                                                    "v44"
                                                 ],
                                                 "op": "lt",
                                                 "out": [
-                                                    "v80"
+                                                    "v45"
                                                 ]
                                             },
                                             {
                                                 "in": [
                                                     "0xffffffffffffffff",
-                                                    "v79"
+                                                    "v44"
                                                 ],
                                                 "op": "gt",
                                                 "out": [
-                                                    "v81"
+                                                    "v46"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v80",
-                                                    "v81"
+                                                    "v45",
+                                                    "v46"
                                                 ],
                                                 "op": "or",
                                                 "out": [
-                                                    "v82"
+                                                    "v47"
                                                 ]
                                             }
                                         ],
                                         "liveness": {
                                             "in": [
-                                                "v46",
-                                                "v73"
+                                                "v25",
+                                                "phi14"
                                             ],
                                             "out": [
-                                                "v46",
-                                                "v73",
-                                                "v79"
+                                                "v25",
+                                                "phi14",
+                                                "v44"
                                             ]
                                         },
                                         "type": "BuiltinCall"
@@ -1520,24 +1520,24 @@
                                                 "in": [],
                                                 "op": "returndatasize",
                                                 "out": [
-                                                    "v70"
+                                                    "v40"
                                                 ]
                                             }
                                         ],
                                         "liveness": {
                                             "in": [
-                                                "v46"
+                                                "v25"
                                             ],
                                             "out": [
-                                                "v70",
-                                                "v46"
+                                                "v40",
+                                                "v25"
                                             ]
                                         },
                                         "type": "BuiltinCall"
                                     },
                                     {
                                         "exit": {
-                                            "cond": "v92",
+                                            "cond": "v51",
                                             "targets": [
                                                 "Block28",
                                                 "Block27"
@@ -1548,7 +1548,7 @@
                                         "instructions": [
                                             {
                                                 "in": [
-                                                    "v79",
+                                                    "v44",
                                                     "0x40"
                                                 ],
                                                 "op": "mstore",
@@ -1556,43 +1556,43 @@
                                             },
                                             {
                                                 "in": [
-                                                    "v73",
-                                                    "v46"
+                                                    "phi14",
+                                                    "v25"
                                                 ],
                                                 "op": "add",
                                                 "out": [
-                                                    "v90"
+                                                    "v49"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v46",
-                                                    "v90"
+                                                    "v25",
+                                                    "v49"
                                                 ],
                                                 "op": "sub",
                                                 "out": [
-                                                    "v91"
+                                                    "v50"
                                                 ]
                                             },
                                             {
                                                 "in": [
                                                     "0x20",
-                                                    "v91"
+                                                    "v50"
                                                 ],
                                                 "op": "slt",
                                                 "out": [
-                                                    "v92"
+                                                    "v51"
                                                 ]
                                             }
                                         ],
                                         "liveness": {
                                             "in": [
-                                                "v46",
-                                                "v73",
-                                                "v79"
+                                                "v25",
+                                                "phi14",
+                                                "v44"
                                             ],
                                             "out": [
-                                                "v46"
+                                                "v25"
                                             ]
                                         },
                                         "type": "BuiltinCall"
@@ -1610,12 +1610,12 @@
                                                 ],
                                                 "op": "shl",
                                                 "out": [
-                                                    "v83"
+                                                    "v48"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v83",
+                                                    "v48",
                                                     "0x00"
                                                 ],
                                                 "op": "mstore",
@@ -1655,20 +1655,20 @@
                                         "instructions": [
                                             {
                                                 "in": [
-                                                    "v46"
+                                                    "v25"
                                                 ],
                                                 "op": "mload",
                                                 "out": [
-                                                    "v95"
+                                                    "v52"
                                                 ]
                                             }
                                         ],
                                         "liveness": {
                                             "in": [
-                                                "v46"
+                                                "v25"
                                             ],
                                             "out": [
-                                                "v95"
+                                                "v52"
                                             ]
                                         },
                                         "type": "BuiltinCall"
@@ -1701,7 +1701,7 @@
                                         "blocks": [
                                             {
                                                 "exit": {
-                                                    "cond": "v2",
+                                                    "cond": "v1",
                                                     "targets": [
                                                         "Block2",
                                                         "Block1"
@@ -1732,7 +1732,7 @@
                                                         "in": [],
                                                         "op": "callvalue",
                                                         "out": [
-                                                            "v2"
+                                                            "v1"
                                                         ]
                                                     }
                                                 ],
@@ -1757,7 +1757,7 @@
                                                         ],
                                                         "op": "datasize",
                                                         "out": [
-                                                            "v4"
+                                                            "v2"
                                                         ]
                                                     },
                                                     {
@@ -1767,13 +1767,13 @@
                                                         ],
                                                         "op": "dataoffset",
                                                         "out": [
-                                                            "v5"
+                                                            "v3"
                                                         ]
                                                     },
                                                     {
                                                         "in": [
-                                                            "v4",
-                                                            "v5",
+                                                            "v2",
+                                                            "v3",
                                                             "v0"
                                                         ],
                                                         "op": "codecopy",
@@ -1781,7 +1781,7 @@
                                                     },
                                                     {
                                                         "in": [
-                                                            "v4",
+                                                            "v2",
                                                             "v0"
                                                         ],
                                                         "op": "return",
@@ -1824,7 +1824,7 @@
                                                 "blocks": [
                                                     {
                                                         "exit": {
-                                                            "cond": "v5",
+                                                            "cond": "v3",
                                                             "targets": [
                                                                 "Block2",
                                                                 "Block1"
@@ -1855,26 +1855,26 @@
                                                                 "in": [],
                                                                 "op": "calldatasize",
                                                                 "out": [
-                                                                    "v3"
+                                                                    "v1"
                                                                 ]
                                                             },
                                                             {
                                                                 "in": [
                                                                     "0x04",
-                                                                    "v3"
+                                                                    "v1"
                                                                 ],
                                                                 "op": "lt",
                                                                 "out": [
-                                                                    "v4"
+                                                                    "v2"
                                                                 ]
                                                             },
                                                             {
                                                                 "in": [
-                                                                    "v4"
+                                                                    "v2"
                                                                 ],
                                                                 "op": "iszero",
                                                                 "out": [
-                                                                    "v5"
+                                                                    "v3"
                                                                 ]
                                                             }
                                                         ],
@@ -1909,7 +1909,7 @@
                                                     },
                                                     {
                                                         "exit": {
-                                                            "cond": "v11",
+                                                            "cond": "v6",
                                                             "targets": [
                                                                 "Block4",
                                                                 "Block3"
@@ -1924,27 +1924,27 @@
                                                                 ],
                                                                 "op": "calldataload",
                                                                 "out": [
-                                                                    "v7"
+                                                                    "v4"
                                                                 ]
                                                             },
                                                             {
                                                                 "in": [
-                                                                    "v7",
+                                                                    "v4",
                                                                     "0xe0"
                                                                 ],
                                                                 "op": "shr",
                                                                 "out": [
-                                                                    "v9"
+                                                                    "v5"
                                                                 ]
                                                             },
                                                             {
                                                                 "in": [
-                                                                    "v9",
+                                                                    "v5",
                                                                     "0x26121ff0"
                                                                 ],
                                                                 "op": "eq",
                                                                 "out": [
-                                                                    "v11"
+                                                                    "v6"
                                                                 ]
                                                             }
                                                         ],
@@ -1974,7 +1974,7 @@
                                                     },
                                                     {
                                                         "exit": {
-                                                            "cond": "v12",
+                                                            "cond": "v7",
                                                             "targets": [
                                                                 "Block6",
                                                                 "Block5"
@@ -1987,7 +1987,7 @@
                                                                 "in": [],
                                                                 "op": "callvalue",
                                                                 "out": [
-                                                                    "v12"
+                                                                    "v7"
                                                                 ]
                                                             }
                                                         ],
@@ -2003,7 +2003,7 @@
                                                     },
                                                     {
                                                         "exit": {
-                                                            "cond": "v17",
+                                                            "cond": "v11",
                                                             "targets": [
                                                                 "Block9",
                                                                 "Block8"
@@ -2018,34 +2018,34 @@
                                                                 ],
                                                                 "op": "not",
                                                                 "out": [
-                                                                    "v14"
+                                                                    "v8"
                                                                 ]
                                                             },
                                                             {
                                                                 "in": [],
                                                                 "op": "calldatasize",
                                                                 "out": [
-                                                                    "v15"
+                                                                    "v9"
                                                                 ]
                                                             },
                                                             {
                                                                 "in": [
-                                                                    "v14",
-                                                                    "v15"
+                                                                    "v8",
+                                                                    "v9"
                                                                 ],
                                                                 "op": "add",
                                                                 "out": [
-                                                                    "v16"
+                                                                    "v10"
                                                                 ]
                                                             },
                                                             {
                                                                 "in": [
                                                                     "0x00",
-                                                                    "v16"
+                                                                    "v10"
                                                                 ],
                                                                 "op": "slt",
                                                                 "out": [
-                                                                    "v17"
+                                                                    "v11"
                                                                 ]
                                                             }
                                                         ],

--- a/test/cmdlineTests/strict_asm_yul_cfg_json_export/output
+++ b/test/cmdlineTests/strict_asm_yul_cfg_json_export/output
@@ -7,7 +7,7 @@ Yul Control Flow Graph:
         "blocks": [
             {
                 "exit": {
-                    "cond": "v2",
+                    "cond": "v1",
                     "targets": [
                         "Block2",
                         "Block1"
@@ -38,7 +38,7 @@ Yul Control Flow Graph:
                         "in": [],
                         "op": "callvalue",
                         "out": [
-                            "v2"
+                            "v1"
                         ]
                     }
                 ],
@@ -63,7 +63,7 @@ Yul Control Flow Graph:
                         ],
                         "op": "datasize",
                         "out": [
-                            "v4"
+                            "v2"
                         ]
                     },
                     {
@@ -73,13 +73,13 @@ Yul Control Flow Graph:
                         ],
                         "op": "dataoffset",
                         "out": [
-                            "v5"
+                            "v3"
                         ]
                     },
                     {
                         "in": [
-                            "v4",
-                            "v5",
+                            "v2",
+                            "v3",
                             "v0"
                         ],
                         "op": "codecopy",
@@ -87,7 +87,7 @@ Yul Control Flow Graph:
                     },
                     {
                         "in": [
-                            "v4",
+                            "v2",
                             "v0"
                         ],
                         "op": "return",
@@ -130,7 +130,7 @@ Yul Control Flow Graph:
                 "blocks": [
                     {
                         "exit": {
-                            "cond": "v5",
+                            "cond": "v3",
                             "targets": [
                                 "Block2",
                                 "Block1"
@@ -161,26 +161,26 @@ Yul Control Flow Graph:
                                 "in": [],
                                 "op": "calldatasize",
                                 "out": [
-                                    "v3"
+                                    "v1"
                                 ]
                             },
                             {
                                 "in": [
                                     "0x04",
-                                    "v3"
+                                    "v1"
                                 ],
                                 "op": "lt",
                                 "out": [
-                                    "v4"
+                                    "v2"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v4"
+                                    "v2"
                                 ],
                                 "op": "iszero",
                                 "out": [
-                                    "v5"
+                                    "v3"
                                 ]
                             }
                         ],
@@ -215,7 +215,7 @@ Yul Control Flow Graph:
                     },
                     {
                         "exit": {
-                            "cond": "v11",
+                            "cond": "v6",
                             "targets": [
                                 "Block4",
                                 "Block3"
@@ -230,27 +230,27 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "calldataload",
                                 "out": [
-                                    "v7"
+                                    "v4"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v7",
+                                    "v4",
                                     "0xe0"
                                 ],
                                 "op": "shr",
                                 "out": [
-                                    "v9"
+                                    "v5"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v9",
+                                    "v5",
                                     "0x26121ff0"
                                 ],
                                 "op": "eq",
                                 "out": [
-                                    "v11"
+                                    "v6"
                                 ]
                             }
                         ],
@@ -280,7 +280,7 @@ Yul Control Flow Graph:
                     },
                     {
                         "exit": {
-                            "cond": "v12",
+                            "cond": "v7",
                             "targets": [
                                 "Block6",
                                 "Block5"
@@ -293,7 +293,7 @@ Yul Control Flow Graph:
                                 "in": [],
                                 "op": "callvalue",
                                 "out": [
-                                    "v12"
+                                    "v7"
                                 ]
                             }
                         ],
@@ -309,7 +309,7 @@ Yul Control Flow Graph:
                     },
                     {
                         "exit": {
-                            "cond": "v17",
+                            "cond": "v11",
                             "targets": [
                                 "Block9",
                                 "Block8"
@@ -324,34 +324,34 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "not",
                                 "out": [
-                                    "v14"
+                                    "v8"
                                 ]
                             },
                             {
                                 "in": [],
                                 "op": "calldatasize",
                                 "out": [
-                                    "v15"
+                                    "v9"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v14",
-                                    "v15"
+                                    "v8",
+                                    "v9"
                                 ],
                                 "op": "add",
                                 "out": [
-                                    "v16"
+                                    "v10"
                                 ]
                             },
                             {
                                 "in": [
                                     "0x00",
-                                    "v16"
+                                    "v10"
                                 ],
                                 "op": "slt",
                                 "out": [
-                                    "v17"
+                                    "v11"
                                 ]
                             }
                         ],

--- a/test/cmdlineTests/yul_cfg_json_export/output
+++ b/test/cmdlineTests/yul_cfg_json_export/output
@@ -6,7 +6,7 @@ Yul Control Flow Graph:
         "blocks": [
             {
                 "exit": {
-                    "cond": "v2",
+                    "cond": "v1",
                     "targets": [
                         "Block2",
                         "Block1"
@@ -37,7 +37,7 @@ Yul Control Flow Graph:
                         "in": [],
                         "op": "callvalue",
                         "out": [
-                            "v2"
+                            "v1"
                         ]
                     }
                 ],
@@ -62,7 +62,7 @@ Yul Control Flow Graph:
                         ],
                         "op": "datasize",
                         "out": [
-                            "v4"
+                            "v2"
                         ]
                     },
                     {
@@ -72,13 +72,13 @@ Yul Control Flow Graph:
                         ],
                         "op": "dataoffset",
                         "out": [
-                            "v5"
+                            "v3"
                         ]
                     },
                     {
                         "in": [
-                            "v4",
-                            "v5",
+                            "v2",
+                            "v3",
                             "v0"
                         ],
                         "op": "codecopy",
@@ -86,7 +86,7 @@ Yul Control Flow Graph:
                     },
                     {
                         "in": [
-                            "v4",
+                            "v2",
                             "v0"
                         ],
                         "op": "return",
@@ -129,7 +129,7 @@ Yul Control Flow Graph:
                 "blocks": [
                     {
                         "exit": {
-                            "cond": "v5",
+                            "cond": "v3",
                             "targets": [
                                 "Block2",
                                 "Block1"
@@ -160,26 +160,26 @@ Yul Control Flow Graph:
                                 "in": [],
                                 "op": "calldatasize",
                                 "out": [
-                                    "v3"
+                                    "v1"
                                 ]
                             },
                             {
                                 "in": [
                                     "0x04",
-                                    "v3"
+                                    "v1"
                                 ],
                                 "op": "lt",
                                 "out": [
-                                    "v4"
+                                    "v2"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v4"
+                                    "v2"
                                 ],
                                 "op": "iszero",
                                 "out": [
-                                    "v5"
+                                    "v3"
                                 ]
                             }
                         ],
@@ -214,7 +214,7 @@ Yul Control Flow Graph:
                     },
                     {
                         "exit": {
-                            "cond": "v11",
+                            "cond": "v6",
                             "targets": [
                                 "Block4",
                                 "Block3"
@@ -229,27 +229,27 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "calldataload",
                                 "out": [
-                                    "v7"
+                                    "v4"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v7",
+                                    "v4",
                                     "0xe0"
                                 ],
                                 "op": "shr",
                                 "out": [
-                                    "v9"
+                                    "v5"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v9",
+                                    "v5",
                                     "0x26121ff0"
                                 ],
                                 "op": "eq",
                                 "out": [
-                                    "v11"
+                                    "v6"
                                 ]
                             }
                         ],
@@ -279,7 +279,7 @@ Yul Control Flow Graph:
                     },
                     {
                         "exit": {
-                            "cond": "v12",
+                            "cond": "v7",
                             "targets": [
                                 "Block6",
                                 "Block5"
@@ -292,7 +292,7 @@ Yul Control Flow Graph:
                                 "in": [],
                                 "op": "callvalue",
                                 "out": [
-                                    "v12"
+                                    "v7"
                                 ]
                             }
                         ],
@@ -308,7 +308,7 @@ Yul Control Flow Graph:
                     },
                     {
                         "exit": {
-                            "cond": "v17",
+                            "cond": "v11",
                             "targets": [
                                 "Block9",
                                 "Block8"
@@ -323,34 +323,34 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "not",
                                 "out": [
-                                    "v14"
+                                    "v8"
                                 ]
                             },
                             {
                                 "in": [],
                                 "op": "calldatasize",
                                 "out": [
-                                    "v15"
+                                    "v9"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v14",
-                                    "v15"
+                                    "v8",
+                                    "v9"
                                 ],
                                 "op": "add",
                                 "out": [
-                                    "v16"
+                                    "v10"
                                 ]
                             },
                             {
                                 "in": [
                                     "0x00",
-                                    "v16"
+                                    "v10"
                                 ],
                                 "op": "slt",
                                 "out": [
-                                    "v17"
+                                    "v11"
                                 ]
                             }
                         ],
@@ -454,7 +454,7 @@ Yul Control Flow Graph:
         "blocks": [
             {
                 "exit": {
-                    "cond": "v2",
+                    "cond": "v1",
                     "targets": [
                         "Block2",
                         "Block1"
@@ -485,7 +485,7 @@ Yul Control Flow Graph:
                         "in": [],
                         "op": "callvalue",
                         "out": [
-                            "v2"
+                            "v1"
                         ]
                     }
                 ],
@@ -510,7 +510,7 @@ Yul Control Flow Graph:
                         ],
                         "op": "datasize",
                         "out": [
-                            "v4"
+                            "v2"
                         ]
                     },
                     {
@@ -520,13 +520,13 @@ Yul Control Flow Graph:
                         ],
                         "op": "dataoffset",
                         "out": [
-                            "v5"
+                            "v3"
                         ]
                     },
                     {
                         "in": [
-                            "v4",
-                            "v5",
+                            "v2",
+                            "v3",
                             "v0"
                         ],
                         "op": "codecopy",
@@ -534,7 +534,7 @@ Yul Control Flow Graph:
                     },
                     {
                         "in": [
-                            "v4",
+                            "v2",
                             "v0"
                         ],
                         "op": "return",
@@ -577,7 +577,7 @@ Yul Control Flow Graph:
                 "blocks": [
                     {
                         "exit": {
-                            "cond": "v5",
+                            "cond": "v3",
                             "targets": [
                                 "Block2",
                                 "Block1"
@@ -608,26 +608,26 @@ Yul Control Flow Graph:
                                 "in": [],
                                 "op": "calldatasize",
                                 "out": [
-                                    "v3"
+                                    "v1"
                                 ]
                             },
                             {
                                 "in": [
                                     "0x04",
-                                    "v3"
+                                    "v1"
                                 ],
                                 "op": "lt",
                                 "out": [
-                                    "v4"
+                                    "v2"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v4"
+                                    "v2"
                                 ],
                                 "op": "iszero",
                                 "out": [
-                                    "v5"
+                                    "v3"
                                 ]
                             }
                         ],
@@ -662,7 +662,7 @@ Yul Control Flow Graph:
                     },
                     {
                         "exit": {
-                            "cond": "v11",
+                            "cond": "v6",
                             "targets": [
                                 "Block4",
                                 "Block3"
@@ -677,27 +677,27 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "calldataload",
                                 "out": [
-                                    "v7"
+                                    "v4"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v7",
+                                    "v4",
                                     "0xe0"
                                 ],
                                 "op": "shr",
                                 "out": [
-                                    "v9"
+                                    "v5"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v9",
+                                    "v5",
                                     "0x26121ff0"
                                 ],
                                 "op": "eq",
                                 "out": [
-                                    "v11"
+                                    "v6"
                                 ]
                             }
                         ],
@@ -727,7 +727,7 @@ Yul Control Flow Graph:
                     },
                     {
                         "exit": {
-                            "cond": "v12",
+                            "cond": "v7",
                             "targets": [
                                 "Block6",
                                 "Block5"
@@ -740,7 +740,7 @@ Yul Control Flow Graph:
                                 "in": [],
                                 "op": "callvalue",
                                 "out": [
-                                    "v12"
+                                    "v7"
                                 ]
                             }
                         ],
@@ -756,7 +756,7 @@ Yul Control Flow Graph:
                     },
                     {
                         "exit": {
-                            "cond": "v17",
+                            "cond": "v11",
                             "targets": [
                                 "Block9",
                                 "Block8"
@@ -771,34 +771,34 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "not",
                                 "out": [
-                                    "v14"
+                                    "v8"
                                 ]
                             },
                             {
                                 "in": [],
                                 "op": "calldatasize",
                                 "out": [
-                                    "v15"
+                                    "v9"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v14",
-                                    "v15"
+                                    "v8",
+                                    "v9"
                                 ],
                                 "op": "add",
                                 "out": [
-                                    "v16"
+                                    "v10"
                                 ]
                             },
                             {
                                 "in": [
                                     "0x00",
-                                    "v16"
+                                    "v10"
                                 ],
                                 "op": "slt",
                                 "out": [
-                                    "v17"
+                                    "v11"
                                 ]
                             }
                         ],
@@ -835,7 +835,7 @@ Yul Control Flow Graph:
                     },
                     {
                         "exit": {
-                            "cond": "v28",
+                            "cond": "v16",
                             "targets": [
                                 "Block12",
                                 "Block11"
@@ -851,47 +851,47 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "datasize",
                                 "out": [
-                                    "v18"
+                                    "v12"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v18",
+                                    "v12",
                                     "v0"
                                 ],
                                 "op": "add",
                                 "out": [
-                                    "v24"
+                                    "v13"
                                 ]
                             },
                             {
                                 "in": [
                                     "v0",
-                                    "v24"
+                                    "v13"
                                 ],
                                 "op": "lt",
                                 "out": [
-                                    "v25"
+                                    "v14"
                                 ]
                             },
                             {
                                 "in": [
                                     "0xffffffffffffffff",
-                                    "v24"
+                                    "v13"
                                 ],
                                 "op": "gt",
                                 "out": [
-                                    "v27"
+                                    "v15"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v25",
-                                    "v27"
+                                    "v14",
+                                    "v15"
                                 ],
                                 "op": "or",
                                 "out": [
-                                    "v28"
+                                    "v16"
                                 ]
                             }
                         ],
@@ -901,8 +901,8 @@ Yul Control Flow Graph:
                             ],
                             "out": [
                                 "v0",
-                                "v24",
-                                "v18"
+                                "v13",
+                                "v12"
                             ]
                         },
                         "type": "BuiltinCall"
@@ -930,7 +930,7 @@ Yul Control Flow Graph:
                     },
                     {
                         "exit": {
-                            "cond": "v42",
+                            "cond": "v21",
                             "targets": [
                                 "Block15",
                                 "Block14"
@@ -946,13 +946,13 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "dataoffset",
                                 "out": [
-                                    "v35"
+                                    "v18"
                                 ]
                             },
                             {
                                 "in": [
+                                    "v12",
                                     "v18",
-                                    "v35",
                                     "v0"
                                 ],
                                 "op": "datacopy",
@@ -961,42 +961,42 @@ Yul Control Flow Graph:
                             {
                                 "in": [
                                     "v0",
-                                    "v24"
+                                    "v13"
                                 ],
                                 "op": "sub",
                                 "out": [
-                                    "v40"
+                                    "v19"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v40",
+                                    "v19",
                                     "v0",
                                     "0x00"
                                 ],
                                 "op": "create",
                                 "out": [
-                                    "v41"
+                                    "v20"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v41"
+                                    "v20"
                                 ],
                                 "op": "iszero",
                                 "out": [
-                                    "v42"
+                                    "v21"
                                 ]
                             }
                         ],
                         "liveness": {
                             "in": [
                                 "v0",
-                                "v24",
-                                "v18"
+                                "v13",
+                                "v12"
                             ],
                             "out": [
-                                "v41"
+                                "v20"
                             ]
                         },
                         "type": "BuiltinCall"
@@ -1014,12 +1014,12 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "shl",
                                 "out": [
-                                    "v30"
+                                    "v17"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v30",
+                                    "v17",
                                     "0x00"
                                 ],
                                 "op": "mstore",
@@ -1050,7 +1050,7 @@ Yul Control Flow Graph:
                     },
                     {
                         "exit": {
-                            "cond": "v60",
+                            "cond": "v32",
                             "targets": [
                                 "Block18",
                                 "Block17"
@@ -1065,7 +1065,7 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "mload",
                                 "out": [
-                                    "v46"
+                                    "v25"
                                 ]
                             },
                             {
@@ -1075,13 +1075,13 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "shl",
                                 "out": [
-                                    "v49"
+                                    "v26"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v49",
-                                    "v46"
+                                    "v26",
+                                    "v25"
                                 ],
                                 "op": "mstore",
                                 "out": []
@@ -1093,67 +1093,67 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "shl",
                                 "out": [
-                                    "v53"
+                                    "v27"
                                 ]
                             },
                             {
                                 "in": [
                                     "0x01",
-                                    "v53"
+                                    "v27"
                                 ],
                                 "op": "sub",
                                 "out": [
-                                    "v54"
+                                    "v28"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v54",
-                                    "v41"
+                                    "v28",
+                                    "v20"
                                 ],
                                 "op": "and",
                                 "out": [
-                                    "v57"
+                                    "v29"
                                 ]
                             },
                             {
                                 "in": [],
                                 "op": "gas",
                                 "out": [
-                                    "v58"
+                                    "v30"
                                 ]
                             },
                             {
                                 "in": [
                                     "0x20",
-                                    "v46",
+                                    "v25",
                                     "0x04",
-                                    "v46",
-                                    "v57",
-                                    "v58"
+                                    "v25",
+                                    "v29",
+                                    "v30"
                                 ],
                                 "op": "staticcall",
                                 "out": [
-                                    "v59"
+                                    "v31"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v59"
+                                    "v31"
                                 ],
                                 "op": "iszero",
                                 "out": [
-                                    "v60"
+                                    "v32"
                                 ]
                             }
                         ],
                         "liveness": {
                             "in": [
-                                "v41"
+                                "v20"
                             ],
                             "out": [
-                                "v46",
-                                "v59"
+                                "v25",
+                                "v31"
                             ]
                         },
                         "type": "BuiltinCall"
@@ -1170,21 +1170,21 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "mload",
                                 "out": [
-                                    "v43"
+                                    "v22"
                                 ]
                             },
                             {
                                 "in": [],
                                 "op": "returndatasize",
                                 "out": [
-                                    "v44"
+                                    "v23"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v44",
+                                    "v23",
                                     "0x00",
-                                    "v43"
+                                    "v22"
                                 ],
                                 "op": "returndatacopy",
                                 "out": []
@@ -1193,13 +1193,13 @@ Yul Control Flow Graph:
                                 "in": [],
                                 "op": "returndatasize",
                                 "out": [
-                                    "v45"
+                                    "v24"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v45",
-                                    "v43"
+                                    "v24",
+                                    "v22"
                                 ],
                                 "op": "revert",
                                 "out": []
@@ -1213,7 +1213,7 @@ Yul Control Flow Graph:
                     },
                     {
                         "exit": {
-                            "cond": "v59",
+                            "cond": "v31",
                             "targets": [
                                 "Block21",
                                 "Block20"
@@ -1228,18 +1228,18 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "LiteralAssignment",
                                 "out": [
-                                    "v64"
+                                    "v36"
                                 ]
                             }
                         ],
                         "liveness": {
                             "in": [
-                                "v46",
-                                "v59"
+                                "v25",
+                                "v31"
                             ],
                             "out": [
-                                "v64",
-                                "v46"
+                                "v36",
+                                "v25"
                             ]
                         }
                     },
@@ -1255,21 +1255,21 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "mload",
                                 "out": [
-                                    "v61"
+                                    "v33"
                                 ]
                             },
                             {
                                 "in": [],
                                 "op": "returndatasize",
                                 "out": [
-                                    "v62"
+                                    "v34"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v62",
+                                    "v34",
                                     "0x00",
-                                    "v61"
+                                    "v33"
                                 ],
                                 "op": "returndatacopy",
                                 "out": []
@@ -1278,13 +1278,13 @@ Yul Control Flow Graph:
                                 "in": [],
                                 "op": "returndatasize",
                                 "out": [
-                                    "v63"
+                                    "v35"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v63",
-                                    "v61"
+                                    "v35",
+                                    "v33"
                                 ],
                                 "op": "revert",
                                 "out": []
@@ -1308,12 +1308,12 @@ Yul Control Flow Graph:
                         "instructions": [
                             {
                                 "in": [
-                                    "v64",
-                                    "v95"
+                                    "v36",
+                                    "v52"
                                 ],
                                 "op": "PhiFunction",
                                 "out": [
-                                    "v97"
+                                    "phi26"
                                 ]
                             },
                             {
@@ -1322,13 +1322,13 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "mload",
                                 "out": [
-                                    "v96"
+                                    "v53"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v97",
-                                    "v96"
+                                    "phi26",
+                                    "v53"
                                 ],
                                 "op": "mstore",
                                 "out": []
@@ -1336,7 +1336,7 @@ Yul Control Flow Graph:
                             {
                                 "in": [
                                     "0x20",
-                                    "v96"
+                                    "v53"
                                 ],
                                 "op": "return",
                                 "out": []
@@ -1344,7 +1344,7 @@ Yul Control Flow Graph:
                         ],
                         "liveness": {
                             "in": [
-                                "v97"
+                                "phi26"
                             ],
                             "out": []
                         },
@@ -1352,7 +1352,7 @@ Yul Control Flow Graph:
                     },
                     {
                         "exit": {
-                            "cond": "v69",
+                            "cond": "v39",
                             "targets": [
                                 "Block23",
                                 "Block22"
@@ -1367,34 +1367,34 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "LiteralAssignment",
                                 "out": [
-                                    "v67"
+                                    "v37"
                                 ]
                             },
                             {
                                 "in": [],
                                 "op": "returndatasize",
                                 "out": [
-                                    "v68"
+                                    "v38"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v68",
+                                    "v38",
                                     "0x20"
                                 ],
                                 "op": "gt",
                                 "out": [
-                                    "v69"
+                                    "v39"
                                 ]
                             }
                         ],
                         "liveness": {
                             "in": [
-                                "v46"
+                                "v25"
                             ],
                             "out": [
-                                "v67",
-                                "v46"
+                                "v37",
+                                "v25"
                             ]
                         },
                         "type": "BuiltinCall"
@@ -1405,7 +1405,7 @@ Yul Control Flow Graph:
                             "Block22"
                         ],
                         "exit": {
-                            "cond": "v82",
+                            "cond": "v47",
                             "targets": [
                                 "Block25",
                                 "Block24"
@@ -1416,12 +1416,12 @@ Yul Control Flow Graph:
                         "instructions": [
                             {
                                 "in": [
-                                    "v67",
-                                    "v70"
+                                    "v37",
+                                    "v40"
                                 ],
                                 "op": "PhiFunction",
                                 "out": [
-                                    "v73"
+                                    "phi14"
                                 ]
                             },
                             {
@@ -1430,79 +1430,79 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "not",
                                 "out": [
-                                    "v72"
+                                    "v41"
                                 ]
                             },
                             {
                                 "in": [
                                     "0x1f",
-                                    "v73"
+                                    "phi14"
                                 ],
                                 "op": "add",
                                 "out": [
-                                    "v74"
+                                    "v42"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v72",
-                                    "v74"
+                                    "v41",
+                                    "v42"
                                 ],
                                 "op": "and",
                                 "out": [
-                                    "v75"
+                                    "v43"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v75",
-                                    "v46"
+                                    "v43",
+                                    "v25"
                                 ],
                                 "op": "add",
                                 "out": [
-                                    "v79"
+                                    "v44"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v46",
-                                    "v79"
+                                    "v25",
+                                    "v44"
                                 ],
                                 "op": "lt",
                                 "out": [
-                                    "v80"
+                                    "v45"
                                 ]
                             },
                             {
                                 "in": [
                                     "0xffffffffffffffff",
-                                    "v79"
+                                    "v44"
                                 ],
                                 "op": "gt",
                                 "out": [
-                                    "v81"
+                                    "v46"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v80",
-                                    "v81"
+                                    "v45",
+                                    "v46"
                                 ],
                                 "op": "or",
                                 "out": [
-                                    "v82"
+                                    "v47"
                                 ]
                             }
                         ],
                         "liveness": {
                             "in": [
-                                "v46",
-                                "v73"
+                                "v25",
+                                "phi14"
                             ],
                             "out": [
-                                "v46",
-                                "v73",
-                                "v79"
+                                "v25",
+                                "phi14",
+                                "v44"
                             ]
                         },
                         "type": "BuiltinCall"
@@ -1520,24 +1520,24 @@ Yul Control Flow Graph:
                                 "in": [],
                                 "op": "returndatasize",
                                 "out": [
-                                    "v70"
+                                    "v40"
                                 ]
                             }
                         ],
                         "liveness": {
                             "in": [
-                                "v46"
+                                "v25"
                             ],
                             "out": [
-                                "v70",
-                                "v46"
+                                "v40",
+                                "v25"
                             ]
                         },
                         "type": "BuiltinCall"
                     },
                     {
                         "exit": {
-                            "cond": "v92",
+                            "cond": "v51",
                             "targets": [
                                 "Block28",
                                 "Block27"
@@ -1548,7 +1548,7 @@ Yul Control Flow Graph:
                         "instructions": [
                             {
                                 "in": [
-                                    "v79",
+                                    "v44",
                                     "0x40"
                                 ],
                                 "op": "mstore",
@@ -1556,43 +1556,43 @@ Yul Control Flow Graph:
                             },
                             {
                                 "in": [
-                                    "v73",
-                                    "v46"
+                                    "phi14",
+                                    "v25"
                                 ],
                                 "op": "add",
                                 "out": [
-                                    "v90"
+                                    "v49"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v46",
-                                    "v90"
+                                    "v25",
+                                    "v49"
                                 ],
                                 "op": "sub",
                                 "out": [
-                                    "v91"
+                                    "v50"
                                 ]
                             },
                             {
                                 "in": [
                                     "0x20",
-                                    "v91"
+                                    "v50"
                                 ],
                                 "op": "slt",
                                 "out": [
-                                    "v92"
+                                    "v51"
                                 ]
                             }
                         ],
                         "liveness": {
                             "in": [
-                                "v46",
-                                "v73",
-                                "v79"
+                                "v25",
+                                "phi14",
+                                "v44"
                             ],
                             "out": [
-                                "v46"
+                                "v25"
                             ]
                         },
                         "type": "BuiltinCall"
@@ -1610,12 +1610,12 @@ Yul Control Flow Graph:
                                 ],
                                 "op": "shl",
                                 "out": [
-                                    "v83"
+                                    "v48"
                                 ]
                             },
                             {
                                 "in": [
-                                    "v83",
+                                    "v48",
                                     "0x00"
                                 ],
                                 "op": "mstore",
@@ -1655,20 +1655,20 @@ Yul Control Flow Graph:
                         "instructions": [
                             {
                                 "in": [
-                                    "v46"
+                                    "v25"
                                 ],
                                 "op": "mload",
                                 "out": [
-                                    "v95"
+                                    "v52"
                                 ]
                             }
                         ],
                         "liveness": {
                             "in": [
-                                "v46"
+                                "v25"
                             ],
                             "out": [
-                                "v95"
+                                "v52"
                             ]
                         },
                         "type": "BuiltinCall"
@@ -1701,7 +1701,7 @@ Yul Control Flow Graph:
                         "blocks": [
                             {
                                 "exit": {
-                                    "cond": "v2",
+                                    "cond": "v1",
                                     "targets": [
                                         "Block2",
                                         "Block1"
@@ -1732,7 +1732,7 @@ Yul Control Flow Graph:
                                         "in": [],
                                         "op": "callvalue",
                                         "out": [
-                                            "v2"
+                                            "v1"
                                         ]
                                     }
                                 ],
@@ -1757,7 +1757,7 @@ Yul Control Flow Graph:
                                         ],
                                         "op": "datasize",
                                         "out": [
-                                            "v4"
+                                            "v2"
                                         ]
                                     },
                                     {
@@ -1767,13 +1767,13 @@ Yul Control Flow Graph:
                                         ],
                                         "op": "dataoffset",
                                         "out": [
-                                            "v5"
+                                            "v3"
                                         ]
                                     },
                                     {
                                         "in": [
-                                            "v4",
-                                            "v5",
+                                            "v2",
+                                            "v3",
                                             "v0"
                                         ],
                                         "op": "codecopy",
@@ -1781,7 +1781,7 @@ Yul Control Flow Graph:
                                     },
                                     {
                                         "in": [
-                                            "v4",
+                                            "v2",
                                             "v0"
                                         ],
                                         "op": "return",
@@ -1824,7 +1824,7 @@ Yul Control Flow Graph:
                                 "blocks": [
                                     {
                                         "exit": {
-                                            "cond": "v5",
+                                            "cond": "v3",
                                             "targets": [
                                                 "Block2",
                                                 "Block1"
@@ -1855,26 +1855,26 @@ Yul Control Flow Graph:
                                                 "in": [],
                                                 "op": "calldatasize",
                                                 "out": [
-                                                    "v3"
+                                                    "v1"
                                                 ]
                                             },
                                             {
                                                 "in": [
                                                     "0x04",
-                                                    "v3"
+                                                    "v1"
                                                 ],
                                                 "op": "lt",
                                                 "out": [
-                                                    "v4"
+                                                    "v2"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v4"
+                                                    "v2"
                                                 ],
                                                 "op": "iszero",
                                                 "out": [
-                                                    "v5"
+                                                    "v3"
                                                 ]
                                             }
                                         ],
@@ -1909,7 +1909,7 @@ Yul Control Flow Graph:
                                     },
                                     {
                                         "exit": {
-                                            "cond": "v11",
+                                            "cond": "v6",
                                             "targets": [
                                                 "Block4",
                                                 "Block3"
@@ -1924,27 +1924,27 @@ Yul Control Flow Graph:
                                                 ],
                                                 "op": "calldataload",
                                                 "out": [
-                                                    "v7"
+                                                    "v4"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v7",
+                                                    "v4",
                                                     "0xe0"
                                                 ],
                                                 "op": "shr",
                                                 "out": [
-                                                    "v9"
+                                                    "v5"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v9",
+                                                    "v5",
                                                     "0x26121ff0"
                                                 ],
                                                 "op": "eq",
                                                 "out": [
-                                                    "v11"
+                                                    "v6"
                                                 ]
                                             }
                                         ],
@@ -1974,7 +1974,7 @@ Yul Control Flow Graph:
                                     },
                                     {
                                         "exit": {
-                                            "cond": "v12",
+                                            "cond": "v7",
                                             "targets": [
                                                 "Block6",
                                                 "Block5"
@@ -1987,7 +1987,7 @@ Yul Control Flow Graph:
                                                 "in": [],
                                                 "op": "callvalue",
                                                 "out": [
-                                                    "v12"
+                                                    "v7"
                                                 ]
                                             }
                                         ],
@@ -2003,7 +2003,7 @@ Yul Control Flow Graph:
                                     },
                                     {
                                         "exit": {
-                                            "cond": "v17",
+                                            "cond": "v11",
                                             "targets": [
                                                 "Block9",
                                                 "Block8"
@@ -2018,34 +2018,34 @@ Yul Control Flow Graph:
                                                 ],
                                                 "op": "not",
                                                 "out": [
-                                                    "v14"
+                                                    "v8"
                                                 ]
                                             },
                                             {
                                                 "in": [],
                                                 "op": "calldatasize",
                                                 "out": [
-                                                    "v15"
+                                                    "v9"
                                                 ]
                                             },
                                             {
                                                 "in": [
-                                                    "v14",
-                                                    "v15"
+                                                    "v8",
+                                                    "v9"
                                                 ],
                                                 "op": "add",
                                                 "out": [
-                                                    "v16"
+                                                    "v10"
                                                 ]
                                             },
                                             {
                                                 "in": [
                                                     "0x00",
-                                                    "v16"
+                                                    "v10"
                                                 ],
                                                 "op": "slt",
                                                 "out": [
-                                                    "v17"
+                                                    "v11"
                                                 ]
                                             }
                                         ],

--- a/test/libsolutil/DisjointSet.cpp
+++ b/test/libsolutil/DisjointSet.cpp
@@ -29,8 +29,8 @@ BOOST_AUTO_TEST_SUITE(DisjointSetTest)
 
 BOOST_AUTO_TEST_CASE(full_union)
 {
-	ContiguousDisjointSet ds(10);
-	for (size_t i = 1; i < 10; ++i)
+	ContiguousDisjointSet<std::uint32_t> ds(10);
+	for (std::uint32_t i = 1; i < 10; ++i)
 	{
 		BOOST_CHECK(!ds.sameSubset(0, i));
 		ds.merge(0, i);
@@ -42,16 +42,16 @@ BOOST_AUTO_TEST_CASE(full_union)
 	std::set<size_t> fullSet{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 	BOOST_CHECK_EQUAL_COLLECTIONS(subsets[0].begin(), subsets[0].end(), fullSet.begin(), fullSet.end());
 
-	for (size_t i = 1; i < 10; ++i) BOOST_CHECK_EQUAL(ds.find(0), ds.find(i));
+	for (std::uint32_t i = 1; i < 10; ++i) BOOST_CHECK_EQUAL(ds.find(0), ds.find(i));
 }
 
 BOOST_AUTO_TEST_CASE(pairs)
 {
-	ContiguousDisjointSet ds(10);
+	ContiguousDisjointSet<std::uint32_t> ds(10);
 	BOOST_CHECK_EQUAL(ds.numSets(), 10);
 	BOOST_CHECK_EQUAL(ds.subsets().size(), 10);
 
-	auto const checkPair = [&](size_t expectedNumSubsets, size_t x, size_t y)
+	auto const checkPair = [&](size_t expectedNumSubsets, std::uint32_t x, std::uint32_t y)
 	{
 		BOOST_CHECK_EQUAL(ds.numSets(), expectedNumSubsets);
 		BOOST_CHECK_EQUAL(ds.subsets().size(), expectedNumSubsets);
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(pairs)
 
 BOOST_AUTO_TEST_CASE(merge_with_fixed_representative)
 {
-	ContiguousDisjointSet ds(10);
+	ContiguousDisjointSet<std::uint32_t> ds(10);
 	ds.merge(5, 3, false);
 	BOOST_CHECK_EQUAL(ds.find(5), 5);
 	ds.merge(1, 2);

--- a/test/libyul/yulSSAControlFlowGraph/complex.yul
+++ b/test/libyul/yulSSAControlFlowGraph/complex.yul
@@ -51,10 +51,10 @@
 //
 // Entry0 [label="Entry"];
 // Entry0 -> Block0_0;
-// Block0_0 [label="\
+// Block0_0 [fillcolor="#FF746C", style=filled, label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
-// LiveOut: \l\nv2 := f(2, 1)\l\
-// pop(v2)\l\
+// LiveOut: \l\nUsed: \l\nv0 := f(0x02, 0x01)\l\
+// pop(v0)\l\
 // "];
 // Block0_0Exit [label="MainExit"];
 // Block0_0 -> Block0_0Exit;
@@ -63,135 +63,135 @@
 // FunctionEntry_f_0 -> Block1_0;
 // Block1_0 [label="\
 // Block 0; (0, max 17)\nLiveIn: v1[1], v0[1]\l\
-// LiveOut: v4[1], v1[1], v0[1]\l\nv4 := 42\l\
+// LiveOut: v2[1], v1[1], v0[1]\l\nUsed: \l\nv2 := 0x2a\l\
 // "];
 // Block1_0 -> Block1_0Exit [arrowhead=none];
 // Block1_0Exit [label="Jump" shape=oval];
 // Block1_0Exit -> Block1_1 [style="solid"];
 // Block1_1 [label="\
-// Block 1; (1, max 17)\nLiveIn: v6[4], v1[1], v0[1]\l\
-// LiveOut: v6[2], v1[1], v0[1]\l\nv6 := φ(\l\
-// 	Block 0 => v4,\l\
-// 	Block 21 => v44\l\
+// Block 1; (1, max 17)\nLiveIn: phi1[4], v1[1], v0[1]\l\
+// LiveOut: phi1[2], v1[1], v0[1]\l\nUsed: phi1[2]\l\nphi1 := φ(\l\
+// 	Block 0 => v2,\l\
+// 	Block 21 => v10\l\
 // )\l\
-// v7 := lt(v0, v6)\l\
+// v3 := lt(v0, phi1)\l\
 // "];
 // Block1_1 -> Block1_1Exit;
-// Block1_1Exit [label="{ If v7 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_1Exit [label="{ If v3 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_1Exit:0 -> Block1_4 [style="solid"];
 // Block1_1Exit:1 -> Block1_2 [style="solid"];
 // Block1_2 [label="\
-// Block 2; (2, max 17)\nLiveIn: v6[2], v1[1], v0[1]\l\
-// LiveOut: v6[1], v1[1], v8[3], v0[1]\l\nv8 := mload(v6)\l\
-// v9 := eq(0, v8)\l\
+// Block 2; (2, max 17)\nLiveIn: phi1[2], v1[1], v0[1]\l\
+// LiveOut: phi1[1], v1[1], v4[3], v0[1]\l\nUsed: phi1[1]\l\nv4 := mload(phi1)\l\
+// v5 := eq(0x00, v4)\l\
 // "];
 // Block1_2 -> Block1_2Exit;
-// Block1_2Exit [label="{ If v9 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_2Exit [label="{ If v5 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_2Exit:0 -> Block1_7 [style="solid"];
 // Block1_2Exit:1 -> Block1_6 [style="solid"];
 // Block1_4 [label="\
 // Block 4; (4, max 4)\nLiveIn: \l\
-// LiveOut: \l\nsstore(3084, 12)\l\
+// LiveOut: \l\nUsed: \l\nsstore(0x0c0c, 0x0c)\l\
 // "];
-// Block1_4Exit [label="FunctionReturn[0]"];
+// Block1_4Exit [label="FunctionReturn[0x00]"];
 // Block1_4 -> Block1_4Exit;
 // Block1_6 [label="\
 // Block 6; (3, max 4)\nLiveIn: \l\
-// LiveOut: \l\nsstore(514, 2)\l\
+// LiveOut: \l\nUsed: \l\nsstore(0x0202, 0x02)\l\
 // "];
 // Block1_6 -> Block1_6Exit [arrowhead=none];
 // Block1_6Exit [label="Jump" shape=oval];
 // Block1_6Exit -> Block1_4 [style="solid"];
 // Block1_7 [label="\
-// Block 7; (5, max 17)\nLiveIn: v6[1], v1[1], v8[3], v0[1]\l\
-// LiveOut: v6[1], v1[1], v8[2], v0[1]\l\nv14 := eq(1, v8)\l\
+// Block 7; (5, max 17)\nLiveIn: phi1[1], v1[1], v4[3], v0[1]\l\
+// LiveOut: phi1[1], v1[1], v4[2], v0[1]\l\nUsed: v4[1]\l\nv6 := eq(0x01, v4)\l\
 // "];
 // Block1_7 -> Block1_7Exit;
-// Block1_7Exit [label="{ If v14 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_7Exit [label="{ If v6 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_7Exit:0 -> Block1_10 [style="solid"];
 // Block1_7Exit:1 -> Block1_9 [style="solid"];
 // Block1_9 [label="\
 // Block 9; (6, max 6)\nLiveIn: \l\
-// LiveOut: \l\nsstore(1028, 4)\l\
+// LiveOut: \l\nUsed: \l\nsstore(0x0404, 0x04)\l\
 // "];
-// Block1_9Exit [label="FunctionReturn[0]"];
+// Block1_9Exit [label="FunctionReturn[0x00]"];
 // Block1_9 -> Block1_9Exit;
 // Block1_10 [label="\
-// Block 10; (7, max 17)\nLiveIn: v6[1], v1[1], v8[2], v0[1]\l\
-// LiveOut: v6[1], v1[1], v8[1], v0[1]\l\nv21 := eq(2, v8)\l\
+// Block 10; (7, max 17)\nLiveIn: phi1[1], v1[1], v4[2], v0[1]\l\
+// LiveOut: phi1[1], v1[1], v4[1], v0[1]\l\nUsed: v4[1]\l\nv7 := eq(0x02, v4)\l\
 // "];
 // Block1_10 -> Block1_10Exit;
-// Block1_10Exit [label="{ If v21 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_10Exit [label="{ If v7 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_10Exit:0 -> Block1_13 [style="solid"];
 // Block1_10Exit:1 -> Block1_12 [style="solid"];
-// Block1_12 [label="\
+// Block1_12 [fillcolor="#FF746C", style=filled, label="\
 // Block 12; (8, max 8)\nLiveIn: \l\
-// LiveOut: \l\nsstore(1542, 6)\l\
-// revert(0, 0)\l\
+// LiveOut: \l\nUsed: \l\nsstore(0x0606, 0x06)\l\
+// revert(0x00, 0x00)\l\
 // "];
 // Block1_12Exit [label="Terminated"];
 // Block1_12 -> Block1_12Exit;
 // Block1_13 [label="\
-// Block 13; (9, max 17)\nLiveIn: v6[1], v1[1], v8[1], v0[1]\l\
-// LiveOut: v6[1], v1[1], v0[1]\l\nv26 := eq(3, v8)\l\
+// Block 13; (9, max 17)\nLiveIn: phi1[1], v1[1], v4[1], v0[1]\l\
+// LiveOut: phi1[1], v1[1], v0[1]\l\nUsed: v4[1]\l\nv8 := eq(0x03, v4)\l\
 // "];
 // Block1_13 -> Block1_13Exit;
-// Block1_13Exit [label="{ If v26 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_13Exit [label="{ If v8 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_13Exit:0 -> Block1_16 [style="solid"];
 // Block1_13Exit:1 -> Block1_15 [style="solid"];
 // Block1_15 [label="\
-// Block 15; (10, max 14)\nLiveIn: v6[1], v1[1], v0[1]\l\
-// LiveOut: v6[1], v1[1], v0[1]\l\nsstore(2056, 8)\l\
+// Block 15; (10, max 14)\nLiveIn: phi1[1], v1[1], v0[1]\l\
+// LiveOut: phi1[1], v1[1], v0[1]\l\nUsed: \l\nsstore(0x0808, 0x08)\l\
 // "];
 // Block1_15 -> Block1_15Exit [arrowhead=none];
 // Block1_15Exit [label="Jump" shape=oval];
 // Block1_15Exit -> Block1_5 [style="solid"];
 // Block1_16 [label="\
-// Block 16; (15, max 17)\nLiveIn: v6[1], v1[1], v0[1]\l\
-// LiveOut: v6[1], v1[1], v0[1]\l\nv30 := mload(v1)\l\
+// Block 16; (15, max 17)\nLiveIn: phi1[1], v1[1], v0[1]\l\
+// LiveOut: phi1[1], v1[1], v0[1]\l\nUsed: \l\nv9 := mload(v1)\l\
 // "];
 // Block1_16 -> Block1_16Exit;
-// Block1_16Exit [label="{ If v30 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_16Exit [label="{ If v9 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_16Exit:0 -> Block1_18 [style="solid"];
 // Block1_16Exit:1 -> Block1_17 [style="solid"];
 // Block1_5 [label="\
-// Block 5; (11, max 14)\nLiveIn: v6[1], v1[1], v0[1]\l\
-// LiveOut: v6[1], v1[1], v0[1]\l\nsstore(2827, 11)\l\
+// Block 5; (11, max 14)\nLiveIn: phi1[1], v1[1], v0[1]\l\
+// LiveOut: phi1[1], v1[1], v0[1]\l\nUsed: \l\nsstore(0x0b0b, 0x0b)\l\
 // "];
 // Block1_5 -> Block1_5Exit [arrowhead=none];
 // Block1_5Exit [label="Jump" shape=oval];
 // Block1_5Exit -> Block1_3 [style="solid"];
-// Block1_17 [label="\
+// Block1_17 [fillcolor="#FF746C", style=filled, label="\
 // Block 17; (16, max 16)\nLiveIn: \l\
-// LiveOut: \l\nreturn(0, 0)\l\
+// LiveOut: \l\nUsed: \l\nreturn(0x00, 0x00)\l\
 // "];
 // Block1_17Exit [label="Terminated"];
 // Block1_17 -> Block1_17Exit;
 // Block1_18 [label="\
-// Block 18; (17, max 17)\nLiveIn: v6[1], v1[1], v0[1]\l\
-// LiveOut: v6[1], v1[1], v0[1]\l\nsstore(2570, 10)\l\
+// Block 18; (17, max 17)\nLiveIn: phi1[1], v1[1], v0[1]\l\
+// LiveOut: phi1[1], v1[1], v0[1]\l\nUsed: \l\nsstore(0x0a0a, 0x0a)\l\
 // "];
 // Block1_18 -> Block1_18Exit [arrowhead=none];
 // Block1_18Exit [label="Jump" shape=oval];
 // Block1_18Exit -> Block1_5 [style="solid"];
 // Block1_3 [label="\
-// Block 3; (12, max 14)\nLiveIn: v6[1], v1[1], v0[1]\l\
-// LiveOut: v44[1], v1[1], v0[1]\l\nv44 := add(1, v6)\l\
-// v45 := calldataload(v44)\l\
+// Block 3; (12, max 14)\nLiveIn: phi1[1], v1[1], v0[1]\l\
+// LiveOut: v10[1], v1[1], v0[1]\l\nUsed: phi1[1]\l\nv10 := add(0x01, phi1)\l\
+// v11 := calldataload(v10)\l\
 // "];
 // Block1_3 -> Block1_3Exit;
-// Block1_3Exit [label="{ If v45 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_3Exit [label="{ If v11 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_3Exit:0 -> Block1_21 [style="solid"];
 // Block1_3Exit:1 -> Block1_20 [style="solid"];
 // Block1_20 [label="\
-// Block 20; (13, max 13)\nLiveIn: v44[1]\l\
-// LiveOut: \l\nsstore(v44, 0)\l\
+// Block 20; (13, max 13)\nLiveIn: v10[1]\l\
+// LiveOut: \l\nUsed: v10[1]\l\nsstore(v10, 0x00)\l\
 // "];
-// Block1_20Exit [label="FunctionReturn[0]"];
+// Block1_20Exit [label="FunctionReturn[0x00]"];
 // Block1_20 -> Block1_20Exit;
 // Block1_21 [label="\
-// Block 21; (14, max 14)\nLiveIn: v44[1], v1[1], v0[1]\l\
-// LiveOut: v44[1], v1[1], v0[1]\l\nsstore(65535, 255)\l\
+// Block 21; (14, max 14)\nLiveIn: v10[1], v1[1], v0[1]\l\
+// LiveOut: v10[1], v1[1], v0[1]\l\nUsed: \l\nsstore(0xffff, 0xff)\l\
 // "];
 // Block1_21 -> Block1_21Exit [arrowhead=none];
 // Block1_21Exit [label="Jump" shape=oval];

--- a/test/libyul/yulSSAControlFlowGraph/complex2.yul
+++ b/test/libyul/yulSSAControlFlowGraph/complex2.yul
@@ -58,19 +58,19 @@
 //
 // Entry0 [label="Entry"];
 // Entry0 -> Block0_0;
-// Block0_0 [label="\
+// Block0_0 [fillcolor="#FF746C", style=filled, label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
-// LiveOut: \l\nsstore(1, 1)\l\
-// v2 := f(2, 1)\l\
-// pop(v2)\l\
-// v4 := sload(0)\l\
-// v6 := add(v4, 5)\l\
-// v8 := sload(4)\l\
-// v9 := f(v8, v6)\l\
-// sstore(v9, v6)\l\
-// v10 := sload(5)\l\
-// v11 := f(v10, v9)\l\
-// sstore(v11, 1)\l\
+// LiveOut: \l\nUsed: \l\nsstore(0x01, 0x01)\l\
+// v0 := f(0x02, 0x01)\l\
+// pop(v0)\l\
+// v1 := sload(0x00)\l\
+// v2 := add(v1, 0x05)\l\
+// v3 := sload(0x04)\l\
+// v4 := f(v3, v2)\l\
+// sstore(v4, v2)\l\
+// v5 := sload(0x05)\l\
+// v6 := f(v5, v4)\l\
+// sstore(v6, 0x01)\l\
 // "];
 // Block0_0Exit [label="MainExit"];
 // Block0_0 -> Block0_0Exit;
@@ -79,136 +79,136 @@
 // FunctionEntry_f_0 -> Block1_0;
 // Block1_0 [label="\
 // Block 0; (0, max 17)\nLiveIn: v1[1], v0[1]\l\
-// LiveOut: v4[1], v1[1], v0[1]\l\nv4 := 42\l\
+// LiveOut: v2[1], v1[1], v0[1]\l\nUsed: \l\nv2 := 0x2a\l\
 // "];
 // Block1_0 -> Block1_0Exit [arrowhead=none];
 // Block1_0Exit [label="Jump" shape=oval];
 // Block1_0Exit -> Block1_1 [style="solid"];
 // Block1_1 [label="\
-// Block 1; (1, max 17)\nLiveIn: v6[4], v1[1], v0[1]\l\
-// LiveOut: v6[2], v1[1], v0[1]\l\nv6 := φ(\l\
-// 	Block 0 => v4,\l\
-// 	Block 21 => v44\l\
+// Block 1; (1, max 17)\nLiveIn: phi1[4], v1[1], v0[1]\l\
+// LiveOut: phi1[2], v1[1], v0[1]\l\nUsed: phi1[2]\l\nphi1 := φ(\l\
+// 	Block 0 => v2,\l\
+// 	Block 21 => v10\l\
 // )\l\
-// v7 := lt(v0, v6)\l\
+// v3 := lt(v0, phi1)\l\
 // "];
 // Block1_1 -> Block1_1Exit;
-// Block1_1Exit [label="{ If v7 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_1Exit [label="{ If v3 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_1Exit:0 -> Block1_4 [style="solid"];
 // Block1_1Exit:1 -> Block1_2 [style="solid"];
 // Block1_2 [label="\
-// Block 2; (2, max 17)\nLiveIn: v6[2], v1[1], v0[1]\l\
-// LiveOut: v6[1], v1[1], v8[3], v0[1]\l\nv8 := mload(v6)\l\
-// v9 := eq(0, v8)\l\
+// Block 2; (2, max 17)\nLiveIn: phi1[2], v1[1], v0[1]\l\
+// LiveOut: phi1[1], v1[1], v4[3], v0[1]\l\nUsed: phi1[1]\l\nv4 := mload(phi1)\l\
+// v5 := eq(0x00, v4)\l\
 // "];
 // Block1_2 -> Block1_2Exit;
-// Block1_2Exit [label="{ If v9 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_2Exit [label="{ If v5 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_2Exit:0 -> Block1_7 [style="solid"];
 // Block1_2Exit:1 -> Block1_6 [style="solid"];
 // Block1_4 [label="\
 // Block 4; (4, max 4)\nLiveIn: \l\
-// LiveOut: v78[1]\l\nsstore(3084, 12)\l\
-// v78 := 27\l\
+// LiveOut: v12[1]\l\nUsed: \l\nsstore(0x0c0c, 0x0c)\l\
+// v12 := 0x1b\l\
 // "];
-// Block1_4Exit [label="FunctionReturn[v78]"];
+// Block1_4Exit [label="FunctionReturn[v12]"];
 // Block1_4 -> Block1_4Exit;
 // Block1_6 [label="\
 // Block 6; (3, max 4)\nLiveIn: \l\
-// LiveOut: \l\nsstore(514, 2)\l\
+// LiveOut: \l\nUsed: \l\nsstore(0x0202, 0x02)\l\
 // "];
 // Block1_6 -> Block1_6Exit [arrowhead=none];
 // Block1_6Exit [label="Jump" shape=oval];
 // Block1_6Exit -> Block1_4 [style="solid"];
 // Block1_7 [label="\
-// Block 7; (5, max 17)\nLiveIn: v6[1], v1[1], v8[3], v0[1]\l\
-// LiveOut: v6[1], v1[1], v8[2], v0[1]\l\nv14 := eq(1, v8)\l\
+// Block 7; (5, max 17)\nLiveIn: phi1[1], v1[1], v4[3], v0[1]\l\
+// LiveOut: phi1[1], v1[1], v4[2], v0[1]\l\nUsed: v4[1]\l\nv6 := eq(0x01, v4)\l\
 // "];
 // Block1_7 -> Block1_7Exit;
-// Block1_7Exit [label="{ If v14 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_7Exit [label="{ If v6 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_7Exit:0 -> Block1_10 [style="solid"];
 // Block1_7Exit:1 -> Block1_9 [style="solid"];
 // Block1_9 [label="\
 // Block 9; (6, max 6)\nLiveIn: \l\
-// LiveOut: \l\nsstore(1028, 4)\l\
+// LiveOut: \l\nUsed: \l\nsstore(0x0404, 0x04)\l\
 // "];
-// Block1_9Exit [label="FunctionReturn[0]"];
+// Block1_9Exit [label="FunctionReturn[0x00]"];
 // Block1_9 -> Block1_9Exit;
 // Block1_10 [label="\
-// Block 10; (7, max 17)\nLiveIn: v6[1], v1[1], v8[2], v0[1]\l\
-// LiveOut: v6[1], v1[1], v8[1], v0[1]\l\nv21 := eq(2, v8)\l\
+// Block 10; (7, max 17)\nLiveIn: phi1[1], v1[1], v4[2], v0[1]\l\
+// LiveOut: phi1[1], v1[1], v4[1], v0[1]\l\nUsed: v4[1]\l\nv7 := eq(0x02, v4)\l\
 // "];
 // Block1_10 -> Block1_10Exit;
-// Block1_10Exit [label="{ If v21 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_10Exit [label="{ If v7 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_10Exit:0 -> Block1_13 [style="solid"];
 // Block1_10Exit:1 -> Block1_12 [style="solid"];
-// Block1_12 [label="\
+// Block1_12 [fillcolor="#FF746C", style=filled, label="\
 // Block 12; (8, max 8)\nLiveIn: \l\
-// LiveOut: \l\nsstore(1542, 6)\l\
-// revert(0, 0)\l\
+// LiveOut: \l\nUsed: \l\nsstore(0x0606, 0x06)\l\
+// revert(0x00, 0x00)\l\
 // "];
 // Block1_12Exit [label="Terminated"];
 // Block1_12 -> Block1_12Exit;
 // Block1_13 [label="\
-// Block 13; (9, max 17)\nLiveIn: v6[1], v1[1], v8[1], v0[1]\l\
-// LiveOut: v6[1], v1[1], v0[1]\l\nv26 := eq(3, v8)\l\
+// Block 13; (9, max 17)\nLiveIn: phi1[1], v1[1], v4[1], v0[1]\l\
+// LiveOut: phi1[1], v1[1], v0[1]\l\nUsed: v4[1]\l\nv8 := eq(0x03, v4)\l\
 // "];
 // Block1_13 -> Block1_13Exit;
-// Block1_13Exit [label="{ If v26 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_13Exit [label="{ If v8 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_13Exit:0 -> Block1_16 [style="solid"];
 // Block1_13Exit:1 -> Block1_15 [style="solid"];
 // Block1_15 [label="\
-// Block 15; (10, max 14)\nLiveIn: v6[1], v1[1], v0[1]\l\
-// LiveOut: v6[1], v1[1], v0[1]\l\nsstore(2056, 8)\l\
+// Block 15; (10, max 14)\nLiveIn: phi1[1], v1[1], v0[1]\l\
+// LiveOut: phi1[1], v1[1], v0[1]\l\nUsed: \l\nsstore(0x0808, 0x08)\l\
 // "];
 // Block1_15 -> Block1_15Exit [arrowhead=none];
 // Block1_15Exit [label="Jump" shape=oval];
 // Block1_15Exit -> Block1_5 [style="solid"];
 // Block1_16 [label="\
-// Block 16; (15, max 17)\nLiveIn: v6[1], v1[1], v0[1]\l\
-// LiveOut: v6[1], v1[1], v0[1]\l\nv30 := mload(v1)\l\
+// Block 16; (15, max 17)\nLiveIn: phi1[1], v1[1], v0[1]\l\
+// LiveOut: phi1[1], v1[1], v0[1]\l\nUsed: \l\nv9 := mload(v1)\l\
 // "];
 // Block1_16 -> Block1_16Exit;
-// Block1_16Exit [label="{ If v30 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_16Exit [label="{ If v9 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_16Exit:0 -> Block1_18 [style="solid"];
 // Block1_16Exit:1 -> Block1_17 [style="solid"];
 // Block1_5 [label="\
-// Block 5; (11, max 14)\nLiveIn: v6[1], v1[1], v0[1]\l\
-// LiveOut: v6[1], v1[1], v0[1]\l\nsstore(2827, 11)\l\
+// Block 5; (11, max 14)\nLiveIn: phi1[1], v1[1], v0[1]\l\
+// LiveOut: phi1[1], v1[1], v0[1]\l\nUsed: \l\nsstore(0x0b0b, 0x0b)\l\
 // "];
 // Block1_5 -> Block1_5Exit [arrowhead=none];
 // Block1_5Exit [label="Jump" shape=oval];
 // Block1_5Exit -> Block1_3 [style="solid"];
-// Block1_17 [label="\
+// Block1_17 [fillcolor="#FF746C", style=filled, label="\
 // Block 17; (16, max 16)\nLiveIn: \l\
-// LiveOut: \l\nreturn(0, 0)\l\
+// LiveOut: \l\nUsed: \l\nreturn(0x00, 0x00)\l\
 // "];
 // Block1_17Exit [label="Terminated"];
 // Block1_17 -> Block1_17Exit;
 // Block1_18 [label="\
-// Block 18; (17, max 17)\nLiveIn: v6[1], v1[1], v0[1]\l\
-// LiveOut: v6[1], v1[1], v0[1]\l\nsstore(2570, 10)\l\
+// Block 18; (17, max 17)\nLiveIn: phi1[1], v1[1], v0[1]\l\
+// LiveOut: phi1[1], v1[1], v0[1]\l\nUsed: \l\nsstore(0x0a0a, 0x0a)\l\
 // "];
 // Block1_18 -> Block1_18Exit [arrowhead=none];
 // Block1_18Exit [label="Jump" shape=oval];
 // Block1_18Exit -> Block1_5 [style="solid"];
 // Block1_3 [label="\
-// Block 3; (12, max 14)\nLiveIn: v6[1], v1[1], v0[1]\l\
-// LiveOut: v44[1], v1[1], v0[1]\l\nv44 := add(1, v6)\l\
-// v45 := calldataload(v44)\l\
+// Block 3; (12, max 14)\nLiveIn: phi1[1], v1[1], v0[1]\l\
+// LiveOut: v10[1], v1[1], v0[1]\l\nUsed: phi1[1]\l\nv10 := add(0x01, phi1)\l\
+// v11 := calldataload(v10)\l\
 // "];
 // Block1_3 -> Block1_3Exit;
-// Block1_3Exit [label="{ If v45 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_3Exit [label="{ If v11 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_3Exit:0 -> Block1_21 [style="solid"];
 // Block1_3Exit:1 -> Block1_20 [style="solid"];
 // Block1_20 [label="\
-// Block 20; (13, max 13)\nLiveIn: v44[1]\l\
-// LiveOut: \l\nsstore(v44, 0)\l\
+// Block 20; (13, max 13)\nLiveIn: v10[1]\l\
+// LiveOut: \l\nUsed: v10[1]\l\nsstore(v10, 0x00)\l\
 // "];
-// Block1_20Exit [label="FunctionReturn[0]"];
+// Block1_20Exit [label="FunctionReturn[0x00]"];
 // Block1_20 -> Block1_20Exit;
 // Block1_21 [label="\
-// Block 21; (14, max 14)\nLiveIn: v44[1], v1[1], v0[1]\l\
-// LiveOut: v44[1], v1[1], v0[1]\l\nsstore(65535, 255)\l\
+// Block 21; (14, max 14)\nLiveIn: v10[1], v1[1], v0[1]\l\
+// LiveOut: v10[1], v1[1], v0[1]\l\nUsed: \l\nsstore(0xffff, 0xff)\l\
 // "];
 // Block1_21 -> Block1_21Exit [arrowhead=none];
 // Block1_21Exit [label="Jump" shape=oval];

--- a/test/libyul/yulSSAControlFlowGraph/default_initialized_variable.yul
+++ b/test/libyul/yulSSAControlFlowGraph/default_initialized_variable.yul
@@ -15,27 +15,27 @@
 // Entry0 -> Block0_0;
 // Block0_0 [label="\
 // Block 0; (0, max 2)\nLiveIn: \l\
-// LiveOut: v1[1]\l\nv1 := 0\l\
-// v3 := mload(42)\l\
+// LiveOut: v0[1]\l\nUsed: \l\nv0 := 0x00\l\
+// v1 := mload(0x2a)\l\
 // "];
 // Block0_0 -> Block0_0Exit;
-// Block0_0Exit [label="{ If v3 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_0Exit [label="{ If v1 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block0_0Exit:0 -> Block0_2 [style="solid"];
 // Block0_0Exit:1 -> Block0_1 [style="solid"];
 // Block0_1 [label="\
 // Block 1; (1, max 2)\nLiveIn: \l\
-// LiveOut: v5[1]\l\nv5 := 5\l\
+// LiveOut: v2[1]\l\nUsed: \l\nv2 := 0x05\l\
 // "];
 // Block0_1 -> Block0_1Exit [arrowhead=none];
 // Block0_1Exit [label="Jump" shape=oval];
 // Block0_1Exit -> Block0_2 [style="solid"];
 // Block0_2 [label="\
-// Block 2; (2, max 2)\nLiveIn: v6[3]\l\
-// LiveOut: \l\nv6 := φ(\l\
-// 	Block 0 => v1,\l\
-// 	Block 1 => v5\l\
+// Block 2; (2, max 2)\nLiveIn: phi0[3]\l\
+// LiveOut: \l\nUsed: phi0[3]\l\nphi0 := φ(\l\
+// 	Block 0 => v0,\l\
+// 	Block 1 => v2\l\
 // )\l\
-// sstore(v6, v6)\l\
+// sstore(phi0, phi0)\l\
 // "];
 // Block0_2Exit [label="MainExit"];
 // Block0_2 -> Block0_2Exit;

--- a/test/libyul/yulSSAControlFlowGraph/function.yul
+++ b/test/libyul/yulSSAControlFlowGraph/function.yul
@@ -26,9 +26,9 @@
 //
 // Entry0 [label="Entry"];
 // Entry0 -> Block0_0;
-// Block0_0 [label="\
+// Block0_0 [fillcolor="#FF746C", style=filled, label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
-// LiveOut: \l\nv0, v1 := i()\l\
+// LiveOut: \l\nUsed: \l\nv0, v1 := i()\l\
 // h(v0)\l\
 // "];
 // Block0_0Exit [label="Terminated"];
@@ -38,27 +38,27 @@
 // FunctionEntry_f_0 -> Block1_0;
 // Block1_0 [label="\
 // Block 0; (0, max 0)\nLiveIn: v0[2], v1[1]\l\
-// LiveOut: v4[1]\l\nv3 := add(v1, v0)\l\
-// v4 := sub(v0, v3)\l\
+// LiveOut: v3[1]\l\nUsed: v0[2], v1[1]\l\nv2 := add(v1, v0)\l\
+// v3 := sub(v0, v2)\l\
 // "];
-// Block1_0Exit [label="FunctionReturn[v4]"];
+// Block1_0Exit [label="FunctionReturn[v3]"];
 // Block1_0 -> Block1_0Exit;
 // FunctionEntry_g_0 [label="function g:
 //  g()"];
 // FunctionEntry_g_0 -> Block2_0;
 // Block2_0 [label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
-// LiveOut: \l\nsstore(257, 1)\l\
+// LiveOut: \l\nUsed: \l\nsstore(0x0101, 0x01)\l\
 // "];
 // Block2_0Exit [label="FunctionReturn[]"];
 // Block2_0 -> Block2_0Exit;
 // FunctionEntry_h_0 [label="function h:
 //  h(v0)"];
 // FunctionEntry_h_0 -> Block3_0;
-// Block3_0 [label="\
+// Block3_0 [fillcolor="#FF746C", style=filled, label="\
 // Block 0; (0, max 0)\nLiveIn: v0[1]\l\
-// LiveOut: \l\nv2 := f(0, v0)\l\
-// h(v2)\l\
+// LiveOut: \l\nUsed: v0[1]\l\nv1 := f(0x00, v0)\l\
+// h(v1)\l\
 // "];
 // Block3_0Exit [label="Terminated"];
 // Block3_0 -> Block3_0Exit;
@@ -67,9 +67,9 @@
 // FunctionEntry_i_0 -> Block4_0;
 // Block4_0 [label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
-// LiveOut: v2[1], v4[1]\l\nv2 := 514\l\
-// v4 := 771\l\
+// LiveOut: v0[1], v1[1]\l\nUsed: \l\nv0 := 0x0202\l\
+// v1 := 0x0303\l\
 // "];
-// Block4_0Exit [label="FunctionReturn[v2, v4]"];
+// Block4_0Exit [label="FunctionReturn[v0, v1]"];
 // Block4_0 -> Block4_0Exit;
 // }

--- a/test/libyul/yulSSAControlFlowGraph/if.yul
+++ b/test/libyul/yulSSAControlFlowGraph/if.yul
@@ -16,28 +16,28 @@
 // Entry0 -> Block0_0;
 // Block0_0 [label="\
 // Block 0; (0, max 2)\nLiveIn: \l\
-// LiveOut: v1[1]\l\nv1 := calldataload(3)\l\
-// v3 := mload(42)\l\
+// LiveOut: v0[1]\l\nUsed: \l\nv0 := calldataload(0x03)\l\
+// v1 := mload(0x2a)\l\
 // "];
 // Block0_0 -> Block0_0Exit;
-// Block0_0Exit [label="{ If v3 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_0Exit [label="{ If v1 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block0_0Exit:0 -> Block0_2 [style="solid"];
 // Block0_0Exit:1 -> Block0_1 [style="solid"];
 // Block0_1 [label="\
 // Block 1; (1, max 2)\nLiveIn: \l\
-// LiveOut: v5[1]\l\nv5 := calldataload(77)\l\
+// LiveOut: v2[1]\l\nUsed: \l\nv2 := calldataload(0x4d)\l\
 // "];
 // Block0_1 -> Block0_1Exit [arrowhead=none];
 // Block0_1Exit [label="Jump" shape=oval];
 // Block0_1Exit -> Block0_2 [style="solid"];
 // Block0_2 [label="\
-// Block 2; (2, max 2)\nLiveIn: v6[2]\l\
-// LiveOut: \l\nv6 := φ(\l\
-// 	Block 0 => v1,\l\
-// 	Block 1 => v5\l\
+// Block 2; (2, max 2)\nLiveIn: phi0[2]\l\
+// LiveOut: \l\nUsed: phi0[2]\l\nphi0 := φ(\l\
+// 	Block 0 => v0,\l\
+// 	Block 1 => v2\l\
 // )\l\
-// v7 := calldataload(v6)\l\
-// sstore(0, v7)\l\
+// v3 := calldataload(phi0)\l\
+// sstore(0x00, v3)\l\
 // "];
 // Block0_2Exit [label="MainExit"];
 // Block0_2 -> Block0_2Exit;

--- a/test/libyul/yulSSAControlFlowGraph/if_const.yul
+++ b/test/libyul/yulSSAControlFlowGraph/if_const.yul
@@ -19,12 +19,12 @@
 //
 // Entry0 [label="Entry"];
 // Entry0 -> Block0_0;
-// Block0_0 [label="\
+// Block0_0 [fillcolor="#FF746C", style=filled, label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
-// LiveOut: \l\nv1 := calldataload(3)\l\
-// v3 := calldataload(42)\l\
-// v4 := calldataload(v3)\l\
-// sstore(0, v4)\l\
+// LiveOut: \l\nUsed: \l\nv0 := calldataload(0x03)\l\
+// v1 := calldataload(0x2a)\l\
+// v2 := calldataload(v1)\l\
+// sstore(0x00, v2)\l\
 // "];
 // Block0_0Exit [label="MainExit"];
 // Block0_0 -> Block0_0Exit;

--- a/test/libyul/yulSSAControlFlowGraph/nested_for.yul
+++ b/test/libyul/yulSSAControlFlowGraph/nested_for.yul
@@ -25,201 +25,201 @@
 //
 // Entry0 [label="Entry"];
 // Entry0 -> Block0_0;
-// Block0_0 [label="\
+// Block0_0 [fillcolor="#FF746C", style=filled, label="\
 // Block 0; (0, max 24)\nLiveIn: \l\
-// LiveOut: v1[1]\l\nv1 := 0\l\
+// LiveOut: v0[1]\l\nUsed: \l\nv0 := 0x00\l\
 // "];
 // Block0_0 -> Block0_0Exit [arrowhead=none];
 // Block0_0Exit [label="Jump" shape=oval];
 // Block0_0Exit -> Block0_1 [style="solid"];
-// Block0_1 [label="\
-// Block 1; (1, max 24)\nLiveIn: v3[3]\l\
-// LiveOut: v3[1]\l\nv3 := φ(\l\
-// 	Block 0 => v1,\l\
-// 	Block 3 => v43\l\
+// Block0_1 [fillcolor="#FF746C", style=filled, label="\
+// Block 1; (1, max 24)\nLiveIn: phi0[3]\l\
+// LiveOut: phi0[1]\l\nUsed: phi0[2]\l\nphi0 := φ(\l\
+// 	Block 0 => v0,\l\
+// 	Block 3 => v20\l\
 // )\l\
-// v4 := lt(3, v3)\l\
+// v1 := lt(0x03, phi0)\l\
 // "];
 // Block0_1 -> Block0_1Exit;
-// Block0_1Exit [label="{ If v4 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_1Exit [label="{ If v1 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block0_1Exit:0 -> Block0_4 [style="solid"];
 // Block0_1Exit:1 -> Block0_2 [style="solid"];
 // Block0_2 [label="\
-// Block 2; (2, max 23)\nLiveIn: v3[1]\l\
-// LiveOut: v5[1], v3[1]\l\nv5 := 0\l\
+// Block 2; (2, max 23)\nLiveIn: phi0[1]\l\
+// LiveOut: v2[1], phi0[1]\l\nUsed: \l\nv2 := 0x00\l\
 // "];
 // Block0_2 -> Block0_2Exit [arrowhead=none];
 // Block0_2Exit [label="Jump" shape=oval];
 // Block0_2Exit -> Block0_5 [style="solid"];
-// Block0_4 [label="\
+// Block0_4 [fillcolor="#FF746C", style=filled, label="\
 // Block 4; (24, max 24)\nLiveIn: \l\
-// LiveOut: \l\n"];
+// LiveOut: \l\nUsed: \l\n"];
 // Block0_4Exit [label="MainExit"];
 // Block0_4 -> Block0_4Exit;
 // Block0_5 [label="\
-// Block 5; (3, max 23)\nLiveIn: v6[3], v3[1]\l\
-// LiveOut: v6[1], v3[1]\l\nv6 := φ(\l\
-// 	Block 2 => v5,\l\
-// 	Block 7 => v42\l\
+// Block 5; (3, max 23)\nLiveIn: phi1[3], phi0[1]\l\
+// LiveOut: phi1[1], phi0[1]\l\nUsed: phi1[2]\l\nphi1 := φ(\l\
+// 	Block 2 => v2,\l\
+// 	Block 7 => v19\l\
 // )\l\
-// v7 := lt(3, v6)\l\
+// v3 := lt(0x03, phi1)\l\
 // "];
 // Block0_5 -> Block0_5Exit;
-// Block0_5Exit [label="{ If v7 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_5Exit [label="{ If v3 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block0_5Exit:0 -> Block0_8 [style="solid"];
 // Block0_5Exit:1 -> Block0_6 [style="solid"];
 // Block0_6 [label="\
-// Block 6; (4, max 21)\nLiveIn: v6[1], v3[1]\l\
-// LiveOut: v8[1], v6[1], v3[1]\l\nv8 := 0\l\
+// Block 6; (4, max 21)\nLiveIn: phi1[1], phi0[1]\l\
+// LiveOut: v4[1], phi1[1], phi0[1]\l\nUsed: \l\nv4 := 0x00\l\
 // "];
 // Block0_6 -> Block0_6Exit [arrowhead=none];
 // Block0_6Exit [label="Jump" shape=oval];
 // Block0_6Exit -> Block0_9 [style="solid"];
 // Block0_8 [label="\
-// Block 8; (22, max 23)\nLiveIn: v3[1]\l\
-// LiveOut: v3[1]\l\n"];
+// Block 8; (22, max 23)\nLiveIn: phi0[1]\l\
+// LiveOut: phi0[1]\l\nUsed: \l\n"];
 // Block0_8 -> Block0_8Exit [arrowhead=none];
 // Block0_8Exit [label="Jump" shape=oval];
 // Block0_8Exit -> Block0_3 [style="solid"];
 // Block0_9 [label="\
-// Block 9; (5, max 21)\nLiveIn: v9[3], v6[1], v3[1]\l\
-// LiveOut: v9[1], v6[1], v3[1]\l\nv9 := φ(\l\
-// 	Block 6 => v8,\l\
-// 	Block 11 => v38\l\
+// Block 9; (5, max 21)\nLiveIn: phi2[3], phi1[1], phi0[1]\l\
+// LiveOut: phi2[1], phi1[1], phi0[1]\l\nUsed: phi2[2]\l\nphi2 := φ(\l\
+// 	Block 6 => v4,\l\
+// 	Block 11 => v18\l\
 // )\l\
-// v10 := lt(3, v9)\l\
+// v5 := lt(0x03, phi2)\l\
 // "];
 // Block0_9 -> Block0_9Exit;
-// Block0_9Exit [label="{ If v10 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_9Exit [label="{ If v5 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block0_9Exit:0 -> Block0_12 [style="solid"];
 // Block0_9Exit:1 -> Block0_10 [style="solid"];
 // Block0_3 [label="\
-// Block 3; (23, max 23)\nLiveIn: v3[1]\l\
-// LiveOut: v43[1]\l\nv43 := add(1, v3)\l\
+// Block 3; (23, max 23)\nLiveIn: phi0[1]\l\
+// LiveOut: v20[1]\l\nUsed: phi0[1]\l\nv20 := add(0x01, phi0)\l\
 // "];
 // Block0_3 -> Block0_3Exit [arrowhead=none];
 // Block0_3Exit [label="Jump" shape=oval];
 // Block0_3Exit -> Block0_1 [style="dashed"];
 // Block0_10 [label="\
-// Block 10; (6, max 19)\nLiveIn: v9[1], v6[1], v3[1]\l\
-// LiveOut: v9[1], v6[1], v3[1]\l\nv11 := mload(0)\l\
+// Block 10; (6, max 19)\nLiveIn: phi2[1], phi1[1], phi0[1]\l\
+// LiveOut: phi2[1], phi1[1], phi0[1]\l\nUsed: \l\nv6 := mload(0x00)\l\
 // "];
 // Block0_10 -> Block0_10Exit;
-// Block0_10Exit [label="{ If v11 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_10Exit [label="{ If v6 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block0_10Exit:0 -> Block0_14 [style="solid"];
 // Block0_10Exit:1 -> Block0_13 [style="solid"];
 // Block0_12 [label="\
-// Block 12; (20, max 21)\nLiveIn: v6[1], v3[1]\l\
-// LiveOut: v6[1], v3[1]\l\n"];
+// Block 12; (20, max 21)\nLiveIn: phi1[1], phi0[1]\l\
+// LiveOut: phi1[1], phi0[1]\l\nUsed: \l\n"];
 // Block0_12 -> Block0_12Exit [arrowhead=none];
 // Block0_12Exit [label="Jump" shape=oval];
 // Block0_12Exit -> Block0_7 [style="solid"];
 // Block0_13 [label="\
-// Block 13; (7, max 19)\nLiveIn: v9[1], v6[1], v3[1]\l\
-// LiveOut: v12[1], v9[1], v6[1], v3[1]\l\nv12 := 0\l\
+// Block 13; (7, max 19)\nLiveIn: phi2[1], phi1[1], phi0[1]\l\
+// LiveOut: v7[1], phi2[1], phi1[1], phi0[1]\l\nUsed: \l\nv7 := 0x00\l\
 // "];
 // Block0_13 -> Block0_13Exit [arrowhead=none];
 // Block0_13Exit [label="Jump" shape=oval];
 // Block0_13Exit -> Block0_15 [style="solid"];
 // Block0_14 [label="\
-// Block 14; (12, max 19)\nLiveIn: v9[1], v6[1], v3[1]\l\
-// LiveOut: v9[1], v6[1], v3[1]\l\nv24 := mload(1)\l\
+// Block 14; (12, max 19)\nLiveIn: phi2[1], phi1[1], phi0[1]\l\
+// LiveOut: phi2[1], phi1[1], phi0[1]\l\nUsed: \l\nv12 := mload(0x01)\l\
 // "];
 // Block0_14 -> Block0_14Exit;
-// Block0_14Exit [label="{ If v24 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_14Exit [label="{ If v12 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block0_14Exit:0 -> Block0_20 [style="solid"];
 // Block0_14Exit:1 -> Block0_19 [style="solid"];
 // Block0_7 [label="\
-// Block 7; (21, max 21)\nLiveIn: v6[1], v3[1]\l\
-// LiveOut: v42[1], v3[1]\l\nv42 := add(1, v6)\l\
+// Block 7; (21, max 21)\nLiveIn: phi1[1], phi0[1]\l\
+// LiveOut: v19[1], phi0[1]\l\nUsed: phi1[1]\l\nv19 := add(0x01, phi1)\l\
 // "];
 // Block0_7 -> Block0_7Exit [arrowhead=none];
 // Block0_7Exit [label="Jump" shape=oval];
 // Block0_7Exit -> Block0_5 [style="dashed"];
 // Block0_15 [label="\
-// Block 15; (8, max 19)\nLiveIn: v13[4], v9[1], v6[1], v3[1]\l\
-// LiveOut: v13[2], v9[1], v6[1], v3[1]\l\nv13 := φ(\l\
-// 	Block 13 => v12,\l\
-// 	Block 17 => v21\l\
+// Block 15; (8, max 19)\nLiveIn: phi3[4], phi2[1], phi1[1], phi0[1]\l\
+// LiveOut: phi3[2], phi2[1], phi1[1], phi0[1]\l\nUsed: phi3[2]\l\nphi3 := φ(\l\
+// 	Block 13 => v7,\l\
+// 	Block 17 => v11\l\
 // )\l\
-// v14 := lt(3, v13)\l\
+// v8 := lt(0x03, phi3)\l\
 // "];
 // Block0_15 -> Block0_15Exit;
-// Block0_15Exit [label="{ If v14 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_15Exit [label="{ If v8 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block0_15Exit:0 -> Block0_18 [style="solid"];
 // Block0_15Exit:1 -> Block0_16 [style="solid"];
 // Block0_19 [label="\
-// Block 19; (13, max 19)\nLiveIn: v9[1], v6[1], v3[1]\l\
-// LiveOut: v25[1], v9[1], v6[1], v3[1]\l\nv25 := 0\l\
+// Block 19; (13, max 19)\nLiveIn: phi2[1], phi1[1], phi0[1]\l\
+// LiveOut: v13[1], phi2[1], phi1[1], phi0[1]\l\nUsed: \l\nv13 := 0x00\l\
 // "];
 // Block0_19 -> Block0_19Exit [arrowhead=none];
 // Block0_19Exit [label="Jump" shape=oval];
 // Block0_19Exit -> Block0_21 [style="solid"];
 // Block0_20 [label="\
-// Block 20; (18, max 19)\nLiveIn: v9[1], v6[1], v3[1]\l\
-// LiveOut: v9[1], v6[1], v3[1]\l\n"];
+// Block 20; (18, max 19)\nLiveIn: phi2[1], phi1[1], phi0[1]\l\
+// LiveOut: phi2[1], phi1[1], phi0[1]\l\nUsed: \l\n"];
 // Block0_20 -> Block0_20Exit [arrowhead=none];
 // Block0_20Exit [label="Jump" shape=oval];
 // Block0_20Exit -> Block0_11 [style="solid"];
 // Block0_16 [label="\
-// Block 16; (9, max 10)\nLiveIn: v13[2], v9[1], v6[1], v3[1]\l\
-// LiveOut: v13[1], v9[1], v6[1], v3[1]\l\nv18 := add(v6, v3)\l\
-// v19 := add(v9, v18)\l\
-// sstore(v19, v13)\l\
+// Block 16; (9, max 10)\nLiveIn: phi3[2], phi2[1], phi1[1], phi0[1]\l\
+// LiveOut: phi3[1], phi2[1], phi1[1], phi0[1]\l\nUsed: phi3[1]\l\nv9 := add(phi1, phi0)\l\
+// v10 := add(phi2, v9)\l\
+// sstore(v10, phi3)\l\
 // "];
 // Block0_16 -> Block0_16Exit [arrowhead=none];
 // Block0_16Exit [label="Jump" shape=oval];
 // Block0_16Exit -> Block0_17 [style="solid"];
 // Block0_18 [label="\
-// Block 18; (11, max 19)\nLiveIn: v9[1], v6[1], v3[1]\l\
-// LiveOut: v9[1], v6[1], v3[1]\l\n"];
+// Block 18; (11, max 19)\nLiveIn: phi2[1], phi1[1], phi0[1]\l\
+// LiveOut: phi2[1], phi1[1], phi0[1]\l\nUsed: \l\n"];
 // Block0_18 -> Block0_18Exit [arrowhead=none];
 // Block0_18Exit [label="Jump" shape=oval];
 // Block0_18Exit -> Block0_14 [style="solid"];
 // Block0_21 [label="\
-// Block 21; (14, max 19)\nLiveIn: v26[4], v9[1], v6[1], v3[1]\l\
-// LiveOut: v26[2], v9[1], v6[1], v3[1]\l\nv26 := φ(\l\
-// 	Block 19 => v25,\l\
-// 	Block 23 => v33\l\
+// Block 21; (14, max 19)\nLiveIn: phi9[4], phi2[1], phi1[1], phi0[1]\l\
+// LiveOut: phi9[2], phi2[1], phi1[1], phi0[1]\l\nUsed: phi9[2]\l\nphi9 := φ(\l\
+// 	Block 19 => v13,\l\
+// 	Block 23 => v17\l\
 // )\l\
-// v27 := lt(3, v26)\l\
+// v14 := lt(0x03, phi9)\l\
 // "];
 // Block0_21 -> Block0_21Exit;
-// Block0_21Exit [label="{ If v27 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_21Exit [label="{ If v14 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block0_21Exit:0 -> Block0_24 [style="solid"];
 // Block0_21Exit:1 -> Block0_22 [style="solid"];
 // Block0_11 [label="\
-// Block 11; (19, max 19)\nLiveIn: v9[1], v6[1], v3[1]\l\
-// LiveOut: v38[1], v6[1], v3[1]\l\nv38 := add(1, v9)\l\
+// Block 11; (19, max 19)\nLiveIn: phi2[1], phi1[1], phi0[1]\l\
+// LiveOut: v18[1], phi1[1], phi0[1]\l\nUsed: phi2[1]\l\nv18 := add(0x01, phi2)\l\
 // "];
 // Block0_11 -> Block0_11Exit [arrowhead=none];
 // Block0_11Exit [label="Jump" shape=oval];
 // Block0_11Exit -> Block0_9 [style="dashed"];
 // Block0_17 [label="\
-// Block 17; (10, max 10)\nLiveIn: v13[1], v9[1], v6[1], v3[1]\l\
-// LiveOut: v21[1], v9[1], v6[1], v3[1]\l\nv21 := add(1, v13)\l\
+// Block 17; (10, max 10)\nLiveIn: phi3[1], phi2[1], phi1[1], phi0[1]\l\
+// LiveOut: v11[1], phi2[1], phi1[1], phi0[1]\l\nUsed: phi3[1]\l\nv11 := add(0x01, phi3)\l\
 // "];
 // Block0_17 -> Block0_17Exit [arrowhead=none];
 // Block0_17Exit [label="Jump" shape=oval];
 // Block0_17Exit -> Block0_15 [style="dashed"];
 // Block0_22 [label="\
-// Block 22; (15, max 16)\nLiveIn: v26[2], v9[1], v6[1], v3[1]\l\
-// LiveOut: v26[1], v9[1], v6[1], v3[1]\l\nv31 := add(v6, v3)\l\
-// v32 := add(v9, v31)\l\
-// sstore(v32, v26)\l\
+// Block 22; (15, max 16)\nLiveIn: phi9[2], phi2[1], phi1[1], phi0[1]\l\
+// LiveOut: phi9[1], phi2[1], phi1[1], phi0[1]\l\nUsed: phi9[1]\l\nv15 := add(phi1, phi0)\l\
+// v16 := add(phi2, v15)\l\
+// sstore(v16, phi9)\l\
 // "];
 // Block0_22 -> Block0_22Exit [arrowhead=none];
 // Block0_22Exit [label="Jump" shape=oval];
 // Block0_22Exit -> Block0_23 [style="solid"];
 // Block0_24 [label="\
-// Block 24; (17, max 19)\nLiveIn: v9[1], v6[1], v3[1]\l\
-// LiveOut: v9[1], v6[1], v3[1]\l\n"];
+// Block 24; (17, max 19)\nLiveIn: phi2[1], phi1[1], phi0[1]\l\
+// LiveOut: phi2[1], phi1[1], phi0[1]\l\nUsed: \l\n"];
 // Block0_24 -> Block0_24Exit [arrowhead=none];
 // Block0_24Exit [label="Jump" shape=oval];
 // Block0_24Exit -> Block0_20 [style="solid"];
 // Block0_23 [label="\
-// Block 23; (16, max 16)\nLiveIn: v26[1], v9[1], v6[1], v3[1]\l\
-// LiveOut: v33[1], v9[1], v6[1], v3[1]\l\nv33 := add(1, v26)\l\
+// Block 23; (16, max 16)\nLiveIn: phi9[1], phi2[1], phi1[1], phi0[1]\l\
+// LiveOut: v17[1], phi2[1], phi1[1], phi0[1]\l\nUsed: phi9[1]\l\nv17 := add(0x01, phi9)\l\
 // "];
 // Block0_23 -> Block0_23Exit [arrowhead=none];
 // Block0_23Exit [label="Jump" shape=oval];

--- a/test/libyul/yulSSAControlFlowGraph/nested_function.yul
+++ b/test/libyul/yulSSAControlFlowGraph/nested_function.yul
@@ -37,9 +37,9 @@
 //
 // Entry0 [label="Entry"];
 // Entry0 -> Block0_0;
-// Block0_0 [label="\
+// Block0_0 [fillcolor="#FF746C", style=filled, label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
-// LiveOut: \l\n"];
+// LiveOut: \l\nUsed: \l\n"];
 // Block0_0Exit [label="MainExit"];
 // Block0_0 -> Block0_0Exit;
 // FunctionEntry_f_0 [label="function f:
@@ -47,20 +47,20 @@
 // FunctionEntry_f_0 -> Block1_0;
 // Block1_0 [label="\
 // Block 0; (0, max 0)\nLiveIn: v0[2], v1[1]\l\
-// LiveOut: v4[1]\l\nv3 := add(v1, v0)\l\
-// v4 := sub(v0, v3)\l\
+// LiveOut: v3[1]\l\nUsed: v0[2], v1[1]\l\nv2 := add(v1, v0)\l\
+// v3 := sub(v0, v2)\l\
 // "];
-// Block1_0Exit [label="FunctionReturn[v4]"];
+// Block1_0Exit [label="FunctionReturn[v3]"];
 // Block1_0 -> Block1_0Exit;
 // FunctionEntry_g_0 [label="function g:
 //  g()"];
 // FunctionEntry_g_0 -> Block2_0;
 // Block2_0 [label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
-// LiveOut: \l\nv1 := v()\l\
-// v2 := f(2, v1)\l\
-// v3 := z()\l\
-// sstore(v2, v3)\l\
+// LiveOut: \l\nUsed: \l\nv0 := v()\l\
+// v1 := f(0x02, v0)\l\
+// v2 := z()\l\
+// sstore(v1, v2)\l\
 // "];
 // Block2_0Exit [label="FunctionReturn[]"];
 // Block2_0 -> Block2_0Exit;
@@ -69,89 +69,89 @@
 // FunctionEntry_z_0 -> Block3_0;
 // Block3_0 [label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
-// LiveOut: v1[1]\l\nv1 := w()\l\
+// LiveOut: v0[1]\l\nUsed: \l\nv0 := w()\l\
 // "];
-// Block3_0Exit [label="FunctionReturn[v1]"];
+// Block3_0Exit [label="FunctionReturn[v0]"];
 // Block3_0 -> Block3_0Exit;
 // FunctionEntry_w_0 [label="function w:
 //  rw1 := w()"];
 // FunctionEntry_w_0 -> Block4_0;
 // Block4_0 [label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
-// LiveOut: v2[1]\l\nv2 := 1\l\
+// LiveOut: v0[1]\l\nUsed: \l\nv0 := 0x01\l\
 // "];
-// Block4_0Exit [label="FunctionReturn[v2]"];
+// Block4_0Exit [label="FunctionReturn[v0]"];
 // Block4_0 -> Block4_0Exit;
 // FunctionEntry_v_0 [label="function v:
 //  r := v()"];
 // FunctionEntry_v_0 -> Block5_0;
 // Block5_0 [label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
-// LiveOut: v1[1]\l\nv1 := w()\l\
+// LiveOut: v0[1]\l\nUsed: \l\nv0 := w()\l\
 // "];
-// Block5_0Exit [label="FunctionReturn[v1]"];
+// Block5_0Exit [label="FunctionReturn[v0]"];
 // Block5_0 -> Block5_0Exit;
 // FunctionEntry_w_0 [label="function w:
 //  rw2 := w()"];
 // FunctionEntry_w_0 -> Block6_0;
 // Block6_0 [label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
-// LiveOut: v2[1]\l\nv2 := 17\l\
+// LiveOut: v0[1]\l\nUsed: \l\nv0 := 0x11\l\
 // "];
-// Block6_0Exit [label="FunctionReturn[v2]"];
+// Block6_0Exit [label="FunctionReturn[v0]"];
 // Block6_0 -> Block6_0Exit;
 // FunctionEntry_cycle1_0 [label="function cycle1:
 //  r := cycle1()"];
 // FunctionEntry_cycle1_0 -> Block7_0;
 // Block7_0 [label="\
 // Block 0; (0, max 2)\nLiveIn: \l\
-// LiveOut: \l\nv2 := mload(3)\l\
+// LiveOut: \l\nUsed: \l\nv0 := mload(0x03)\l\
 // "];
 // Block7_0 -> Block7_0Exit;
-// Block7_0Exit [label="{ If v2 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block7_0Exit [label="{ If v0 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block7_0Exit:0 -> Block7_2 [style="solid"];
 // Block7_0Exit:1 -> Block7_1 [style="solid"];
 // Block7_1 [label="\
 // Block 1; (1, max 2)\nLiveIn: \l\
-// LiveOut: v3[1]\l\nv3 := cycle2()\l\
+// LiveOut: v1[1]\l\nUsed: \l\nv1 := cycle2()\l\
 // "];
 // Block7_1 -> Block7_1Exit [arrowhead=none];
 // Block7_1Exit [label="Jump" shape=oval];
 // Block7_1Exit -> Block7_2 [style="solid"];
 // Block7_2 [label="\
-// Block 2; (2, max 2)\nLiveIn: v4[3]\l\
-// LiveOut: v4[1]\l\nv4 := φ(\l\
-// 	Block 0 => 0,\l\
-// 	Block 1 => v3\l\
+// Block 2; (2, max 2)\nLiveIn: phi0[3]\l\
+// LiveOut: phi0[1]\l\nUsed: phi0[2]\l\nphi0 := φ(\l\
+// 	Block 0 => 0x00,\l\
+// 	Block 1 => v1\l\
 // )\l\
 // "];
-// Block7_2Exit [label="FunctionReturn[v4]"];
+// Block7_2Exit [label="FunctionReturn[phi0]"];
 // Block7_2 -> Block7_2Exit;
 // FunctionEntry_cycle2_0 [label="function cycle2:
 //  r := cycle2()"];
 // FunctionEntry_cycle2_0 -> Block8_0;
 // Block8_0 [label="\
 // Block 0; (0, max 2)\nLiveIn: \l\
-// LiveOut: \l\nv2 := mload(4)\l\
+// LiveOut: \l\nUsed: \l\nv0 := mload(0x04)\l\
 // "];
 // Block8_0 -> Block8_0Exit;
-// Block8_0Exit [label="{ If v2 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block8_0Exit [label="{ If v0 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block8_0Exit:0 -> Block8_2 [style="solid"];
 // Block8_0Exit:1 -> Block8_1 [style="solid"];
 // Block8_1 [label="\
 // Block 1; (1, max 2)\nLiveIn: \l\
-// LiveOut: v3[1]\l\nv3 := cycle1()\l\
+// LiveOut: v1[1]\l\nUsed: \l\nv1 := cycle1()\l\
 // "];
 // Block8_1 -> Block8_1Exit [arrowhead=none];
 // Block8_1Exit [label="Jump" shape=oval];
 // Block8_1Exit -> Block8_2 [style="solid"];
 // Block8_2 [label="\
-// Block 2; (2, max 2)\nLiveIn: v4[3]\l\
-// LiveOut: v4[1]\l\nv4 := φ(\l\
-// 	Block 0 => 0,\l\
-// 	Block 1 => v3\l\
+// Block 2; (2, max 2)\nLiveIn: phi0[3]\l\
+// LiveOut: phi0[1]\l\nUsed: phi0[2]\l\nphi0 := φ(\l\
+// 	Block 0 => 0x00,\l\
+// 	Block 1 => v1\l\
 // )\l\
 // "];
-// Block8_2Exit [label="FunctionReturn[v4]"];
+// Block8_2Exit [label="FunctionReturn[phi0]"];
 // Block8_2 -> Block8_2Exit;
 // }

--- a/test/libyul/yulSSAControlFlowGraph/switch.yul
+++ b/test/libyul/yulSSAControlFlowGraph/switch.yul
@@ -23,50 +23,50 @@
 // Entry0 -> Block0_0;
 // Block0_0 [label="\
 // Block 0; (0, max 5)\nLiveIn: \l\
-// LiveOut: v3[1]\l\nv1 := calldataload(3)\l\
-// v3 := sload(0)\l\
-// v4 := eq(0, v3)\l\
+// LiveOut: v1[1]\l\nUsed: \l\nv0 := calldataload(0x03)\l\
+// v1 := sload(0x00)\l\
+// v2 := eq(0x00, v1)\l\
 // "];
 // Block0_0 -> Block0_0Exit;
-// Block0_0Exit [label="{ If v4 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_0Exit [label="{ If v2 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block0_0Exit:0 -> Block0_3 [style="solid"];
 // Block0_0Exit:1 -> Block0_2 [style="solid"];
 // Block0_2 [label="\
 // Block 2; (1, max 2)\nLiveIn: \l\
-// LiveOut: v6[1]\l\nv6 := calldataload(77)\l\
+// LiveOut: v3[1]\l\nUsed: \l\nv3 := calldataload(0x4d)\l\
 // "];
 // Block0_2 -> Block0_2Exit [arrowhead=none];
 // Block0_2Exit [label="Jump" shape=oval];
 // Block0_2Exit -> Block0_1 [style="solid"];
 // Block0_3 [label="\
-// Block 3; (3, max 5)\nLiveIn: v3[1]\l\
-// LiveOut: \l\nv7 := eq(1, v3)\l\
+// Block 3; (3, max 5)\nLiveIn: v1[1]\l\
+// LiveOut: \l\nUsed: v1[1]\l\nv4 := eq(0x01, v1)\l\
 // "];
 // Block0_3 -> Block0_3Exit;
-// Block0_3Exit [label="{ If v7 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_3Exit [label="{ If v4 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block0_3Exit:0 -> Block0_5 [style="solid"];
 // Block0_3Exit:1 -> Block0_4 [style="solid"];
 // Block0_1 [label="\
-// Block 1; (2, max 2)\nLiveIn: v13[2]\l\
-// LiveOut: \l\nv13 := φ(\l\
-// 	Block 2 => v6,\l\
-// 	Block 4 => v10,\l\
-// 	Block 5 => v12\l\
+// Block 1; (2, max 2)\nLiveIn: phi0[2]\l\
+// LiveOut: \l\nUsed: phi0[2]\l\nphi0 := φ(\l\
+// 	Block 2 => v3,\l\
+// 	Block 4 => v5,\l\
+// 	Block 5 => v6\l\
 // )\l\
-// sstore(0, v13)\l\
+// sstore(0x00, phi0)\l\
 // "];
 // Block0_1Exit [label="MainExit"];
 // Block0_1 -> Block0_1Exit;
 // Block0_4 [label="\
 // Block 4; (4, max 4)\nLiveIn: \l\
-// LiveOut: v10[1]\l\nv10 := calldataload(88)\l\
+// LiveOut: v5[1]\l\nUsed: \l\nv5 := calldataload(0x58)\l\
 // "];
 // Block0_4 -> Block0_4Exit [arrowhead=none];
 // Block0_4Exit [label="Jump" shape=oval];
 // Block0_4Exit -> Block0_1 [style="solid"];
 // Block0_5 [label="\
 // Block 5; (5, max 5)\nLiveIn: \l\
-// LiveOut: v12[1]\l\nv12 := calldataload(99)\l\
+// LiveOut: v6[1]\l\nUsed: \l\nv6 := calldataload(0x63)\l\
 // "];
 // Block0_5 -> Block0_5Exit [arrowhead=none];
 // Block0_5Exit [label="Jump" shape=oval];

--- a/test/libyul/yulSSAControlFlowGraph/switch_const.yul
+++ b/test/libyul/yulSSAControlFlowGraph/switch_const.yul
@@ -43,12 +43,12 @@
 //
 // Entry0 [label="Entry"];
 // Entry0 -> Block0_0;
-// Block0_0 [label="\
+// Block0_0 [fillcolor="#FF746C", style=filled, label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
-// LiveOut: \l\nv1 := calldataload(3)\l\
-// v4 := calldataload(88)\l\
-// v7 := calldataload(99)\l\
-// sstore(0, v7)\l\
+// LiveOut: \l\nUsed: \l\nv0 := calldataload(0x03)\l\
+// v1 := calldataload(0x58)\l\
+// v2 := calldataload(0x63)\l\
+// sstore(0x00, v2)\l\
 // "];
 // Block0_0Exit [label="MainExit"];
 // Block0_0 -> Block0_0Exit;


### PR DESCRIPTION
- replace `std::variant` for `SSACFG::ValueId` by tagged union
- replace `std::deque` in `SSACFGBuilder` by a `std::vector`, possible by carefully reording operations in recursive variable definition chain
- make ssacfg json serialization stateless (it was stateless already but wrapped in a class)

Makes the ssa cfg builder 26.5% faster.