### PR TITLE
.gitignore: add .claude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ emscripten_build/
 # OS specific local files
 .DS_Store
 Thumbs.db
+
+# AI tooling
+/.claude/


### PR DESCRIPTION
Claude creates this when e.g. whitelisting tools for the local project.