### PR TITLE
Optimize cfg side effects collector and function reference resolver

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@ Important Bugfixes:
 
 
 Compiler Features:
+* Yul Optimizer: Improve performance of control flow side effects collector and function references resolver.
 * Yul Optimizer: Remove redundant prerequisite steps from the default optimizer sequence.
 
 

--- a/libyul/ControlFlowSideEffectsCollector.cpp
+++ b/libyul/ControlFlowSideEffectsCollector.cpp
@@ -162,8 +162,8 @@ void ControlFlowBuilder::newConnectedNode()
 
 ControlFlowNode* ControlFlowBuilder::newNode()
 {
-	m_nodes.emplace_back(std::make_shared<ControlFlowNode>());
-	return m_nodes.back().get();
+	m_nodes.emplace_back();
+	return &m_nodes.back();
 }
 
 

--- a/libyul/ControlFlowSideEffectsCollector.h
+++ b/libyul/ControlFlowSideEffectsCollector.h
@@ -21,10 +21,10 @@
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/ControlFlowSideEffects.h>
 
-#include <set>
-#include <stack>
-#include <optional>
+#include <deque>
 #include <list>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace solidity::yul
 {
@@ -56,7 +56,7 @@ public:
 	/// Computes the control-flows of all function defined in the block.
 	/// Assumes the functions are hoisted to the topmost block.
 	explicit ControlFlowBuilder(Block const& _ast);
-	std::map<FunctionDefinition const*, FunctionFlow> const& functionFlows() const { return m_functionFlows; }
+	std::unordered_map<FunctionDefinition const*, FunctionFlow> const& functionFlows() const { return m_functionFlows; }
 
 private:
 	using ASTWalker::operator();
@@ -72,14 +72,14 @@ private:
 	void newConnectedNode();
 	ControlFlowNode* newNode();
 
-	std::vector<std::shared_ptr<ControlFlowNode>> m_nodes;
+	std::deque<ControlFlowNode> m_nodes;
 
 	ControlFlowNode* m_currentNode = nullptr;
 	ControlFlowNode const* m_leave = nullptr;
 	ControlFlowNode const* m_break = nullptr;
 	ControlFlowNode const* m_continue = nullptr;
 
-	std::map<FunctionDefinition const*, FunctionFlow> m_functionFlows;
+	std::unordered_map<FunctionDefinition const*, FunctionFlow> m_functionFlows;
 };
 
 
@@ -96,7 +96,7 @@ public:
 		Block const& _ast
 	);
 
-	std::map<FunctionDefinition const*, ControlFlowSideEffects> const& functionSideEffects() const
+	std::unordered_map<FunctionDefinition const*, ControlFlowSideEffects> const& functionSideEffects() const
 	{
 		return m_functionSideEffects;
 	}
@@ -124,15 +124,15 @@ private:
 	Dialect const& m_dialect;
 	ControlFlowBuilder m_cfgBuilder;
 	/// Function references, but only for calls to user-defined functions.
-	std::map<FunctionCall const*, FunctionDefinition const*> m_functionReferences;
+	std::unordered_map<FunctionCall const*, FunctionDefinition const*> m_functionReferences;
 	/// Side effects of user-defined functions, is being constructod.
-	std::map<FunctionDefinition const*, ControlFlowSideEffects> m_functionSideEffects;
+	std::unordered_map<FunctionDefinition const*, ControlFlowSideEffects> m_functionSideEffects;
 	/// Control flow nodes still to process, per function.
-	std::map<FunctionDefinition const*, std::list<ControlFlowNode const*>> m_pendingNodes;
+	std::unordered_map<FunctionDefinition const*, std::list<ControlFlowNode const*>> m_pendingNodes;
 	/// Control flow nodes already processed, per function.
-	std::map<FunctionDefinition const*, std::set<ControlFlowNode const*>> m_processedNodes;
+	std::unordered_map<FunctionDefinition const*, std::unordered_set<ControlFlowNode const*>> m_processedNodes;
 	/// Set of reachable function calls nodes in each function (including calls to builtins).
