### PR TITLE
Add Constantinople EVM version requirement to long byte array cleanup test due to the use of shl

### DIFF
--- a/test/libsolidity/semanticTests/array/long_byte_array_cleanup_after_overwrite_with_long.sol
+++ b/test/libsolidity/semanticTests/array/long_byte_array_cleanup_after_overwrite_with_long.sol
@@ -82,6 +82,8 @@ contract C {
         return result;
     }
 }
+// ====
+// EVMVersion: >=constantinople
 // ----
 // arrayLength() ->0
 // canaryValue() -> 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff


### PR DESCRIPTION
Fix https://app.circleci.com/pipelines/github/argotorg/solidity/41189/workflows/050f89da-c20e-45ec-a7d6-87d10a5c949c/jobs/1923480/parallel-runs/47?filterBy=FAILED

```txt

Error: The "shl" instruction is only available for Constantinople-compatible VMs (you are currently compiling for "homestead").
  --> :74:26:
   |
74 |             lastBytes := shl(144, slot1)
   |                          ^^^

Error: Variable count for assignment to "lastBytes" does not match number of values (1 vs. 0)
  --> :74:13:
   |
74 |             lastBytes := shl(144, slot1)
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

/solidity/test/libsolidity/SolidityExecutionFramework.cpp(80): error: in "semanticTests/array/long_byte_array_cleanup_after_overwrite_with_long": Compiling contract failed
/solidity/test/soltest.cpp(120): error: in "semanticTests/array/long_byte_array_cleanup_after_overwrite_with_long": Exception during extracted test: /solidity/libsolidity/interface/CompilerStack.cpp(853): Throw in function const std::string solidity::frontend::CompilerStack::lastContractName(const std::optional<std::__cxx11::basic_string<char> >&) const
Dynamic exception type: boost::wrapexcept<solidity::langutil::InternalCompilerError>
std::exception::what: Parsing was not successful.
[solidity::util::tag_comment*] = Parsing was not successful.
```