### PR TITLE
fix: replace CMAKE_SOURCE_DIR with CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/cmake/fmtlib.cmake
+++ b/cmake/fmtlib.cmake
@@ -1,9 +1,9 @@
-include(${CMAKE_SOURCE_DIR}/cmake/submodules.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/submodules.cmake)
 initialize_submodule(fmtlib)
 
 set(FMT_SYSTEM_HEADERS ON)
 add_subdirectory(
-	${CMAKE_SOURCE_DIR}/deps/fmtlib
+	${CMAKE_CURRENT_SOURCE_DIR}/deps/fmtlib
 	EXCLUDE_FROM_ALL
 )
 

--- a/cmake/nlohmann-json.cmake
+++ b/cmake/nlohmann-json.cmake
@@ -1,9 +1,9 @@
-include(${CMAKE_SOURCE_DIR}/cmake/submodules.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/submodules.cmake)
 initialize_submodule(nlohmann-json)
 
 set(JSON_Install OFF CACHE INTERNAL "")
 add_subdirectory(
-	${CMAKE_SOURCE_DIR}/deps/nlohmann-json
+	${CMAKE_CURRENT_SOURCE_DIR}/deps/nlohmann-json
 	EXCLUDE_FROM_ALL
 )
 

--- a/cmake/range-v3.cmake
+++ b/cmake/range-v3.cmake
@@ -1,11 +1,11 @@
-include(${CMAKE_SOURCE_DIR}/cmake/submodules.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/submodules.cmake)
 initialize_submodule(range-v3)
 
 add_library(range-v3 INTERFACE IMPORTED)
 set_target_properties(range-v3 PROPERTIES
 	INTERFACE_COMPILE_OPTIONS "\$<\$<CXX_COMPILER_ID:MSVC>:/permissive->"
-	INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR}/deps/range-v3/include
-	INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR}/deps/range-v3/include
+	INTERFACE_SYSTEM_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/deps/range-v3/include
+	INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/deps/range-v3/include
 )
 add_dependencies(range-v3 range-v3-project)
 

--- a/cmake/submodules.cmake
+++ b/cmake/submodules.cmake
@@ -1,18 +1,18 @@
 macro(initialize_submodule SUBMODULE_PATH)
 	if(NOT IGNORE_VENDORED_DEPENDENCIES)
-		file(GLOB submodule_contents "${CMAKE_SOURCE_DIR}/deps/${SUBMODULE_PATH}/*")
+		file(GLOB submodule_contents "${CMAKE_CURRENT_SOURCE_DIR}/deps/${SUBMODULE_PATH}/*")
 
 		if(submodule_contents)
 			message(STATUS "git submodule '${SUBMODULE_PATH}' seem to be already initialized: nothing to do.")
 		else()
-			message(STATUS "git submodule '${SUBMODULE_PATH}' seem not to be initialized: implicitly executing 'git submodule update --init '${CMAKE_SOURCE_DIR}/deps/${SUBMODULE_PATH}'.")
+			message(STATUS "git submodule '${SUBMODULE_PATH}' seem not to be initialized: implicitly executing 'git submodule update --init '${CMAKE_CURRENT_SOURCE_DIR}/deps/${SUBMODULE_PATH}'.")
 			find_package(Git)
 			if(NOT Git_FOUND)
 				message(FATAL_ERROR "Failed to initialize submodules: 'git' command not found.")
 			endif()
 			execute_process(
-					COMMAND git submodule update --init ${CMAKE_SOURCE_DIR}/deps/${SUBMODULE_PATH}
-					WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+					COMMAND git submodule update --init ${CMAKE_CURRENT_SOURCE_DIR}/deps/${SUBMODULE_PATH}
+					WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 					RESULT_VARIABLE result
 			)
 			if(NOT result EQUAL 0)


### PR DESCRIPTION
This PR replaces occurrences of `CMAKE_SOURCE_DIR` in the CMake configuration file with `CMAKE_CURRENT_SOURCE_DIR`. This change would allow the project to be usable as a CMake dependency for other CMake projects.