### PR TITLE
Fix `check_style.sh` regex patterns to properly detect style issues

### DIFF
--- a/libsolidity/analysis/ControlFlowBuilder.h
+++ b/libsolidity/analysis/ControlFlowBuilder.h
@@ -152,7 +152,7 @@ private:
 
 	CFGNode* newLabel();
 	CFGNode* createLabelHere();
-	void placeAndConnectLabel(CFGNode *_node);
+	void placeAndConnectLabel(CFGNode* _node);
 
 	CFG::NodeContainer& m_nodeContainer;
 

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -1447,7 +1447,7 @@ void TypeChecker::checkExpressionAssignment(Type const& _type, Expression const&
 	{
 		bool isLocalOrReturn = false;
 		if (auto const* identifier = dynamic_cast<Identifier const*>(&_expression))
-			if (auto const *variableDeclaration = dynamic_cast<VariableDeclaration const*>(identifier->annotation().referencedDeclaration))
+			if (auto const* variableDeclaration = dynamic_cast<VariableDeclaration const*>(identifier->annotation().referencedDeclaration))
 				if (variableDeclaration->isLocalOrReturn())
 					isLocalOrReturn = true;
 		if (!isLocalOrReturn)

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3474,7 +3474,7 @@ MemberList::MemberMap FunctionType::nativeMembers(ASTNode const* _scope) const
 		if (auto const* functionDefinition = dynamic_cast<FunctionDefinition const*>(m_declaration))
 		{
 			solAssert(functionDefinition->visibility() > Visibility::Internal, "");
-			auto const *contract = dynamic_cast<ContractDefinition const*>(m_declaration->scope());
+			auto const* contract = dynamic_cast<ContractDefinition const*>(m_declaration->scope());
 			solAssert(contract, "");
 			solAssert(contract->isLibrary(), "");
 			return {{"selector", TypeProvider::fixedBytes(4)}};

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -374,7 +374,7 @@ private:
 	/// Stack of current visited AST nodes, used for location attachment
 	std::stack<ASTNode const*> m_visitedNodes;
 	/// The runtime context if in Creation mode, this is used for generating tags that would be stored into the storage and then used at runtime.
-	CompilerContext *m_runtimeContext;
+	CompilerContext* m_runtimeContext;
 	/// The index of the runtime subroutine.
 	evmasm::SubAssemblyID m_runtimeSub{};
 	/// An index of low-level function labels by name.

--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -2298,7 +2298,7 @@ bool ExpressionCompiler::visit(IndexRangeAccess const& _indexAccess)
 
 	Type const& baseType = *_indexAccess.baseExpression().annotation().type;
 
-	ArrayType const *arrayType = dynamic_cast<ArrayType const*>(&baseType);
+	ArrayType const* arrayType = dynamic_cast<ArrayType const*>(&baseType);
 	if (!arrayType)
 		if (ArraySliceType const* sliceType = dynamic_cast<ArraySliceType const*>(&baseType))
 			arrayType = &sliceType->arrayType();

--- a/libyul/backends/evm/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/StackLayoutGenerator.cpp
@@ -371,7 +371,7 @@ void StackLayoutGenerator::processEntryPoint(CFG::BasicBlock const& _entry, CFG:
 		// entry layout of the backwards jump target as the initial exit layout of the backwards-jumping block.
 		while (!toVisit.empty())
 		{
-			CFG::BasicBlock const *block = *toVisit.begin();
+			CFG::BasicBlock const* block = *toVisit.begin();
 			toVisit.pop_front();
 
 			if (visited.count(block))

--- a/scripts/check_style.sh
+++ b/scripts/check_style.sh
@@ -55,7 +55,7 @@ FORMATERROR=$(
     preparedGrep "^ [^*]|[^*] 	|	 [^*]" # uses spaces for indentation or mixes spaces and tabs
     preparedGrep "[a-zA-Z0-9_]\s*[&][a-zA-Z_]" | grep -E -v "return [&]" # right-aligned reference ampersand (needs to exclude return)
     # right-aligned reference pointer star (needs to exclude return and comments)
-    preparedGrep "[a-zA-Z0-9_]\s*[*][a-zA-Z_]" | grep -E -v -e "return [*]" -e "^* [*]" -e "^*//.*"
+    preparedGrep "[a-zA-Z0-9_]\s*[*][a-zA-Z_]" | grep -E -v -e "return [*]" -e ":[0-9]+:\s*\*\s" -e "//"
     # unqualified move()/forward() checks, i.e. make sure that std::move() and std::forward() are used instead of move() and forward()
     preparedGrep "move\(.+\)" | grep -v "std::move" | grep -E "[^a-z]move"
     preparedGrep "forward\(.+\)" | grep -v "std::forward" | grep -E "[^a-z]forward"

--- a/scripts/check_style.sh
+++ b/scripts/check_style.sh
@@ -59,7 +59,7 @@ FORMATERROR=$(
     # unqualified move()/forward() checks, i.e. make sure that std::move() and std::forward() are used instead of move() and forward()
     preparedGrep "move\(.+\)" | grep -v "std::move" | grep -E "[^a-z]move"
     preparedGrep "forward\(.+\)" | grep -v "std::forward" | grep -E "[^a-z]forward"
-) | grep -E -v -e "^[a-zA-Z\./]*:[0-9]*:\s*\/(\/|\*)" -e "^test/" || true
+) | grep -E -v -e "^[a-zA-Z./]*:[0-9]*:\s*/[/*]" -e "^test/" || true
 )
 
 # Special error handling for `using namespace std;` exclusion, since said statement can be present in the test directory


### PR DESCRIPTION
While working on https://github.com/argotorg/solidity/pull/16266, I noticed that some style issues were not being caught by our script. This PR fixes issues in `check_style.sh` that were causing:

1. `grep` warnings due to invalid or unnecessary regex syntax when using the Extended Regular Expressions (`-E`) option
2. Real style violations being incorrectly excluded from detection

The old patterns `^* [*]` and `^*//.*` were flagged as invalid regex by `grep` (i.e., `*` at start of expression) and inadvertently matched any line containing ` *` (space followed by asterisk). This caused real pointer alignment issues like `CFGNode *_node` to be excluded from detection.

The new pattern `:[0-9]+:\s*\*\s` only excludes comment continuation lines (where the source starts `*` followed by whitespace), allowing real style violations to be properly detected.

I also changed `\/(\/|\*)` to `/[/*]`. [Forward slashes are not special characters in regular expressions](https://www.gnu.org/software/grep/manual/grep.html#Basic-vs-Extended-Regular-Expressions) and do not need escaping. The unnecessary escaping was causing `grep: warning: stray \ before /` to appear in the script output.