### PR TITLE
Speed up CI builds with ccache (seeded from develop)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ commands:
             equal: ["ci-ccache", << pipeline.git.branch >>]
           steps:
             - save_cache:
-                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache
+                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-{{ .Revision }}
                 paths:
                   - ~/.ccache
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,12 +93,10 @@ commands:
   restore_ccache_if_allowed:
     description: "Restore ccache unless on a tag or a skipped branch."
     parameters:
-      # TODO: remove the line below
-      # Before merging this PR we need to use an alternative develop branch to test the functionality, `ci-ccache`
       skip_branches_regex:
         description: "Regex of branches that should skip restoring the cache."
         type: string
-        default: "^(ci-ccache|breaking)$"
+        default: "^(develop|breaking)$"
     steps:
       # Tags always skip ccache. Selected branches intentionally start from scratch.
       - when:
@@ -112,19 +110,19 @@ commands:
           steps:
             - restore_cache:
                 keys:
-                  # Reuse cache produced on ci-ccache (prefix match; restores the most recent).
-                  - v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-
+                  # Reuse cache produced on develop (prefix match; restores the most recent).
+                  - v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-develop-
 
   save_ccache_if_develop:
-    description: "Save a fresh ccache only on the ci-ccache branch."
+    description: "Save a fresh ccache only on the develop branch."
     steps:
-      # On `ci-ccache` we always generate a fresh cache by never restoring and by saving under a unique key.
+      # On `develop` we always generate a fresh cache by never restoring and by saving under a unique key.
       - when:
           condition:
-            equal: ["ci-ccache", << pipeline.git.branch >>]
+            equal: ["develop", << pipeline.git.branch >>]
           steps:
             - save_cache:
-                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-{{ .Revision }}
+                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-develop-{{ .Revision }}
                 paths:
                   - ~/.ccache
   run_with_ccache_unless_tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,44 @@ commands:
               exit 1
             fi
 
+  restore_ccache_if_allowed:
+    description: "Restore ccache unless on a tag or a skipped branch."
+    parameters:
+      # TODO: remove the line below
+      # Before merging this PR we need to use an alternative develop branch to test the functionality, `ci-ccache`
+      skip_branches_regex:
+        description: "Regex of branches that should skip restoring the cache."
+        type: string
+        default: "^(ci-ccache|breaking)$"
+    steps:
+      # Tags always skip ccache. Selected branches intentionally start from scratch.
+      - when:
+          condition:
+            and:
+              - equal: ["", << pipeline.git.tag >>]
+              - not:
+                  matches:
+                    pattern: "<< parameters.skip_branches_regex >>"
+                    value: << pipeline.git.branch >>
+          steps:
+            - restore_cache:
+                keys:
+                  # Reuse cache produced on ci-ccache (prefix match; restores the most recent).
+                  - v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-
+
+  save_ccache_if_develop:
+    description: "Save a fresh ccache only on the ci-ccache branch."
+    steps:
+      # On `ci-ccache` we always generate a fresh cache by never restoring and by saving under a unique key.
+      - when:
+          condition:
+            equal: ["ci-ccache", << pipeline.git.branch >>]
+          steps:
+            - save_cache:
+                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache
+                paths:
+                  - ~/.ccache
+
   prepare_bytecode_report:
     description: "Generate bytecode report and upload it as an artifact."
     parameters:
@@ -224,24 +262,7 @@ commands:
             equal: ["", << pipeline.git.tag >>]
           steps:
             - ensure_ccache_key
-      # TODO: remove the line below
-      # Before merging this PR we need to use an alternative develop branch to test the functionality, `ci-ccache`
-
-      # On `ci-ccache` and `breaking` we intentionally do NOT restore any ccache, so every run starts from scratch.
-      # Tags always skip ccache. Other branches restore the most recent cache produced on `ci-ccache`.
-      - when:
-          condition:
-            and:
-              - equal: ["", << pipeline.git.tag >>]
-              - not:
-                  or:
-                    - equal: ["ci-ccache", << pipeline.git.branch >>]
-                    - equal: ["breaking", << pipeline.git.branch >>]
-          steps:
-            - restore_cache:
-                keys:
-                  # Reuse cache produced on ci-ccache (prefix match; restores the most recent).
-                  - v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-
+      - restore_ccache_if_allowed
       # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
       - when:
           condition:
@@ -261,15 +282,7 @@ commands:
                 name: Build (no ccache)
                 command: scripts/ci/build.sh
 
-      # On `ci-ccache` we always generate a fresh cache by never restoring and by saving under a unique key.
-      - when:
-          condition:
-            equal: ["ci-ccache", << pipeline.git.branch >>]
-          steps:
-            - save_cache:
-                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache
-                paths:
-                  - ~/.ccache
+      - save_ccache_if_develop
 
   run_build_ossfuzz:
     steps:
@@ -278,21 +291,7 @@ commands:
             equal: ["", << pipeline.git.tag >>]
           steps:
             - ensure_ccache_key
-      # On `ci-ccache` and `breaking` we intentionally do NOT restore any ccache, so every run starts from scratch.
-      # Tags always skip ccache. Other branches restore the most recent cache produced on `ci-ccache`.
-      - when:
-          condition:
-            and:
-              - equal: ["", << pipeline.git.tag >>]
-              - not:
-                  or:
-                    - equal: ["ci-ccache", << pipeline.git.branch >>]
-                    - equal: ["breaking", << pipeline.git.branch >>]
-          steps:
-            - restore_cache:
-                keys:
-                  # Reuse cache produced on ci-ccache (prefix match; restores the most recent).
-                  - v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-
+      - restore_ccache_if_allowed
       # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
       - when:
           condition:
@@ -312,15 +311,7 @@ commands:
                 name: Build_ossfuzz (no ccache)
                 command: scripts/ci/build_ossfuzz.sh
 
-      # On `ci-ccache` we always generate a fresh cache by never restoring and by saving under a unique key.
-      - when:
-          condition:
-            equal: ["ci-ccache", << pipeline.git.branch >>]
-          steps:
-            - save_cache:
-                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache
-                paths:
-                  - ~/.ccache
+      - save_ccache_if_develop
 
   run_proofs:
     steps:
@@ -1366,21 +1357,7 @@ jobs:
             equal: ["", << pipeline.git.tag >>]
           steps:
             - ensure_ccache_key
-      # On `ci-ccache` and `breaking` we intentionally do NOT restore any ccache, so every run starts from scratch.
-      # Tags always skip ccache. Other branches restore the most recent cache produced on `ci-ccache`.
-      - when:
-          condition:
-            and:
-              - equal: ["", << pipeline.git.tag >>]
-              - not:
-                  or:
-                    - equal: ["ci-ccache", << pipeline.git.branch >>]
-                    - equal: ["breaking", << pipeline.git.branch >>]
-          steps:
-            - restore_cache:
-                keys:
-                  # Reuse cache produced on ci-ccache (prefix match; restores the most recent).
-                  - v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-
+      - restore_ccache_if_allowed
       # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
       - when:
           condition:
