### PR TITLE
Update Docker requirements on the release checklist

### DIFF
--- a/ReleaseChecklist.md
+++ b/ReleaseChecklist.md
@@ -1,14 +1,14 @@
 # Checklist for making a Solidity release
 
 ## Requirements
-- [ ] GitHub account with access to [solidity](https://github.com/argotorg/solidity), [solc-js](https://github.com/argotorg/solc-js),
+- GitHub account with access to [solidity](https://github.com/argotorg/solidity), [solc-js](https://github.com/argotorg/solc-js),
       [solc-bin](https://github.com/argotorg/solc-bin), [solidity-website](https://github.com/argotorg/solidity-website).
-- [ ] Personal Access Token (PAT) with `write:packages` scope to access Github's container registry.
+- Personal Access Token (PAT) with `write:packages` scope to access Github's container registry.
     You can generate one by visiting https://github.com/settings/tokens/new?scopes=write:packages.
-- [ ] Ubuntu/Debian dependencies of the Docker script: `docker-buildx`.
-- [ ] [npm Registry](https://www.npmjs.com) account added as a collaborator for the [`solc` package](https://www.npmjs.com/package/solc).
-- [ ] Access to the [solidity_lang Twitter account](https://twitter.com/solidity_lang).
-- [ ] [Reddit](https://www.reddit.com) account that is at least 10 days old with a minimum of 20 comment karma (`/r/ethereum` requirements).
+- Ubuntu/Debian dependencies of the Docker script: `docker-buildx`.
+- [npm Registry](https://www.npmjs.com) account added as a collaborator for the [`solc` package](https://www.npmjs.com/package/solc).
+- Access to the [solidity_lang Twitter account](https://twitter.com/solidity_lang).
+- [Reddit](https://www.reddit.com) account that is at least 10 days old with a minimum of 20 comment karma (`/r/ethereum` requirements).
 
 ## Full release
 

--- a/ReleaseChecklist.md
+++ b/ReleaseChecklist.md
@@ -3,7 +3,8 @@
 ## Requirements
 - [ ] GitHub account with access to [solidity](https://github.com/argotorg/solidity), [solc-js](https://github.com/argotorg/solc-js),
       [solc-bin](https://github.com/argotorg/solc-bin), [solidity-website](https://github.com/argotorg/solidity-website).
-- [ ] DockerHub account with push rights to the [`solc` image](https://hub.docker.com/r/ethereum/solc).
+- [ ] Personal Access Token (PAT) with `write:packages` scope to access Github's container registry.
+    You can generate one by visiting https://github.com/settings/tokens/new?scopes=write:packages.
 - [ ] Ubuntu/Debian dependencies of the Docker script: `docker-buildx`.
 - [ ] [npm Registry](https://www.npmjs.com) account added as a collaborator for the [`solc` package](https://www.npmjs.com/package/solc).
 - [ ] Access to the [solidity_lang Twitter account](https://twitter.com/solidity_lang).

--- a/scripts/docker_deploy_manual.sh
+++ b/scripts/docker_deploy_manual.sh
@@ -25,7 +25,7 @@ fi
 # NOTE: Login to GHCR before running this script with a PAT:
 # echo $GHCR_TOKEN | docker login ghcr.io -u USERNAME --password-stdin
 #
-# Create a classic PAT with write:packages scope only visiting the following url:
+# Create a classic PAT with write:packages scope by visiting the following URL:
 # https://github.com/settings/tokens/new?scopes=write:packages
 
 DIR=$(mktemp -d)


### PR DESCRIPTION
These were not updated after #16257 and still mention DockerHub.

While at it I also removed the checkboxes, since these requirements are not steps we go through during the release. They always remain unchecked.