### PR TITLE
cmake: generate compile_commands.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.13.0)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 set(ETH_CMAKE_DIR   "${CMAKE_CURRENT_LIST_DIR}/cmake"   CACHE PATH "The path to the cmake directory")
 list(APPEND CMAKE_MODULE_PATH ${ETH_CMAKE_DIR})
 


### PR DESCRIPTION
Makes cmake generate `compile_commands.json` by default. This is used by `clangd` and makes life a little nicer when browsing in non-clion environments. Seems to have no impact on configure times (on my laptop at least).