@@ -1401,15 +1378,7 @@ jobs:
                 command: |
                   scripts/ci/build_emscripten.sh
 
-      # On `ci-ccache` we always generate a fresh cache by never restoring and by saving under a unique key.
-      - when:
-          condition:
-            equal: ["ci-ccache", << pipeline.git.branch >>]
-          steps:
-            - save_cache:
-                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache
-                paths:
-                  - ~/.ccache
+      - save_ccache_if_develop
       - store_artifacts:
           path: upload/soljson.js
           destination: soljson.js
@@ -1891,21 +1860,7 @@ jobs:
             equal: ["", << pipeline.git.tag >>]
           steps:
             - ensure_ccache_key
-      # On `ci-ccache` and `breaking` we intentionally do NOT restore any ccache, so every run starts from scratch.
-      # Tags always skip ccache. Other branches restore the most recent cache produced on `ci-ccache`.
-      - when:
-          condition:
-            and:
-              - equal: ["", << pipeline.git.tag >>]
-              - not:
-                  or:
-                    - equal: ["ci-ccache", << pipeline.git.branch >>]
-                    - equal: ["breaking", << pipeline.git.branch >>]
-          steps:
-            - restore_cache:
-                keys:
-                  # Reuse cache produced on ci-ccache (prefix match; restores the most recent).
-                  - v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-
+      - restore_ccache_if_allowed
       # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
       - when:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,17 @@ commands:
           event: release
           condition: on_success
 
+  ensure_ccache_key:
+    description: "Fail fast when CCACHE_KEY is missing."
+    steps:
+      - run:
+          name: Check CCACHE_KEY
+          command: |
+            if [ -z "${CCACHE_KEY:-}" ]; then
+              echo "CCACHE_KEY is not set. Please set it in CircleCI environment settings."
+              exit 1
+            fi
+
   prepare_bytecode_report:
     description: "Generate bytecode report and upload it as an artifact."
     parameters:
@@ -208,6 +219,11 @@ commands:
 
   run_build:
     steps:
+      - when:
+          condition:
+            equal: ["", << pipeline.git.tag >>]
+          steps:
+            - ensure_ccache_key
       # TODO: remove the line below
       # Before merging this PR we need to use an alternative develop branch to test the functionality, `ci-ccache`
 
@@ -226,7 +242,7 @@ commands:
                 keys:
                   # Reuse cache produced on ci-ccache (prefix match; restores the most recent).
                   - v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-
-      # WARNING! If you edit anything between here and save_cache, remember to bump version or invalidate the cache manually.
+      # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
       - when:
           condition:
             and:
@@ -234,7 +250,7 @@ commands:
           steps:
             - run:
                 name: Build (ccache)
-                command: CCACHE_ENABLED=1 scripts/ci/build.sh
+                command: CCACHE_ENABLED=${CCACHE_ENABLED:-1} scripts/ci/build.sh
       - when:
           condition:
             or:
@@ -251,12 +267,17 @@ commands:
             equal: ["ci-ccache", << pipeline.git.branch >>]
           steps:
             - save_cache:
-                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-{{ .Revision }}
+                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache
                 paths:
                   - ~/.ccache
 
   run_build_ossfuzz:
     steps:
+      - when:
+          condition:
+            equal: ["", << pipeline.git.tag >>]
+          steps:
+            - ensure_ccache_key
       # On `ci-ccache` and `breaking` we intentionally do NOT restore any ccache, so every run starts from scratch.
       # Tags always skip ccache. Other branches restore the most recent cache produced on `ci-ccache`.
       - when:
@@ -272,7 +293,7 @@ commands:
                 keys:
                   # Reuse cache produced on ci-ccache (prefix match; restores the most recent).
                   - v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-
-      # WARNING! If you edit anything between here and save_cache, remember to bump version or invalidate the cache manually.
+      # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
       - when:
           condition:
             and:
@@ -280,7 +301,7 @@ commands:
           steps:
             - run:
                 name: Build_ossfuzz (ccache)
-                command: CCACHE_ENABLED=1 scripts/ci/build_ossfuzz.sh
+                command: CCACHE_ENABLED=${CCACHE_ENABLED:-1} scripts/ci/build_ossfuzz.sh
       - when:
           condition:
             or:
@@ -297,7 +318,7 @@ commands:
             equal: ["ci-ccache", << pipeline.git.branch >>]
           steps:
             - save_cache:
-                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-{{ .Revision }}
+                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache
                 paths:
                   - ~/.ccache
 
@@ -1340,6 +1361,11 @@ jobs:
       MAKEFLAGS: -j 10
     steps:
       - checkout
+      - when:
+          condition:
+            equal: ["", << pipeline.git.tag >>]
+          steps:
+            - ensure_ccache_key
       # On `ci-ccache` and `breaking` we intentionally do NOT restore any ccache, so every run starts from scratch.
       # Tags always skip ccache. Other branches restore the most recent cache produced on `ci-ccache`.
       - when:
@@ -1355,7 +1381,7 @@ jobs:
                 keys:
                   # Reuse cache produced on ci-ccache (prefix match; restores the most recent).
                   - v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-
-      # WARNING! If you edit anything between here and save_cache, remember to bump version or invalidate the cache manually.
+      # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
       - when:
           condition:
             and:
@@ -1363,7 +1389,7 @@ jobs:
           steps:
             - run:
                 name: Build (ccache)
-                command: CCACHE_ENABLED=1 scripts/ci/build_emscripten.sh
+                command: CCACHE_ENABLED=${CCACHE_ENABLED:-1} scripts/ci/build_emscripten.sh
       - when:
           condition:
             or:
@@ -1381,7 +1407,7 @@ jobs:
             equal: ["ci-ccache", << pipeline.git.branch >>]
           steps:
             - save_cache:
-                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-{{ .Revision }}
+                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache
                 paths:
                   - ~/.ccache
       - store_artifacts:
@@ -1860,6 +1886,11 @@ jobs:
           key: dependencies-win-{{ arch }}-{{ checksum "scripts/install_deps.ps1" }}
           paths:
             - .\deps
+      - when:
+          condition:
+            equal: ["", << pipeline.git.tag >>]
+          steps:
+            - ensure_ccache_key
       # On `ci-ccache` and `breaking` we intentionally do NOT restore any ccache, so every run starts from scratch.
       # Tags always skip ccache. Other branches restore the most recent cache produced on `ci-ccache`.
       - when:
@@ -1875,7 +1906,7 @@ jobs:
                 keys:
                   # Reuse cache produced on ci-ccache (prefix match; restores the most recent).
                   - v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-
