### PR TITLE
optimiser: avoid double lookup in translateIdentifier

### DIFF
--- a/libyul/optimiser/ASTCopier.cpp
+++ b/libyul/optimiser/ASTCopier.cpp
@@ -180,5 +180,5 @@ NameWithDebugData ASTCopier::translate(NameWithDebugData const& _typedName)
 
 YulName FunctionCopier::translateIdentifier(YulName _name)
 {
-    return util::valueOrDefault(m_translations, _name, _name);
+	return util::valueOrDefault(m_translations, _name, _name);
 }

--- a/libyul/optimiser/ASTCopier.cpp
+++ b/libyul/optimiser/ASTCopier.cpp
@@ -180,7 +180,5 @@ NameWithDebugData ASTCopier::translate(NameWithDebugData const& _typedName)
 
 YulName FunctionCopier::translateIdentifier(YulName _name)
 {
-	if (m_translations.count(_name))
-		return m_translations.at(_name);
-	return _name;
+    return util::valueOrDefault(m_translations, _name, _name);
 }


### PR DESCRIPTION
Replaces double map lookup with a single find() call in translateIdentifier, removing redundant access without changing behavior or logic