### PR TITLE
Replace `transfer` (deprecated) occurrences with `call` in smt tests

### DIFF
--- a/test/cmdlineTests/model_checker_targets_assert_chc/err
+++ b/test/cmdlineTests/model_checker_targets_assert_chc/err
@@ -1,20 +1,16 @@
-Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
-  --> input.sol:10:3:
-   |
-10 | 		a.transfer(x);
-   | 		^^^^^^^^^^
-
 Warning: CHC: Assertion violation happens here.
 Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = true
 
 Transaction trace:
 test.constructor()
 State: arr = []
 test.f(0x0, 1)
-  --> input.sol:11:3:
+    a.call{value: x}("") -- untrusted external call
+  --> input.sol:12:3:
    |
-11 | 		assert(x > 0);
+12 | 		assert(x > 0);
    | 		^^^^^^^^^^^^^

--- a/test/cmdlineTests/model_checker_targets_assert_chc/input.sol
+++ b/test/cmdlineTests/model_checker_targets_assert_chc/input.sol
@@ -7,7 +7,8 @@ contract test {
 		--x;
 		x + type(uint).max;
 		2 / x;
-		a.transfer(x);
+		(bool success, ) = a.call{value: x}("");
+		require(success);
 		assert(x > 0);
 		arr.pop();
 		arr[x];

--- a/test/cmdlineTests/model_checker_targets_constant_condition_chc/err
+++ b/test/cmdlineTests/model_checker_targets_constant_condition_chc/err
@@ -1,5 +1,0 @@
-Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
-  --> input.sol:11:3:
-   |
-11 | 		a.transfer(x);
-   | 		^^^^^^^^^^

--- a/test/cmdlineTests/model_checker_targets_constant_condition_chc/input.sol
+++ b/test/cmdlineTests/model_checker_targets_constant_condition_chc/input.sol
@@ -8,7 +8,8 @@ contract test {
 		--x;
 		x + type(uint).max;
 		2 / x;
-		a.transfer(x);
+		(bool success, ) = a.call{value: x}("");
+		require(success);
 		assert(x > 0);
 		arr.pop();
 		arr[x];

--- a/test/cmdlineTests/model_checker_targets_div_by_zero_chc/err
+++ b/test/cmdlineTests/model_checker_targets_div_by_zero_chc/err
@@ -1,14 +1,9 @@
-Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
-  --> input.sol:10:3:
-   |
-10 | 		a.transfer(x);
-   | 		^^^^^^^^^^
-
 Warning: CHC: Division by zero happens here.
 Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = false
 
 Transaction trace:
 test.constructor()

--- a/test/cmdlineTests/model_checker_targets_div_by_zero_chc/input.sol
+++ b/test/cmdlineTests/model_checker_targets_div_by_zero_chc/input.sol
@@ -7,7 +7,8 @@ contract test {
 		--x;
 		x + type(uint).max;
 		2 / x;
-		a.transfer(x);
+		(bool success, ) = a.call{value: x}("");
+		require(success);
 		assert(x > 0);
 		arr.pop();
 		arr[x];

--- a/test/cmdlineTests/model_checker_targets_error/input.sol
+++ b/test/cmdlineTests/model_checker_targets_error/input.sol
@@ -7,7 +7,8 @@ contract test {
 		--x;
 		x + type(uint).max;
 		2 / x;
-		a.transfer(x);
+		(bool success, ) = a.call{value: x}("");
+		require(success);
 		assert(x > 0);
 		arr.pop();
 		arr[x];

--- a/test/cmdlineTests/model_checker_targets_out_of_bounds_chc/err
+++ b/test/cmdlineTests/model_checker_targets_out_of_bounds_chc/err
@@ -1,20 +1,16 @@
-Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
-  --> input.sol:10:3:
-   |
-10 | 		a.transfer(x);
-   | 		^^^^^^^^^^
-
 Warning: CHC: Out of bounds access happens here.
 Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = true
 
 Transaction trace:
 test.constructor()
 State: arr = []
 test.f(0x0, 1)
-  --> input.sol:13:3:
+    a.call{value: x}("") -- untrusted external call
+  --> input.sol:14:3:
    |
-13 | 		arr[x];
+14 | 		arr[x];
    | 		^^^^^^

--- a/test/cmdlineTests/model_checker_targets_out_of_bounds_chc/input.sol
+++ b/test/cmdlineTests/model_checker_targets_out_of_bounds_chc/input.sol
@@ -7,7 +7,8 @@ contract test {
 		--x;
 		x + type(uint).max;
 		2 / x;
-		a.transfer(x);
+		(bool success, ) = a.call{value: x}("");
+		require(success);
 		assert(x > 0);
 		arr.pop();
 		arr[x];

--- a/test/cmdlineTests/model_checker_targets_overflow_chc/err
+++ b/test/cmdlineTests/model_checker_targets_overflow_chc/err
@@ -1,14 +1,9 @@
-Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
-  --> input.sol:10:3:
-   |
-10 | 		a.transfer(x);
-   | 		^^^^^^^^^^
-
 Warning: CHC: Overflow (resulting value larger than 2**256 - 1) happens here.
 Counterexample:
 arr = []
 a = 0x0
 x = 1
+success = false
 
 Transaction trace:
 test.constructor()

--- a/test/cmdlineTests/model_checker_targets_overflow_chc/input.sol
+++ b/test/cmdlineTests/model_checker_targets_overflow_chc/input.sol
@@ -7,7 +7,8 @@ contract test {
 		--x;
 		x + type(uint).max;
 		2 / x;
-		a.transfer(x);
+		(bool success, ) = a.call{value: x}("");
+		require(success);
 		assert(x > 0);
 		arr.pop();
 		arr[x];

--- a/test/cmdlineTests/model_checker_targets_pop_empty_chc/err
+++ b/test/cmdlineTests/model_checker_targets_pop_empty_chc/err
@@ -1,20 +1,16 @@
-Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
-  --> input.sol:10:3:
-   |
-10 | 		a.transfer(x);
-   | 		^^^^^^^^^^
-
 Warning: CHC: Empty array "pop" happens here.
 Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = true
 
 Transaction trace:
 test.constructor()
 State: arr = []
 test.f(0x0, 1)
-  --> input.sol:12:3:
+    a.call{value: x}("") -- untrusted external call
+  --> input.sol:13:3:
    |
-12 | 		arr.pop();
+13 | 		arr.pop();
    | 		^^^^^^^^^

--- a/test/cmdlineTests/model_checker_targets_pop_empty_chc/input.sol
+++ b/test/cmdlineTests/model_checker_targets_pop_empty_chc/input.sol
@@ -7,7 +7,8 @@ contract test {
 		--x;
 		x + type(uint).max;
 		2 / x;
-		a.transfer(x);
+		(bool success, ) = a.call{value: x}("");
+		require(success);
 		assert(x > 0);
 		arr.pop();
 		arr[x];

--- a/test/cmdlineTests/model_checker_targets_underflow_chc/err
+++ b/test/cmdlineTests/model_checker_targets_underflow_chc/err
@@ -1,14 +1,9 @@
-Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
-  --> input.sol:10:3:
-   |
-10 | 		a.transfer(x);
-   | 		^^^^^^^^^^
-
 Warning: CHC: Underflow (resulting value less than 0) happens here.
 Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = false
 
 Transaction trace:
 test.constructor()

--- a/test/cmdlineTests/model_checker_targets_underflow_chc/input.sol
+++ b/test/cmdlineTests/model_checker_targets_underflow_chc/input.sol
@@ -7,7 +7,8 @@ contract test {
 		--x;
 		x + type(uint).max;
 		2 / x;
-		a.transfer(x);
+		(bool success, ) = a.call{value: x}("");
+		require(success);
 		assert(x > 0);
 		arr.pop();
 		arr[x];

--- a/test/cmdlineTests/model_checker_targets_underflow_overflow_assert_chc/err
+++ b/test/cmdlineTests/model_checker_targets_underflow_overflow_assert_chc/err
@@ -1,14 +1,9 @@
-Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
-  --> input.sol:10:3:
-   |
-10 | 		a.transfer(x);
-   | 		^^^^^^^^^^
-
 Warning: CHC: Underflow (resulting value less than 0) happens here.
 Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = false
 
 Transaction trace:
 test.constructor()
@@ -24,6 +19,7 @@ Counterexample:
 arr = []
 a = 0x0
 x = 1
+success = false
 
 Transaction trace:
 test.constructor()
@@ -39,12 +35,14 @@ Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = true
 
 Transaction trace:
 test.constructor()
 State: arr = []
 test.f(0x0, 1)
-  --> input.sol:11:3:
+    a.call{value: x}("") -- untrusted external call
+  --> input.sol:12:3:
    |
-11 | 		assert(x > 0);
+12 | 		assert(x > 0);
    | 		^^^^^^^^^^^^^

--- a/test/cmdlineTests/model_checker_targets_underflow_overflow_assert_chc/input.sol
+++ b/test/cmdlineTests/model_checker_targets_underflow_overflow_assert_chc/input.sol
@@ -7,7 +7,8 @@ contract test {
 		--x;
 		x + type(uint).max;
 		2 / x;
-		a.transfer(x);
+		(bool success, ) = a.call{value: x}("");
+		require(success);
 		assert(x > 0);
 		arr.pop();
 		arr[x];

--- a/test/cmdlineTests/model_checker_targets_underflow_overflow_chc/err
+++ b/test/cmdlineTests/model_checker_targets_underflow_overflow_chc/err
@@ -1,14 +1,9 @@
-Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}("")' instead.
-  --> input.sol:10:3:
-   |
-10 | 		a.transfer(x);
-   | 		^^^^^^^^^^
-
 Warning: CHC: Underflow (resulting value less than 0) happens here.
 Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = false
 
 Transaction trace:
 test.constructor()
@@ -24,6 +19,7 @@ Counterexample:
 arr = []
 a = 0x0
 x = 1
+success = false
 
 Transaction trace:
 test.constructor()

--- a/test/cmdlineTests/model_checker_targets_underflow_overflow_chc/input.sol
+++ b/test/cmdlineTests/model_checker_targets_underflow_overflow_chc/input.sol
@@ -7,7 +7,8 @@ contract test {
 		--x;
 		x + type(uint).max;
 		2 / x;
-		a.transfer(x);
+		(bool success, ) = a.call{value: x}("");
+		require(success);
 		assert(x > 0);
 		arr.pop();
 		arr[x];

--- a/test/cmdlineTests/standard_model_checker_targets_assert_chc/input.json
+++ b/test/cmdlineTests/standard_model_checker_targets_assert_chc/input.json
@@ -11,7 +11,8 @@
 						--x;
 						x + type(uint).max;
 						2 / x;
-						a.transfer(x);
+						(bool success, ) = a.call{value: x}(\"\");
+						require(success);
 						assert(x > 0);
 						arr.pop();
 						arr[x];

--- a/test/cmdlineTests/standard_model_checker_targets_assert_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_assert_chc/output.json
@@ -2,39 +2,22 @@
     "errors": [
         {
             "component": "general",
-            "errorCode": "9207",
-            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
-  --> A:11:7:
-   |
-11 | \t\t\t\t\t\ta.transfer(x);
-   | \t\t\t\t\t\t^^^^^^^^^^
-
-",
-            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
-            "severity": "warning",
-            "sourceLocation": {
-                "end": 234,
-                "file": "A",
-                "start": 224
-            },
-            "type": "Warning"
-        },
-        {
-            "component": "general",
             "errorCode": "6328",
             "formattedMessage": "Warning: CHC: Assertion violation happens here.
 Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = true
 
 Transaction trace:
 test.constructor()
 State: arr = []
 test.f(0x0, 1)
-  --> A:12:7:
+    a.call{value: x}(\"\") -- untrusted external call
+  --> A:13:7:
    |
-12 | \t\t\t\t\t\tassert(x > 0);
+13 | \t\t\t\t\t\tassert(x > 0);
    | \t\t\t\t\t\t^^^^^^^^^^^^^
 
 ",
@@ -43,16 +26,18 @@ Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = true
 
 Transaction trace:
 test.constructor()
 State: arr = []
-test.f(0x0, 1)",
+test.f(0x0, 1)
+    a.call{value: x}(\"\") -- untrusted external call",
             "severity": "warning",
             "sourceLocation": {
-                "end": 258,
+                "end": 308,
                 "file": "A",
-                "start": 245
+                "start": 295
             },
             "type": "Warning"
         }

--- a/test/cmdlineTests/standard_model_checker_targets_constantCondition_chc/input.json
+++ b/test/cmdlineTests/standard_model_checker_targets_constantCondition_chc/input.json
@@ -11,7 +11,8 @@
 						--x;
 						x + type(uint).max;
 						2 / x;
-						a.transfer(x);
+						(bool success, ) = a.call{value: x}(\"\");
+						require(success);
 						assert(x > 0);
 						arr.pop();
 						arr[x];

--- a/test/cmdlineTests/standard_model_checker_targets_constantCondition_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_constantCondition_chc/output.json
@@ -1,25 +1,4 @@
 {
-    "errors": [
-        {
-            "component": "general",
-            "errorCode": "9207",
-            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
-  --> A:11:7:
-   |
-11 | \t\t\t\t\t\ta.transfer(x);
-   | \t\t\t\t\t\t^^^^^^^^^^
-
-",
-            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
-            "severity": "warning",
-            "sourceLocation": {
-                "end": 234,
-                "file": "A",
-                "start": 224
-            },
-            "type": "Warning"
-        }
-    ],
     "sources": {
         "A": {
             "id": 0

--- a/test/cmdlineTests/standard_model_checker_targets_div_by_zero_chc/input.json
+++ b/test/cmdlineTests/standard_model_checker_targets_div_by_zero_chc/input.json
@@ -11,7 +11,8 @@
 						--x;
 						x + type(uint).max;
 						2 / x;
-						a.transfer(x);
+						(bool success, ) = a.call{value: x}(\"\");
+						require(success);
 						assert(x > 0);
 						arr.pop();
 						arr[x];

--- a/test/cmdlineTests/standard_model_checker_targets_div_by_zero_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_div_by_zero_chc/output.json
@@ -2,31 +2,13 @@
     "errors": [
         {
             "component": "general",
-            "errorCode": "9207",
-            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
-  --> A:11:7:
-   |
-11 | \t\t\t\t\t\ta.transfer(x);
-   | \t\t\t\t\t\t^^^^^^^^^^
-
-",
-            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
-            "severity": "warning",
-            "sourceLocation": {
-                "end": 234,
-                "file": "A",
-                "start": 224
-            },
-            "type": "Warning"
-        },
-        {
-            "component": "general",
             "errorCode": "4281",
             "formattedMessage": "Warning: CHC: Division by zero happens here.
 Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = false
 
 Transaction trace:
 test.constructor()
@@ -43,6 +25,7 @@ Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = false
 
 Transaction trace:
 test.constructor()

--- a/test/cmdlineTests/standard_model_checker_targets_empty_array/input.json
+++ b/test/cmdlineTests/standard_model_checker_targets_empty_array/input.json
@@ -11,7 +11,8 @@
 						--x;
 						x + type(uint).max;
 						2 / x;
-						a.transfer(x);
+						(bool success, ) = a.call{value: x}(\"\");
+						require(success);
 						assert(x > 0);
 						arr.pop();
 						arr[x];

--- a/test/cmdlineTests/standard_model_checker_targets_out_of_bounds_chc/input.json
+++ b/test/cmdlineTests/standard_model_checker_targets_out_of_bounds_chc/input.json
@@ -11,7 +11,8 @@
 						--x;
 						x + type(uint).max;
 						2 / x;
-						a.transfer(x);
+						(bool success, ) = a.call{value: x}(\"\");
+						require(success);
 						assert(x > 0);
 						arr.pop();
 						arr[x];

--- a/test/cmdlineTests/standard_model_checker_targets_out_of_bounds_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_out_of_bounds_chc/output.json
@@ -2,39 +2,22 @@
     "errors": [
         {
             "component": "general",
-            "errorCode": "9207",
-            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
-  --> A:11:7:
-   |
-11 | \t\t\t\t\t\ta.transfer(x);
-   | \t\t\t\t\t\t^^^^^^^^^^
-
-",
-            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
-            "severity": "warning",
-            "sourceLocation": {
-                "end": 234,
-                "file": "A",
-                "start": 224
-            },
-            "type": "Warning"
-        },
-        {
-            "component": "general",
             "errorCode": "6368",
             "formattedMessage": "Warning: CHC: Out of bounds access happens here.
 Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = true
 
 Transaction trace:
 test.constructor()
 State: arr = []
 test.f(0x0, 1)
-  --> A:14:7:
+    a.call{value: x}(\"\") -- untrusted external call
+  --> A:15:7:
    |
-14 | \t\t\t\t\t\tarr[x];
+15 | \t\t\t\t\t\tarr[x];
    | \t\t\t\t\t\t^^^^^^
 
 ",
@@ -43,16 +26,18 @@ Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = true
 
 Transaction trace:
 test.constructor()
 State: arr = []
-test.f(0x0, 1)",
+test.f(0x0, 1)
+    a.call{value: x}(\"\") -- untrusted external call",
             "severity": "warning",
             "sourceLocation": {
-                "end": 289,
+                "end": 339,
                 "file": "A",
-                "start": 283
+                "start": 333
             },
             "type": "Warning"
         }

--- a/test/cmdlineTests/standard_model_checker_targets_overflow_chc/input.json
+++ b/test/cmdlineTests/standard_model_checker_targets_overflow_chc/input.json
@@ -11,7 +11,8 @@
 						--x;
 						x + type(uint).max;
 						2 / x;
-						a.transfer(x);
+						(bool success, ) = a.call{value: x}(\"\");
+						require(success);
 						assert(x > 0);
 						arr.pop();
 						arr[x];

--- a/test/cmdlineTests/standard_model_checker_targets_overflow_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_overflow_chc/output.json
@@ -2,31 +2,13 @@
     "errors": [
         {
             "component": "general",
-            "errorCode": "9207",
-            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
-  --> A:11:7:
-   |
-11 | \t\t\t\t\t\ta.transfer(x);
-   | \t\t\t\t\t\t^^^^^^^^^^
-
-",
-            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
-            "severity": "warning",
-            "sourceLocation": {
-                "end": 234,
-                "file": "A",
-                "start": 224
-            },
-            "type": "Warning"
-        },
-        {
-            "component": "general",
             "errorCode": "4984",
             "formattedMessage": "Warning: CHC: Overflow (resulting value larger than 2**256 - 1) happens here.
 Counterexample:
 arr = []
 a = 0x0
 x = 1
+success = false
 
 Transaction trace:
 test.constructor()
@@ -43,6 +25,7 @@ Counterexample:
 arr = []
 a = 0x0
 x = 1
+success = false
 
 Transaction trace:
 test.constructor()

--- a/test/cmdlineTests/standard_model_checker_targets_pop_empty_chc/input.json
+++ b/test/cmdlineTests/standard_model_checker_targets_pop_empty_chc/input.json
@@ -11,7 +11,8 @@
 						--x;
 						x + type(uint).max;
 						2 / x;
-						a.transfer(x);
+						(bool success, ) = a.call{value: x}(\"\");
+						require(success);
 						assert(x > 0);
 						arr.pop();
 						arr[x];

--- a/test/cmdlineTests/standard_model_checker_targets_pop_empty_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_pop_empty_chc/output.json
@@ -2,39 +2,22 @@
     "errors": [
         {
             "component": "general",
-            "errorCode": "9207",
-            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
-  --> A:11:7:
-   |
-11 | \t\t\t\t\t\ta.transfer(x);
-   | \t\t\t\t\t\t^^^^^^^^^^
-
-",
-            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
-            "severity": "warning",
-            "sourceLocation": {
-                "end": 234,
-                "file": "A",
-                "start": 224
-            },
-            "type": "Warning"
-        },
-        {
-            "component": "general",
             "errorCode": "2529",
             "formattedMessage": "Warning: CHC: Empty array \"pop\" happens here.
 Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = true
 
 Transaction trace:
 test.constructor()
 State: arr = []
 test.f(0x0, 1)
-  --> A:13:7:
+    a.call{value: x}(\"\") -- untrusted external call
+  --> A:14:7:
    |
-13 | \t\t\t\t\t\tarr.pop();
+14 | \t\t\t\t\t\tarr.pop();
    | \t\t\t\t\t\t^^^^^^^^^
 
 ",
@@ -43,16 +26,18 @@ Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = true
 
 Transaction trace:
 test.constructor()
 State: arr = []
-test.f(0x0, 1)",
+test.f(0x0, 1)
+    a.call{value: x}(\"\") -- untrusted external call",
             "severity": "warning",
             "sourceLocation": {
-                "end": 275,
+                "end": 325,
                 "file": "A",
-                "start": 266
+                "start": 316
             },
             "type": "Warning"
         }

--- a/test/cmdlineTests/standard_model_checker_targets_underflow_chc/input.json
+++ b/test/cmdlineTests/standard_model_checker_targets_underflow_chc/input.json
@@ -11,7 +11,8 @@
 						--x;
 						x + type(uint).max;
 						2 / x;
-						a.transfer(x);
+						(bool success, ) = a.call{value: x}(\"\");
+						require(success);
 						assert(x > 0);
 						arr.pop();
 						arr[x];

--- a/test/cmdlineTests/standard_model_checker_targets_underflow_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_underflow_chc/output.json
@@ -2,31 +2,13 @@
     "errors": [
         {
             "component": "general",
-            "errorCode": "9207",
-            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
-  --> A:11:7:
-   |
-11 | \t\t\t\t\t\ta.transfer(x);
-   | \t\t\t\t\t\t^^^^^^^^^^
-
-",
-            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
-            "severity": "warning",
-            "sourceLocation": {
-                "end": 234,
-                "file": "A",
-                "start": 224
-            },
-            "type": "Warning"
-        },
-        {
-            "component": "general",
             "errorCode": "3944",
             "formattedMessage": "Warning: CHC: Underflow (resulting value less than 0) happens here.
 Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = false
 
 Transaction trace:
 test.constructor()
@@ -43,6 +25,7 @@ Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = false
 
 Transaction trace:
 test.constructor()

--- a/test/cmdlineTests/standard_model_checker_targets_underflow_overflow_assert_chc/input.json
+++ b/test/cmdlineTests/standard_model_checker_targets_underflow_overflow_assert_chc/input.json
@@ -11,7 +11,8 @@
 						--x;
 						x + type(uint).max;
 						2 / x;
-						a.transfer(x);
+						(bool success, ) = a.call{value: x}(\"\");
+						require(success);
 						assert(x > 0);
 						arr.pop();
 						arr[x];

--- a/test/cmdlineTests/standard_model_checker_targets_underflow_overflow_assert_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_underflow_overflow_assert_chc/output.json
@@ -2,31 +2,13 @@
     "errors": [
         {
             "component": "general",
-            "errorCode": "9207",
-            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
-  --> A:11:7:
-   |
-11 | \t\t\t\t\t\ta.transfer(x);
-   | \t\t\t\t\t\t^^^^^^^^^^
-
-",
-            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
-            "severity": "warning",
-            "sourceLocation": {
-                "end": 234,
-                "file": "A",
-                "start": 224
-            },
-            "type": "Warning"
-        },
-        {
-            "component": "general",
             "errorCode": "3944",
             "formattedMessage": "Warning: CHC: Underflow (resulting value less than 0) happens here.
 Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = false
 
 Transaction trace:
 test.constructor()
@@ -43,6 +25,7 @@ Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = false
 
 Transaction trace:
 test.constructor()
@@ -64,6 +47,7 @@ Counterexample:
 arr = []
 a = 0x0
 x = 1
+success = false
 
 Transaction trace:
 test.constructor()
@@ -80,6 +64,7 @@ Counterexample:
 arr = []
 a = 0x0
 x = 1
+success = false
 
 Transaction trace:
 test.constructor()
@@ -101,14 +86,16 @@ Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = true
 
 Transaction trace:
 test.constructor()
 State: arr = []
 test.f(0x0, 1)
-  --> A:12:7:
+    a.call{value: x}(\"\") -- untrusted external call
+  --> A:13:7:
    |
-12 | \t\t\t\t\t\tassert(x > 0);
+13 | \t\t\t\t\t\tassert(x > 0);
    | \t\t\t\t\t\t^^^^^^^^^^^^^
 
 ",
@@ -117,16 +104,18 @@ Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = true
 
 Transaction trace:
 test.constructor()
 State: arr = []
-test.f(0x0, 1)",
+test.f(0x0, 1)
+    a.call{value: x}(\"\") -- untrusted external call",
             "severity": "warning",
             "sourceLocation": {
-                "end": 258,
+                "end": 308,
                 "file": "A",
-                "start": 245
+                "start": 295
             },
             "type": "Warning"
         }

--- a/test/cmdlineTests/standard_model_checker_targets_underflow_overflow_chc/input.json
+++ b/test/cmdlineTests/standard_model_checker_targets_underflow_overflow_chc/input.json
@@ -11,7 +11,8 @@
 						--x;
 						x + type(uint).max;
 						2 / x;
-						a.transfer(x);
+						(bool success, ) = a.call{value: x}(\"\");
+						require(success);
 						assert(x > 0);
 						arr.pop();
 						arr[x];

--- a/test/cmdlineTests/standard_model_checker_targets_underflow_overflow_chc/output.json
+++ b/test/cmdlineTests/standard_model_checker_targets_underflow_overflow_chc/output.json
@@ -2,31 +2,13 @@
     "errors": [
         {
             "component": "general",
-            "errorCode": "9207",
-            "formattedMessage": "Warning: 'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.
-  --> A:11:7:
-   |
-11 | \t\t\t\t\t\ta.transfer(x);
-   | \t\t\t\t\t\t^^^^^^^^^^
-
-",
-            "message": "'transfer' is deprecated and scheduled for removal. Use 'call{value: <amount>}(\"\")' instead.",
-            "severity": "warning",
-            "sourceLocation": {
-                "end": 234,
-                "file": "A",
-                "start": 224
-            },
-            "type": "Warning"
-        },
-        {
-            "component": "general",
             "errorCode": "3944",
             "formattedMessage": "Warning: CHC: Underflow (resulting value less than 0) happens here.
 Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = false
 
 Transaction trace:
 test.constructor()
@@ -43,6 +25,7 @@ Counterexample:
 arr = []
 a = 0x0
 x = 0
+success = false
 
 Transaction trace:
 test.constructor()
@@ -64,6 +47,7 @@ Counterexample:
 arr = []
 a = 0x0
 x = 1
+success = false
 
 Transaction trace:
 test.constructor()
@@ -80,6 +64,7 @@ Counterexample:
 arr = []
 a = 0x0
 x = 1
+success = false
 
 Transaction trace:
 test.constructor()

--- a/test/cmdlineTests/standard_model_checker_targets_wrong_target_types/input.json
+++ b/test/cmdlineTests/standard_model_checker_targets_wrong_target_types/input.json
@@ -11,7 +11,8 @@
 						--x;
 						x + type(uint).max;
 						2 / x;
-						a.transfer(x);
+						(bool success, ) = a.call{value: x}(\"\");
+						require(success);
 						assert(x > 0);
 						arr.pop();
 						arr[x];

--- a/test/cmdlineTests/standard_model_checker_targets_wrong_target_types_2/input.json
+++ b/test/cmdlineTests/standard_model_checker_targets_wrong_target_types_2/input.json
@@ -11,7 +11,8 @@
 						--x;
 						x + type(uint).max;
 						2 / x;
-						a.transfer(x);
+						(bool success, ) = a.call{value: x}(\"\");
+						require(success);
 						assert(x > 0);
 						arr.pop();
 						arr[x];

--- a/test/cmdlineTests/standard_model_checker_targets_wrong_targets/input.json
+++ b/test/cmdlineTests/standard_model_checker_targets_wrong_targets/input.json
@@ -11,7 +11,8 @@
 						--x;
 						x + type(uint).max;
 						2 / x;
-						a.transfer(x);
+						(bool success, ) = a.call{value: x}(\"\");
+						require(success);
 						assert(x > 0);
 						arr.pop();
 						arr[x];


### PR DESCRIPTION
`transfer` is deprecated and will be removed in the next breaking release.
~depends on #16174.~ Merged.