### PR TITLE
Add optional debug output to ssa stack layout generator and code transform

### DIFF
--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(yul
 	backends/evm/ssa/CodeTransform.h
 	backends/evm/ssa/ControlFlow.cpp
 	backends/evm/ssa/ControlFlow.h
+	backends/evm/ssa/DebugConfig.h
 	backends/evm/ssa/JunkAdmittingBlocksFinder.cpp
 	backends/evm/ssa/JunkAdmittingBlocksFinder.h
 	backends/evm/ssa/LivenessAnalysis.cpp

--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -18,6 +18,7 @@
 
 #include <libyul/backends/evm/ssa/CodeTransform.h>
 
+#include <libyul/backends/evm/ssa/DebugConfig.h>
 #include <libyul/backends/evm/ssa/StackLayoutGenerator.h>
 #include <libyul/backends/evm/ssa/StackShuffler.h>
 #include <libyul/backends/evm/ssa/StackUtils.h>
@@ -28,6 +29,8 @@
 
 #include <range/v3/view/take_last.hpp>
 #include <range/v3/view/zip.hpp>
+
+#include <iostream>
 
 using namespace solidity::yul;
 using namespace solidity::yul::ssa;
@@ -48,6 +51,16 @@ void CodeTransform::run
 	BuiltinContext& _builtinContext
 )
 {
+	if constexpr (debug::codeTransform.enabled)
+	{
+		std::cout << "\n\n\n";
+		std::cout << "--------------------\n";
+		std::cout << "Running SSA CFG code transform\n";
+		std::cout << "--------------------\n";
+	}
+	if constexpr (debug::codeTransform.dotOutput)
+		std::cout << _controlFlowLiveness.toDot() << '\n';
+
 	yulAssert(!_controlFlowLiveness.cfgLiveness.empty());
 	ControlFlow const& controlFlow = _controlFlowLiveness.controlFlow.get();
 	yulAssert(controlFlow.functionGraphs.size() == _controlFlowLiveness.cfgLiveness.size());
@@ -143,6 +156,9 @@ CodeTransform::CodeTransform(
 	}()),
 	m_stack(m_stackData, m_assemblyCallbacks)
 {
+	if constexpr (debug::codeTransform.enabled)
+		std::cout << "Code transform for " << (m_cfg.function ? m_cfg.function->name.str() : "main") << '\n';
+
 	if (_function)
 	{
 		auto const findIt = m_functionLabels.find(_function);
@@ -165,6 +181,8 @@ void CodeTransform::operator()(SSACFG::BlockId const _blockId)
 	m_blockIsTransformed[_blockId.value] = true;
 
 	m_assembly.appendLabel(m_blockLabels[_blockId.value]);
+	if constexpr (debug::codeTransform.enabled)
+		std::cout << "\tGenerating for Block " << _blockId.value  << " with label " << m_blockLabels[_blockId.value] << '\n';
 
 	auto const& blockLayout = m_stackLayout[_blockId];
 	yulAssert(blockLayout);
@@ -178,6 +196,9 @@ void CodeTransform::operator()(SSACFG::BlockId const _blockId)
 	{
 		auto const& operationInLayout = blockLayout->operationIn[operationIndex];
 
+		if constexpr (debug::codeTransform.enabled)
+			std::cout << "\t\t" << debug::operationName(m_cfg.operation(block.operations[operationIndex])) << ": " << stackToString(m_stack.data()) << " -> " << stackToString(operationInLayout) << '\n';
+
 		// perform the operation
 		(*this)(block.operations[operationIndex], operationInLayout);
 	}
@@ -185,7 +206,11 @@ void CodeTransform::operator()(SSACFG::BlockId const _blockId)
 	// Shuffle to the block's exit layout before dispatching the exit.
 	// This ensures the condition is on top for ConditionalJump, phi pre-images are
 	// in the right positions for jumps, and return values are accessible for FunctionReturn.
+	if constexpr (debug::codeTransform.shuffler)
+		std::cout << "\t\t\tshuffling: ";
 	StackShuffler<AssemblyCallbacks>::shuffle(m_stack, blockLayout->stackOut);
+	if constexpr (debug::codeTransform.shuffler)
+		std::cout << '\n';
 
 	// handle the block exit
 	std::visit(util::GenericVisitor{ [this, &_blockId](auto const& exit) { (*this)(_blockId, exit); } }, block.exit);
@@ -209,7 +234,11 @@ void CodeTransform::operator()(SSACFG::OperationId _opId, StackData const& _oper
 	yulAssert(static_cast<int>(m_stack.size()) == m_assembly.stackHeight());
 
 	// prepare stack for operation
+	if constexpr (debug::codeTransform.shuffler)
+		std::cout << "\t\t\tshuffling: ";
 	StackShuffler<AssemblyCallbacks>::shuffle(m_stack, _operationInputLayout);
+	if constexpr (debug::codeTransform.shuffler)
+		std::cout << '\n';
 
 	// check that the assembly stack height corresponds to the stack size after shuffling
 	yulAssert(static_cast<int>(m_stack.size()) == m_assembly.stackHeight());
@@ -250,6 +279,8 @@ void CodeTransform::operator()(SSACFG::OperationId _opId, StackData const& _oper
 	// generate code for the operation
 	std::visit(util::GenericVisitor{
 		[&](SSACFG::BuiltinCall const& _builtin) {
+			if constexpr (debug::codeTransform.enabled)
+				std::cout << "\t\t\tBuiltin call: " << _builtin.builtin.get().name << ": " << stackToString(m_stack.data());
 			m_assembly.setSourceLocation(opOriginLocation);
 			static_cast<BuiltinFunctionForEVM const&>(_builtin.builtin.get()).generateCode(
 				_builtin.call,
@@ -261,6 +292,15 @@ void CodeTransform::operator()(SSACFG::OperationId _opId, StackData const& _oper
 			auto const* returnLabel = util::valueOrNullptr(m_returnLabels, &_call.call.get());
 			// check that if we have a return label, the call can continue
 			yulAssert(!!returnLabel == _call.canContinue);
+			if constexpr (debug::codeTransform.enabled)
+			{
+				std::cout
+					<< "\t\t\tCall: " << _call.function.get().name.str()
+					<< " (label=" << m_functionLabels.at(&_call.function.get()) << ")"
+					<< ": " << stackToString(m_stack.data());
+				if (returnLabel)
+					std::cout << ", returnLabel: " << *returnLabel;
+			}
 			m_assembly.setSourceLocation(opOriginLocation);
 			m_assembly.appendJumpTo(
 				m_functionLabels.at(&_call.function.get()),
@@ -276,7 +316,10 @@ void CodeTransform::operator()(SSACFG::OperationId _opId, StackData const& _oper
 				m_stack.pop<false>();
 			}
 		},
-		[&](SSACFG::LiteralAssignment const&){}
+		[&](SSACFG::LiteralAssignment const&) {
+			if constexpr (debug::codeTransform.enabled)
+				std::cout << "\t\t\tLiteral assignment: " << stackToString(m_stack.data());
+		}
 	}, _operation.kind);
 	// simulate that the inputs are consumed
 	for (size_t i = 0; i < _operation.inputs.size(); ++i)
@@ -284,6 +327,9 @@ void CodeTransform::operator()(SSACFG::OperationId _opId, StackData const& _oper
 	// simulate that the outputs are produced
 	for (auto value: _operation.outputs)
 		m_stack.push<false>(StackSlot::makeValueID(value));
+
+	if constexpr (debug::codeTransform.enabled)
+		std::cout << " -> " << stackToString(m_stack.data()) << '\n';
 
 	// Assert that the operation produced its proclaimed output.
 	yulAssert(m_stack.size() == baseHeight + _operation.outputs.size());
@@ -319,6 +365,13 @@ void CodeTransform::operator()(SSACFG::BlockId const& _currentBlock, SSACFG::Bas
 		ScopedSaveAndRestore restoreStack(m_stackData, StackData(m_stackData));
 		yulAssert(m_stackLayout[_conditionalJump.zero]);
 
+		if constexpr (debug::codeTransform.enabled)
+			std::cout
+				<< "\t\tJUMPI creating stack for zero layout (to Block "
+				<< _conditionalJump.zero.value << ") "
+				<< stackToString(m_stack.data()) << " -> "
+				<< stackToString(m_stackLayout[_conditionalJump.zero]->stackIn) << '\n';
+
 		// transform stack to a state in which we can jump to the zero branch
 		prepareBlockExitStack(
 			m_stackLayout[_conditionalJump.zero]->stackIn,
@@ -343,6 +396,8 @@ void CodeTransform::operator()(SSACFG::BlockId const& _currentBlock, SSACFG::Bas
 void CodeTransform::operator()(SSACFG::BlockId const& _currentBlock, SSACFG::BasicBlock::Jump const& _jump)
 {
 	yulAssert(static_cast<int>(m_stack.size()) == m_assembly.stackHeight());
+	if constexpr (debug::codeTransform.enabled)
+		std::cout << "\t\tJUMP creating target stack for jump " << _currentBlock.value << " -> " << _jump.target.value << '\n';
 	yulAssert(m_stackLayout[_jump.target]);
 	prepareBlockExitStack(m_stackLayout[_jump.target]->stackIn, PhiInverse(m_cfg, _currentBlock, _jump.target));
 	assertLayoutCompatibility(m_stack.data(), m_stackLayout[_jump.target]->stackIn);
@@ -395,7 +450,11 @@ void CodeTransform::prepareBlockExitStack(StackData const& _target, PhiInverse c
 	// pull back target to live in current variable space
 	auto const pulledBackTarget = stackPreImage(_target, _phiInverse);
 	// shuffle to target
+	if constexpr (debug::codeTransform.shuffler)
+		std::cout << "\t\t\tshuffling: ";
 	StackShuffler<AssemblyCallbacks>::shuffle(m_stack, pulledBackTarget);
+	if constexpr (debug::codeTransform.shuffler)
+		std::cout << '\n';
 	// check that shuffling was successful
 	assertLayoutCompatibility(m_stack.data(), pulledBackTarget);
 	// now we can simply set the target to the actual one which will take care of the application of phi functions

--- a/libyul/backends/evm/ssa/CodeTransform.h
+++ b/libyul/backends/evm/ssa/CodeTransform.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <libyul/backends/evm/ssa/DebugConfig.h>
 #include <libyul/backends/evm/ssa/PhiInverse.h>
 #include <libyul/backends/evm/ssa/Stack.h>
 #include <libyul/backends/evm/ssa/StackLayout.h>
@@ -25,6 +26,8 @@
 #include <libyul/backends/evm/AbstractAssembly.h>
 
 #include <libevmasm/Instruction.h>
+
+#include <iostream>
 
 namespace solidity::yul
 {
@@ -37,16 +40,22 @@ struct AssemblyCallbacks
 {
 	void swap(StackDepth const _depth)
 	{
+		if constexpr (debug::codeTransform.shuffler)
+			std::cout << "SWAP" << _depth.value << " " << std::flush;
 		assembly->appendInstruction(evmasm::swapInstruction(static_cast<unsigned>(_depth.value)));
 	}
 
 	void pop()
 	{
+		if constexpr (debug::codeTransform.shuffler)
+			std::cout << "POP " << std::flush;
 		assembly->appendInstruction(evmasm::Instruction::POP);
 	}
 
 	void push(StackSlot const& _slot)
 	{
+		if constexpr (debug::codeTransform.shuffler)
+			std::cout << "PUSH(" << slotToString(_slot) << ") " << std::flush;
 		switch (_slot.kind())
 		{
 		case StackSlot::Kind::ValueID:
@@ -80,6 +89,8 @@ struct AssemblyCallbacks
 
 	void dup(StackDepth const _depth)
 	{
+		if constexpr (debug::codeTransform.shuffler)
+			std::cout << "DUP" << _depth.value << " " << std::flush;
 		assembly->appendInstruction(evmasm::dupInstruction(static_cast<unsigned>(_depth.value)));
 	}
 

--- a/libyul/backends/evm/ssa/DebugConfig.h
+++ b/libyul/backends/evm/ssa/DebugConfig.h
@@ -1,0 +1,67 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libyul/backends/evm/ssa/SSACFG.h>
+
+#include <libsolutil/Visitor.h>
+
+#include <string>
+#include <variant>
+
+namespace solidity::yul::ssa::debug
+{
+
+inline std::string operationName(SSACFG::Operation const& _operation)
+{
+	return std::visit(util::GenericVisitor{
+		[](SSACFG::Call const& _call) { return _call.function.get().name.str(); },
+		[](SSACFG::BuiltinCall const& _call) { return _call.builtin.get().name; },
+		[](SSACFG::LiteralAssignment const&) -> std::string { return "assign"; }
+	}, _operation.kind);
+}
+
+struct StackLayoutGenerationFlags
+{
+	consteval StackLayoutGenerationFlags(bool _enabled, bool _shuffler):
+		enabled(_enabled),
+		shuffler(_enabled && _shuffler)
+	{}
+
+	bool enabled;
+	bool shuffler;
+};
+
+struct CodeTransformFlags
+{
+	consteval CodeTransformFlags(bool _enabled, bool _dotOutput, bool _shuffler):
+		enabled(_enabled),
+		dotOutput(_enabled && _dotOutput),
+		shuffler(_enabled && _shuffler)
+	{}
+
+	bool enabled;
+	bool dotOutput;
+	bool shuffler;
+};
+
+inline constexpr StackLayoutGenerationFlags stackLayoutGeneration(false, true);
+inline constexpr CodeTransformFlags codeTransform(false, true, true);
+
+}

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -18,6 +18,7 @@
 
 #include <libyul/backends/evm/ssa/StackLayoutGenerator.h>
 
+#include <libyul/backends/evm/ssa/DebugConfig.h>
 #include <libyul/backends/evm/ssa/JunkAdmittingBlocksFinder.h>
 #include <libyul/backends/evm/ssa/PhiInverse.h>
 #include <libyul/backends/evm/ssa/StackShuffler.h>
@@ -30,6 +31,7 @@
 #include <range/v3/to_container.hpp>
 
 #include <boost/container/flat_map.hpp>
+#include <iostream>
 #include <queue>
 
 using namespace solidity::yul::ssa;
@@ -64,7 +66,7 @@ void handlePhiFunctions(StackData& _stackData, PhiInverse const& _phiInverse, Li
 	}
 }
 
-using StackType = Stack<CountingInstructionsCallbacks>;
+using StackType = Stack<CountingInstructionsCallbacks<debug::stackLayoutGeneration.shuffler>>;
 
 void declareJunk(StackType& _stack, LivenessAnalysis::LivenessData const& _live)
 {
@@ -84,6 +86,8 @@ SSACFGStackLayout StackLayoutGenerator::generate(
 	ControlFlow::FunctionGraphID const _graphID
 )
 {
+	if constexpr (debug::stackLayoutGeneration.enabled)
+		std::cout << "Stack layout for " << (_liveness.cfg().function ? _liveness.cfg().function->name.str() : "main graph") << '\n';
 	return StackLayoutGenerator(_liveness, _callSites, _graphID).m_resultLayout;
 }
 
@@ -232,6 +236,9 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 	StackType stack(currentStackData, {});
 	bool const junkCanBeAdded = m_junkAdmittingBlocksFinder->allowsAdditionOfJunk(_blockId);
 
+	if constexpr (debug::stackLayoutGeneration.enabled)
+		std::cout << fmt::format("\tBlock {} (junk={}, stackIn={})\n", _blockId, junkCanBeAdded, stackToString(currentStackData));
+
 	auto const& operationsLiveOut = m_liveness.operationsLiveOut(_blockId);
 	blockLayout.operationIn.reserve(block.operations.size());
 	for (std::size_t operationIndex = 0; operationIndex < block.operations.size(); ++operationIndex)
@@ -260,19 +267,31 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 			)
 				stack.declareJunk(depth);
 
+		if constexpr (debug::stackLayoutGeneration.enabled)
+			std::cout << "\t\t" << debug::operationName(operation) << ": " << stackToString(currentStackData) << " -> " << stackToString(requiredStackTop) << '\n';
+
 		std::size_t const targetSize = findOptimalTargetSize(stack.data(), requiredStackTop, opLiveOutWithoutOutputs, junkCanBeAdded, m_hasFunctionReturnLabel);
+		if constexpr (debug::stackLayoutGeneration.shuffler)
+			std::cout << "\t\t\tshuffling:   ";
 		StackShuffler<StackType::Callbacks>::shuffle(
 			stack,
 			requiredStackTop,
 			opLiveOutWithoutOutputs,
 			targetSize
 		);
+		if constexpr (debug::stackLayoutGeneration.shuffler)
+			std::cout << '\n';
+		if constexpr (debug::stackLayoutGeneration.enabled)
+			std::cout << "\t\t\tshuffled to: " << stackToString(stack.data()) << '\n';
 
 		blockLayout.operationIn.push_back(currentStackData);
 		for (std::size_t i = 0; i < requiredStackTop.size(); ++i)
-			stack.pop();
+			stack.pop<false>();
 		for (auto const& val: operation.outputs)
-			stack.push(Slot::makeValueID(val));
+			stack.push<false>(Slot::makeValueID(val));
+
+		if constexpr (debug::stackLayoutGeneration.enabled)
+			std::cout << "\t\t\tresult:      " << stackToString(currentStackData) << '\n';
 	}
 
 	if (auto const* cjump = std::get_if<SSACFG::BasicBlock::ConditionalJump>(&block.exit))
@@ -330,4 +349,7 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 	}
 
 	blockLayout.stackOut = currentStackData;
+
+	if constexpr (debug::stackLayoutGeneration.enabled)
+		std::cout << fmt::format("\t\tstack out = {}\n", stackToString(currentStackData));
 }

--- a/libyul/backends/evm/ssa/StackUtils.cpp
+++ b/libyul/backends/evm/ssa/StackUtils.cpp
@@ -67,8 +67,8 @@ std::size_t solidity::yul::ssa::findOptimalTargetSize
 	auto const evaluateCost = [&](std::size_t const _targetSize) -> std::size_t
 	{
 		data = _stackData;
-		Stack<CountingInstructionsCallbacks> countOpsStack(data, {});
-		StackShuffler<CountingInstructionsCallbacks>::shuffle(countOpsStack, _targetArgs, _targetLiveOut, _targetSize);
+		Stack<CountingInstructionsCallbacks<false>> countOpsStack(data, {});
+		StackShuffler<CountingInstructionsCallbacks<false>>::shuffle(countOpsStack, _targetArgs, _targetLiveOut, _targetSize);
 		yulAssert(countOpsStack.size() == _targetSize);
 		return countOpsStack.callbacks().numOps;
 	};

--- a/libyul/backends/evm/ssa/StackUtils.h
+++ b/libyul/backends/evm/ssa/StackUtils.h
@@ -18,9 +18,11 @@
 
 #pragma once
 
+#include <libyul/backends/evm/ssa/DebugConfig.h>
 #include <libyul/backends/evm/ssa/PhiInverse.h>
 #include <libyul/backends/evm/ssa/Stack.h>
 
+#include <iostream>
 #include <string>
 #include <vector>
 
@@ -38,13 +40,34 @@ private:
 	std::vector<std::string> m_errors;
 };
 
+template<bool debugOutput>
 struct CountingInstructionsCallbacks
 {
 	std::size_t numOps = 0;
-	void swap(StackDepth) { ++numOps; }
-	void dup(StackDepth) { ++numOps; }
-	void push(StackSlot const&) { ++numOps; }
-	void pop() { ++numOps; }
+	void swap([[maybe_unused]] StackDepth _depth)
+	{
+		++numOps;
+		if constexpr (debugOutput)
+			std::cout << "SWAP" << _depth.value << " " << std::flush;
+	}
+	void dup([[maybe_unused]] StackDepth _depth)
+	{
+		++numOps;
+		if constexpr (debugOutput)
+			std::cout << "DUP" << _depth.value << " " << std::flush;
+	}
+	void push([[maybe_unused]] StackSlot const& _slot)
+	{
+		++numOps;
+		if constexpr (debugOutput)
+			std::cout << "PUSH(" << slotToString(_slot) << ") " << std::flush;
+	}
+	void pop()
+	{
+		++numOps;
+		if constexpr (debugOutput)
+			std::cout << "POP " << std::flush;
+	}
 };
 
 /// Transform stack data by replacing all its phi variables with their respective preimages.


### PR DESCRIPTION
Can be switched on/off via compile-time flags in `libyul/backends/evm/ssa/DebugConfig.h`