### PR TITLE
Move constantinople and petersburg runs to nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1328,7 +1328,7 @@ jobs:
       - attach_workspace:
           at: build
       - run_soltest_all:
-          evm_versions: homestead byzantium
+          evm_versions: homestead byzantium constantinople petersburg
       - store_test_results:
           path: test_results/
       - store_artifacts_test_results

--- a/.circleci/soltest_all.sh
+++ b/.circleci/soltest_all.sh
@@ -31,7 +31,7 @@ REPODIR="$(realpath "$(dirname "$0")"/..)"
 # shellcheck source=scripts/common.sh
 source "${REPODIR}/scripts/common.sh"
 
-DEFAULT_EVM_VALUES=(constantinople petersburg istanbul berlin london paris shanghai cancun prague osaka)
+DEFAULT_EVM_VALUES=(istanbul berlin london paris shanghai cancun prague osaka)
 EVMS_WITH_EOF=(osaka)
 
 # Deserialize the EVM_VALUES array if it was provided as argument or


### PR DESCRIPTION
See https://github.com/argotorg/solidity/issues/16349

This PR reduces CI runtime and cost by moving tests for the Constantinople and Petersburg EVM versions from the "main" workflow to the nightly workflow.