### PR TITLE
Fix optimising out `returndatacopy` call.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@ Language Features:
 Compiler Features:
 
 Bugfixes:
- * Yul Optimizer: Fix ``UnusedStoreEliminator`` incorrectly removing ``returndatacopy`` operations when the length comes from a stale ``returndatasize()`` call that was invalidated by subsequent call opcodes.
+ * Yul Optimizer: Fix `UnusedStoreEliminator` incorrectly removing `returndatacopy` operations when the length comes from a stale `returndatasize()` call that was invalidated by subsequent call opcodes.
 
 
 ### 0.8.34 (2026-02-18)

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Language Features:
 Compiler Features:
 
 Bugfixes:
+ * Yul Optimizer: Fix ``UnusedStoreEliminator`` incorrectly removing ``returndatacopy`` operations when the length comes from a stale ``returndatasize()`` call that was invalidated by subsequent call opcodes.
 
 
 ### 0.8.34 (2026-02-18)

--- a/docs/bugs.json
+++ b/docs/bugs.json
@@ -1,5 +1,18 @@
 [
     {
+        "uid": "SOL-2026-2",
+        "name": "UnusedStoreEliminatorStaleReturnDataSize",
+        "summary": "The Yul optimizer's ``UnusedStoreEliminator`` may incorrectly remove ``returndatacopy`` operations when using a stale value from ``returndatasize()`` that was invalidated by subsequent call operations.",
+        "description": "The ``UnusedStoreEliminator`` is a Yul optimizer step that removes redundant memory and storage writes. It has a special optimization for ``returndatacopy(0, 0, returndatasize())``, which copies the entire return data buffer to memory. This operation can be removed if the start offset is zero and the length equals ``returndatasize()``, similar to other memory write operations. However, the check for this pattern did not account for ``returndatasize()`` values becoming stale. The size of the return data buffer is updated by ``CALL``, ``STATICCALL``, ``DELEGATECALL``, and ``CALLCODE`` opcodes. If a ``returndatasize()`` value is stored in a variable before such an operation and then used in a subsequent ``returndatacopy``, the stored size no longer reflects the actual return data buffer size. It should revert, if the stale return data size is greater then actual return data size. The optimizer would still consider it safe to remove, even though it may revert and should not be removed. This could lead to incorrect behavior when the code should revert but it does not. The bug only affects inline assembly or handwritten Yul code code that uses optimizer sequences including the ``UnusedStoreEliminator`` step, which is a part of default optimizer sequance",
+        "link": "https://blog.soliditylang.org/2026/X/Y/Z/",
+        "introduced": "0.8.12",
+        "fixed": "0.8.35",
+        "severity": "low",
+        "conditions": {
+            "yulOptimizer": true
+        }
+    },
+    {
         "uid": "SOL-2026-1",
         "name": "TransientStorageClearingHelperCollision",
         "summary": "Clearing both storage and transient storage variables in the same contract may result in only one of these locations being cleared.",

--- a/docs/bugs_by_version.json
+++ b/docs/bugs_by_version.json
@@ -1855,6 +1855,7 @@
     },
     "0.8.12": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "LostStorageArrayWriteOnSlotOverflow",
             "VerbatimInvalidDeduplication",
             "FullInlinerNonExpressionSplitArgumentEvaluationOrder",
@@ -1869,6 +1870,7 @@
     },
     "0.8.13": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "LostStorageArrayWriteOnSlotOverflow",
             "VerbatimInvalidDeduplication",
             "FullInlinerNonExpressionSplitArgumentEvaluationOrder",
@@ -1884,6 +1886,7 @@
     },
     "0.8.14": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "LostStorageArrayWriteOnSlotOverflow",
             "VerbatimInvalidDeduplication",
             "FullInlinerNonExpressionSplitArgumentEvaluationOrder",
@@ -1897,6 +1900,7 @@
     },
     "0.8.15": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "LostStorageArrayWriteOnSlotOverflow",
             "VerbatimInvalidDeduplication",
             "FullInlinerNonExpressionSplitArgumentEvaluationOrder",
