### PR TITLE
SSA: Tighten condition in shuffler

### DIFF
--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -394,7 +394,7 @@ private:
 			return false;
 
 		// if we have at least one slot in the args section, try to fix something there
-		if (!_stack.empty() && _stack.size() >= _state.target().tailSize)
+		if (_stack.size() > _state.target().tailSize)
 		{
 			StackOffset const stackTop{_stack.size() - 1};
 			// if the stack top isn't where it likes to be right now, try to put it somewhere more sensible


### PR DESCRIPTION
The condition did not match the comment above it.

This is the part of the algorithm that attempts to fix a slot in the arguments section of the target stack. But if the current stack size matches exactly the target tail size, we don't have any slot in the arguments section at that moment. I believe the comment is correct and we should enter this code only if there is a slot in args section. The condition has been tightened accordingly.