### PR TITLE
Fix emitting events via module member access

### DIFF
--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -2133,6 +2133,7 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 			dynamic_cast<VariableDeclaration const*>(_memberAccess.annotation().referencedDeclaration) ||
 			dynamic_cast<FunctionDefinition const*>(_memberAccess.annotation().referencedDeclaration) ||
 			dynamic_cast<ErrorDefinition const*>(_memberAccess.annotation().referencedDeclaration) ||
+			dynamic_cast<EventDefinition const*>(_memberAccess.annotation().referencedDeclaration) ||
 			category == Type::Category::TypeType ||
 			category == Type::Category::Module,
 			""

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -2252,6 +2252,7 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 			dynamic_cast<VariableDeclaration const*>(_memberAccess.annotation().referencedDeclaration) ||
 			dynamic_cast<FunctionDefinition const*>(_memberAccess.annotation().referencedDeclaration) ||
 			dynamic_cast<ErrorDefinition const*>(_memberAccess.annotation().referencedDeclaration) ||
+			dynamic_cast<EventDefinition const*>(_memberAccess.annotation().referencedDeclaration) ||
 			category == Type::Category::TypeType ||
 			category == Type::Category::Module,
 			""

--- a/test/libsolidity/semanticTests/events/event_emit_from_imported_contract_via_member_access.sol
+++ b/test/libsolidity/semanticTests/events/event_emit_from_imported_contract_via_member_access.sol
@@ -1,0 +1,13 @@
+==== Source: a ====
+event Transfer(address indexed _from, address indexed _to, uint256 _value);
+==== Source: b ====
+import * as Test2 from "a";
+
+contract A {
+    function returnAddress() external {
+        emit Test2.Transfer(address(11), address(12), 13);
+    }
+}
+// ----
+// returnAddress() ->
+// ~ emit Transfer(address,address,uint256): #0x0b, #0x0c, 0x0d


### PR DESCRIPTION
This PR fixes a bug in implementation of accessing an event which is defined in a separated, imported contract.

Closes: https://github.com/argotorg/solidity/issues/16314

