### PR TITLE
Fix nightly builds: Disable partial clone on Alpine Linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1932,6 +1932,12 @@ jobs:
           docker_layer_caching: false
       - checkout
       - run:
+          name: Disable partial clone and fetch all objects
+          command: |
+            git config remote.origin.promisor false
+            git config --unset remote.origin.partialclonefilter
+            git fetch --refetch origin
+      - run:
           name: Build and tag the container
           command: scripts/docker_deploy_manual.sh develop "file://$PWD" --no-push
       - run:


### PR DESCRIPTION
The nightly builds were failing with the following error when attempting to clone the repository inside the Alpine Docker container:
```
Cloning into 'solidity'...
remote: Enumerating objects: 11932, done.
remote: warning: lazy fetching disabled; some objects may not be available
remote: fatal: could not fetch a24549d4b8303d5475c479961df1b7742ca07e2b from promisor remote
error: git upload-pack: git-pack-objects died with error.
remote: aborting due to possible repository corruption on the remote side.
fatal: git upload-pack: aborting due to possible repository corruption on the remote side.
fatal: early EOF
fatal: fetch-pack: invalid index-pack output

Exited with code exit status 128
```
See: https://app.circleci.com/pipelines/github/argotorg/solidity/40991/workflows/3ed0c82d-2b24-44eb-8418-a0e7c437d792/jobs/1909077
 
CircleCI's checkout seems to now be using partial clone by default, which creates a "promisor remote" that lazily fetches objects on demand. The git config on the CircleCI machine now shows `remote.origin.promisor` set to `true` (not sure if this was always the case):
```
> git config --list
...
remote.origin.promisor=true
remote.origin.partialclonefilter=blob:none
...
``` 
However, when the Alpine Docker build script clones from the local checkout using the `file://` protocol, the promisor remote configuration causes issues as the lazy fetch mechanism doesn't seem to work properly in this context.

I couldn't find much reference to these changes though. But I noticed that git 2.52.0 updated promisor-remote to allow `partialCloneFilter` (https://lore.kernel.org/git/xmqqh5usmvsd.fsf@gitster.g/):

```txt
The "promisor-remote" capability mechanism has been updated to
allow the "partialCloneFilter" settings and the "token" value to be
communicated from the server side.
```

And that the [b_alpine_docker](https://github.com/argotorg/solidity/blob/ca26deccfcd6b5f93a9d8c23813847e241b79080/.circleci/config.yml#L499C18-L499C35) uses the latest version of CircleCI's [cimg/base](https://circleci.com/developer/images/image/cimg/base) which bumped git to 2.52.0:

```txt
build-essential 12.10ubuntu1, curl 8.5.0, docker 28.1.1, 
docker-compose /usr/local/bin/docker-compose Docker Compose version v2.27.1 v2.27.1, 
dockerize v0.8.0, git 2.52.0, jq 1.7, ubuntu 24.04.3 LTS, wget 1.21.4
```

Disabling the remote promisor and unsetting the partial clone filter resolved the issue. This should be fine, since for Alpine we are using the `file://` protocol, and thus, instead of cloning from GitHub again, we are already cloning from the local filesystem. So disabling the promisor and refetching ensures the local repository is fully populated before the `file://` clone happens.