### PR TITLE
Do not remove custom errors in IR codegen when strip revert strings is requested

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -19,6 +19,7 @@ Compiler Features:
 Bugfixes:
 * Yul: Fix incorrect serialization of Yul object names containing double quotes and escape sequences, producing output that could not be parsed as valid Yul.
 * Yul EVM Code Transform: Improve stack shuffler performance by fixing a BFS deduplication issue.
+* Yul IR Code Generation: Preserve custom error argument of `require` when stripping of revert strings is selected via `--revert-strings strip`.
 
 
 ### 0.8.34 (2026-02-18)

--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -378,7 +378,8 @@ Input Description
           // How to treat revert (and require) reason strings. Settings are
           // "default", "strip", "debug" and "verboseDebug".
           // "default" does not inject compiler-generated revert strings and keeps user-supplied ones.
-          // "strip" removes all revert strings (if possible, i.e. if literals are used) keeping side-effects
+          // "strip" removes all revert strings (if possible, i.e. if literals are used) keeping side-effects.
+          // NOTE: "strip" does not remove custom errors.
           // "debug" injects strings for compiler-generated internal reverts, implemented for ABI encoders V1 and V2 for now.
           // "verboseDebug" even appends further information to user-supplied revert strings (not yet implemented)
           "revertStrings": "default",

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1158,10 +1158,7 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		solAssert(arguments.size() > 0, "Expected at least one parameter for require/assert");
 		solAssert(arguments.size() <= 2, "Expected no more than two parameters for require/assert");
 
-		Type const* messageArgumentType =
-			arguments.size() > 1 && m_context.revertStrings() != RevertStrings::Strip ?
-			arguments[1]->annotation().type :
-			nullptr;
+		Type const* messageArgumentType = arguments.size() == 2 ? arguments[1]->annotation().type : nullptr;
 
 		auto const* magicType = dynamic_cast<MagicType const*>(messageArgumentType);
 		if (magicType && magicType->kind() == MagicType::Kind::Error)
