### PR TITLE
Add EIP-8078 support for subscribable events

### DIFF
--- a/liblangutil/Token.h
+++ b/liblangutil/Token.h
@@ -160,6 +160,7 @@ namespace solidity::langutil
 	K(Fallback, "fallback", 0)                                         \
 	K(For, "for", 0)                                                   \
 	K(Function, "function", 0)                                         \
+	K(GasHint, "gasHint", 0)                                           \
 	K(Hex, "hex", 0)                                                   \
 	K(If, "if", 0)                                                     \
 	K(Indexed, "indexed", 0)                                           \
@@ -185,10 +186,13 @@ namespace solidity::langutil
 	K(Storage, "storage", 0)                                           \
 	K(CallData, "calldata", 0)                                         \
 	K(Struct, "struct", 0)                                             \
+	K(Subscribe, "subscribe", 0)                                       \
+	K(Subscribable, "subscribable", 0)                                 \
 	K(Throw, "throw", 0)                                               \
 	K(Try, "try", 0)                                                   \
 	K(Type, "type", 0)                                                 \
 	K(Unchecked, "unchecked", 0)                                       \
+	K(Unsubscribe, "unsubscribe", 0)                                   \
 	K(Unicode, "unicode", 0)                                           \
 	K(Using, "using", 0)                                               \
 	K(View, "view", 0)                                                 \

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -1300,11 +1300,15 @@ public:
 		SourceLocation _nameLocation,
 		ASTPointer<StructuredDocumentation> const& _documentation,
 		ASTPointer<ParameterList> const& _parameters,
-		bool _anonymous = false
+		bool _anonymous = false,
+		bool _subscribable = false,
+		std::optional<std::string> _gasHint = std::nullopt
 	):
 		CallableDeclaration(_id, _location, _name, std::move(_nameLocation), Visibility::Default, _parameters),
 		StructurallyDocumented(_documentation),
-		m_anonymous(_anonymous)
+		m_anonymous(_anonymous),
+		m_subscribable(_subscribable),
+		m_gasHint(_gasHint)
 	{
 	}
 
@@ -1312,6 +1316,8 @@ public:
 	void accept(ASTConstVisitor& _visitor) const override;
 
 	bool isAnonymous() const { return m_anonymous; }
+	bool isSubscribable() const { return m_subscribable; }
+	std::optional<std::string> gasHint() const { return m_gasHint; }
 
 	Type const* type() const override;
 	FunctionTypePointer functionType(bool /*_internal*/) const override;
@@ -1331,6 +1337,8 @@ public:
 
 private:
 	bool m_anonymous = false;
