### PR TITLE
repair changelog: move performance optimization from 0.8.34 to 0.8.35 and reclassify BFS deduplication issue as bugfix

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,9 +9,10 @@ Compiler Features:
 * General: Restrict the existing experimental features (`generic-solidity`, `lsp`, `ethdebug`, `eof`, `evm`, `ast-import`, `evmasm-import`, `ir-ast`, `ssa-cfg`) to experimental mode.
 * Metadata: Store the state of the experimental mode in JSON and CBOR metadata. In CBOR this broadens the meaning of the existing `experimental` field, which used to indicate only the presence of certain experimental pragmas in the source.
 * Standard JSON Interface: Introduce `settings.experimental` setting required for enabling the experimental mode.
-* Yul EVM Code Transform: Improve stack shuffler performance by fixing a BFS deduplication issue.
+* Yul Optimizer: Improve performance of control flow side effects collector and function references resolver.
 
 Bugfixes:
+* Yul EVM Code Transform: Improve stack shuffler performance by fixing a BFS deduplication issue.
 
 
 ### 0.8.34 (2026-02-18)
@@ -21,7 +22,6 @@ Important Bugfixes:
 
 
 Compiler Features:
-* Yul Optimizer: Improve performance of control flow side effects collector and function references resolver.
 * Yul Optimizer: Remove redundant prerequisite steps from the default optimizer sequence.
 
 


### PR DESCRIPTION
This PR fixes two issues (pointed out in https://github.com/argotorg/solidity/pull/16486#discussion_r2933283348):

- https://github.com/argotorg/solidity/pull/16499 was classified as compiler feature when it much rather is a bugfix
- https://github.com/argotorg/solidity/pull/16486 was erroneously put into the changelog of 0.8.34 (past the release of that version) when it should have been 0.8.35  