### PR TITLE
libsolutil: Remove duplicate include of <type_traits>

### DIFF
--- a/libsolutil/CommonData.h
+++ b/libsolutil/CommonData.h
@@ -35,7 +35,6 @@
 #include <set>
 #include <functional>
 #include <utility>
-#include <type_traits>
 #include <list>
 #include <algorithm>
 


### PR DESCRIPTION
Removes duplicate `#include <type_traits>` directive in `libsolutil/CommonData.h`.