### PR TITLE
Remove unused store_benchmark_report helper stub

### DIFF
--- a/scripts/externalTests/test_helpers.py
+++ b/scripts/externalTests/test_helpers.py
@@ -140,10 +140,6 @@ def get_solc_short_version(solc_full_version: str) -> str:
     return solc_short_version_match.group(1)
 
 
-def store_benchmark_report(self):
-    raise NotImplementedError()
-
-
 def replace_version_pragmas(test_dir: Path):
     """
     Replace fixed-version pragmas (part of Consensys best practice).


### PR DESCRIPTION
Drop the dead store_benchmark_report stub from scripts/externalTests/test_helpers.py; it was never referenced and only raised NotImplementedError. Keeps the external test helpers leaner and removes reviewer confusion about an unimplemented path.