### PR TITLE
Build SSA CFG in phi-upsilon form

### DIFF
--- a/libyul/backends/evm/ssa/BridgeFinder.h
+++ b/libyul/backends/evm/ssa/BridgeFinder.h
@@ -21,7 +21,7 @@
 
 #include <libyul/backends/evm/ssa/SSACFG.h>
 
-#include <range/v3/view/concat.hpp>
+#include <range/v3/algorithm/find.hpp>
 
 #include <cstdint>
 #include <optional>
@@ -79,7 +79,7 @@ private:
 		SSACFG::BlockId const& _neighbor,
 		size_t& _time,
 		SSACFG::BlockId const& _vertex,
-		std::set<SSACFG::BlockId> const& _vertexEntries,
+		std::vector<SSACFG::BlockId> const& _vertexEntries,
 		std::optional<SSACFG::BlockId> const& _parent
 	)
 	{
@@ -93,8 +93,8 @@ private:
 			if (m_low[_neighbor.value] > m_disc[_vertex.value])
 			{
 				// vertex <-> neighbor is a bridge in the undirected graph
-				bool const edgeNeighborToVertex = _vertexEntries.contains(_neighbor);
-				bool const edgeVertexToNeighbor = m_cfg.block(_neighbor).entries.contains(_vertex);
+				bool const edgeNeighborToVertex = ranges::find(_vertexEntries, _neighbor) != _vertexEntries.end();
+				bool const edgeVertexToNeighbor = ranges::find(m_cfg.block(_neighbor).entries, _vertex) != m_cfg.block(_neighbor).entries.end();
 
 				// special case: if it's the entry itself, we mark it as bridge vertex (provided correct orientation),
 				// so that functions which do nothing but revert have their whole tree marked as such (sans loops)

--- a/libyul/backends/evm/ssa/LivenessAnalysis.cpp
+++ b/libyul/backends/evm/ssa/LivenessAnalysis.cpp
@@ -201,19 +201,12 @@ void LivenessAnalysis::runDagDfs()
 
 		// live <- PhiUses(B)
 		LivenessData live{};
-		block.forEachExit(
-			[&](SSACFG::BlockId const& _successor)
-			{
-				for (auto const& phi: m_cfg.block(_successor).phis)
-				{
-					auto const& info = m_cfg.phiInfo(phi);
-					auto const& argIndex = m_cfg.phiArgumentIndex(blockId, _successor);
-					yulAssert(argIndex < info.arguments.size());
-					auto const& arg = info.arguments.at(argIndex);
-					if (!arg.isLiteral())
-						live.insert(arg);
-				}
-			});
+		for (auto const& upsilon: block.upsilons)
+		{
+			yulAssert(!upsilon.value.isUnreachable());
+			if (!upsilon.value.isLiteral())
+				live.insert(upsilon.value);
+		}
 
 		// for each S \in succs(B) s.t. (B, S) not a back edge: live <- live \cup (LiveIn(S) - PhiDefs(S))
 		block.forEachExit(

--- a/libyul/backends/evm/ssa/PhiInverse.cpp
+++ b/libyul/backends/evm/ssa/PhiInverse.cpp
@@ -22,12 +22,9 @@ using namespace solidity::yul::ssa;
 
 PhiInverse::PhiInverse(SSACFG const& _cfg, SSACFG::BlockId const& _from, SSACFG::BlockId const& _to)
 {
-	auto const argIndex = _cfg.phiArgumentIndex(_from, _to);
-	for (auto const& phiId: _cfg.block(_to).phis)
-	{
-		auto const& phiInfo = _cfg.phiInfo(phiId);
-		m_phiToPreImage[phiId] = phiInfo.arguments[argIndex];
-	}
+	for (auto const& [phiValue, phi]: _cfg.block(_from).upsilons)
+		if (_cfg.phiInfo(phi).block == _to)
+			m_phiToPreImage[phi] = phiValue;
 }
 
 bool PhiInverse::noOp() const

--- a/libyul/backends/evm/ssa/SSACFG.cpp
+++ b/libyul/backends/evm/ssa/SSACFG.cpp
@@ -40,17 +40,21 @@ using namespace solidity::yul::ssa;
 namespace
 {
 
-std::string formatPhi(SSACFG const& _cfg, SSACFG::PhiValue const& _phiValue)
+/// Build a human-readable Phi/Upsilon annotation for a phi value.
+/// Shows which upsilons feed it, listed per predecessor block.
+std::string formatPhi(SSACFG const& _cfg, SSACFG::ValueId _phiId)
 {
-	auto const transform = [&](SSACFG::ValueId const& valueId) { return valueId.str(_cfg); };
-	std::vector<std::string> formattedArgs;
-	formattedArgs.reserve(_phiValue.arguments.size());
-	for (auto const& [arg, entry]: ranges::zip_view(_phiValue.arguments | ranges::views::transform(transform), _cfg.block(_phiValue.block).entries))
-		formattedArgs.push_back(fmt::format("Block {} => {}", entry.value, arg));
-	if (!formattedArgs.empty())
-		return fmt::format("φ(\\l\\\n\t{}\\l\\\n)", fmt::join(formattedArgs, ",\\l\\\n\t"));
-	else
-		return "φ()";
+	// Collect all upsilons targeting _phiId from the whole CFG.
+	std::vector<std::string> formattedUpsilons;
+	for (SSACFG::BlockId::ValueType bv = 0; bv < _cfg.numBlocks(); ++bv)
+		for (auto const& u: _cfg.block(SSACFG::BlockId{bv}).upsilons)
+			if (u.phi == _phiId)
+				formattedUpsilons.push_back(
+					fmt::format("Block {} => {}", bv, u.value.str(_cfg))
+				);
+	if (!formattedUpsilons.empty())
+		return fmt::format("φ(\\l\\\n\t{}\\l\\\n)", fmt::join(formattedUpsilons, ",\\l\\\n\t"));
+	return "φ()";
 }
 
 class SSACFGDotExporter: public io::DotExporterBase
@@ -96,10 +100,7 @@ protected:
 			_out << fmt::format("\\\nBlock {}\\n", _blockId.value);
 
 		for (auto const& phi: block.phis)
-		{
-			auto const& phiInfo = m_cfg.phiInfo(phi);
-			_out << fmt::format("phi{} := {}\\l\\\n", phi.value(), formatPhi(m_cfg, phiInfo));
-		}
+			_out << fmt::format("phi{} := {}\\l\\\n", phi.value(), formatPhi(m_cfg, phi));
 		for (auto const opId: block.operations)
 		{
 			auto const& operation = m_cfg.operation(opId);

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -74,6 +74,15 @@ public:
 	};
 	struct LiteralAssignment {};
 
+	/// Upsilon records a phi pre-image at a block exit.
+	/// Upsilon(value, phi) means: the value flowing into `phi` from this block is `value`.
+	/// Lives in the predecessor block; the corresponding Phi lives in the successor.
+	struct Upsilon
+	{
+		ValueId value;  ///< pre-image value for the phi
+		ValueId phi;    ///< target phi
+	};
+
 	struct Operation {
 		std::vector<ValueId> outputs{};
 		std::variant<BuiltinCall, Call, LiteralAssignment> kind;
@@ -97,9 +106,12 @@ public:
 			std::vector<ValueId> returnValues;
 		};
 		struct Terminated {};
-		std::set<BlockId> entries;
-		std::set<ValueId> phis;
+		std::vector<BlockId> entries;
+		std::vector<ValueId> phis;
 		std::vector<OperationId> operations;
+		/// Upsilon assignments placed at the block exit (before the terminator).
+		/// They record the phi pre-images for successor blocks.
+		std::vector<Upsilon> upsilons;
 		std::variant<MainExit, Jump, ConditionalJump, FunctionReturn, Terminated> exit = MainExit{};
 		template<typename Callable>
 		void forEachExit(Callable&& _callable) const
@@ -137,7 +149,7 @@ public:
 	BlockId makeBlock(langutil::DebugData::ConstPtr _debugData)
 	{
 		BlockId blockId { static_cast<BlockId::ValueType>(m_blocks.size()) };
-		m_blocks.emplace_back(BasicBlock{{}, {}, {}, BasicBlock::Terminated{}});
+		m_blocks.emplace_back(BasicBlock{{}, {}, {}, {}, BasicBlock::Terminated{}});
 		if (debugInfo)
 			debugInfo->setBlockDebugData(blockId, std::move(_debugData));
 		return blockId;
@@ -169,12 +181,11 @@ public:
 	};
 	struct PhiValue {
 		BlockId block;
-		std::vector<ValueId> arguments;
 	};
 	struct UnreachableValue {};
 	ValueId newPhi(BlockId const _definingBlock)
 	{
-		m_phis.emplace_back(PhiValue{_definingBlock, std::vector<ValueId>{}});
+		m_phis.emplace_back(PhiValue{_definingBlock});
 		auto const value = m_phis.size() - 1;
 		yulAssert(value < std::numeric_limits<ValueId::ValueType>::max());
 		auto const id = ValueId::makePhi(static_cast<ValueId::ValueType>(value));
@@ -218,14 +229,6 @@ public:
 			debugInfo->setValueDebugData(literalId, std::move(_debugData));
 		m_literalMapping.emplace(_value, literalId);
 		return literalId;
-	}
-
-	size_t phiArgumentIndex(BlockId const _source, BlockId const _target) const
-	{
-		auto const& targetBlock = block(_target);
-		auto idx = util::findOffset(targetBlock.entries, _source);
-		yulAssert(idx, fmt::format("Target block {} not found as entry in one of the exits of the current block {}.", _target.value, _source.value));
-		return *idx;
 	}
 
 	std::string toDot(

--- a/libyul/backends/evm/ssa/SSACFGBuilder.cpp
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.cpp
@@ -97,15 +97,18 @@ SSACFG::ValueId SSACFGBuilder::tryRemoveTrivialPhi(SSACFG::ValueId _phi)
 	auto const& phiInfo = m_graph.phiInfo(_phi);
 	yulAssert(blockInfo(phiInfo.block).sealed);
 
+	// Collect upsilon values targeting this phi.
 	SSACFG::ValueId same;
-	for (SSACFG::ValueId arg: phiInfo.arguments)
-	{
-		if (arg == same || arg == _phi)
-			continue;  // unique value or self-reference
-		if (same.hasValue())
-			return _phi;  // phi merges at least two distinct values -> not trivial
-		same = arg;
-	}
+	for (auto const& entry: m_graph.block(phiInfo.block).entries)
+		for (auto const& u: m_graph.block(entry).upsilons)
+			if (u.phi == _phi)
+			{
+				if (u.value == same || u.value == _phi)
+					continue;  // unique value or self-reference
+				if (same.hasValue())
+					return _phi;  // phi merges at least two distinct values -> not trivial
+				same = u.value;
+			}
 	if (!same.hasValue())
 	{
 		// This will happen for unreachable paths.
@@ -113,7 +116,7 @@ SSACFG::ValueId SSACFGBuilder::tryRemoveTrivialPhi(SSACFG::ValueId _phi)
 		same = m_graph.unreachableValue();
 	}
 
-	m_graph.block(phiInfo.block).phis.erase(_phi);
+	std::erase(m_graph.block(phiInfo.block).phis, _phi);
 
 	std::vector<SSACFG::ValueId> phiUses;
 	for (SSACFG::BlockId::ValueType blockIdValue = 0; blockIdValue < m_graph.numBlocks(); ++blockIdValue)
@@ -123,22 +126,21 @@ SSACFG::ValueId SSACFGBuilder::tryRemoveTrivialPhi(SSACFG::ValueId _phi)
 		{
 			yulAssert(blockPhi.hasValue());
 			yulAssert(blockPhi != _phi, "Phis should be defined in exactly one block, _phi was erased.");
-			auto& blockPhiInfo = m_graph.phiInfo(blockPhi);
-			bool usedInPhi = false;
-			for (auto& arg: blockPhiInfo.arguments)
-				if (arg == _phi)
-				{
-					arg = same;
-					usedInPhi = true;
-				}
-			if (usedInPhi)
-				phiUses.push_back(blockPhi);
 		}
+		// Replace _phi with same in upsilon values and collect affected phis.
+		for (auto& u: block.upsilons)
+			if (u.value == _phi)
+			{
+				u.value = same;
+				phiUses.push_back(u.phi);
+			}
+		// Erase upsilons targeting _phi.
+		std::erase_if(block.upsilons, [_phi](auto const& u) { return u.phi == _phi; });
 		for (auto opId: block.operations)
 			ranges::replace(m_graph.operation(opId).inputs, _phi, same);
 		std::visit(util::GenericVisitor{
 			[_phi, same](SSACFG::BasicBlock::FunctionReturn& _functionReturn) {
-				ranges::replace(_functionReturn.returnValues,_phi, same);
+				ranges::replace(_functionReturn.returnValues, _phi, same);
 			},
 			[_phi, same](SSACFG::BasicBlock::ConditionalJump& _condJump) {
 				if (_condJump.condition == _phi)
@@ -179,28 +181,34 @@ void SSACFGBuilder::cleanUnreachable()
 			}, block.exit);
 	});
 
-	// Remove all entries from unreachable nodes from the graph.
+	// Remove unreachable predecessor entries.
 	for (SSACFG::BlockId blockId: reachabilityCheck.visited)
 	{
 		auto& block = m_graph.block(blockId);
-
-		std::vector<SSACFG::ValueId> maybeTrivialPhi;
 		std::erase_if(block.entries, [&](auto const& entry) { return !reachabilityCheck.visited.contains(entry); });
-		for (auto phi: block.phis)
-		{
-			yulAssert(phi.hasValue());
-			auto& phiInfo = m_graph.phiInfo(phi);
-			auto const erasedCount = std::erase_if(phiInfo.arguments, [&](SSACFG::ValueId const _arg) {
-				return _arg.isUnreachable();
-			});
-			if (erasedCount > 0)
-				maybeTrivialPhi.push_back(phi);
-		}
-
-		// After removing a phi argument, we might end up with a trivial phi that can be removed.
-		for (auto phi: maybeTrivialPhi)
-			tryRemoveTrivialPhi(phi);
 	}
+
+	// Remove upsilons that are now invalid:
+	//   - upsilons in unreachable blocks (their block will never execute), or
+	//   - upsilons with an unreachable value (product of earlier trivial-phi removal).
+	// Collect the affected target phis so we can attempt trivial-phi removal afterward.
+	std::vector<SSACFG::ValueId> maybeTrivialPhi;
+	for (SSACFG::BlockId blockId{0}; blockId.value < m_graph.numBlocks(); ++blockId.value)
+	{
+		auto& block = m_graph.block(blockId);
+		bool const isReachable = reachabilityCheck.visited.contains(blockId);
+
+		for (auto const& u: block.upsilons)
+			if (!isReachable || u.value.isUnreachable())
+				maybeTrivialPhi.push_back(u.phi);
+
+		std::erase_if(block.upsilons, [&](SSACFG::Upsilon const& u) {
+			return !isReachable || u.value.isUnreachable();
+		});
+	}
+
+	for (auto const phi: maybeTrivialPhi)
+		tryRemoveTrivialPhi(phi);
 }
 
 void SSACFGBuilder::buildFunctionGraph(
@@ -615,9 +623,9 @@ SSACFG::ValueId SSACFGBuilder::readVariableRecursive(Scope::Variable const& _var
 	SSACFG::ValueId val;
 	if (!info.sealed)
 	{
-		// incomplete block
+		// incomplete block: create a phi and defer upsilon emission until the block is sealed
 		val = m_graph.newPhi(_block);
-		block.phis.insert(val);
+		block.phis.push_back(val);
 		info.incompletePhis.emplace_back(val, _variable);
 	}
 	else if (block.entries.size() == 1)
@@ -625,27 +633,32 @@ SSACFG::ValueId SSACFGBuilder::readVariableRecursive(Scope::Variable const& _var
 		val = readVariable(_variable, *block.entries.begin());
 	else
 	{
-		// Break potential cycles with operandless phi
+		// Break potential cycles with an argument-less phi; emit upsilons for all predecessors.
 		val = m_graph.newPhi(_block);
-		block.phis.insert(val);
+		block.phis.push_back(val);
 		writeVariable(_variable, _block, val);
 		// we call tryRemoveTrivialPhi explicitly opposed to what is presented in Algorithm 2, as our implementation
 		// does not call it in addPhiOperands to avoid removing phis in unsealed blocks
-		val = tryRemoveTrivialPhi(addPhiOperands(_variable, val));
+		addPhiOperands(_variable, val);
+		val = tryRemoveTrivialPhi(val);
 	}
 	writeVariable(_variable, _block, val);
 	return val;
 }
 
-SSACFG::ValueId SSACFGBuilder::addPhiOperands(Scope::Variable const& _variable, SSACFG::ValueId _phi)
+void SSACFGBuilder::addPhiOperands(Scope::Variable const& _variable, SSACFG::ValueId _phi)
 {
 	for (auto const& pred: m_graph.block(m_graph.phiInfo(_phi).block).entries)
 	{
-		auto const var = readVariable(_variable, pred);
-		m_graph.phiInfo(_phi).arguments.emplace_back(var);
+		auto const val = readVariable(_variable, pred);
+		emitUpsilon(pred, val, _phi);
 	}
-	// we call tryRemoveTrivialPhi explicitly to avoid removing trivial phis in unsealed blocks
-	return _phi;
+}
+
+void SSACFGBuilder::emitUpsilon(SSACFG::BlockId _block, SSACFG::ValueId _value, SSACFG::ValueId _phi)
+{
+	yulAssert(_phi.isPhi());
+	m_graph.block(_block).upsilons.emplace_back(SSACFG::Upsilon{_value, _phi});
 }
 
 void SSACFGBuilder::writeVariable(Scope::Variable const& _variable, SSACFG::BlockId _block, SSACFG::ValueId _value)
@@ -710,8 +723,8 @@ void SSACFGBuilder::conditionalJump(
 		_nonZero,
 		_zero
 	};
-	m_graph.block(_nonZero).entries.insert(m_currentBlock);
-	m_graph.block(_zero).entries.insert(m_currentBlock);
+	m_graph.block(_nonZero).entries.push_back(m_currentBlock);
+	m_graph.block(_zero).entries.push_back(m_currentBlock);
 	m_currentBlock = {};
 }
 
@@ -724,7 +737,7 @@ void SSACFGBuilder::jump(
 		m_graph.debugInfo->setExitDebugData(m_currentBlock, std::move(_debugData));
 	currentBlock().exit = SSACFG::BasicBlock::Jump{_target};
 	yulAssert(!blockInfo(_target).sealed);
-	m_graph.block(_target).entries.insert(m_currentBlock);
+	m_graph.block(_target).entries.push_back(m_currentBlock);
 	m_currentBlock = _target;
 }
 

--- a/libyul/backends/evm/ssa/SSACFGBuilder.h
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.h
@@ -16,9 +16,9 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 /**
-* Transformation of a Yul AST into a control flow graph.
+* Transformation of a Yul AST into a control flow graph in Phi/Upsilon SSA form.
 *
-* Based on https://doi.org/10.1007/978-3-642-37051-9_6
+* SSA construction is based on https://doi.org/10.1007/978-3-642-37051-9_6
 * Braun, Matthias, et al. "Simple and efficient construction of static single assignment form."
 * Compiler Construction: 22nd International Conference, CC 2013,
 * ETAPS 2013, Rome, Italy, March 16-24, 2013. Proceedings 22. Springer Berlin Heidelberg, 2013.
@@ -26,6 +26,13 @@
 * We have small deviations in Algorithms 2 and 4, as the paper's presentation leads to trivial phis being spuriously
 * removed from not yet sealed blocks via a call to addPhiOperands in Algorithm 4. Instead, we perform the deletion
 * of trivial phis only after a block has been sealed, i.e., all block's predecessors are present.
+*
+* The IR uses Phi/Upsilon form (see https://gist.github.com/pizlonator/cf1e72b8600b1437dda8153ea3fdb963) rather than
+* traditional phi nodes with explicit argument lists.
+* In Phi/Upsilon form each predecessor block emits an Upsilon operation that records the phi pre-image
+* for that edge; the Phi itself carries no argument list. This makes the phi pre-image relationship
+* explicit in the IR and means that adding or removing a predecessor never requires reindexing
+* phi arguments.
 */
 #pragma once
 
@@ -88,7 +95,10 @@ private:
 	SSACFG::ValueId zero();
 	SSACFG::ValueId readVariable(Scope::Variable const& _variable, SSACFG::BlockId _block);
 	SSACFG::ValueId readVariableRecursive(Scope::Variable const& _variable, SSACFG::BlockId _block);
-	SSACFG::ValueId addPhiOperands(Scope::Variable const& _variable, SSACFG::ValueId _phi);
+	/// Emit upsilons in each predecessor of _phi's block, recording the phi pre-images.
+	void addPhiOperands(Scope::Variable const& _variable, SSACFG::ValueId _phi);
+	/// Emit a single Upsilon(_value -> _phi) into block _block.
+	void emitUpsilon(SSACFG::BlockId _block, SSACFG::ValueId _value, SSACFG::ValueId _phi);
 	void writeVariable(Scope::Variable const& _variable, SSACFG::BlockId _block, SSACFG::ValueId _value);
 
 	ControlFlow& m_controlFlow;

--- a/libyul/backends/evm/ssa/io/JSONExporter.cpp
+++ b/libyul/backends/evm/ssa/io/JSONExporter.cpp
@@ -115,10 +115,18 @@ Json toJson(SSACFG const& _cfg, SSACFG::BlockId _blockId, LivenessAnalysis const
 			| ranges::to<Json::array_t>();
 		for (auto const& phi: block.phis)
 		{
-			auto const& phiInfo = _cfg.phiInfo(phi);
+			// Reconstruct phi arguments from upsilon nodes in predecessor blocks.
+			std::vector<SSACFG::ValueId> phiArgs;
+			for (auto const& entryId: block.entries)
+				for (auto const& upsilon: _cfg.block(entryId).upsilons)
+					if (upsilon.phi == phi)
+					{
+						phiArgs.push_back(upsilon.value);
+						break;
+					}
 			Json phiJson = Json::object();
 			phiJson["op"] = "PhiFunction";
-			phiJson["in"] = toJson(_cfg, phiInfo.arguments);
+			phiJson["in"] = toJson(_cfg, phiArgs);
 			phiJson["out"] = toJson(_cfg, std::vector{phi});
 			blockJson["instructions"].push_back(phiJson);
 		}


### PR DESCRIPTION
Replaces phi functions with Phi/Upsilon form in the SSA CFG.
Currently the phi nodes carry positional argument lists coupled to their block's predecessor list. This PR changes this so that each block emits explicit `Upsilon(value, phi)` operations that reflect the value `value` flowing into `phi` upon entry of a block's successor. Consequently, the phi itself becomes argument-less.

This means that
- changes to predecessors stay local (no need to reindex phi arguments in successors), and
- the pre-image relationship is explicit per-edge and not encoded through positions. 