-	std::map<FunctionDefinition const*, std::set<FunctionCall const*>> m_functionCalls;
+	std::unordered_map<FunctionDefinition const*, std::unordered_set<FunctionCall const*>> m_functionCalls;
 };
 
 

--- a/libyul/FunctionReferenceResolver.h
+++ b/libyul/FunctionReferenceResolver.h
@@ -20,6 +20,8 @@
 
 #include <libyul/optimiser/ASTWalker.h>
 
+#include <unordered_map>
+
 namespace solidity::yul
 {
 
@@ -33,15 +35,15 @@ class FunctionReferenceResolver: private ASTWalker
 {
 public:
 	explicit FunctionReferenceResolver(Block const& _ast);
-	std::map<FunctionCall const*, FunctionDefinition const*> const& references() const { return m_functionReferences; }
+	std::unordered_map<FunctionCall const*, FunctionDefinition const*> const& references() const { return m_functionReferences; }
 
 private:
 	using ASTWalker::operator();
 	void operator()(FunctionCall const& _functionCall) override;
 	void operator()(Block const& _block) override;
 
-	std::map<FunctionCall const*, FunctionDefinition const*> m_functionReferences;
-	std::vector<std::map<YulName, FunctionDefinition const*>> m_scopes;
+	std::unordered_map<FunctionCall const*, FunctionDefinition const*> m_functionReferences;
+	std::vector<std::unordered_map<YulName, FunctionDefinition const*>> m_scopes;
 };
 
 

--- a/libyul/backends/evm/ControlFlowGraphBuilder.cpp
+++ b/libyul/backends/evm/ControlFlowGraphBuilder.cpp
@@ -258,7 +258,7 @@ std::unique_ptr<CFG> ControlFlowGraphBuilder::build(
 ControlFlowGraphBuilder::ControlFlowGraphBuilder(
 	CFG& _graph,
 	AsmAnalysisInfo const& _analysisInfo,
-	std::map<FunctionDefinition const*, ControlFlowSideEffects> const& _functionSideEffects,
+	std::unordered_map<FunctionDefinition const*, ControlFlowSideEffects> const& _functionSideEffects,
 	Dialect const& _dialect
 ):
 	m_graph(_graph),

--- a/libyul/backends/evm/ControlFlowGraphBuilder.h
+++ b/libyul/backends/evm/ControlFlowGraphBuilder.h
@@ -23,6 +23,8 @@
 #include <libyul/backends/evm/ControlFlowGraph.h>
 #include <libyul/ControlFlowSideEffects.h>
 
+#include <unordered_map>
+
 namespace solidity::yul
 {
 
@@ -56,7 +58,7 @@ private:
 	ControlFlowGraphBuilder(
 		CFG& _graph,
 		AsmAnalysisInfo const& _analysisInfo,
-		std::map<FunctionDefinition const*, ControlFlowSideEffects> const& _functionSideEffects,
+		std::unordered_map<FunctionDefinition const*, ControlFlowSideEffects> const& _functionSideEffects,
 		Dialect const& _dialect
 	);
 	void registerFunction(FunctionDefinition const& _function);
@@ -79,7 +81,7 @@ private:
 	);
 	CFG& m_graph;
 	AsmAnalysisInfo const& m_info;
-	std::map<FunctionDefinition const*, ControlFlowSideEffects> const& m_functionSideEffects;
+	std::unordered_map<FunctionDefinition const*, ControlFlowSideEffects> const& m_functionSideEffects;
 	Dialect const& m_dialect;
 	CFG::BasicBlock* m_currentBlock = nullptr;
 	Scope* m_scope = nullptr;


### PR DESCRIPTION
- exchange `map` and `set` by `unordered_map` and `unordered_set`, respectively
- use `deque<ControlFlowNode>` over `vector<shared_ptr<ControlFlowNode>>` which preserves the property that pointers aren't invalidated but also eliminates refcounting/shared ptr control block per node 

nets me a 4% speedup when compiling eigenlayer 0.3.0. 