### PR TITLE
CLI Parser: Use defaulted comparison operators for options

### DIFF
--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -157,14 +157,6 @@ void CommandLineParser::checkMutuallyExclusive(std::vector<std::string> const& _
 	}
 }
 
-bool CompilerOutputs::operator==(CompilerOutputs const& _other) const noexcept
-{
-	for (bool CompilerOutputs::* member: componentMap() | ranges::views::values)
-		if (this->*member != _other.*member)
-			return false;
-	return true;
-}
-
 std::ostream& operator<<(std::ostream& _out, CompilerOutputs const& _selection)
 {
 	std::vector<std::string> serializedSelection;
@@ -187,15 +179,6 @@ std::string const& CompilerOutputs::componentName(bool CompilerOutputs::* _compo
 	solAssert(false, "");
 }
 
-bool CombinedJsonRequests::operator==(CombinedJsonRequests const& _other) const noexcept
-{
-	for (bool CombinedJsonRequests::* member: componentMap() | ranges::views::values)
-		if (this->*member != _other.*member)
-			return false;
-	return true;
-}
-
-
 std::ostream& operator<<(std::ostream& _out, CombinedJsonRequests const& _requests)
 {
 	std::vector<std::string> serializedRequests;
@@ -215,46 +198,6 @@ std::string const& CombinedJsonRequests::componentName(bool CombinedJsonRequests
 			return componentName;
 
 	solAssert(false, "");
-}
-
-bool CommandLineOptions::operator==(CommandLineOptions const& _other) const noexcept
-{
-	return
-		input.paths == _other.input.paths &&
-		input.remappings == _other.input.remappings &&
-		input.addStdin == _other.input.addStdin &&
-		input.basePath == _other.input.basePath &&
-		input.includePaths == _other.input.includePaths &&
-		input.allowedDirectories == _other.input.allowedDirectories &&
-		input.ignoreMissingFiles == _other.input.ignoreMissingFiles &&
-		input.noImportCallback == _other.input.noImportCallback &&
-		output.dir == _other.output.dir &&
-		output.overwriteFiles == _other.output.overwriteFiles &&
-		output.evmVersion == _other.output.evmVersion &&
-		output.viaIR == _other.output.viaIR &&
-		output.revertStrings == _other.output.revertStrings &&
-		output.debugInfoSelection == _other.output.debugInfoSelection &&
-		output.stopAfter == _other.output.stopAfter &&
-		output.eofVersion == _other.output.eofVersion &&
-		input.mode == _other.input.mode &&
-		assembly.targetMachine == _other.assembly.targetMachine &&
-		assembly.inputLanguage == _other.assembly.inputLanguage &&
-		linker.libraries == _other.linker.libraries &&
-		formatting.json == _other.formatting.json &&
-		formatting.coloredOutput == _other.formatting.coloredOutput &&
-		formatting.withErrorIds == _other.formatting.withErrorIds &&
-		compiler.outputs == _other.compiler.outputs &&
-		compiler.estimateGas == _other.compiler.estimateGas &&
-		compiler.combinedJsonRequests == _other.compiler.combinedJsonRequests &&
-		metadata.format == _other.metadata.format &&
-		metadata.hash == _other.metadata.hash &&
-		metadata.literalSources == _other.metadata.literalSources &&
-		optimizer.optimizeEvmasm == _other.optimizer.optimizeEvmasm &&
-		optimizer.optimizeYul == _other.optimizer.optimizeYul &&
-		optimizer.expectedExecutionsPerDeployment == _other.optimizer.expectedExecutionsPerDeployment &&
-		optimizer.yulSteps == _other.optimizer.yulSteps &&
-		modelChecker.initialize == _other.modelChecker.initialize &&
-		modelChecker.settings == _other.modelChecker.settings;
 }
 
 OptimiserSettings CommandLineOptions::optimiserSettings() const

--- a/solc/CommandLineParser.h
+++ b/solc/CommandLineParser.h
@@ -62,8 +62,8 @@ enum class InputMode
 
 struct CompilerOutputs
 {
-	bool operator!=(CompilerOutputs const& _other) const noexcept { return !(*this == _other); }
-	bool operator==(CompilerOutputs const& _other) const noexcept;
+	bool operator!=(CompilerOutputs const& _other) const noexcept = default;
+	bool operator==(CompilerOutputs const& _other) const noexcept = default;
 	friend std::ostream& operator<<(std::ostream& _out, CompilerOutputs const& _requests);
 
 	static std::string const& componentName(bool CompilerOutputs::* _component);
@@ -118,8 +118,8 @@ struct CompilerOutputs
 
 struct CombinedJsonRequests
 {
-	bool operator!=(CombinedJsonRequests const& _other) const noexcept { return !(*this == _other); }
-	bool operator==(CombinedJsonRequests const& _other) const noexcept;
+	bool operator!=(CombinedJsonRequests const& _other) const noexcept = default;
+	bool operator==(CombinedJsonRequests const& _other) const noexcept = default;
 	friend std::ostream& operator<<(std::ostream& _out, CombinedJsonRequests const& _requests);
 
 	static std::string const& componentName(bool CombinedJsonRequests::* _component);
@@ -170,13 +170,16 @@ struct CombinedJsonRequests
 
 struct CommandLineOptions
 {
-	bool operator==(CommandLineOptions const& _other) const noexcept;
-	bool operator!=(CommandLineOptions const& _other) const noexcept { return !(*this == _other); }
+	bool operator==(CommandLineOptions const& _other) const noexcept = default;
+	bool operator!=(CommandLineOptions const& _other) const noexcept = default;
 
 	OptimiserSettings optimiserSettings() const;
 
-	struct
+	struct Input
 	{
+		bool operator==(Input const&) const noexcept = default;
+		bool operator!=(Input const&) const noexcept = default;
+
 		InputMode mode = InputMode::Compiler;
 		std::set<boost::filesystem::path> paths;
 		std::vector<ImportRemapper::Remapping> remappings;
@@ -188,8 +191,11 @@ struct CommandLineOptions
 		bool noImportCallback = false;
 	} input;
 
-	struct
+	struct Output
 	{
+		bool operator==(Output const&) const noexcept = default;
+		bool operator!=(Output const&) const noexcept = default;
+
 		boost::filesystem::path dir;
 		bool overwriteFiles = false;
 		langutil::EVMVersion evmVersion;
@@ -200,48 +206,69 @@ struct CommandLineOptions
 		std::optional<uint8_t> eofVersion;
 	} output;
 
-	struct
+	struct Assembly
 	{
+		bool operator==(Assembly const&) const noexcept = default;
+		bool operator!=(Assembly const&) const noexcept = default;
+
 		yul::YulStack::Machine targetMachine = yul::YulStack::Machine::EVM;
 		yul::YulStack::Language inputLanguage = yul::YulStack::Language::StrictAssembly;
 	} assembly;
 
-	struct
+	struct Linker
 	{
+		bool operator==(Linker const&) const noexcept = default;
+		bool operator!=(Linker const&) const noexcept = default;
+
 		std::map<std::string, util::h160> libraries; // library name -> address
 	} linker;
 
-	struct
+	struct Formatting
 	{
+		bool operator==(Formatting const&) const noexcept = default;
+		bool operator!=(Formatting const&) const noexcept = default;
+
 		util::JsonFormat json;
 		std::optional<bool> coloredOutput;
 		bool withErrorIds = false;
 	} formatting;
 
-	struct
+	struct Compiler
 	{
+		bool operator==(Compiler const&) const noexcept = default;
+		bool operator!=(Compiler const&) const noexcept = default;
+
 		CompilerOutputs outputs;
 		bool estimateGas = false;
 		std::optional<CombinedJsonRequests> combinedJsonRequests;
 	} compiler;
 
-	struct
+	struct Metadata
 	{
+		bool operator==(Metadata const&) const noexcept = default;
+		bool operator!=(Metadata const&) const noexcept = default;
+
 		CompilerStack::MetadataFormat format = CompilerStack::defaultMetadataFormat();
 		CompilerStack::MetadataHash hash = CompilerStack::MetadataHash::IPFS;
 		bool literalSources = false;
 	} metadata;
 
-	struct
+	struct Optimizer
 	{
+		bool operator==(Optimizer const&) const noexcept = default;
+		bool operator!=(Optimizer const&) const noexcept = default;
+
 		bool optimizeEvmasm = false;
 		bool optimizeYul = false;
 		std::optional<unsigned> expectedExecutionsPerDeployment;
 		std::optional<std::string> yulSteps;
 	} optimizer;
 
-	struct
+	struct ModelChecker
 	{
+		bool operator==(ModelChecker const&) const noexcept = default;
+		bool operator!=(ModelChecker const&) const noexcept = default;
+
 		bool initialize = false;
 		ModelCheckerSettings settings;
 	} modelChecker;


### PR DESCRIPTION
by giving the formerly anonymous inner structs names so that their respective comparison operators can be defaulted, too