-      # WARNING! If you edit anything between here and save_cache, remember to bump version or invalidate the cache manually.
+      # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
       - when:
           condition:
             and:
@@ -1883,7 +1914,7 @@ jobs:
           steps:
             - run:
                 name: "Building solidity (ccache)"
-                command: CCACHE_ENABLED=1 scripts/ci/build_win.sh
+                command: CCACHE_ENABLED=${CCACHE_ENABLED:-1} scripts/ci/build_win.sh
       - when:
           condition:
             or:
@@ -1899,7 +1930,7 @@ jobs:
             equal: ["ci-ccache", << pipeline.git.branch >>]
           steps:
             - save_cache:
-                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-{{ .Revision }}
+                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache
                 paths:
                   - ~/.ccache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,16 +75,20 @@ commands:
           event: release
           condition: on_success
 
-  ensure_ccache_key:
-    description: "Fail fast when CCACHE_KEY is missing."
+  ensure_ccache_key_unless_tag:
+    description: "Fail fast when CCACHE_KEY is missing (skipped on tags)."
     steps:
-      - run:
-          name: Check CCACHE_KEY
-          command: |
-            if [ -z "${CCACHE_KEY:-}" ]; then
-              echo "CCACHE_KEY is not set. Please set it in CircleCI environment settings."
-              exit 1
-            fi
+      - when:
+          condition:
+            equal: ["", << pipeline.git.tag >>]
+          steps:
+            - run:
+                name: Check CCACHE_KEY
+                command: |
+                  if [ -z "${CCACHE_KEY:-}" ]; then
+                    echo "CCACHE_KEY is not set. Please set it in CircleCI environment settings."
+                    exit 1
+                  fi
 
   restore_ccache_if_allowed:
     description: "Restore ccache unless on a tag or a skipped branch."
@@ -123,6 +127,29 @@ commands:
                 key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-{{ .Revision }}
                 paths:
                   - ~/.ccache
+  run_with_ccache_unless_tag:
+    description: "Run a command with ccache enabled unless building a tag."
+    parameters:
+      command:
+        type: string
+      step_name:
+        type: string
+    steps:
+      - when:
+          condition:
+            equal: ["", << pipeline.git.tag >>]
+          steps:
+            - run:
+                name: << parameters.step_name >> (ccache)
+                command: << parameters.command >>
+      - when:
+          condition:
+            not:
+              equal: ["", << pipeline.git.tag >>]
+          steps:
+            - run:
+                name: << parameters.step_name >> (no ccache)
+                command: CCACHE_DISABLE=1 << parameters.command >>
 
   prepare_bytecode_report:
     description: "Generate bytecode report and upload it as an artifact."
@@ -257,60 +284,22 @@ commands:
 
   run_build:
     steps:
-      - when:
-          condition:
-            equal: ["", << pipeline.git.tag >>]
-          steps:
-            - ensure_ccache_key
+      - ensure_ccache_key_unless_tag
       - restore_ccache_if_allowed
       # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
-      - when:
-          condition:
-            and:
-              - equal: ["", << pipeline.git.tag >>]
-          steps:
-            - run:
-                name: Build (ccache)
-                command: CCACHE_ENABLED=${CCACHE_ENABLED:-1} scripts/ci/build.sh
-      - when:
-          condition:
-            or:
-              - not:
-                  equal: ["", << pipeline.git.tag >>]
-          steps:
-            - run:
-                name: Build (no ccache)
-                command: scripts/ci/build.sh
-
+      - run_with_ccache_unless_tag:
+          step_name: Build
+          command: scripts/ci/build.sh
       - save_ccache_if_develop
 
   run_build_ossfuzz:
     steps:
-      - when:
-          condition:
-            equal: ["", << pipeline.git.tag >>]
-          steps:
-            - ensure_ccache_key
+      - ensure_ccache_key_unless_tag
       - restore_ccache_if_allowed
       # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
-      - when:
-          condition:
-            and:
-              - equal: ["", << pipeline.git.tag >>]
-          steps:
-            - run:
-                name: Build_ossfuzz (ccache)
-                command: CCACHE_ENABLED=${CCACHE_ENABLED:-1} scripts/ci/build_ossfuzz.sh
-      - when:
-          condition:
-            or:
-              - not:
-                  equal: ["", << pipeline.git.tag >>]
-          steps:
-            - run:
-                name: Build_ossfuzz (no ccache)
-                command: scripts/ci/build_ossfuzz.sh
-
+      - run_with_ccache_unless_tag:
+          step_name: Build_ossfuzz
+          command: scripts/ci/build_ossfuzz.sh
       - save_ccache_if_develop
 
   run_proofs:
@@ -1352,32 +1341,12 @@ jobs:
       MAKEFLAGS: -j 10
     steps:
       - checkout
-      - when:
-          condition:
-            equal: ["", << pipeline.git.tag >>]
-          steps:
-            - ensure_ccache_key
+      - ensure_ccache_key_unless_tag
       - restore_ccache_if_allowed
       # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
-      - when:
-          condition:
-            and:
-              - equal: ["", << pipeline.git.tag >>]
-          steps:
-            - run:
-                name: Build (ccache)
-                command: CCACHE_ENABLED=${CCACHE_ENABLED:-1} scripts/ci/build_emscripten.sh
-      - when:
-          condition:
-            or:
-              - not:
-                  equal: ["", << pipeline.git.tag >>]
-          steps:
-            - run:
-                name: Build (no ccache)
-                command: |
-                  scripts/ci/build_emscripten.sh
-
+      - run_with_ccache_unless_tag:
+          step_name: Build
+          command: scripts/ci/build_emscripten.sh
       - save_ccache_if_develop
       - store_artifacts:
           path: upload/soljson.js
@@ -1855,39 +1824,13 @@ jobs:
           key: dependencies-win-{{ arch }}-{{ checksum "scripts/install_deps.ps1" }}
           paths:
             - .\deps
-      - when:
-          condition:
-            equal: ["", << pipeline.git.tag >>]
-          steps:
-            - ensure_ccache_key
+      - ensure_ccache_key_unless_tag
       - restore_ccache_if_allowed
       # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
