### PR TITLE
Fix missing full stops in error messages

### DIFF
--- a/libsolidity/analysis/ContractLevelChecker.cpp
+++ b/libsolidity/analysis/ContractLevelChecker.cpp
@@ -526,7 +526,7 @@ void ContractLevelChecker::checkLibraryRequirements(ContractDefinition const& _c
 
 	for (auto const& var: _contract.stateVariables())
 		if (!var->isConstant())
-			m_errorReporter.typeError(9957_error, var->location(), "Library cannot have non-constant state variables");
+			m_errorReporter.typeError(9957_error, var->location(), "Library cannot have non-constant state variables.");
 }
 
 void ContractLevelChecker::checkBaseABICompatibility(ContractDefinition const& _contract)

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -435,13 +435,13 @@ void NameAndTypeResolver::linearizeBaseContracts(ContractDefinition& _contract)
 		input.back().push_front(base);
 		std::vector<ContractDefinition const*> const& basesBases = base->annotation().linearizedBaseContracts;
 		if (basesBases.empty())
-			m_errorReporter.fatalTypeError(2449_error, baseName.location(), "Definition of base has to precede definition of derived contract");
+			m_errorReporter.fatalTypeError(2449_error, baseName.location(), "Definition of base has to precede definition of derived contract.");
 		input.push_front(std::list<ContractDefinition const*>(basesBases.begin(), basesBases.end()));
 	}
 	input.back().push_front(&_contract);
 	std::vector<ContractDefinition const*> result = cThreeMerge(input);
 	if (result.empty())
-		m_errorReporter.fatalTypeError(5005_error, _contract.location(), "Linearization of inheritance graph impossible");
+		m_errorReporter.fatalTypeError(5005_error, _contract.location(), "Linearization of inheritance graph impossible.");
 	_contract.annotation().linearizedBaseContracts = result;
 }
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -314,7 +314,7 @@ bool TypeChecker::visit(FunctionDefinition const& _function)
 		else if (_function.isConstructor())
 			m_errorReporter.typeError(7001_error, _function.location(), "Constructors cannot be virtual.");
 		else if (_function.annotation().contract->isInterface())
-			m_errorReporter.warning(5815_error, _function.location(), "Interface functions are implicitly \"virtual\"");
+			m_errorReporter.warning(5815_error, _function.location(), "Interface functions are implicitly \"virtual\".");
 		else if (_function.visibility() == Visibility::Private)
 			m_errorReporter.typeError(3942_error, _function.location(), "\"virtual\" and \"private\" cannot be used together.");
 		else if (_function.libraryFunction())

--- a/libsolidity/parsing/DocStringParser.cpp
+++ b/libsolidity/parsing/DocStringParser.cpp
@@ -136,7 +136,7 @@ DocStringParser::iter DocStringParser::parseDocTagParam(iter _pos, iter _end)
 	auto nameStartPos = skipWhitespace(_pos, _end);
 	if (nameStartPos == _end)
 	{
-		m_errorReporter.docstringParsingError(3335_error, m_node.location(), "No param name given");
+		m_errorReporter.docstringParsingError(3335_error, m_node.location(), "No param name given.");
 		return _end;
 	}
 	auto nameEndPos = firstNonIdentifier(nameStartPos, _end);

--- a/test/libsolidity/natspecJSON/dev_documenting_no_param_name.sol
+++ b/test/libsolidity/natspecJSON/dev_documenting_no_param_name.sol
@@ -6,4 +6,4 @@ contract test {
 }
 
 // ----
-// DocstringParsingError 3335: (20-149): No param name given
+// DocstringParsingError 3335: (20-149): No param name given.

--- a/test/libsolidity/natspecJSON/invalid/docstring_empty_tag.sol
+++ b/test/libsolidity/natspecJSON/invalid/docstring_empty_tag.sol
@@ -3,4 +3,4 @@ abstract contract C {
     function vote(uint id) public {}
 }
 // ----
-// DocstringParsingError 3335: (26-36): No param name given
+// DocstringParsingError 3335: (26-36): No param name given.

