### PR TITLE
Pin uniswap sdk versions to fix recent uniswap bug

### DIFF
--- a/test/externalTests/euler.sh
+++ b/test/externalTests/euler.sh
@@ -71,6 +71,7 @@ function euler_test
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")"
     force_hardhat_unlimited_contract_size "$config_file"
+    npm install @uniswap/v3-sdk@3.29.1 # TODO: Remove after https://github.com/Uniswap/sdks/issues/557 is resolved
     npm install
     replace_version_pragmas
     neutralize_packaged_contracts

--- a/test/externalTests/yield-liquidator.sh
+++ b/test/externalTests/yield-liquidator.sh
@@ -63,6 +63,23 @@ function yield_liquidator_test
     force_hardhat_compiler_binary "$config_file" "$BINARY_TYPE" "$BINARY_PATH"
     force_hardhat_compiler_settings "$config_file" "$(first_word "$SELECTED_PRESETS")" "$config_var"
     force_hardhat_unlimited_contract_size "$config_file" "$config_var"
+    # TODO: Remove after https://github.com/Uniswap/sdks/issues/557 is resolved
+    # Pin broken @uniswap/* packages via overrides. The following versions were published with
+    # 'workspace:*' deps that npm cannot resolve (EUNSUPPORTEDPROTOCOL), causing a silent exit-1:
+    #   @uniswap/v3-sdk@3.29.2  (via smart-order-router -> ^3.7.0)
+    #   @uniswap/v4-sdk@1.29.2  (via smart-order-router -> router-sdk -> ^1.20.0)
+    #   @uniswap/v2-sdk@4.19.2  (via smart-order-router -> router-sdk -> ^4.14.0)
+    # Cannot just run npm install with unbroken version because these are indirect dependencies.
+    node -e "
+        const fs = require('fs');
+        const p = JSON.parse(fs.readFileSync('package.json'));
+        p.overrides = Object.assign(p.overrides || {}, {
+            '@uniswap/v3-sdk': '3.29.1',
+            '@uniswap/v4-sdk': '1.29.1',
+            '@uniswap/v2-sdk': '4.19.1',
+        });
+        fs.writeFileSync('package.json', JSON.stringify(p, null, 2));
+    "
     npm install
 
     # The contract below is not used in any test and it depends on ISwapRouter which does not exists


### PR DESCRIPTION
This fix is needed because of the buggy uniswap package published recently.
https://github.com/Uniswap/sdks/issues/557

This PR contains fix of recent uniswap sdk bug. 
It pins sdk versions for euler and yield-liquidator tests. The later depends on the sdks indirectly, so we had override deps.