### PR TITLE
CI: Copy libevmone from Linux ARM Dockerfile image base to final build

### DIFF
--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2404.arm
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2404.arm
@@ -22,7 +22,7 @@
 # (c) 2016-2025 solidity contributors.
 #------------------------------------------------------------------------------
 FROM --platform=linux/arm64 buildpack-deps:noble AS base
-LABEL version="1"
+LABEL version="2"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -104,6 +104,7 @@ RUN <<-EOF
 EOF
 
 FROM base
+COPY --from=libraries /usr/local/lib/libevmone* /usr/lib
 COPY --from=libraries /usr/lib /usr/lib
 COPY --from=libraries /usr/bin /usr/bin
 COPY --from=libraries /usr/include /usr/include


### PR DESCRIPTION
While trying to figure out why `soltest` didn't run in Linux ARM we found out that `libevmone` is not copied to the final build.