### PR TITLE
SMTChecker: Use Eldarica in more tests

### DIFF
--- a/test/libsolidity/smtCheckerTests/external_calls/external_call_indirect_2.sol
+++ b/test/libsolidity/smtCheckerTests/external_calls/external_call_indirect_2.sol
@@ -47,7 +47,7 @@ contract C {
 // ====
 // SMTEngine: chc
 // SMTExtCalls: trusted
-// SMTIgnoreOS: macos
+// SMTSolvers: eld
 // ----
 // Warning 6328: (434-455): CHC: Assertion violation happens here.
 // Warning 6328: (1270-1291): CHC: Assertion violation happens here.

--- a/test/libsolidity/smtCheckerTests/external_calls/external_call_indirect_5.sol
+++ b/test/libsolidity/smtCheckerTests/external_calls/external_call_indirect_5.sol
@@ -46,6 +46,7 @@ contract C {
 // SMTContract: C
 // SMTEngine: chc
 // SMTExtCalls: trusted
+// SMTSolvers: eld
 // ----
 // Warning 6328: (601-622): CHC: Assertion violation happens here.
 // Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/functions/functions_external_2.sol
+++ b/test/libsolidity/smtCheckerTests/functions/functions_external_2.sol
@@ -20,9 +20,9 @@ contract C
 	}
 }
 // ====
-// SMTEngine: all
+// SMTEngine: chc
 // SMTIgnoreCex: yes
-// SMTIgnoreOS: macos
+// SMTSolvers: eld
 // ----
 // Warning 6328: (234-253): CHC: Assertion violation happens here.
 // Info 1391: CHC: 2 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.


### PR DESCRIPTION
Eldarica is more reliable on Z3 and results in fewer differences of behaviour across different platforms.
The disadvantage is that Eldarica often takes longer to solve the problems than Z3.