### PR TITLE
Introduce DotExporterBase for SSA CFG dot export

### DIFF
--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -90,6 +90,8 @@ add_library(yul
 	backends/evm/ssa/Stack.h
 	backends/evm/ssa/StackShuffler.cpp
 	backends/evm/ssa/StackShuffler.h
+	backends/evm/ssa/io/DotExporterBase.cpp
+	backends/evm/ssa/io/DotExporterBase.h
 	backends/evm/ssa/io/JSONExporter.cpp
 	backends/evm/ssa/io/JSONExporter.h
 	backends/evm/ssa/traversal/ForwardTopologicalSort.cpp

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -82,8 +82,6 @@ add_library(yul
 	backends/evm/ssa/LivenessAnalysis.h
 	backends/evm/ssa/SSACFGLoopNestingForest.cpp
 	backends/evm/ssa/SSACFGLoopNestingForest.h
-	backends/evm/ssa/SSACFGTopologicalSort.cpp
-	backends/evm/ssa/SSACFGTopologicalSort.h
 	backends/evm/ssa/SSACFG.cpp
 	backends/evm/ssa/SSACFG.h
 	backends/evm/ssa/SSACFGBuilder.cpp
@@ -94,6 +92,8 @@ add_library(yul
 	backends/evm/ssa/Stack.h
 	backends/evm/ssa/StackShuffler.cpp
 	backends/evm/ssa/StackShuffler.h
+	backends/evm/ssa/traversal/ForwardTopologicalSort.cpp
+	backends/evm/ssa/traversal/ForwardTopologicalSort.h
 	optimiser/ASTCopier.cpp
 	optimiser/ASTCopier.h
 	optimiser/ASTWalker.cpp

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -86,12 +86,12 @@ add_library(yul
 	backends/evm/ssa/SSACFG.h
 	backends/evm/ssa/SSACFGBuilder.cpp
 	backends/evm/ssa/SSACFGBuilder.h
-	backends/evm/ssa/SSACFGJsonExporter.cpp
-	backends/evm/ssa/SSACFGJsonExporter.h
 	backends/evm/ssa/Stack.cpp
 	backends/evm/ssa/Stack.h
 	backends/evm/ssa/StackShuffler.cpp
 	backends/evm/ssa/StackShuffler.h
+	backends/evm/ssa/io/JSONExporter.cpp
+	backends/evm/ssa/io/JSONExporter.h
 	backends/evm/ssa/traversal/ForwardTopologicalSort.cpp
 	backends/evm/ssa/traversal/ForwardTopologicalSort.h
 	optimiser/ASTCopier.cpp

--- a/libyul/YulStack.cpp
+++ b/libyul/YulStack.cpp
@@ -21,7 +21,7 @@
 #include <libyul/AsmAnalysis.h>
 #include <libyul/AsmAnalysisInfo.h>
 #include <libyul/backends/evm/ssa/SSACFGBuilder.h>
-#include <libyul/backends/evm/ssa/SSACFGJsonExporter.h>
+#include <libyul/backends/evm/ssa/io/JSONExporter.h>
 #include <libyul/backends/evm/EthAssemblyAdapter.h>
 #include <libyul/backends/evm/EVMCodeTransform.h>
 #include <libyul/backends/evm/EVMDialect.h>
@@ -405,7 +405,7 @@ Json YulStack::cfgJson() const
 			keepLiteralAssignments
 		);
 		std::unique_ptr<ssa::ControlFlowLiveness> liveness = std::make_unique<ssa::ControlFlowLiveness>(*controlFlow);
-		return ssa::json::exportControlFlow(*controlFlow, liveness.get());
+		return ssa::io::json::exportControlFlow(*controlFlow, liveness.get());
 	};
 
 	std::function<Json(std::vector<std::shared_ptr<ObjectNode>>)> exportCFGFromSubObjects;

--- a/libyul/backends/evm/ssa/JunkAdmittingBlocksFinder.cpp
+++ b/libyul/backends/evm/ssa/JunkAdmittingBlocksFinder.cpp
@@ -23,7 +23,7 @@
 namespace solidity::yul::ssa
 {
 
-JunkAdmittingBlocksFinder::JunkAdmittingBlocksFinder(SSACFG const& _cfg, ForwardSSACFGTopologicalSort const& _topologicalSort):
+JunkAdmittingBlocksFinder::JunkAdmittingBlocksFinder(SSACFG const& _cfg, traversal::ForwardTopologicalSort const& _topologicalSort):
 	m_blockAllowsJunk(_cfg.numBlocks(), false)
 {
 	// special case: only one block here, we mark it as junkable in case it's not a function return

--- a/libyul/backends/evm/ssa/JunkAdmittingBlocksFinder.h
+++ b/libyul/backends/evm/ssa/JunkAdmittingBlocksFinder.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <libyul/backends/evm/ssa/SSACFGTopologicalSort.h>
+#include <libyul/backends/evm/ssa/traversal/ForwardTopologicalSort.h>
 #include <libyul/backends/evm/ssa/SSACFG.h>
 
 #include <cstdint>
@@ -37,7 +37,7 @@ namespace solidity::yul::ssa
 class JunkAdmittingBlocksFinder
 {
 public:
-	explicit JunkAdmittingBlocksFinder(SSACFG const& _cfg, ForwardSSACFGTopologicalSort const& _topologicalSort);
+	explicit JunkAdmittingBlocksFinder(SSACFG const& _cfg, traversal::ForwardTopologicalSort const& _topologicalSort);
 	bool allowsAdditionOfJunk(SSACFG::BlockId const& _blockId) const;
 private:
 	std::vector<std::uint8_t> m_blockAllowsJunk;

--- a/libyul/backends/evm/ssa/LivenessAnalysis.h
+++ b/libyul/backends/evm/ssa/LivenessAnalysis.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <libyul/backends/evm/ssa/SSACFGTopologicalSort.h>
+#include <libyul/backends/evm/ssa/traversal/ForwardTopologicalSort.h>
 #include <libyul/backends/evm/ssa/SSACFG.h>
 #include <libyul/backends/evm/ssa/SSACFGLoopNestingForest.h>
 
@@ -107,7 +107,7 @@ public:
 	LivenessData const& liveOut(SSACFG::BlockId const _blockId) const { return m_liveOuts[_blockId.value]; }
 	LivenessData used(SSACFG::BlockId _blockId) const;
 	std::vector<LivenessData> const& operationsLiveOut(SSACFG::BlockId _blockId) const { return m_operationLiveOuts[_blockId.value]; }
-	ForwardSSACFGTopologicalSort const& topologicalSort() const { return m_topologicalSort; }
+	traversal::ForwardTopologicalSort const& topologicalSort() const { return m_topologicalSort; }
 	SSACFG const& cfg() const { return m_cfg; }
 
 private:
@@ -117,7 +117,7 @@ private:
 	LivenessData blockExitValues(SSACFG::BlockId const& _blockId) const;
 
 	SSACFG const& m_cfg;
-	ForwardSSACFGTopologicalSort m_topologicalSort;
+	traversal::ForwardTopologicalSort m_topologicalSort;
 	SSACFGLoopNestingForest m_loopNestingForest;
 	std::vector<LivenessData> m_liveIns;
 	std::vector<LivenessData> m_liveOuts;

--- a/libyul/backends/evm/ssa/SSACFG.cpp
+++ b/libyul/backends/evm/ssa/SSACFG.cpp
@@ -19,6 +19,8 @@
 #include <libyul/backends/evm/ssa/SSACFG.h>
 
 #include <libyul/backends/evm/ssa/LivenessAnalysis.h>
+#include <libyul/backends/evm/ssa/JunkAdmittingBlocksFinder.h>
+#include <libyul/backends/evm/ssa/io/DotExporterBase.h>
 
 #include <libsolutil/StringUtils.h>
 #include <libsolutil/Visitor.h>
@@ -27,8 +29,6 @@
 #pragma GCC diagnostic ignored "-Wtautological-compare"
 #include <fmt/ranges.h>
 #pragma GCC diagnostic pop
-
-#include <libyul/backends/evm/ssa/JunkAdmittingBlocksFinder.h>
 
 #include <range/v3/view/zip.hpp>
 
@@ -39,256 +39,120 @@ using namespace solidity::yul::ssa;
 
 namespace
 {
-class SSACFGPrinter
+
+std::string formatPhi(SSACFG const& _cfg, SSACFG::PhiValue const& _phiValue)
+{
+	auto const transform = [&](SSACFG::ValueId const& valueId) { return valueId.str(_cfg); };
+	std::vector<std::string> formattedArgs;
+	formattedArgs.reserve(_phiValue.arguments.size());
+	for (auto const& [arg, entry]: ranges::zip_view(_phiValue.arguments | ranges::views::transform(transform), _cfg.block(_phiValue.block).entries))
+		formattedArgs.push_back(fmt::format("Block {} => {}", entry.value, arg));
+	if (!formattedArgs.empty())
+		return fmt::format("φ(\\l\\\n\t{}\\l\\\n)", fmt::join(formattedArgs, ",\\l\\\n\t"));
+	else
+		return "φ()";
+}
+
+class SSACFGDotExporter: public io::DotExporterBase
 {
 public:
-	SSACFGPrinter(SSACFG const& _cfg, SSACFG::BlockId _blockId, LivenessAnalysis const* _liveness):
-		m_cfg(_cfg), m_functionIndex(0), m_liveness(_liveness)
+	SSACFGDotExporter(SSACFG const& _cfg, size_t _functionIndex, LivenessAnalysis const* _liveness):
+		DotExporterBase(_cfg, _functionIndex),
+		m_liveness(_liveness)
 	{
 		if (_liveness)
 			m_junkAdmittingBlocks = std::make_unique<JunkAdmittingBlocksFinder>(_cfg, _liveness->topologicalSort());
-		printBlock(_blockId);
 	}
-	SSACFGPrinter(SSACFG const& _cfg, size_t _functionIndex, Scope::Function const& _function, LivenessAnalysis const* _liveness):
-		m_cfg(_cfg), m_functionIndex(_functionIndex), m_liveness(_liveness)
+
+protected:
+	void writeBlockLabel(std::ostream& _out, SSACFG::BlockId _blockId) override
 	{
-		if (_liveness)
-			m_junkAdmittingBlocks = std::make_unique<JunkAdmittingBlocksFinder>(_cfg, _liveness->topologicalSort());
-		printFunction(_function);
+		auto const& block = m_cfg.block(_blockId);
+		auto const valueToString = [&](SSACFG::ValueId const& valueId) { return valueId.str(m_cfg); };
+
+		if (m_liveness)
+		{
+			_out << fmt::format(
+				"\\\nBlock {}; ({}, max {})\\n",
+				_blockId.value,
+				m_liveness->topologicalSort().preOrderIndexOf(_blockId.value),
+				m_liveness->topologicalSort().maxSubtreePreOrderIndexOf(_blockId.value)
+			);
+			_out << fmt::format(
+				"LiveIn: {}\\l\\\n",
+				fmt::join(m_liveness->liveIn(_blockId) | ranges::views::transform([&](auto const& liveIn) { return valueToString(SSACFG::ValueId{liveIn.first}) + fmt::format("[{}]", liveIn.second); }), ", ")
+			);
+			_out << fmt::format(
+				"LiveOut: {}\\l\\n",
+				fmt::join(m_liveness->liveOut(_blockId) | ranges::views::transform([&](auto const& liveOut) { return valueToString(SSACFG::ValueId{liveOut.first}) + fmt::format("[{}]", liveOut.second); }), ", ")
+			);
+			auto const usedVariables = m_liveness->used(_blockId);
+			_out << fmt::format(
+				"Used: {}\\l\\n",
+				fmt::join(usedVariables | ranges::views::transform([&](auto const& used) { return valueToString(SSACFG::ValueId{used.first}) + fmt::format("[{}]", used.second); }), ", ")
+			);
+		}
+		else
+			_out << fmt::format("\\\nBlock {}\\n", _blockId.value);
+
+		for (auto const& phi: block.phis)
+		{
+			auto const& phiInfo = m_cfg.phiInfo(phi);
+			_out << fmt::format("phi{} := {}\\l\\\n", phi.value(), formatPhi(m_cfg, phiInfo));
+		}
+		for (auto const& operation: block.operations)
+		{
+			std::string const label = std::visit(GenericVisitor{
+				[&](SSACFG::Call const& _call) {
+					return _call.function.get().name.str();
+				},
+				[&](SSACFG::BuiltinCall const& _call) {
+					return _call.builtin.get().name;
+				},
+				[&](SSACFG::LiteralAssignment const&)
+				{
+					yulAssert(operation.inputs.size() == 1);
+					return operation.inputs.back().str(m_cfg);
+				}
+			}, operation.kind);
+			if (!operation.outputs.empty())
+				_out << fmt::format(
+					"{} := ",
+					fmt::join(operation.outputs | ranges::views::transform(valueToString), ", ")
+				);
+			if (std::holds_alternative<SSACFG::LiteralAssignment>(operation.kind))
+				_out << fmt::format(
+					"{}\\l\\\n",
+					escapeLabel(label)
+				);
+			else
+				_out << fmt::format(
+					"{}({})\\l\\\n",
+					escapeLabel(label),
+					fmt::join(operation.inputs | ranges::views::transform(valueToString), ", ")
+				);
+		}
 	}
-	friend std::ostream& operator<<(std::ostream& stream, SSACFGPrinter const& printer) {
-		stream << printer.m_result.str();
-		return stream;
+
+	std::vector<std::pair<std::string, std::string>> blockNodeAttributes(SSACFG::BlockId _blockId) override
+	{
+		if (m_junkAdmittingBlocks && m_junkAdmittingBlocks->allowsAdditionOfJunk(_blockId))
+			return {{"fillcolor", "\"#FF746C\""}, {"style", "filled"}};
+		return {};
+	}
+
+	EdgeStyle edgeStyle(SSACFG::BlockId _source, SSACFG::BlockId _target) override
+	{
+		if (m_liveness && m_liveness->topologicalSort().backEdge(_source, _target))
+			return EdgeStyle::Dashed;
+		return EdgeStyle::Solid;
 	}
 
 private:
-	static std::string escape(std::string_view const str)
-	{
-		using namespace std::literals;
-		static constexpr auto replacements = std::array{std::make_tuple('$', "_d_")};
-		std::stringstream ss;
-		for (auto const c: str)
-		{
-			auto const it = std::find_if(replacements.begin(), replacements.end(), [c](auto const& replacement)
-			{
-				return std::get<0>(replacement) == c;
-			});
-			if (it != replacements.end())
-				ss << std::get<1>(*it);
-			else
-				ss << c;
-		}
-		return ss.str();
-	}
-
-	std::string formatBlockHandle(SSACFG::BlockId const& _id) const
-	{
-		return fmt::format("Block{}_{}", m_functionIndex, _id.value);
-	}
-
-	std::string formatEdge(SSACFG::BlockId const& _v, SSACFG::BlockId const& _w, std::optional<std::string> const& _vPort = std::nullopt)
-	{
-		std::string const style = m_liveness && m_liveness->topologicalSort().backEdge(_v, _w) ? "dashed" : "solid";
-		if (_vPort)
-			return fmt::format("{}Exit:{} -> {} [style=\"{}\"];\n", formatBlockHandle(_v), *_vPort, formatBlockHandle(_w), style);
-		else
-			return fmt::format("{}Exit -> {} [style=\"{}\"];\n", formatBlockHandle(_v), formatBlockHandle(_w), style);
-	}
-
-	static std::string formatPhi(SSACFG const& _cfg, SSACFG::PhiValue const& _phiValue)
-	{
-		auto const transform = [&](SSACFG::ValueId const& valueId) { return valueId.str(_cfg); };
-		std::vector<std::string> formattedArgs;
-		formattedArgs.reserve(_phiValue.arguments.size());
-		for (auto const& [arg, entry]: ranges::zip_view(_phiValue.arguments | ranges::views::transform(transform), _cfg.block(_phiValue.block).entries))
-			formattedArgs.push_back(fmt::format("Block {} => {}", entry.value, arg));
-		if (!formattedArgs.empty())
-			return fmt::format("φ(\\l\\\n\t{}\\l\\\n)", fmt::join(formattedArgs, ",\\l\\\n\t"));
-		else
-			return "φ()";
-	}
-
-	void writeBlock(SSACFG::BlockId const& _id, SSACFG::BasicBlock const& _block)
-	{
-		auto const valueToString = [&](SSACFG::ValueId const& valueId) { return valueId.str(m_cfg); };
-		bool entryBlock = _id.value == 0 && m_functionIndex == 0;
-		if (entryBlock)
-		{
-			m_result << fmt::format("Entry{} [label=\"Entry\"];\n", m_functionIndex);
-			m_result << fmt::format("Entry{} -> {};\n", m_functionIndex, formatBlockHandle(_id));
-		}
-		{
-			std::string revertPathInfo;
-			if (m_junkAdmittingBlocks)
-				revertPathInfo = m_junkAdmittingBlocks->allowsAdditionOfJunk(_id) ? "fillcolor=\"#FF746C\", style=filled, " : "";
-			if (m_liveness)
-			{
-				m_result << fmt::format(
-					"{} [{}label=\"\\\nBlock {}; ({}, max {})\\n",
-					formatBlockHandle(_id),
-					revertPathInfo,
-					_id.value,
-					m_liveness->topologicalSort().preOrderIndexOf(_id.value),
-					m_liveness->topologicalSort().maxSubtreePreOrderIndexOf(_id.value)
-				);
-				m_result << fmt::format(
-					"LiveIn: {}\\l\\\n",
-					fmt::join(m_liveness->liveIn(_id) | ranges::views::transform([&](auto const& liveIn) { return valueToString(SSACFG::ValueId{liveIn.first}) + fmt::format("[{}]", liveIn.second); }), ", ")
-				);
-				m_result << fmt::format(
-					"LiveOut: {}\\l\\n",
-					fmt::join(m_liveness->liveOut(_id) | ranges::views::transform([&](auto const& liveOut) { return valueToString(SSACFG::ValueId{liveOut.first}) + fmt::format("[{}]", liveOut.second); }), ", ")
-				);
-				auto const usedVariables = m_liveness->used(_id);
-				m_result << fmt::format(
-					"Used: {}\\l\\n",
-					fmt::join(usedVariables | ranges::views::transform([&](auto const& used) { return valueToString(SSACFG::ValueId{used.first}) + fmt::format("[{}]", used.second); }), ", ")
-				);
-			}
-			else
-				m_result << fmt::format("{} [{}label=\"\\\nBlock {}\\n", formatBlockHandle(_id), revertPathInfo, _id.value);
-
-			for (auto const& phi: _block.phis)
-			{
-				auto const& phiInfo = m_cfg.phiInfo(phi);
-				m_result << fmt::format("phi{} := {}\\l\\\n", phi.value(), formatPhi(m_cfg, phiInfo));
-			}
-			for (auto const& operation: _block.operations)
-			{
-				std::string const label = std::visit(GenericVisitor{
-					[&](SSACFG::Call const& _call) {
-						return _call.function.get().name.str();
-					},
-					[&](SSACFG::BuiltinCall const& _call) {
-						return _call.builtin.get().name;
-					},
-					[&](SSACFG::LiteralAssignment const&)
-					{
-						yulAssert(operation.inputs.size() == 1);
-						return operation.inputs.back().str(m_cfg);
-					}
-				}, operation.kind);
-				if (!operation.outputs.empty())
-					m_result << fmt::format(
-						"{} := ",
-						fmt::join(operation.outputs | ranges::views::transform(valueToString), ", ")
-					);
-				if (std::holds_alternative<SSACFG::LiteralAssignment>(operation.kind))
-					m_result << fmt::format(
-						"{}\\l\\\n",
-						escape(label)
-					);
-				else
-					m_result << fmt::format(
-						"{}({})\\l\\\n",
-						escape(label),
-						fmt::join(operation.inputs | ranges::views::transform(valueToString), ", ")
-					);
-			}
-			m_result << "\"];\n";
-			std::visit(GenericVisitor{
-				[&](SSACFG::BasicBlock::MainExit const&)
-				{
-					m_result << fmt::format("{}Exit [label=\"MainExit\"];\n", formatBlockHandle(_id));
-					m_result << fmt::format("{} -> {}Exit;\n", formatBlockHandle(_id), formatBlockHandle(_id));
-				},
-				[&](SSACFG::BasicBlock::Jump const& _jump)
-				{
-					m_result << fmt::format("{} -> {}Exit [arrowhead=none];\n", formatBlockHandle(_id), formatBlockHandle(_id));
-					m_result << fmt::format("{}Exit [label=\"Jump\" shape=oval];\n", formatBlockHandle(_id));
-					m_result << formatEdge(_id, _jump.target);
-				},
-				[&](SSACFG::BasicBlock::ConditionalJump const& _conditionalJump)
-				{
-					m_result << fmt::format("{} -> {}Exit;\n", formatBlockHandle(_id), formatBlockHandle(_id));
-					m_result << fmt::format(
-						"{}Exit [label=\"{{ If {} | {{ <0> Zero | <1> NonZero }}}}\" shape=Mrecord];\n",
-						formatBlockHandle(_id), _conditionalJump.condition.str(m_cfg)
-					);
-					m_result << formatEdge(_id, _conditionalJump.zero, "0");
-					m_result << formatEdge(_id, _conditionalJump.nonZero, "1");
-				},
-				[&](SSACFG::BasicBlock::JumpTable const& jt)
-				{
-					m_result << fmt::format("{} -> {}Exit;\n", formatBlockHandle(_id), formatBlockHandle(_id));
-					std::string options;
-					for (auto const& jumpCase: jt.cases)
-					{
-						if (!options.empty())
-							options += " | ";
-						options += fmt::format("<{0}> {0}", formatNumber(jumpCase.first));
-					}
-					if (!options.empty())
-						options += " | ";
-					options += "<default> default";
-					m_result << fmt::format("{}Exit [label=\"{{ JT | {{ {} }} }}\" shape=Mrecord];\n", formatBlockHandle(_id), options);
-					for (auto const& jumpCase: jt.cases)
-						m_result << formatEdge(_id, jumpCase.second, formatNumber(jumpCase.first));
-					m_result << formatEdge(_id, jt.defaultCase, "default");
-				},
-				[&](SSACFG::BasicBlock::FunctionReturn const& fr)
-				{
-					m_result << formatBlockHandle(_id) << "Exit [label=\"FunctionReturn["
-							<< fmt::format("{}", fmt::join(fr.returnValues | ranges::views::transform(valueToString), ", "))
-							<< "]\"];\n";
-					m_result << formatBlockHandle(_id) << " -> " << formatBlockHandle(_id) << "Exit;\n";
-				},
-				[&](SSACFG::BasicBlock::Terminated const&)
-				{
-					m_result << formatBlockHandle(_id) << "Exit [label=\"Terminated\"];\n";
-					m_result << formatBlockHandle(_id) << " -> " << formatBlockHandle(_id) << "Exit;\n";
-				}
-			}, _block.exit);
-		}
-	}
-
-	void printBlock(SSACFG::BlockId const& _rootId)
-	{
-		std::set<SSACFG::BlockId> explored{};
-		explored.insert(_rootId);
-
-		std::deque<SSACFG::BlockId> toVisit{};
-		toVisit.emplace_back(_rootId);
-
-		while (!toVisit.empty())
-		{
-			auto const id = toVisit.front();
-			toVisit.pop_front();
-			auto const& block = m_cfg.block(id);
-			writeBlock(id, block);
-			block.forEachExit(
-				[&](SSACFG::BlockId const& _exitBlock)
-				{
-					if (explored.count(_exitBlock) == 0)
-					{
-						explored.insert(_exitBlock);
-						toVisit.emplace_back(_exitBlock);
-					}
-				}
-			);
-		}
-	}
-
-	void printFunction(Scope::Function const& _fun)
-	{
-		static auto constexpr returnsTransform = [](auto const& functionReturnValue) { return escape(functionReturnValue.get().name.str()); };
-		static auto constexpr argsTransform = [](auto const& arg) { return fmt::format("v{}", std::get<1>(arg).value()); };
-		m_result << "FunctionEntry_" << escape(_fun.name.str()) << "_" << m_cfg.entry.value << " [label=\"";
-		if (!m_cfg.returns.empty())
-			m_result << fmt::format("function {0}:\n {1} := {0}({2})", escape(_fun.name.str()), fmt::join(m_cfg.returns | ranges::views::transform(returnsTransform), ", "), fmt::join(m_cfg.arguments | ranges::views::transform(argsTransform), ", "));
-		else
-			m_result << fmt::format("function {0}:\n {0}({1})", escape(_fun.name.str()), fmt::join(m_cfg.arguments | ranges::views::transform(argsTransform), ", "));
-		m_result << "\"];\n";
-		m_result << "FunctionEntry_" << escape(_fun.name.str()) << "_" << m_cfg.entry.value << " -> Block" << m_functionIndex << "_" << m_cfg.entry.value << ";\n";
-		printBlock(m_cfg.entry);
-	}
-
-	SSACFG const& m_cfg;
-	std::unique_ptr<JunkAdmittingBlocksFinder> m_junkAdmittingBlocks;
-	size_t m_functionIndex;
 	LivenessAnalysis const* m_liveness;
-	std::stringstream m_result{};
+	std::unique_ptr<JunkAdmittingBlocksFinder> m_junkAdmittingBlocks;
 };
+
 }
 
 std::string SSACFG::ValueId::str(SSACFG const& _cfg) const
@@ -312,14 +176,9 @@ std::string SSACFG::toDot(
 	LivenessAnalysis const* _liveness
 ) const
 {
-	std::ostringstream output;
-	if (_includeDiGraphDefinition)
-		output << "digraph SSACFG {\nnodesep=0.7;\ngraph[fontname=\"DejaVu Sans\", rankdir=LR]\nnode[shape=box,fontname=\"DejaVu Sans\"];\n\n";
+	SSACFGDotExporter exporter(*this, _functionIndex.value_or(function ? 1 : 0), _liveness);
 	if (function)
-		output << SSACFGPrinter(*this, _functionIndex ? *_functionIndex : static_cast<size_t>(1), *function, _liveness);
+		return exporter.exportFunction(*function, _includeDiGraphDefinition);
 	else
-		output << SSACFGPrinter(*this, entry, _liveness);
-	if (_includeDiGraphDefinition)
-		output << "}\n";
-	return output.str();
+		return exporter.exportBlocks(entry, _includeDiGraphDefinition);
 }

--- a/libyul/backends/evm/ssa/SSACFGLoopNestingForest.cpp
+++ b/libyul/backends/evm/ssa/SSACFGLoopNestingForest.cpp
@@ -22,7 +22,7 @@
 
 using namespace solidity::yul::ssa;
 
-SSACFGLoopNestingForest::SSACFGLoopNestingForest(ForwardSSACFGTopologicalSort const& _sort):
+SSACFGLoopNestingForest::SSACFGLoopNestingForest(traversal::ForwardTopologicalSort const& _sort):
 	m_sort(_sort),
 	m_cfg(_sort.cfg()),
 	m_vertexPartition(m_cfg.numBlocks()),

--- a/libyul/backends/evm/ssa/SSACFGLoopNestingForest.h
+++ b/libyul/backends/evm/ssa/SSACFGLoopNestingForest.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <libyul/backends/evm/ssa/SSACFGTopologicalSort.h>
+#include <libyul/backends/evm/ssa/traversal/ForwardTopologicalSort.h>
 #include <libyul/backends/evm/ssa/SSACFG.h>
 
 #include <libsolutil/DisjointSet.h>
@@ -39,7 +39,7 @@ class SSACFGLoopNestingForest
 	using BlockIdValue = SSACFG::BlockId::ValueType;
 
 public:
-	explicit SSACFGLoopNestingForest(ForwardSSACFGTopologicalSort const& _sort);
+	explicit SSACFGLoopNestingForest(traversal::ForwardTopologicalSort const& _sort);
 
 	/// blocks which are not contained in a loop get assigned the loop parent numeric_limit<size_t>::max()
 	std::vector<BlockIdValue> const& loopParents() const { return m_loopParents; }
@@ -51,7 +51,7 @@ private:
 	void findLoop(BlockIdValue _potentialHeader);
 	void collapse(std::set<BlockIdValue> const& _loopBody, BlockIdValue _loopHeader);
 
-	ForwardSSACFGTopologicalSort const& m_sort;
+	traversal::ForwardTopologicalSort const& m_sort;
 	SSACFG const& m_cfg;
 
 	util::ContiguousDisjointSet<BlockIdValue> m_vertexPartition;

--- a/libyul/backends/evm/ssa/io/DotExporterBase.cpp
+++ b/libyul/backends/evm/ssa/io/DotExporterBase.cpp
@@ -1,0 +1,220 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libyul/backends/evm/ssa/io/DotExporterBase.h>
+
+#include <libsolutil/Numeric.h>
+#include <libsolutil/Visitor.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtautological-compare"
+#include <fmt/ranges.h>
+#pragma GCC diagnostic pop
+
+#include <deque>
+#include <set>
+
+using namespace solidity;
+using namespace solidity::util;
+using namespace solidity::yul;
+using namespace solidity::yul::ssa;
+using namespace solidity::yul::ssa::io;
+
+DotExporterBase::DotExporterBase(SSACFG const& _cfg, size_t const _functionIndex, RankDir const _rankDir):
+	m_cfg(_cfg),
+	m_functionIndex(_functionIndex),
+	m_rankDir(_rankDir)
+{
+}
+
+std::string DotExporterBase::escapeId(std::string_view const _str)
+{
+	std::string result;
+	result.reserve(_str.size());
+	for (auto const c: _str)
+	{
+		if (std::isalnum(static_cast<unsigned char>(c)) || c == '_')
+			result += c;
+		else
+			result += '_';
+	}
+	return result;
+}
+
+std::string DotExporterBase::escapeLabel(std::string_view const _str)
+{
+	std::string result;
+	result.reserve(_str.size());
+	for (auto const c: _str)
+	{
+		if (c == '"' || c == '\\')
+			result += '\\';
+		result += c;
+	}
+	return result;
+}
+
+std::string DotExporterBase::formatBlockHandle(SSACFG::BlockId _id) const
+{
+	return fmt::format("Block{}_{}", m_functionIndex, _id.value);
+}
+
+std::string DotExporterBase::formatEdge(SSACFG::BlockId _source, SSACFG::BlockId _target, std::optional<std::string> const& _exitPort)
+{
+	std::string const style = edgeStyle(_source, _target) == EdgeStyle::Dashed ? "dashed" : "solid";
+	if (_exitPort)
+		return fmt::format("{}Exit:{} -> {} [style=\"{}\"];\n", formatBlockHandle(_source), *_exitPort, formatBlockHandle(_target), style);
+	else
+		return fmt::format("{}Exit -> {} [style=\"{}\"];\n", formatBlockHandle(_source), formatBlockHandle(_target), style);
+}
+
+void DotExporterBase::writeBlock(std::ostream& _out, SSACFG::BlockId const _id)
+{
+	auto const& block = m_cfg.block(_id);
+
+	auto const attributes = blockNodeAttributes(_id);
+	std::string attrStr;
+	for (auto const& [name, value]: attributes)
+		attrStr += fmt::format("{}={}, ", name, value);
+	_out << fmt::format("{} [{}label=\"", formatBlockHandle(_id), attrStr);
+	writeBlockLabel(_out, _id);
+	_out << "\"];\n";
+
+	std::visit(GenericVisitor{
+		[&](SSACFG::BasicBlock::MainExit const&)
+		{
+			_out << fmt::format("{}Exit [label=\"MainExit\"];\n", formatBlockHandle(_id));
+			_out << fmt::format("{} -> {}Exit;\n", formatBlockHandle(_id), formatBlockHandle(_id));
+		},
+		[&](SSACFG::BasicBlock::Jump const& _jump)
+		{
+			_out << fmt::format("{} -> {}Exit [arrowhead=none];\n", formatBlockHandle(_id), formatBlockHandle(_id));
+			_out << fmt::format("{}Exit [label=\"Jump\" shape=oval];\n", formatBlockHandle(_id));
+			_out << formatEdge(_id, _jump.target);
+		},
+		[&](SSACFG::BasicBlock::ConditionalJump const& _conditionalJump)
+		{
+			_out << fmt::format("{} -> {}Exit;\n", formatBlockHandle(_id), formatBlockHandle(_id));
+			_out << fmt::format(
+				"{}Exit [label=\"{{ If {} | {{ <0> Zero | <1> NonZero }}}}\" shape=Mrecord];\n",
+				formatBlockHandle(_id), _conditionalJump.condition.str(m_cfg)
+			);
+			_out << formatEdge(_id, _conditionalJump.zero, "0");
+			_out << formatEdge(_id, _conditionalJump.nonZero, "1");
+		},
+		[&](SSACFG::BasicBlock::JumpTable const& jt)
+		{
+			_out << fmt::format("{} -> {}Exit;\n", formatBlockHandle(_id), formatBlockHandle(_id));
+			std::string options;
+			for (auto const& jumpCase: jt.cases)
+			{
+				if (!options.empty())
+					options += " | ";
+				options += fmt::format("<{0}> {0}", formatNumber(jumpCase.first));
+			}
+			if (!options.empty())
+				options += " | ";
+			options += "<default> default";
+			_out << fmt::format("{}Exit [label=\"{{ JT | {{ {} }} }}\" shape=Mrecord];\n", formatBlockHandle(_id), options);
+			for (auto const& jumpCase: jt.cases)
+				_out << formatEdge(_id, jumpCase.second, formatNumber(jumpCase.first));
+			_out << formatEdge(_id, jt.defaultCase, "default");
+		},
+		[&](SSACFG::BasicBlock::FunctionReturn const& fr)
+		{
+			auto const valueToString = [&](SSACFG::ValueId const& valueId) { return valueId.str(m_cfg); };
+			_out << fmt::format("{}Exit [label=\"FunctionReturn[{}]\"];\n",
+				formatBlockHandle(_id),
+				fmt::join(fr.returnValues | ranges::views::transform(valueToString), ", ")
+			);
+			_out << fmt::format("{} -> {}Exit;\n", formatBlockHandle(_id), formatBlockHandle(_id));
+		},
+		[&](SSACFG::BasicBlock::Terminated const&)
+		{
+			_out << fmt::format("{}Exit [label=\"Terminated\"];\n", formatBlockHandle(_id));
+			_out << fmt::format("{} -> {}Exit;\n", formatBlockHandle(_id), formatBlockHandle(_id));
+		}
+	}, block.exit);
+}
+
+void DotExporterBase::traverse(std::ostream& _out, SSACFG::BlockId _entry)
+{
+	std::vector<std::uint8_t> explored(m_cfg.numBlocks(), false);
+	explored[_entry.value] = true;
+
+	std::deque<SSACFG::BlockId> toVisit{};
+	toVisit.emplace_back(_entry);
+
+	while (!toVisit.empty())
+	{
+		auto const id = toVisit.front();
+		toVisit.pop_front();
+		writeBlock(_out, id);
+		m_cfg.block(id).forEachExit(
+			[&](SSACFG::BlockId const& _exitBlock)
+			{
+				if (!explored[_exitBlock.value])
+				{
+					explored[_exitBlock.value] = true;
+					toVisit.emplace_back(_exitBlock);
+				}
+			}
+		);
+	}
+}
+
+std::string DotExporterBase::exportBlocks(SSACFG::BlockId _entry, bool _wrapInDigraph)
+{
+	std::ostringstream out;
+	if (_wrapInDigraph)
+		out << fmt::format("digraph SSACFG {{\nnodesep=0.7;\ngraph[fontname=\"DejaVu Sans\", rankdir={}]\nnode[shape=box,fontname=\"DejaVu Sans\"];\n\n", m_rankDir);
+	out << fmt::format("Entry [label=\"Entry\"];\n");
+	out << fmt::format("Entry -> {};\n", formatBlockHandle(_entry));
+	traverse(out, _entry);
+	if (_wrapInDigraph)
+		out << "}\n";
+	return out.str();
+}
+
+std::string DotExporterBase::exportFunction(Scope::Function const& _function, bool _wrapInDigraph)
+{
+	std::ostringstream out;
+	if (_wrapInDigraph)
+		out << fmt::format("digraph SSACFG {{\nnodesep=0.7;\ngraph[fontname=\"DejaVu Sans\", rankdir={}]\nnode[shape=box,fontname=\"DejaVu Sans\"];\n\n", m_rankDir);
+
+	static auto constexpr returnsTransform = [](auto const& functionReturnValue) { return escapeLabel(functionReturnValue.get().name.str()); };
+	static auto constexpr argsTransform = [](auto const& arg) { return fmt::format("v{}", std::get<1>(arg).value()); };
+	auto const entryHandle = fmt::format("FunctionEntry_{}_{}", escapeId(_function.name.str()), m_cfg.entry.value);
+	if (!m_cfg.returns.empty())
+		out << fmt::format("{} [label=\"function {}:\n {} := {}({})\"];\n",
+			entryHandle, escapeLabel(_function.name.str()),
+			fmt::join(m_cfg.returns | ranges::views::transform(returnsTransform), ", "),
+			escapeLabel(_function.name.str()),
+			fmt::join(m_cfg.arguments | ranges::views::transform(argsTransform), ", "));
+	else
+		out << fmt::format("{} [label=\"function {}:\n {}({})\"];\n",
+			entryHandle, escapeLabel(_function.name.str()),
+			escapeLabel(_function.name.str()),
+			fmt::join(m_cfg.arguments | ranges::views::transform(argsTransform), ", "));
+	out << fmt::format("{} -> {};\n", entryHandle, formatBlockHandle(m_cfg.entry));
+	traverse(out, m_cfg.entry);
+
+	if (_wrapInDigraph)
+		out << "}\n";
+	return out.str();
+}

--- a/libyul/backends/evm/ssa/io/DotExporterBase.h
+++ b/libyul/backends/evm/ssa/io/DotExporterBase.h
@@ -1,0 +1,93 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libyul/backends/evm/ssa/SSACFG.h>
+
+#include <fmt/format.h>
+
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace solidity::yul::ssa::io
+{
+
+/// Base class for exporting an SSACFG to Graphviz dot format.
+/// Handles graph structure (BFS traversal, edges, exit nodes, entry nodes) and
+/// delegates block content rendering to derived classes via writeBlockLabel().
+class DotExporterBase
+{
+public:
+	enum class EdgeStyle { Solid, Dashed };
+	enum class RankDir { TB, BT, LR, RL };
+
+	DotExporterBase(SSACFG const& _cfg, size_t _functionIndex, RankDir _rankDir = RankDir::LR);
+	virtual ~DotExporterBase() = default;
+
+	std::string exportBlocks(SSACFG::BlockId _entry, bool _wrapInDigraph = true);
+	std::string exportFunction(Scope::Function const& _function, bool _wrapInDigraph = true);
+
+protected:
+	/// Override to write the content inside a block's dot label.
+	/// Everything between the opening `label="` and the closing `"` is the responsibility of this method.
+	virtual void writeBlockLabel(std::ostream& _out, SSACFG::BlockId _blockId) = 0;
+
+	/// Override to provide extra node attributes (e.g., fillcolor).
+	virtual std::vector<std::pair<std::string, std::string>> blockNodeAttributes(SSACFG::BlockId) { return {}; }
+
+	/// Override to customize edge style (e.g., dashed for back edges).
+	virtual EdgeStyle edgeStyle(SSACFG::BlockId, SSACFG::BlockId) { return EdgeStyle::Solid; }
+
+	std::string formatBlockHandle(SSACFG::BlockId _id) const;
+	/// Escapes a string for use in dot node IDs (replaces non-alphanumeric characters with underscores).
+	static std::string escapeId(std::string_view _str);
+	/// Escapes a string for use inside dot label text (escapes quotes and backslashes).
+	static std::string escapeLabel(std::string_view _str);
+
+	SSACFG const& m_cfg;
+	size_t m_functionIndex;
+	RankDir m_rankDir;
+
+private:
+	void writeBlock(std::ostream& _out, SSACFG::BlockId _id);
+	std::string formatEdge(SSACFG::BlockId _source, SSACFG::BlockId _target, std::optional<std::string> const& _exitPort = std::nullopt);
+	void traverse(std::ostream& _out, SSACFG::BlockId _entry);
+};
+
+}
+
+template<>
+struct fmt::formatter<solidity::yul::ssa::io::DotExporterBase::RankDir>: fmt::formatter<std::string_view>
+{
+	auto format(solidity::yul::ssa::io::DotExporterBase::RankDir _rankDir, fmt::format_context& _ctx) const
+	{
+		using RankDir = solidity::yul::ssa::io::DotExporterBase::RankDir;
+		std::string_view name;
+		switch (_rankDir)
+		{
+			case RankDir::TB: name = "TB"; break;
+			case RankDir::BT: name = "BT"; break;
+			case RankDir::LR: name = "LR"; break;
+			case RankDir::RL: name = "RL"; break;
+		}
+		return fmt::formatter<std::string_view>::format(name, _ctx);
+	}
+};

--- a/libyul/backends/evm/ssa/io/JSONExporter.cpp
+++ b/libyul/backends/evm/ssa/io/JSONExporter.cpp
@@ -16,7 +16,7 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
-#include <libyul/backends/evm/ssa/SSACFGJsonExporter.h>
+#include <libyul/backends/evm/ssa/io/JSONExporter.h>
 
 #include <libyul/Utilities.h>
 
@@ -31,7 +31,7 @@
 using namespace solidity;
 using namespace solidity::yul;
 using namespace solidity::yul::ssa;
-using namespace solidity::yul::ssa::json;
+using namespace solidity::yul::ssa::io::json;
 
 namespace
 {
@@ -134,8 +134,6 @@ Json exportBlock(SSACFG const& _cfg, SSACFG::BlockId _entryId, LivenessAnalysis 
 	Json blocksJson = Json::array();
 	util::BreadthFirstSearch<SSACFG::BlockId> bfs{{{_entryId}}};
 	bfs.run([&](SSACFG::BlockId _blockId, auto _addChild) {
-		auto const& block = _cfg.block(_blockId);
-		// Convert current block to JSON
 		Json blockJson = toJson(_cfg, _blockId, _liveness);
 
 		Json exitBlockJson = Json::object();
@@ -166,7 +164,7 @@ Json exportBlock(SSACFG const& _cfg, SSACFG::BlockId _entryId, LivenessAnalysis 
 			[&](SSACFG::BasicBlock::JumpTable const&) {
 				yulAssert(false);
 			}
-		}, block.exit);
+		}, _cfg.block(_blockId).exit);
 		blockJson["exit"] = exitBlockJson;
 		blocksJson.emplace_back(blockJson);
 	});
@@ -188,7 +186,7 @@ Json exportFunction(SSACFG const& _cfg, LivenessAnalysis const* _liveness)
 
 }
 
-Json json::exportControlFlow(ControlFlow const& _controlFlow, ControlFlowLiveness const* _liveness)
+Json io::json::exportControlFlow(ControlFlow const& _controlFlow, ControlFlowLiveness const* _liveness)
 {
 	if (_liveness)
 		yulAssert(&_liveness->controlFlow.get() == &_controlFlow);

--- a/libyul/backends/evm/ssa/io/JSONExporter.h
+++ b/libyul/backends/evm/ssa/io/JSONExporter.h
@@ -21,7 +21,7 @@
 #include <libyul/backends/evm/ssa/ControlFlow.h>
 #include <libsolutil/JSON.h>
 
-namespace solidity::yul::ssa::json
+namespace solidity::yul::ssa::io::json
 {
 
 Json exportControlFlow(ControlFlow const& _controlFlow, ControlFlowLiveness const* _liveness);

--- a/libyul/backends/evm/ssa/traversal/ForwardTopologicalSort.cpp
+++ b/libyul/backends/evm/ssa/traversal/ForwardTopologicalSort.cpp
@@ -16,11 +16,11 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
-#include <libyul/backends/evm/ssa/SSACFGTopologicalSort.h>
+#include <libyul/backends/evm/ssa/traversal/ForwardTopologicalSort.h>
 
-using namespace solidity::yul::ssa;
+using namespace solidity::yul::ssa::traversal;
 
-ForwardSSACFGTopologicalSort::ForwardSSACFGTopologicalSort(SSACFG const& _cfg):
+ForwardTopologicalSort::ForwardTopologicalSort(SSACFG const& _cfg):
 	m_cfg(_cfg),
 	m_explored(m_cfg.numBlocks(), false), m_blockWisePreOrder(m_cfg.numBlocks(), 0),
 	m_blockWiseMaxSubtreePreOrder(m_cfg.numBlocks(), 0)
@@ -35,7 +35,7 @@ ForwardSSACFGTopologicalSort::ForwardSSACFGTopologicalSort(SSACFG const& _cfg):
 			m_backEdgeTargets.insert(v2);
 }
 
-void ForwardSSACFGTopologicalSort::dfs(SSACFG::BlockId::ValueType const _vertex) {
+void ForwardTopologicalSort::dfs(SSACFG::BlockId::ValueType const _vertex) {
 	yulAssert(!m_explored[_vertex]);
 	m_explored[_vertex] = true;
 	m_blockWisePreOrder[_vertex] = static_cast<SSACFG::BlockId::ValueType>(m_preOrder.size());
@@ -55,7 +55,7 @@ void ForwardSSACFGTopologicalSort::dfs(SSACFG::BlockId::ValueType const _vertex)
 	m_postOrder.push_back(_vertex);
 }
 
-bool ForwardSSACFGTopologicalSort::ancestor(SSACFG::BlockId::ValueType const _block1, SSACFG::BlockId::ValueType const _block2) const {
+bool ForwardTopologicalSort::ancestor(SSACFG::BlockId::ValueType const _block1, SSACFG::BlockId::ValueType const _block2) const {
 	yulAssert(_block1 < m_blockWisePreOrder.size());
 	yulAssert(_block2 < m_blockWisePreOrder.size());
 
@@ -67,7 +67,7 @@ bool ForwardSSACFGTopologicalSort::ancestor(SSACFG::BlockId::ValueType const _bl
 	return node1VisitedBeforeNode2 && node2InSubtreeOfNode1;
 }
 
-bool ForwardSSACFGTopologicalSort::backEdge(SSACFG::BlockId const& _block1, SSACFG::BlockId const& _block2) const
+bool ForwardTopologicalSort::backEdge(SSACFG::BlockId const& _block1, SSACFG::BlockId const& _block2) const
 {
 	if (ancestor(_block2.value, _block1.value))
 	{

--- a/libyul/backends/evm/ssa/traversal/ForwardTopologicalSort.h
+++ b/libyul/backends/evm/ssa/traversal/ForwardTopologicalSort.h
@@ -24,14 +24,14 @@
 #include <set>
 #include <vector>
 
-namespace solidity::yul::ssa
+namespace solidity::yul::ssa::traversal
 {
 
 /// Performs a topological sort on the forward CFG (no back/cross edges)
-class ForwardSSACFGTopologicalSort
+class ForwardTopologicalSort
 {
 public:
-	explicit ForwardSSACFGTopologicalSort(SSACFG const& _cfg);
+	explicit ForwardTopologicalSort(SSACFG const& _cfg);
 
 	std::vector<SSACFG::BlockId::ValueType> const& preOrder() const { return m_preOrder; }
 	std::vector<SSACFG::BlockId::ValueType> const& postOrder() const { return m_postOrder; }

--- a/test/libyul/yulSSAControlFlowGraph/complex.yul
+++ b/test/libyul/yulSSAControlFlowGraph/complex.yul
@@ -49,8 +49,8 @@
 // graph[fontname="DejaVu Sans"]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry0 [label="Entry"];
-// Entry0 -> Block0_0;
+// Entry [label="Entry"];
+// Entry -> Block0_0;
 // Block0_0 [fillcolor="#FF746C", style=filled, label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
 // LiveOut: \l\nUsed: \l\nv0 := f(0x02, 0x01)\l\

--- a/test/libyul/yulSSAControlFlowGraph/complex2.yul
+++ b/test/libyul/yulSSAControlFlowGraph/complex2.yul
@@ -56,8 +56,8 @@
 // graph[fontname="DejaVu Sans"]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry0 [label="Entry"];
-// Entry0 -> Block0_0;
+// Entry [label="Entry"];
+// Entry -> Block0_0;
 // Block0_0 [fillcolor="#FF746C", style=filled, label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
 // LiveOut: \l\nUsed: \l\nsstore(0x01, 0x01)\l\

--- a/test/libyul/yulSSAControlFlowGraph/default_initialized_variable.yul
+++ b/test/libyul/yulSSAControlFlowGraph/default_initialized_variable.yul
@@ -11,8 +11,8 @@
 // graph[fontname="DejaVu Sans"]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry0 [label="Entry"];
-// Entry0 -> Block0_0;
+// Entry [label="Entry"];
+// Entry -> Block0_0;
 // Block0_0 [label="\
 // Block 0; (0, max 2)\nLiveIn: \l\
 // LiveOut: v0[1]\l\nUsed: \l\nv0 := 0x00\l\

--- a/test/libyul/yulSSAControlFlowGraph/function.yul
+++ b/test/libyul/yulSSAControlFlowGraph/function.yul
@@ -24,8 +24,8 @@
 // graph[fontname="DejaVu Sans"]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry0 [label="Entry"];
-// Entry0 -> Block0_0;
+// Entry [label="Entry"];
+// Entry -> Block0_0;
 // Block0_0 [fillcolor="#FF746C", style=filled, label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
 // LiveOut: \l\nUsed: \l\nv0, v1 := i()\l\

--- a/test/libyul/yulSSAControlFlowGraph/if.yul
+++ b/test/libyul/yulSSAControlFlowGraph/if.yul
@@ -12,8 +12,8 @@
 // graph[fontname="DejaVu Sans"]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry0 [label="Entry"];
-// Entry0 -> Block0_0;
+// Entry [label="Entry"];
+// Entry -> Block0_0;
 // Block0_0 [label="\
 // Block 0; (0, max 2)\nLiveIn: \l\
 // LiveOut: v0[1]\l\nUsed: \l\nv0 := calldataload(0x03)\l\

--- a/test/libyul/yulSSAControlFlowGraph/if_const.yul
+++ b/test/libyul/yulSSAControlFlowGraph/if_const.yul
@@ -17,8 +17,8 @@
 // graph[fontname="DejaVu Sans"]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry0 [label="Entry"];
-// Entry0 -> Block0_0;
+// Entry [label="Entry"];
+// Entry -> Block0_0;
 // Block0_0 [fillcolor="#FF746C", style=filled, label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
 // LiveOut: \l\nUsed: \l\nv0 := calldataload(0x03)\l\

--- a/test/libyul/yulSSAControlFlowGraph/nested_for.yul
+++ b/test/libyul/yulSSAControlFlowGraph/nested_for.yul
@@ -23,8 +23,8 @@
 // graph[fontname="DejaVu Sans"]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry0 [label="Entry"];
-// Entry0 -> Block0_0;
+// Entry [label="Entry"];
+// Entry -> Block0_0;
 // Block0_0 [fillcolor="#FF746C", style=filled, label="\
 // Block 0; (0, max 24)\nLiveIn: \l\
 // LiveOut: v0[1]\l\nUsed: \l\nv0 := 0x00\l\

--- a/test/libyul/yulSSAControlFlowGraph/nested_function.yul
+++ b/test/libyul/yulSSAControlFlowGraph/nested_function.yul
@@ -35,8 +35,8 @@
 // graph[fontname="DejaVu Sans"]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry0 [label="Entry"];
-// Entry0 -> Block0_0;
+// Entry [label="Entry"];
+// Entry -> Block0_0;
 // Block0_0 [fillcolor="#FF746C", style=filled, label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
 // LiveOut: \l\nUsed: \l\n"];

--- a/test/libyul/yulSSAControlFlowGraph/switch.yul
+++ b/test/libyul/yulSSAControlFlowGraph/switch.yul
@@ -19,8 +19,8 @@
 // graph[fontname="DejaVu Sans"]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry0 [label="Entry"];
-// Entry0 -> Block0_0;
+// Entry [label="Entry"];
+// Entry -> Block0_0;
 // Block0_0 [label="\
 // Block 0; (0, max 5)\nLiveIn: \l\
 // LiveOut: v1[1]\l\nUsed: \l\nv0 := calldataload(0x03)\l\

--- a/test/libyul/yulSSAControlFlowGraph/switch_const.yul
+++ b/test/libyul/yulSSAControlFlowGraph/switch_const.yul
@@ -41,8 +41,8 @@
 // graph[fontname="DejaVu Sans"]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry0 [label="Entry"];
-// Entry0 -> Block0_0;
+// Entry [label="Entry"];
+// Entry -> Block0_0;
 // Block0_0 [fillcolor="#FF746C", style=filled, label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
 // LiveOut: \l\nUsed: \l\nv0 := calldataload(0x03)\l\


### PR DESCRIPTION
Multiple dot export variants are needed (e.g. for stack layout visualization in tests), and the graph structure boilerplate stays the same. Just the block label content differs. Therefore this PR introduces a base class that bundles the commonalities and makes the implementation of the actual exporters more focused.

- Reorganizes SSA CFG IO and traversal utilities into dedicated subdirectories (io/, traversal/)
- Introduces a reusable DotExporterBase class that handles the common graph structure for Graphviz dot export
- Rewrites the existing toDot in SSACFG.cpp using the new base class