-      - when:
-          condition:
-            and:
-              - equal: ["", << pipeline.git.tag >>]
-          steps:
-            - run:
-                name: "Building solidity (ccache)"
-                command: CCACHE_ENABLED=${CCACHE_ENABLED:-1} scripts/ci/build_win.sh
-      - when:
-          condition:
-            or:
-              - not:
-                  equal: ["", << pipeline.git.tag >>]
-          steps:
-            - run:
-                name: "Building solidity (no ccache)"
-                command: scripts/ci/build_win.sh
-      # On `ci-ccache` we always generate a fresh cache by never restoring and by saving under a unique key.
-      - when:
-          condition:
-            equal: ["ci-ccache", << pipeline.git.branch >>]
-          steps:
-            - save_cache:
-                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache
-                paths:
-                  - ~/.ccache
+      - run_with_ccache_unless_tag:
+          step_name: "Building solidity"
+          command: scripts/ci/build_win.sh
+      - save_ccache_if_develop
       - run:
           name: "Run solc.exe to make sure build was successful."
           command: .\build\solc\Release\solc.exe --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,25 +13,25 @@ parameters:
     default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:1f387a77be889f65a2a25986a5c5eccc88cec23fabe6aeaf351790751145c81e"
   ubuntu-2404-docker-image:
     type: string
-    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu2404-6
-    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:c0412c53e59ce0c96bde4c08e7332ea12e4cadba9bbac829621947897fa21272"
+    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu2404-7
+    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:e52bd8fbb38908f203c6866e39562548faf26e5b7a5174f9860b44aae2b8f0cd"
   ubuntu-2404-arm-docker-image:
     type: string
-    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu2404.arm-2
-    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:27b03c1c4688e5d69b10e0539460346a3dee3b10b0e04fb406b9707c6f0dd95e"
+    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu2404.arm-3
+    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:1e6dbf9a9173f2645449281a1e11918a95ca6dc04e59aa9d70824cffc44697ed"
   ubuntu-2404-clang-docker-image:
     type: string
-    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu2404.clang-7
-    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:7466ed23590cf14e60da884894723bcdab064742f017dcfcce015999b4f9143b"
+    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu2404.clang-8
+    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:e283c8ec6a59c76565c89b856d8019af2fa5beb96f27d3064fc4dda42bf3524d"
   ubuntu-clang-ossfuzz-docker-image:
     type: string
-    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu.clang.ossfuzz-12
-    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:c7088af5082bf764244a6251ecf3dd29d280d2cd2cd071f011f7f32e0326f426"
+    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu.clang.ossfuzz-13
+    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:2acb5d6f254ece25a96096f26960b5fe114eb86ceca92312cd20d59c096bf6e4"
   emscripten-docker-image:
     type: string
     # NOTE: Please remember to update the `scripts/build_emscripten.sh` whenever the hash of this image changes.
-    # ghcr.io/argotorg/solidity-buildpack-deps:emscripten-21
-    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:fc53d68a4680ffa7d5f70164e13a903478964f15bcc07434d74833a05f4fbc19"
+    # ghcr.io/argotorg/solidity-buildpack-deps:emscripten-22
+    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:b9c953144d82cca5553f65626bc43b8af456dbc8966f8732ff9522f33ca8d722"
   evm-version:
     type: string
     default: osaka
@@ -208,15 +208,98 @@ commands:
 
   run_build:
     steps:
-      - run:
-          name: Build
-          command: scripts/ci/build.sh
+      # TODO: remove the line below
+      # Before merging this PR we need to use an alternative develop branch to test the functionality, `ci-ccache`
+
+      # On `ci-ccache` and `breaking` we intentionally do NOT restore any ccache, so every run starts from scratch.
+      # Tags always skip ccache. Other branches restore the most recent cache produced on `ci-ccache`.
+      - when:
+          condition:
+            and:
+              - equal: ["", << pipeline.git.tag >>]
+              - not:
+                  or:
+                    - equal: ["ci-ccache", << pipeline.git.branch >>]
+                    - equal: ["breaking", << pipeline.git.branch >>]
+          steps:
+            - restore_cache:
+                keys:
+                  # Reuse cache produced on ci-ccache (prefix match; restores the most recent).
+                  - v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-
+      # WARNING! If you edit anything between here and save_cache, remember to bump version or invalidate the cache manually.
+      - when:
+          condition:
+            and:
+              - equal: ["", << pipeline.git.tag >>]
+          steps:
+            - run:
+                name: Build (ccache)
+                command: CCACHE_ENABLED=1 scripts/ci/build.sh
+      - when:
+          condition:
+            or:
+              - not:
+                  equal: ["", << pipeline.git.tag >>]
+          steps:
+            - run:
+                name: Build (no ccache)
+                command: scripts/ci/build.sh
+
+      # On `ci-ccache` we always generate a fresh cache by never restoring and by saving under a unique key.
+      - when:
+          condition:
+            equal: ["ci-ccache", << pipeline.git.branch >>]
+          steps:
+            - save_cache:
+                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-{{ .Revision }}
+                paths:
+                  - ~/.ccache
 
   run_build_ossfuzz:
     steps:
-      - run:
-          name: Build_ossfuzz
-          command: scripts/ci/build_ossfuzz.sh
+      # On `ci-ccache` and `breaking` we intentionally do NOT restore any ccache, so every run starts from scratch.
+      # Tags always skip ccache. Other branches restore the most recent cache produced on `ci-ccache`.
+      - when:
+          condition:
+            and:
+              - equal: ["", << pipeline.git.tag >>]
+              - not:
+                  or:
+                    - equal: ["ci-ccache", << pipeline.git.branch >>]
+                    - equal: ["breaking", << pipeline.git.branch >>]
+          steps:
+            - restore_cache:
+                keys:
+                  # Reuse cache produced on ci-ccache (prefix match; restores the most recent).
+                  - v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-
+      # WARNING! If you edit anything between here and save_cache, remember to bump version or invalidate the cache manually.
+      - when:
+          condition:
+            and:
+              - equal: ["", << pipeline.git.tag >>]
+          steps:
+            - run:
+                name: Build_ossfuzz (ccache)
+                command: CCACHE_ENABLED=1 scripts/ci/build_ossfuzz.sh
+      - when:
+          condition:
+            or:
+              - not:
+                  equal: ["", << pipeline.git.tag >>]
+          steps:
+            - run:
+                name: Build_ossfuzz (no ccache)
+                command: scripts/ci/build_ossfuzz.sh
+
+      # On `ci-ccache` we always generate a fresh cache by never restoring and by saving under a unique key.
+      - when:
+          condition:
+            equal: ["ci-ccache", << pipeline.git.branch >>]
+          steps:
+            - save_cache:
+                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-{{ .Revision }}
+                paths:
+                  - ~/.ccache
 
   run_proofs:
     steps:
@@ -1197,7 +1280,7 @@ jobs:
       - run:
           name: Install build dependencies
           command: |
-            pacman --noconfirm -Syu --noprogressbar --needed base-devel boost cmake git openssh tar
+            pacman --noconfirm -Syu --noprogressbar --needed base-devel boost cmake ccache git openssh tar
       - checkout
       - run_build
       - store_artifacts_solc
@@ -1257,10 +1340,50 @@ jobs:
       MAKEFLAGS: -j 10
     steps:
       - checkout