@@ -1908,6 +1912,7 @@
     },
     "0.8.16": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "LostStorageArrayWriteOnSlotOverflow",
             "VerbatimInvalidDeduplication",
             "FullInlinerNonExpressionSplitArgumentEvaluationOrder",
@@ -1918,6 +1923,7 @@
     },
     "0.8.17": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "LostStorageArrayWriteOnSlotOverflow",
             "VerbatimInvalidDeduplication",
             "FullInlinerNonExpressionSplitArgumentEvaluationOrder",
@@ -1927,6 +1933,7 @@
     },
     "0.8.18": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "LostStorageArrayWriteOnSlotOverflow",
             "VerbatimInvalidDeduplication",
             "FullInlinerNonExpressionSplitArgumentEvaluationOrder",
@@ -1936,6 +1943,7 @@
     },
     "0.8.19": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "LostStorageArrayWriteOnSlotOverflow",
             "VerbatimInvalidDeduplication",
             "FullInlinerNonExpressionSplitArgumentEvaluationOrder",
@@ -1960,6 +1968,7 @@
     },
     "0.8.20": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "LostStorageArrayWriteOnSlotOverflow",
             "VerbatimInvalidDeduplication",
             "FullInlinerNonExpressionSplitArgumentEvaluationOrder",
@@ -1969,6 +1978,7 @@
     },
     "0.8.21": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "LostStorageArrayWriteOnSlotOverflow",
             "VerbatimInvalidDeduplication"
         ],
@@ -1976,6 +1986,7 @@
     },
     "0.8.22": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "LostStorageArrayWriteOnSlotOverflow",
             "VerbatimInvalidDeduplication"
         ],
@@ -1983,36 +1994,42 @@
     },
     "0.8.23": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "LostStorageArrayWriteOnSlotOverflow"
         ],
         "released": "2023-11-08"
     },
     "0.8.24": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "LostStorageArrayWriteOnSlotOverflow"
         ],
         "released": "2024-01-25"
     },
     "0.8.25": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "LostStorageArrayWriteOnSlotOverflow"
         ],
         "released": "2024-03-14"
     },
     "0.8.26": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "LostStorageArrayWriteOnSlotOverflow"
         ],
         "released": "2024-05-21"
     },
     "0.8.27": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "LostStorageArrayWriteOnSlotOverflow"
         ],
         "released": "2024-09-04"
     },
     "0.8.28": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "TransientStorageClearingHelperCollision",
             "LostStorageArrayWriteOnSlotOverflow"
         ],
@@ -2020,6 +2037,7 @@
     },
     "0.8.29": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "TransientStorageClearingHelperCollision",
             "LostStorageArrayWriteOnSlotOverflow"
         ],
@@ -2041,6 +2059,7 @@
     },
     "0.8.30": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "TransientStorageClearingHelperCollision",
             "LostStorageArrayWriteOnSlotOverflow"
         ],
@@ -2048,6 +2067,7 @@
     },
     "0.8.31": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "TransientStorageClearingHelperCollision",
             "LostStorageArrayWriteOnSlotOverflow"
         ],
