### PR TITLE
Test coverage for constants and literal expressions with type smaller than `uint256`

### DIFF
--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/expression_with_constant_and_literal_types_smaller_than_uint256.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/expression_with_constant_and_literal_types_smaller_than_uint256.sol
@@ -1,0 +1,13 @@
+uint8 constant base = 255;
+contract C layout at base + 257 {
+    uint public x = 7;
+    function test() public returns (uint r) {
+        assembly {
+            r := sload(512)
+            sstore(512, add(r, 1))
+        }
+    }
+}
+// ----
+// test() -> 7
+// x() -> 8

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/expression_with_constant_type_smaller_than_uint256.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/expression_with_constant_type_smaller_than_uint256.sol
@@ -1,0 +1,14 @@
+uint16 constant base = 511;
+uint8 constant offset = 1;
+contract C layout at base + offset {
+    uint public x = 7;
+    function test() public returns (uint r) {
+        assembly {
+            r := sload(512)
+            sstore(512, add(r, 1))
+        }
+    }
+}
+// ----
+// test() -> 7
+// x() -> 8

--- a/test/libsolidity/syntaxTests/array/length/constant_and_literal_type_smaller_than_uint256.sol
+++ b/test/libsolidity/syntaxTests/array/length/constant_and_literal_type_smaller_than_uint256.sol
@@ -1,0 +1,8 @@
+contract C {
+    uint8 constant LEN = 254;
+    uint[LEN + 1] array1;
+    uint[LEN + 256] array2;
+    uint[LEN * 2] array3; // Error, outside of constant and literal range
+}
+// ----
+// TypeError 2643: (106-113): Arithmetic error when computing constant value.

--- a/test/libsolidity/syntaxTests/array/length/constant_type_smaller_than_uint256.sol
+++ b/test/libsolidity/syntaxTests/array/length/constant_type_smaller_than_uint256.sol
@@ -1,0 +1,9 @@
+contract C {
+    uint8 constant LEN = 255;
+    uint16 constant MORE = 32767;
+    uint[LEN] array1;
+    uint[LEN + MORE] array2;
+    uint[LEN * MORE] array3; // Error, outside uint16 range
+}
+// ----
+// TypeError 2643: (137-147): Arithmetic error when computing constant value.

--- a/test/libsolidity/syntaxTests/array/length/overflow_constant_expression.sol
+++ b/test/libsolidity/syntaxTests/array/length/overflow_constant_expression.sol
@@ -1,0 +1,7 @@
+uint constant LEN = 2**255;
+uint constant MUL = 2;
+contract C {
+    uint[LEN * MUL] array;
+}
+// ----
+// TypeError 2643: (73-82): Arithmetic error when computing constant value.

--- a/test/libsolidity/syntaxTests/array/length/underflow_constant_expression.sol
+++ b/test/libsolidity/syntaxTests/array/length/underflow_constant_expression.sol
@@ -1,0 +1,7 @@
+uint constant START = 10;
+uint constant END = 2;
+contract C {
+    uint[END - START] array;
+}
+// ----
+// TypeError 2643: (71-82): Arithmetic error when computing constant value.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/constant_and_literal_integer_type_smaller_than_uint256.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/constant_and_literal_integer_type_smaller_than_uint256.sol
@@ -1,0 +1,5 @@
+uint8 constant base = 2;
+contract A layout at base + 256 {}
+contract B layout at base + 255 {} // Error, outside of range of constant and literal
+// ----
+// TypeError 2643: (81-91): Arithmetic error when computing constant value.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/constants_with_integer_type_smaller_than_uint256.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/constants_with_integer_type_smaller_than_uint256.sol
@@ -1,0 +1,7 @@
+uint8 constant base = 255;
+uint16 constant offset = 32767;
+contract A layout at base {}            // Ok
+contract B layout at base + offset {}   // Ok, inside uint16 range
+contract D layout at base * offset {}   // Error, outside uint16 range
+// ----
+// TypeError 2643: (193-206): Arithmetic error when computing constant value.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specification_overflow_constant_and_literal_expression.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specification_overflow_constant_and_literal_expression.sol
@@ -1,0 +1,4 @@
+uint constant base = 2**256 - 1;
+contract C layout at base + 1 {}
+// ----
+// TypeError 2643: (54-62): Arithmetic error when computing constant value.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specification_overflow_constant_expression.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specification_overflow_constant_expression.sol
@@ -1,0 +1,5 @@
+uint constant base = 2**256 - 1;
+uint constant offset = 512;
+contract C layout at base + offset {}
+// ----
+// TypeError 2643: (82-95): Arithmetic error when computing constant value.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specification_underflow_constant_and_literal_expression.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specification_underflow_constant_and_literal_expression.sol
@@ -1,0 +1,4 @@
+uint constant base = 512;
+contract C layout at base - 1024 {}
+// ----
+// TypeError 2643: (47-58): Arithmetic error when computing constant value.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specification_underflow_constant_expression.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/layout_specification_underflow_constant_expression.sol
@@ -1,0 +1,5 @@
+uint constant base = 256;
+uint constant offset = 512;
+contract C layout at base - offset {}
+// ----
+// TypeError 2643: (75-88): Arithmetic error when computing constant value.


### PR DESCRIPTION
Suggested in https://github.com/argotorg/solidity/pull/15968#discussion_r2718873467.