### PR TITLE
Fix assigning error or event selectors to constant variables.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Language Features:
 Compiler Features:
 
 Bugfixes:
+* TypeChecker: Fix error and event selectors not being considered compile-time constant.
 
 
 ### 0.8.31 (2025-12-03)

--- a/test/libsolidity/syntaxTests/types/functionTypes/selector/event_error_selector_pure_assignment.sol
+++ b/test/libsolidity/syntaxTests/types/functionTypes/selector/event_error_selector_pure_assignment.sol
@@ -1,0 +1,20 @@
+event EvExt();
+error ErExt();
+
+bytes32 constant eventExtSelectorGlobal = EvExt.selector;
+bytes4 constant errorExtSelectorGlobal = ErExt.selector;
+
+contract C {
+    event Ev();
+    error Er();
+
+    bytes4 constant errorExtSelector = ErExt.selector;
+    bytes32 constant eventExtSelector = EvExt.selector;
+
+    bytes4 constant errorSelector = Er.selector;
+    bytes32 constant eventSelector = Ev.selector;
+
+    bytes4 constant errorSelectorC = C.Er.selector;
+    bytes32 constant eventSelectorC = C.Ev.selector;
+}
+// ----


### PR DESCRIPTION
Initially reviewed in https://github.com/argotorg/solidity/pull/16325

This PR fixes assigning error or event selector value to a constant variable and adds a unit test covering this issue.
Closes: https://github.com/argotorg/solidity/issues/13137