### PR TITLE
Stack layout generation for SSA-based CFGs

### DIFF
--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -91,6 +91,8 @@ add_library(yul
 	backends/evm/ssa/Stack.cpp
 	backends/evm/ssa/Stack.h
 	backends/evm/ssa/StackLayout.h
+	backends/evm/ssa/StackLayoutGenerator.cpp
+	backends/evm/ssa/StackLayoutGenerator.h
 	backends/evm/ssa/StackShuffler.cpp
 	backends/evm/ssa/StackShuffler.h
 	backends/evm/ssa/io/DotExporterBase.cpp

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -80,6 +80,8 @@ add_library(yul
 	backends/evm/ssa/JunkAdmittingBlocksFinder.h
 	backends/evm/ssa/LivenessAnalysis.cpp
 	backends/evm/ssa/LivenessAnalysis.h
+	backends/evm/ssa/PhiInverse.cpp
+	backends/evm/ssa/PhiInverse.h
 	backends/evm/ssa/SSACFGLoopNestingForest.cpp
 	backends/evm/ssa/SSACFGLoopNestingForest.h
 	backends/evm/ssa/SSACFG.cpp

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -95,6 +95,8 @@ add_library(yul
 	backends/evm/ssa/StackLayoutGenerator.h
 	backends/evm/ssa/StackShuffler.cpp
 	backends/evm/ssa/StackShuffler.h
+	backends/evm/ssa/StackUtils.cpp
+	backends/evm/ssa/StackUtils.h
 	backends/evm/ssa/io/DotExporterBase.cpp
 	backends/evm/ssa/io/DotExporterBase.h
 	backends/evm/ssa/io/JSONExporter.cpp

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -90,6 +90,7 @@ add_library(yul
 	backends/evm/ssa/SSACFGBuilder.h
 	backends/evm/ssa/Stack.cpp
 	backends/evm/ssa/Stack.h
+	backends/evm/ssa/StackLayout.h
 	backends/evm/ssa/StackShuffler.cpp
 	backends/evm/ssa/StackShuffler.h
 	backends/evm/ssa/io/DotExporterBase.cpp

--- a/libyul/backends/evm/ssa/PhiInverse.cpp
+++ b/libyul/backends/evm/ssa/PhiInverse.cpp
@@ -1,0 +1,46 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libyul/backends/evm/ssa/PhiInverse.h>
+
+using namespace solidity::yul::ssa;
+
+PhiInverse::PhiInverse(SSACFG const& _cfg, SSACFG::BlockId const& _from, SSACFG::BlockId const& _to)
+{
+	auto const argIndex = _cfg.phiArgumentIndex(_from, _to);
+	for (auto const& phiId: _cfg.block(_to).phis)
+	{
+		auto const& phiInfo = _cfg.phiInfo(phiId);
+		m_phiToPreImage[phiId] = phiInfo.arguments[argIndex];
+	}
+}
+
+bool PhiInverse::noOp() const
+{
+	return m_phiToPreImage.empty();
+}
+
+SSACFG::ValueId PhiInverse::operator()(SSACFG::ValueId _valueId) const
+{
+	return util::valueOrDefault(m_phiToPreImage, _valueId, _valueId);
+}
+
+std::map<SSACFG::ValueId, SSACFG::ValueId> const& PhiInverse::data() const
+{
+	return m_phiToPreImage;
+}

--- a/libyul/backends/evm/ssa/PhiInverse.h
+++ b/libyul/backends/evm/ssa/PhiInverse.h
@@ -1,0 +1,46 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libyul/backends/evm/ssa/SSACFG.h>
+
+#include <map>
+
+namespace solidity::yul::ssa
+{
+
+/// If Block `_from` -> Block `_to` and `_to` has phi functions `v_k := phi(..., _from => v_i, ...)`, this transform
+/// pulls values `v_k` back to `v_i`.
+class PhiInverse
+{
+public:
+	PhiInverse() = default;
+	PhiInverse(SSACFG const& _cfg, SSACFG::BlockId const& _from, SSACFG::BlockId const& _to);
+
+	/// whether the transform is guaranteed to be a no-op, ie, there is no phi function in `_to`
+	bool noOp() const;
+	SSACFG::ValueId operator()(SSACFG::ValueId _valueId) const;
+
+	std::map<SSACFG::ValueId, SSACFG::ValueId> const& data() const;
+
+private:
+	std::map<SSACFG::ValueId, SSACFG::ValueId> m_phiToPreImage = {};
+};
+
+}

--- a/libyul/backends/evm/ssa/Stack.h
+++ b/libyul/backends/evm/ssa/Stack.h
@@ -250,7 +250,8 @@ public:
 	bool swapReachable(Offset const& _offset) const noexcept { return swapReachable(offsetToDepth(_offset)); }
 	bool swapReachable(Depth const& _depth) const noexcept { return _depth < size() && 1 <= _depth.value && _depth.value <= reachableStackDepth; }
 
-	void declareJunk(Depth const& _depth) { (*m_data)[depthToOffset(_depth).value] = Slot::makeJunk(); }
+	void declareJunk(Offset const& _offset) { (*m_data)[_offset.value] = Slot::makeJunk(); }
+	void declareJunk(Depth const& _depth) { declareJunk(depthToOffset(_depth)); }
 
 	Slot const& slot(Depth const& _depth) const { return (*m_data)[depthToOffset(_depth).value]; }
 	Slot const& slot(Offset const& _offset) const { return slot(offsetToDepth(_offset)); }

--- a/libyul/backends/evm/ssa/StackLayout.h
+++ b/libyul/backends/evm/ssa/StackLayout.h
@@ -1,0 +1,60 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libyul/backends/evm/ssa/Stack.h>
+
+#include <vector>
+
+namespace solidity::yul::ssa
+{
+
+struct BlockLayout
+{
+	// stack layout required to enter the block
+	StackData stackIn;
+	// stack layout required to execute the i-th operation in the block
+	std::vector<StackData> operationIn;
+	// stack after the block was executed
+	StackData stackOut;
+};
+
+/// For each (reachable) block in the SSACFG one block layout
+class SSACFGStackLayout
+{
+public:
+	SSACFGStackLayout(std::size_t const _numBlocks): m_blockLayouts(_numBlocks) {}
+
+	std::optional<BlockLayout>& operator[](SSACFG::BlockId const& _blockId)
+	{
+		yulAssert(_blockId.hasValue() && _blockId.value < m_blockLayouts.size());
+		return m_blockLayouts[_blockId.value];
+	}
+
+	std::optional<BlockLayout> const& operator[](SSACFG::BlockId const& _blockId) const
+	{
+		yulAssert(_blockId.hasValue() && _blockId.value < m_blockLayouts.size());
+		return m_blockLayouts[_blockId.value];
+	}
+
+private:
+	std::vector<std::optional<BlockLayout>> m_blockLayouts;
+};
+
+}

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -1,0 +1,311 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libyul/backends/evm/ssa/StackLayoutGenerator.h>
+
+#include <libyul/backends/evm/ssa/JunkAdmittingBlocksFinder.h>
+#include <libyul/backends/evm/ssa/PhiInverse.h>
+#include <libyul/backends/evm/ssa/StackShuffler.h>
+#include <libyul/backends/evm/ssa/StackUtils.h>
+
+#include <range/v3/algorithm/count.hpp>
+#include <range/v3/algorithm/min_element.hpp>
+#include <range/v3/algorithm/replace.hpp>
+#include <range/v3/to_container.hpp>
+
+#include <boost/container/flat_map.hpp>
+#include <queue>
+
+using namespace solidity::yul::ssa;
+
+namespace
+{
+void handlePhiFunctions(StackData& _stackData, PhiInverse const& _phiInverse, LivenessAnalysis::LivenessData const& _liveness)
+{
+	// add any phi function values here that are not already contained in the stack
+	for (auto const& [phi, preImage]: _phiInverse.data())
+	{
+		auto reversedStackData = _stackData | ranges::views::reverse;
+		auto it = ranges::find(reversedStackData, StackSlot::makeValueID(preImage));
+		if (_liveness.contains(preImage))
+		{
+			// Both the phi function and the preimage are part of the live-in set.
+			// If the preimage occurs more than once on the stack, one occurrence is
+			// symbolically replaced by the phi function; otherwise, we push the phi value.
+			if (ranges::count(_stackData, StackSlot::makeValueID(preImage)) > 1)
+				*it = StackSlot::makeValueID(phi);
+			else
+				_stackData.emplace_back(StackSlot::makeValueID(phi));
+		}
+		else
+		{
+			// replace all occurrences of the preimage with the phi value
+			ranges::replace(_stackData, StackSlot::makeValueID(preImage), StackSlot::makeValueID(phi));
+			// if it's not contained, push it (could be derived from a literal)
+			if (it == ranges::end(reversedStackData))
+				_stackData.emplace_back(StackSlot::makeValueID(phi));
+		}
+	}
+}
+
+using StackType = Stack<CountingInstructionsCallbacks>;
+
+void declareJunk(StackType& _stack, LivenessAnalysis::LivenessData const& _live)
+{
+	for (StackOffset offset{0}; offset < _stack.size(); ++offset.value)
+	{
+		auto const& slot = _stack[offset];
+		if (slot.isValueID() && !_live.contains(slot.valueID()))
+			_stack.declareJunk(offset);
+	}
+}
+
+}
+
+SSACFGStackLayout StackLayoutGenerator::generate(LivenessAnalysis const& _liveness, CallSites const& _callSites)
+{
+	return StackLayoutGenerator(_liveness, _callSites).m_resultLayout;
+}
+
+StackLayoutGenerator::StackLayoutGenerator(LivenessAnalysis const& _liveness, CallSites const& _callSites):
+	m_cfg(_liveness.cfg()),
+	m_liveness(_liveness),
+	m_callSites(_callSites),
+	m_junkAdmittingBlocksFinder(std::make_unique<JunkAdmittingBlocksFinder>(_liveness.cfg(), _liveness.topologicalSort())),
+	m_resultLayout(m_cfg.numBlocks())
+{
+	// traverse the cfg layer-wise using Kahn's algorithm:
+	// if a block is visited, the predecessors of that block have already their exit layouts defined
+	// with minor exceptions when dealing with back-edges
+	{
+		// Future optimization: it might be beneficial to revisit the loop heads (back edge targets) after the first iteration
+		std::vector<std::size_t> inDegreesIgnoringBackedges(m_cfg.numBlocks(), 0);
+
+		for (SSACFG::BlockId id{0}; id.value < m_cfg.numBlocks(); ++id.value)
+			for (auto const& entry: m_cfg.block(id).entries)
+				if (!m_liveness.topologicalSort().backEdge(entry, id))
+					inDegreesIgnoringBackedges[id.value] += 1;
+
+		std::queue<SSACFG::BlockId> traversalQueue;
+		traversalQueue.push(m_cfg.entry);
+
+		std::size_t numVisited = 0;
+		while (!traversalQueue.empty())
+		{
+			auto currentBlockId = traversalQueue.front();
+			traversalQueue.pop();
+
+			visitBlock(currentBlockId);
+
+			m_cfg.block(currentBlockId).forEachExit([&](SSACFG::BlockId const& _exit){
+				if (--inDegreesIgnoringBackedges[_exit.value] == 0)
+					traversalQueue.push(_exit);
+			});
+			++numVisited;
+		}
+		yulAssert(numVisited == m_liveness.topologicalSort().preOrder().size());
+	}
+}
+
+void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
+{
+	// we already have an input layout defined, return
+	if (m_resultLayout[_blockId])
+		return;
+	BlockLayout blockLayout{};
+
+	if (_blockId == m_cfg.entry)
+	{
+		if (m_cfg.function)
+			blockLayout.stackIn =
+				m_cfg.arguments |
+				ranges::views::reverse |
+				ranges::views::transform([](auto&& _variableAndValueId) -> Slot { return Slot::makeValueID(std::get<1>(_variableAndValueId)); }) |
+				ranges::to<std::vector>;
+		m_resultLayout[_blockId] = blockLayout;
+		return;
+	}
+
+	auto const& block = m_cfg.block(_blockId);
+
+	std::vector<std::pair<SSACFG::BlockId, StackData const*>> parentExits;
+	for (auto const& entry: block.entries)
+		if (m_resultLayout[entry])
+			parentExits.emplace_back(entry, &m_resultLayout[entry]->stackOut);
+
+	yulAssert(!parentExits.empty(), fmt::format("None of the parents of block {} were generated", _blockId));
+
+	if (block.entries.size() == 1)
+	{
+		// pass through
+		yulAssert(parentExits.size() == 1);
+		blockLayout.stackIn = *parentExits[0].second;
+
+		if (!block.phis.empty())
+			handlePhiFunctions(blockLayout.stackIn, PhiInverse(m_cfg, parentExits[0].first, _blockId), m_liveness.liveIn(_blockId));
+	}
+	else
+	{
+		// we have more than one entry and need to unify or at the very least apply phi fct.
+		auto const& liveIn = m_liveness.liveIn(_blockId);
+		std::vector cumulativeCosts(parentExits.size(), std::numeric_limits<std::size_t>::max());
+		for (std::size_t i = 0; i < parentExits.size(); ++i)
+		{
+			if (!parentExits[i].second)
+				continue;
+			std::size_t cumulativeCost = 0;
+			auto referenceStackIn = *parentExits[i].second;
+			{
+				StackType stack(referenceStackIn, {});
+				declareJunk(stack, liveIn);
+			}
+			handlePhiFunctions(referenceStackIn, PhiInverse(m_cfg, parentExits[i].first, _blockId), liveIn);
+			for (std::size_t j = 0; j < parentExits.size(); ++j)
+			{
+				if (j != i)
+				{
+					if (parentExits[j].second != nullptr)
+					{
+						auto otherStackIn = *parentExits[j].second;
+						StackType stack(otherStackIn, {});
+						StackShuffler<StackType::Callbacks>::shuffle(
+							stack,
+							stackPreImage(referenceStackIn, PhiInverse(m_cfg, parentExits[j].first, _blockId)),
+							{},
+							referenceStackIn.size()
+						);
+						cumulativeCost += stack.callbacks().numOps;
+					}
+				}
+			}
+			cumulativeCosts[i] = cumulativeCost;
+		}
+		auto const argMin = static_cast<std::size_t>(
+			std::distance(cumulativeCosts.begin(), ranges::min_element(cumulativeCosts))
+		);
+		yulAssert(parentExits[argMin].second);
+		blockLayout.stackIn = *parentExits[argMin].second;
+		StackType stack(blockLayout.stackIn, {});
+		declareJunk(stack, liveIn);
+		handlePhiFunctions(blockLayout.stackIn, PhiInverse(m_cfg, parentExits[argMin].first, _blockId), liveIn);
+	}
+	m_resultLayout[_blockId] = blockLayout;
+}
+
+void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
+{
+	defineStackIn(_blockId);
+	yulAssert(m_resultLayout[_blockId]);
+	BlockLayout& blockLayout = *m_resultLayout[_blockId];
+
+	SSACFG::BasicBlock const& block = m_cfg.block(_blockId);
+
+	StackData currentStackData = blockLayout.stackIn;
+	StackType stack(currentStackData, {});
+	bool const junkCanBeAdded = m_junkAdmittingBlocksFinder->allowsAdditionOfJunk(_blockId);
+
+	auto const& operationsLiveOut = m_liveness.operationsLiveOut(_blockId);
+	blockLayout.operationIn.reserve(block.operations.size());
+	for (std::size_t operationIndex = 0; operationIndex < block.operations.size(); ++operationIndex)
+	{
+		SSACFG::Operation const& operation = block.operations[operationIndex];
+		LivenessAnalysis::LivenessData opLiveOut = operationsLiveOut[operationIndex];
+		auto opLiveOutWithoutOutputs = opLiveOut;
+		for (auto const& output: operation.outputs)
+			opLiveOutWithoutOutputs.erase(output);
+
+		std::vector<Slot> requiredStackTop;
+		if (auto const* call = std::get_if<SSACFG::Call>(&operation.kind))
+			if (call->canContinue)
+			{
+				auto const callSiteID = m_callSites.callSiteID(&call->call.get());
+				yulAssert(callSiteID.has_value());
+				requiredStackTop.emplace_back(Slot::makeFunctionCallReturnLabel(*callSiteID));
+			}
+		requiredStackTop += operation.inputs | ranges::views::transform(Slot::makeValueID);
+
+		for (StackType::Depth depth{0}; depth < stack.size(); ++depth.value)
+			if (
+				stack.slot(depth).isValueID() &&
+				!opLiveOutWithoutOutputs.contains(stack.slot(depth).valueID()) &&
+				ranges::find(requiredStackTop, stack.slot(depth)) == ranges::end(requiredStackTop)
+			)
+				stack.declareJunk(depth);
+
+		std::size_t const targetSize = findOptimalTargetSize(stack.data(), requiredStackTop, opLiveOutWithoutOutputs, junkCanBeAdded);
+		StackShuffler<StackType::Callbacks>::shuffle(
+			stack,
+			requiredStackTop,
+			opLiveOutWithoutOutputs,
+			targetSize
+		);
+
+		blockLayout.operationIn.push_back(currentStackData);
+		for (std::size_t i = 0; i < requiredStackTop.size(); ++i)
+			stack.pop();
+		for (auto const& val: operation.outputs)
+			stack.push(Slot::makeValueID(val));
+	}
+
+	if (auto const* cjump = std::get_if<SSACFG::BasicBlock::ConditionalJump>(&block.exit))
+	{
+		auto const& zeroLiveIn = m_liveness.liveIn(cjump->zero);
+		auto const& blockLiveOut = m_liveness.liveOut(_blockId);
+
+		// check if we have to do anything (dup the condition, bring it to the top etc)
+		bool const conditionSlotAlreadyFinal =
+			!blockLiveOut.contains(cjump->condition) &&  // if our live out does not contain the condition (ie we dont have to dup it)
+			!stack.empty() &&   // our stack is not empty
+			stack.top().isValueID() && stack.top().valueID() == cjump->condition;  // and the condition is already on top
+		if (!conditionSlotAlreadyFinal)
+		{
+			auto const condition = Slot::makeValueID(cjump->condition);
+			auto const targetSize = findOptimalTargetSize(stack.data(), {condition}, blockLiveOut, false);
+			StackShuffler<StackType::Callbacks>::shuffle(
+				stack, {condition}, blockLiveOut, targetSize
+			);
+		}
+
+		yulAssert(!stack.empty() && stack.top().isValueID() && stack.top().valueID() == cjump->condition);
+		yulAssert(m_cfg.block(cjump->nonZero).phis.empty());
+
+		// define zero and non-zero stack in layouts
+		{
+			std::optional<BlockLayout>& nonZeroLayout = m_resultLayout[cjump->nonZero];
+			yulAssert(!nonZeroLayout, "There should be no way to reach this block other than by going through the parent.");
+			nonZeroLayout = BlockLayout{};
+			nonZeroLayout->stackIn = currentStackData;
+			// Remove condition; consumed by JUMPI
+			nonZeroLayout->stackIn.pop_back();
+
+			if (
+				std::optional<BlockLayout>& zeroLayout = m_resultLayout[cjump->zero];
+				!zeroLayout
+			)
+			{
+				// same as nonzero stack in initially
+				zeroLayout = nonZeroLayout;
+				handlePhiFunctions(zeroLayout->stackIn, PhiInverse(m_cfg, _blockId, cjump->zero), zeroLiveIn);
+				StackType zeroStack(zeroLayout->stackIn, {});
+				declareJunk(zeroStack, zeroLiveIn);
+			}
+		}
+	}
+
+	blockLayout.stackOut = currentStackData;
+}

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.h
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.h
@@ -1,0 +1,51 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libyul/backends/evm/ssa/Stack.h>
+#include <libyul/backends/evm/ssa/StackLayout.h>
+
+#include <memory>
+
+namespace solidity::yul::ssa
+{
+
+class JunkAdmittingBlocksFinder;
+
+class StackLayoutGenerator
+{
+public:
+	using Slot = StackSlot;
+	static SSACFGStackLayout generate(LivenessAnalysis const& _liveness, CallSites const& _callSites);
+
+private:
+	explicit StackLayoutGenerator(LivenessAnalysis const& _liveness, CallSites const& _callSites);
+
+	void defineStackIn(SSACFG::BlockId const& _blockId);
+	void visitBlock(SSACFG::BlockId const& _blockId);
+
+	SSACFG const& m_cfg;
+	LivenessAnalysis const& m_liveness;
+	CallSites const& m_callSites;
+
+	std::unique_ptr<JunkAdmittingBlocksFinder> m_junkAdmittingBlocksFinder;
+	SSACFGStackLayout m_resultLayout;
+};
+
+}

--- a/libyul/backends/evm/ssa/StackUtils.cpp
+++ b/libyul/backends/evm/ssa/StackUtils.cpp
@@ -1,0 +1,143 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libyul/backends/evm/ssa/StackUtils.h>
+
+#include <libyul/backends/evm/ssa/StackShuffler.h>
+
+#include <range/v3/numeric/accumulate.hpp>
+
+#include <boost/container/flat_map.hpp>
+
+using namespace solidity::yul::ssa;
+
+StackData solidity::yul::ssa::stackPreImage(StackData _stack, PhiInverse const& _phiInverse)
+{
+	if (!_phiInverse.noOp())
+		for (auto& slot: _stack)
+			if (slot.isValueID())
+				slot = StackSlot::makeValueID(_phiInverse(slot.valueID()));
+	return _stack;
+}
+
+std::size_t solidity::yul::ssa::findOptimalTargetSize
+(
+	StackData const& _stackData,
+	StackData const& _targetArgs,
+	LivenessAnalysis::LivenessData const& _targetLiveOut,
+	bool const _canIntroduceJunk
+)
+{
+	std::size_t const minSize = _targetLiveOut.size() + _targetArgs.size();
+	boost::container::flat_map<StackSlot, std::size_t> deficit;
+	for (auto const& v: _targetLiveOut | ranges::views::keys)
+		deficit[StackSlot::makeValueID(v)]++;
+	for (auto const& arg: _targetArgs)
+		deficit[arg]++;
+	for (auto const& slot: _stackData)
+		if (auto it = deficit.find(slot); it != deficit.end())
+			it->second = it->second > 0 ? it->second - 1 : 0;
+
+	std::size_t const pivot = _canIntroduceJunk ? _stackData.size() + _targetArgs.size() : _stackData.size() + ranges::accumulate(deficit | ranges::views::values, 0u);
+	std::size_t const startSize = std::max(pivot, minSize);
+	static std::size_t constexpr maxUpwardExpansion = 32;
+
+	StackData data;
+	data.reserve(startSize + maxUpwardExpansion);
+	auto const evaluateCost = [&](std::size_t const _targetSize) -> std::size_t
+	{
+		data = _stackData;
+		Stack<CountingInstructionsCallbacks> countOpsStack(data, {});
+		StackShuffler<CountingInstructionsCallbacks>::shuffle(countOpsStack, _targetArgs, _targetLiveOut, _targetSize);
+		yulAssert(countOpsStack.size() == _targetSize);
+		return countOpsStack.callbacks().numOps;
+	};
+
+	std::size_t bestCost = evaluateCost(startSize);
+	auto result = startSize;
+
+	// On non-reverting paths, only search downward from pivot to avoid growing the stack.
+	// On reverting paths, search in both directions since stack cleanup doesn't matter.
+	static std::size_t constexpr stopAfter = 3;
+	std::size_t consecutiveIncreases = 0;
+	// search downward
+	{
+		std::size_t size = startSize;
+		while (size > minSize)
+		{
+			--size;
+			auto const cost = evaluateCost(size);
+			if (cost < bestCost)
+			{
+				bestCost = cost;
+				result = size;
+				consecutiveIncreases = 0;
+			}
+			else if (++consecutiveIncreases >= stopAfter)
+				break;
+		}
+	}
+	// search upward (only on reverting paths)
+	if (_canIntroduceJunk)
+	{
+		consecutiveIncreases = 0;
+		for (std::size_t size = startSize + 1; size <= startSize + maxUpwardExpansion; ++size)
+		{
+			auto const cost = evaluateCost(size);
+			if (cost < bestCost)
+			{
+				bestCost = cost;
+				result = size;
+				consecutiveIncreases = 0;
+			}
+			else if (++consecutiveIncreases >= stopAfter)
+				break;
+		}
+	}
+	return result;
+}
+
+CallSites solidity::yul::ssa::gatherCallSites(SSACFG const& _cfg)
+{
+	CallSites result;
+	std::vector<std::uint8_t> visited(_cfg.numBlocks(), false);
+	visited[_cfg.entry.value] = true;
+	std::vector<SSACFG::BlockId> toVisit;
+	toVisit.reserve(_cfg.numBlocks());
+	toVisit.push_back(_cfg.entry);
+
+	while (!toVisit.empty())
+	{
+		auto const blockId = toVisit.back();
+		toVisit.pop_back();
+		auto const& block = _cfg.block(blockId);
+		block.forEachExit([&toVisit, &visited](SSACFG::BlockId const& _exitBlockId){
+			if (!visited[_exitBlockId.value])
+			{
+				visited[_exitBlockId.value] = true;
+				toVisit.push_back(_exitBlockId);
+			}
+		});
+
+		for (auto const& operation: block.operations)
+			if (auto const* call = std::get_if<SSACFG::Call>(&operation.kind))
+				if (call->canContinue)
+					result.addCallSite(&call->call.get());
+	}
+	return result;
+}

--- a/libyul/backends/evm/ssa/StackUtils.h
+++ b/libyul/backends/evm/ssa/StackUtils.h
@@ -1,0 +1,43 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libyul/backends/evm/ssa/PhiInverse.h>
+#include <libyul/backends/evm/ssa/Stack.h>
+
+namespace solidity::yul::ssa
+{
+
+struct CountingInstructionsCallbacks
+{
+	std::size_t numOps = 0;
+	void swap(std::size_t) { ++numOps; }
+	void dup(std::size_t) { ++numOps; }
+	void push(StackSlot const&) { ++numOps; }
+	void pop() { ++numOps; }
+};
+
+/// Transform stack data by replacing all its phi variables with their respective preimages.
+StackData stackPreImage(StackData _stack, PhiInverse const& _phiInverse);
+
+std::size_t findOptimalTargetSize(StackData const& _stackData, StackData const& _targetArgs, LivenessAnalysis::LivenessData const& _targetLiveOut, bool _canIntroduceJunk);
+
+CallSites gatherCallSites(SSACFG const& _cfg);
+
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -173,6 +173,8 @@ set(libyul_sources
     libyul/YulOptimizerTest.h
     libyul/YulOptimizerTestCommon.cpp
     libyul/YulOptimizerTestCommon.h
+    libyul/ssa/StackLayoutGeneratorTest.cpp
+    libyul/ssa/StackLayoutGeneratorTest.h
     libyul/ssa/StackShufflerTest.cpp
     libyul/ssa/StackShufflerTest.h
 )

--- a/test/InteractiveTests.h
+++ b/test/InteractiveTests.h
@@ -31,6 +31,7 @@
 #include <test/libsolidity/SemanticTest.h>
 #include <test/libsolidity/SMTCheckerTest.h>
 
+#include <test/libyul/ssa/StackLayoutGeneratorTest.h>
 #include <test/libyul/ssa/StackShufflerTest.h>
 #include <test/libyul/ControlFlowGraphTest.h>
 #include <test/libyul/SSAControlFlowGraphTest.h>
@@ -74,7 +75,8 @@ Testsuite const g_interactiveTestsuites[] = {
 	{"Yul Object Compiler",         "libyul",      "objectCompiler",                false, false, &yul::test::ObjectCompilerTest::create},
 	{"Yul Control Flow Graph",      "libyul",      "yulControlFlowGraph",           false, false, &yul::test::ControlFlowGraphTest::create},
 	{"Yul SSA Control Flow Graph",  "libyul",      "yulSSAControlFlowGraph",        false, false, &yul::test::SSAControlFlowGraphTest::create},
-	{"Yul SSA StackShuffling",      "libyul",      "ssa/stackShuffler",            false, false, &yul::ssa::test::ShufflingTest::create},
+	{"Yul SSA StackShuffling",      "libyul",      "ssa/stackShuffler",             false, false, &yul::test::ssa::ShufflingTest::create},
+	{"Yul SSA StackLayoutGenerator","libyul",      "ssa/stackLayoutGenerator",      false, false, &yul::test::ssa::StackLayoutGeneratorTest::create},
 	{"Yul Stack Layout",            "libyul",      "yulStackLayout",                false, false, &yul::test::StackLayoutGeneratorTest::create},
 	{"Yul Stack Shuffling",         "libyul",      "yulStackShuffling",             false, false, &yul::test::StackShufflingTest::create},
 	{"Control Flow Side Effects",   "libyul",      "controlFlowSideEffects",        false, false, &yul::test::ControlFlowSideEffectsTest::create},

--- a/test/libyul/ssa/StackLayoutGeneratorTest.cpp
+++ b/test/libyul/ssa/StackLayoutGeneratorTest.cpp
@@ -1,0 +1,216 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <test/libyul/ssa/StackLayoutGeneratorTest.h>
+
+#include <libyul/backends/evm/ssa/io/DotExporterBase.h>
+#include <libyul/backends/evm/ssa/ControlFlow.h>
+#include <libyul/backends/evm/ssa/SSACFGBuilder.h>
+#include <libyul/backends/evm/ssa/Stack.h>
+#include <libyul/backends/evm/ssa/StackLayout.h>
+#include <libyul/backends/evm/ssa/StackLayoutGenerator.h>
+#include <libyul/backends/evm/ssa/StackUtils.h>
+
+#include <libyul/Common.h>
+#include <libyul/YulStack.h>
+
+#include <libsolutil/Visitor.h>
+
+#include <range/v3/view/split.hpp>
+
+#ifdef ISOLTEST
+#include <boost/version.hpp>
+#if (BOOST_VERSION < 108800)
+#include <boost/process.hpp>
+#else
+#define BOOST_PROCESS_VERSION 1
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/pipe.hpp>
+#endif
+#endif
+
+using namespace solidity;
+using namespace solidity::util;
+using namespace solidity::yul::ssa;
+using namespace solidity::yul::test::ssa;
+
+namespace
+{
+
+class StackLayoutDotExporter: public io::DotExporterBase
+{
+public:
+	StackLayoutDotExporter(SSACFG const& _cfg, std::size_t _functionIndex, SSACFGStackLayout const& _layout):
+		DotExporterBase(_cfg, _functionIndex),
+		m_layout(_layout)
+	{
+	}
+
+protected:
+	void writeBlockLabel(std::ostream& _out, SSACFG::BlockId _blockId) override
+	{
+		auto const& block = m_cfg.block(_blockId);
+		auto const& blockLayout = m_layout[_blockId];
+		yulAssert(blockLayout.has_value());
+
+		_out << "\\\n";
+		_out << "IN: " << stackToString(blockLayout->stackIn) << "\\l\\\n";
+
+		for (std::size_t i = 0; i < block.operations.size(); ++i)
+		{
+			auto const& operation = block.operations[i];
+			yulAssert(i < blockLayout->operationIn.size());
+			auto operationStack = blockLayout->operationIn[i];
+
+			_out << "\\l\\\n";
+			_out << stackToString(operationStack) << "\\l\\\n";
+
+			std::visit(GenericVisitor{
+				[&](SSACFG::Call const& _call) {
+					_out << escapeLabel(_call.function.get().name.str());
+				},
+				[&](SSACFG::BuiltinCall const& _call) {
+					_out << escapeLabel(_call.builtin.get().name);
+				},
+				[&](SSACFG::LiteralAssignment const&) {
+					yulAssert(operation.inputs.size() == 1);
+					_out << escapeLabel(operation.inputs.back().str(m_cfg));
+				}
+			}, operation.kind);
+			_out << "\\l\\\n";
+
+			yulAssert(operation.inputs.size() <= operationStack.size());
+			for (std::size_t j = 0; j < operation.inputs.size(); ++j)
+				operationStack.pop_back();
+			for (auto const& output: operation.outputs)
+				operationStack.push_back(StackSlot::makeValueID(output));
+			_out << stackToString(operationStack) << "\\l\\\n";
+		}
+
+		_out << "\\l\\\n";
+		_out << "OUT: " << stackToString(blockLayout->stackOut) << "\\l\\\n";
+	}
+
+private:
+	SSACFGStackLayout const& m_layout;
+};
+
+}
+
+std::unique_ptr<frontend::test::TestCase> StackLayoutGeneratorTest::create(Config const& _config)
+{
+	return std::make_unique<StackLayoutGeneratorTest>(_config.filename);
+}
+
+StackLayoutGeneratorTest::StackLayoutGeneratorTest(std::string const& _filename): TestCase(_filename)
+{
+	m_source = m_reader.source();
+	auto dialectName = m_reader.stringSetting("dialect", "evm");
+	soltestAssert(dialectName == "evm");
+	m_expectation = m_reader.simpleExpectations();
+}
+
+frontend::test::TestCase::TestResult StackLayoutGeneratorTest::run(std::ostream& _stream, std::string const& _linePrefix, bool const _formatted)
+{
+	static std::string_view constexpr SUBOBJECT_GRAPH_SEPARATOR = "\n>>>>> GRAPH SEPARATOR\n";
+	YulStack const yulStack = yul::test::parseYul(m_source);
+	if (yulStack.hasErrors())
+	{
+		yul::test::printYulErrors(yulStack, _stream, _linePrefix, _formatted);
+		return TestResult::FatalError;
+	}
+
+	std::set<Object const*> visited;
+	visited.insert(yulStack.parserResult().get());
+
+	std::vector<Object const*> toVisit{yulStack.parserResult().get()};
+	while (!toVisit.empty())
+	{
+		auto const& object = *toVisit.back();
+		toVisit.pop_back();
+
+		std::unique_ptr<ControlFlow> const controlFlow = SSACFGBuilder::build(
+			*object.analysisInfo,
+			*object.dialect(),
+			object.code()->root(),
+			false
+		);
+		// insert separator
+		if (!m_obtainedResult.empty())
+			m_obtainedResult += SUBOBJECT_GRAPH_SEPARATOR;
+
+		m_obtainedResult += "digraph SSACFG {\nnodesep=0.7;\ngraph[fontname=\"DejaVu Sans\", rankdir=LR]\nnode[shape=box,fontname=\"DejaVu Sans\"];\n\n";
+
+		for (std::size_t index = 0; index < controlFlow->functionGraphs.size(); ++index)
+		{
+			auto const& cfg = *controlFlow->functionGraphs[index];
+			SSACFGStackLayout const layout = StackLayoutGenerator::generate(
+				LivenessAnalysis(cfg),
+				gatherCallSites(cfg)
+			);
+			StackLayoutDotExporter exporter(cfg, index, layout);
+			if (cfg.function)
+				m_obtainedResult += exporter.exportFunction(*cfg.function, false);
+			else
+				m_obtainedResult += exporter.exportBlocks(cfg.entry, false);
+		}
+
+		m_obtainedResult += "}\n";
+
+		for (auto const& subNode: object.subObjects)
+			if (auto subObject = std::dynamic_pointer_cast<Object>(subNode))
+				if (!visited.contains(subObject.get()))
+				{
+					visited.insert(subObject.get());
+					toVisit.push_back(subObject.get());
+				}
+	}
+
+	auto const result = checkResult(_stream, _linePrefix, _formatted);
+
+#ifdef ISOLTEST
+	char* graphDisplayer = nullptr;
+	if (result == TestResult::Failure)
+		graphDisplayer = getenv("ISOLTEST_DISPLAY_GRAPHS_FAILURE");
+	else if (result == TestResult::Success)
+		graphDisplayer = getenv("ISOLTEST_DISPLAY_GRAPHS_SUCCESS");
+
+	if (graphDisplayer)
+	{
+		if (result == TestResult::Success)
+			std::cout << std::endl << m_source << std::endl;
+		for (auto const dotRange: ranges::views::split(m_obtainedResult, SUBOBJECT_GRAPH_SEPARATOR))
+		{
+			std::string_view dot(&*dotRange.begin(), static_cast<std::size_t>(ranges::distance(dotRange)));
+			boost::process::opstream pipe;
+			boost::process::child child(graphDisplayer, boost::process::std_in < pipe);
+
+			pipe << dot;
+			pipe.flush();
+			pipe.pipe().close();
+			if (result == TestResult::Success)
+				child.wait();
+			else
+				child.detach();
+		}
+	}
+#endif
+
+	return result;
+}

--- a/test/libyul/ssa/StackLayoutGeneratorTest.h
+++ b/test/libyul/ssa/StackLayoutGeneratorTest.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+
 #include <test/TestCase.h>
 
 #include <memory>
@@ -25,11 +26,11 @@
 namespace solidity::yul::test::ssa
 {
 
-class ShufflingTest: public frontend::test::TestCase
+class StackLayoutGeneratorTest: public frontend::test::TestCase
 {
 public:
 	static std::unique_ptr<TestCase> create(Config const& _config);
-	explicit ShufflingTest(std::string const& _filename);
+	explicit StackLayoutGeneratorTest(std::string const& _filename);
 	TestResult run(std::ostream& _stream, std::string const& _linePrefix, bool _formatted) override;
 };
 

--- a/test/libyul/ssa/StackShufflerTest.cpp
+++ b/test/libyul/ssa/StackShufflerTest.cpp
@@ -39,8 +39,10 @@
 #include <vector>
 
 using namespace solidity;
+using namespace solidity::yul;
 using namespace solidity::yul::ssa;
-using namespace solidity::yul::ssa::test;
+using namespace solidity::yul::test;
+using namespace solidity::yul::test::ssa;
 
 namespace
 {

--- a/test/libyul/ssa/stackLayoutGenerator/dead_code.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/dead_code.yul
@@ -1,0 +1,79 @@
+{
+    let x := calldataload(0)
+    if x {
+        revert(0, 0)
+    }
+    let y := calldataload(32)
+    if y {
+        revert(0, 0)
+    }
+    sstore(x, y)
+}
+// ----
+// digraph SSACFG {
+// nodesep=0.7;
+// graph[fontname="DejaVu Sans", rankdir=LR]
+// node[shape=box,fontname="DejaVu Sans"];
+//
+// Entry [label="Entry"];
+// Entry -> Block0_0;
+// Block0_0 [label="\
+// IN: []\l\
+// \l\
+// [lit0]\l\
+// calldataload\l\
+// [v0]\l\
+// \l\
+// OUT: [v0, v0]\l\
+// "];
+// Block0_0 -> Block0_0Exit;
+// Block0_0Exit [label="{ If v0 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_0Exit:0 -> Block0_2 [style="solid"];
+// Block0_0Exit:1 -> Block0_1 [style="solid"];
+// Block0_1 [label="\
+// IN: [v0]\l\
+// \l\
+// [JUNK, lit0, lit0]\l\
+// revert\l\
+// [JUNK]\l\
+// \l\
+// OUT: [JUNK]\l\
+// "];
+// Block0_1Exit [label="Terminated"];
+// Block0_1 -> Block0_1Exit;
+// Block0_2 [label="\
+// IN: [v0]\l\
+// \l\
+// [v0, lit1]\l\
+// calldataload\l\
+// [v0, v1]\l\
+// \l\
+// OUT: [v0, v1, v1]\l\
+// "];
+// Block0_2 -> Block0_2Exit;
+// Block0_2Exit [label="{ If v1 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_2Exit:0 -> Block0_5 [style="solid"];
+// Block0_2Exit:1 -> Block0_4 [style="solid"];
+// Block0_4 [label="\
+// IN: [v0, v1]\l\
+// \l\
+// [JUNK, JUNK, lit0, lit0]\l\
+// revert\l\
+// [JUNK, JUNK]\l\
+// \l\
+// OUT: [JUNK, JUNK]\l\
+// "];
+// Block0_4Exit [label="Terminated"];
+// Block0_4 -> Block0_4Exit;
+// Block0_5 [label="\
+// IN: [v0, v1]\l\
+// \l\
+// [v0, v1, v0]\l\
+// sstore\l\
+// [v0]\l\
+// \l\
+// OUT: [v0]\l\
+// "];
+// Block0_5Exit [label="MainExit"];
+// Block0_5 -> Block0_5Exit;
+// }

--- a/test/libyul/ssa/stackLayoutGenerator/function.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/function.yul
@@ -1,0 +1,106 @@
+{
+    function f(a, b) -> r {
+        let x := add(a,b)
+        r := sub(x,a)
+    }
+    function g() {
+        sstore(0x01, 0x0101)
+    }
+    function h(x) {
+        h(f(x, 0))
+        g()
+    }
+    function i() -> v, w {
+        v := 0x0202
+        w := 0x0303
+    }
+    let x, y := i()
+    h(x)
+    h(y)
+    // This call of g() is unreachable too as the one in h() but we wanna cover both cases.
+    g()
+}
+// ----
+// digraph SSACFG {
+// nodesep=0.7;
+// graph[fontname="DejaVu Sans", rankdir=LR]
+// node[shape=box,fontname="DejaVu Sans"];
+//
+// Entry [label="Entry"];
+// Entry -> Block0_0;
+// Block0_0 [label="\
+// IN: []\l\
+// \l\
+// [FunctionCallReturnLabel[0]]\l\
+// i\l\
+// [FunctionCallReturnLabel[0], v0, v1]\l\
+// \l\
+// [v0, JUNK, v0]\l\
+// h\l\
+// [v0, JUNK]\l\
+// \l\
+// OUT: [v0, JUNK]\l\
+// "];
+// Block0_0Exit [label="Terminated"];
+// Block0_0 -> Block0_0Exit;
+// FunctionEntry_f_0 [label="function f:
+//  r := f(v0, v1)"];
+// FunctionEntry_f_0 -> Block1_0;
+// Block1_0 [label="\
+// IN: [v1, v0]\l\
+// \l\
+// [v0, v1, v0]\l\
+// add\l\
+// [v0, v2]\l\
+// \l\
+// [v0, v2]\l\
+// sub\l\
+// [v3]\l\
+// \l\
+// OUT: [v3]\l\
+// "];
+// Block1_0Exit [label="FunctionReturn[v3]"];
+// Block1_0 -> Block1_0Exit;
+// FunctionEntry_g_0 [label="function g:
+//  g()"];
+// FunctionEntry_g_0 -> Block2_0;
+// Block2_0 [label="\
+// IN: []\l\
+// \l\
+// [lit0, lit1]\l\
+// sstore\l\
+// []\l\
+// \l\
+// OUT: []\l\
+// "];
+// Block2_0Exit [label="FunctionReturn[]"];
+// Block2_0 -> Block2_0Exit;
+// FunctionEntry_h_0 [label="function h:
+//  h(v0)"];
+// FunctionEntry_h_0 -> Block3_0;
+// Block3_0 [label="\
+// IN: [v0]\l\
+// \l\
+// [v0, FunctionCallReturnLabel[0], lit0, v0]\l\
+// f\l\
+// [v0, FunctionCallReturnLabel[0], v1]\l\
+// \l\
+// [JUNK, v1]\l\
+// h\l\
+// [JUNK]\l\
+// \l\
+// OUT: [JUNK]\l\
+// "];
+// Block3_0Exit [label="Terminated"];
+// Block3_0 -> Block3_0Exit;
+// FunctionEntry_i_0 [label="function i:
+//  v, w := i()"];
+// FunctionEntry_i_0 -> Block4_0;
+// Block4_0 [label="\
+// IN: []\l\
+// \l\
+// OUT: []\l\
+// "];
+// Block4_0Exit [label="FunctionReturn[0x0202, 0x0303]"];
+// Block4_0 -> Block4_0Exit;
+// }

--- a/test/libyul/ssa/stackLayoutGenerator/multi_return.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/multi_return.yul
@@ -1,0 +1,59 @@
+{
+    function pair(a) -> x, y {
+        x := add(a, 1)
+        y := add(a, 2)
+    }
+    let p, q := pair(42)
+    let r, s := pair(p)
+    sstore(q, add(r, s))
+}
+// ----
+// digraph SSACFG {
+// nodesep=0.7;
+// graph[fontname="DejaVu Sans", rankdir=LR]
+// node[shape=box,fontname="DejaVu Sans"];
+//
+// Entry [label="Entry"];
+// Entry -> Block0_0;
+// Block0_0 [label="\
+// IN: []\l\
+// \l\
+// [FunctionCallReturnLabel[0], lit0]\l\
+// pair\l\
+// [FunctionCallReturnLabel[0], v0, v1]\l\
+// \l\
+// [v0, v1, FunctionCallReturnLabel[1], v0]\l\
+// pair\l\
+// [v0, v1, FunctionCallReturnLabel[1], v2, v3]\l\
+// \l\
+// [JUNK, v1, v2, v3, v2]\l\
+// add\l\
+// [JUNK, v1, v2, v4]\l\
+// \l\
+// [JUNK, v1, JUNK, v4, v1]\l\
+// sstore\l\
+// [JUNK, v1, JUNK]\l\
+// \l\
+// OUT: [JUNK, v1, JUNK]\l\
+// "];
+// Block0_0Exit [label="MainExit"];
+// Block0_0 -> Block0_0Exit;
+// FunctionEntry_pair_0 [label="function pair:
+//  x, y := pair(v0)"];
+// FunctionEntry_pair_0 -> Block1_0;
+// Block1_0 [label="\
+// IN: [v0]\l\
+// \l\
+// [v0, lit1, v0]\l\
+// add\l\
+// [v0, v1]\l\
+// \l\
+// [v1, lit2, v0]\l\
+// add\l\
+// [v1, v2]\l\
+// \l\
+// OUT: [v1, v2]\l\
+// "];
+// Block1_0Exit [label="FunctionReturn[v1, v2]"];
+// Block1_0 -> Block1_0Exit;
+// }

--- a/test/libyul/ssa/stackLayoutGenerator/nested_for.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/nested_for.yul
@@ -1,0 +1,119 @@
+{
+    let s
+    for {let i := 0} lt(i, 10) {i := add(i, 1)} {
+        for {let j := 0} lt(j, 10) {j := add(j, 1)} {
+            s := add(s, mul(i, j))
+        }
+    }
+    mstore(0, s)
+}
+// ----
+// digraph SSACFG {
+// nodesep=0.7;
+// graph[fontname="DejaVu Sans", rankdir=LR]
+// node[shape=box,fontname="DejaVu Sans"];
+//
+// Entry [label="Entry"];
+// Entry -> Block0_0;
+// Block0_0 [label="\
+// IN: []\l\
+// \l\
+// OUT: []\l\
+// "];
+// Block0_0 -> Block0_0Exit [arrowhead=none];
+// Block0_0Exit [label="Jump" shape=oval];
+// Block0_0Exit -> Block0_1 [style="solid"];
+// Block0_1 [label="\
+// IN: [phi0, phi4]\l\
+// \l\
+// [phi0, phi4, lit1, phi0]\l\
+// lt\l\
+// [phi0, phi4, v0]\l\
+// \l\
+// OUT: [phi0, phi4, v0]\l\
+// "];
+// Block0_1 -> Block0_1Exit;
+// Block0_1Exit [label="{ If v0 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_1Exit:0 -> Block0_4 [style="solid"];
+// Block0_1Exit:1 -> Block0_2 [style="solid"];
+// Block0_2 [label="\
+// IN: [phi0, phi4]\l\
+// \l\
+// OUT: [phi0, phi4]\l\
+// "];
+// Block0_2 -> Block0_2Exit [arrowhead=none];
+// Block0_2Exit [label="Jump" shape=oval];
+// Block0_2Exit -> Block0_5 [style="solid"];
+// Block0_4 [label="\
+// IN: [JUNK, phi4]\l\
+// \l\
+// [JUNK, phi4, lit0]\l\
+// mstore\l\
+// [JUNK]\l\
+// \l\
+// OUT: [JUNK]\l\
+// "];
+// Block0_4Exit [label="MainExit"];
+// Block0_4 -> Block0_4Exit;
+// Block0_5 [label="\
+// IN: [phi0, JUNK, phi1, phi3]\l\
+// \l\
+// [phi0, JUNK, phi1, phi3, lit1, phi1]\l\
+// lt\l\
+// [phi0, JUNK, phi1, phi3, v1]\l\
+// \l\
+// OUT: [phi0, JUNK, phi1, phi3, v1]\l\
+// "];
+// Block0_5 -> Block0_5Exit;
+// Block0_5Exit [label="{ If v1 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_5Exit:0 -> Block0_8 [style="solid"];
+// Block0_5Exit:1 -> Block0_6 [style="solid"];
+// Block0_6 [label="\
+// IN: [phi0, JUNK, phi1, phi3]\l\
+// \l\
+// [phi0, JUNK, phi1, phi3, phi1, phi0]\l\
+// mul\l\
+// [phi0, JUNK, phi1, phi3, v2]\l\
+// \l\
+// [phi0, JUNK, phi1, v2, phi3]\l\
+// add\l\
+// [phi0, JUNK, phi1, v3]\l\
+// \l\
+// OUT: [phi0, JUNK, phi1, v3]\l\
+// "];
+// Block0_6 -> Block0_6Exit [arrowhead=none];
+// Block0_6Exit [label="Jump" shape=oval];
+// Block0_6Exit -> Block0_7 [style="solid"];
+// Block0_8 [label="\
+// IN: [phi0, JUNK, JUNK, phi3]\l\
+// \l\
+// OUT: [phi0, JUNK, JUNK, phi3]\l\
+// "];
+// Block0_8 -> Block0_8Exit [arrowhead=none];
+// Block0_8Exit [label="Jump" shape=oval];
+// Block0_8Exit -> Block0_3 [style="solid"];
+// Block0_7 [label="\
+// IN: [phi0, JUNK, phi1, v3]\l\
+// \l\
+// [phi0, JUNK, v3, lit2, phi1]\l\
+// add\l\
+// [phi0, JUNK, v3, v4]\l\
+// \l\
+// OUT: [phi0, JUNK, v3, v4]\l\
+// "];
+// Block0_7 -> Block0_7Exit [arrowhead=none];
+// Block0_7Exit [label="Jump" shape=oval];
+// Block0_7Exit -> Block0_5 [style="solid"];
+// Block0_3 [label="\
+// IN: [phi0, JUNK, JUNK, phi3]\l\
+// \l\
+// [phi3, JUNK, JUNK, lit2, phi0]\l\
+// add\l\
+// [phi3, JUNK, JUNK, v5]\l\
+// \l\
+// OUT: [phi3, JUNK, JUNK, v5]\l\
+// "];
+// Block0_3 -> Block0_3Exit [arrowhead=none];
+// Block0_3Exit [label="Jump" shape=oval];
+// Block0_3Exit -> Block0_1 [style="solid"];
+// }

--- a/test/libyul/ssa/stackLayoutGenerator/recursion.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/recursion.yul
@@ -1,0 +1,71 @@
+{
+    function sum(n) -> s {
+        if n {
+            s := add(n, sum(sub(n, 1)))
+        }
+    }
+    mstore(0, sum(10))
+}
+// ----
+// digraph SSACFG {
+// nodesep=0.7;
+// graph[fontname="DejaVu Sans", rankdir=LR]
+// node[shape=box,fontname="DejaVu Sans"];
+//
+// Entry [label="Entry"];
+// Entry -> Block0_0;
+// Block0_0 [label="\
+// IN: []\l\
+// \l\
+// [FunctionCallReturnLabel[0], lit0]\l\
+// sum\l\
+// [FunctionCallReturnLabel[0], v0]\l\
+// \l\
+// [v0, lit1]\l\
+// mstore\l\
+// []\l\
+// \l\
+// OUT: []\l\
+// "];
+// Block0_0Exit [label="MainExit"];
+// Block0_0 -> Block0_0Exit;
+// FunctionEntry_sum_0 [label="function sum:
+//  s := sum(v0)"];
+// FunctionEntry_sum_0 -> Block1_0;
+// Block1_0 [label="\
+// IN: [v0]\l\
+// \l\
+// OUT: [v0, v0]\l\
+// "];
+// Block1_0 -> Block1_0Exit;
+// Block1_0Exit [label="{ If v0 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_0Exit:0 -> Block1_2 [style="solid"];
+// Block1_0Exit:1 -> Block1_1 [style="solid"];
+// Block1_1 [label="\
+// IN: [v0]\l\
+// \l\
+// [v0, lit1, v0]\l\
+// sub\l\
+// [v0, v1]\l\
+// \l\
+// [v0, FunctionCallReturnLabel[0], v1]\l\
+// sum\l\
+// [v0, FunctionCallReturnLabel[0], v2]\l\
+// \l\
+// [v2, v0]\l\
+// add\l\
+// [v3]\l\
+// \l\
+// OUT: [v3]\l\
+// "];
+// Block1_1 -> Block1_1Exit [arrowhead=none];
+// Block1_1Exit [label="Jump" shape=oval];
+// Block1_1Exit -> Block1_2 [style="solid"];
+// Block1_2 [label="\
+// IN: [JUNK, phi0]\l\
+// \l\
+// OUT: [JUNK, phi0]\l\
+// "];
+// Block1_2Exit [label="FunctionReturn[phi0]"];
+// Block1_2 -> Block1_2Exit;
+// }

--- a/test/libyul/ssa/stackLayoutGenerator/simple_for.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/simple_for.yul
@@ -1,0 +1,100 @@
+{
+    let x
+    for {let i := 0} x {i := add(i, 1)} {
+        if mload(i) {
+            x := add(x, i)
+            x := add(x, mload(32))
+        }
+    }
+    mstore(x, 33)
+}
+// ----
+// digraph SSACFG {
+// nodesep=0.7;
+// graph[fontname="DejaVu Sans", rankdir=LR]
+// node[shape=box,fontname="DejaVu Sans"];
+//
+// Entry [label="Entry"];
+// Entry -> Block0_0;
+// Block0_0 [label="\
+// IN: []\l\
+// \l\
+// OUT: []\l\
+// "];
+// Block0_0 -> Block0_0Exit [arrowhead=none];
+// Block0_0Exit [label="Jump" shape=oval];
+// Block0_0Exit -> Block0_1 [style="solid"];
+// Block0_1 [label="\
+// IN: [phi0, phi1]\l\
+// \l\
+// OUT: [phi0, phi1, phi0]\l\
+// "];
+// Block0_1 -> Block0_1Exit;
+// Block0_1Exit [label="{ If phi0 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_1Exit:0 -> Block0_4 [style="solid"];
+// Block0_1Exit:1 -> Block0_2 [style="solid"];
+// Block0_2 [label="\
+// IN: [phi0, phi1]\l\
+// \l\
+// [phi0, phi1, phi1]\l\
+// mload\l\
+// [phi0, phi1, v0]\l\
+// \l\
+// OUT: [phi0, phi1, v0]\l\
+// "];
+// Block0_2 -> Block0_2Exit;
+// Block0_2Exit [label="{ If v0 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_2Exit:0 -> Block0_6 [style="solid"];
+// Block0_2Exit:1 -> Block0_5 [style="solid"];
+// Block0_4 [label="\
+// IN: [phi0, JUNK]\l\
+// \l\
+// [phi0, JUNK, lit3, phi0]\l\
+// mstore\l\
+// [phi0, JUNK]\l\
+// \l\
+// OUT: [phi0, JUNK]\l\
+// "];
+// Block0_4Exit [label="MainExit"];
+// Block0_4 -> Block0_4Exit;
+// Block0_5 [label="\
+// IN: [phi0, phi1]\l\
+// \l\
+// [phi1, phi1, phi0]\l\
+// add\l\
+// [phi1, v1]\l\
+// \l\
+// [phi1, v1, lit1]\l\
+// mload\l\
+// [phi1, v1, v2]\l\
+// \l\
+// [phi1, v2, v1]\l\
+// add\l\
+// [phi1, v3]\l\
+// \l\
+// OUT: [phi1, v3]\l\
+// "];
+// Block0_5 -> Block0_5Exit [arrowhead=none];
+// Block0_5Exit [label="Jump" shape=oval];
+// Block0_5Exit -> Block0_6 [style="solid"];
+// Block0_6 [label="\
+// IN: [phi3, phi1]\l\
+// \l\
+// OUT: [phi3, phi1]\l\
+// "];
+// Block0_6 -> Block0_6Exit [arrowhead=none];
+// Block0_6Exit [label="Jump" shape=oval];
+// Block0_6Exit -> Block0_3 [style="solid"];
+// Block0_3 [label="\
+// IN: [phi3, phi1]\l\
+// \l\
+// [phi3, lit2, phi1]\l\
+// add\l\
+// [phi3, v4]\l\
+// \l\
+// OUT: [phi3, v4]\l\
+// "];
+// Block0_3 -> Block0_3Exit [arrowhead=none];
+// Block0_3Exit [label="Jump" shape=oval];
+// Block0_3Exit -> Block0_1 [style="solid"];
+// }

--- a/test/libyul/ssa/stackLayoutGenerator/simple_if.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/simple_if.yul
@@ -1,0 +1,76 @@
+{
+    function f(a, b) -> c {
+        if mload(a) {
+            a := add(a, 2)
+            revert(a, a)
+        }
+        c := add(a, b)
+    }
+    mstore(42, f(0, 1))
+}
+// ----
+// digraph SSACFG {
+// nodesep=0.7;
+// graph[fontname="DejaVu Sans", rankdir=LR]
+// node[shape=box,fontname="DejaVu Sans"];
+//
+// Entry [label="Entry"];
+// Entry -> Block0_0;
+// Block0_0 [label="\
+// IN: []\l\
+// \l\
+// [FunctionCallReturnLabel[0], lit0, lit1]\l\
+// f\l\
+// [FunctionCallReturnLabel[0], v0]\l\
+// \l\
+// [v0, lit2]\l\
+// mstore\l\
+// []\l\
+// \l\
+// OUT: []\l\
+// "];
+// Block0_0Exit [label="MainExit"];
+// Block0_0 -> Block0_0Exit;
+// FunctionEntry_f_0 [label="function f:
+//  c := f(v0, v1)"];
+// FunctionEntry_f_0 -> Block1_0;
+// Block1_0 [label="\
+// IN: [v1, v0]\l\
+// \l\
+// [v1, v0, v0]\l\
+// mload\l\
+// [v1, v0, v2]\l\
+// \l\
+// OUT: [v1, v0, v2]\l\
+// "];
+// Block1_0 -> Block1_0Exit;
+// Block1_0Exit [label="{ If v2 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_0Exit:0 -> Block1_2 [style="solid"];
+// Block1_0Exit:1 -> Block1_1 [style="solid"];
+// Block1_1 [label="\
+// IN: [v1, v0]\l\
+// \l\
+// [JUNK, v0, lit1, v0]\l\
+// add\l\
+// [JUNK, v0, v3]\l\
+// \l\
+// [JUNK, JUNK, v3, v3]\l\
+// revert\l\
+// [JUNK, JUNK]\l\
+// \l\
+// OUT: [JUNK, JUNK]\l\
+// "];
+// Block1_1Exit [label="Terminated"];
+// Block1_1 -> Block1_1Exit;
+// Block1_2 [label="\
+// IN: [v1, v0]\l\
+// \l\
+// [v1, v0]\l\
+// add\l\
+// [v4]\l\
+// \l\
+// OUT: [v4]\l\
+// "];
+// Block1_2Exit [label="FunctionReturn[v4]"];
+// Block1_2 -> Block1_2Exit;
+// }

--- a/test/libyul/ssa/stackLayoutGenerator/switch.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/switch.yul
@@ -1,0 +1,95 @@
+{
+    let x := 0x0101
+    let y := 0x0202
+    let z := 0x0303
+    switch sload(x)
+    case 0 {
+        x := 0x42
+    }
+    case 1 {
+        y := 0x42
+    }
+    default {
+        sstore(z, z)
+    }
+
+    sstore(0x0404, y)
+}
+// ----
+// digraph SSACFG {
+// nodesep=0.7;
+// graph[fontname="DejaVu Sans", rankdir=LR]
+// node[shape=box,fontname="DejaVu Sans"];
+//
+// Entry [label="Entry"];
+// Entry -> Block0_0;
+// Block0_0 [label="\
+// IN: []\l\
+// \l\
+// [lit0]\l\
+// sload\l\
+// [v0]\l\
+// \l\
+// [v0, lit3, v0]\l\
+// eq\l\
+// [v0, v1]\l\
+// \l\
+// OUT: [v0, v1]\l\
+// "];
+// Block0_0 -> Block0_0Exit;
+// Block0_0Exit [label="{ If v1 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_0Exit:0 -> Block0_3 [style="solid"];
+// Block0_0Exit:1 -> Block0_2 [style="solid"];
+// Block0_2 [label="\
+// IN: [v0]\l\
+// \l\
+// OUT: [v0]\l\
+// "];
+// Block0_2 -> Block0_2Exit [arrowhead=none];
+// Block0_2Exit [label="Jump" shape=oval];
+// Block0_2Exit -> Block0_1 [style="solid"];
+// Block0_3 [label="\
+// IN: [v0]\l\
+// \l\
+// [lit5, v0]\l\
+// eq\l\
+// [v2]\l\
+// \l\
+// OUT: [v2]\l\
+// "];
+// Block0_3 -> Block0_3Exit;
+// Block0_3Exit [label="{ If v2 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block0_3Exit:0 -> Block0_5 [style="solid"];
+// Block0_3Exit:1 -> Block0_4 [style="solid"];
+// Block0_1 [label="\
+// IN: [JUNK, phi0]\l\
+// \l\
+// [JUNK, phi0, lit6]\l\
+// sstore\l\
+// [JUNK]\l\
+// \l\
+// OUT: [JUNK]\l\
+// "];
+// Block0_1Exit [label="MainExit"];
+// Block0_1 -> Block0_1Exit;
+// Block0_4 [label="\
+// IN: []\l\
+// \l\
+// OUT: []\l\
+// "];
+// Block0_4 -> Block0_4Exit [arrowhead=none];
+// Block0_4Exit [label="Jump" shape=oval];
+// Block0_4Exit -> Block0_1 [style="solid"];
+// Block0_5 [label="\
+// IN: []\l\
+// \l\
+// [lit2, lit2]\l\
+// sstore\l\
+// []\l\
+// \l\
+// OUT: []\l\
+// "];
+// Block0_5 -> Block0_5Exit [arrowhead=none];
+// Block0_5Exit [label="Jump" shape=oval];
+// Block0_5Exit -> Block0_1 [style="solid"];
+// }

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -53,6 +53,8 @@ add_executable(isoltest
 	../libyul/YulOptimizerTest.cpp
 	../libyul/YulOptimizerTestCommon.cpp
 	../libyul/YulInterpreterTest.cpp
+	../libyul/ssa/StackLayoutGeneratorTest.cpp
+	../libyul/ssa/StackLayoutGeneratorTest.h
 	../libyul/ssa/StackShufflerTest.cpp
 	../libyul/ssa/StackShufflerTest.h
 )


### PR DESCRIPTION
Adds a stack layout generator that operates directly on SSA-form control flow graphs, computing concrete EVM stack layouts for each basic block.

The generator traverses the CFG in topological order (Kahn's algorithm, ignoring back edges) so that when a block is visited, its predecessors' exit layouts are already known.

For each block, the layout is determined in two phases:

1. Entry layout (`defineStackIn`)
  - Single-predecessor blocks inherit the parent's exit layout directly, applying phi-function resolution via `PhiInverse` (which maps phi values back to their incoming preimages from the respective predecessor).
  - Multi-predecessor blocks (merge points) select the cheapest entry layout among all parents by simulating shuffles from each candidate to every other parent's exit. The candidate with the lowest cumulative shuffle cost wins.
2. Block body (`visitBlock`)
  - For each operation, dead values on the stack are declared as junk (reclaimable/wildcard slots), then the `StackShuffler` arranges the stack so that the operation's inputs are on top.
  - `findOptimalTargetSize` searches for the target stack height that minimizes shuffle cost, scanning downward from a pivot (and upward on junk-admitting/reverting paths where growing the stack is free).
  - Conditional jumps explicitly define both successor entry layouts, consuming the condition slot for the nonzero branch and applying phi resolution for the zero branch.

The PR also adds tests that output generated stack layouts in dot format. Can be invoked through `isoltest -t ssa/stackLayoutGenerator/*`. Setting environment variables
- `ISOLTEST_DISPLAY_GRAPHS_FAILURE=xdot - ` for failed tests and
- `ISOLTEST_DISPLAY_GRAPHS_SUCCESS=xdot - ` for successfully executed tests will interactively launch the selected (in this case `xdot`) dot display upon invoking `isoltest`.
