### PR TITLE
Remove unused errs assignment in jsonParseStrict success path

### DIFF
--- a/libsolutil/JSON.cpp
+++ b/libsolutil/JSON.cpp
@@ -149,7 +149,6 @@ bool jsonParseStrict(std::string const& _input, Json& _json, std::string* _errs 
 			/* allow exceptions */ true,
 			/* ignore_comments */true
 		);
-		_errs = {};
 		return true;
 	}
 	catch (Json::parse_error const& e)


### PR DESCRIPTION
Delete a no-op _errs = {}; write in jsonParseStrict that never reached the caller because the pointer is passed by value, no behavior change; eliminates dead code in the success path