### PR TITLE
docs: fix reentrancy vulnerability in micropayment close() example

### DIFF
--- a/docs/examples/micropayment.rst
+++ b/docs/examples/micropayment.rst
@@ -408,9 +408,9 @@ The full contract
             require(msg.sender == recipient);
             require(isValidSignature(amount, signature));
 
+            freeze();
             (bool success, ) = recipient.call{value: amount}("");
             require(success);
-            freeze();
             (success, ) = sender.call{value: address(this).balance}("");
             require(success);
         }


### PR DESCRIPTION
The `close()` function in the `SimplePaymentChannel` example calls `freeze()` after the external call to `recipient`. This means a malicious recipient contract can re-enter `close()` before the channel is frozen, draining more funds than intended.

This PR moves `freeze()` before the external calls to follow the Checks-Effects-Interactions pattern.

**Before:**
```solidity
(bool success, ) = recipient.call{value: amount}("");
require(success);
freeze();
```

**After:**
```solidity
freeze();
(bool success, ) = recipient.call{value: amount}("");
require(success);
```