### PR TITLE
Remove CCACHE_KEY from cache keys in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,7 +268,7 @@ commands:
   run_build:
     steps:
       - restore_ccache_if_allowed
-      # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
+      # WARNING! If you edit anything between here and save_cache, remember to invalidate the cache manually by bumping the version
       - run_with_ccache_unless_tag:
           step_name: Build
           command: scripts/ci/build.sh
@@ -277,7 +277,7 @@ commands:
   run_build_ossfuzz:
     steps:
       - restore_ccache_if_allowed
-      # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
+      # WARNING! If you edit anything between here and save_cache, remember to invalidate the cache manually by bumping the version
       - run_with_ccache_unless_tag:
           step_name: Build_ossfuzz
           command: scripts/ci/build_ossfuzz.sh
@@ -1323,7 +1323,7 @@ jobs:
     steps:
       - checkout
       - restore_ccache_if_allowed
-      # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
+      # WARNING! If you edit anything between here and save_cache, remember to invalidate the cache manually by bumping the version
       - run_with_ccache_unless_tag:
           step_name: Build
           command: scripts/ci/build_emscripten.sh
@@ -1805,7 +1805,7 @@ jobs:
           paths:
             - .\deps
       - restore_ccache_if_allowed
-      # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
+      # WARNING! If you edit anything between here and save_cache, remember to invalidate the cache manually by bumping the version
       - run_with_ccache_unless_tag:
           step_name: "Building solidity"
           command: scripts/ci/build_win.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,21 +75,6 @@ commands:
           event: release
           condition: on_success
 
-  ensure_ccache_key_unless_tag:
-    description: "Fail fast when CCACHE_KEY is missing (skipped on tags)."
-    steps:
-      - when:
-          condition:
-            equal: ["", << pipeline.git.tag >>]
-          steps:
-            - run:
-                name: Check CCACHE_KEY
-                command: |
-                  if [ -z "${CCACHE_KEY:-}" ]; then
-                    echo "CCACHE_KEY is not set. Please set it in CircleCI environment settings."
-                    exit 1
-                  fi
-
   restore_ccache_if_allowed:
     description: "Restore ccache unless on a tag or a skipped branch."
     parameters:
@@ -282,7 +267,6 @@ commands:
 
   run_build:
     steps:
-      - ensure_ccache_key_unless_tag
       - restore_ccache_if_allowed
       # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
       - run_with_ccache_unless_tag:
@@ -292,7 +276,6 @@ commands:
 
   run_build_ossfuzz:
     steps:
-      - ensure_ccache_key_unless_tag
       - restore_ccache_if_allowed
       # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
       - run_with_ccache_unless_tag:
@@ -1339,7 +1322,6 @@ jobs:
       MAKEFLAGS: -j 10
     steps:
       - checkout
-      - ensure_ccache_key_unless_tag
       - restore_ccache_if_allowed
       # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
       - run_with_ccache_unless_tag:
@@ -1822,7 +1804,6 @@ jobs:
           key: dependencies-win-{{ arch }}-{{ checksum "scripts/install_deps.ps1" }}
           paths:
             - .\deps
-      - ensure_ccache_key_unless_tag
       - restore_ccache_if_allowed
       # WARNING! If you edit anything between here and save_cache, remember to bump the CCACHE_KEY version in CircleCI environment settings
       - run_with_ccache_unless_tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ commands:
             - restore_cache:
                 keys:
                   # Reuse cache produced on develop (prefix match; restores the most recent).
-                  - v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-develop-
+                  - v1-ccache-{{ .Environment.CIRCLE_JOB }}-develop-
 
   save_ccache_if_develop:
     description: "Save a fresh ccache only on the develop branch."
@@ -122,7 +122,7 @@ commands:
             equal: ["develop", << pipeline.git.branch >>]
           steps:
             - save_cache:
-                key: v1-{{ .Environment.CCACHE_KEY }}-ccache-{{ .Environment.CIRCLE_JOB }}-develop-{{ .Revision }}
+                key: v1-ccache-{{ .Environment.CIRCLE_JOB }}-develop-{{ .Revision }}
                 paths:
                   - ~/.ccache
   run_with_ccache_unless_tag:


### PR DESCRIPTION
CCACHE_KEY is currently used to invalidate the stored ccache without having to push anything to develop. Unfortunately, the current system doesn’t work because CircleCI environment variables are treated as secrets, so they aren’t set on external PRs.

With this PR, we remove `CCACHE_KEY` usage and instead rely on the `v1` prefix in the cache key.