### PR TITLE
Remove unused AsmPrinter include from UnusedAssignEliminator

### DIFF
--- a/libyul/optimiser/UnusedAssignEliminator.cpp
+++ b/libyul/optimiser/UnusedAssignEliminator.cpp
@@ -27,8 +27,6 @@
 #include <libyul/ControlFlowSideEffectsCollector.h>
 #include <libyul/Utilities.h>
 #include <libyul/AST.h>
-#include <libyul/AsmPrinter.h>
-
 #include <libsolutil/CommonData.h>
 
 #include <range/v3/action/remove_if.hpp>


### PR DESCRIPTION
remove an unused AsmPrinter include to reduce header clutter and keep the file focused