### PR TITLE
Fix variable cleanup docs: max int8 has 7 bits set to 1, not 8 bits

### DIFF
--- a/docs/internals/variable_cleanup.rst
+++ b/docs/internals/variable_cleanup.rst
@@ -91,7 +91,7 @@ Positive
     0000...0000 0000 0001
     0000...0000 0000 0010
     ....
-    0000...0000 1111 1111
+    0000...0000 0111 1111
 
 The compiler will ``signextend`` the sign bit, which is 1 for negative and 0 for
 positive values, overwriting the higher bits:


### PR DESCRIPTION
before:   0000...0000 1111 1111
after:      0000...0000 0111 1111