-      - run:
-          name: Build
-          command: |
-            scripts/ci/build_emscripten.sh
+      # On `ci-ccache` and `breaking` we intentionally do NOT restore any ccache, so every run starts from scratch.
+      # Tags always skip ccache. Other branches restore the most recent cache produced on `ci-ccache`.
+      - when:
+          condition:
+            and:
+              - equal: ["", << pipeline.git.tag >>]
+              - not:
+                  or:
+                    - equal: ["ci-ccache", << pipeline.git.branch >>]
+                    - equal: ["breaking", << pipeline.git.branch >>]
+          steps:
+            - restore_cache:
+                keys:
+                  # Reuse cache produced on ci-ccache (prefix match; restores the most recent).
+                  - v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-
+      # WARNING! If you edit anything between here and save_cache, remember to bump version or invalidate the cache manually.
+      - when:
+          condition:
+            and:
+              - equal: ["", << pipeline.git.tag >>]
+          steps:
+            - run:
+                name: Build (ccache)
+                command: CCACHE_ENABLED=1 scripts/ci/build_emscripten.sh
+      - when:
+          condition:
+            or:
+              - not:
+                  equal: ["", << pipeline.git.tag >>]
+          steps:
+            - run:
+                name: Build (no ccache)
+                command: |
+                  scripts/ci/build_emscripten.sh
+
+      # On `ci-ccache` we always generate a fresh cache by never restoring and by saving under a unique key.
+      - when:
+          condition:
+            equal: ["ci-ccache", << pipeline.git.branch >>]
+          steps:
+            - save_cache:
+                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-{{ .Revision }}
+                paths:
+                  - ~/.ccache
       - store_artifacts:
           path: upload/soljson.js
           destination: soljson.js
@@ -1737,9 +1860,48 @@ jobs:
           key: dependencies-win-{{ arch }}-{{ checksum "scripts/install_deps.ps1" }}
           paths:
             - .\deps
-      - run:
-          name: "Building solidity"
-          command: scripts/ci/build_win.sh
+      # On `ci-ccache` and `breaking` we intentionally do NOT restore any ccache, so every run starts from scratch.
+      # Tags always skip ccache. Other branches restore the most recent cache produced on `ci-ccache`.
+      - when:
+          condition:
+            and:
+              - equal: ["", << pipeline.git.tag >>]
+              - not:
+                  or:
+                    - equal: ["ci-ccache", << pipeline.git.branch >>]
+                    - equal: ["breaking", << pipeline.git.branch >>]
+          steps:
+            - restore_cache:
+                keys:
+                  # Reuse cache produced on ci-ccache (prefix match; restores the most recent).
+                  - v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-
+      # WARNING! If you edit anything between here and save_cache, remember to bump version or invalidate the cache manually.
+      - when:
+          condition:
+            and:
+              - equal: ["", << pipeline.git.tag >>]
+          steps:
+            - run:
+                name: "Building solidity (ccache)"
+                command: CCACHE_ENABLED=1 scripts/ci/build_win.sh
+      - when:
+          condition:
+            or:
+              - not:
+                  equal: ["", << pipeline.git.tag >>]
+          steps:
+            - run:
+                name: "Building solidity (no ccache)"
+                command: scripts/ci/build_win.sh
+      # On `ci-ccache` we always generate a fresh cache by never restoring and by saving under a unique key.
+      - when:
+          condition:
+            equal: ["ci-ccache", << pipeline.git.branch >>]
+          steps:
+            - save_cache:
+                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-ci-ccache-{{ .Revision }}
+                paths:
+                  - ~/.ccache
       - run:
           name: "Run solc.exe to make sure build was successful."
           command: .\build\solc\Release\solc.exe --version

--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -51,6 +51,7 @@ then
   brew update
   brew upgrade
   brew install cmake
+  brew install ccache
   brew install wget
   brew install coreutils
   brew install diffutils

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -16,23 +16,17 @@ cd build
 
 [[ -n $COVERAGE && -z $CIRCLE_TAG ]] && CMAKE_OPTIONS="$CMAKE_OPTIONS -DCOVERAGE=ON"
 
-if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
-  export CCACHE_DIR="$HOME/.ccache"
-  export CCACHE_BASEDIR="$ROOTDIR"
-  export CCACHE_NOHASHDIR=1
-  CMAKE_OPTIONS="${CMAKE_OPTIONS:-} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
-  mkdir -p "$CCACHE_DIR"
-fi
+export CCACHE_DIR="$HOME/.ccache"
+export CCACHE_BASEDIR="$ROOTDIR"
+export CCACHE_NOHASHDIR=1
+CMAKE_OPTIONS="${CMAKE_OPTIONS:-} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+mkdir -p "$CCACHE_DIR"
 
 # shellcheck disable=SC2086
 cmake .. -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}" $CMAKE_OPTIONS
 
-if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
-  ccache -z
-fi
+ccache -z
 
 cmake --build .
 
-if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
-  ccache -s
-fi
+ccache -s

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -17,9 +17,11 @@ cd build
 [[ -n $COVERAGE && -z $CIRCLE_TAG ]] && CMAKE_OPTIONS="$CMAKE_OPTIONS -DCOVERAGE=ON"
 
 if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
+  export CCACHE_DIR="$HOME/.ccache"
   export CCACHE_BASEDIR="$ROOTDIR"
   export CCACHE_NOHASHDIR=1
   CMAKE_OPTIONS="${CMAKE_OPTIONS:-} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+  mkdir -p "$CCACHE_DIR"
 fi
 
 # shellcheck disable=SC2086

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -ex
 
-ROOTDIR="$(dirname "$0")/../.."
+ROOTDIR="$(realpath "$(dirname "$0")/../..")"
 # shellcheck source=scripts/common.sh
 source "${ROOTDIR}/scripts/common.sh"
 
@@ -16,7 +16,21 @@ cd build
 
 [[ -n $COVERAGE && -z $CIRCLE_TAG ]] && CMAKE_OPTIONS="$CMAKE_OPTIONS -DCOVERAGE=ON"
 
+if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
+  export CCACHE_BASEDIR="$ROOTDIR"
+  export CCACHE_NOHASHDIR=1
+  CMAKE_OPTIONS="${CMAKE_OPTIONS:-} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+fi
+
 # shellcheck disable=SC2086
 cmake .. -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}" $CMAKE_OPTIONS
 
+if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
+  ccache -z
+fi
+
 cmake --build .
+
+if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
+  ccache -s
+fi

