### PR TITLE
Fix emitting events or reverting with error via module member access

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Language Features:
 Compiler Features:
 
 Bugfixes:
+* Codegen: Fix internal compiler error when emitting events via module member access.
 * TypeChecker: Fix error and event selectors not being considered compile-time constant.
 
 

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -2133,6 +2133,7 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 			dynamic_cast<VariableDeclaration const*>(_memberAccess.annotation().referencedDeclaration) ||
 			dynamic_cast<FunctionDefinition const*>(_memberAccess.annotation().referencedDeclaration) ||
 			dynamic_cast<ErrorDefinition const*>(_memberAccess.annotation().referencedDeclaration) ||
+			dynamic_cast<EventDefinition const*>(_memberAccess.annotation().referencedDeclaration) ||
 			category == Type::Category::TypeType ||
 			category == Type::Category::Module,
 			""

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -2252,6 +2252,7 @@ void IRGeneratorForStatements::endVisit(MemberAccess const& _memberAccess)
 			dynamic_cast<VariableDeclaration const*>(_memberAccess.annotation().referencedDeclaration) ||
 			dynamic_cast<FunctionDefinition const*>(_memberAccess.annotation().referencedDeclaration) ||
 			dynamic_cast<ErrorDefinition const*>(_memberAccess.annotation().referencedDeclaration) ||
+			dynamic_cast<EventDefinition const*>(_memberAccess.annotation().referencedDeclaration) ||
 			category == Type::Category::TypeType ||
 			category == Type::Category::Module,
 			""

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -170,7 +170,7 @@ ASTPointer<SourceUnit> Parser::parse(CharStream& _charStream)
 					expectToken(Token::Semicolon);
 				}
 				else
-					fatalParserError(7858_error, "Expected pragma, import directive or contract/interface/library/struct/enum/constant/function/error definition.");
+					fatalParserError(7858_error, "Expected pragma, import directive or contract/interface/library/user-defined type/constant/function/error/event definition.");
 			}
 		}
 		solAssert(m_recursionDepth == 0, "");

--- a/test/cmdlineTests/standard_outputs_on_parsing_error/output.json
+++ b/test/cmdlineTests/standard_outputs_on_parsing_error/output.json
@@ -3,14 +3,14 @@
         {
             "component": "general",
             "errorCode": "7858",
-            "formattedMessage": "ParserError: Expected pragma, import directive or contract/interface/library/struct/enum/constant/function/error definition.
+            "formattedMessage": "ParserError: Expected pragma, import directive or contract/interface/library/user-defined type/constant/function/error/event definition.
  --> C:5:14:
   |
 5 | contract C {}}
   |              ^
 
 ",
