### PR TITLE
Fix ICE when combining --optimize with --no-optimize-yul

### DIFF
--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -270,10 +270,7 @@ OptimiserSettings CommandLineOptions::optimiserSettings() const
 			settings = OptimiserSettings::minimal();
 
 	settings.runYulOptimiser = optimizer.optimizeYul;
-	if (optimizer.optimizeYul)
-		// NOTE: Standard JSON disables optimizeStackAllocation by default when yul optimizer is disabled.
-		// --optimize --no-optimize-yul on the CLI does not have that effect.
-		settings.optimizeStackAllocation = true;
+	settings.optimizeStackAllocation = optimizer.optimizeYul;
 
 	if (optimizer.expectedExecutionsPerDeployment.has_value())
 		settings.expectedExecutionsPerDeployment = optimizer.expectedExecutionsPerDeployment.value();

--- a/test/cmdlineTests/optimizer_evmasm_only_no_yul/args
+++ b/test/cmdlineTests/optimizer_evmasm_only_no_yul/args
@@ -1,0 +1,1 @@
+--optimize --no-optimize-yul --bin

--- a/test/cmdlineTests/optimizer_evmasm_only_no_yul/input.sol
+++ b/test/cmdlineTests/optimizer_evmasm_only_no_yul/input.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity *;
+
+// Test case for issue #16306: --optimize --no-optimize-yul should not cause ICE
+contract C {
+    struct A { string a; }
+    function f() public pure returns (A memory) {
+        A memory t;
+        return t;
+    }
+}

--- a/test/cmdlineTests/optimizer_evmasm_only_no_yul/output
+++ b/test/cmdlineTests/optimizer_evmasm_only_no_yul/output
@@ -1,0 +1,4 @@
+
+======= input.sol:C =======
+Binary:
+<BYTECODE REMOVED>

--- a/test/solc/CommandLineParser.cpp
+++ b/test/solc/CommandLineParser.cpp
@@ -462,6 +462,7 @@ BOOST_AUTO_TEST_CASE(optimizer_flags)
 
 	OptimiserSettings evmasmOnly = OptimiserSettings::standard();
 	evmasmOnly.runYulOptimiser = false;
+	evmasmOnly.optimizeStackAllocation = false;
 
 	std::map<std::vector<std::string>, OptimiserSettings> settingsMap = {
 		{{}, OptimiserSettings::minimal()},


### PR DESCRIPTION
Fixes https://github.com/argotorg/solidity/issues/16306

Using `--optimize --no-optimize-yul` caused an internal compiler error in `createMetadata()` because `optimizeStackAllocation` remained `true` (from `OptimiserSettings::standard()`) while `runYulOptimiser` was set to `false`.

This PR sets `optimizeStackAllocation` to match `runYulOptimiser`, ensuring consistency.