### PR TITLE
Remove unreachable return in SemanticInformation::movable

### DIFF
--- a/libevmasm/SemanticInformation.cpp
+++ b/libevmasm/SemanticInformation.cpp
@@ -472,7 +472,6 @@ bool SemanticInformation::movable(Instruction _instruction)
 	default:
 		return true;
 	}
-	return true;
 }
 
 bool SemanticInformation::canBeRemoved(Instruction _instruction)


### PR DESCRIPTION
The switch statement's default case already returns, making the trailing return true unreachable. Remove dead code.