### PR TITLE
docs: fix import remapping precedence rules in path-resolution

### DIFF
--- a/docs/path-resolution.rst
+++ b/docs/path-resolution.rst
@@ -629,9 +629,9 @@ Here are the detailed rules governing the behavior of remappings:
 
 #. **At most one remapping is applied to a single import.**
 
-   - If multiple remappings match the same source unit name, the one with the longest matching
-     prefix is chosen.
-   - If prefixes are identical, the one specified last wins.
+   - If multiple remappings match the same source unit name, the one with the longest matching context is chosen.
+   - If contexts are identical, the one with the longest matching prefix is chosen.
+   - If contexts and prefixes are identical, the one specified last wins.
    - Remappings do not work on other remappings. For example ``a=b b=c c=d`` will not result in ``a``
      being remapped to ``d``.
 


### PR DESCRIPTION
## Description

This PR fixes the incorrect precedence rules in the import remapping documentation that contradict the actual compiler implementation.

## Problem

The documentation at https://docs.soliditylang.org/en/v0.8.33/path-resolution.html#import-remapping incorrectly states that when multiple remappings match, "the one with the longest matching prefix is chosen."

However, the actual implementation in `libsolidity/interface/ImportRemapper.cpp` (lines 42-69) prioritizes context length first, not prefix length.

## Solution

Updated the documentation in `docs/path-resolution.rst` to correctly reflect the actual precedence order:

1. **Context length** (longest first) - highest priority
2. **Prefix length** (longest first, if context is equal) - second priority  
3. **Latest remapping** (if both are equal) - lowest priority

## Changes Made

- Line 632: Changed "longest matching prefix" → "longest matching context"
- Added new rule: "If contexts are identical, the one with the longest matching prefix is chosen."
- Line 634: Updated "If prefixes are identical" → "If contexts and prefixes are identical"

## References

Fixes #16383

**Related code:** https://github.com/argotorg/solidity/blob/develop/libsolidity/interface/ImportRemapper.cpp#L42-L69