### PR TITLE
Remove unused <functional> include from GasEstimator.cpp

### DIFF
--- a/libsolidity/interface/GasEstimator.cpp
+++ b/libsolidity/interface/GasEstimator.cpp
@@ -33,7 +33,6 @@
 #include <libsolutil/FunctionSelector.h>
 #include <libsolutil/Keccak256.h>
 
-#include <functional>
 #include <map>
 #include <memory>
 


### PR DESCRIPTION
Remove the unused <functional> header from libsolidity/interface/GasEstimator.cpp