### PR TITLE
Fix ICE when emitting event with indexed function type requiring implicit conversion

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ Compiler Features:
 * Yul EVM Code Transform: Improve stack shuffler performance by fixing a BFS deduplication issue.
 
 Bugfixes:
+* Yul IR Code Generation: Fix internal compiler error when emitting an event with an indexed function type parameter that requires implicit conversion.
 
 
 ### 0.8.34 (2026-02-18)

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -1090,12 +1090,11 @@ void IRGeneratorForStatements::endVisit(FunctionCall const& _functionCall)
 						")\n";
 				else if (auto functionType = dynamic_cast<FunctionType const*>(paramTypes[i]))
 				{
-					solAssert(
-						IRVariable(arg).type() == *functionType &&
-						functionType->kind() == FunctionType::Kind::External &&
-						!functionType->hasBoundFirstArgument(),
-						""
-					);
+					auto const* argFunctionType = dynamic_cast<FunctionType const*>(&IRVariable(arg).type());
+					solAssert(argFunctionType);
+					solAssert(argFunctionType->kind() == FunctionType::Kind::External);
+					solAssert(!argFunctionType->hasBoundFirstArgument());
+					solAssert(functionType->kind() == FunctionType::Kind::External);
 					define(indexedArgs.emplace_back(m_context.newYulVariable(), *TypeProvider::fixedBytes(32))) <<
 						m_utils.combineExternalFunctionIdFunction() <<
 						"(" <<

--- a/test/libsolidity/semanticTests/events/event_indexed_function_mutability_conversion.sol
+++ b/test/libsolidity/semanticTests/events/event_indexed_function_mutability_conversion.sol
@@ -1,0 +1,36 @@
+// Used to cause ICE in IR codegen when emitting an indexed event parameter
+// with an implicitly convertible function type (different state mutability).
+contract C {
+    event ViewEvent(function() external view indexed);
+    event NonpayableEvent(function() external indexed);
+
+    function externalPure() external pure {}
+    function externalView() external view {}
+    function externalPayable() external payable {}
+
+    // pure -> view
+    function test_pure_to_view() public {
+        emit ViewEvent(C(address(0x1234)).externalPure);
+    }
+    // pure -> nonpayable
+    function test_pure_to_nonpayable() public {
+        emit NonpayableEvent(C(address(0x1234)).externalPure);
+    }
+    // view -> nonpayable
+    function test_view_to_nonpayable() public {
+        emit NonpayableEvent(C(address(0x1234)).externalView);
+    }
+    // payable -> nonpayable
+    function test_payable_to_nonpayable() public {
+        emit NonpayableEvent(C(address(0x1234)).externalPayable);
+    }
+}
+// ----
+// test_pure_to_view() ->
+// ~ emit ViewEvent(function): #0x123432de51f20000000000000000
+// test_pure_to_nonpayable() ->
+// ~ emit NonpayableEvent(function): #0x123432de51f20000000000000000
+// test_view_to_nonpayable() ->
+// ~ emit NonpayableEvent(function): #0x12347fb3a0c30000000000000000
+// test_payable_to_nonpayable() ->
+// ~ emit NonpayableEvent(function): #0x12349298fb810000000000000000


### PR DESCRIPTION
The IR codegen asserted exact type equality between the argument and event parameter types for indexed function-type parameters (`IRVariable(arg).type() == *functionType`). This fails when the argument has a different but implicitly convertible state mutability (e.g. `function() external pure` passed to an event expecting `function() external view indexed`), since `FunctionType::operator==` compares mutability.

Replace the strict equality check with individual structural assertions matching the legacy codegen (`ExpressionCompiler.cpp:999-1009`): verify both types are external function types and the argument has no bound first argument. The underlying `combineExternalFunctionIdFunction` operates on raw `(address, selector)` stack values and is unaffected by mutability differences.

The legacy codegen is not affected — it already checks the argument and parameter types separately without requiring equality.

Fixes #16298