-            "message": "Expected pragma, import directive or contract/interface/library/struct/enum/constant/function/error definition.",
+            "message": "Expected pragma, import directive or contract/interface/library/user-defined type/constant/function/error/event definition.",
             "severity": "error",
             "sourceLocation": {
                 "end": 121,

--- a/test/libsolidity/ASTJSON/emit_event_from_module_via_member_access.json
+++ b/test/libsolidity/ASTJSON/emit_event_from_module_via_member_access.json
@@ -1,0 +1,1046 @@
+[
+{
+  "absolutePath": "A.sol",
+  "exportedSymbols": {
+    "AContract": [
+      17
+    ],
+    "TransferA": [
+      8
+    ]
+  },
+  "id": 18,
+  "nodeType": "SourceUnit",
+  "nodes": [
+    {
+      "anonymous": false,
+      "eventSelector": "ef0684aa87ada311bea2dad2b653ce28cd604aa1c10a123df8fb2f789c3178f0",
+      "id": 8,
+      "name": "TransferA",
+      "nameLocation": "6:9:1",
+      "nodeType": "EventDefinition",
+      "parameters": {
+        "id": 7,
+        "nodeType": "ParameterList",
+        "parameters": [
+          {
+            "constant": false,
+            "id": 2,
+            "indexed": true,
+            "mutability": "mutable",
+            "name": "from",
+            "nameLocation": "32:4:1",
+            "nodeType": "VariableDeclaration",
+            "scope": 8,
+            "src": "16:20:1",
+            "stateVariable": false,
+            "storageLocation": "default",
+            "typeDescriptions": {
+              "typeIdentifier": "t_address",
+              "typeString": "address"
+            },
+            "typeName": {
+              "id": 1,
+              "name": "address",
+              "nodeType": "ElementaryTypeName",
+              "src": "16:7:1",
+              "stateMutability": "nonpayable",
+              "typeDescriptions": {
+                "typeIdentifier": "t_address",
+                "typeString": "address"
+              }
+            },
+            "visibility": "internal"
+          },
+          {
+            "constant": false,
+            "id": 4,
+            "indexed": true,
+            "mutability": "mutable",
+            "name": "to",
+            "nameLocation": "54:2:1",
+            "nodeType": "VariableDeclaration",
+            "scope": 8,
+            "src": "38:18:1",
+            "stateVariable": false,
+            "storageLocation": "default",
+            "typeDescriptions": {
+              "typeIdentifier": "t_address",
+              "typeString": "address"
+            },
+            "typeName": {
+              "id": 3,
+              "name": "address",
+              "nodeType": "ElementaryTypeName",
+              "src": "38:7:1",
+              "stateMutability": "nonpayable",
+              "typeDescriptions": {
+                "typeIdentifier": "t_address",
+                "typeString": "address"
+              }
+            },
+            "visibility": "internal"
+          },
+          {
+            "constant": false,
+            "id": 6,
+            "indexed": false,
+            "mutability": "mutable",
+            "name": "amount",
+            "nameLocation": "63:6:1",
+            "nodeType": "VariableDeclaration",
+            "scope": 8,
+            "src": "58:11:1",
+            "stateVariable": false,
+            "storageLocation": "default",
+            "typeDescriptions": {
+              "typeIdentifier": "t_uint256",
+              "typeString": "uint256"
+            },
+            "typeName": {
+              "id": 5,
+              "name": "uint",
+              "nodeType": "ElementaryTypeName",
+              "src": "58:4:1",
+              "typeDescriptions": {
+                "typeIdentifier": "t_uint256",
+                "typeString": "uint256"
+              }
+            },
+            "visibility": "internal"
+          }
+        ],
+        "src": "15:55:1"
+      },
+      "src": "0:71:1"
+    },
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "canonicalName": "AContract",
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "fullyImplemented": true,
+      "id": 17,
+      "linearizedBaseContracts": [
+        17
+      ],
+      "name": "AContract",
+      "nameLocation": "81:9:1",
+      "nodeType": "ContractDefinition",
+      "nodes": [
+        {
+          "anonymous": false,
+          "eventSelector": "665f5beb8eab22c2d0fba9f14e33a83ad719ffbed2f484458c23490e8577adc9",
+          "id": 16,
+          "name": "TransferAContract",
+          "nameLocation": "103:17:1",
+          "nodeType": "EventDefinition",
+          "parameters": {
+            "id": 15,
+            "nodeType": "ParameterList",
+            "parameters": [
+              {
+                "constant": false,
+                "id": 10,
+                "indexed": true,
+                "mutability": "mutable",
+                "name": "from",
+                "nameLocation": "137:4:1",
+                "nodeType": "VariableDeclaration",
+                "scope": 16,
+                "src": "121:20:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_address",
+                  "typeString": "address"
+                },
+                "typeName": {
+                  "id": 9,
+                  "name": "address",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "121:7:1",
+                  "stateMutability": "nonpayable",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  }
+                },
+                "visibility": "internal"
+              },
+              {
+                "constant": false,
+                "id": 12,
+                "indexed": true,
+                "mutability": "mutable",
+                "name": "to",
+                "nameLocation": "159:2:1",
+                "nodeType": "VariableDeclaration",
+                "scope": 16,
+                "src": "143:18:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_address",
+                  "typeString": "address"
+                },
+                "typeName": {
+                  "id": 11,
+                  "name": "address",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "143:7:1",
+                  "stateMutability": "nonpayable",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  }
+                },
+                "visibility": "internal"
+              },
+              {
+                "constant": false,
+                "id": 14,
+                "indexed": false,
+                "mutability": "mutable",
+                "name": "amount",
+                "nameLocation": "168:6:1",
+                "nodeType": "VariableDeclaration",
+                "scope": 16,
+                "src": "163:11:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_uint256",
+                  "typeString": "uint256"
+                },
+                "typeName": {
+                  "id": 13,
+                  "name": "uint",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "163:4:1",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  }
+                },
+                "visibility": "internal"
+              }
+            ],
+            "src": "120:55:1"
+          },
+          "src": "97:79:1"
+        }
+      ],
+      "scope": 18,
+      "src": "72:106:1",
+      "usedErrors": [],
+      "usedEvents": [
+        16
+      ]
+    }
+  ],
+  "src": "0:179:1"
+},
+{
+  "absolutePath": "ERC20.sol",
+  "exportedSymbols": {
+    "A": [
+      19
+    ],
+    "ERC20": [
+      74
+    ]
+  },
+  "id": 75,
+  "nodeType": "SourceUnit",
+  "nodes": [
+    {
+      "absolutePath": "A.sol",
+      "file": "A.sol",
+      "id": 19,
+      "nameLocation": "12:1:2",
+      "nodeType": "ImportDirective",
+      "scope": 75,
+      "sourceUnit": 18,
+      "src": "0:27:2",
+      "symbolAliases": [],
+      "unitAlias": "A"
+    },
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "canonicalName": "ERC20",
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "fullyImplemented": true,
+      "id": 74,
+      "linearizedBaseContracts": [
+        74
+      ],
+      "name": "ERC20",
+      "nameLocation": "37:5:2",
+      "nodeType": "ContractDefinition",
+      "nodes": [
+        {
+          "anonymous": false,
+          "eventSelector": "ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+          "id": 27,
+          "name": "Transfer",
+          "nameLocation": "55:8:2",
+          "nodeType": "EventDefinition",
+          "parameters": {
+            "id": 26,
+            "nodeType": "ParameterList",
+            "parameters": [
+              {
+                "constant": false,
+                "id": 21,
+                "indexed": true,
+                "mutability": "mutable",
+                "name": "from",
+                "nameLocation": "80:4:2",
+                "nodeType": "VariableDeclaration",
+                "scope": 27,
+                "src": "64:20:2",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_address",
+                  "typeString": "address"
+                },
+                "typeName": {
+                  "id": 20,
+                  "name": "address",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "64:7:2",
+                  "stateMutability": "nonpayable",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  }
+                },
+                "visibility": "internal"
+              },
+              {
+                "constant": false,
+                "id": 23,
+                "indexed": true,
+                "mutability": "mutable",
+                "name": "to",
+                "nameLocation": "102:2:2",
+                "nodeType": "VariableDeclaration",
+                "scope": 27,
+                "src": "86:18:2",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_address",
+                  "typeString": "address"
+                },
+                "typeName": {
+                  "id": 22,
+                  "name": "address",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "86:7:2",
+                  "stateMutability": "nonpayable",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_address",
+                    "typeString": "address"
+                  }
+                },
+                "visibility": "internal"
+              },
+              {
+                "constant": false,
+                "id": 25,
+                "indexed": false,
+                "mutability": "mutable",
+                "name": "amount",
+                "nameLocation": "111:6:2",
+                "nodeType": "VariableDeclaration",
+                "scope": 27,
+                "src": "106:11:2",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_uint256",
+                  "typeString": "uint256"
+                },
+                "typeName": {
+                  "id": 24,
+                  "name": "uint",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "106:4:2",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint256",
+                    "typeString": "uint256"
+                  }
+                },
+                "visibility": "internal"
+              }
+            ],
+            "src": "63:55:2"
+          },
+          "src": "49:70:2"
+        },
+        {
+          "body": {
+            "id": 72,
+            "nodeType": "Block",
+            "src": "145:181:2",
+            "statements": [
+              {
+                "eventCall": {
+                  "arguments": [
+                    {
+                      "arguments": [
+                        {
+                          "hexValue": "31",
+                          "id": 33,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "177:1:2",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_rational_1_by_1",
+                            "typeString": "int_const 1"
+                          },
+                          "value": "1"
+                        }
+                      ],
+                      "expression": {
+                        "argumentTypes": [
+                          {
+                            "typeIdentifier": "t_rational_1_by_1",
+                            "typeString": "int_const 1"
+                          }
+                        ],
+                        "id": 32,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "lValueRequested": false,
+                        "nodeType": "ElementaryTypeNameExpression",
+                        "src": "169:7:2",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_type$_t_address_$",
+                          "typeString": "type(address)"
+                        },
+                        "typeName": {
+                          "id": 31,
+                          "name": "address",
+                          "nodeType": "ElementaryTypeName",
+                          "src": "169:7:2",
+                          "typeDescriptions": {}
+                        }
+                      },
+                      "id": 34,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "typeConversion",
+                      "lValueRequested": false,
+                      "nameLocations": [],
+                      "names": [],
+                      "nodeType": "FunctionCall",
+                      "src": "169:10:2",
+                      "tryCall": false,
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    {
+                      "arguments": [
+                        {
+                          "hexValue": "32",
+                          "id": 37,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "189:1:2",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_rational_2_by_1",
+                            "typeString": "int_const 2"
+                          },
+                          "value": "2"
+                        }
+                      ],
+                      "expression": {
+                        "argumentTypes": [
+                          {
+                            "typeIdentifier": "t_rational_2_by_1",
+                            "typeString": "int_const 2"
+                          }
+                        ],
+                        "id": 36,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "lValueRequested": false,
+                        "nodeType": "ElementaryTypeNameExpression",
+                        "src": "181:7:2",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_type$_t_address_$",
+                          "typeString": "type(address)"
+                        },
+                        "typeName": {
+                          "id": 35,
+                          "name": "address",
+                          "nodeType": "ElementaryTypeName",
+                          "src": "181:7:2",
+                          "typeDescriptions": {}
+                        }
+                      },
+                      "id": 38,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "typeConversion",
+                      "lValueRequested": false,
+                      "nameLocations": [],
+                      "names": [],
+                      "nodeType": "FunctionCall",
+                      "src": "181:10:2",
+                      "tryCall": false,
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    {
+                      "hexValue": "33",
+                      "id": 39,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "number",
+                      "lValueRequested": false,
+                      "nodeType": "Literal",
+                      "src": "193:1:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_rational_3_by_1",
+                        "typeString": "int_const 3"
+                      },
+                      "value": "3"
+                    }
+                  ],
+                  "expression": {
+                    "argumentTypes": [
+                      {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      },
+                      {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      },
+                      {
+                        "typeIdentifier": "t_rational_3_by_1",
+                        "typeString": "int_const 3"
+                      }
+                    ],
+                    "id": 30,
+                    "name": "Transfer",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "referencedDeclaration": 27,
+                    "src": "160:8:2",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_address_$_t_uint256_$returns$__$",
+                      "typeString": "function (address,address,uint256)"
+                    }
+                  },
+                  "id": 40,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": false,
+                  "kind": "functionCall",
+                  "lValueRequested": false,
+                  "nameLocations": [],
+                  "names": [],
+                  "nodeType": "FunctionCall",
+                  "src": "160:35:2",
+                  "tryCall": false,
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_tuple$__$",
+                    "typeString": "tuple()"
+                  }
+                },
+                "id": 41,
+                "nodeType": "EmitStatement",
+                "src": "155:40:2"
+              },
+              {
+                "eventCall": {
+                  "arguments": [
+                    {
+                      "arguments": [
+                        {
+                          "hexValue": "31",
+                          "id": 47,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "230:1:2",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_rational_1_by_1",
+                            "typeString": "int_const 1"
+                          },
+                          "value": "1"
+                        }
+                      ],
+                      "expression": {
+                        "argumentTypes": [
+                          {
+                            "typeIdentifier": "t_rational_1_by_1",
+                            "typeString": "int_const 1"
+                          }
+                        ],
+                        "id": 46,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "lValueRequested": false,
+                        "nodeType": "ElementaryTypeNameExpression",
+                        "src": "222:7:2",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_type$_t_address_$",
+                          "typeString": "type(address)"
+                        },
+                        "typeName": {
+                          "id": 45,
+                          "name": "address",
+                          "nodeType": "ElementaryTypeName",
+                          "src": "222:7:2",
+                          "typeDescriptions": {}
+                        }
+                      },
+                      "id": 48,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "typeConversion",
+                      "lValueRequested": false,
+                      "nameLocations": [],
+                      "names": [],
+                      "nodeType": "FunctionCall",
+                      "src": "222:10:2",
+                      "tryCall": false,
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    {
+                      "arguments": [
+                        {
+                          "hexValue": "32",
+                          "id": 51,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "242:1:2",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_rational_2_by_1",
+                            "typeString": "int_const 2"
+                          },
+                          "value": "2"
+                        }
+                      ],
+                      "expression": {
+                        "argumentTypes": [
+                          {
+                            "typeIdentifier": "t_rational_2_by_1",
+                            "typeString": "int_const 2"
+                          }
+                        ],
+                        "id": 50,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "lValueRequested": false,
+                        "nodeType": "ElementaryTypeNameExpression",
+                        "src": "234:7:2",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_type$_t_address_$",
+                          "typeString": "type(address)"
+                        },
+                        "typeName": {
+                          "id": 49,
+                          "name": "address",
+                          "nodeType": "ElementaryTypeName",
+                          "src": "234:7:2",
+                          "typeDescriptions": {}
+                        }
+                      },
+                      "id": 52,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "typeConversion",
+                      "lValueRequested": false,
+                      "nameLocations": [],
+                      "names": [],
+                      "nodeType": "FunctionCall",
+                      "src": "234:10:2",
+                      "tryCall": false,
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    {
+                      "hexValue": "33",
+                      "id": 53,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "number",
+                      "lValueRequested": false,
+                      "nodeType": "Literal",
+                      "src": "246:1:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_rational_3_by_1",
+                        "typeString": "int_const 3"
+                      },
+                      "value": "3"
+                    }
+                  ],
+                  "expression": {
+                    "argumentTypes": [
+                      {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      },
+                      {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      },
+                      {
+                        "typeIdentifier": "t_rational_3_by_1",
+                        "typeString": "int_const 3"
+                      }
+                    ],
+                    "expression": {
+                      "id": 42,
+                      "name": "A",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 19,
+                      "src": "210:1:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_module_18",
+                        "typeString": "module \"A.sol\""
+                      }
+                    },
+                    "id": 44,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": true,
+                    "lValueRequested": false,
+                    "memberLocation": "212:9:2",
+                    "memberName": "TransferA",
+                    "nodeType": "MemberAccess",
+                    "referencedDeclaration": 8,
+                    "src": "210:11:2",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_address_$_t_uint256_$returns$__$",
+                      "typeString": "function (address,address,uint256)"
+                    }
+                  },
+                  "id": 54,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": false,
+                  "kind": "functionCall",
+                  "lValueRequested": false,
+                  "nameLocations": [],
+                  "names": [],
+                  "nodeType": "FunctionCall",
+                  "src": "210:38:2",
+                  "tryCall": false,
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_tuple$__$",
+                    "typeString": "tuple()"
+                  }
+                },
+                "id": 55,
+                "nodeType": "EmitStatement",
+                "src": "205:43:2"
+              },
+              {
+                "eventCall": {
+                  "arguments": [
+                    {
+                      "arguments": [
+                        {
+                          "hexValue": "31",
+                          "id": 63,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "301:1:2",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_rational_1_by_1",
+                            "typeString": "int_const 1"
+                          },
+                          "value": "1"
+                        }
+                      ],
+                      "expression": {
+                        "argumentTypes": [
+                          {
+                            "typeIdentifier": "t_rational_1_by_1",
+                            "typeString": "int_const 1"
+                          }
+                        ],
+                        "id": 62,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "lValueRequested": false,
+                        "nodeType": "ElementaryTypeNameExpression",
+                        "src": "293:7:2",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_type$_t_address_$",
+                          "typeString": "type(address)"
+                        },
+                        "typeName": {
+                          "id": 61,
+                          "name": "address",
+                          "nodeType": "ElementaryTypeName",
+                          "src": "293:7:2",
+                          "typeDescriptions": {}
+                        }
+                      },
+                      "id": 64,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "typeConversion",
+                      "lValueRequested": false,
+                      "nameLocations": [],
+                      "names": [],
+                      "nodeType": "FunctionCall",
+                      "src": "293:10:2",
+                      "tryCall": false,
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    {
+                      "arguments": [
+                        {
+                          "hexValue": "32",
+                          "id": 67,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": true,
+                          "kind": "number",
+                          "lValueRequested": false,
+                          "nodeType": "Literal",
+                          "src": "313:1:2",
+                          "typeDescriptions": {
+                            "typeIdentifier": "t_rational_2_by_1",
+                            "typeString": "int_const 2"
+                          },
+                          "value": "2"
+                        }
+                      ],
+                      "expression": {
+                        "argumentTypes": [
+                          {
+                            "typeIdentifier": "t_rational_2_by_1",
+                            "typeString": "int_const 2"
+                          }
+                        ],
+                        "id": 66,
+                        "isConstant": false,
+                        "isLValue": false,
+                        "isPure": true,
+                        "lValueRequested": false,
+                        "nodeType": "ElementaryTypeNameExpression",
+                        "src": "305:7:2",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_type$_t_address_$",
+                          "typeString": "type(address)"
+                        },
+                        "typeName": {
+                          "id": 65,
+                          "name": "address",
+                          "nodeType": "ElementaryTypeName",
+                          "src": "305:7:2",
+                          "typeDescriptions": {}
+                        }
+                      },
+                      "id": 68,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "typeConversion",
+                      "lValueRequested": false,
+                      "nameLocations": [],
+                      "names": [],
+                      "nodeType": "FunctionCall",
+                      "src": "305:10:2",
+                      "tryCall": false,
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      }
+                    },
+                    {
+                      "hexValue": "33",
+                      "id": 69,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "number",
+                      "lValueRequested": false,
+                      "nodeType": "Literal",
+                      "src": "317:1:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_rational_3_by_1",
+                        "typeString": "int_const 3"
+                      },
+                      "value": "3"
+                    }
+                  ],
+                  "expression": {
+                    "argumentTypes": [
+                      {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      },
+                      {
+                        "typeIdentifier": "t_address",
+                        "typeString": "address"
+                      },
+                      {
+                        "typeIdentifier": "t_rational_3_by_1",
+                        "typeString": "int_const 3"
+                      }
+                    ],
+                    "expression": {
+                      "expression": {
+                        "id": 56,
+                        "name": "A",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 19,
+                        "src": "263:1:2",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_module_18",
+                          "typeString": "module \"A.sol\""
+                        }
+                      },
+                      "id": 59,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "lValueRequested": false,
+                      "memberLocation": "265:9:2",
+                      "memberName": "AContract",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": 17,
+                      "src": "263:11:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_type$_t_contract$_AContract_$17_$",
+                        "typeString": "type(contract AContract)"
+                      }
+                    },
+                    "id": 60,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "memberLocation": "275:17:2",
+                    "memberName": "TransferAContract",
+                    "nodeType": "MemberAccess",
+                    "referencedDeclaration": 16,
+                    "src": "263:29:2",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_function_event_nonpayable$_t_address_$_t_address_$_t_uint256_$returns$__$",
+                      "typeString": "function (address,address,uint256)"
+                    }
+                  },
+                  "id": 70,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": false,
+                  "kind": "functionCall",
+                  "lValueRequested": false,
+                  "nameLocations": [],
+                  "names": [],
+                  "nodeType": "FunctionCall",
+                  "src": "263:56:2",
+                  "tryCall": false,
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_tuple$__$",
+                    "typeString": "tuple()"
+                  }
+                },
+                "id": 71,
+                "nodeType": "EmitStatement",
+                "src": "258:61:2"
+              }
+            ]
+          },
+          "functionSelector": "26121ff0",
+          "id": 73,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f",
+          "nameLocation": "133:1:2",
+          "nodeType": "FunctionDefinition",
+          "parameters": {
+            "id": 28,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "135:2:2"
+          },
+          "returnParameters": {
+            "id": 29,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "145:0:2"
+          },
+          "scope": 74,
+          "src": "124:202:2",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "scope": 75,
+      "src": "28:300:2",
+      "usedErrors": [],
+      "usedEvents": [
+        8,
+        16,
+        27
+      ]
+    }
+  ],
+  "src": "0:329:2"
+}
+]