--- a/scripts/ci/build_emscripten.sh
+++ b/scripts/ci/build_emscripten.sh
@@ -54,14 +54,12 @@ function build() {
     # TODO: This can be removed if and when all usages of `move()` in our codebase use the `std::` qualifier.
     CMAKE_CXX_FLAGS="-Wno-unqualified-std-cast-call"
 
-    if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
-        export CCACHE_DIR="$HOME/.ccache"
-        CCACHE_BASEDIR="$(pwd)"
-        export CCACHE_BASEDIR
-        export CCACHE_NOHASHDIR=1
-        mkdir -p "$CCACHE_DIR"
-        ccache -z
-    fi
+    export CCACHE_DIR="$HOME/.ccache"
+    CCACHE_BASEDIR="$(pwd)"
+    export CCACHE_BASEDIR
+    export CCACHE_NOHASHDIR=1
+    mkdir -p "$CCACHE_DIR"
+    ccache -z
 
     mkdir -p "$build_dir"
     cd "$build_dir"
@@ -73,9 +71,7 @@ function build() {
         -DTESTS=0 \
     ..
     make soljson
-    if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
-        ccache -s
-    fi
+    ccache -s
 
     cd ..
     mkdir -p upload

--- a/scripts/ci/build_emscripten.sh
+++ b/scripts/ci/build_emscripten.sh
@@ -54,6 +54,15 @@ function build() {
     # TODO: This can be removed if and when all usages of `move()` in our codebase use the `std::` qualifier.
     CMAKE_CXX_FLAGS="-Wno-unqualified-std-cast-call"
 
+    if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
+        export CCACHE_DIR="$HOME/.ccache"
+        CCACHE_BASEDIR="$(pwd)"
+        export CCACHE_BASEDIR
+        export CCACHE_NOHASHDIR=1
+        mkdir -p "$CCACHE_DIR"
+        ccache -z
+    fi
+
     mkdir -p "$build_dir"
     cd "$build_dir"
     emcmake cmake \
@@ -64,6 +73,9 @@ function build() {
         -DTESTS=0 \
     ..
     make soljson
+    if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
+        ccache -s
+    fi
 
     cd ..
     mkdir -p upload

--- a/scripts/ci/build_ossfuzz.sh
+++ b/scripts/ci/build_ossfuzz.sh
@@ -19,9 +19,11 @@ function build_fuzzers
 {
   cd "${BUILDDIR}"
   if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
+    export CCACHE_DIR="$HOME/.ccache"
     export CCACHE_BASEDIR="$ROOTDIR"
     export CCACHE_NOHASHDIR=1
     CMAKE_OPTIONS="${CMAKE_OPTIONS:-} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+    mkdir -p "$CCACHE_DIR"
   fi
   # shellcheck disable=SC2086
   cmake .. -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}" \

--- a/scripts/ci/build_ossfuzz.sh
+++ b/scripts/ci/build_ossfuzz.sh
@@ -18,24 +18,18 @@ function generate_protobuf_bindings
 function build_fuzzers
 {
   cd "${BUILDDIR}"
-  if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
-    export CCACHE_DIR="$HOME/.ccache"
-    export CCACHE_BASEDIR="$ROOTDIR"
-    export CCACHE_NOHASHDIR=1
-    CMAKE_OPTIONS="${CMAKE_OPTIONS:-} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
-    mkdir -p "$CCACHE_DIR"
-  fi
+  export CCACHE_DIR="$HOME/.ccache"
+  export CCACHE_BASEDIR="$ROOTDIR"
+  export CCACHE_NOHASHDIR=1
+  CMAKE_OPTIONS="${CMAKE_OPTIONS:-} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+  mkdir -p "$CCACHE_DIR"
   # shellcheck disable=SC2086
   cmake .. -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}" \
     -DCMAKE_TOOLCHAIN_FILE="${ROOTDIR}"/cmake/toolchains/libfuzzer.cmake \
     $CMAKE_OPTIONS
-  if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
-    ccache -z
-  fi
+  ccache -z
   make ossfuzz ossfuzz_proto ossfuzz_abiv2 -j 4
-  if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
-    ccache -s
-  fi
+  ccache -s
 }
 
 generate_protobuf_bindings

--- a/scripts/ci/build_win.sh
+++ b/scripts/ci/build_win.sh
@@ -6,6 +6,7 @@ prerelease_source="${1:-ci}"
 ROOTDIR="$(realpath "$(dirname "$0")/../../")"
 FORCE_RELEASE="${FORCE_RELEASE:-}"
 CIRCLE_TAG="${CIRCLE_TAG:-}"
+CMAKE_VS_GLOBALS_ARG=()
 
 cd "$ROOTDIR"
 "${ROOTDIR}/scripts/prerelease_suffix.sh" "$prerelease_source" "$CIRCLE_TAG" > prerelease.txt
@@ -24,7 +25,8 @@ if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
   WIN_PWD="$(pwd -W)"
   # Visual Studio generator doesn't use compiler launchers; use ccache masquerade.
   # See https://github.com/ccache/ccache/wiki/MS-Visual-Studio
-  CMAKE_OPTIONS="${CMAKE_OPTIONS:-} -DCMAKE_VS_GLOBALS=CLToolPath=${WIN_PWD}/deps/ccache;UseMultiToolTask=true"
+  CMAKE_VS_GLOBALS="CLToolPath=${WIN_PWD}/deps/ccache;UseMultiToolTask=true"
+  CMAKE_VS_GLOBALS_ARG=(-DCMAKE_VS_GLOBALS="$CMAKE_VS_GLOBALS")
   mkdir -p "$CCACHE_DIR"
 fi
 
@@ -40,6 +42,7 @@ boost_dir=("${ROOTDIR}/deps/boost/lib/cmake/Boost-"*)
     -DBoost_DIR="${boost_dir[*]}" \
     -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded \
     -DCMAKE_INSTALL_PREFIX="${ROOTDIR}/uploads/" \
+    "${CMAKE_VS_GLOBALS_ARG[@]}" \
     ${CMAKE_OPTIONS:-} \
     ..
 if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then

--- a/scripts/ci/build_win.sh
+++ b/scripts/ci/build_win.sh
@@ -19,7 +19,6 @@ if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
   VSWHERE="C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
   CCACHE_COMPILER="$("$VSWHERE" -latest -products "*" \
     -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
-    -version "[16.0,17.0)" \
     -find "VC/Tools/MSVC/*/bin/Hostx64/x64/cl.exe" | sort -V | tail -n 1 | tr -d '\r')"
   CCACHE_COMPILER="${CCACHE_COMPILER//\\//}"
   export CCACHE_COMPILER

--- a/scripts/ci/build_win.sh
+++ b/scripts/ci/build_win.sh
@@ -16,10 +16,12 @@ if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
   export CCACHE_BASEDIR="$ROOTDIR"
   export CCACHE_NOHASHDIR=1
   export CCACHE_COMPILERTYPE=msvc
-  VSWHERE="C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
-  CCACHE_COMPILER="$("$VSWHERE" -latest -products "*" \
+  VSWHERE="${VSWHERE:-C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe}"
+  VS_INSTALL="$("$VSWHERE" -latest -products "*" \
     -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
-    -find "VC/Tools/MSVC/*/bin/Hostx64/x64/cl.exe" | head -n 1 | tr -d '\r')"
+    -property installationPath | tr -d '\r')"
+  VCTOOLS_VERSION="$(tr -d '\r' < "$VS_INSTALL/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt")"
+  CCACHE_COMPILER="$VS_INSTALL/VC/Tools/MSVC/$VCTOOLS_VERSION/bin/Hostx64/x64/cl.exe"
   CCACHE_COMPILER="${CCACHE_COMPILER//\\//}"
   export CCACHE_COMPILER
   PATH="$ROOTDIR/deps/ccache:$(dirname "$CCACHE_COMPILER"):$PATH"

