### PR TITLE
fix: unify ForLoop traversal order between ASTWalker and ASTModifier

### DIFF
--- a/libyul/optimiser/ASTWalker.cpp
+++ b/libyul/optimiser/ASTWalker.cpp
@@ -148,8 +148,8 @@ void ASTModifier::operator()(ForLoop& _for)
 {
 	(*this)(_for.pre);
 	visit(*_for.condition);
-	(*this)(_for.post);
 	(*this)(_for.body);
+	(*this)(_for.post);
 }
 
 void ASTModifier::operator()(Break&)


### PR DESCRIPTION
Standardize ForLoop traversal to pre→condition→body→post order in ASTModifier to match ASTWalker. This ensures consistent behavior when inheriting from both classes and prevents potential bugs in optimizers that depend on traversal order.