--- a/test/libsolidity/ASTJSON/emit_event_from_module_via_member_access.sol
+++ b/test/libsolidity/ASTJSON/emit_event_from_module_via_member_access.sol
@@ -1,0 +1,18 @@
+==== Source: A.sol ====
+event TransferA(address indexed from, address indexed to, uint amount);
+contract AContract {
+    event TransferAContract(address indexed from, address indexed to, uint amount);
+}
+
+==== Source: ERC20.sol ====
+import * as A from "A.sol";
+contract ERC20 {
+    event Transfer(address indexed from, address indexed to, uint amount);
+    function f () public {
+        emit Transfer(address(1), address(2), 3);
+        emit A.TransferA(address(1), address(2), 3);
+        emit A.AContract.TransferAContract(address(1), address(2), 3);
+    }
+}
+
+// ----

--- a/test/libsolidity/ASTJSON/error_from_module_via_member_access.json
+++ b/test/libsolidity/ASTJSON/error_from_module_via_member_access.json
@@ -1,0 +1,544 @@
+[
+{
+  "absolutePath": "A.sol",
+  "exportedSymbols": {
+    "AContract": [
+      9
+    ],
+    "ErrorA": [
+      4
+    ]
+  },
+  "id": 10,
+  "nodeType": "SourceUnit",
+  "nodes": [
+    {
+      "errorSelector": "23b0db14",
+      "id": 4,
+      "name": "ErrorA",
+      "nameLocation": "6:6:1",
+      "nodeType": "ErrorDefinition",
+      "parameters": {
+        "id": 3,
+        "nodeType": "ParameterList",
+        "parameters": [
+          {
+            "constant": false,
+            "id": 2,
+            "mutability": "mutable",
+            "name": "msg",
+            "nameLocation": "20:3:1",
+            "nodeType": "VariableDeclaration",
+            "scope": 4,
+            "src": "13:10:1",
+            "stateVariable": false,
+            "storageLocation": "default",
+            "typeDescriptions": {
+              "typeIdentifier": "t_string_memory_ptr",
+              "typeString": "string"
+            },
+            "typeName": {
+              "id": 1,
+              "name": "string",
+              "nodeType": "ElementaryTypeName",
+              "src": "13:6:1",
+              "typeDescriptions": {
+                "typeIdentifier": "t_string_storage_ptr",
+                "typeString": "string"
+              }
+            },
+            "visibility": "internal"
+          }
+        ],
+        "src": "12:12:1"
+      },
+      "src": "0:25:1"
+    },
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "canonicalName": "AContract",
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "fullyImplemented": true,
+      "id": 9,
+      "linearizedBaseContracts": [
+        9
+      ],
+      "name": "AContract",
+      "nameLocation": "35:9:1",
+      "nodeType": "ContractDefinition",
+      "nodes": [
+        {
+          "errorSelector": "e00f4941",
+          "id": 8,
+          "name": "ErrorAContract",
+          "nameLocation": "57:14:1",
+          "nodeType": "ErrorDefinition",
+          "parameters": {
+            "id": 7,
+            "nodeType": "ParameterList",
+            "parameters": [
+              {
+                "constant": false,
+                "id": 6,
+                "mutability": "mutable",
+                "name": "msg",
+                "nameLocation": "79:3:1",
+                "nodeType": "VariableDeclaration",
+                "scope": 8,
+                "src": "72:10:1",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_string_memory_ptr",
+                  "typeString": "string"
+                },
+                "typeName": {
+                  "id": 5,
+                  "name": "string",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "72:6:1",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_string_storage_ptr",
+                    "typeString": "string"
+                  }
+                },
+                "visibility": "internal"
+              }
+            ],
+            "src": "71:12:1"
+          },
+          "src": "51:33:1"
+        }
+      ],
+      "scope": 10,
+      "src": "26:60:1",
+      "usedErrors": [
+        8
+      ],
+      "usedEvents": []
+    }
+  ],
+  "src": "0:87:1"
+},
+{
+  "absolutePath": "B.sol",
+  "exportedSymbols": {
+    "A": [
+      11
+    ],
+    "BContract": [
+      46
+    ]
+  },
+  "id": 47,
+  "nodeType": "SourceUnit",
+  "nodes": [
+    {
+      "absolutePath": "A.sol",
+      "file": "A.sol",
+      "id": 11,
+      "nameLocation": "12:1:2",
+      "nodeType": "ImportDirective",
+      "scope": 47,
+      "sourceUnit": 10,
+      "src": "0:27:2",
+      "symbolAliases": [],
+      "unitAlias": "A"
+    },
+    {
+      "abstract": false,
+      "baseContracts": [],
+      "canonicalName": "BContract",
+      "contractDependencies": [],
+      "contractKind": "contract",
+      "fullyImplemented": true,
+      "id": 46,
+      "linearizedBaseContracts": [
+        46
+      ],
+      "name": "BContract",
+      "nameLocation": "37:9:2",
+      "nodeType": "ContractDefinition",
+      "nodes": [
+        {
+          "errorSelector": "1e012d26",
+          "id": 15,
+          "name": "ErrorBContract",
+          "nameLocation": "59:14:2",
+          "nodeType": "ErrorDefinition",
+          "parameters": {
+            "id": 14,
+            "nodeType": "ParameterList",
+            "parameters": [
+              {
+                "constant": false,
+                "id": 13,
+                "mutability": "mutable",
+                "name": "msg",
+                "nameLocation": "81:3:2",
+                "nodeType": "VariableDeclaration",
+                "scope": 15,
+                "src": "74:10:2",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_string_memory_ptr",
+                  "typeString": "string"
+                },
+                "typeName": {
+                  "id": 12,
+                  "name": "string",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "74:6:2",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_string_storage_ptr",
+                    "typeString": "string"
+                  }
+                },
+                "visibility": "internal"
+              }
+            ],
+            "src": "73:12:2"
+          },
+          "src": "53:33:2"
+        },
+        {
+          "body": {
+            "id": 22,
+            "nodeType": "Block",
+            "src": "113:52:2",
+            "statements": [
+              {
+                "errorCall": {
+                  "arguments": [
+                    {
+                      "hexValue": "736f6d65206572726f72",
+                      "id": 19,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "string",
+                      "lValueRequested": false,
+                      "nodeType": "Literal",
+                      "src": "145:12:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_stringliteral_b4ae9cd779cde5df80ff601d28c3fa893d24133d1b4e6fdffbb3a05b40d7a577",
+                        "typeString": "literal_string \"some error\""
+                      },
+                      "value": "some error"
+                    }
+                  ],
+                  "expression": {
+                    "argumentTypes": [
+                      {
+                        "typeIdentifier": "t_stringliteral_b4ae9cd779cde5df80ff601d28c3fa893d24133d1b4e6fdffbb3a05b40d7a577",
+                        "typeString": "literal_string \"some error\""
+                      }
+                    ],
+                    "id": 18,
+                    "name": "ErrorBContract",
+                    "nodeType": "Identifier",
+                    "overloadedDeclarations": [],
+                    "referencedDeclaration": 15,
+                    "src": "130:14:2",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_function_error_pure$_t_string_memory_ptr_$returns$_t_error_$",
+                      "typeString": "function (string memory) pure returns (error)"
+                    }
+                  },
+                  "id": 20,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": false,
+                  "kind": "functionCall",
+                  "lValueRequested": false,
+                  "nameLocations": [],
+                  "names": [],
+                  "nodeType": "FunctionCall",
+                  "src": "130:28:2",
+                  "tryCall": false,
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_error",
+                    "typeString": "error"
+                  }
+                },
+                "id": 21,
+                "nodeType": "RevertStatement",
+                "src": "123:35:2"
+              }
+            ]
+          },
+          "functionSelector": "c27fc305",
+          "id": 23,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f1",
+          "nameLocation": "100:2:2",
+          "nodeType": "FunctionDefinition",
+          "parameters": {
+            "id": 16,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "103:2:2"
+          },
+          "returnParameters": {
+            "id": 17,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "113:0:2"
+          },
+          "scope": 46,
+          "src": "91:74:2",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        },
+        {
+          "body": {
+            "id": 32,
+            "nodeType": "Block",
+            "src": "192:46:2",
+            "statements": [
+              {
+                "errorCall": {
+                  "arguments": [
+                    {
+                      "hexValue": "736f6d65206572726f72",
+                      "id": 29,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "string",
+                      "lValueRequested": false,
+                      "nodeType": "Literal",
+                      "src": "218:12:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_stringliteral_b4ae9cd779cde5df80ff601d28c3fa893d24133d1b4e6fdffbb3a05b40d7a577",
+                        "typeString": "literal_string \"some error\""
+                      },
+                      "value": "some error"
+                    }
+                  ],
+                  "expression": {
+                    "argumentTypes": [
+                      {
+                        "typeIdentifier": "t_stringliteral_b4ae9cd779cde5df80ff601d28c3fa893d24133d1b4e6fdffbb3a05b40d7a577",
+                        "typeString": "literal_string \"some error\""
+                      }
+                    ],
+                    "expression": {
+                      "id": 26,
+                      "name": "A",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 11,
+                      "src": "209:1:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_module_10",
+                        "typeString": "module \"A.sol\""
+                      }
+                    },
+                    "id": 28,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": true,
+                    "lValueRequested": false,
+                    "memberLocation": "211:6:2",
+                    "memberName": "ErrorA",
+                    "nodeType": "MemberAccess",
+                    "referencedDeclaration": 4,
+                    "src": "209:8:2",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_function_error_pure$_t_string_memory_ptr_$returns$_t_error_$",
+                      "typeString": "function (string memory) pure returns (error)"
+                    }
+                  },
+                  "id": 30,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": false,
+                  "kind": "functionCall",
+                  "lValueRequested": false,
+                  "nameLocations": [],
+                  "names": [],
+                  "nodeType": "FunctionCall",
+                  "src": "209:22:2",
+                  "tryCall": false,
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_error",
+                    "typeString": "error"
+                  }
+                },
+                "id": 31,
+                "nodeType": "RevertStatement",
+                "src": "202:29:2"
+              }
+            ]
+          },
+          "functionSelector": "9942ec6f",
+          "id": 33,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f2",
+          "nameLocation": "179:2:2",
+          "nodeType": "FunctionDefinition",
+          "parameters": {
+            "id": 24,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "182:2:2"
+          },
+          "returnParameters": {
+            "id": 25,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "192:0:2"
+          },
+          "scope": 46,
+          "src": "170:68:2",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        },
+        {
+          "body": {
+            "id": 44,
+            "nodeType": "Block",
+            "src": "265:64:2",
+            "statements": [
+              {
+                "errorCall": {
+                  "arguments": [
+                    {
+                      "hexValue": "736f6d65206572726f72",
+                      "id": 41,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "kind": "string",
+                      "lValueRequested": false,
+                      "nodeType": "Literal",
+                      "src": "309:12:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_stringliteral_b4ae9cd779cde5df80ff601d28c3fa893d24133d1b4e6fdffbb3a05b40d7a577",
+                        "typeString": "literal_string \"some error\""
+                      },
+                      "value": "some error"
+                    }
+                  ],
+                  "expression": {
+                    "argumentTypes": [
+                      {
+                        "typeIdentifier": "t_stringliteral_b4ae9cd779cde5df80ff601d28c3fa893d24133d1b4e6fdffbb3a05b40d7a577",
+                        "typeString": "literal_string \"some error\""
+                      }
+                    ],
+                    "expression": {
+                      "expression": {
+                        "id": 36,
+                        "name": "A",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 11,
+                        "src": "282:1:2",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_module_10",
+                          "typeString": "module \"A.sol\""
+                        }
+                      },
+                      "id": 39,
+                      "isConstant": false,
+                      "isLValue": false,
+                      "isPure": true,
+                      "lValueRequested": false,
+                      "memberLocation": "284:9:2",
+                      "memberName": "AContract",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": 9,
+                      "src": "282:11:2",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_type$_t_contract$_AContract_$9_$",
+                        "typeString": "type(contract AContract)"
+                      }
+                    },
+                    "id": 40,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "memberLocation": "294:14:2",
+                    "memberName": "ErrorAContract",
+                    "nodeType": "MemberAccess",
+                    "referencedDeclaration": 8,
+                    "src": "282:26:2",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_function_error_pure$_t_string_memory_ptr_$returns$_t_error_$",
+                      "typeString": "function (string memory) pure returns (error)"
+                    }
+                  },
+                  "id": 42,
+                  "isConstant": false,
+                  "isLValue": false,
+                  "isPure": false,
+                  "kind": "functionCall",
+                  "lValueRequested": false,
+                  "nameLocations": [],
+                  "names": [],
+                  "nodeType": "FunctionCall",
+                  "src": "282:40:2",
+                  "tryCall": false,
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_error",
+                    "typeString": "error"
+                  }
+                },
+                "id": 43,
+                "nodeType": "RevertStatement",
+                "src": "275:47:2"
+              }
+            ]
+          },
+          "functionSelector": "aaf05f3d",
+          "id": 45,
+          "implemented": true,
+          "kind": "function",
+          "modifiers": [],
+          "name": "f3",
+          "nameLocation": "252:2:2",
+          "nodeType": "FunctionDefinition",
+          "parameters": {
+            "id": 34,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "255:2:2"
+          },
+          "returnParameters": {
+            "id": 35,
+            "nodeType": "ParameterList",
+            "parameters": [],
+            "src": "265:0:2"
+          },
+          "scope": 46,
+          "src": "243:86:2",
+          "stateMutability": "nonpayable",
+          "virtual": false,
+          "visibility": "public"
+        }
+      ],
+      "scope": 47,
+      "src": "28:303:2",
+      "usedErrors": [
+        4,
+        8,
+        15
+      ],
+      "usedEvents": []
+    }
+  ],
+  "src": "0:332:2"
+}
+]

