### PR TITLE
Remove redundant process import from prepare_report.js

### DIFF
--- a/scripts/bytecodecompare/prepare_report.js
+++ b/scripts/bytecodecompare/prepare_report.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-const process = require('process')
 const fs = require('fs')
 
 const compiler = require('solc')


### PR DESCRIPTION
drop the unused require('process') import from scripts/bytecodecompare/prepare_report.js; Node exposes process globally, so the extra import was dead code, behavior stays the same, keeps the script cleaner for reviewers