### PR TITLE
Fix capitalization, minor typos and wording in documentation

### DIFF
--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -46,7 +46,7 @@ foo->bar(someLongVariableName,
 cout << "some very long string that contains completely irrelevant text that talks about this and that and contains the words \"lorem\" and \"ipsum\"" << endl;
 ```
 
-To set indentation and tab width settings uniformly, the repository contains an [EditorConfig](https://editorconfig.org/) [`.editorconfig`](https://github.com/argotorg/solidity/blob/develop/.editorconfig) file, which describes some of the styles used and which is recognized by many IDE's and editors.
+To set indentation and tab width settings uniformly, the repository contains an [EditorConfig](https://editorconfig.org/) [`.editorconfig`](https://github.com/argotorg/solidity/blob/develop/.editorconfig) file, which describes some of the styles used and which is recognized by many IDEs and editors.
 
 ## 1. Namespaces
 

--- a/ReleaseChecklist.md
+++ b/ReleaseChecklist.md
@@ -3,7 +3,7 @@
 ## Requirements
 - GitHub account with access to [solidity](https://github.com/argotorg/solidity), [solc-js](https://github.com/argotorg/solc-js),
       [solc-bin](https://github.com/argotorg/solc-bin), [solidity-website](https://github.com/argotorg/solidity-website).
-- Personal Access Token (PAT) with `write:packages` scope to access Github's container registry.
+- Personal Access Token (PAT) with `write:packages` scope to access GitHub's container registry.
     You can generate one by visiting https://github.com/settings/tokens/new?scopes=write:packages.
 - Ubuntu/Debian dependencies of the Docker script: `docker-buildx`.
 - [npm Registry](https://www.npmjs.com) account added as a collaborator for the [`solc` package](https://www.npmjs.com/package/solc).
@@ -31,7 +31,7 @@ At least a day before the release:
 - [ ] Create a draft PR to sort the changelog.
 - [ ] Create draft PRs to bump version in `solidity` and `solc-js`.
       **Note**: The `solc-js` PR won't pass CI checks yet because it depends on the soljson binary from `solc-bin`.
-- [ ] Create a draft of the release on github.
+- [ ] Create a draft of the release on GitHub.
 - [ ] Create a draft PR to update soliditylang.org.
 - [ ] Create drafts of blog posts.
 - [ ] Prepare drafts of Twitter, Reddit and Solidity Forum announcements.
@@ -72,7 +72,7 @@ At least a day before the release:
 - [ ] Run `npm run update -- --reuse-hashes` in `solc-bin` and verify that the script has updated `list.js`, `list.txt` and `list.json` files correctly and that symlinks to the new release have been added in `solc-bin/wasm/` and `solc-bin/emscripten-wasm32/`.
 - [ ] Create a pull request in solc-bin and merge.
 
-### Homebrew and MacOS
+### Homebrew and macOS
 - [ ] Update the version and the hash (`sha256sum solidity_$VERSION.tar.gz`) in the [`solidity` formula in Homebrew core repository](https://github.com/Homebrew/homebrew-core/blob/master/Formula/s/solidity.rb).
 
 ### Docker

--- a/ReviewChecklist.md
+++ b/ReviewChecklist.md
@@ -22,7 +22,7 @@ It is also meant to serve as a final checklist for reviewers to go through befor
 - [ ] **Is this a breaking change?** Breaking changes should be based on the `breaking` branch rather than on the `develop` branch.
 - [ ] **Does the PR actually address the issue?**
     - [ ] Mention the issue number in the PR description.
-        If the PR solves it completely, use the `Fixes #<issue number>` form so that Github will close the issue automatically.
+        If the PR solves it completely, use the `Fixes #<issue number>` form so that GitHub will close the issue automatically.
     - [ ] Do not include the issue number in the PR title, branch name or commit description.
 - [ ] When submitting a PR from a fork **create a branch and give it a descriptive name.**
     E.g. `fix-array-abi-encoding-bug`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,8 @@
 
 ## Local environment setup
 
-1. Install python https://www.python.org/downloads/
-1. Install sphinx (the tool used to generate the docs) https://www.sphinx-doc.org/en/master/usage/installation.html
+1. Install Python https://www.python.org/downloads/
+1. Install Sphinx (the tool used to generate the docs) https://www.sphinx-doc.org/en/master/usage/installation.html
 
 Go to `/docs` and run `./docs.sh` to install dependencies and build the project:
 
@@ -12,9 +12,9 @@ cd docs
 ./docs.sh
 ```
 
-That will output the generated htmls under _build/
+That will output the generated HTML files under _build/
 
-## Serve environment
+## Serving environment
 
 ```py
 python3 -m http.server -d _build/html --cgi 8080

--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -45,7 +45,7 @@ source code (e.g. `pragma once <https://en.wikipedia.org/wiki/Pragma_once>`_).
 A contract in the sense of Solidity is a collection of code (its *functions*) and
 data (its *state*) that resides at a specific address on the Ethereum
 blockchain. The line ``uint storedData;`` declares a state variable called ``storedData`` of
-type ``uint`` (*u*\nsigned *int*\eger of *256* bits). You can think of it as a single slot
+type ``uint`` (unsigned integer of *256* bits). You can think of it as a single slot
 in a database that you can query and alter by calling functions of the
 code that manages the database. In this example, the contract defines the
 functions ``set`` and ``get`` that can be used to modify


### PR DESCRIPTION


**Summary**  
- Fix minor spelling mistakes and broken words in docs.  
- Normalize capitalization of brand names (GitHub, macOS, Python, Sphinx, HTML).  
- Improve a few small phrasing issues in documentation titles and sentences.