--- a/test/libsolidity/ASTJSON/error_from_module_via_member_access.sol
+++ b/test/libsolidity/ASTJSON/error_from_module_via_member_access.sol
@@ -1,0 +1,22 @@
+==== Source: A.sol ====
+error ErrorA(string msg);
+contract AContract {
+    error ErrorAContract(string msg);
+}
+
+==== Source: B.sol ====
+import * as A from "A.sol";
+contract BContract {
+    error ErrorBContract(string msg);
+    function f1 () public {
+        revert ErrorBContract("some error");
+    }
+    function f2 () public {
+        revert A.ErrorA("some error");
+    }
+    function f3 () public {
+        revert A.AContract.ErrorAContract("some error");
+    }
+}
+
+// ----

--- a/test/libsolidity/natspecJSON/emit_event_from_module_via_member_access.sol
+++ b/test/libsolidity/natspecJSON/emit_event_from_module_via_member_access.sol
@@ -1,0 +1,115 @@
+==== Source: A.sol ====
+/// @notice This event is emitted when a transfer from A occurs.
+/// @param from The source account.
+/// @param to The destination account.
+/// @param amount The amount.
+/// @dev A test case!
+event TransferA(address indexed from, address indexed to, uint amount);
+
+contract AContract {
+    /// @notice This event is emitted when a transfer from AContract occurs.
+    /// @param from The source account.
+    /// @param to The destination account.
+    /// @param amount The amount.
+    /// @dev A test case!
+    event TransferAContract(address indexed from, address indexed to, uint amount);
+}
+
+==== Source: ERC20.sol ====
+import * as A from "A.sol";
+contract ERC20 {
+    /// @notice This event is emitted when a transfer from ERC20 occurs.
+    /// @param from The source account.
+    /// @param to The destination account.
+    /// @param amount The amount.
+    /// @dev A test case!
+    event Transfer(address indexed from, address indexed to, uint amount);
+
+    function test() public {
+        emit Transfer(address(1), address(5), 1);
+        emit A.AContract.TransferAContract(address(1), address(5), 1);
+        emit A.TransferA(address(1), address(5), 1);
+    }
+}
+
+// ----
+// ----
+// A.sol:AContract devdoc
+// {
+//     "events": {
+//         "TransferAContract(address,address,uint256)": {
+//             "details": "A test case!",
+//             "params": {
+//                 "amount": "The amount.",
+//                 "from": "The source account.",
+//                 "to": "The destination account."
+//             }
+//         }
+//     },
+//     "kind": "dev",
+//     "methods": {},
+//     "version": 1
+// }
+//
+// A.sol:AContract userdoc
+// {
+//     "events": {
+//         "TransferAContract(address,address,uint256)": {
+//             "notice": "This event is emitted when a transfer from AContract occurs."
+//         }
+//     },
+//     "kind": "user",
+//     "methods": {},
+//     "version": 1
+// }
+//
+// ERC20.sol:ERC20 devdoc
+// {
+//     "events": {
+//         "Transfer(address,address,uint256)": {
+//             "details": "A test case!",
+//             "params": {
+//                 "amount": "The amount.",
+//                 "from": "The source account.",
+//                 "to": "The destination account."
+//             }
+//         },
+//         "TransferA(address,address,uint256)": {
+//             "details": "A test case!",
+//             "params": {
+//                 "amount": "The amount.",
+//                 "from": "The source account.",
+//                 "to": "The destination account."
+//             }
+//         },
+//         "TransferAContract(address,address,uint256)": {
+//             "details": "A test case!",
+//             "params": {
+//                 "amount": "The amount.",
+//                 "from": "The source account.",
+//                 "to": "The destination account."
+//             }
+//         }
+//     },
+//     "kind": "dev",
+//     "methods": {},
+//     "version": 1
+// }
+//
+// ERC20.sol:ERC20 userdoc
+// {
+//     "events": {
+//         "Transfer(address,address,uint256)": {
+//             "notice": "This event is emitted when a transfer from ERC20 occurs."
+//         },
+//         "TransferA(address,address,uint256)": {
+//             "notice": "This event is emitted when a transfer from A occurs."
+//         },
+//         "TransferAContract(address,address,uint256)": {
+//             "notice": "This event is emitted when a transfer from AContract occurs."
+//         }
+//     },
+//     "kind": "user",
+//     "methods": {},
+//     "version": 1
+// }

