### PR TITLE
fix: disambiguate library functions vs native properties in member access

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -3074,12 +3074,18 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 	size_t const initialMemberCount = possibleMembers.size();
 	if (initialMemberCount > 1 && arguments)
 	{
-		// do overload resolution
+		// Do overload resolution, and filter out non-functions when called with parentheses.
+		// This allows library functions to work alongside native properties with the same name
+		// (e.g., a library function `balance()` alongside the native `address.balance` property).
+		// Mirrors the identifier resolution pattern in visit(Identifier) where
+		// VariableDeclarations are preferred without parentheses.
 		for (auto it = possibleMembers.begin(); it != possibleMembers.end();)
 			if (
 				it->type->category() == Type::Category::Function &&
 				!dynamic_cast<FunctionType const&>(*it->type).canTakeArguments(*arguments, exprType)
 			)
+				it = possibleMembers.erase(it);
+			else if (it->type->category() != Type::Category::Function)
 				it = possibleMembers.erase(it);
 			else
 				++it;

--- a/test/libsolidity/syntaxTests/memberLookup/library_function_vs_native_property_with_parens.sol
+++ b/test/libsolidity/syntaxTests/memberLookup/library_function_vs_native_property_with_parens.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0;
+
+// Test that library function is preferred over native property when called with parentheses.
+// This allows library functions like `balance()` to work alongside native `address.balance`.
+library AddressUtils {
+    function balance(address a) internal view returns (uint256) {
+        return a.balance / 1e18;
+    }
+}
+
+contract C {
+    using AddressUtils for address;
+
+    function getBalance(address a) public view returns (uint256) {
+        // With parentheses - should use library function
+        return a.balance();
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/memberLookup/library_function_vs_native_property_without_parens.sol
+++ b/test/libsolidity/syntaxTests/memberLookup/library_function_vs_native_property_without_parens.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0;
+
+// Test that accessing a member without parentheses when both a native property
+// and a library function exist with the same name results in an ambiguity error.
+// Users should access the native property directly without "using for" to avoid this.
+library AddressUtils {
+    function balance(address a) internal view returns (uint256) {
+        return a.balance / 1e18;
+    }
+}
+
+contract C {
+    using AddressUtils for address;
+
+    function getBalance(address a) public view returns (uint256) {
+        // Without parentheses - ambiguous between native property and library function
+        return a.balance;
+    }
+}
+// ----
+// TypeError 6675: (517-526): Member "balance" not unique after argument-dependent lookup in address.


### PR DESCRIPTION
## What

When both a native property (e.g., `address.balance`) and a library function with the same name are available via `using for`, disambiguate based on call syntax:

- **With parentheses**: prefer library function (e.g., `a.balance()`)
- **Without parentheses**: unchanged behavior ("not unique" error)

## Why

This allows library functions to shadow native properties when explicitly called with parentheses, enabling patterns like:

```solidity
library AddressUtils {
    function balance(address a) internal view returns (uint256) {
        return a.balance / 1e18;  // custom logic
    }
}

contract C {
    using AddressUtils for address;
    function f(address a) public view returns (uint256) {
        return a.balance();  // uses library function (now works)
    }
}
```

Currently this fails with: `Error: Member "balance" not unique after argument-dependent lookup in address.`

## How

The fix adds a single `else if` branch to the existing overload resolution loop in `visit(MemberAccess)`, filtering out non-function members when called with parentheses.

This mirrors the identifier resolution pattern in `visit(Identifier)` where `VariableDeclaration`s are preferred without parentheses.

## Tests

- `library_function_vs_native_property_with_parens.sol` - verifies `a.balance()` works