### PR TITLE
ci:  Replace `t_ubu_soltest_all` with `t_ubu_soltest`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1300,7 +1300,6 @@ jobs:
       EVM: << pipeline.parameters.evm-version >>
       EOF_VERSION: 0
       OPTIMIZE: 0
-      SOLTEST_FLAGS: --no-smt
     steps:
       - soltest
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1304,12 +1304,6 @@ jobs:
     steps:
       - soltest
 
-  t_ubu_soltest_all: &t_ubu_soltest_all
-    <<: *base_ubuntu2404_large
-    parallelism: 50
-    steps:
-      - soltest_all
-
   t_ubu_arm_soltest: &t_ubu_arm_soltest
     <<: *base_ubuntu2404_arm_medium
     parallelism: 20
@@ -1384,9 +1378,10 @@ jobs:
       - soltest
 
   t_ubu_force_release_soltest_all: &t_ubu_force_release_soltest_all
-    # NOTE: This definition is identical to t_ubu_soltest_all but in the workflow we make it depend on
-    # a different job (b_ubu_force_release) so the workspace it attaches contains a different executable.
-    <<: *t_ubu_soltest_all
+    <<: *base_ubuntu2404_large
+    parallelism: 50
+    steps:
+      - soltest_all
 
   t_ubu_cli: &t_ubu_cli
     <<: *base_ubuntu2404_small

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1292,6 +1292,18 @@ jobs:
           destination: docs-html
       - matrix_notify_failure_unless_pr
 
+  t_ubu_soltest: &t_ubu_soltest
+    <<: *base_ubuntu2404_large
+    parallelism: 20
+    environment:
+      <<: *base_ubuntu2404_large_env
+      EVM: << pipeline.parameters.evm-version >>
+      EOF_VERSION: 0
+      OPTIMIZE: 0
+      SOLTEST_FLAGS: --no-smt
+    steps:
+      - soltest
+
   t_ubu_soltest_all: &t_ubu_soltest_all
     <<: *base_ubuntu2404_large
     parallelism: 50
@@ -2038,7 +2050,7 @@ workflows:
       - t_ubu_cli: *requires_b_ubu
       - t_ubu_arm_cli: *requires_b_ubu_static_arm
       - t_ubu_locale: *requires_b_ubu
-      - t_ubu_soltest_all: *requires_b_ubu
+      - t_ubu_soltest: *requires_b_ubu
       - t_ubu_arm_soltest: *requires_b_ubu_static_arm
       - b_ubu_clang: *requires_nothing
       - t_ubu_clang_soltest: *requires_b_ubu_clang


### PR DESCRIPTION
See 2. of #16349

Replaces the  `t_ubu_soltest_all` job with a new job `t_ubu_soltest` that only runs on the current EVM version. Other EVM versions will still be tested through the `t_ubu_force_release_soltest_all` job.