--- a/test/libsolidity/natspecJSON/error_from_module_via_member_access.sol
+++ b/test/libsolidity/natspecJSON/error_from_module_via_member_access.sol
@@ -1,0 +1,127 @@
+==== Source: A.sol ====
+/// Something failed.
+/// @dev an error.
+/// @param a first parameter
+/// @param b second parameter
+error E(uint a, uint b);
+
+contract AContract {
+    /// Something failed.
+    /// @dev an error.
+    /// @param a first parameter
+    /// @param b second parameter
+    error EAContract(uint a, uint b);
+}
+
+==== Source: ERC20.sol ====
+import * as A from "A.sol";
+contract ERC20 {
+    /// Something failed.
+    /// @dev an error.
+    /// @param a first parameter
+    /// @param b second parameter
+    error EERC20(uint a, uint b);
+
+    function f(uint a) public pure {
+        if (a > 0)
+            revert EERC20(1, 2);
+        else if (a < 0)
+            revert A.AContract.EAContract(5, 6);
+        else
+            revert A.E(5, 6);
+    }
+}
+
+// ----
+// ----
+// A.sol:AContract devdoc
+// {
+//     "errors": {
+//         "EAContract(uint256,uint256)": [
+//             {
+//                 "details": "an error.",
+//                 "params": {
+//                     "a": "first parameter",
+//                     "b": "second parameter"
+//                 }
+//             }
+//         ]
+//     },
+//     "kind": "dev",
+//     "methods": {},
+//     "version": 1
+// }
+//
+// A.sol:AContract userdoc
+// {
+//     "errors": {
+//         "EAContract(uint256,uint256)": [
+//             {
+//                 "notice": "Something failed."
+//             }
+//         ]
+//     },
+//     "kind": "user",
+//     "methods": {},
+//     "version": 1
+// }
+//
+// ERC20.sol:ERC20 devdoc
+// {
+//     "errors": {
+//         "E(uint256,uint256)": [
+//             {
+//                 "details": "an error.",
+//                 "params": {
+//                     "a": "first parameter",
+//                     "b": "second parameter"
+//                 }
+//             }
+//         ],
+//         "EAContract(uint256,uint256)": [
+//             {
+//                 "details": "an error.",
+//                 "params": {
+//                     "a": "first parameter",
+//                     "b": "second parameter"
+//                 }
+//             }
+//         ],
+//         "EERC20(uint256,uint256)": [
+//             {
+//                 "details": "an error.",
+//                 "params": {
+//                     "a": "first parameter",
+//                     "b": "second parameter"
+//                 }
+//             }
+//         ]
+//     },
+//     "kind": "dev",
+//     "methods": {},
+//     "version": 1
+// }
+//
+// ERC20.sol:ERC20 userdoc
+// {
+//     "errors": {
+//         "E(uint256,uint256)": [
+//             {
+//                 "notice": "Something failed."
+//             }
+//         ],
+//         "EAContract(uint256,uint256)": [
+//             {
+//                 "notice": "Something failed."
+//             }
+//         ],
+//         "EERC20(uint256,uint256)": [
+//             {
+//                 "notice": "Something failed."
+//             }
+//         ]
+//     },
+//     "kind": "user",
+//     "methods": {},
+//     "version": 1
+// }