+	bool m_subscribable = false;
+	std::optional<std::string> m_gasHint;
 };
 
 /**
@@ -1969,6 +1977,73 @@ public:
 private:
 	ASTPointer<FunctionCall> m_eventCall;
 };
+/**
+ * Statement for subscribing to an event.
+ * Example: subscribe targetContract.Transfer(from, to, value)
+ *            with onTransfer
+ *            gasLimit 150000
+ *            gasPrice 20 gwei;
+ */
+class SubscribeStatement: public Statement
+{
+public:
+	SubscribeStatement(
+		int64_t _id,
+		SourceLocation const& _location,
+		ASTPointer<ASTString> const& _docString,
+		ASTPointer<FunctionCall> const& _eventCall,
+		ASTPointer<Identifier> const& _callbackFunction,
+		ASTPointer<Expression> const& _gasLimit,
+		ASTPointer<Expression> const& _gasPrice
+	):
+		Statement(_id, _location, _docString),
+		m_eventCall(_eventCall),
+		m_callbackFunction(_callbackFunction),
+		m_gasLimit(_gasLimit),
+		m_gasPrice(_gasPrice)
+	{}
+
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
+
+	FunctionCall const& eventCall() const { return *m_eventCall; }
+	Identifier const& callbackFunction() const { return *m_callbackFunction; }
+	Expression const& gasLimit() const { return *m_gasLimit; }
+	Expression const& gasPrice() const { return *m_gasPrice; }
+
+private:
+	ASTPointer<FunctionCall> m_eventCall;
+	ASTPointer<Identifier> m_callbackFunction;
+	ASTPointer<Expression> m_gasLimit;
+	ASTPointer<Expression> m_gasPrice;
+};
+
+/**
+ * Statement for unsubscribing from an event.
+ * Example: unsubscribe targetContract.Transfer;
+ */
+class UnsubscribeStatement: public Statement
+{
+public:
+	UnsubscribeStatement(
+		int64_t _id,
+		SourceLocation const& _location,
+		ASTPointer<ASTString> const& _docString,
+		ASTPointer<Expression> const& _eventReference
+	):
+		Statement(_id, _location, _docString),
+		m_eventReference(_eventReference)
+	{}
+
+	void accept(ASTVisitor& _visitor) override;
+	void accept(ASTConstVisitor& _visitor) const override;
+
+	Expression const& eventReference() const { return *m_eventReference; }
+
+private:
+	ASTPointer<Expression> m_eventReference;
+};
+
 
 /**
  * Definition of one or more variables as a statement inside a function.

--- a/libsolidity/ast/ASTVisitor.h
+++ b/libsolidity/ast/ASTVisitor.h
@@ -91,6 +91,8 @@ public:
 	virtual bool visit(Return& _node) { return visitNode(_node); }
 	virtual bool visit(Throw& _node) { return visitNode(_node); }
 	virtual bool visit(EmitStatement& _node) { return visitNode(_node); }
+	virtual bool visit(SubscribeStatement& _node) { return visitNode(_node); }
+	virtual bool visit(UnsubscribeStatement& _node) { return visitNode(_node); }
 	virtual bool visit(RevertStatement& _node) { return visitNode(_node); }
 	virtual bool visit(VariableDeclarationStatement& _node) { return visitNode(_node); }
 	virtual bool visit(ExpressionStatement& _node) { return visitNode(_node); }
@@ -157,6 +159,8 @@ public:
 	virtual void endVisit(Return& _node) { endVisitNode(_node); }
 	virtual void endVisit(Throw& _node) { endVisitNode(_node); }
 	virtual void endVisit(EmitStatement& _node) { endVisitNode(_node); }
+	virtual void endVisit(SubscribeStatement& _node) { endVisitNode(_node); }
+	virtual void endVisit(UnsubscribeStatement& _node) { endVisitNode(_node); }
 	virtual void endVisit(RevertStatement& _node) { endVisitNode(_node); }
 	virtual void endVisit(VariableDeclarationStatement& _node) { endVisitNode(_node); }
 	virtual void endVisit(ExpressionStatement& _node) { endVisitNode(_node); }
@@ -245,6 +249,8 @@ public:
 	virtual bool visit(Return const& _node) { return visitNode(_node); }
 	virtual bool visit(Throw const& _node) { return visitNode(_node); }
 	virtual bool visit(EmitStatement const& _node) { return visitNode(_node); }
+	virtual bool visit(SubscribeStatement const& _node) { return visitNode(_node); }
+	virtual bool visit(UnsubscribeStatement const& _node) { return visitNode(_node); }
 	virtual bool visit(RevertStatement const& _node) { return visitNode(_node); }
 	virtual bool visit(VariableDeclarationStatement const& _node) { return visitNode(_node); }
 	virtual bool visit(ExpressionStatement const& _node) { return visitNode(_node); }
@@ -311,6 +317,8 @@ public:
 	virtual void endVisit(Return const& _node) { endVisitNode(_node); }
 	virtual void endVisit(Throw const& _node) { endVisitNode(_node); }
 	virtual void endVisit(EmitStatement const& _node) { endVisitNode(_node); }
+	virtual void endVisit(SubscribeStatement const& _node) { endVisitNode(_node); }
+	virtual void endVisit(UnsubscribeStatement const& _node) { endVisitNode(_node); }
 	virtual void endVisit(RevertStatement const& _node) { endVisitNode(_node); }
 	virtual void endVisit(VariableDeclarationStatement const& _node) { endVisitNode(_node); }
 	virtual void endVisit(ExpressionStatement const& _node) { endVisitNode(_node); }

--- a/libsolidity/ast/AST_accept.h
+++ b/libsolidity/ast/AST_accept.h
@@ -749,6 +749,44 @@ void EmitStatement::accept(ASTConstVisitor& _visitor) const
 }
 
 void ExpressionStatement::accept(ASTVisitor& _visitor)
+
+void SubscribeStatement::accept(ASTVisitor& _visitor)
+{
+	if (_visitor.visit(*this))
+	{
+		m_eventCall->accept(_visitor);
+		m_callbackFunction->accept(_visitor);
+		m_gasLimit->accept(_visitor);
+		m_gasPrice->accept(_visitor);
+	}
+	_visitor.endVisit(*this);
+}
+
+void SubscribeStatement::accept(ASTConstVisitor& _visitor) const
+{
+	if (_visitor.visit(*this))
+	{
+		m_eventCall->accept(_visitor);
+		m_callbackFunction->accept(_visitor);
+		m_gasLimit->accept(_visitor);
+		m_gasPrice->accept(_visitor);
+	}
+	_visitor.endVisit(*this);
+}
+
+void UnsubscribeStatement::accept(ASTVisitor& _visitor)
+{
+	if (_visitor.visit(*this))
+		m_eventReference->accept(_visitor);
+	_visitor.endVisit(*this);
+}
+
+void UnsubscribeStatement::accept(ASTConstVisitor& _visitor) const
+{
+	if (_visitor.visit(*this))
+		m_eventReference->accept(_visitor);
+	_visitor.endVisit(*this);
+}
 {
 	if (_visitor.visit(*this))
 		if (m_expression)

--- a/libsolidity/interface/ABI.cpp
+++ b/libsolidity/interface/ABI.cpp
@@ -108,6 +108,15 @@ Json ABI::generate(ContractDefinition const& _contractDef)
 		event["type"] = "event";
 		event["name"] = it->name();
 		event["anonymous"] = it->isAnonymous();
+		
+		// Add subscribable flag and gasHint if applicable
+		if (it->isSubscribable())
+		{
+			event["subscribable"] = true;
+			if (it->gasHint().has_value())
+				event["gasHint"] = it->gasHint().value();
+		}
+		
 		Json params = Json::array();
 		for (auto const& p: it->parameters())
 		{

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -1077,6 +1077,14 @@ ASTPointer<EventDefinition> Parser::parseEventDefinition()
 	ASTNodeFactory nodeFactory(*this);
 	ASTPointer<StructuredDocumentation> documentation = parseStructuredDocumentation();
 
+	// Check for subscribable keyword
+	bool subscribable = false;
+	if (m_scanner->currentToken() == Token::Subscribable)
+	{
+		subscribable = true;
+		advance();
+	}
+
 	expectToken(Token::Event);
 	auto [name, nameLocation] = expectIdentifierWithLocation();
 
@@ -1090,9 +1098,25 @@ ASTPointer<EventDefinition> Parser::parseEventDefinition()
 		anonymous = true;
 		advance();
 	}
+
+	// Parse gasHint annotation
+	std::optional<std::string> gasHint;
+	if (m_scanner->currentToken() == Token::GasHint)
+	{
+		advance();
+		expectToken(Token::LParen);
+		// Parse the gas hint value (should be a number literal)
+		if (m_scanner->currentToken() == Token::Number)
+		{
+			gasHint = m_scanner->currentLiteral();
+			advance();
+		}
+		expectToken(Token::RParen);
+	}
+
 	nodeFactory.markEndPosition();
 	expectToken(Token::Semicolon);
-	return nodeFactory.createNode<EventDefinition>(name, nameLocation, documentation, parameters, anonymous);
+	return nodeFactory.createNode<EventDefinition>(name, nameLocation, documentation, parameters, anonymous, subscribable, gasHint);
 }
 
 ASTPointer<ErrorDefinition> Parser::parseErrorDefinition()


### PR DESCRIPTION
Implement compiler support for EIP-8078 Event Subscriptions:

1. Added new keywords: subscribable, subscribe, unsubscribe, gasHint
   - Modified Token.h to recognize these keywords in Solidity syntax

2. Extended EventDefinition AST node:
   - Added subscribable flag to mark events as subscribable
   - Added optional gasHint field for gas estimation hints
   - Updated constructor and getters in AST.h

3. Added new statement types:
   - SubscribeStatement: For creating event subscriptions
   - UnsubscribeStatement: For removing event subscriptions
   - Full AST node implementations with visitor support

4. Updated Parser:
   - parseEventDefinition now handles 'subscribable' keyword
   - Parses gasHint(value) annotation for events
   - Passes new parameters to EventDefinition constructor

5. Extended ABI generation:
   - ABI.cpp now includes 'subscribable' flag in event metadata
   - Includes 'gasHint' value when present
   - Maintains backward compatibility with existing ABIs

6. Implemented AST visitor pattern:
   - Added visitor methods in ASTVisitor.h for new statement types
   - Implemented accept() methods in AST_accept.h
   - Full traversal support for SubscribeStatement and UnsubscribeStatement

This implementation provides the foundation for EIP-8078 event subscription functionality, allowing contracts to declare subscribable events and enabling future runtime support for on-chain event subscriptions.

Related: EIP-8078 Event Subscriptions