### PR TITLE
Fix external tests for hardhat-gas-reporter v2 compatibility

### DIFF
--- a/scripts/externalTests/common.sh
+++ b/scripts/externalTests/common.sh
@@ -18,7 +18,7 @@
 #
 # (c) 2019 solidity contributors.
 #------------------------------------------------------------------------------
-set -e
+set -eo pipefail
 
 # Requires $REPO_ROOT to be defined and "${REPO_ROOT}/scripts/common.sh" to be included before.
 

--- a/scripts/externalTests/common.sh
+++ b/scripts/externalTests/common.sh
@@ -434,9 +434,9 @@ function eth_gas_reporter_settings
     echo "    enabled: true,"
     echo "    gasPrice: 1,"                           # Gas price does not matter to us at all. Set to whatever to avoid API call.
     echo "    noColors: true,"
-    echo "    showTimeSpent: false,"                  # We're not interested in test timing
-    echo "    onlyCalledMethods: true,"               # Exclude entries with no gas for shorter report
+    echo "    showUncalledMethods: false,"            # Exclude entries with no gas for shorter report
     echo "    showMethodSig: true,"                   # Should make diffs more stable if there are overloaded functions
+    echo "    reportFormat: 'legacy',"                # Use v1.x format for compatibility with parse_eth_gas_report.py
     echo "    outputFile: \"$(gas_report_path "$preset")\""
     echo "}"
 }

--- a/test/externalTests/gp2.sh
+++ b/test/externalTests/gp2.sh
@@ -68,7 +68,8 @@ function gp2_test
     yarn
     # Hardhat 3.0+ breaks the test suite
     # v2.27.1 is the last v2 Hardhat (introduces Osaka support)
-    yarn add hardhat@2.27.1
+    # hardhat-gas-reporter v2 is required for compatibility with our injected gas reporter settings
+    yarn add hardhat@2.27.1 hardhat-gas-reporter@^2
 
     # Ignore bench directory which fails to compile with current hardhat and ethers versions.
     # bench/trace/gas.ts:123:19 - error TS2339: Property 'equals' does not exist on type 'Uint8Array'.


### PR DESCRIPTION
While investigating https://github.com/argotorg/solidity/issues/16351, I noticed that our gas report parsing is broken in CI but still "passing" ([CI job](https://app.circleci.com/pipelines/github/argotorg/solidity/41218/workflows/53f0b827-b3ab-4409-bad0-ca0bfc05752e/jobs/1925706)):

```
Traceback (most recent call last):
  File "/home/circleci/project/scripts/externalTests/parse_eth_gas_report.py", line 263, in <module>
    report = parse_report(sys.stdin.read())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/circleci/project/scripts/externalTests/parse_eth_gas_report.py", line 240, in parse_report
    raise ReportParsingError("Found data row without a section header.", line, line_number)
ReportParsingError: Parsing error on line 2: Found data row without a section header.
|  Solidity and Network Configuration                                                                                                                                                         |
Done.
```

This PR:

- Enables `pipefail` globally so parsing errors fail CI instead of being silently ignored
- Updates `hardhat-gas-reporter` settings in `common.sh` to fix breaking changes:
  - OpenZeppelin `v5.5.0` uses `hardhat-gas-reporter` [^2.1.0](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/308c4914b5482e8ffcbbe6f00be7d7f0429856f6/package.json#L77), which has [breaking changes](https://github.com/cgewecke/hardhat-gas-reporter/releases/tag/v2.0.0):
    - `onlyCalledMethods` renamed to `showUncalledMethods`
    - `showTimeSpent` option removed (Not really sure about that, but I couldn't find the option in the [readme](https://github.com/cgewecke/hardhat-gas-reporter/blob/master/README.md) anymore)
    - Numbers are now formatted with thousands separators (commas): see [commit d7c33469](https://github.com/cgewecke/hardhat-gas-reporter/commit/d7c33469dffea4cba1ce2fcaf9ad78a4547917cc)
  - Added `reportFormat: 'legacy'` to use v1.x table structure
    - We should consider switching to JSON output instead of parsing RST tables. `hardhat-gas-reporter` supports this via the [outputJSON](https://github.com/cgewecke/hardhat-gas-reporter/blob/master/docs/advanced.md#json-output) option since [v2.0.0](https://github.com/cgewecke/hardhat-gas-reporter/pull/170). See: https://github.com/argotorg/solidity/issues/16373
- Updates `parse_eth_gas_report.py` to handle comma-formatted numbers
