### PR TITLE
Remove the wrong codegen assumption that a conversion between non-byte calldata arrays can never happen

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ Compiler Features:
 
 Bugfixes:
 * NatSpec: Disallow `@return` tag in event documentation.
+* Yul IR Code Generation: Fix identical tuple types sometimes being seen by the compiler as different, leading to superfluous conversion code being emitted.
+* Yul IR Code Generation: Fix internal compiler error when non-byte calldata arrays of the same type were involved in operations that require converting operands to a common type, such as ternary operator.
 
 
 ### 0.8.35 (2026-04-29)

--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -3876,9 +3876,13 @@ std::string YulUtilFunctions::copyStructToStorageFunction(StructType const& _fro
 std::string YulUtilFunctions::arrayConversionFunction(ArrayType const& _from, ArrayType const& _to)
 {
 	if (_to.dataStoredIn(DataLocation::CallData))
+		// NOTE: Calldata array slices (ArraySliceType) are handled via a separate code path and
+		// do not reach this function when targeting calldata.
 		solAssert(
-			_from.dataStoredIn(DataLocation::CallData) && _from.isByteArrayOrString() && _to.isByteArrayOrString(),
-			""
+			_from.dataStoredIn(DataLocation::CallData) &&
+			(_from == _to || (_from.isByteArrayOrString() && _to.isByteArrayOrString())),
+			"Conversion to calldata array is possible only from a calldata array of the same type or for "
+			"(bytes calldata) <-> (string calldata) conversion."
 		);
 
 	// Other cases are done explicitly in LValue::storeValue, and only possible by assignment.

--- a/test/libsolidity/semanticTests/array/integer_calldata_array_conversion_in_ternary_with_tuple_operands.sol
+++ b/test/libsolidity/semanticTests/array/integer_calldata_array_conversion_in_ternary_with_tuple_operands.sol
@@ -1,0 +1,26 @@
+contract C {
+    function g_int(uint[] calldata a, uint[] calldata b) public returns(uint, uint, uint, uint) {
+        (uint[] calldata r, ) = true ? (a, 0) : (b, 0);
+        return (r.length, r[0], r[1], r[2]);
+    }
+
+    function g_slice(uint[] calldata a, uint[] calldata b) public returns(uint, uint, uint, uint) {
+        (uint[] calldata r, ) = true ? (a[:], 0) : (b[0:1], 0);
+        return (r.length, r[0], r[1], r[2]);
+    }
+
+    function g_mix_array_slice(uint[] calldata a, uint[] calldata b) public returns(uint, uint, uint, uint) {
+        (uint[] calldata r, ) = true ? (a, 0) : (b[:], 0);
+        return (r.length, r[0], r[1], r[2]);
+    }
+
+    function g_static(uint[3] calldata a, uint[3] calldata b) public returns(uint, uint, uint, uint) {
+        (uint[3] calldata r, ) = true ? (a, 0) : (b, 0);
+        return (r.length, r[0], r[1], r[2]);
+    }
+}
+// ----
+// g_int(uint256[],uint256[]): 0x40, 0xC0, 3, 11111111, 2222222, 888888888, 3, 11111111, 2222222, 888888888 -> 3, 11111111, 2222222, 888888888
+// g_slice(uint256[],uint256[]): 0x40, 0xC0, 3, 11111111, 2222222, 888888888, 3, 11111111, 2222222, 888888888 -> 3, 11111111, 2222222, 888888888
+// g_mix_array_slice(uint256[],uint256[]): 0x40, 0xC0, 3, 11111111, 2222222, 888888888, 3, 11111111, 2222222, 888888888 -> 3, 11111111, 2222222, 888888888
+// g_static(uint256[3],uint256[3]): 11111111, 2222222, 888888888, 11111111, 2222222, 888888888 -> 3, 11111111, 2222222, 888888888

--- a/test/libsolidity/semanticTests/array/struct_calldata_array_conversion_in_ternary_with_tuple_operands.sol
+++ b/test/libsolidity/semanticTests/array/struct_calldata_array_conversion_in_ternary_with_tuple_operands.sol
@@ -1,0 +1,92 @@
+pragma abicoder v2;
+
+contract C {
+    struct N {
+        address addr;
+        bytes32 data32;
+    }
+
+    struct S {
+        uint8 a;
+        address addr;
+        N[] ns;
+        bytes data;
+    }
+
+    function g() private returns(S[] memory) {
+        S[] memory ss = new S[](3);
+
+        ss[0].a = 123;
+        ss[0].addr = address(1);
+        ss[0].ns = new N[](1);
+        ss[0].ns[0].addr = address(1);
+        ss[0].ns[0].data32 = "abdeff00";
+        ss[0].data = "abdeff";
+
+        ss[1].a = 124;
+        ss[1].addr = address(2);
+        ss[1].ns = new N[](2);
+        ss[1].ns[0].addr = address(2);
+        ss[1].ns[0].data32 = "abdeff10";
+        ss[1].ns[1].addr = address(2);
+        ss[1].ns[1].data32 = "abdeff11";
+        ss[1].data = "deabff";
+
+        ss[2].a = 125;
+        ss[2].addr = address(3);
+        ss[2].ns = new N[](3);
+        ss[2].ns[0].addr = address(3);
+        ss[2].ns[0].data32 = "abdeff20";
+        ss[2].ns[1].addr = address(3);
+        ss[2].ns[1].data32 = "abdeff21";
+        ss[2].ns[2].addr = address(3);
+        ss[2].ns[2].data32 = "abdeff22";
+        ss[2].data = "deffab";
+
+        return ss;
+    }
+
+    function g(S[] calldata a, S[] calldata b) public returns(S[] memory) {
+        (S[] calldata r, ) = true ? (a, 0) : (b, 0);
+        return r;
+    }
+
+    function compare_bytes(bytes memory a, bytes memory b) private pure returns(bool)
+    {
+        require(a.length == b.length);
+        for (uint i = 0; i < a.length; i = i + 1)
+            if (a[i] != b[i])
+                return false;
+
+        return true;
+    }
+
+    function test() public
+    {
+        S[] memory s0 = g();
+        S[] memory s1 = this.g(s0, s0);
+
+        require(s0.length == s1.length);
+
+        for (uint i = 0; i < s0.length; i = i + 1)
+        {
+            require(s0[i].a == s1[i].a);
+            require(s0[i].addr == s1[i].addr);
+
+            require(s0[i].ns.length == s1[i].ns.length);
+
+            for (uint j = 0; j < s0[i].ns.length; j = j + 1)
+            {
+                require(s0[i].ns[j].addr == s1[i].ns[j].addr);
+                require(s0[i].ns[j].data32 == s1[i].ns[j].data32);
+            }
+
+            require(compare_bytes(s0[i].data, s1[i].data));
+        }
+    }
+}
+// ====
+// EVMVersion: >homestead
+// ----
+// test() ->
+// gas legacy: 85950


### PR DESCRIPTION
This PR allows generating a array conversion code for the same types array. It was mentioned already in https://github.com/argotorg/solidity/pull/10893#discussion_r569573114 that is should be allowed for equal types but it was not added eventually. Not sure why.

Fixes: https://github.com/argotorg/solidity/issues/16066
