### PR TITLE
Fix incorrect shadow warning for variables in non-overlapping scopes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Language Features:
 Compiler Features:
 
 Bugfixes:
+ * Name Resolver: Fix incorrect shadowing warning for variables declared in non-overlapping scopes.
 
 
 ### 0.8.33 (2025-12-18)

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -260,6 +260,9 @@ void NameAndTypeResolver::warnHomonymDeclarations() const
 		for (Declaration const* outerDeclaration: outerDeclarations)
 		{
 			solAssert(outerDeclaration, "");
+			if (auto const* varDecl = dynamic_cast<VariableDeclaration const*>(outerDeclaration))
+				if (varDecl->isLocalVariable() && outerDeclaration->location().start >= innerLocation->start)
+					continue;
 			if (dynamic_cast<MagicVariableDeclaration const*>(outerDeclaration))
 				magicShadowed = true;
 			else if (!outerDeclaration->isVisibleInContract())

--- a/test/libsolidity/syntaxTests/scoping/double_variable_declaration_disjoint_scope_activation.sol
+++ b/test/libsolidity/syntaxTests/scoping/double_variable_declaration_disjoint_scope_activation.sol
@@ -5,6 +5,5 @@ contract test {
     }
 }
 // ----
-// Warning 2519: (57-63): This declaration shadows an existing declaration.
 // Warning 2072: (57-63): Unused local variable.
 // Warning 2072: (75-81): Unused local variable.


### PR DESCRIPTION
Fixes https://github.com/argotorg/solidity/issues/16190

When a local variable is declared in a block that ends before another local variable with the same name is declared at function scope, the compiler incorrectly warns that the first variable shadows the second.

This PR skips shadow warnings for local variables where the outer declaration appears after the inner declaration in source order, since the outer variable was not visible when the inner one was declared.