### PR TITLE
Remove redundant else after return statements in libevmasm

### DIFF
--- a/libevmasm/PeepholeOptimiser.cpp
+++ b/libevmasm/PeepholeOptimiser.cpp
@@ -222,8 +222,7 @@ struct DoublePush
 			_state.i += windowSize;
 			return true;
 		}
-		else
-			return false;
+		return false;
 	}
 };
 

--- a/libevmasm/SimplificationRules.cpp
+++ b/libevmasm/SimplificationRules.cpp
@@ -130,8 +130,7 @@ AssemblyItem Pattern::toAssemblyItem(langutil::DebugData::ConstPtr _debugData) c
 {
 	if (m_type == Operation)
 		return AssemblyItem(m_instruction, std::move(_debugData));
-	else
-		return AssemblyItem(m_type, data(), std::move(_debugData));
+	return AssemblyItem(m_type, data(), std::move(_debugData));
 }
 
 std::string Pattern::toString() const


### PR DESCRIPTION
Removes redundant `else` statements after `return` in two files within the `libevmasm` module, improving code readability and consistency with project style guidelines.