### PR TITLE
Fix parse_bool handling of "false" values in parse_eth_gas_report

### DIFF
--- a/scripts/externalTests/parse_eth_gas_report.py
+++ b/scripts/externalTests/parse_eth_gas_report.py
@@ -115,12 +115,10 @@ class GasReport:
 
 
 def parse_bool(input_string: str) -> bool:
-    if input_string == 'true':
-        return True
-    elif input_string == 'false':
-        return True
-    else:
+    if input_string not in ('true', 'false'):
         raise ValueError(f"Invalid boolean value: '{input_string}'")
+
+    return input_string == 'true'
 
 
 def parse_optional_int(input_string: str, default: Optional[int] = None) -> Optional[int]:


### PR DESCRIPTION
Correct parse_bool so only the string "true" maps to True, "false" maps to False. Guard against unexpected inputs by raising a clear ValueError for anything else.