### PR TITLE
fixes Disallow --libraries <file>:<library>:<address> format

### DIFF
--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -352,20 +352,15 @@ void CommandLineParser::parseLibraryOption(string const& _input)
 	for (string const& lib: libraries)
 		if (!lib.empty())
 		{
-			//search for equal sign or last colon in string as our binaries output placeholders in the form of file=Name or file:Name
-			//so we need to search for `=` or `:` in the string
+			//search for equal sign in string as our binaries output placeholders in the form of file=Name
+			//so we need to search for `=` in the string
 			auto separator = lib.rfind('=');
-			bool isSeparatorEqualSign = true;
 			if (separator == string::npos)
 			{
-				separator = lib.rfind(':');
-				if (separator == string::npos)
-					solThrow(
-						CommandLineValidationError,
-						"Equal sign separator missing in library address specifier \"" + lib + "\""
-					);
-				else
-					isSeparatorEqualSign = false; // separator is colon
+				solThrow(
+					CommandLineValidationError,
+					"Equal sign separator missing in library address specifier \"" + lib + "\""
+				);
 			}
 			else
 				if (lib.rfind('=') != lib.find('='))
@@ -388,8 +383,7 @@ void CommandLineParser::parseLibraryOption(string const& _input)
 				solThrow(
 					CommandLineValidationError,
 					"Empty address provided for library \"" + libName + "\".\n"
-					"Note that there should not be any whitespace after the " +
-					(isSeparatorEqualSign ? "equal sign" : "colon") + "."
+					"Note that there should not be any whitespace after the equal sign ."
 				);
 
 			if (addrString.substr(0, 2) == "0x")

--- a/test/solc/CommandLineParser.cpp
+++ b/test/solc/CommandLineParser.cpp
@@ -426,6 +426,24 @@ BOOST_AUTO_TEST_CASE(invalid_options_input_modes_combinations)
 		}
 }
 
+BOOST_AUTO_TEST_CASE(libraries_equal_sign_required)
+{
+	std::string badLib = "dir1/file1.sol:L:0x1234567890123456789012345678901234567890";
+	std::vector<std::string> commandLine = {"solc", "--libraries=" + badLib, "contract.sol"};
+
+	auto hasCorrectMessage = [&](CommandLineValidationError const& _exception) {
+		return _exception.what() == ("Equal sign separator missing in library address specifier \"" + badLib + "\"");
+	};
+
+	BOOST_CHECK_EXCEPTION(parseCommandLine(commandLine), CommandLineValidationError, hasCorrectMessage);
+
+	// Ensure the correct '=' format is accepted and parsed.
+	std::string goodLib = "dir1/file1.sol:L=0x1234567890123456789012345678901234567890";
+	CommandLineOptions parsed = parseCommandLine({"solc", "--libraries=" + goodLib, "contract.sol"});
+	BOOST_CHECK(parsed.linker.libraries.count("dir1/file1.sol:L") == 1);
+	BOOST_CHECK(parsed.linker.libraries.at("dir1/file1.sol:L") == h160("1234567890123456789012345678901234567890"));
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 } // namespace solidity::frontend::test


### PR DESCRIPTION
**Summary:**

This change makes the --libraries CLI option accept only the file:library=address form and rejects the legacy colon-separated file:library:address format. The parser now errors when the library specifier does not contain a single '='. A unit test was added to test the behavior.

fixes #16166 

**What I changed:**

Updated the parser to require a single '=' separator and to report a clear CommandLineValidationError when '=' is missing or duplicated.
Adjusted error messages to reference the equal sign only.
Added a unit test that verifies a ':'-style spec triggers the expected error and that the '='-style spec parses correctly.

**Backwards compatibility:**

This is a breaking change to the CLI. Users relying on the old file:library:address syntax must migrate to file:library=address.

**Documentation:**

References to the colon-separated format in user documentation and manpages should be removed or updated to show the '=' form. This PR covers code, comments and tests only; doc updates can follow in a separate change or be included here if desired.

**Notes:**

Applied the change on the develop branch, built and ran the tests without any issues, tried doing the same on the breaking branch, couldn't build because of issues unrelated to my PR