@@ -1175,6 +1172,9 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 		}
 		else
 		{
+			// This option only removes strings, not custom errors
+			if (m_context.revertStrings() == RevertStrings::Strip)
+				messageArgumentType = nullptr;
 			ASTPointer<Expression const> stringArgumentExpression = messageArgumentType ? arguments[1] : nullptr;
 			std::string requireOrAssertFunction = m_utils.requireOrAssertFunction(
 				functionType->kind() == FunctionType::Kind::Assert,

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -648,7 +648,8 @@ General Information)").c_str(),
 		(
 			g_strRevertStrings.c_str(),
 			po::value<std::string>()->value_name(util::joinHumanReadable(g_revertStringsArgs, ",")),
-			"Strip revert (and require) reason strings or add additional debugging information."
+			"Strip revert (and require) reason strings or add additional debugging information. "
+			"Note that 'strip' does not remove custom errors."
 		)
 		(
 			g_strDebugInfo.c_str(),

--- a/test/cmdlineTests/revert_strings_strip_legacy_require_custom_error/args
+++ b/test/cmdlineTests/revert_strings_strip_legacy_require_custom_error/args
@@ -1,0 +1,1 @@
+--revert-strings strip --debug-info none --asm --optimize

--- a/test/cmdlineTests/revert_strings_strip_legacy_require_custom_error/input.sol
+++ b/test/cmdlineTests/revert_strings_strip_legacy_require_custom_error/input.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+contract C {
+    error MyError(uint errorCode, string errorMsg, bool flag);
+    function flag() pure public returns (bool) { return false; }
+    function f() pure external {
+        uint code = 8;
+        string memory eMsg = "error";
+        require(false, MyError(code, eMsg, flag()));
+    }
+}

--- a/test/cmdlineTests/revert_strings_strip_legacy_require_custom_error/output
+++ b/test/cmdlineTests/revert_strings_strip_legacy_require_custom_error/output
@@ -1,0 +1,173 @@
+
+======= input.sol:C =======
+EVM assembly:
+  mstore(0x40, 0x80)
+  callvalue
+  dup1
+  iszero
+  tag_1
+  jumpi
+  revert(0x00, 0x00)
+tag_1:
+  pop
+  dataSize(sub_0)
+  dup1
+  dataOffset(sub_0)
+  0x00
+  codecopy
+  0x00
+  return
+stop
+
+sub_0: assembly {
+      mstore(0x40, 0x80)
+      callvalue
+      dup1
+      iszero
+      tag_1
+      jumpi
+      revert(0x00, 0x00)
+    tag_1:
+      pop
+      jumpi(tag_2, lt(calldatasize, 0x04))
+      shr(0xe0, calldataload(0x00))
+      dup1
+      0x26121ff0
+      eq
+      tag_3
+      jumpi
+      dup1
+      0x890eba68
+      eq
+      tag_4
+      jumpi
+    tag_2:
+      revert(0x00, 0x00)
+    tag_3:
+      tag_5
+      tag_6
+      jump	// in
+    tag_5:
+      stop
+    tag_4:
+      0x40
+      dup1
+      mload
+      0x00
+      dup2
+      mstore
+      swap1
+      mload
+      swap1
+      dup2
+      swap1
+      sub
+      0x20
+      add
+      swap1
+      return
+    tag_6:
+      0x40
+      dup1
+      mload
+      dup1
+      dup3
+      add
+      swap1
+      swap2
+      mstore
+      0x05
+      dup2
+      mstore
+      shl(0xd9, 0x32b93937b9)
+      0x20
+      dup3
+      add
+      mstore
+      0x08
+      swap1
+      dup2
+      dup2
+      0x00
+      mload(0x40)
+      shl(0xe5, 0x01676c8b)
+      dup2
+      mstore
+      0x04
+      add
+      tag_14
+      swap4
+      swap3
+      swap2
+      swap1
+      tag_15
+      jump	// in
+    tag_14:
+      mload(0x40)
+      dup1
+      swap2
+      sub
+      swap1
+      revert
+    tag_15:
+      dup4
+      dup2
+      mstore
+      0x60
+      0x20
+      dup3
+      add
+      mstore
+      0x00
+      dup4
+      mload
+      dup1
+      0x60
+      dup5
+      add
+      mstore
+      dup1
+      0x20
+      dup7
+      add
+      0x80
+      dup6
+      add
+      mcopy
+      0x00
+      0x80
+      dup3
+      dup6
+      add
+      add
+      mstore
+      0x80
+      0x1f
+      not
+      0x1f
+      dup4
+      add
+      and
+      dup5
+      add
+      add
+      swap2
+      pop
+      pop
+      dup3
+      iszero
+      iszero
+      0x40
+      dup4
+      add
+      mstore
+      swap5
+      swap4
+      pop
+      pop
+      pop
+      pop
+      jump	// out
+
+    auxdata: <AUXDATA REMOVED>
+}

--- a/test/cmdlineTests/revert_strings_strip_legacy_require_custom_error_constructor_param_side_effect/args
+++ b/test/cmdlineTests/revert_strings_strip_legacy_require_custom_error_constructor_param_side_effect/args
@@ -1,0 +1,1 @@
+--revert-strings strip --debug-info none --asm --optimize

--- a/test/cmdlineTests/revert_strings_strip_legacy_require_custom_error_constructor_param_side_effect/input.sol
+++ b/test/cmdlineTests/revert_strings_strip_legacy_require_custom_error_constructor_param_side_effect/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+contract C {
+    error MyError(uint errorCode, string errorMsg);
+    uint public counter = 0;
+    function count() public returns (uint) { return ++counter; }
+    function f() external {
+        string memory eMsg = "error";
+        require(false, MyError(count(), eMsg));
+        counter += 2;
+    }
+}

--- a/test/cmdlineTests/revert_strings_strip_legacy_require_custom_error_constructor_param_side_effect/output
+++ b/test/cmdlineTests/revert_strings_strip_legacy_require_custom_error_constructor_param_side_effect/output
@@ -1,0 +1,271 @@
+
+======= input.sol:C =======
+EVM assembly:
+  mstore(0x40, 0x80)
+  0x00
+  0x00
+  sstore
+  callvalue
+  dup1
+  iszero
+  tag_1
+  jumpi
+  revert(0x00, 0x00)
+tag_1:
+  pop
+  dataSize(sub_0)
+  dup1
+  dataOffset(sub_0)
+  0x00
+  codecopy
+  0x00
+  return
+stop
+
+sub_0: assembly {
+      mstore(0x40, 0x80)
+      callvalue
+      dup1
+      iszero
+      tag_1
+      jumpi
+      revert(0x00, 0x00)
+    tag_1:
+      pop
+      jumpi(tag_2, lt(calldatasize, 0x04))
+      shr(0xe0, calldataload(0x00))
+      dup1
+      0x06661abd
+      eq
+      tag_3
+      jumpi
+      dup1
+      0x26121ff0
+      eq
+      tag_4
+      jumpi
+      dup1
+      0x61bc221a
+      eq
+      tag_5
+      jumpi
+    tag_2:
+      revert(0x00, 0x00)
+    tag_3:
+      tag_6
+      tag_7
+      jump	// in
+    tag_6:
+      mload(0x40)
+      swap1
+      dup2
+      mstore
+      0x20
+      add
+      mload(0x40)
+      dup1
+      swap2
+      sub
+      swap1
+      return
+    tag_4:
+      tag_10
+      tag_11
+      jump	// in
+    tag_10:
+      stop
+    tag_5:
+      tag_6
+      sload(0x00)
+      dup2
+      jump
+    tag_7:
+      0x00
+      0x00
+      0x00
+      dup2
+      sload
+      tag_16
+      swap1
+      tag_17
+      jump	// in
+    tag_16:
+      swap2
+      dup3
+      swap1
+      sstore
+      pop
+      swap2
+      swap1
+      pop
+      jump	// out
+    tag_11:
+      0x40
+      dup1
+      mload
+      dup1
+      dup3
+      add
+      swap1
+      swap2
+      mstore
+      0x05
+      dup2
+      mstore
+      shl(0xd9, 0x32b93937b9)
+      0x20
+      dup3
+      add
+      mstore
+      0x00
+      tag_19
+      tag_7
+      jump	// in
+    tag_19:
+      dup3
+      swap1
+      swap2
+      tag_20
+      jumpi
+      mload(0x40)
+      shl(0xe1, 0x05c9a271)
+      dup2
+      mstore
+      0x04
+      add
+      tag_21
+      swap3
+      swap2
+      swap1
+      tag_22
+      jump	// in
+    tag_21:
+      mload(0x40)
+      dup1
+      swap2
+      sub
+      swap1
+      revert
+    tag_20:
+      pop
+      pop
+      0x02
+      0x00
+      0x00
+      dup3
+      dup3
+      sload
+      tag_23
+      swap2
+      swap1
+      tag_24
+      jump	// in
+    tag_23:
+      swap1
+      swap2
+      sstore
+      pop
+      pop
+      pop
+      jump	// out
+    tag_25:
+      0x4e487b71
+      0xe0
+      shl
+      0x00
+      mstore
+      0x11
+      0x04
+      mstore
+      0x24
+      0x00
+      revert
+    tag_17:
+      0x00
+      0x01
+      dup3
+      add
+      tag_31
+      jumpi
+      tag_31
+      tag_25
+      jump	// in
+    tag_31:
+      pop
+      0x01
+      add
+      swap1
+      jump	// out
+    tag_22:
+      dup3
+      dup2
+      mstore
+      0x40
+      0x20
+      dup3
+      add
+      mstore
+      0x00
+      dup3
+      mload
+      dup1
+      0x40
+      dup5
+      add
+      mstore
+      dup1
+      0x20
+      dup6
+      add
+      0x60
+      dup6
+      add
+      mcopy
+      0x00
+      0x60
+      dup3
+      dup6
+      add
+      add
+      mstore
+      0x60
+      0x1f
+      not
+      0x1f
+      dup4
+      add
+      and
+      dup5
+      add
+      add
+      swap2
+      pop
+      pop
+      swap4
+      swap3
+      pop
+      pop
+      pop
+      jump	// out
+    tag_24:
+      dup1
+      dup3
+      add
+      dup1
+      dup3
+      gt
+      iszero
+      tag_35
+      jumpi
+      tag_35
+      tag_25
+      jump	// in
+    tag_35:
+      swap3
+      swap2
+      pop
+      pop
+      jump	// out
+
+    auxdata: <AUXDATA REMOVED>
+}

--- a/test/cmdlineTests/revert_strings_strip_via_ir_require_custom_error/args
+++ b/test/cmdlineTests/revert_strings_strip_via_ir_require_custom_error/args
@@ -1,0 +1,1 @@
+--revert-strings strip --debug-info none --asm --optimize --via-ir

--- a/test/cmdlineTests/revert_strings_strip_via_ir_require_custom_error/input.sol
+++ b/test/cmdlineTests/revert_strings_strip_via_ir_require_custom_error/input.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+contract C {
+    error MyError(uint errorCode, string errorMsg, bool flag);
+    function flag() pure public returns (bool) { return false; }
+    function f() pure external {
+        uint code = 8;
+        string memory eMsg = "error";
+        require(false, MyError(code, eMsg, flag()));
+    }
+}

--- a/test/cmdlineTests/revert_strings_strip_via_ir_require_custom_error/output
+++ b/test/cmdlineTests/revert_strings_strip_via_ir_require_custom_error/output
@@ -1,0 +1,146 @@
+
+======= input.sol:C =======
+EVM assembly:
+  0x80
+  dup1
+  0x40
+  mstore
+  jumpi(tag_1, callvalue)
+  dataSize(sub_0)
+  swap1
+  dup2
+  dataOffset(sub_0)
+  dup3
+  codecopy
+  return
+tag_1:
+  0x00
+  dup1
+  revert
+stop
+
+sub_0: assembly {
+      0x80
+      dup1
+      0x40
+      mstore
+      jumpi(tag_1, iszero(lt(calldatasize, 0x04)))
+      0x00
+      dup1
+      revert
+    tag_1:
+      shr(0xe0, calldataload(0x00))
+      swap1
+      dup2
+      0x26121ff0
+      eq
+      tag_3
+      jumpi
+      pop
+      0x890eba68
+      eq
+      tag_5
+      jumpi
+      0x00
+      dup1
+      revert
+    tag_5:
+      jumpi(tag_9, callvalue)
+      jumpi(tag_9, slt(add(not(0x03), calldatasize), 0x00))
+      0x20
+      mload(0x40)
+      0x00
+      dup2
+      mstore
+      return
+    tag_9:
+      0x00
+      dup1
+      revert
+    tag_3:
+      jumpi(tag_9, callvalue)
+      jumpi(tag_9, slt(add(not(0x03), calldatasize), 0x00))
+      0x40
+      dup2
+      add
+      dup2
+      dup2
+      lt
+      0xffffffffffffffff
+      dup3
+      gt
+      or
+      tag_15
+      jumpi
+      0x40
+      mstore
+      0x05
+      dup2
+      mstore
+      0x84
+      0x20
+      dup3
+      add
+      swap2
+      shl(0xd9, 0x32b93937b9)
+      dup4
+      mstore
+      mload(0x40)
+      swap3
+      dup4
+      swap2
+      shl(0xe5, 0x01676c8b)
+      dup4
+      mstore
+      0x08
+      0x04
+      dup5
+      add
+      mstore
+      0x60
+      0x24
+      dup5
+      add
+      mstore
+      mload
+      dup1
+      swap2
+      dup2
+      0x64
+      dup6
+      add
+      mstore
+      dup5
+      dup5
+      add
+      mcopy
+      0x00
+      dup3
+      dup3
+      add
+      dup5
+      add
+      dup2
+      swap1
+      mstore
+      0x44
+      dup4
+      add
+      mstore
+      0x1f
+      add
+      not(0x1f)
+      and
+      dup2
+      add
+      sub
+      add
+      swap1
+      revert
+    tag_15:
+      mstore(0x00, shl(0xe0, 0x4e487b71))
+      mstore(0x04, 0x41)
+      revert(0x00, 0x24)
+
+    auxdata: <AUXDATA REMOVED>
+}

--- a/test/cmdlineTests/revert_strings_strip_via_ir_require_custom_error_constructor_param_side_effect/args
+++ b/test/cmdlineTests/revert_strings_strip_via_ir_require_custom_error_constructor_param_side_effect/args
@@ -1,0 +1,1 @@
+--revert-strings strip --debug-info none --asm --optimize --via-ir

--- a/test/cmdlineTests/revert_strings_strip_via_ir_require_custom_error_constructor_param_side_effect/input.sol
+++ b/test/cmdlineTests/revert_strings_strip_via_ir_require_custom_error_constructor_param_side_effect/input.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+contract C {
+    error MyError(uint errorCode, string errorMsg);
+    uint public counter = 0;
+    function genCode() public returns (uint) { return ++counter; }
+    function f() external {
+        string memory eMsg = "error";
+        require(false, MyError(genCode(), eMsg));
+        counter += 2;
+    }
+}

--- a/test/cmdlineTests/revert_strings_strip_via_ir_require_custom_error_constructor_param_side_effect/output
+++ b/test/cmdlineTests/revert_strings_strip_via_ir_require_custom_error_constructor_param_side_effect/output
@@ -1,0 +1,183 @@
+
+======= input.sol:C =======
+EVM assembly:
+  0x80
+  dup1
+  0x40
+  mstore
+  jumpi(tag_1, callvalue)
+  0x00
+  dup1
+  sstore
+  dataSize(sub_0)
+  swap1
+  dup2
+  dataOffset(sub_0)
+  dup3
+  codecopy
+  return
+tag_1:
+  0x00
+  dup1
+  revert
+stop
+
+sub_0: assembly {
+      0x80
+      dup1
+      0x40
+      mstore
+      jumpi(tag_2, iszero(lt(calldatasize, 0x04)))
+      0x00
+      dup1
+      revert
+    tag_2:
+      shr(0xe0, calldataload(0x00))
+      swap1
+      dup2
+      0x26121ff0
+      eq
+      tag_4
+      jumpi
+      pop
+      dup1
+      0x61bc221a
+      eq
+      tag_6
+      jumpi
+      0xaefa573d
+      eq
+      tag_8
+      jumpi
+      0x00
+      dup1
+      revert
+    tag_8:
+      jumpi(tag_12, callvalue)
+      jumpi(tag_12, slt(add(not(0x03), calldatasize), 0x00))
+      0x20
+      tag_14
+      tag_1
+      jump	// in
+    tag_14:
+      mload(0x40)
+      swap1
+      dup2
+      mstore
+      return
+    tag_12:
+      0x00
+      dup1
+      revert
+    tag_6:
+      jumpi(tag_12, callvalue)
+      jumpi(tag_12, slt(add(not(0x03), calldatasize), 0x00))
+      0x20
+      sload(0x00)
+      mload(0x40)
+      swap1
+      dup2
+      mstore
+      return
+    tag_4:
+      jumpi(tag_12, callvalue)
+      jumpi(tag_12, slt(add(not(0x03), calldatasize), 0x00))
+      0x40
+      dup2
+      add
+      dup2
+      dup2
+      lt
+      0xffffffffffffffff
+      dup3
+      gt
+      or
+      tag_23
+      jumpi
+      0x40
+      mstore
+      0x05
+      dup2
+      mstore
+      0x64
+      0x20
+      dup3
+      add
+      shl(0xd9, 0x32b93937b9)
+      dup2
+      mstore
+      tag_25
+      tag_1
+      jump	// in
+    tag_25:
+      swap1
+      mload(0x40)
+      swap4
+      dup5
+      swap3
+      shl(0xe1, 0x05c9a271)
+      dup5
+      mstore
+      0x04
+      dup5
+      add
+      mstore
+      0x40
+      0x24
+      dup5
+      add
+      mstore
+      mload
+      dup1
+      swap2
+      dup2
+      0x44
+      dup6
+      add
+      mstore
+      dup5
+      dup5
+      add
+      mcopy
+      0x00
+      dup3
+      dup3
+      add
+      dup5
+      add
+      mstore
+      0x1f
+      add
+      not(0x1f)
+      and
+      dup2
+      add
+      sub
+      add
+      swap1
+      revert
+    tag_23:
+      mstore(0x00, shl(0xe0, 0x4e487b71))
+      mstore(0x04, 0x41)
+      revert(0x00, 0x24)
+    tag_1:
+      sload(0x00)
+      not(0x00)
+      dup2
+      eq
+      tag_26
+      jumpi
+      0x01
+      add
+      dup1
+      0x00
+      sstore
+      swap1
+      jump	// out
+    tag_26:
+      mstore(0x00, shl(0xe0, 0x4e487b71))
+      mstore(0x04, 0x11)
+      revert(0x00, 0x24)
+
+    auxdata: <AUXDATA REMOVED>
+}

--- a/test/libsolidity/semanticTests/errors/require_custom_error_and_string_literal_revert_strings_strip.sol
+++ b/test/libsolidity/semanticTests/errors/require_custom_error_and_string_literal_revert_strings_strip.sol
@@ -1,0 +1,14 @@
+contract C {
+    error MyError(string message);
+    function customError() pure external {
+        require(false, MyError("Error"));
+    }
+    function stringLiteral() pure external {
+        require(false, "Error");
+    }
+}
+// ====
+// revertStrings: strip
+// ----
+// customError() -> FAILURE, hex"8b3d2d43", 0x20, 5, "Error"
+// stringLiteral() -> FAILURE

--- a/test/libsolidity/semanticTests/errors/require_custom_error_constructor_side_effect.sol
+++ b/test/libsolidity/semanticTests/errors/require_custom_error_constructor_side_effect.sol
@@ -1,0 +1,15 @@
+// The purpose of this test is to check that the side-effect of
+// the error parameter occurs, i.e, MyError is constructed with errorCode = 1
+// and also confirm the state is properly reverted
+contract C {
+    error MyError(uint errorCode);
+    uint public counter = 0;
+    function count() public returns (uint) { return ++counter; }
+    function f() external {
+        require(false, MyError(count()));
+        counter = 42;
+    }
+}
+// ----
+// f() -> FAILURE, hex"30b1b565", 1
+// counter() -> 0

--- a/test/libsolidity/semanticTests/errors/require_custom_error_constructor_side_effect_revert_strings_strip.sol
+++ b/test/libsolidity/semanticTests/errors/require_custom_error_constructor_side_effect_revert_strings_strip.sol
@@ -1,0 +1,17 @@
+// The purpose of this test is to check that the side-effect of
+// the error parameter occurs, i.e, MyError is constructed with errorCode = 1
+// and also confirm the state is properly reverted
+contract C {
+    error MyError(uint errorCode);
+    uint public counter = 0;
+    function count() public returns (uint) { return ++counter; }
+    function f() external {
+        require(false, MyError(count()));
+        counter = 42;
+    }
+}
+// ====
+// revertStrings: strip
+// ----
+// f() -> FAILURE, hex"30b1b565", 1
+// counter() -> 0

--- a/test/libsolidity/semanticTests/errors/require_custom_error_no_args_revert_strings_strip.sol
+++ b/test/libsolidity/semanticTests/errors/require_custom_error_no_args_revert_strings_strip.sol
@@ -1,0 +1,13 @@
+contract C {
+    error MyError();
+    function flag() pure public returns (bool) { return false; }
+    function f(int param) pure external returns (int) {
+        require(param % 2 == 0, MyError());
+        return param / 2;
+    }
+}
+// ====
+// revertStrings: strip
+// ----
+// f(int256): 3 -> FAILURE, hex"dd6c951c"
+// f(int256): 4 -> 2

--- a/test/libsolidity/semanticTests/errors/require_custom_error_revert_strings_strip.sol
+++ b/test/libsolidity/semanticTests/errors/require_custom_error_revert_strings_strip.sol
@@ -1,0 +1,14 @@
+contract C {
+    error MyError(uint errorCode, string errorMsg, bool flag);
+    function flag() pure public returns (bool) { return false; }
+    function f(int param) pure external {
+        uint code = 8;
+        string memory eMsg = "error";
+        require(param % 2 == 0, MyError(code, eMsg, flag()));
+    }
+}
+// ====
+// revertStrings: strip
+// ----
+// f(int256): 3 -> FAILURE, hex"2ced9160", 8, 0x60, false, 5, "error"
+// f(int256): 4 ->

--- a/test/libsolidity/semanticTests/errors/require_error_condition_evaluated_only_once_revert_strings_strip.sol
+++ b/test/libsolidity/semanticTests/errors/require_error_condition_evaluated_only_once_revert_strings_strip.sol
@@ -1,0 +1,25 @@
+contract C {
+    uint256 counter = 0;
+
+    error CustomError(uint256);
+
+    function getCounter() public view returns (uint256) {
+        return counter;
+    }
+
+    function g(bool condition) internal returns (bool) {
+        counter++;
+        return condition;
+    }
+
+    function f(bool condition) external {
+        require(g(condition), CustomError(counter));
+    }
+}
+// ====
+// revertStrings: strip
+// ----
+// f(bool): false -> FAILURE, hex"110b3655", 1
+// getCounter() -> 0
+// f(bool): true ->
+// getCounter() -> 1

--- a/test/libsolidity/semanticTests/errors/require_error_evaluation_order_revert_strings_strip.sol
+++ b/test/libsolidity/semanticTests/errors/require_error_evaluation_order_revert_strings_strip.sol
@@ -1,0 +1,22 @@
+contract C {
+    error E(uint256);
+
+    uint counter = 0;
+
+    function even() internal returns (bool) {
+        return counter % 2 == 0;
+    }
+
+    function inc() internal returns (uint256) {
+        return ++counter;
+    }
+
+    function flip() public {
+        require(even(), E(inc()));
+    }
+}
+// ====
+// revertStrings: strip
+// ----
+// flip() ->
+// flip() -> FAILURE, hex"002ff067", 2

--- a/test/libsolidity/semanticTests/errors/require_error_stack_check_revert_strings_strip.sol
+++ b/test/libsolidity/semanticTests/errors/require_error_stack_check_revert_strings_strip.sol
@@ -1,0 +1,21 @@
+// The purpose of this test is to make sure that error constructor call
+// stack items are popped from the stack in the success branch, i.e. when
+// require condition is true.
+contract C {
+    error E(uint, uint, uint, function(uint256) external pure returns (uint256));
+    uint public x;
+
+    function e(uint256 y) external pure returns (uint256) {
+        return y;
+    }
+
+    function f(bool condition, uint a, uint b, uint c) public {
+        require(condition, E(a, b, c, this.e));
+        x = b;
+    }
+}
+// ====
+// revertStrings: strip
+// ----
+// f(bool,uint256,uint256,uint256): true, 42, 4242, 424242 ->
+// x() -> 4242

--- a/test/libsolidity/semanticTests/errors/require_inherited_error_revert_strings_strip.sol
+++ b/test/libsolidity/semanticTests/errors/require_inherited_error_revert_strings_strip.sol
@@ -1,0 +1,16 @@
+contract Base
+{
+    error CustomError(uint256, string, uint256);
+}
+
+contract C is Base
+{
+    function f() external pure
+    {
+        require(false, CustomError(1, "two", 3));
+    }
+}
+// ====
+// revertStrings: strip
+// ----
+// f() -> FAILURE, hex"11a1077e", 1, 0x60, 3, 3, "two"

--- a/test/libsolidity/semanticTests/errors/revert_statement_error_revert_strings_strip.sol
+++ b/test/libsolidity/semanticTests/errors/revert_statement_error_revert_strings_strip.sol
@@ -1,0 +1,10 @@
+contract C {
+    error MyError(string message);
+    function revertStatement() pure external {
+        revert MyError("Error");
+    }
+}
+// ====
+// revertStrings: strip
+// ----
+// revertStatement() -> FAILURE, hex"8b3d2d43", 0x20, 5, "Error"


### PR DESCRIPTION
Fix #16465.