--- a/test/libsolidity/syntaxTests/inheritance/interface/linearization/invalid/lists_a.sol
+++ b/test/libsolidity/syntaxTests/inheritance/interface/linearization/invalid/lists_a.sol
@@ -5,4 +5,4 @@ interface Sub is ParentA, ParentB {}
 contract ListsA is Sub, ParentA {}
 
 // ----
-// TypeError 5005: (80-114): Linearization of inheritance graph impossible
+// TypeError 5005: (80-114): Linearization of inheritance graph impossible.

--- a/test/libsolidity/syntaxTests/inheritance/interface/linearization/invalid/lists_b.sol
+++ b/test/libsolidity/syntaxTests/inheritance/interface/linearization/invalid/lists_b.sol
@@ -5,4 +5,4 @@ interface Sub is ParentA, ParentB {}
 contract ListsB is Sub, ParentB {}
 
 // ----
-// TypeError 5005: (80-114): Linearization of inheritance graph impossible
+// TypeError 5005: (80-114): Linearization of inheritance graph impossible.

--- a/test/libsolidity/syntaxTests/inheritance/interface/linearization/invalid/lists_both.sol
+++ b/test/libsolidity/syntaxTests/inheritance/interface/linearization/invalid/lists_both.sol
@@ -5,4 +5,4 @@ interface Sub is ParentA, ParentB {}
 contract ListsBoth is Sub, ParentA, ParentB {}
 
 // ----
-// TypeError 5005: (80-126): Linearization of inheritance graph impossible
+// TypeError 5005: (80-126): Linearization of inheritance graph impossible.

--- a/test/libsolidity/syntaxTests/inheritance/interface_virtual_warning.sol
+++ b/test/libsolidity/syntaxTests/inheritance/interface_virtual_warning.sol
@@ -2,4 +2,4 @@ interface I {
 	function foo() virtual external;
 }
 // ----
-// Warning 5815: (15-47): Interface functions are implicitly "virtual"
+// Warning 5815: (15-47): Interface functions are implicitly "virtual".

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/056_cyclic_inheritance.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/056_cyclic_inheritance.sol
@@ -1,4 +1,4 @@
 contract A is B { }
 contract B is A { }
 // ----
-// TypeError 2449: (14-15): Definition of base has to precede definition of derived contract
+// TypeError 2449: (14-15): Definition of base has to precede definition of derived contract.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/227_library_having_variables.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/227_library_having_variables.sol
@@ -1,3 +1,3 @@
 library Lib { uint x; }
 // ----
-// TypeError 9957: (14-20): Library cannot have non-constant state variables
+// TypeError 9957: (14-20): Library cannot have non-constant state variables.

--- a/test/libsolidity/syntaxTests/nameAndTypeResolution/237_cyclic_binary_dependency_via_inheritance.sol
+++ b/test/libsolidity/syntaxTests/nameAndTypeResolution/237_cyclic_binary_dependency_via_inheritance.sol
@@ -2,4 +2,4 @@ contract A is B { }
 contract B { function f() public { new C(); } }
 contract C { function f() public { new A(); } }
 // ----
-// TypeError 2449: (14-15): Definition of base has to precede definition of derived contract
+// TypeError 2449: (14-15): Definition of base has to precede definition of derived contract.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/inheriting_from_itself.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/inheriting_from_itself.sol
@@ -1,3 +1,3 @@
 contract C layout at 42 is C { }
 // ----
-// TypeError 2449: (27-28): Definition of base has to precede definition of derived contract
+// TypeError 2449: (27-28): Definition of base has to precede definition of derived contract.


### PR DESCRIPTION
This commit adds missing full stops (periods) to error and warning messages in the Solidity compiler to improve consistency and readability.

Changes include:
- Added full stop to error message in ContractLevelChecker.cpp for library state variable validation
- Added full stops to error messages in NameAndTypeResolver.cpp for base contract definition and inheritance linearization errors
- Added full stop to warning message in TypeChecker.cpp for interface function virtual keyword
- Added full stop to error message in DocStringParser.cpp for missing parameter name in docstring
- Updated corresponding test expectations to match the new error message format

All affected error codes:
- 9957: Library cannot have non-constant state variables
- 2449: Definition of base has to precede definition of derived contract
- 5005: Linearization of inheritance graph impossible
- 5815: Interface functions are implicitly "virtual"
- 3335: No param name given