### PR TITLE
Restore EVM version wrongly moved to nightly + adjust to run tests only on meaningfully different EVMs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1400,7 +1400,7 @@ jobs:
       - attach_workspace:
           at: build
       - run_soltest_all:
-          evm_versions: homestead byzantium constantinople petersburg
+          evm_versions: homestead byzantium
       - store_test_results:
           path: test_results/
       - store_artifacts_test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ commands:
   run_soltest_all:
     parameters:
       # NOTE: If not specified, soltest_all.sh will use the default values as specified in the script.
-      # In other words, it will execute for all EVM versions that are not marked as deprecated.
+      # In other words, it will execute for all EVM versions that are not marked as low priority.
       evm_versions:
         description: "List of EVM versions (separated by space)."
         type: string
@@ -1392,7 +1392,7 @@ jobs:
       - store_artifacts_test_results
       - matrix_notify_failure_unless_pr
 
-  t_ubu_soltest_deprecated_evm_versions: &t_ubu_soltest_deprecated_evm_versions
+  t_ubu_soltest_low_priority_evm_versions: &t_ubu_soltest_low_priority_evm_versions
     <<: *base_ubuntu2404_large
     parallelism: 50
     steps:
@@ -1400,7 +1400,18 @@ jobs:
       - attach_workspace:
           at: build
       - run_soltest_all:
-          evm_versions: homestead byzantium
+          # We test most EVM versions on every PR. The ones below are the exceptions.
+          #
+          # We do not test these at all. We were never doing that and no point starting now since
+          # they are deprecated anyway:
+          # - tangerineWhistle
+          # - spuriousDragon
+          #
+          # These have a low chance of breaking so we only run them in nightly to save credits:
+          # - byzantium: deprecated, if it breaks, homestead likely will as well
+          # - petersburg: no changes compared to constantinople
+          # - prague: no changes compared to cancun
+          evm_versions: byzantium petersburg prague
       - store_test_results:
           path: test_results/
       - store_artifacts_test_results
@@ -2259,7 +2270,7 @@ workflows:
 
       # Deprecated EVM versions tests
       - b_ubu: *requires_nothing
-      - t_ubu_soltest_deprecated_evm_versions: *requires_b_ubu
+      - t_ubu_soltest_low_priority_evm_versions: *requires_b_ubu
 
       # Build in a Docker container (on Alpine Linux)
       - b_alpine_docker: *requires_nothing

--- a/.circleci/soltest_all.sh
+++ b/.circleci/soltest_all.sh
@@ -31,7 +31,18 @@ REPODIR="$(realpath "$(dirname "$0")"/..)"
 # shellcheck source=scripts/common.sh
 source "${REPODIR}/scripts/common.sh"
 
-DEFAULT_EVM_VALUES=(istanbul berlin london paris shanghai cancun prague osaka)
+DEFAULT_EVM_VALUES=(
+    constantinople
+    petersburg
+    istanbul
+    berlin
+    london
+    paris
+    shanghai
+    cancun
+    prague
+    osaka
+)
 EVMS_WITH_EOF=(osaka)
 
 # Deserialize the EVM_VALUES array if it was provided as argument or

--- a/.circleci/soltest_all.sh
+++ b/.circleci/soltest_all.sh
@@ -32,15 +32,14 @@ REPODIR="$(realpath "$(dirname "$0")"/..)"
 source "${REPODIR}/scripts/common.sh"
 
 DEFAULT_EVM_VALUES=(
+    homestead
     constantinople
-    petersburg
     istanbul
     berlin
     london
     paris
     shanghai
     cancun
-    prague
     osaka
 )
 EVMS_WITH_EOF=(osaka)


### PR DESCRIPTION
In #16349 I proposed moving test runs on `constantinople` and `petersburg` EVMs to the nightly workflow, wrongly assuming that these are deprecated. This is not true as documented under [Target options](https://docs.soliditylang.org/en/develop/using-the-compiler.html#target-options). I did not notice my mistake until now and unfortunately no one caught it in the review of #16350 either so the change went in.

This was an obvious mistake on my part. I didn't have the order of the early EVMs memorized and instead of verifying, I just looked at the config and assumed that the 4 oldest ones there were the ones we deprecated. That was wrong, the deprecated ones were `tangerineWhistle` and `spuriousDragon`. They were not in the config because we never had test runs for them. This PR fixes the mess that resulted from this.

While at it, I'd also like to replace `prague` with `homestead`. It's a common occurrence that we get a failure in nightly after a PR is merged because we did not account for something in those older versions, so `homestead` is actually relatively useful to have on PRs. On the other hand `prague` had zero changes compared to `cancun`, so testing it on every PR adds very little value.

EDIT: Actually, I changed it to keep `petersburg` in nightly. Just like `prague`, this version is identical to `constantinople` from compiler's perspective.