### PR TITLE
EVM instruction interpreter: Add loadimmutable and setimmutable mocks, improve linkersymbol

### DIFF
--- a/test/libyul/yulInterpreterTests/isoltestTesting/linkersymbol.yul
+++ b/test/libyul/yulInterpreterTests/isoltestTesting/linkersymbol.yul
@@ -1,0 +1,11 @@
+{
+    // yields some value based on the hash of the argument literal
+    let value := linkersymbol("address")
+    mstore(0, value)
+}
+// ----
+// Trace:
+// Memory dump:
+//      0: 421683f821a0574472445355be6d2b769119e8515f8376a1d7878523dfdecf7b
+// Storage dump:
+// Transient storage dump:

--- a/test/libyul/yulInterpreterTests/isoltestTesting/loadimmutable.yul
+++ b/test/libyul/yulInterpreterTests/isoltestTesting/loadimmutable.yul
@@ -1,0 +1,11 @@
+{
+    // yields some value based on the hash of the argument literal
+    let value := loadimmutable("address")
+    mstore(0, value)
+}
+// ----
+// Trace:
+// Memory dump:
+//      0: 421683f821a0574472445355be6d2b769119e8515f8376a1d7878523dfdecf7b
+// Storage dump:
+// Transient storage dump:

--- a/test/libyul/yulInterpreterTests/isoltestTesting/setimmutable_stub.yul
+++ b/test/libyul/yulInterpreterTests/isoltestTesting/setimmutable_stub.yul
@@ -1,0 +1,9 @@
+{
+    // implemented as no-op
+    setimmutable(42, "42", 42)
+}
+// ----
+// Trace:
+// Memory dump:
+// Storage dump:
+// Transient storage dump:

--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
@@ -562,7 +562,7 @@ u256 EVMInstructionInterpreter::evalBuiltin(
 		std::string const placeholder = formatLiteral(std::get<Literal>(_arguments[0]));
 		h256 const identifier(keccak256(placeholder));
 		m_linkerSymbols.emplace(identifier, placeholder);
-		return 0;
+		return u256(identifier);
 	}
 
 	if (fun == "loadimmutable")

--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
@@ -565,6 +565,26 @@ u256 EVMInstructionInterpreter::evalBuiltin(
 		return 0;
 	}
 
+	if (fun == "loadimmutable")
+	{
+		yulAssert(_arguments.size() == 1);
+		yulAssert(std::holds_alternative<Literal>(_arguments[0]));
+		std::string const identifier = formatLiteral(std::get<Literal>(_arguments[0]));
+		// Return a deterministic value based on the identifier.
+		// This is sufficient for differential fuzzing since the same identifier
+		// will always return the same value, maintaining trace equivalence.
+		return u256(h256(keccak256(identifier)));
+	}
+
+	if (fun == "setimmutable")
+	{
+		yulAssert(_arguments.size() == 3);
+		// No-op: The real implementation patches placeholder bytes in memory-loaded runtime code.
+		// For differential fuzzing, this ensures correct code never fails (no false positives), though some
+		// bugs in setimmutable handling may not be detected (potential false negatives).
+		return 0;
+	}
+
 	yulAssert(false, "Unknown builtin: " + fun);
 }
 


### PR DESCRIPTION
Theoretically, `loadimmutable` inserts a placeholder into the contract to be deployed which is then replaced by `setimmutable` once the runtime code is loaded into memory.

The interpreter is mainly used for differential fuzzing so we should satisfy that correct code never fails and we can still - most of the time - detect bugs.

Therefore, `loadimmutable` is decoupled from `setimmutable` and just returns a random value (hash of the identifier), `setimmutable` is treated as a no-op.

This PR also implements https://github.com/argotorg/solidity/pull/16267#discussion_r2691619672