### PR TITLE
Work around broken `isPure` sanity check for constants accessed through getters

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Language Features:
 Compiler Features:
 
 Bugfixes:
+* TypeChecker: Fix internal error when accessing getters of constant variables.
 
 
 ### 0.8.32 (2025-12-18)

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -3409,16 +3409,6 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 	if (!annotation.isPure.set())
 		annotation.isPure = false;
 
-	if (
-		auto const* funcType = dynamic_cast<FunctionType const*>(annotation.type);
-		funcType &&
-		funcType->kind() != FunctionType::Kind::Declaration &&
-		funcType->kind() != FunctionType::Kind::Internal &&
-		funcType->kind() != FunctionType::Kind::Error &&
-		funcType->kind() != FunctionType::Kind::Event
-	)
-		solAssert(funcType->isPure() == *annotation.isPure);
-
 	return false;
 }
 

--- a/test/libsolidity/syntaxTests/constants/access_via_getter.sol
+++ b/test/libsolidity/syntaxTests/constants/access_via_getter.sol
@@ -1,0 +1,8 @@
+contract Counter {
+    uint256 public constant MIN_LIQUIDITY = 1000;
+
+    function run() view public {
+        this.MIN_LIQUIDITY();
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/immutable/access_via_getter.sol
+++ b/test/libsolidity/syntaxTests/immutable/access_via_getter.sol
@@ -1,0 +1,8 @@
+contract Counter {
+    uint256 public immutable MIN_LIQUIDITY = 1000;
+
+    function run() view public {
+        this.MIN_LIQUIDITY();
+    }
+}
+// ----


### PR DESCRIPTION
Fixes https://github.com/argotorg/solidity/issues/16360