### PR TITLE
SSA CFG Codegen: make function return label slot handling explicit

### DIFF
--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -107,7 +107,7 @@ CodeTransform::CodeTransform(
 	SSACFG const& _cfg,
 	SSACFGStackLayout const& _stackLayout,
 	Scope::Function const* _function,
-	ControlFlow::FunctionGraphID
+	ControlFlow::FunctionGraphID _graphID
 ):
 	m_assembly(_assembly),
 	m_builtinContext(_builtinContext),
@@ -115,6 +115,7 @@ CodeTransform::CodeTransform(
 	m_callSites(_callSites),
 	m_cfg(_cfg),
 	m_stackLayout(_stackLayout),
+	m_graphID(_graphID),
 	m_blockIsTransformed(_cfg.numBlocks(), false),
 	m_blockLabels([this] {
 		std::vector<AbstractAssembly::LabelID> blockLabels;
@@ -142,10 +143,12 @@ CodeTransform::CodeTransform(
 		auto const findIt = m_functionLabels.find(_function);
 		yulAssert(findIt != m_functionLabels.end());
 		m_assembly.appendLabel(findIt->second);
-		m_assembly.setStackHeight(static_cast<int>(_function->numArguments));
+		m_assembly.setStackHeight(static_cast<int>(_function->numArguments) + (m_cfg.canContinue ? 1 : 0));
 	}
 	StackData expectedStackTop;
-	expectedStackTop.reserve(m_cfg.arguments.size());
+	expectedStackTop.reserve(m_cfg.arguments.size() + (m_cfg.function && m_cfg.canContinue ? 1 : 0));
+		if (m_cfg.function && m_cfg.canContinue)
+			expectedStackTop.push_back(StackSlot::makeFunctionReturnLabel(m_graphID));
 	for (auto const& [_, valueID]: m_cfg.arguments | ranges::views::reverse)
 		expectedStackTop.push_back(StackSlot::makeValueID(valueID));
 	assertLayoutCompatibility(m_stack.data(), expectedStackTop);
@@ -339,35 +342,38 @@ void CodeTransform::operator()(SSACFG::BlockId const& _currentBlock, SSACFG::Bas
 void CodeTransform::operator()(SSACFG::BlockId const&, SSACFG::BasicBlock::FunctionReturn const& _functionReturn)
 {
 	yulAssert(static_cast<int>(m_stack.size()) == m_assembly.stackHeight());
+	// Each CodeTransform instance handles exactly one function's CFG, so a FunctionReturn exit
+	// here necessarily belongs to m_cfg.function. No identity cross-check is needed.
 	yulAssert(m_cfg.function);
-	// The return label sits physically below the tracked virtual stack.
-	// Inform the assembler so SWAP can reach it.
-	m_assembly.setStackHeight(m_assembly.stackHeight() + 1);
-	// Build target: [rv1, rv2, ..., rvN-1, rv0] (rv0 at top).
-	// After shuffle: EVM = [label, rv1, ..., rvN-1, rv0].
-	// After SWAP(N):  EVM = [rv0, rv1, ..., rvN-1, label].
-	// After JUMP:     EVM = [rv0, rv1, ..., rvN-1].
-	// TODO: it would be better to account for function return labels from the entry of the function to the end symbolically
-	StackData returnTarget;
-	if (!_functionReturn.returnValues.empty())
+	yulAssert(m_cfg.canContinue);
+	yulAssert(m_stack.size() == _functionReturn.returnValues.size() + 1, "There must be at least the function return label element on stack");
+	yulAssert(m_stack.top().isFunctionReturnLabel());
+	yulAssert(m_stack.top().functionReturnLabel() == m_graphID);
+	for (std::size_t i = 0; i < _functionReturn.returnValues.size(); ++i)
 	{
-		returnTarget.reserve(_functionReturn.returnValues.size());
-		for (std::size_t i = 1; i < _functionReturn.returnValues.size(); ++i)
-			returnTarget.push_back(StackSlot::makeValueID(_functionReturn.returnValues[i]));
-		returnTarget.push_back(StackSlot::makeValueID(_functionReturn.returnValues.front()));
-		StackShuffler<AssemblyCallbacks>::shuffle(m_stack, returnTarget, {}, returnTarget.size());
-		m_assembly.appendInstruction(evmasm::swapInstruction(
-			static_cast<unsigned>(_functionReturn.returnValues.size())
-		));
+		auto const& returnValueSlot = m_stack.slot(StackOffset{i});
+		yulAssert(returnValueSlot.isValueID());
+		yulAssert(returnValueSlot.valueID() == _functionReturn.returnValues[i]);
 	}
-	else
-		StackShuffler<AssemblyCallbacks>::shuffle(m_stack, returnTarget, {}, 0);
 	m_assembly.appendJump(0, AbstractAssembly::JumpType::OutOfFunction);
 }
 
-void CodeTransform::operator()(SSACFG::BlockId const&, SSACFG::BasicBlock::Terminated const&)
+void CodeTransform::operator()(SSACFG::BlockId const& _blockId, SSACFG::BasicBlock::Terminated const&)
 {
 	yulAssert(static_cast<int>(m_stack.size()) == m_assembly.stackHeight());
+	auto const& block = m_cfg.block(_blockId);
+	yulAssert(!block.operations.empty(), "Terminated block must have at least one operation.");
+	std::visit(util::GenericVisitor{
+		[](SSACFG::BuiltinCall const& _builtin) {
+			yulAssert(_builtin.builtin.get().controlFlowSideEffects.terminatesOrReverts(), "Last operation of Terminated block must terminate or revert.");
+		},
+		[](SSACFG::Call const& _call) {
+			yulAssert(!_call.canContinue, "Last operation of Terminated block must be a non-continuable call.");
+		},
+		[](SSACFG::LiteralAssignment const&) {
+			yulAssert(false, "Terminated block cannot end with a literal assignment.");
+		}
+	}, block.operations.back().kind);
 	// To be sure just emit another INVALID - should be removed by optimizer.
 	m_assembly.appendInstruction(evmasm::Instruction::INVALID);
 }

--- a/libyul/backends/evm/ssa/CodeTransform.h
+++ b/libyul/backends/evm/ssa/CodeTransform.h
@@ -67,6 +67,7 @@ struct AssemblyCallbacks
 		case StackSlot::Kind::FunctionCallReturnLabel:
 		{
 			auto const& call = callSites->functionCall(_slot.functionCallReturnLabel());
+			yulAssert(returnLabels->count(&call), "FunctionCallReturnLabel not pre-registered before shuffle.");
 			assembly->appendLabelReference(returnLabels->at(&call));
 			return;
 		}
@@ -132,6 +133,7 @@ private:
 	CallSites const& m_callSites;
 	SSACFG const& m_cfg;
 	SSACFGStackLayout const& m_stackLayout;
+	ControlFlow::FunctionGraphID const m_graphID;
 
 	std::vector<std::uint8_t> m_blockIsTransformed;
 	std::vector<AbstractAssembly::LabelID> m_blockLabels;

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -27,6 +27,7 @@
 #include <range/v3/algorithm/min_element.hpp>
 #include <range/v3/algorithm/replace.hpp>
 #include <range/v3/view/transform.hpp>
+#include <range/v3/to_container.hpp>
 
 #include <boost/container/flat_map.hpp>
 #include <queue>
@@ -77,15 +78,25 @@ void declareJunk(StackType& _stack, LivenessAnalysis::LivenessData const& _live)
 
 }
 
-SSACFGStackLayout StackLayoutGenerator::generate(LivenessAnalysis const& _liveness, CallSites const& _callSites, ControlFlow::FunctionGraphID _graphID)
+SSACFGStackLayout StackLayoutGenerator::generate(
+	LivenessAnalysis const& _liveness,
+	CallSites const& _callSites,
+	ControlFlow::FunctionGraphID const _graphID
+)
 {
 	return StackLayoutGenerator(_liveness, _callSites, _graphID).m_resultLayout;
 }
 
-StackLayoutGenerator::StackLayoutGenerator(LivenessAnalysis const& _liveness, CallSites const& _callSites, ControlFlow::FunctionGraphID):
+StackLayoutGenerator::StackLayoutGenerator(
+	LivenessAnalysis const& _liveness,
+	CallSites const& _callSites,
+	ControlFlow::FunctionGraphID const _graphID
+):
 	m_cfg(_liveness.cfg()),
 	m_liveness(_liveness),
 	m_callSites(_callSites),
+	m_graphID(_graphID),
+	m_hasFunctionReturnLabel(_liveness.cfg().function && _liveness.cfg().canContinue),
 	m_junkAdmittingBlocksFinder(std::make_unique<JunkAdmittingBlocksFinder>(_liveness.cfg(), _liveness.topologicalSort())),
 	m_resultLayout(m_cfg.numBlocks())
 {
@@ -133,6 +144,9 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 	{
 		if (m_cfg.function)
 		{
+			blockLayout.stackIn.reserve(m_cfg.arguments.size() + (m_hasFunctionReturnLabel ? 1u : 0u));
+			if (m_hasFunctionReturnLabel)
+				blockLayout.stackIn.push_back(Slot::makeFunctionReturnLabel(m_graphID));
 			for (auto const& [_, valueID]: m_cfg.arguments | ranges::views::reverse)
 				blockLayout.stackIn.push_back(Slot::makeValueID(valueID));
 		}
@@ -246,7 +260,7 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 			)
 				stack.declareJunk(depth);
 
-		std::size_t const targetSize = findOptimalTargetSize(stack.data(), requiredStackTop, opLiveOutWithoutOutputs, junkCanBeAdded);
+		std::size_t const targetSize = findOptimalTargetSize(stack.data(), requiredStackTop, opLiveOutWithoutOutputs, junkCanBeAdded, m_hasFunctionReturnLabel);
 		StackShuffler<StackType::Callbacks>::shuffle(
 			stack,
 			requiredStackTop,
@@ -274,7 +288,7 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 		if (!conditionSlotAlreadyFinal)
 		{
 			auto const condition = Slot::makeValueID(cjump->condition);
-			auto const targetSize = findOptimalTargetSize(stack.data(), {condition}, blockLiveOut, false);
+			auto const targetSize = findOptimalTargetSize(stack.data(), {condition}, blockLiveOut, false, m_hasFunctionReturnLabel);
 			StackShuffler<StackType::Callbacks>::shuffle(
 				stack, {condition}, blockLiveOut, targetSize
 			);
@@ -304,6 +318,15 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 				declareJunk(zeroStack, zeroLiveIn);
 			}
 		}
+	}
+
+	if (auto const* functionReturn = std::get_if<SSACFG::BasicBlock::FunctionReturn>(&block.exit))
+	{
+		yulAssert(m_hasFunctionReturnLabel, "When there is a proper function return, we need to have a label for it");
+		// in case there are return values, let's bring the function return label to the top
+		StackData returnStack = functionReturn->returnValues | ranges::views::transform(StackSlot::makeValueID) | ranges::to<std::vector>;
+		returnStack.push_back(StackSlot::makeFunctionReturnLabel(m_graphID));
+		StackShuffler<StackType::Callbacks>::shuffle(stack, returnStack);
 	}
 
 	blockLayout.stackOut = currentStackData;

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.h
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.h
@@ -51,6 +51,8 @@ private:
 	SSACFG const& m_cfg;
 	LivenessAnalysis const& m_liveness;
 	CallSites const& m_callSites;
+	ControlFlow::FunctionGraphID m_graphID;
+	bool m_hasFunctionReturnLabel;
 
 	std::unique_ptr<JunkAdmittingBlocksFinder> m_junkAdmittingBlocksFinder;
 	SSACFGStackLayout m_resultLayout;

--- a/libyul/backends/evm/ssa/StackUtils.cpp
+++ b/libyul/backends/evm/ssa/StackUtils.cpp
@@ -44,10 +44,11 @@ std::size_t solidity::yul::ssa::findOptimalTargetSize
 	StackData const& _stackData,
 	StackData const& _targetArgs,
 	LivenessAnalysis::LivenessData const& _targetLiveOut,
-	bool const _canIntroduceJunk
+	bool const _canIntroduceJunk,
+	bool const _hasFunctionReturnLabel
 )
 {
-	std::size_t const minSize = _targetLiveOut.size() + _targetArgs.size();
+	std::size_t const minSize = _targetLiveOut.size() + _targetArgs.size() + (_hasFunctionReturnLabel ? 1 : 0);
 	boost::container::flat_map<StackSlot, std::size_t> deficit;
 	for (auto const& v: _targetLiveOut | ranges::views::keys)
 		deficit[StackSlot::makeValueID(v)]++;

--- a/libyul/backends/evm/ssa/StackUtils.h
+++ b/libyul/backends/evm/ssa/StackUtils.h
@@ -50,7 +50,7 @@ struct CountingInstructionsCallbacks
 /// Transform stack data by replacing all its phi variables with their respective preimages.
 StackData stackPreImage(StackData _stack, PhiInverse const& _phiInverse);
 
-std::size_t findOptimalTargetSize(StackData const& _stackData, StackData const& _targetArgs, LivenessAnalysis::LivenessData const& _targetLiveOut, bool _canIntroduceJunk);
+std::size_t findOptimalTargetSize(StackData const& _stackData, StackData const& _targetArgs, LivenessAnalysis::LivenessData const& _targetLiveOut, bool _canIntroduceJunk, bool _hasFunctionReturnLabel);
 
 CallSites gatherCallSites(SSACFG const& _cfg);
 

--- a/test/libyul/ssa/stackLayoutGenerator/can_continue.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/can_continue.yul
@@ -1,0 +1,67 @@
+{
+    // a function that can continue depending on condition
+    function revert_wrapper(val, condition)
+    {
+        if iszero(condition)
+        {
+            revert(val, val)
+        }
+        // if we don't revert, we return nothing and the stack out should contain nothing but the return label
+    }
+
+    revert_wrapper(42, 1)
+}
+// ----
+// digraph SSACFG {
+// nodesep=0.7;
+// graph[fontname="DejaVu Sans", rankdir=LR]
+// node[shape=box,fontname="DejaVu Sans"];
+//
+// Entry [label="Entry"];
+// Entry -> Block0_0;
+// Block0_0 [label="\
+// IN: []\l\
+// \l\
+// [FunctionCallReturnLabel[0], lit0, lit1]\l\
+// revert_wrapper\l\
+// [FunctionCallReturnLabel[0]]\l\
+// \l\
+// OUT: []\l\
+// "];
+// Block0_0Exit [label="MainExit"];
+// Block0_0 -> Block0_0Exit;
+// FunctionEntry_revert_wrapper_0 [label="function revert_wrapper:
+//  revert_wrapper(v0, v1)"];
+// FunctionEntry_revert_wrapper_0 -> Block1_0;
+// Block1_0 [label="\
+// IN: [ReturnLabel[1], v1, v0]\l\
+// \l\
+// [ReturnLabel[1], v0, v1]\l\
+// iszero\l\
+// [ReturnLabel[1], v0, v2]\l\
+// \l\
+// OUT: [ReturnLabel[1], v0, v2]\l\
+// "];
+// Block1_0 -> Block1_0Exit;
+// Block1_0Exit [label="{ If v2 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block1_0Exit:0 -> Block1_2 [style="solid"];
+// Block1_0Exit:1 -> Block1_1 [style="solid"];
+// Block1_1 [label="\
+// IN: [ReturnLabel[1], v0]\l\
+// \l\
+// [ReturnLabel[1], v0, v0]\l\
+// revert\l\
+// [ReturnLabel[1]]\l\
+// \l\
+// OUT: [ReturnLabel[1]]\l\
+// "];
+// Block1_1Exit [label="Terminated"];
+// Block1_1 -> Block1_1Exit;
+// Block1_2 [label="\
+// IN: [ReturnLabel[1], JUNK]\l\
+// \l\
+// OUT: [ReturnLabel[1]]\l\
+// "];
+// Block1_2Exit [label="FunctionReturn[]"];
+// Block1_2 -> Block1_2Exit;
+// }

--- a/test/libyul/ssa/stackLayoutGenerator/function.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/function.yul
@@ -47,17 +47,17 @@
 //  r := f(v0, v1)"];
 // FunctionEntry_f_0 -> Block1_0;
 // Block1_0 [label="\
-// IN: [v1, v0]\l\
+// IN: [ReturnLabel[1], v1, v0]\l\
 // \l\
-// [v0, v1, v0]\l\
+// [ReturnLabel[1], v0, v1, v0]\l\
 // add\l\
-// [v0, v2]\l\
+// [ReturnLabel[1], v0, v2]\l\
 // \l\
-// [v0, v2]\l\
+// [ReturnLabel[1], v0, v2]\l\
 // sub\l\
-// [v3]\l\
+// [ReturnLabel[1], v3]\l\
 // \l\
-// OUT: [v3]\l\
+// OUT: [v3, ReturnLabel[1]]\l\
 // "];
 // Block1_0Exit [label="FunctionReturn[v3]"];
 // Block1_0 -> Block1_0Exit;
@@ -65,13 +65,13 @@
 //  g()"];
 // FunctionEntry_g_0 -> Block2_0;
 // Block2_0 [label="\
-// IN: []\l\
+// IN: [ReturnLabel[2]]\l\
 // \l\
-// [lit0, lit1]\l\
+// [ReturnLabel[2], lit0, lit1]\l\
 // sstore\l\
-// []\l\
+// [ReturnLabel[2]]\l\
 // \l\
-// OUT: []\l\
+// OUT: [ReturnLabel[2]]\l\
 // "];
 // Block2_0Exit [label="FunctionReturn[]"];
 // Block2_0 -> Block2_0Exit;
@@ -97,9 +97,9 @@
 //  v, w := i()"];
 // FunctionEntry_i_0 -> Block4_0;
 // Block4_0 [label="\
-// IN: []\l\
+// IN: [ReturnLabel[4]]\l\
 // \l\
-// OUT: []\l\
+// OUT: [lit1, lit2, ReturnLabel[4]]\l\
 // "];
 // Block4_0Exit [label="FunctionReturn[0x0202, 0x0303]"];
 // Block4_0 -> Block4_0Exit;

--- a/test/libyul/ssa/stackLayoutGenerator/multi_return.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/multi_return.yul
@@ -42,17 +42,17 @@
 //  x, y := pair(v0)"];
 // FunctionEntry_pair_0 -> Block1_0;
 // Block1_0 [label="\
-// IN: [v0]\l\
+// IN: [ReturnLabel[1], v0]\l\
 // \l\
-// [v0, lit1, v0]\l\
+// [ReturnLabel[1], v0, lit1, v0]\l\
 // add\l\
-// [v0, v1]\l\
+// [ReturnLabel[1], v0, v1]\l\
 // \l\
-// [v1, lit2, v0]\l\
+// [ReturnLabel[1], v1, lit2, v0]\l\
 // add\l\
-// [v1, v2]\l\
+// [ReturnLabel[1], v1, v2]\l\
 // \l\
-// OUT: [v1, v2]\l\
+// OUT: [v1, v2, ReturnLabel[1]]\l\
 // "];
 // Block1_0Exit [label="FunctionReturn[v1, v2]"];
 // Block1_0 -> Block1_0Exit;

--- a/test/libyul/ssa/stackLayoutGenerator/recursion.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/recursion.yul
@@ -33,38 +33,38 @@
 //  s := sum(v0)"];
 // FunctionEntry_sum_0 -> Block1_0;
 // Block1_0 [label="\
-// IN: [v0]\l\
+// IN: [ReturnLabel[1], v0]\l\
 // \l\
-// OUT: [v0, v0]\l\
+// OUT: [ReturnLabel[1], v0, v0]\l\
 // "];
 // Block1_0 -> Block1_0Exit;
 // Block1_0Exit [label="{ If v0 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_0Exit:0 -> Block1_2 [style="solid"];
 // Block1_0Exit:1 -> Block1_1 [style="solid"];
 // Block1_1 [label="\
-// IN: [v0]\l\
+// IN: [ReturnLabel[1], v0]\l\
 // \l\
-// [v0, lit1, v0]\l\
+// [ReturnLabel[1], v0, lit1, v0]\l\
 // sub\l\
-// [v0, v1]\l\
+// [ReturnLabel[1], v0, v1]\l\
 // \l\
-// [v0, FunctionCallReturnLabel[0], v1]\l\
+// [ReturnLabel[1], v0, FunctionCallReturnLabel[0], v1]\l\
 // sum\l\
-// [v0, FunctionCallReturnLabel[0], v2]\l\
+// [ReturnLabel[1], v0, FunctionCallReturnLabel[0], v2]\l\
 // \l\
-// [v2, v0]\l\
+// [ReturnLabel[1], v2, v0]\l\
 // add\l\
-// [v3]\l\
+// [ReturnLabel[1], v3]\l\
 // \l\
-// OUT: [v3]\l\
+// OUT: [ReturnLabel[1], v3]\l\
 // "];
 // Block1_1 -> Block1_1Exit [arrowhead=none];
 // Block1_1Exit [label="Jump" shape=oval];
 // Block1_1Exit -> Block1_2 [style="solid"];
 // Block1_2 [label="\
-// IN: [JUNK, phi0]\l\
+// IN: [ReturnLabel[1], JUNK, phi0]\l\
 // \l\
-// OUT: [JUNK, phi0]\l\
+// OUT: [phi0, ReturnLabel[1]]\l\
 // "];
 // Block1_2Exit [label="FunctionReturn[phi0]"];
 // Block1_2 -> Block1_2Exit;

--- a/test/libyul/ssa/stackLayoutGenerator/simple_if.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/simple_if.yul
@@ -35,41 +35,41 @@
 //  c := f(v0, v1)"];
 // FunctionEntry_f_0 -> Block1_0;
 // Block1_0 [label="\
-// IN: [v1, v0]\l\
+// IN: [ReturnLabel[1], v1, v0]\l\
 // \l\
-// [v1, v0, v0]\l\
+// [ReturnLabel[1], v1, v0, v0]\l\
 // mload\l\
-// [v1, v0, v2]\l\
+// [ReturnLabel[1], v1, v0, v2]\l\
 // \l\
-// OUT: [v1, v0, v2]\l\
+// OUT: [ReturnLabel[1], v1, v0, v2]\l\
 // "];
 // Block1_0 -> Block1_0Exit;
 // Block1_0Exit [label="{ If v2 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
 // Block1_0Exit:0 -> Block1_2 [style="solid"];
 // Block1_0Exit:1 -> Block1_1 [style="solid"];
 // Block1_1 [label="\
-// IN: [v1, v0]\l\
+// IN: [ReturnLabel[1], v1, v0]\l\
 // \l\
-// [JUNK, v0, lit1, v0]\l\
+// [ReturnLabel[1], JUNK, v0, lit1, v0]\l\
 // add\l\
-// [JUNK, v0, v3]\l\
+// [ReturnLabel[1], JUNK, v0, v3]\l\
 // \l\
-// [JUNK, JUNK, v3, v3]\l\
+// [ReturnLabel[1], JUNK, JUNK, v3, v3]\l\
 // revert\l\
-// [JUNK, JUNK]\l\
+// [ReturnLabel[1], JUNK, JUNK]\l\
 // \l\
-// OUT: [JUNK, JUNK]\l\
+// OUT: [ReturnLabel[1], JUNK, JUNK]\l\
 // "];
 // Block1_1Exit [label="Terminated"];
 // Block1_1 -> Block1_1Exit;
 // Block1_2 [label="\
-// IN: [v1, v0]\l\
+// IN: [ReturnLabel[1], v1, v0]\l\
 // \l\
-// [v1, v0]\l\
+// [ReturnLabel[1], v1, v0]\l\
 // add\l\
-// [v4]\l\
+// [ReturnLabel[1], v4]\l\
 // \l\
-// OUT: [v4]\l\
+// OUT: [v4, ReturnLabel[1]]\l\
 // "];
 // Block1_2Exit [label="FunctionReturn[v4]"];
 // Block1_2 -> Block1_2Exit;


### PR DESCRIPTION
The function return label (the address the callee jumps back to) is now tracked as an explicit `FunctionReturnLabel` slot on the virtual stack throughout a function's CFG, rather than being treated as an implicit/invisible slot below the tracked stack.