### PR TITLE
Fix operator precedence in StackLimitEvader memory guard assertion

### DIFF
--- a/libyul/optimiser/StackLimitEvader.cpp
+++ b/libyul/optimiser/StackLimitEvader.cpp
@@ -210,7 +210,7 @@ void StackLimitEvader::run(
 
 	// Make sure all calls to ``memoryguard`` we found have the same value as argument (otherwise, abort).
 	u256 reservedMemory = literalArgumentValue(*memoryGuardCalls.front());
-	yulAssert(reservedMemory < u256(1) << 32 - 1, "");
+	yulAssert(reservedMemory < (u256(1) << 32) - 1, "");
 
 	for (FunctionCall const* memoryGuardCall: memoryGuardCalls)
 		if (reservedMemory != literalArgumentValue(*memoryGuardCall))


### PR DESCRIPTION
The expression u256(1) << 32 - 1 was incorrectly evaluated as u256(1) << 31 due to operator precedence (32 - 1 evaluated first). Add parentheses to correctly compute (u256(1) << 32) - 1, i.e. the maximum 32-bit value.