@@ -2055,18 +2075,22 @@
     },
     "0.8.32": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "TransientStorageClearingHelperCollision"
         ],
         "released": "2025-12-18"
     },
     "0.8.33": {
         "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize",
             "TransientStorageClearingHelperCollision"
         ],
         "released": "2025-12-18"
     },
     "0.8.34": {
-        "bugs": [],
+        "bugs": [
+            "UnusedStoreEliminatorStaleReturnDataSize"
+        ],
         "released": "2026-02-18"
     },
     "0.8.4": {

--- a/libyul/optimiser/UnusedStoreEliminator.cpp
+++ b/libyul/optimiser/UnusedStoreEliminator.cpp
@@ -104,7 +104,11 @@ void UnusedStoreEliminator::operator()(FunctionCall const& _functionCall)
 
 	ControlFlowSideEffects sideEffects;
 	if (auto builtin = resolveBuiltinFunction(_functionCall.functionName, m_dialect))
+	{
 		sideEffects = builtin->controlFlowSideEffects;
+		registerReturnDataSizeCall(_functionCall);
+		invalidateReturnDataSize(_functionCall);
+	}
 	else
 	{
 		yulAssert(std::holds_alternative<Identifier>(_functionCall.functionName));
@@ -193,7 +197,7 @@ void UnusedStoreEliminator::visit(Statement const& _statement)
 				if (
 					m_knowledgeBase.knownToBeZero(*startOffset) &&
 					lengthCall &&
-					toEVMInstruction(m_dialect, lengthCall->functionName) == Instruction::RETURNDATASIZE
+					isValidReturnDataSize(lengthCall)
 				)
 					allowReturndatacopyToBeRemoved = true;
 			}
@@ -435,4 +439,26 @@ std::optional<YulName> UnusedStoreEliminator::identifierNameIfSSA(Expression con
 		if (m_ssaValues.count(identifier->name))
 			return {identifier->name};
 	return std::nullopt;
+}
+
+void UnusedStoreEliminator::invalidateReturnDataSize(FunctionCall const& _functionCall)
+{
+	auto const instruction = toEVMInstruction(m_dialect, _functionCall.functionName);
+	if (
+		instruction &&
+		(
+			*instruction == evmasm::Instruction::STATICCALL ||
+			*instruction == evmasm::Instruction::CALL ||
+			*instruction == evmasm::Instruction::DELEGATECALL ||
+			*instruction == evmasm::Instruction::CALLCODE
+		)
+	)
+		m_validReturnDataSizeCalls.clear();
+}
+
+void UnusedStoreEliminator::registerReturnDataSizeCall(FunctionCall const& _functionCall)
+{
+	auto const instruction = toEVMInstruction(m_dialect, _functionCall.functionName);
+	if (instruction == evmasm::Instruction::RETURNDATASIZE)
+		m_validReturnDataSizeCalls.insert(&_functionCall);
 }

--- a/libyul/optimiser/UnusedStoreEliminator.cpp
+++ b/libyul/optimiser/UnusedStoreEliminator.cpp
@@ -106,8 +106,7 @@ void UnusedStoreEliminator::operator()(FunctionCall const& _functionCall)
 	if (auto builtin = resolveBuiltinFunction(_functionCall.functionName, m_dialect))
 	{
 		sideEffects = builtin->controlFlowSideEffects;
-		registerReturnDataSizeCall(_functionCall);
-		invalidateReturnDataSize(_functionCall);
+		updateReturnDataSizeCalls(_functionCall);
 	}
 	else
 	{
@@ -441,24 +440,18 @@ std::optional<YulName> UnusedStoreEliminator::identifierNameIfSSA(Expression con
 	return std::nullopt;
 }
 
-void UnusedStoreEliminator::invalidateReturnDataSize(FunctionCall const& _functionCall)
+void UnusedStoreEliminator::updateReturnDataSizeCalls(FunctionCall const& _functionCall)
 {
-	auto const instruction = toEVMInstruction(m_dialect, _functionCall.functionName);
-	if (
-		instruction &&
-		(
+	if (auto const instruction = toEVMInstruction(m_dialect, _functionCall.functionName))
+	{
+		if (
 			*instruction == evmasm::Instruction::STATICCALL ||
 			*instruction == evmasm::Instruction::CALL ||
 			*instruction == evmasm::Instruction::DELEGATECALL ||
 			*instruction == evmasm::Instruction::CALLCODE
 		)
-	)
-		m_validReturnDataSizeCalls.clear();
-}
-
-void UnusedStoreEliminator::registerReturnDataSizeCall(FunctionCall const& _functionCall)
-{
-	auto const instruction = toEVMInstruction(m_dialect, _functionCall.functionName);
-	if (instruction == evmasm::Instruction::RETURNDATASIZE)
-		m_validReturnDataSizeCalls.insert(&_functionCall);
+			m_validReturnDataSizeCalls.clear();
+		else if (*instruction == evmasm::Instruction::RETURNDATASIZE)
+			m_validReturnDataSizeCalls.insert(&_functionCall);
+	}
 }

--- a/libyul/optimiser/UnusedStoreEliminator.h
+++ b/libyul/optimiser/UnusedStoreEliminator.h
@@ -111,8 +111,10 @@ private:
 		markActiveAsUsed();
 	}
 
-	void registerReturnDataSizeCall(FunctionCall const& _functionCall);
-	void invalidateReturnDataSize(FunctionCall const& _functionCall);
+	/// Updates the state of valid `returndatasize` calls.
+	/// Invalidates the current state when `_functionCall` is one of the invalidating calls  (CALL, STATICCALL,
+	/// DELEGATECALL, or CODECAL). Adds a new valid call when `_functionCall` is `returndatasize`.
+	void updateReturnDataSizeCalls(FunctionCall const& _functionCall);
 	bool isValidReturnDataSize(FunctionCall const* _returnDataSizeFunctionCall) const
 	{
 		return m_validReturnDataSizeCalls.contains(_returnDataSizeFunctionCall);
@@ -136,8 +138,8 @@ private:
 
 	KnowledgeBase mutable m_knowledgeBase;
 
-	// Contains valid return data size calls. Call is valid until any of invalidating return data size instruction is
-	// called. Currently, they are CALL, STATICCALL or DELEGATECALL.
+	// Contains valid return data size calls. Call is valid until any of the invalidating return data size instructions
+	// is called. Currently, they are CALL, STATICCALL, DELEGATECALL or CODECALL.
 	std::set<FunctionCall const*> m_validReturnDataSizeCalls;
 };
 

--- a/libyul/optimiser/UnusedStoreEliminator.h
+++ b/libyul/optimiser/UnusedStoreEliminator.h
@@ -111,6 +111,12 @@ private:
 		markActiveAsUsed();
 	}
 
+	void registerReturnDataSizeCall(FunctionCall const& _functionCall);
+	void invalidateReturnDataSize(FunctionCall const& _functionCall);
+	bool isValidReturnDataSize(FunctionCall const* _returnDataSizeFunctionCall) const
+	{
+		return m_validReturnDataSizeCalls.contains(_returnDataSizeFunctionCall);
+	}
 	std::vector<Operation> operationsFromFunctionCall(FunctionCall const& _functionCall) const;
 	void applyOperation(Operation const& _operation);
 	bool knownUnrelated(Operation const& _op1, Operation const& _op2) const;
@@ -129,6 +135,10 @@ private:
 	std::map<Statement const*, Operation> m_storeOperations;
 
 	KnowledgeBase mutable m_knowledgeBase;
+
+	// Contains valid return data size calls. Call is valid until any of invalidating return data size instruction is
+	// called. Currently, they are CALL, STATICCALL or DELEGATECALL.
+	std::set<FunctionCall const*> m_validReturnDataSizeCalls;
 };
 
 }

