### PR TITLE
Chore: drop unused isfile import from wasm isolate script

### DIFF
--- a/scripts/wasm-rebuild/docker-scripts/isolate_tests.py
+++ b/scripts/wasm-rebuild/docker-scripts/isolate_tests.py
@@ -7,8 +7,7 @@ import sys
 import re
 import os
 import hashlib
-# Pylint for some reason insists that isfile() is unused
-from os.path import join, isfile  # pylint: disable=unused-import
+from os.path import join
 
 
 def extract_test_cases(path):


### PR DESCRIPTION
Remove the unused isfile import and the obsolete pylint suppression from scripts/wasm-rebuild/docker-scripts/isolate_tests.py keep the required join helper so the script’s filesystem traversal remains intact let tooling surface genuine dead-import issues instead of hiding them behind suppressions