### PR TITLE
SSA: Add shuffler test

### DIFF
--- a/test/libyul/ssa/stackShuffler/replace_junk_with_top_value.stack
+++ b/test/libyul/ssa/stackShuffler/replace_junk_with_top_value.stack
@@ -1,0 +1,15 @@
+// we want to replace JUNK at the bottom of the stack with the top value, all other slots must be preserved exactly
+initial: [JUNK, v2, v1, v0]
+targetStackTop: [v0, v2, v1, v0]
+targetStackTailSet: {}
+targetStackSize: 4
+// ----
+//             |      0      1      2      3 |      4
+//             +---------------------------- +-------
+//    (initial)|      *     v2     v1     v0
+//        SWAP3|     v0     v2     v1      *
+//         DUP4|     v0     v2     v1      * |     v0
+//        SWAP1|     v0     v2     v1     v0 |      *
+//          POP|     v0     v2     v1     v0
+//             +---------------------------- +-------
+//     (target)|     v0     v2     v1     v0 |


### PR DESCRIPTION
This test captures a situation where we have a JUNK at the bottom of the source stack and we need to replace the JUNK with the same value that currently sits on top of the stack. All other slots in the stack must stay the same.
This scenario demonstrates an inefficiency in the current implementation of the shuffler.
For the given source and target stack, it produces a sequence of operations "SWAP3 + DUP4 + SWAP1 + POP" when shorter sequence is sufficient: "SWAP3 + POP + DUP3".