--- a/test/libyul/YulOptimizerTestCommon.cpp
+++ b/test/libyul/YulOptimizerTestCommon.cpp
@@ -311,6 +311,16 @@ YulOptimizerTestCommon::YulOptimizerTestCommon(std::shared_ptr<Object const> _ob
 			ExpressionJoiner::run(*m_context, block);
 			return block;
 		}},
+		{"unusedStoreEliminatorNoSsaTransform", [&]() {
+			auto block = disambiguate();
+			updateContext(block);
+			ForLoopInitRewriter::run(*m_context, block);
+			ExpressionSplitter::run(*m_context, block);
+			UnusedStoreEliminator::run(*m_context, block);
+			SSAReverser::run(*m_context, block);
+			ExpressionJoiner::run(*m_context, block);
+			return block;
+		}},
 		{"equalStoreEliminator", [&]() {
 			auto block = disambiguate();
 			updateContext(block);

--- a/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_control_flow_if.yul
+++ b/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_control_flow_if.yul
@@ -1,0 +1,22 @@
+{
+    let s := returndatasize()
+    if iszero(0) {
+        pop(staticcall(gas(), 0x01, 0, 0, 0, 0))
+    }
+    returndatacopy(0, 0, s)
+}
+// ====
+// EVMVersion: >homestead
+// ----
+// step: unusedStoreEliminator
+//
+// {
+//     {
+//         let s := returndatasize()
+//         if iszero(0)
+//         {
+//             pop(staticcall(gas(), 0x01, 0, 0, 0, 0))
+//         }
+//         returndatacopy(0, 0, s)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_immediate_use.yul
+++ b/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_immediate_use.yul
@@ -1,0 +1,21 @@
+{
+    returndatacopy(0, 0, returndatasize())
+
+    let s := returndatasize()
+    returndatacopy(0, 0, s)
+}
+// ====
+// EVMVersion: >homestead
+// ----
+// step: unusedStoreEliminator
+//
+// {
+//     {
+//         let _1 := returndatasize()
+//         let _2 := 0
+//         let _3 := 0
+//         let s := returndatasize()
+//         let _4 := 0
+//         let _5 := 0
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_mixed_calls.yul
+++ b/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_mixed_calls.yul
@@ -1,0 +1,21 @@
+{
+    let s := returndatasize()
+    pop(call(gas(), 0x01, 0, 0, 0, 0, 0))
+    pop(delegatecall(gas(), 0x02, 0, 0, 0, 0))
+    pop(staticcall(gas(), 0x03, 0, 0, 0, 0))
+    returndatacopy(0, 0, s)
+}
+// ====
+// EVMVersion: >homestead
+// ----
+// step: unusedStoreEliminator
+//
+// {
+//     {
+//         let s := returndatasize()
+//         pop(call(gas(), 0x01, 0, 0, 0, 0, 0))
+//         pop(delegatecall(gas(), 0x02, 0, 0, 0, 0))
+//         pop(staticcall(gas(), 0x03, 0, 0, 0, 0))
+//         returndatacopy(0, 0, s)
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_multiple_calls.yul
+++ b/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_multiple_calls.yul
@@ -1,0 +1,24 @@
+{
+    let s1 := returndatasize()
+    pop(staticcall(gas(), 0x01, 0, 0, 0, 0))
+    pop(staticcall(gas(), 0x02, 0, 0, 0, 0))
+    let s2 := returndatasize()
+    returndatacopy(0, 0, s1)
+    returndatacopy(0, 0, s2)
+}
+// ====
+// EVMVersion: >homestead
+// ----
+// step: unusedStoreEliminator
+//
+// {
+//     {
+//         let s1 := returndatasize()
+//         pop(staticcall(gas(), 0x01, 0, 0, 0, 0))
+//         pop(staticcall(gas(), 0x02, 0, 0, 0, 0))
+//         let s2 := returndatasize()
+//         returndatacopy(0, 0, s1)
+//         let _17 := 0
+//         let _18 := 0
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_nested_function.yul
+++ b/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_nested_function.yul
@@ -1,0 +1,30 @@
+{
+    function helper() -> size {
+        size := returndatasize()
+    }
+
+    let s := helper()
+    pop(staticcall(gas(), 0x01, 0, 0, 0, 0))
+    returndatacopy(0, 0, s)
+
+    let s1 := helper()
+    returndatacopy(0, 0, s1)
+}
+// ====
+// EVMVersion: >homestead
+// ----
+// step: unusedStoreEliminator
+//
+// {
+//     {
+//         let s := helper()
+//         pop(staticcall(gas(), 0x01, 0, 0, 0, 0))
+//         returndatacopy(0, 0, s)
+//         returndatacopy(0, 0, helper())
+//     }
+//     function helper() -> size
+//     {
+//         size := returndatasize()
+//         let size_12 := size
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_nonzero_offset_stale.yul
+++ b/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_nonzero_offset_stale.yul
@@ -1,0 +1,23 @@
+{
+    let s := returndatasize()
+    pop(staticcall(gas(), 0x01, 0, 0, 0, 0))
+    returndatacopy(10, 0, s)
+
+    let s1 := returndatasize()
+    returndatacopy(10, 0, s1)
+}
+// ====
+// EVMVersion: >homestead
+// ----
+// step: unusedStoreEliminator
+//
+// {
+//     {
+//         let s := returndatasize()
+//         pop(staticcall(gas(), 0x01, 0, 0, 0, 0))
+//         returndatacopy(10, 0, s)
+//         let s1 := returndatasize()
+//         let _10 := 0
+//         let _11 := 10
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_returndatasize_invalidate.yul
+++ b/test/libyul/yulOptimizerTests/unusedStoreEliminator/returndatacopy_returndatasize_invalidate.yul
@@ -1,0 +1,58 @@
+{
+    let s := returndatasize()
+    pop(staticcall(gas(), 0x01, 0, 0, 0, 0))
+    let s1 := returndatasize()
+    returndatacopy(0, 0, s)
+    returndatacopy(0, 0, s1)
+
+    let c := returndatasize()
+    pop(call(gas(), 0x01, 0, 0, 0, 0, 0))
+    let c1 := returndatasize()
+    returndatacopy(0, 0, c)
+    returndatacopy(0, 0, c1)
+
+    let d := returndatasize()
+    pop(delegatecall(gas(), 0x01, 0, 0, 0, 0))
+    let d1 := returndatasize()
+    returndatacopy(0, 0, d)
+    returndatacopy(0, 0, d1)
+
+    let cc := returndatasize()
+    pop(callcode(gas(), 0x01, 0, 0, 0, 0, 0))
+    let cc1 := returndatasize()
+    returndatacopy(0, 0, cc)
+    returndatacopy(0, 0, cc1)
+}
+// ====
+// EVMVersion: >homestead
+// ----
+// step: unusedStoreEliminator
+//
+// {
+//     {
+//         let s := returndatasize()
+//         pop(staticcall(gas(), 0x01, 0, 0, 0, 0))
+//         let s1 := returndatasize()
+//         returndatacopy(0, 0, s)
+//         let _10 := 0
+//         let _11 := 0
+//         let c := returndatasize()
+//         pop(call(gas(), 0x01, 0, 0, 0, 0, 0))
+//         let c1 := returndatasize()
+//         returndatacopy(0, 0, c)
+//         let _22 := 0
+//         let _23 := 0
+//         let d := returndatasize()
+//         pop(delegatecall(gas(), 0x01, 0, 0, 0, 0))
+//         let d1 := returndatasize()
+//         returndatacopy(0, 0, d)
+//         let _33 := 0
+//         let _34 := 0
+//         let cc := returndatasize()
+//         pop(callcode(gas(), 0x01, 0, 0, 0, 0, 0))
+//         let cc1 := returndatasize()
+//         returndatacopy(0, 0, cc)
+//         let _45 := 0
+//         let _46 := 0
+//     }
+// }

--- a/test/libyul/yulOptimizerTests/unusedStoreEliminatorNoSsaTransform/returndatacopy_non_ssa.yul
+++ b/test/libyul/yulOptimizerTests/unusedStoreEliminatorNoSsaTransform/returndatacopy_non_ssa.yul
@@ -1,0 +1,19 @@
+{
+    let s := 0
+    s := returndatasize()
+    pop(staticcall(gas(), 0x01, 0, 0, 0, 0))
+    returndatacopy(0, 0, s)
+}
+// ====
+// EVMVersion: >homestead
+// ----
+// step: unusedStoreEliminatorNoSsaTransform
+//
+// {
+//     {
+//         let s := 0
+//         s := returndatasize()
+//         pop(staticcall(gas(), 0x01, 0, 0, 0, 0))
+//         returndatacopy(0, 0, s)
+//     }
+// }


### PR DESCRIPTION
Fixes removing `returndatacopy` calls when `returndatasize` is stale.

This problem is fixed by registering `returndatasize` calls and invalidating them when any of call opcode (potentially changing the size) is called. 