--- a/scripts/ci/build_win.sh
+++ b/scripts/ci/build_win.sh
@@ -11,6 +11,7 @@ cd "$ROOTDIR"
 "${ROOTDIR}/scripts/prerelease_suffix.sh" "$prerelease_source" "$CIRCLE_TAG" > prerelease.txt
 
 if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
+  export CCACHE_DIR="$HOME/.ccache"
   export CCACHE_BASEDIR="$ROOTDIR"
   export CCACHE_NOHASHDIR=1
   export CCACHE_COMPILERTYPE=msvc
@@ -24,6 +25,7 @@ if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
   # Visual Studio generator doesn't use compiler launchers; use ccache masquerade.
   # See https://github.com/ccache/ccache/wiki/MS-Visual-Studio
   CMAKE_OPTIONS="${CMAKE_OPTIONS:-} -DCMAKE_VS_GLOBALS=CLToolPath=${WIN_PWD}/deps/ccache;UseMultiToolTask=true"
+  mkdir -p "$CCACHE_DIR"
 fi
 
 mkdir -p build/

--- a/scripts/ci/build_win.sh
+++ b/scripts/ci/build_win.sh
@@ -19,7 +19,7 @@ if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
   VSWHERE="C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
   CCACHE_COMPILER="$("$VSWHERE" -latest -products "*" \
     -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
-    -find "VC/Tools/MSVC/*/bin/Hostx64/x64/cl.exe" | sort -V | tail -n 1 | tr -d '\r')"
+    -find "VC/Tools/MSVC/*/bin/Hostx64/x64/cl.exe" | head -n 1 | tr -d '\r')"
   CCACHE_COMPILER="${CCACHE_COMPILER//\\//}"
   export CCACHE_COMPILER
   PATH="$ROOTDIR/deps/ccache:$(dirname "$CCACHE_COMPILER"):$PATH"

--- a/scripts/ci/build_win.sh
+++ b/scripts/ci/build_win.sh
@@ -10,18 +10,39 @@ CIRCLE_TAG="${CIRCLE_TAG:-}"
 cd "$ROOTDIR"
 "${ROOTDIR}/scripts/prerelease_suffix.sh" "$prerelease_source" "$CIRCLE_TAG" > prerelease.txt
 
+if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
+  export CCACHE_BASEDIR="$ROOTDIR"
+  export CCACHE_NOHASHDIR=1
+  export CCACHE_COMPILERTYPE=msvc
+  # Hard-coded MSVC cl.exe path
+  CCACHE_COMPILER="C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe"
+  export CCACHE_COMPILER
+  PATH="$ROOTDIR/deps/ccache:$(dirname "$CCACHE_COMPILER"):$PATH"
+  export PATH
+  # Use a Windows-style path for Visual Studio globals.
+  WIN_PWD="$(pwd -W)"
+  # Visual Studio generator doesn't use compiler launchers; use ccache masquerade.
+  # See https://github.com/ccache/ccache/wiki/MS-Visual-Studio
+  CMAKE_OPTIONS="${CMAKE_OPTIONS:-} -DCMAKE_VS_GLOBALS=CLToolPath=${WIN_PWD}/deps/ccache;UseMultiToolTask=true"
+fi
+
 mkdir -p build/
 cd build/
 
 # NOTE: Using an array to force Bash to do wildcard expansion
 boost_dir=("${ROOTDIR}/deps/boost/lib/cmake/Boost-"*)
 
-"${ROOTDIR}/deps/cmake/bin/cmake" \
+ # shellcheck disable=SC2086
+ "${ROOTDIR}/deps/cmake/bin/cmake" \
     -G "Visual Studio 16 2019" \
     -DBoost_DIR="${boost_dir[*]}" \
     -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded \
     -DCMAKE_INSTALL_PREFIX="${ROOTDIR}/uploads/" \
+    ${CMAKE_OPTIONS:-} \
     ..
+if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
+  ccache -z
+fi
 MSBuild.exe solidity.sln \
     -property:Configuration=Release \
     -maxCpuCount:10 \
@@ -31,3 +52,6 @@ MSBuild.exe solidity.sln \
     -j 10 \
     --target install \
     --config Release
+if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
+  ccache -s
+fi

--- a/scripts/ci/build_win.sh
+++ b/scripts/ci/build_win.sh
@@ -11,29 +11,27 @@ CMAKE_VS_GLOBALS_ARG=()
 cd "$ROOTDIR"
 "${ROOTDIR}/scripts/prerelease_suffix.sh" "$prerelease_source" "$CIRCLE_TAG" > prerelease.txt
 
