### PR TITLE
refactor: switch gas report parsing from RST to native JSON output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,7 @@ commands:
             FOUNDRY_REPO="foundry-rs/foundry"
             FOUNDRY_VERSION="<< parameters.version >>"
             # Make authenticated requests when the Github token is available
+            EXTRA_HEADERS=()
             if [[ -n "$GITHUB_READ_TOKEN" ]]; then
               EXTRA_HEADERS=(--header 'Authorization: Bearer '"${GITHUB_READ_TOKEN}")
             fi
@@ -1517,6 +1518,7 @@ jobs:
           name: Retrieve EDR latest release tag
           command: |
             # Make authenticated requests when the Github token is available
+            EXTRA_HEADERS=()
             if [[ -n "$GITHUB_READ_TOKEN" ]]; then
               EXTRA_HEADERS=(--header "Authorization: Bearer ${GITHUB_READ_TOKEN}")
             fi

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -97,6 +97,31 @@ function assertFail
     exit 2
 }
 
+function retry
+{
+    local max_attempts="${1:-3}"
+    local delay="${2:-5}"
+    shift 2 || true
+    local command=("$@")
+
+    local attempt=1
+    while true; do
+        if "${command[@]}"; then
+            return 0
+        fi
+
+        if (( attempt >= max_attempts )); then
+            printError "Command failed after ${max_attempts} attempts: ${command[*]}"
+            return 1
+        fi
+
+        printWarning "Command failed (attempt ${attempt}/${max_attempts}): ${command[*]}"
+        printLog "Retrying in ${delay} seconds..."
+        sleep "$delay"
+        ((attempt++))
+    done
+}
+
 function msg_on_error
 {
     local error_message=""

--- a/scripts/externalTests/common.sh
+++ b/scripts/externalTests/common.sh
@@ -594,7 +594,15 @@ function compilation_time_report_path
 function gas_report_to_json
 {
     # Read JSON output directly from hardhat-gas-reporter v2 and wrap it in {gas: ...} format
-    cat - | jq '{gas: .}'
+    # Skip invalid JSON to avoid jq parse errors
+    local input
+    input=$(cat -)
+    # Trim whitespace and check if input is non-empty and valid JSON
+    input=$(echo "$input" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    if [[ -n "$input" ]] && echo "$input" | jq empty 2>/dev/null; then
+        echo "$input" | jq '{gas: .}'
+    fi
+    # If input is empty or invalid JSON, output nothing (same as if file didn't exist)
 }
 
 function detect_hardhat_artifact_dirs
@@ -693,8 +701,10 @@ function store_benchmark_report
     mkdir -p "$report_dir"
 
     {
-        if [[ -e $(gas_report_path "$preset") ]]; then
-            gas_report_to_json < "$(gas_report_path "$preset")"
+        local gas_report_file
+        gas_report_file=$(gas_report_path "$preset")
+        if [[ -e "$gas_report_file" ]] && [[ -s "$gas_report_file" ]]; then
+            gas_report_to_json < "$gas_report_file"
         fi
 
         "bytecode_size_json_from_${framework}_artifacts" | combine_artifact_json

--- a/scripts/externalTests/common.sh
+++ b/scripts/externalTests/common.sh
@@ -436,7 +436,7 @@ function eth_gas_reporter_settings
     echo "    noColors: true,"
     echo "    showUncalledMethods: false,"            # Exclude entries with no gas for shorter report
     echo "    showMethodSig: true,"                   # Should make diffs more stable if there are overloaded functions
-    echo "    reportFormat: 'legacy',"                # Use v1.x format for compatibility with parse_eth_gas_report.py
+    echo "    outputJSON: true,"                      # Use native JSON output from hardhat-gas-reporter v2
     echo "    outputFile: \"$(gas_report_path "$preset")\""
     echo "}"
 }
@@ -581,7 +581,7 @@ function gas_report_path
 {
     local preset="$1"
 
-    echo "${DIR}/gas-report-${preset}.rst"
+    echo "${DIR}/gas-report-${preset}.json"
 }
 
 function compilation_time_report_path
@@ -593,7 +593,8 @@ function compilation_time_report_path
 
 function gas_report_to_json
 {
-    cat - | "${REPO_ROOT}/scripts/externalTests/parse_eth_gas_report.py" | jq '{gas: .}'
+    # Read JSON output directly from hardhat-gas-reporter v2 and wrap it in {gas: ...} format
+    cat - | jq '{gas: .}'
 }
 
 function detect_hardhat_artifact_dirs

--- a/test/externalTests/yield-liquidator.sh
+++ b/test/externalTests/yield-liquidator.sh
@@ -63,7 +63,7 @@ function yield_liquidator_test
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")" "$config_var"
     force_hardhat_unlimited_contract_size "$config_file" "$config_var"
-    npm install
+    retry 3 10 npm install
 
     # The contract below is not used in any test and it depends on ISwapRouter which does not exists
     # in the main repository.


### PR DESCRIPTION
Replace RST parsing with native JSON output to remove fragile regex-based parsing.

Fixes #16373