### PR TITLE
chore: remove unused optional include from wallet test

### DIFF
--- a/test/contracts/Wallet.cpp
+++ b/test/contracts/Wallet.cpp
@@ -25,7 +25,6 @@
 
 #include <string>
 #include <tuple>
-#include <optional>
 
 #if defined(_MSC_VER)
 #pragma warning(push)


### PR DESCRIPTION
Verified with rg "optional" solidity/test/contracts/Wallet.cpp that the file never touches std::optional. Dropped the redundant #include <optional> to keep the translation unit’s dependency surface minimal. No behaviour changes; compilation output stays identical, just avoids parsing an unnecessary header.