### PR TITLE
Mention unofficial Nix builds in Installing Solidity

### DIFF
--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -113,23 +113,34 @@ self-contained (i.e. it does not refer to any external files that would have to 
 Linux Packages
 ==============
 
-Binary packages of Solidity are available at
-`solidity/releases <https://github.com/argotorg/solidity/releases>`_.
+We provide :ref:`standalone binaries <static-binaries>` of the compiler that should run on most
+distributions without any additional installation steps.
 
 Ubuntu packages for versions up to 0.8.30 are available in the
 `ethereum/ethereum PPA <https://launchpad.net/~ethereum/+archive/ubuntu/ethereum>`_.
 However, we have discontinued this distribution method and future versions will not be added there.
 
-Furthermore, some Linux distributions provide their own packages. These packages are not directly
-maintained by us but usually kept up-to-date by the respective package maintainers.
+Some Linux distributions provide their own packages.
+These packages are not directly maintained by us but usually kept up-to-date by the respective
+package maintainers.
 
-For example, Arch Linux has packages for the latest development version as AUR packages: `solidity <https://aur.archlinux.org/packages/solidity>`_
-and `solidity-bin <https://aur.archlinux.org/packages/solidity-bin>`_.
+Unofficial, community-maintained scripts for building and installing the compiler are also
+available for some distributions:
+
+- Arch Linux / (AUR):
+
+    - `solidity <https://aur.archlinux.org/packages/solidity>`_ (builds from source),
+    - `solidity-bin <https://aur.archlinux.org/packages/solidity-bin>`_ (uses our standalone binaries).
+
+- Nix:
+
+    - `solc.nix <https://github.com/hellwolf/solc.nix>`_ (builds from source).
 
 .. note::
 
-    Please be aware that `AUR <https://wiki.archlinux.org/title/Arch_User_Repository>`_ packages
-    are user-produced content and unofficial packages. Exercise caution when using them.
+    Please be aware that these scripts are produced and maintained by users and not vetted in any
+    way by the distro maintainers.
+    Exercise caution when using them.
 
 There is also a `snap package <https://snapcraft.io/solc>`_, however, it is **currently unmaintained**.
 It is installable in all the `supported Linux distros <https://snapcraft.io/docs/core/install>`_. To
@@ -191,6 +202,8 @@ Install it using ``brew``:
     brew unlink solidity
     # eg. Install 0.4.8
     brew install solidity.rb
+
+.. _static-binaries:
 
 Static Binaries
 ===============


### PR DESCRIPTION
Extracted from #16243. This is the part that still makes sense to merge even if we're keeping docker releases for now.