### PR TITLE
Fix broken doc links

### DIFF
--- a/docs/060-breaking-changes.rst
+++ b/docs/060-breaking-changes.rst
@@ -119,7 +119,7 @@ Metadata Hash Options
 
 The compiler now appends the `IPFS <https://ipfs.io/>`_ hash of the metadata file to the end of the bytecode by default
 (for details, see documentation on :doc:`contract metadata <metadata>`). Before 0.6.0, the compiler appended the
-`Swarm <https://ethersphere.github.io/swarm-home/>`_ hash by default, and in order to still support this behavior,
+`Swarm <https://www.ethswarm.org/>`_ hash by default, and in order to still support this behavior,
 the new command-line option ``--metadata-hash`` was introduced. It allows you to select the hash to be produced and
 appended, by passing either ``ipfs`` or ``swarm`` as value to the ``--metadata-hash`` command-line option.
 Passing the value ``none`` completely removes the hash.

--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -142,7 +142,7 @@ available for some distributions:
     Exercise caution when using them.
 
 There is also a `snap package <https://snapcraft.io/solc>`_, however, it is **currently unmaintained**.
-It is installable in all the `supported Linux distros <https://snapcraft.io/docs/core/install>`_. To
+It is installable in all the `supported Linux distros <https://snapcraft.io/docs/reference/administration/distribution-support/>`_. To
 install the latest stable version of solc:
 
 .. code-block:: bash


### PR DESCRIPTION
linkcheck revealed two broken links:

- https://ethersphere.github.io/swarm-home/ which i replaced with https://www.ethswarm.org/, and
- https://snapcraft.io/docs/core/install which i replaced with https://snapcraft.io/docs/reference/administration/distribution-support/