--- a/test/libsolidity/semanticTests/errors/error_throw_from_module_via_member_access.sol
+++ b/test/libsolidity/semanticTests/errors/error_throw_from_module_via_member_access.sol
@@ -1,0 +1,31 @@
+==== Source: A.sol ====
+error ErrorA(string msg);
+==== Source: B.sol ====
+import * as A from "A.sol";
+
+error ErrorB(string msg);
+
+contract BContract {
+    error ErrorB(string msg);
+}
+==== Source: C.sol ====
+import * as B from "B.sol";
+
+contract CContract {
+    function error1() external {
+        revert B.ErrorB("B error");
+    }
+
+    function error2() external {
+        revert B.BContract.ErrorB("B.BContract error");
+    }
+
+    function error3() external {
+        revert B.A.ErrorA("B.A error");
+    }
+}
+
+// ----
+// error1() -> FAILURE, hex"a5f9ec67", 0x20, 7, "B error"
+// error2() -> FAILURE, hex"a5f9ec67", 0x20, 17, "B.BContract error"
+// error3() -> FAILURE, hex"23b0db14", 0x20, 9, "B.A error"

--- a/test/libsolidity/semanticTests/events/event_emit_from_module_via_member_access.sol
+++ b/test/libsolidity/semanticTests/events/event_emit_from_module_via_member_access.sol
@@ -1,0 +1,26 @@
+==== Source: A.sol ====
+event Transfer(address indexed _from, address indexed _to, uint256 _value);
+==== Source: B.sol ====
+import * as A from "A.sol";
+
+event Transfer(address indexed _from, address indexed _to, uint256 _value);
+
+contract BContract {
+    event Transfer(address indexed _from, address indexed _to, uint256 _value);
+}
+==== Source: C.sol ====
+import * as B from "B.sol";
+
+contract CContract {
+    function returnAddress() external {
+        emit B.Transfer(address(0x0b), address(0x0c), 0x0d);
+        emit B.BContract.Transfer(address(0x0e), address(0x0f), 0x10);
+        emit B.A.Transfer(address(0x11), address(0x12), 0x13);
+    }
+}
+
+// ----
+// returnAddress() ->
+// ~ emit Transfer(address,address,uint256): #0x0b, #0x0c, 0x0d
+// ~ emit Transfer(address,address,uint256): #0x0e, #0x0f, 0x10
+// ~ emit Transfer(address,address,uint256): #0x11, #0x12, 0x13

