### PR TITLE
Update smtchecker.rst: fix int128 range = [-2^127,2^127-1], was ^128

### DIFF
--- a/docs/smtchecker.rst
+++ b/docs/smtchecker.rst
@@ -263,7 +263,7 @@ A common type of properties in smart contracts are properties that involve the
 state of the contract. Multiple transactions might be needed to make an assertion
 fail for such a property.
 
-As an example, consider a 2D grid where both axis have coordinates in the range (-2^128, 2^128 - 1).
+As an example, consider a 2D grid where both axis have coordinates in the range (-2^127, 2^127 - 1).
 Let us place a robot at position (0, 0). The robot can only move diagonally, one step at a time,
 and cannot move outside the grid. The robot's state machine can be represented by the smart contract
 below.


### PR DESCRIPTION
In the text description of the **State Properties** paragraph:
[...]
As an example, consider a 2D grid where both axis have coordinates in the range (-2^128, 2^128 - 1).
[...]

In the example:
[...]
require(x > type(int128).min && x < type(int128).max);
require(y > type(int128).min && y < type(int128).max);
[...]

With int128 we use a bit for the sign, then 127 bits remain for the value.

Changed in the text description to be coherent:
...in the range (-2^127, 2^127 - 1).