-if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
-  export CCACHE_DIR="$HOME/.ccache"
-  export CCACHE_BASEDIR="$ROOTDIR"
-  export CCACHE_NOHASHDIR=1
-  export CCACHE_COMPILERTYPE=msvc
-  VSWHERE="${VSWHERE:-C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe}"
-  VS_INSTALL="$("$VSWHERE" -latest -products "*" \
-    -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
-    -property installationPath | tr -d '\r')"
-  VCTOOLS_VERSION="$(tr -d '\r' < "$VS_INSTALL/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt")"
-  CCACHE_COMPILER="$VS_INSTALL/VC/Tools/MSVC/$VCTOOLS_VERSION/bin/Hostx64/x64/cl.exe"
-  CCACHE_COMPILER="${CCACHE_COMPILER//\\//}"
-  export CCACHE_COMPILER
-  PATH="$ROOTDIR/deps/ccache:$(dirname "$CCACHE_COMPILER"):$PATH"
-  export PATH
-  # Use a Windows-style path for Visual Studio globals.
-  WIN_PWD="$(pwd -W)"
-  # Visual Studio generator doesn't use compiler launchers; use ccache masquerade.
-  # See https://github.com/ccache/ccache/wiki/MS-Visual-Studio
-  CMAKE_VS_GLOBALS="CLToolPath=${WIN_PWD}/deps/ccache;UseMultiToolTask=true"
-  CMAKE_VS_GLOBALS_ARG=(-DCMAKE_VS_GLOBALS="$CMAKE_VS_GLOBALS")
-  mkdir -p "$CCACHE_DIR"
-fi
+export CCACHE_DIR="$HOME/.ccache"
+export CCACHE_BASEDIR="$ROOTDIR"
+export CCACHE_NOHASHDIR=1
+export CCACHE_COMPILERTYPE=msvc
+VSWHERE="${VSWHERE:-C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe}"
+VS_INSTALL="$("$VSWHERE" -latest -products "*" \
+  -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
+  -property installationPath | tr -d '\r')"
+VCTOOLS_VERSION="$(tr -d '\r' < "$VS_INSTALL/VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt")"
+CCACHE_COMPILER="$VS_INSTALL/VC/Tools/MSVC/$VCTOOLS_VERSION/bin/Hostx64/x64/cl.exe"
+CCACHE_COMPILER="${CCACHE_COMPILER//\\//}"
+export CCACHE_COMPILER
+PATH="$ROOTDIR/deps/ccache:$(dirname "$CCACHE_COMPILER"):$PATH"
+export PATH
+# Use a Windows-style path for Visual Studio globals.
+WIN_PWD="$(pwd -W)"
+# Visual Studio generator doesn't use compiler launchers; use ccache masquerade.
+# See https://github.com/ccache/ccache/wiki/MS-Visual-Studio
+CMAKE_VS_GLOBALS="CLToolPath=${WIN_PWD}/deps/ccache;UseMultiToolTask=true"
+CMAKE_VS_GLOBALS_ARG=(-DCMAKE_VS_GLOBALS="$CMAKE_VS_GLOBALS")
+mkdir -p "$CCACHE_DIR"
 
 mkdir -p build/
 cd build/
@@ -50,9 +48,7 @@ boost_dir=("${ROOTDIR}/deps/boost/lib/cmake/Boost-"*)
     "${CMAKE_VS_GLOBALS_ARG[@]}" \
     ${CMAKE_OPTIONS:-} \
     ..
-if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
-  ccache -z
-fi
+ccache -z
 MSBuild.exe solidity.sln \
     -property:Configuration=Release \
     -maxCpuCount:10 \
@@ -62,6 +58,4 @@ MSBuild.exe solidity.sln \
     -j 10 \
     --target install \
     --config Release
-if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
-  ccache -s
-fi
+ccache -s

--- a/scripts/ci/build_win.sh
+++ b/scripts/ci/build_win.sh
@@ -16,8 +16,12 @@ if [[ "${CCACHE_ENABLED:-}" == "1" ]]; then
   export CCACHE_BASEDIR="$ROOTDIR"
   export CCACHE_NOHASHDIR=1
   export CCACHE_COMPILERTYPE=msvc
-  # Hard-coded MSVC cl.exe path
-  CCACHE_COMPILER="C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe"
+  VSWHERE="C:/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe"
+  CCACHE_COMPILER="$("$VSWHERE" -latest -products "*" \
+    -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
+    -version "[16.0,17.0)" \
+    -find "VC/Tools/MSVC/*/bin/Hostx64/x64/cl.exe" | sort -V | tail -n 1 | tr -d '\r')"
+  CCACHE_COMPILER="${CCACHE_COMPILER//\\//}"
   export CCACHE_COMPILER
   PATH="$ROOTDIR/deps/ccache:$(dirname "$CCACHE_COMPILER"):$PATH"
   export PATH

--- a/scripts/install_deps.ps1
+++ b/scripts/install_deps.ps1
@@ -14,6 +14,17 @@ if ( -not (Test-Path "$PSScriptRoot\..\deps\boost") ) {
   mv cmake-3.27.4-windows-x86_64 "$PSScriptRoot\..\deps\cmake"
   Remove-Item cmake.zip
 
+  Invoke-WebRequest -URI "https://github.com/ccache/ccache/releases/download/v4.12.2/ccache-4.12.2-windows-x86_64.zip" -OutFile ccache.zip
+  if ((Get-FileHash ccache.zip).Hash -ne "82c1b130b25cc162531dc7a062dc5ea99349cd536bc9eba8a66d976802d66516") {
+    throw 'Downloaded ccache package has wrong checksum.'
+  }
+  tar -xf ccache.zip
+  mv ccache-4.12.2-windows-x86_64 "$PSScriptRoot\..\deps\ccache"
+  # ccache MSVC guide: https://github.com/ccache/ccache/wiki/MS-Visual-Studio
+  # Replace ccache.exe as cl.exe so MSBuild still sees "cl.exe" while ccache wraps the real compiler.
+  Copy-Item -Force "$PSScriptRoot\..\deps\ccache\ccache.exe" "$PSScriptRoot\..\deps\ccache\cl.exe"
+  Remove-Item ccache.zip
+
   # FIXME: The default user agent results in Artifactory treating Invoke-WebRequest as a browser
   # and serving it a page that requires JavaScript.
   Invoke-WebRequest -URI "https://archives.boost.io/release/1.83.0/source/boost_1_83_0.zip" -OutFile boost.zip -UserAgent ""


### PR DESCRIPTION
Depends on https://github.com/argotorg/solidity/pull/16384

- This PR enables ccache for the main CMake build in CircleCI and stores the cache between runs.
- CircleCI now restores ~/.ccache on most branches from the latest cache produced on develop, so builds can reuse compiled objects.
- Runs on develop start from an empty cache and then save a fresh ~/.ccache snapshot (one per revision) to keep the seed cache updated.
- The build step also resets and prints ccache stats (ccache -z / ccache -s) so we can see cache hits in the logs.

For the purpose of testing instead of creating the cache from `develop`, the cache is created by this branch `ci-ccache`. We can later create another PR starting from this branch to see if the builds are indeed using the cache generated by `ci-ccache`, before merging this PR let's remember to fix the occurrences of `ci-ccache` in the code.

## Results

[In this PR](https://github.com/argotorg/solidity/pull/16393), I edited a single file and the CI is successfully using ccache for all build job. These are the results of the speedup:

Job | ccache disabled | ccache enabled | speedup
-- | -- | -- | --
b_ubu_force_release | 10:52 | 01:02 | 11×
b_ubu_static_arm | 20:55 | 01:09 | 18×
b_ubu_min_req | 17:25 | 01:39 | 11×
b_ubu_ossfuzz | 22:05 | 02:13 | 10×
b_ubu_min_req_clang | 12:15 | 01:29 | 8×
b_ubu_clang | 12:54 | 01:32 | 8×
b_win | 23:06 | 05:47 | 4×
b_ubu | 11:22 | 00:42 | 16×
b_ems | 07:18 | 03:15 | 2×
b_osx | 09:25 | 01:14 | 8×
b_ubu_static | 11:16 | 00:42 | 16×
b_archlinux | 18:49 | 01:29 | 13×

In total we save ~23 minutes (or around 2$) each run.