--- a/test/libsolidity/syntaxTests/freeFunctions/free_constructor.sol
+++ b/test/libsolidity/syntaxTests/freeFunctions/free_constructor.sol
@@ -1,3 +1,3 @@
 constructor() {}
 // ----
-// ParserError 7858: (0-11): Expected pragma, import directive or contract/interface/library/struct/enum/constant/function/error definition.
+// ParserError 7858: (0-11): Expected pragma, import directive or contract/interface/library/user-defined type/constant/function/error/event definition.

--- a/test/libsolidity/syntaxTests/freeFunctions/free_fallback.sol
+++ b/test/libsolidity/syntaxTests/freeFunctions/free_fallback.sol
@@ -1,3 +1,3 @@
 fallback(){}
 // ----
-// ParserError 7858: (0-8): Expected pragma, import directive or contract/interface/library/struct/enum/constant/function/error definition.
+// ParserError 7858: (0-8): Expected pragma, import directive or contract/interface/library/user-defined type/constant/function/error/event definition.

--- a/test/libsolidity/syntaxTests/freeFunctions/free_receive.sol
+++ b/test/libsolidity/syntaxTests/freeFunctions/free_receive.sol
@@ -1,3 +1,3 @@
 receive() {}
 // ----
-// ParserError 7858: (0-7): Expected pragma, import directive or contract/interface/library/struct/enum/constant/function/error definition.
+// ParserError 7858: (0-7): Expected pragma, import directive or contract/interface/library/user-defined type/constant/function/error/event definition.

--- a/test/libsolidity/syntaxTests/parsing/unexpected.sol
+++ b/test/libsolidity/syntaxTests/parsing/unexpected.sol
@@ -1,3 +1,3 @@
 unexpected
 // ----
-// ParserError 7858: (0-10): Expected pragma, import directive or contract/interface/library/struct/enum/constant/function/error definition.
+// ParserError 7858: (0-10): Expected pragma, import directive or contract/interface/library/user-defined type/constant/function/error/event definition.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specified_by_function_empty_call_options.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specified_by_function_empty_call_options.sol
@@ -3,4 +3,4 @@ contract A {
 }
 contract C is A layout at this.f{}() {}
 // ----
-// ParserError 7858: (98-99): Expected pragma, import directive or contract/interface/library/struct/enum/constant/function/error definition.
+// ParserError 7858: (98-99): Expected pragma, import directive or contract/interface/library/user-defined type/constant/function/error/event definition.


### PR DESCRIPTION
Initially reviewed in https://github.com/argotorg/solidity/pull/16336

This PR fixes a bug in implementation of accessing an event (or error) which is defined in a separated, imported module.

Closes: https://github.com/argotorg/solidity/issues/16314