### PR TITLE
Add ccache to buildpack-deps images

### DIFF
--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -51,6 +51,7 @@ then
   brew update
   brew upgrade
   brew install cmake
+  brew install ccache
   brew install wget
   brew install coreutils
   brew install diffutils

--- a/scripts/ci/docker_upgrade.sh
+++ b/scripts/ci/docker_upgrade.sh
@@ -55,6 +55,7 @@ docker run \
   --rm \
   --volume "${PWD}:/project" \
   -u "$(id -u "${USER}"):$(id -g "${USER}")" \
+  -e CCACHE_DIR=/tmp/ccache \
   "${IMAGE_NAME}" \
   bash -c "/project/scripts/ci/${IMAGE_NAME}_test_${IMAGE_VARIANT}.sh"
 

--- a/scripts/docker/buildpack-deps/Dockerfile.emscripten
+++ b/scripts/docker/buildpack-deps/Dockerfile.emscripten
@@ -33,7 +33,7 @@
 # Using $(em-config CACHE)/sysroot/usr seems to work, though, and still has cmake find the
 # dependencies automatically.
 FROM emscripten/emsdk:3.1.19 AS base
-LABEL version="21"
+LABEL version="22"
 
 ADD emscripten.jam /usr/src
 RUN <<-EOF
@@ -41,6 +41,7 @@ RUN <<-EOF
 	apt-get update
 	apt-get install -qqy --no-install-recommends \
 		lsof \
+		ccache \
 		lz4 \
 		python3 \
 		python3-pip \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu.clang.ossfuzz
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu.clang.ossfuzz
@@ -22,7 +22,7 @@
 # (c) 2016-2021 solidity contributors.
 #------------------------------------------------------------------------------
 FROM gcr.io/oss-fuzz-base/base-builder AS base
-LABEL version="12"
+LABEL version="13"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -31,6 +31,7 @@ RUN apt-get update; \
 		automake \
 		bison \
 		build-essential \
+		ccache \
 		curl \
 		git \
 		jq \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2404
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2404
@@ -22,7 +22,7 @@
 # (c) 2016-2024 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:noble AS base
-LABEL version="6"
+LABEL version="7"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -39,6 +39,7 @@ RUN set -ex; \
 	apt-get install -qqy --no-install-recommends \
 		build-essential \
 		cmake \
+		ccache \
 		jq \
 		libboost-filesystem-dev \
 		libboost-program-options-dev \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2404.arm
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2404.arm
@@ -22,7 +22,7 @@
 # (c) 2016-2025 solidity contributors.
 #------------------------------------------------------------------------------
 FROM --platform=linux/arm64 buildpack-deps:noble AS base
-LABEL version="2"
+LABEL version="3"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -40,6 +40,7 @@ RUN <<-EOF
     apt-get install --quiet=2 --no-install-recommends \
         build-essential \
         cmake \
+        ccache \
         jq \
         libboost-filesystem-dev \
         libboost-program-options-dev \

--- a/scripts/docker/buildpack-deps/Dockerfile.ubuntu2404.clang
+++ b/scripts/docker/buildpack-deps/Dockerfile.ubuntu2404.clang
@@ -22,7 +22,7 @@
 # (c) 2016-2024 solidity contributors.
 #------------------------------------------------------------------------------
 FROM buildpack-deps:noble AS base
-LABEL version="7"
+LABEL version="8"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -40,6 +40,7 @@ RUN set -ex; \
 		build-essential \
 		clang \
 		cmake \
+		ccache \
 		jq \
 		libboost-filesystem-dev \
 		libboost-program-options-dev \


### PR DESCRIPTION
In https://github.com/argotorg/solidity/pull/16356 I created both the new buildpack-deps images and I edited `.circleci/config.yml` in the same PR. This PR is needed to do the first step separately, another PR with the `.circleci/config.yml` will follow.