### PR TITLE
Remove duplicate include directive in CompilerUtils.h

### DIFF
--- a/libsolidity/codegen/CompilerUtils.h
+++ b/libsolidity/codegen/CompilerUtils.h
@@ -27,7 +27,6 @@
 #include <libsolidity/ast/TypeProvider.h>
 #include <libsolidity/interface/DebugSettings.h>
 #include <libsolidity/codegen/CompilerContext.h>
-#include <libsolidity/codegen/CompilerContext.h>
 
 namespace solidity::frontend
 {


### PR DESCRIPTION
This PR removes a duplicate `#include` directive in `CompilerUtils.h`.