### PR TITLE
Fix spurious @notice error for untagged docs on file-level variables

### DIFF
--- a/libsolidity/analysis/DocStringTagParser.cpp
+++ b/libsolidity/analysis/DocStringTagParser.cpp
@@ -312,7 +312,7 @@ void DocStringTagParser::parseDocStrings(
 	if (!_node.documentation())
 		return;
 
-	_annotation.docTags = DocStringParser{*_node.documentation(), m_errorReporter}.parse();
+	_annotation.docTags = DocStringParser{*_node.documentation(), m_errorReporter, _validTags}.parse();
 
 	for (auto const& [tagName, tagValue]: _annotation.docTags)
 	{

--- a/libsolidity/parsing/DocStringParser.cpp
+++ b/libsolidity/parsing/DocStringParser.cpp
@@ -103,13 +103,17 @@ std::multimap<std::string, DocTag> DocStringParser::parse()
 			currPos = parseDocTagLine(currPos, end, true);
 		else if (currPos != end)
 		{
-			// if it begins without a tag then consider it as @notice
+			// if it begins without a tag then consider it as @notice (only if @notice is valid for this node type)
 			if (currPos == m_node.text()->begin())
 			{
-				currPos = parseDocTag(currPos, end, "notice");
-				continue;
+				if (m_validTags.empty() || m_validTags.count("notice"))
+				{
+					currPos = parseDocTag(currPos, end, "notice");
+					continue;
+				}
+				// If notice is not valid, fall through to skip this line
 			}
-			else if (nlPos == end) //end of text
+			if (nlPos == end) //end of text
 				break;
 			// else skip the line if a newline was found and we get here
 			currPos = nlPos + 1;

--- a/libsolidity/parsing/DocStringParser.h
+++ b/libsolidity/parsing/DocStringParser.h
@@ -25,6 +25,7 @@
 
 #include <libsolidity/ast/ASTAnnotations.h>
 #include <liblangutil/SourceLocation.h>
+#include <set>
 #include <string>
 
 namespace solidity::langutil
@@ -41,9 +42,15 @@ class DocStringParser
 {
 public:
 	/// @param _documentedNode the node whose documentation is parsed.
-	DocStringParser(StructuredDocumentation const& _documentedNode, langutil::ErrorReporter& _errorReporter):
+	/// @param _validTags set of valid tags for this node type (used to determine if implicit @notice should be added).
+	DocStringParser(
+		StructuredDocumentation const& _documentedNode,
+		langutil::ErrorReporter& _errorReporter,
+		std::set<std::string> const& _validTags = {}
+	):
 		m_node(_documentedNode),
-		m_errorReporter(_errorReporter)
+		m_errorReporter(_errorReporter),
+		m_validTags(_validTags)
 	{}
 	std::multimap<std::string, DocTag> parse();
 
@@ -62,6 +69,7 @@ private:
 
 	StructuredDocumentation const& m_node;
 	langutil::ErrorReporter& m_errorReporter;
+	std::set<std::string> m_validTags;
 	/// Mapping tag name -> content.
 	std::multimap<std::string, DocTag> m_docTags;
 	DocTag* m_lastTag = nullptr;

--- a/test/libsolidity/syntaxTests/natspec/file_level_dev_tag_allowed.sol
+++ b/test/libsolidity/syntaxTests/natspec/file_level_dev_tag_allowed.sol
@@ -1,0 +1,5 @@
+/**
+ * @dev This is a developer note.
+ */
+uint constant x = 8;
+// ----

--- a/test/libsolidity/syntaxTests/natspec/file_level_explicit_notice_error.sol
+++ b/test/libsolidity/syntaxTests/natspec/file_level_explicit_notice_error.sol
@@ -1,0 +1,6 @@
+/**
+ * @notice This should error.
+ */
+uint constant x = 8;
+// ----
+// DocstringParsingError 6546: (0-37): Documentation tag @notice not valid for file-level variables.

--- a/test/libsolidity/syntaxTests/natspec/file_level_no_error_untagged_doc.sol
+++ b/test/libsolidity/syntaxTests/natspec/file_level_no_error_untagged_doc.sol
@@ -1,3 +1,5 @@
-/// Documentation
+/**
+ * whatever...
+ */
 uint constant x = 8;
 // ----

--- a/test/libsolidity/syntaxTests/natspec/file_level_untagged_then_dev.sol
+++ b/test/libsolidity/syntaxTests/natspec/file_level_untagged_then_dev.sol
@@ -1,0 +1,6 @@
+/**
+ * Whatever untagged text.
+ * @dev This should still be parsed.
+ */
+uint constant x = 8;
+// ----


### PR DESCRIPTION
Fixes #16355

Untagged documentation comments on file-level variables (like `/** whatever... */` above a constant) were being implicitly converted to `@notice`, which then failed validation since `@notice` is not valid for file-level variables. Users would get an error for a tag they never explicitly used.

This fix passes the set of valid tags to the DocString parser so it can check whether `@notice` is valid before adding it implicitly. When it's not valid, the parser skips the untagged text and continues processing so any explicit valid tags like `@dev` still work.

Changes:
* Pass valid tags to DocStringParser
* Skip implicit @notice when not valid for the node type
* Add syntax tests for the new behavior