### PR TITLE
Optimize pagination aggregation in rest_api_helpers

### DIFF
--- a/scripts/common/rest_api_helpers.py
+++ b/scripts/common/rest_api_helpers.py
@@ -1,9 +1,7 @@
 from os import environ
 from pathlib import Path
 from typing import List, Mapping, Optional
-import functools
 import json
-import operator
 import shutil
 
 import requests
@@ -127,7 +125,11 @@ class CircleCI:
                 break
 
     def paginated_query_api(self, url: str, params: Mapping[str, str], max_pages: int = DEFAULT_MAX_PAGES):
-        return functools.reduce(operator.add, self.paginated_query_api_iterator(url, params, max_pages), [])
+        return [
+            item
+            for page in self.paginated_query_api_iterator(url, params, max_pages)
+            for item in page
+        ]
 
     def pipelines(
         self,


### PR DESCRIPTION
Replace the functools.reduce(operator.add, …) flattening with a single list-comprehension, avoiding repeated list reallocations when many pages are returned drop the now-unused functools and operator imports