### PR TITLE
Fix `string.concat` and `bytes.concat` assignment to a constant variable.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Language Features:
 Compiler Features:
 
 Bugfixes:
+* TypeChecker: Allow assignment of `string.concat` or `bytes.concat` to constant variables.
 
 
 ### 0.8.31 (2025-12-03)

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -3271,11 +3271,21 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 	// TODO some members might be pure, but for example `address(0x123).balance` is not pure
 	// although every subexpression is, so leaving this limited for now.
 	if (auto tt = dynamic_cast<TypeType const*>(exprType))
+	{
 		if (
 			tt->actualType()->category() == Type::Category::Enum ||
 			tt->actualType()->category() == Type::Category::UserDefinedValueType
 		)
 			annotation.isPure = true;
+
+		// `concat` purity depends also on its arguments, but this is checked later, in visit(FunctionCall...)
+		if (
+			// This covers `bytes.concat` and `string.concat`.
+			tt->actualType()->category() == Type::Category::Array &&
+			memberName == "concat"
+		)
+			annotation.isPure = true;
+	}
 	if (
 		auto const* functionType = dynamic_cast<FunctionType const*>(exprType);
 		functionType &&

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3713,7 +3713,9 @@ bool FunctionType::isPure() const
 		m_kind == Kind::ABIDecode ||
 		m_kind == Kind::MetaType ||
 		m_kind == Kind::Wrap ||
-		m_kind == Kind::Unwrap;
+		m_kind == Kind::Unwrap ||
+		m_kind == Kind::BytesConcat ||
+		m_kind == Kind::StringConcat;
 }
 
 TypePointers FunctionType::parseElementaryTypeVector(strings const& _types)

--- a/test/libsolidity/syntaxTests/array/concat/bytes_concat_valid_type_literal.sol
+++ b/test/libsolidity/syntaxTests/array/concat/bytes_concat_valid_type_literal.sol
@@ -1,6 +1,6 @@
 contract C {
-    function f() public pure {
-        bytes.concat(
+    function f() public pure returns (bytes memory) {
+        return bytes.concat(
             hex"00",
             hex"aabbcc",
             unicode"abc",

--- a/test/libsolidity/syntaxTests/array/concat/bytes_concat_wrong_type_empty_string_literal.sol
+++ b/test/libsolidity/syntaxTests/array/concat/bytes_concat_wrong_type_empty_string_literal.sol
@@ -1,6 +1,6 @@
 contract C {
-    function f() public pure {
-        bytes.concat(hex"", unicode"", "");
+    function f() public pure returns (bytes memory) {
+        return bytes.concat(hex"", unicode"", "");
     }
 }
 // ----

--- a/test/libsolidity/syntaxTests/constants/bytes_concat_pure_assignment.sol
+++ b/test/libsolidity/syntaxTests/constants/bytes_concat_pure_assignment.sol
@@ -1,0 +1,17 @@
+bytes constant abcGlobal = bytes.concat(
+    hex"aaaa",
+    hex"bbbb",
+    hex"cccc"
+);
+
+contract A {
+    bytes public constant abc = bytes.concat(
+        hex"aaaa",
+        hex"bbbb",
+        hex"cccc"
+    );
+
+    bytes public constant abcCopy = abc;
+    bytes public constant abcGlobalCopy = abcGlobal;
+    bytes public constant abcabc = bytes.concat(abc, abcGlobal);
+}

--- a/test/libsolidity/syntaxTests/constants/bytes_concat_pure_assignment_error.sol
+++ b/test/libsolidity/syntaxTests/constants/bytes_concat_pure_assignment_error.sol
@@ -1,0 +1,20 @@
+contract A {
+    function getData() public view returns (bytes memory) {
+        return msg.data;
+    }
+
+    bytes constant abData = bytes.concat(
+        hex"aaaa",
+        hex"bbbb",
+        msg.data
+    );
+
+    bytes constant abgetData = bytes.concat(
+        hex"aaaa",
+        hex"bbbb",
+        getData()
+    );
+}
+// ----
+// TypeError 8349: (133-207): Initial value for constant variable has to be compile-time constant.
+// TypeError 8349: (241-316): Initial value for constant variable has to be compile-time constant.

--- a/test/libsolidity/syntaxTests/constants/string_concat_pure_assignment.sol
+++ b/test/libsolidity/syntaxTests/constants/string_concat_pure_assignment.sol
@@ -1,0 +1,17 @@
+string constant abcGlobal = string.concat(
+    "aaaa",
+    "bbbb",
+    "cccc"
+);
+
+contract A {
+    string public constant abc = string.concat(
+        "aaaa",
+        "bbbb",
+        "cccc"
+    );
+
+    string public constant abcCopy = abc;
+    string public constant abcGlobalCopy = abcGlobal;
+    string public constant abcabc = string.concat(abc, abcGlobal);
+}

--- a/test/libsolidity/syntaxTests/constants/string_concat_pure_assignment_error.sol
+++ b/test/libsolidity/syntaxTests/constants/string_concat_pure_assignment_error.sol
@@ -1,0 +1,22 @@
+contract A {
+    string name = "name";
+
+    function getName() public view returns (string memory) {
+        return name;
+    }
+
+    string public constant abName = string.concat(
+        "aaaa",
+        "bbbb",
+        name
+    );
+
+    string public constant abgetName = string.concat(
+        "aaaa",
+        "bbbb",
+        getName()
+    );
+}
+// ----
+// TypeError 8349: (165-230): Initial value for constant variable has to be compile-time constant.
+// TypeError 8349: (272-342): Initial value for constant variable has to be compile-time constant.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specified_by_bytes_concat.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specified_by_bytes_concat.sol
@@ -1,3 +1,3 @@
 contract C layout at uint64(bytes8(bytes.concat("ABCD", "EFGH"))) {}
 // ----
-// TypeError 1139: (21-65): The base slot of the storage layout must be a compile-time constant expression.
+// TypeError 1505: (21-65): The base slot expression contains elements that are not yet supported by the internal constant evaluator and therefore cannot be evaluated at compilation time.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specified_by_kecak256.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specified_by_kecak256.sol
@@ -1,3 +1,3 @@
 contract C layout at uint(keccak256(bytes.concat("ABCD"))) {}
 // ----
-// TypeError 1139: (21-58): The base slot of the storage layout must be a compile-time constant expression.
+// TypeError 1505: (21-58): The base slot expression contains elements that are not yet supported by the internal constant evaluator and therefore cannot be evaluated at compilation time.


### PR DESCRIPTION
This PR fixes assignment to a constant variable of a result of string or bytes concatenation, if their arguments are values known in the compile-time.
Closes: https://github.com/argotorg/solidity/issues/16188

Additionally
* Add unit tests
* Update the Changelog.md
* Update existing unit tests:
  * Modify tests, which trigger "no-effect" expression warning to silence the warning.
  * Update error message, because now they fail in different (but very similar) way.
  