### PR TITLE
Separate out debug data from SSA CFG nodes into external structure

### DIFF
--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -90,6 +90,7 @@ add_library(yul
 	backends/evm/ssa/SSACFG.h
 	backends/evm/ssa/SSACFGBuilder.cpp
 	backends/evm/ssa/SSACFGBuilder.h
+	backends/evm/ssa/SSACFGTypes.h
 	backends/evm/ssa/Stack.cpp
 	backends/evm/ssa/Stack.h
 	backends/evm/ssa/StackLayout.h

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -90,6 +90,7 @@ add_library(yul
 	backends/evm/ssa/SSACFG.h
 	backends/evm/ssa/SSACFGBuilder.cpp
 	backends/evm/ssa/SSACFGBuilder.h
+	backends/evm/ssa/SSACFGDebugInfo.h
 	backends/evm/ssa/SSACFGTypes.h
 	backends/evm/ssa/Stack.cpp
 	backends/evm/ssa/Stack.h

--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -87,12 +87,17 @@ CodeTransform::FunctionLabels CodeTransform::registerFunctionLabels(
 		if (!_function)
 			continue;
 		bool nameAlreadySeen = !assignedFunctionNames.insert(_function->name).second;
+		auto const sourceID = [&]() -> std::optional<std::size_t> {
+			if (_functionGraph->debugInfo && _functionGraph->debugInfo->graphDebugData)
+				return _functionGraph->debugInfo->graphDebugData->astID;
+			return std::nullopt;
+		}();
 		functionLabels[_function] = !nameAlreadySeen ?
 			_assembly.namedLabel(
 				_function->name.str(),
 				_functionGraph->arguments.size(),
 				_functionGraph->returns.size(),
-				_functionGraph->debugData ? _functionGraph->debugData->astID : std::nullopt
+				sourceID
 			) :
 			_assembly.newLabelId();
 	}
@@ -171,11 +176,10 @@ void CodeTransform::operator()(SSACFG::BlockId const _blockId)
 
 	for (std::size_t operationIndex = 0; operationIndex < block.operations.size(); ++operationIndex)
 	{
-		SSACFG::Operation const& operation = m_cfg.operation(block.operations[operationIndex]);
 		auto const& operationInLayout = blockLayout->operationIn[operationIndex];
 
 		// perform the operation
-		(*this)(operation, operationInLayout);
+		(*this)(block.operations[operationIndex], operationInLayout);
 	}
 
 	// Shuffle to the block's exit layout before dispatching the exit.
@@ -187,8 +191,9 @@ void CodeTransform::operator()(SSACFG::BlockId const _blockId)
 	std::visit(util::GenericVisitor{ [this, &_blockId](auto const& exit) { (*this)(_blockId, exit); } }, block.exit);
 }
 
-void CodeTransform::operator()(SSACFG::Operation const& _operation, StackData const& _operationInputLayout)
+void CodeTransform::operator()(SSACFG::OperationId _opId, StackData const& _operationInputLayout)
 {
+	SSACFG::Operation const& _operation = m_cfg.operation(_opId);
 	bool const hasReturnLabel =
 			std::holds_alternative<SSACFG::Call>(_operation.kind) &&
 			std::get<SSACFG::Call>(_operation.kind).canContinue;
@@ -235,10 +240,17 @@ void CodeTransform::operator()(SSACFG::Operation const& _operation, StackData co
 	// height of the stack sans function return label and operation inputs
 	std::size_t const baseHeight = m_stack.size() - _operation.inputs.size() - (hasReturnLabel ? 1 : 0);
 
+	auto const opOriginLocation = [&]() -> langutil::SourceLocation {
+		if (m_cfg.debugInfo)
+			if (auto const& dbg = m_cfg.debugInfo->operationDebugData(_opId))
+				return dbg->originLocation;
+		return {};
+	}();
+
 	// generate code for the operation
 	std::visit(util::GenericVisitor{
 		[&](SSACFG::BuiltinCall const& _builtin) {
-			m_assembly.setSourceLocation(originLocationOf(_builtin));
+			m_assembly.setSourceLocation(opOriginLocation);
 			static_cast<BuiltinFunctionForEVM const&>(_builtin.builtin.get()).generateCode(
 				_builtin.call,
 				m_assembly,
@@ -249,7 +261,7 @@ void CodeTransform::operator()(SSACFG::Operation const& _operation, StackData co
 			auto const* returnLabel = util::valueOrNullptr(m_returnLabels, &_call.call.get());
 			// check that if we have a return label, the call can continue
 			yulAssert(!!returnLabel == _call.canContinue);
-			m_assembly.setSourceLocation(originLocationOf(_call));
+			m_assembly.setSourceLocation(opOriginLocation);
 			m_assembly.appendJumpTo(
 				m_functionLabels.at(&_call.function.get()),
 				static_cast<int>(_call.function.get().numReturns - _call.function.get().numArguments) - (_call.canContinue ? 1 : 0),

--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -171,7 +171,7 @@ void CodeTransform::operator()(SSACFG::BlockId const _blockId)
 
 	for (std::size_t operationIndex = 0; operationIndex < block.operations.size(); ++operationIndex)
 	{
-		SSACFG::Operation const& operation = block.operations[operationIndex];
+		SSACFG::Operation const& operation = m_cfg.operation(block.operations[operationIndex]);
 		auto const& operationInLayout = blockLayout->operationIn[operationIndex];
 
 		// perform the operation
@@ -373,7 +373,7 @@ void CodeTransform::operator()(SSACFG::BlockId const& _blockId, SSACFG::BasicBlo
 		[](SSACFG::LiteralAssignment const&) {
 			yulAssert(false, "Terminated block cannot end with a literal assignment.");
 		}
-	}, block.operations.back().kind);
+	}, m_cfg.operation(block.operations.back()).kind);
 	// To be sure just emit another INVALID - should be removed by optimizer.
 	m_assembly.appendInstruction(evmasm::Instruction::INVALID);
 }

--- a/libyul/backends/evm/ssa/CodeTransform.h
+++ b/libyul/backends/evm/ssa/CodeTransform.h
@@ -118,7 +118,7 @@ private:
 		ControlFlow::FunctionGraphID _graphID);
 
 	void operator()(SSACFG::BlockId _blockId);
-	void operator()(SSACFG::Operation const& _operation, StackData const& _operationInputLayout);
+	void operator()(SSACFG::OperationId _opId, StackData const& _operationInputLayout);
 	void operator()(SSACFG::BlockId const& _currentBlock, SSACFG::BasicBlock::MainExit const& _mainExit);
 	void operator()(SSACFG::BlockId const& _currentBlock, SSACFG::BasicBlock::ConditionalJump const& _conditionalJump);
 	void operator()(SSACFG::BlockId const& _currentBlock, SSACFG::BasicBlock::Jump const& _jump);

--- a/libyul/backends/evm/ssa/LivenessAnalysis.cpp
+++ b/libyul/backends/evm/ssa/LivenessAnalysis.cpp
@@ -243,8 +243,9 @@ void LivenessAnalysis::runDagDfs()
 			// add value ids to the live set that are used in exit blocks
 			live += blockExitValues(blockId);
 
-			for (auto const& op: block.operations | ranges::views::reverse)
+			for (auto const opId: block.operations | ranges::views::reverse)
 			{
+				auto const& op = m_cfg.operation(opId);
 				// remove variables defined at p from live
 				live.eraseAll(op.outputs | ranges::views::filter(excludingLiteralsFilter()) | ranges::to<std::vector>);
 				// add uses at p to live
@@ -297,8 +298,9 @@ void LivenessAnalysis::fillOperationsLiveOut()
 			auto live = m_liveOuts[blockId.value];
 			live += blockExitValues(blockId);
 			auto rit = liveOuts.rbegin();
-			for (auto const& op: operations | ranges::views::reverse)
+			for (auto const opId: operations | ranges::views::reverse)
 			{
+				auto const& op = m_cfg.operation(opId);
 				*rit = live;
 				for (auto const& output: op.outputs | ranges::views::filter(excludingLiteralsFilter()))
 					live.erase(output);

--- a/libyul/backends/evm/ssa/SSACFG.cpp
+++ b/libyul/backends/evm/ssa/SSACFG.cpp
@@ -100,8 +100,9 @@ protected:
 			auto const& phiInfo = m_cfg.phiInfo(phi);
 			_out << fmt::format("phi{} := {}\\l\\\n", phi.value(), formatPhi(m_cfg, phiInfo));
 		}
-		for (auto const& operation: block.operations)
+		for (auto const opId: block.operations)
 		{
+			auto const& operation = m_cfg.operation(opId);
 			std::string const label = std::visit(GenericVisitor{
 				[&](SSACFG::Call const& _call) {
 					return _call.function.get().name.str();

--- a/libyul/backends/evm/ssa/SSACFG.cpp
+++ b/libyul/backends/evm/ssa/SSACFG.cpp
@@ -156,7 +156,7 @@ private:
 
 }
 
-std::string SSACFG::ValueId::str(SSACFG const& _cfg) const
+std::string ValueId::str(SSACFG const& _cfg) const
 {
 	if (!hasValue())
 		return "INVALID";

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <libyul/backends/evm/ssa/SSACFGDebugInfo.h>
 #include <libyul/backends/evm/ssa/SSACFGTypes.h>
 
 #include <libyul/AST.h>
@@ -44,7 +45,12 @@ class LivenessAnalysis;
 class SSACFG
 {
 public:
-	SSACFG() = default;
+	using DebugInfo = SSACFGDebugInfo;
+
+	explicit SSACFG(std::unique_ptr<DebugInfo> _debugInfo = std::make_unique<DebugInfo>()):
+		debugInfo(std::move(_debugInfo))
+	{}
+
 	SSACFG(SSACFG const&) = delete;
 	SSACFG(SSACFG&&) = delete;
 	SSACFG& operator=(SSACFG const&) = delete;
@@ -57,21 +63,16 @@ public:
 
 	struct BuiltinCall
 	{
-		langutil::DebugData::ConstPtr debugData;
 		std::reference_wrapper<BuiltinFunction const> builtin;
 		std::reference_wrapper<FunctionCall const> call;
 	};
 	struct Call
 	{
-		langutil::DebugData::ConstPtr debugData;
 		std::reference_wrapper<Scope::Function const> function;
 		std::reference_wrapper<FunctionCall const> call;
 		bool canContinue;
 	};
-	struct LiteralAssignment
-	{
-		langutil::DebugData::ConstPtr debugData;
-	};
+	struct LiteralAssignment {};
 
 	struct Operation {
 		std::vector<ValueId> outputs{};
@@ -83,23 +84,19 @@ public:
 		struct MainExit {};
 		struct ConditionalJump
 		{
-			langutil::DebugData::ConstPtr debugData{};
 			ValueId condition;
 			BlockId nonZero;
 			BlockId zero;
 		};
 		struct Jump
 		{
-			langutil::DebugData::ConstPtr debugData{};
 			BlockId target;
 		};
 		struct FunctionReturn
 		{
-			langutil::DebugData::ConstPtr debugData{};
 			std::vector<ValueId> returnValues;
 		};
 		struct Terminated {};
-		langutil::DebugData::ConstPtr debugData;
 		std::set<BlockId> entries;
 		std::set<ValueId> phis;
 		std::vector<OperationId> operations;
@@ -136,20 +133,25 @@ public:
 			return std::holds_alternative<Jump>(exit);
 		}
 	};
+
 	BlockId makeBlock(langutil::DebugData::ConstPtr _debugData)
 	{
 		BlockId blockId { static_cast<BlockId::ValueType>(m_blocks.size()) };
-		m_blocks.emplace_back(BasicBlock{std::move(_debugData), {}, {}, {}, BasicBlock::Terminated{}});
+		m_blocks.emplace_back(BasicBlock{{}, {}, {}, BasicBlock::Terminated{}});
+		if (debugInfo)
+			debugInfo->setBlockDebugData(blockId, std::move(_debugData));
 		return blockId;
 	}
 	BasicBlock& block(BlockId _id) { return m_blocks.at(_id.value); }
 	BasicBlock const& block(BlockId _id) const { return m_blocks.at(_id.value); }
 	size_t numBlocks() const { return m_blocks.size(); }
 
-	OperationId makeOperation(Operation _op)
+	OperationId makeOperation(Operation _op, langutil::DebugData::ConstPtr _debugData = {})
 	{
 		OperationId id{static_cast<OperationId::ValueType>(m_operations.size())};
 		m_operations.emplace_back(std::move(_op));
+		if (debugInfo && _debugData)
+			debugInfo->setOperationDebugData(id, std::move(_debugData));
 		return id;
 	}
 	Operation& operation(OperationId _id) { return m_operations.at(_id.value); }
@@ -160,34 +162,35 @@ private:
 	std::vector<Operation> m_operations;
 public:
 	struct LiteralValue {
-		langutil::DebugData::ConstPtr debugData;
 		u256 value;
 	};
 	struct VariableValue {
-		langutil::DebugData::ConstPtr debugData;
 		BlockId definingBlock;
 	};
 	struct PhiValue {
-		langutil::DebugData::ConstPtr debugData;
 		BlockId block;
 		std::vector<ValueId> arguments;
 	};
 	struct UnreachableValue {};
 	ValueId newPhi(BlockId const _definingBlock)
 	{
-		auto const& block = m_blocks.at(_definingBlock.value);
-		m_phis.emplace_back(PhiValue{debugDataOf(block), _definingBlock, std::vector<ValueId>{}});
+		m_phis.emplace_back(PhiValue{_definingBlock, std::vector<ValueId>{}});
 		auto const value = m_phis.size() - 1;
 		yulAssert(value < std::numeric_limits<ValueId::ValueType>::max());
-		return ValueId::makePhi(static_cast<ValueId::ValueType>(value));
+		auto const id = ValueId::makePhi(static_cast<ValueId::ValueType>(value));
+		if (debugInfo)
+			debugInfo->setValueDebugData(id, debugInfo->blockDebugData(_definingBlock));
+		return id;
 	}
 	ValueId newVariable(BlockId const _definingBlock)
 	{
-		auto const& block = m_blocks.at(_definingBlock.value);
-		m_variables.emplace_back(VariableValue{debugDataOf(block), _definingBlock});
+		m_variables.emplace_back(VariableValue{_definingBlock});
 		auto const value = m_variables.size() - 1;
 		yulAssert(value < std::numeric_limits<ValueId::ValueType>::max());
-		return ValueId::makeVariable(static_cast<ValueId::ValueType>(value));
+		auto const id = ValueId::makeVariable(static_cast<ValueId::ValueType>(value));
+		if (debugInfo)
+			debugInfo->setValueDebugData(id, debugInfo->blockDebugData(_definingBlock));
+		return id;
 	}
 
 	ValueId unreachableValue()
@@ -207,11 +210,12 @@ public:
 			return valueId;
 		}
 
-
-		m_literals.emplace_back(LiteralValue{std::move(_debugData), std::move(_value)});
+		m_literals.emplace_back(LiteralValue{std::move(_value)});
 		auto const value = m_literals.size() - 1;
 		yulAssert(value < std::numeric_limits<ValueId::ValueType>::max());
 		auto const literalId = ValueId::makeLiteral(static_cast<ValueId::ValueType>(value));
+		if (debugInfo)
+			debugInfo->setValueDebugData(literalId, std::move(_debugData));
 		m_literalMapping.emplace(_value, literalId);
 		return literalId;
 	}
@@ -258,7 +262,7 @@ private:
 	std::vector<VariableValue> m_variables;
 	std::optional<ValueId> m_unreachableValue;
 public:
-	langutil::DebugData::ConstPtr debugData;
+	std::unique_ptr<DebugInfo> debugInfo;
 	BlockId entry = BlockId{0};
 	std::set<BlockId> exits;
 	Scope::Function const* function = nullptr;

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <libyul/backends/evm/ssa/SSACFGTypes.h>
+
 #include <libyul/AST.h>
 #include <libyul/AsmAnalysisInfo.h>
 #include <libyul/Dialect.h>
@@ -49,60 +51,9 @@ public:
 	SSACFG& operator=(SSACFG&&) = delete;
 	~SSACFG() = default;
 
-	struct BlockId
-	{
-		using ValueType = std::uint32_t;
-		ValueType value = std::numeric_limits<ValueType>::max();
-		bool hasValue() const { return value != std::numeric_limits<ValueType>::max(); }
-		auto operator<=>(BlockId const&) const = default;
-	};
-	struct OperationId
-	{
-		using ValueType = std::uint32_t;
-		ValueType value = std::numeric_limits<ValueType>::max();
-		bool hasValue() const { return value != std::numeric_limits<ValueType>::max(); }
-		auto operator<=>(OperationId const&) const = default;
-	};
-	class ValueId
-	{
-	public:
-		enum class Kind: std::uint8_t
-		{
-			Literal,
-			Variable,
-			Phi,
-			Unreachable
-		};
-		using ValueType = std::uint32_t;
-
-		constexpr ValueId() = default;
-		constexpr ValueId(ValueType const _value, Kind const _kind): m_value(_value), m_kind(_kind) {}
-		constexpr ValueId(ValueId const&) = default;
-		constexpr ValueId(ValueId&&) = default;
-		constexpr ValueId& operator=(ValueId const&) = default;
-		constexpr ValueId& operator=(ValueId&&) = default;
-
-		static ValueId constexpr makeLiteral(ValueType const& _value) { return ValueId{_value, Kind::Literal}; }
-		static ValueId constexpr makeVariable(ValueType const& _value) { return ValueId{_value, Kind::Variable}; }
-		static ValueId constexpr makePhi(ValueType const& _value) { return ValueId{_value, Kind::Phi}; }
-		static ValueId constexpr makeUnreachable() { return ValueId{0u, Kind::Unreachable}; }
-
-		bool constexpr isLiteral() const noexcept { return m_kind == Kind::Literal; }
-		bool constexpr isVariable() const noexcept { return m_kind == Kind::Variable; }
-		bool constexpr isPhi() const noexcept { return m_kind == Kind::Phi; }
-		bool constexpr isUnreachable() const noexcept { return m_kind == Kind::Unreachable; }
-
-		bool constexpr hasValue() const { return m_value != std::numeric_limits<ValueType>::max(); }
-		ValueType constexpr value() const noexcept { return m_value; }
-		Kind constexpr kind() const noexcept { return m_kind; }
-		std::string str(SSACFG const& _cfg) const;
-
-		auto operator<=>(ValueId const&) const = default;
-
-	private:
-		ValueType m_value{std::numeric_limits<ValueType>::max()};
-		Kind m_kind{Kind::Unreachable};
-	};
+	using BlockId = ssa::BlockId;
+	using OperationId = ssa::OperationId;
+	using ValueId = ssa::ValueId;
 
 	struct BuiltinCall
 	{
@@ -320,56 +271,3 @@ public:
 };
 
 }
-
-template<>
-struct fmt::formatter<solidity::yul::ssa::SSACFG::BlockId>
-{
-	static auto constexpr parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
-
-	template<typename FormatContext>
-	auto format(solidity::yul::ssa::SSACFG::BlockId const& _blockId, FormatContext& _ctx) const -> decltype(_ctx.out())
-	{
-		if (!_blockId.hasValue())
-			return fmt::format_to(_ctx.out(), "empty");
-		return fmt::format_to(_ctx.out(), "{}", _blockId.value);
-	}
-};
-
-template<>
-struct fmt::formatter<solidity::yul::ssa::SSACFG::OperationId>
-{
-	static auto constexpr parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
-
-	template<typename FormatContext>
-	auto format(solidity::yul::ssa::SSACFG::OperationId const& _opId, FormatContext& _ctx) const -> decltype(_ctx.out())
-	{
-		if (!_opId.hasValue())
-			return fmt::format_to(_ctx.out(), "empty");
-		return fmt::format_to(_ctx.out(), "op{}", _opId.value);
-	}
-};
-
-template<>
-struct fmt::formatter<solidity::yul::ssa::SSACFG::ValueId>
-{
-	static auto constexpr parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
-
-	template<typename FormatContext>
-	auto format(solidity::yul::ssa::SSACFG::ValueId const& _valueId, FormatContext& _ctx) const -> decltype(_ctx.out())
-	{
-		if (!_valueId.hasValue())
-			return fmt::format_to(_ctx.out(), "empty");
-		switch (_valueId.kind())
-		{
-		case solidity::yul::ssa::SSACFG::ValueId::Kind::Literal:
-			return fmt::format_to(_ctx.out(), "lit{}", _valueId.value());
-		case solidity::yul::ssa::SSACFG::ValueId::Kind::Variable:
-			return fmt::format_to(_ctx.out(), "v{}", _valueId.value());
-		case solidity::yul::ssa::SSACFG::ValueId::Kind::Phi:
-			return fmt::format_to(_ctx.out(), "phi{}", _valueId.value());
-		case solidity::yul::ssa::SSACFG::ValueId::Kind::Unreachable:
-			return fmt::format_to(_ctx.out(), "unreachable");
-		}
-		solidity::util::unreachable();
-	}
-};

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -56,6 +56,13 @@ public:
 		bool hasValue() const { return value != std::numeric_limits<ValueType>::max(); }
 		auto operator<=>(BlockId const&) const = default;
 	};
+	struct OperationId
+	{
+		using ValueType = std::uint32_t;
+		ValueType value = std::numeric_limits<ValueType>::max();
+		bool hasValue() const { return value != std::numeric_limits<ValueType>::max(); }
+		auto operator<=>(OperationId const&) const = default;
+	};
 	class ValueId
 	{
 	public:
@@ -144,7 +151,7 @@ public:
 		langutil::DebugData::ConstPtr debugData;
 		std::set<BlockId> entries;
 		std::set<ValueId> phis;
-		std::vector<Operation> operations;
+		std::vector<OperationId> operations;
 		std::variant<MainExit, Jump, ConditionalJump, FunctionReturn, Terminated> exit = MainExit{};
 		template<typename Callable>
 		void forEachExit(Callable&& _callable) const
@@ -188,8 +195,18 @@ public:
 	BasicBlock const& block(BlockId _id) const { return m_blocks.at(_id.value); }
 	size_t numBlocks() const { return m_blocks.size(); }
 
+	OperationId makeOperation(Operation _op)
+	{
+		OperationId id{static_cast<OperationId::ValueType>(m_operations.size())};
+		m_operations.emplace_back(std::move(_op));
+		return id;
+	}
+	Operation& operation(OperationId _id) { return m_operations.at(_id.value); }
+	Operation const& operation(OperationId _id) const { return m_operations.at(_id.value); }
+
 private:
 	std::vector<BasicBlock> m_blocks;
+	std::vector<Operation> m_operations;
 public:
 	struct LiteralValue {
 		langutil::DebugData::ConstPtr debugData;
@@ -315,6 +332,20 @@ struct fmt::formatter<solidity::yul::ssa::SSACFG::BlockId>
 		if (!_blockId.hasValue())
 			return fmt::format_to(_ctx.out(), "empty");
 		return fmt::format_to(_ctx.out(), "{}", _blockId.value);
+	}
+};
+
+template<>
+struct fmt::formatter<solidity::yul::ssa::SSACFG::OperationId>
+{
+	static auto constexpr parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
+
+	template<typename FormatContext>
+	auto format(solidity::yul::ssa::SSACFG::OperationId const& _opId, FormatContext& _ctx) const -> decltype(_ctx.out())
+	{
+		if (!_opId.hasValue())
+			return fmt::format_to(_ctx.out(), "empty");
+		return fmt::format_to(_ctx.out(), "op{}", _opId.value);
 	}
 };
 

--- a/libyul/backends/evm/ssa/SSACFGBuilder.cpp
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.cpp
@@ -51,14 +51,16 @@ SSACFGBuilder::SSACFGBuilder(
 	AsmAnalysisInfo const& _analysisInfo,
 	ControlFlowSideEffectsCollector const& _sideEffects,
 	Dialect const& _dialect,
-	bool _keepLiteralAssignments
+	bool _keepLiteralAssignments,
+	bool _generateDebugInfo
 ):
 	m_controlFlow(_controlFlow),
 	m_graph(_graph),
 	m_info(_analysisInfo),
 	m_sideEffects(_sideEffects),
 	m_dialect(_dialect),
-	m_keepLiteralAssignments(_keepLiteralAssignments)
+	m_keepLiteralAssignments(_keepLiteralAssignments),
+	m_generateDebugInfo(_generateDebugInfo)
 {
 }
 
@@ -66,16 +68,19 @@ std::unique_ptr<ControlFlow> SSACFGBuilder::build(
 	AsmAnalysisInfo const& _analysisInfo,
 	Dialect const& _dialect,
 	Block const& _block,
-	bool _keepLiteralAssignments
+	bool _keepLiteralAssignments,
+	bool _generateDebugInfo
 )
 {
 	ControlFlowSideEffectsCollector sideEffects(_dialect, _block);
 
 	auto controlFlow = std::make_unique<ControlFlow>();
-	controlFlow->functionGraphs.emplace_back(std::make_unique<SSACFG>());
+	controlFlow->functionGraphs.emplace_back(std::make_unique<SSACFG>(
+		_generateDebugInfo ? std::make_unique<SSACFGDebugInfo>() : nullptr
+	));
 	controlFlow->functionGraphMapping.emplace_back(nullptr, controlFlow->functionGraphs.back().get());
 	SSACFG& mainGraph = *controlFlow->functionGraphs.back();
-	SSACFGBuilder builder(*controlFlow, mainGraph, _analysisInfo, sideEffects, _dialect, _keepLiteralAssignments);
+	SSACFGBuilder builder(*controlFlow, mainGraph, _analysisInfo, sideEffects, _dialect, _keepLiteralAssignments, _generateDebugInfo);
 	builder.m_currentBlock = mainGraph.makeBlock(debugDataOf(_block));
 	builder.sealBlock(builder.m_currentBlock);
 	builder(_block);
@@ -203,7 +208,9 @@ void SSACFGBuilder::buildFunctionGraph(
 	FunctionDefinition const* _functionDefinition
 )
 {
-	m_controlFlow.functionGraphs.emplace_back(std::make_unique<SSACFG>());
+	m_controlFlow.functionGraphs.emplace_back(std::make_unique<SSACFG>(
+		m_generateDebugInfo ? std::make_unique<SSACFGDebugInfo>() : nullptr
+	));
 	auto& cfg = *m_controlFlow.functionGraphs.back();
 	m_controlFlow.functionGraphMapping.emplace_back(_function, &cfg);
 
@@ -221,13 +228,14 @@ void SSACFGBuilder::buildFunctionGraph(
 		return std::cref(std::get<Scope::Variable>(virtualFunctionScope->identifiers.at(_param.name)));
 	}) | ranges::to<std::vector>;
 
-	cfg.debugData = _functionDefinition->debugData;
+	if (cfg.debugInfo)
+		cfg.debugInfo->graphDebugData = _functionDefinition->debugData;
 	cfg.function = _function;
 	cfg.canContinue = m_sideEffects.functionSideEffects().at(_functionDefinition).canContinue;
 	cfg.arguments = arguments;
 	cfg.returns = returns;
 
-	SSACFGBuilder builder(m_controlFlow, cfg, m_info, m_sideEffects, m_dialect, m_keepLiteralAssignments);
+	SSACFGBuilder builder(m_controlFlow, cfg, m_info, m_sideEffects, m_dialect, m_keepLiteralAssignments, m_generateDebugInfo);
 	builder.m_currentBlock = cfg.entry;
 	builder.m_functionDefinitions = m_functionDefinitions;
 	for (auto&& [var, varId]: cfg.arguments)
@@ -288,7 +296,7 @@ void SSACFGBuilder::operator()(If const& _if)
 	{
 		auto condition = std::visit(*this, *_if.condition);
 		auto ifBranch = m_graph.makeBlock(debugDataOf(_if.body));
-		auto afterIf = m_graph.makeBlock(debugDataOf(currentBlock()));
+		auto afterIf = m_graph.makeBlock(currentBlockDebugData());
 		conditionalJump(
 			debugDataOf(_if),
 			condition,
@@ -342,17 +350,16 @@ void SSACFGBuilder::operator()(Switch const& _switch)
 		auto opId = m_graph.makeOperation(SSACFG::Operation{
 			{outputValue},
 			SSACFG::BuiltinCall{
-				debugDataOf(_case),
 				m_dialect.builtin(*equalityBuiltinHandle),
 				ghostCall
 			},
 			{m_graph.newLiteral(debugDataOf(_case), _case.value->value.value()), expression}
-		});
+		}, debugDataOf(_case));
 		currentBlock().operations.emplace_back(opId);
 		return outputValue;
 	};
 
-	auto afterSwitch = m_graph.makeBlock(debugDataOf(currentBlock()));
+	auto afterSwitch = m_graph.makeBlock(currentBlockDebugData());
 	yulAssert(!_switch.cases.empty(), "");
 	for (auto const& switchCase: _switch.cases | ranges::views::drop_last(1))
 	{
@@ -384,7 +391,7 @@ void SSACFGBuilder::operator()(ForLoop const& _loop)
 {
 	ScopedSaveAndRestore scopeRestore(m_scope, m_info.scopes.at(&_loop.pre).get());
 	(*this)(_loop.pre);
-	auto preLoopDebugData = debugDataOf(currentBlock());
+	auto preLoopDebugData = currentBlockDebugData();
 
 	std::optional<bool> constantCondition;
 	if (auto const* literalCondition = std::get_if<Literal>(_loop.condition.get()))
@@ -446,31 +453,32 @@ void SSACFGBuilder::operator()(ForLoop const& _loop)
 void SSACFGBuilder::operator()(Break const& _break)
 {
 	yulAssert(!m_forLoopInfo.empty());
-	auto currentBlockDebugData = debugDataOf(currentBlock());
+	auto savedBlockDebugData = currentBlockDebugData();
 	jump(debugDataOf(_break), m_forLoopInfo.top().breakBlock);
-	m_currentBlock = m_graph.makeBlock(currentBlockDebugData);
+	m_currentBlock = m_graph.makeBlock(savedBlockDebugData);
 	sealBlock(m_currentBlock);
 }
 
 void SSACFGBuilder::operator()(Continue const& _continue)
 {
 	yulAssert(!m_forLoopInfo.empty());
-	auto currentBlockDebugData = debugDataOf(currentBlock());
+	auto const savedBlockDebugData = currentBlockDebugData();
 	jump(debugDataOf(_continue), m_forLoopInfo.top().continueBlock);
-	m_currentBlock = m_graph.makeBlock(currentBlockDebugData);
+	m_currentBlock = m_graph.makeBlock(savedBlockDebugData);
 	sealBlock(m_currentBlock);
 }
 
 void SSACFGBuilder::operator()(Leave const& _leaveStatement)
 {
-	auto currentBlockDebugData = debugDataOf(currentBlock());
+	auto const savedBlockDebugData = currentBlockDebugData();
+	if (m_graph.debugInfo)
+		m_graph.debugInfo->setExitDebugData(m_currentBlock, debugDataOf(_leaveStatement));
 	currentBlock().exit = SSACFG::BasicBlock::FunctionReturn{
-		debugDataOf(_leaveStatement),
 		m_graph.returns | ranges::views::transform([&](auto _var) {
 			return readVariable(_var, m_currentBlock);
 		}) | ranges::to<std::vector>
 	};
-	m_currentBlock = m_graph.makeBlock(currentBlockDebugData);
+	m_currentBlock = m_graph.makeBlock(savedBlockDebugData);
 	sealBlock(m_currentBlock);
 }
 
@@ -512,7 +520,7 @@ SSACFG::ValueId SSACFGBuilder::operator()(Identifier const& _identifier)
 
 SSACFG::ValueId SSACFGBuilder::operator()(Literal const& _literal)
 {
-	return m_graph.newLiteral(debugDataOf(currentBlock()), _literal.value.value());
+	return m_graph.newLiteral(currentBlockDebugData(), _literal.value.value());
 }
 
 void SSACFGBuilder::assign(std::vector<std::reference_wrapper<Scope::Variable const>> _variables, Expression const* _expression)
@@ -552,7 +560,7 @@ std::vector<SSACFG::ValueId> SSACFGBuilder::visitFunctionCall(FunctionCall const
 		[&](BuiltinName const& _builtinName)
 		{
 			auto const& builtin = m_dialect.builtin(_builtinName.handle);
-			SSACFG::Operation result{{}, SSACFG::BuiltinCall{_call.debugData, builtin, _call}, {}};
+			SSACFG::Operation result{{}, SSACFG::BuiltinCall{builtin, _call}, {}};
 			for (auto&& [idx, arg]: _call.arguments | ranges::views::enumerate | ranges::views::reverse)
 				if (!builtin.literalArgument(idx).has_value())
 					result.inputs.emplace_back(std::visit(*this, arg));
@@ -568,7 +576,7 @@ std::vector<SSACFG::ValueId> SSACFGBuilder::visitFunctionCall(FunctionCall const
 			auto const* definition = findFunctionDefinition(&function);
 			yulAssert(definition);
 			canContinue = m_sideEffects.functionSideEffects().at(definition).canContinue;
-			SSACFG::Operation result{{}, SSACFG::Call{debugDataOf(_call), function, _call, canContinue}, {}};
+			SSACFG::Operation result{{}, SSACFG::Call{function, _call, canContinue}, {}};
 			for (auto const& arg: _call.arguments | ranges::views::reverse)
 				result.inputs.emplace_back(std::visit(*this, arg));
 			for (size_t i = 0; i < function.numReturns; ++i)
@@ -577,11 +585,11 @@ std::vector<SSACFG::ValueId> SSACFGBuilder::visitFunctionCall(FunctionCall const
 		}
 	}, _call.functionName);
 	auto results = operation.outputs;
-	currentBlock().operations.emplace_back(m_graph.makeOperation(std::move(operation)));
+	currentBlock().operations.emplace_back(m_graph.makeOperation(std::move(operation), debugDataOf(_call)));
 	if (!canContinue)
 	{
 		currentBlock().exit = SSACFG::BasicBlock::Terminated{};
-		m_currentBlock = m_graph.makeBlock(debugDataOf(currentBlock()));
+		m_currentBlock = m_graph.makeBlock(currentBlockDebugData());
 		sealBlock(m_currentBlock);
 	}
 	return results;
@@ -589,7 +597,7 @@ std::vector<SSACFG::ValueId> SSACFGBuilder::visitFunctionCall(FunctionCall const
 
 SSACFG::ValueId SSACFGBuilder::zero()
 {
-	return m_graph.newLiteral(debugDataOf(currentBlock()), 0u);
+	return m_graph.newLiteral(currentBlockDebugData(), 0u);
 }
 
 SSACFG::ValueId SSACFGBuilder::readVariable(Scope::Variable const& _variable, SSACFG::BlockId _block)
@@ -695,8 +703,9 @@ void SSACFGBuilder::conditionalJump(
 	SSACFG::BlockId _zero
 )
 {
+	if (m_graph.debugInfo)
+		m_graph.debugInfo->setExitDebugData(m_currentBlock, std::move(_debugData));
 	currentBlock().exit = SSACFG::BasicBlock::ConditionalJump{
-		std::move(_debugData),
 		_condition,
 		_nonZero,
 		_zero
@@ -711,7 +720,9 @@ void SSACFGBuilder::jump(
 	SSACFG::BlockId _target
 )
 {
-	currentBlock().exit = SSACFG::BasicBlock::Jump{std::move(_debugData), _target};
+	if (m_graph.debugInfo)
+		m_graph.debugInfo->setExitDebugData(m_currentBlock, std::move(_debugData));
+	currentBlock().exit = SSACFG::BasicBlock::Jump{_target};
 	yulAssert(!blockInfo(_target).sealed);
 	m_graph.block(_target).entries.insert(m_currentBlock);
 	m_currentBlock = _target;
@@ -719,9 +730,8 @@ void SSACFGBuilder::jump(
 
 FunctionDefinition const* SSACFGBuilder::findFunctionDefinition(Scope::Function const* _function) const
 {
-	auto it = std::find_if(
-			m_functionDefinitions.begin(),
-			m_functionDefinitions.end(),
+	auto it = ranges::find_if(
+			m_functionDefinitions,
 			[&_function](auto const& _entry) { return std::get<0>(_entry) == _function; }
 		);
 	if (it != m_functionDefinitions.end())

--- a/libyul/backends/evm/ssa/SSACFGBuilder.cpp
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.cpp
@@ -129,8 +129,8 @@ SSACFG::ValueId SSACFGBuilder::tryRemoveTrivialPhi(SSACFG::ValueId _phi)
 			if (usedInPhi)
 				phiUses.push_back(blockPhi);
 		}
-		for (auto& op: block.operations)
-			ranges::replace(op.inputs, _phi, same);
+		for (auto opId: block.operations)
+			ranges::replace(m_graph.operation(opId).inputs, _phi, same);
 		std::visit(util::GenericVisitor{
 			[_phi, same](SSACFG::BasicBlock::FunctionReturn& _functionReturn) {
 				ranges::replace(_functionReturn.returnValues,_phi, same);
@@ -339,7 +339,7 @@ void SSACFGBuilder::operator()(Switch const& _switch)
 			{*_case.value /* skip second argument */ }
 		});
 		auto outputValue = m_graph.newVariable(m_currentBlock);
-		currentBlock().operations.emplace_back(SSACFG::Operation{
+		auto opId = m_graph.makeOperation(SSACFG::Operation{
 			{outputValue},
 			SSACFG::BuiltinCall{
 				debugDataOf(_case),
@@ -348,6 +348,7 @@ void SSACFGBuilder::operator()(Switch const& _switch)
 			},
 			{m_graph.newLiteral(debugDataOf(_case), _case.value->value.value()), expression}
 		});
+		currentBlock().operations.emplace_back(opId);
 		return outputValue;
 	};
 
@@ -534,8 +535,9 @@ void SSACFGBuilder::assign(std::vector<std::reference_wrapper<Scope::Variable co
 				.kind = SSACFG::LiteralAssignment{},
 				.inputs = {value}
 			};
-			currentBlock().operations.emplace_back(assignment);
-			writeVariable(var, m_currentBlock, assignment.outputs.back());
+			auto opId = m_graph.makeOperation(std::move(assignment));
+			currentBlock().operations.emplace_back(opId);
+			writeVariable(var, m_currentBlock, m_graph.operation(opId).outputs.back());
 		}
 		else
 			writeVariable(var, m_currentBlock, value);
@@ -575,7 +577,7 @@ std::vector<SSACFG::ValueId> SSACFGBuilder::visitFunctionCall(FunctionCall const
 		}
 	}, _call.functionName);
 	auto results = operation.outputs;
-	currentBlock().operations.emplace_back(std::move(operation));
+	currentBlock().operations.emplace_back(m_graph.makeOperation(std::move(operation)));
 	if (!canContinue)
 	{
 		currentBlock().exit = SSACFG::BasicBlock::Terminated{};

--- a/libyul/backends/evm/ssa/SSACFGBuilder.h
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.h
@@ -45,7 +45,8 @@ class SSACFGBuilder
 		AsmAnalysisInfo const& _analysisInfo,
 		ControlFlowSideEffectsCollector const& _sideEffects,
 		Dialect const& _dialect,
-		bool _keepLiteralAssignments
+		bool _keepLiteralAssignments,
+		bool _generateDebugInfo
 	);
 public:
 	SSACFGBuilder(SSACFGBuilder const&) = delete;
@@ -54,7 +55,8 @@ public:
 		AsmAnalysisInfo const& _analysisInfo,
 		Dialect const& _dialect,
 		Block const& _block,
-		bool _keepLiteralAssignments
+		bool _keepLiteralAssignments,
+		bool _generateDebugInfo = true
 	);
 
 	void operator()(ExpressionStatement const& _statement);
@@ -95,9 +97,14 @@ private:
 	ControlFlowSideEffectsCollector const& m_sideEffects;
 	Dialect const& m_dialect;
 	bool const m_keepLiteralAssignments;
+	bool const m_generateDebugInfo;
 	std::vector<std::tuple<Scope::Function const*, FunctionDefinition const*>> m_functionDefinitions;
 	SSACFG::BlockId m_currentBlock;
 	SSACFG::BasicBlock& currentBlock() { return m_graph.block(m_currentBlock); }
+	langutil::DebugData::ConstPtr currentBlockDebugData() const
+	{
+		return m_graph.debugInfo ? m_graph.debugInfo->blockDebugData(m_currentBlock) : nullptr;
+	}
 	Scope* m_scope = nullptr;
 	Scope::Function const& lookupFunction(YulName _name) const;
 	Scope::Variable const& lookupVariable(YulName _name) const;

--- a/libyul/backends/evm/ssa/SSACFGDebugInfo.h
+++ b/libyul/backends/evm/ssa/SSACFGDebugInfo.h
@@ -1,0 +1,133 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libyul/backends/evm/ssa/SSACFGTypes.h>
+
+#include <liblangutil/DebugData.h>
+#include <libyul/Exceptions.h>
+
+#include <vector>
+
+namespace solidity::yul::ssa
+{
+
+/// Stores debug data for all SSACFG entities in parallel arrays indexed by the entities' stable IDs.
+struct SSACFGDebugInfo
+{
+	void setBlockDebugData(BlockId _id, langutil::DebugData::ConstPtr _data)
+	{
+		yulAssert(_id.hasValue());
+		ensureSize(m_blockDebugData, _id.value);
+		m_blockDebugData[_id.value] = std::move(_data);
+	}
+
+	langutil::DebugData::ConstPtr const& blockDebugData(BlockId _id) const
+	{
+		return getOrEmpty(m_blockDebugData, _id.value);
+	}
+
+	void setExitDebugData(BlockId _id, langutil::DebugData::ConstPtr _data)
+	{
+		yulAssert(_id.hasValue());
+		ensureSize(m_exitDebugData, _id.value);
+		m_exitDebugData[_id.value] = std::move(_data);
+	}
+
+	langutil::DebugData::ConstPtr const& exitDebugData(BlockId _id) const
+	{
+		return getOrEmpty(m_exitDebugData, _id.value);
+	}
+
+	void setOperationDebugData(OperationId _id, langutil::DebugData::ConstPtr _data)
+	{
+		yulAssert(_id.hasValue());
+		ensureSize(m_operationDebugData, _id.value);
+		m_operationDebugData[_id.value] = std::move(_data);
+	}
+
+	langutil::DebugData::ConstPtr const& operationDebugData(OperationId _id) const
+	{
+		return getOrEmpty(m_operationDebugData, _id.value);
+	}
+
+	void setValueDebugData(ValueId _id, langutil::DebugData::ConstPtr _data)
+	{
+		yulAssert(_id.hasValue());
+		auto& vec = vectorForKind(_id.kind());
+		ensureSize(vec, _id.value());
+		vec[_id.value()] = std::move(_data);
+	}
+
+	langutil::DebugData::ConstPtr const& valueDebugData(ValueId _id) const
+	{
+		return getOrEmpty(vectorForKind(_id.kind()), _id.value());
+	}
+
+	/// Top-level debug data for the SSACFG (e.g. the function definition's debug data).
+	langutil::DebugData::ConstPtr graphDebugData;
+
+private:
+	static void ensureSize(std::vector<langutil::DebugData::ConstPtr>& _vec, std::size_t const _index)
+	{
+		if (_vec.size() <= _index)
+			_vec.resize(_index + 1);
+	}
+
+	static langutil::DebugData::ConstPtr const& getOrEmpty(
+		std::vector<langutil::DebugData::ConstPtr> const& _debugData,
+		std::size_t const _index
+	)
+	{
+		static langutil::DebugData::ConstPtr const empty{nullptr};
+		if (_index >= _debugData.size())
+			return empty;
+		return _debugData[_index];
+	}
+
+	std::vector<langutil::DebugData::ConstPtr>& vectorForKind(ValueId::Kind const _kind)
+	{
+		switch (_kind)
+		{
+		case ValueId::Kind::Literal: return m_literalDebugData;
+		case ValueId::Kind::Variable: return m_variableDebugData;
+		case ValueId::Kind::Phi: return m_phiDebugData;
+		default: yulAssert(false, "No debug data for unreachable values.");
+		}
+	}
+	std::vector<langutil::DebugData::ConstPtr> const& vectorForKind(ValueId::Kind const _kind) const
+	{
+		switch (_kind)
+		{
+		case ValueId::Kind::Literal: return m_literalDebugData;
+		case ValueId::Kind::Variable: return m_variableDebugData;
+		case ValueId::Kind::Phi: return m_phiDebugData;
+		default: yulAssert(false, "No debug data for unreachable values.");
+		}
+	}
+
+	std::vector<langutil::DebugData::ConstPtr> m_blockDebugData;
+	std::vector<langutil::DebugData::ConstPtr> m_exitDebugData;
+	std::vector<langutil::DebugData::ConstPtr> m_operationDebugData;
+	std::vector<langutil::DebugData::ConstPtr> m_literalDebugData;
+	std::vector<langutil::DebugData::ConstPtr> m_variableDebugData;
+	std::vector<langutil::DebugData::ConstPtr> m_phiDebugData;
+};
+
+}

--- a/libyul/backends/evm/ssa/SSACFGTypes.h
+++ b/libyul/backends/evm/ssa/SSACFGTypes.h
@@ -1,0 +1,149 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * Lightweight ID types used throughout the SSA CFG.
+ */
+
+#pragma once
+
+#include <libsolutil/Assertions.h>
+
+#include <fmt/format.h>
+
+#include <cstdint>
+#include <limits>
+#include <string>
+
+namespace solidity::yul::ssa
+{
+
+class SSACFG;
+
+struct BlockId
+{
+	using ValueType = std::uint32_t;
+	ValueType value = std::numeric_limits<ValueType>::max();
+	bool hasValue() const { return value != std::numeric_limits<ValueType>::max(); }
+	auto operator<=>(BlockId const&) const = default;
+};
+
+struct OperationId
+{
+	using ValueType = std::uint32_t;
+	ValueType value = std::numeric_limits<ValueType>::max();
+	bool hasValue() const { return value != std::numeric_limits<ValueType>::max(); }
+	auto operator<=>(OperationId const&) const = default;
+};
+
+class ValueId
+{
+public:
+	enum class Kind: std::uint8_t
+	{
+		Literal,
+		Variable,
+		Phi,
+		Unreachable
+	};
+	using ValueType = std::uint32_t;
+
+	constexpr ValueId() = default;
+	constexpr ValueId(ValueType const _value, Kind const _kind): m_value(_value), m_kind(_kind) {}
+	constexpr ValueId(ValueId const&) = default;
+	constexpr ValueId(ValueId&&) = default;
+	constexpr ValueId& operator=(ValueId const&) = default;
+	constexpr ValueId& operator=(ValueId&&) = default;
+
+	static ValueId constexpr makeLiteral(ValueType const& _value) { return ValueId{_value, Kind::Literal}; }
+	static ValueId constexpr makeVariable(ValueType const& _value) { return ValueId{_value, Kind::Variable}; }
+	static ValueId constexpr makePhi(ValueType const& _value) { return ValueId{_value, Kind::Phi}; }
+	static ValueId constexpr makeUnreachable() { return ValueId{0u, Kind::Unreachable}; }
+
+	bool constexpr isLiteral() const noexcept { return m_kind == Kind::Literal; }
+	bool constexpr isVariable() const noexcept { return m_kind == Kind::Variable; }
+	bool constexpr isPhi() const noexcept { return m_kind == Kind::Phi; }
+	bool constexpr isUnreachable() const noexcept { return m_kind == Kind::Unreachable; }
+
+	bool constexpr hasValue() const { return m_value != std::numeric_limits<ValueType>::max(); }
+	ValueType constexpr value() const noexcept { return m_value; }
+	Kind constexpr kind() const noexcept { return m_kind; }
+
+	/// Returns a human-readable string representation. Requires the full SSACFG for literal values.
+	std::string str(SSACFG const& _cfg) const;
+
+	auto operator<=>(ValueId const&) const = default;
+
+private:
+	ValueType m_value{std::numeric_limits<ValueType>::max()};
+	Kind m_kind{Kind::Unreachable};
+};
+
+}
+
+template<>
+struct fmt::formatter<solidity::yul::ssa::BlockId>
+{
+	static auto constexpr parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
+
+	template<typename FormatContext>
+	auto format(solidity::yul::ssa::BlockId const& _blockId, FormatContext& _ctx) const -> decltype(_ctx.out())
+	{
+		if (!_blockId.hasValue())
+			return fmt::format_to(_ctx.out(), "empty");
+		return fmt::format_to(_ctx.out(), "{}", _blockId.value);
+	}
+};
+
+template<>
+struct fmt::formatter<solidity::yul::ssa::OperationId>
+{
+	static auto constexpr parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
+
+	template<typename FormatContext>
+	auto format(solidity::yul::ssa::OperationId const& _opId, FormatContext& _ctx) const -> decltype(_ctx.out())
+	{
+		if (!_opId.hasValue())
+			return fmt::format_to(_ctx.out(), "empty");
+		return fmt::format_to(_ctx.out(), "op{}", _opId.value);
+	}
+};
+
+template<>
+struct fmt::formatter<solidity::yul::ssa::ValueId>
+{
+	static auto constexpr parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
+
+	template<typename FormatContext>
+	auto format(solidity::yul::ssa::ValueId const& _valueId, FormatContext& _ctx) const -> decltype(_ctx.out())
+	{
+		if (!_valueId.hasValue())
+			return fmt::format_to(_ctx.out(), "empty");
+		switch (_valueId.kind())
+		{
+		case solidity::yul::ssa::ValueId::Kind::Literal:
+			return fmt::format_to(_ctx.out(), "lit{}", _valueId.value());
+		case solidity::yul::ssa::ValueId::Kind::Variable:
+			return fmt::format_to(_ctx.out(), "v{}", _valueId.value());
+		case solidity::yul::ssa::ValueId::Kind::Phi:
+			return fmt::format_to(_ctx.out(), "phi{}", _valueId.value());
+		case solidity::yul::ssa::ValueId::Kind::Unreachable:
+			return fmt::format_to(_ctx.out(), "unreachable");
+		}
+		solidity::util::unreachable();
+	}
+};

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -236,7 +236,7 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 	blockLayout.operationIn.reserve(block.operations.size());
 	for (std::size_t operationIndex = 0; operationIndex < block.operations.size(); ++operationIndex)
 	{
-		SSACFG::Operation const& operation = block.operations[operationIndex];
+		SSACFG::Operation const& operation = m_cfg.operation(block.operations[operationIndex]);
 		LivenessAnalysis::LivenessData opLiveOut = operationsLiveOut[operationIndex];
 		auto opLiveOutWithoutOutputs = opLiveOut;
 		for (auto const& output: operation.outputs)

--- a/libyul/backends/evm/ssa/StackUtils.cpp
+++ b/libyul/backends/evm/ssa/StackUtils.cpp
@@ -139,8 +139,8 @@ CallSites solidity::yul::ssa::gatherCallSites(SSACFG const& _cfg)
 			}
 		});
 
-		for (auto const& operation: block.operations)
-			if (auto const* call = std::get_if<SSACFG::Call>(&operation.kind))
+		for (auto const opId: block.operations)
+			if (auto const* call = std::get_if<SSACFG::Call>(&_cfg.operation(opId).kind))
 				if (call->canContinue)
 					result.addCallSite(&call->call.get());
 	}

--- a/libyul/backends/evm/ssa/io/JSONExporter.cpp
+++ b/libyul/backends/evm/ssa/io/JSONExporter.cpp
@@ -123,8 +123,8 @@ Json toJson(SSACFG const& _cfg, SSACFG::BlockId _blockId, LivenessAnalysis const
 			blockJson["instructions"].push_back(phiJson);
 		}
 	}
-	for (auto const& operation: block.operations)
-		blockJson["instructions"].push_back(toJson(blockJson, _cfg, operation));
+	for (auto const opId: block.operations)
+		blockJson["instructions"].push_back(toJson(blockJson, _cfg, _cfg.operation(opId)));
 
 	return blockJson;
 }

--- a/test/libyul/ssa/StackLayoutGeneratorTest.cpp
+++ b/test/libyul/ssa/StackLayoutGeneratorTest.cpp
@@ -74,7 +74,7 @@ protected:
 
 		for (std::size_t i = 0; i < block.operations.size(); ++i)
 		{
-			auto const& operation = block.operations[i];
+			auto const& operation = m_cfg.operation(block.operations[i]);
 			yulAssert(i < blockLayout->operationIn.size());
 			auto operationStack = blockLayout->operationIn[i];
 


### PR DESCRIPTION
This PR does three things:
- operations get an `OperationId` like blocks and variables, too, so we have stable indexing
- the Id types (`BlockId`, `ValueId`, ...) are extracted into new header to unclutter `SSACFG.h`
- `SSACFG` debug data is stored in a separate data structure

Performance impact on a large yul file (1.7k blocks, 51 functions, 8.1k operations):

| Benchmark | develop (ms) | refactor (ms) | delta |
|---|---|---|---|
| BM_SSACFGBuilder_WithDebugInfo | 3.2189 ± 0.0927 | 3.3274 ± 0.1238 | +3.4% |
| BM_SSACFGBuilder_WithoutDebugInfo | 3.1988 ± 0.0572 | 3.1189 ± 0.0534 | -2.5% |
| BM_CFGIteration_WithDebugInfo | 0.0442 ± 0.0014 | 0.0416 ± 0.0010 | -6.0% |
| BM_CFGIteration_WithoutDebugInfo | 0.0431 ± 0.0017 | 0.0218 ± 0.0003 | -49.4% |
| BM_LivenessAnalysis_WithDebugInfo | 0.6922 ± 0.0025 | 0.7039 ± 0.0052 | +1.7% |
| BM_LivenessAnalysis_WithoutDebugInfo | 0.6907 ± 0.0044 | 0.7008 ± 0.0041 | +1.5% |

Slight regression of performance when building the ssa cfg with debug data (most likely due to more allocations and such) but on the other hand slightly faster constructing without debug data and much faster iteration. liveness analysis benchmark is basically same and within standard deviations.
