### PR TITLE
Optimize SSA CFG Builder trivial phi removal

### DIFF
--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -91,6 +91,8 @@ add_library(yul
 	backends/evm/ssa/SSACFGBuilder.cpp
 	backends/evm/ssa/SSACFGBuilder.h
 	backends/evm/ssa/SSACFGDebugInfo.h
+	backends/evm/ssa/SSACFGTrivialPhiEliminator.cpp
+	backends/evm/ssa/SSACFGTrivialPhiEliminator.h
 	backends/evm/ssa/SSACFGTypes.h
 	backends/evm/ssa/Stack.cpp
 	backends/evm/ssa/Stack.h

--- a/libyul/backends/evm/ssa/SSACFGBuilder.cpp
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.cpp
@@ -32,7 +32,7 @@
 #include <libsolutil/StringUtils.h>
 #include <libsolutil/Visitor.h>
 
-#include <range/v3/algorithm/replace.hpp>
+#include <range/v3/algorithm/find.hpp>
 #include <range/v3/range/conversion.hpp>
 #include <range/v3/view/drop_last.hpp>
 #include <range/v3/view/enumerate.hpp>
@@ -88,73 +88,94 @@ std::unique_ptr<ControlFlow> SSACFGBuilder::build(
 		builder.sealBlock(builder.m_currentBlock);
 	mainGraph.block(builder.m_currentBlock).exit = SSACFG::BasicBlock::MainExit{};
 	builder.cleanUnreachable();
+	builder.applyPhiSubstitutions();
 	return controlFlow;
 }
 
 SSACFG::ValueId SSACFGBuilder::tryRemoveTrivialPhi(SSACFG::ValueId _phi)
 {
-	// TODO: double-check if this is sane
 	auto const& phiInfo = m_graph.phiInfo(_phi);
 	yulAssert(blockInfo(phiInfo.block).sealed);
 
-	// Collect upsilon values targeting this phi.
-	SSACFG::ValueId same;
-	for (auto const& entry: m_graph.block(phiInfo.block).entries)
-		for (auto const& u: m_graph.block(entry).upsilons)
-			if (u.phi == _phi)
-			{
-				if (u.value == same || u.value == _phi)
-					continue;  // unique value or self-reference
-				if (same.hasValue())
-					return _phi;  // phi merges at least two distinct values -> not trivial
-				same = u.value;
-			}
-	if (!same.hasValue())
-	{
-		// This will happen for unreachable paths.
-		// TODO: check how best to deal with this
-		same = m_graph.unreachableValue();
-	}
+	auto const phiIdx = _phi.value();
 
+	// early exit if this phi was already processed
+	if (phiIdx < m_phiSubstitution.size() && m_phiSubstitution[phiIdx].hasValue())
+		return canonicalize(m_phiSubstitution[phiIdx]);
+
+	// check triviality
+	SSACFG::ValueId same;
+	if (phiIdx < m_upsilonValuesForPhi.size())
+		for (auto const arg: m_upsilonValuesForPhi[phiIdx])
+		{
+			if (arg == same || arg == _phi)
+				continue;  // duplicate or self-reference
+			if (same.hasValue())
+				return _phi;  // two distinct values -> non-trivial
+			same = arg;
+		}
+
+	if (!same.hasValue())
+		// phi has only self-references (unreachable cycle), or no upsilons at all
+		same = m_graph.unreachableValue();
+
+	// remove the phi from its defining block
 	std::erase(m_graph.block(phiInfo.block).phis, _phi);
 
-	std::vector<SSACFG::ValueId> phiUses;
-	for (SSACFG::BlockId::ValueType blockIdValue = 0; blockIdValue < m_graph.numBlocks(); ++blockIdValue)
-	{
-		auto& block = m_graph.block(SSACFG::BlockId{blockIdValue});
-		for (auto blockPhi: block.phis)
-		{
-			yulAssert(blockPhi.hasValue());
-			yulAssert(blockPhi != _phi, "Phis should be defined in exactly one block, _phi was erased.");
-		}
-		// Replace _phi with same in upsilon values and collect affected phis.
-		for (auto& u: block.upsilons)
-			if (u.value == _phi)
-			{
-				u.value = same;
-				phiUses.push_back(u.phi);
-			}
-		// Erase upsilons targeting _phi.
-		std::erase_if(block.upsilons, [_phi](auto const& u) { return u.phi == _phi; });
-		for (auto opId: block.operations)
-			ranges::replace(m_graph.operation(opId).inputs, _phi, same);
-		std::visit(util::GenericVisitor{
-			[_phi, same](SSACFG::BasicBlock::FunctionReturn& _functionReturn) {
-				ranges::replace(_functionReturn.returnValues, _phi, same);
-			},
-			[_phi, same](SSACFG::BasicBlock::ConditionalJump& _condJump) {
-				if (_condJump.condition == _phi)
-					_condJump.condition = same;
-			},
-			[](SSACFG::BasicBlock::Jump&) {},
-			[](SSACFG::BasicBlock::MainExit&) {},
-			[](SSACFG::BasicBlock::Terminated&) {}
-		}, block.exit);
-	}
-	for (auto& currentVariableDefs: m_currentDef | ranges::views::values)
-		ranges::replace(currentVariableDefs, _phi, same);
+	// record the substitution for deferred application to op.inputs / block exits.
+	if (phiIdx >= m_phiSubstitution.size())
+		m_phiSubstitution.resize(phiIdx + 1);
+	m_phiSubstitution[phiIdx] = same;
 
-	for (auto phiUse: phiUses)
+	// update upsilon.value fields and `m_upsilonValuesForPhi` for all phis whose upsilons reference `_phi` as a value
+	std::vector<SSACFG::ValueId> phiUses;
+	if (phiIdx < m_reversePhiUpsilonValues.size())
+	{
+		for (auto const targetPhi: m_reversePhiUpsilonValues[phiIdx])
+		{
+			// update m_upsilonValuesForPhi[targetPhi]: _phi with same.
+			{
+				auto& vals = m_upsilonValuesForPhi[targetPhi.value()];
+				if (
+					auto it = ranges::find(vals, _phi);
+					it != ranges::end(vals)
+				)
+					*it = same;
+			}
+			// update the actual upsilon.value fields in targetPhi's predecessor blocks, needed for `cleanUnreachable`
+			if (targetPhi.value() < m_phiTargetBlocks.size())
+			{
+				for (auto const blockId: m_phiTargetBlocks[targetPhi.value()])
+					for (auto& u: m_graph.block(blockId).upsilons)
+						if (u.phi == targetPhi && u.value == _phi)
+							u.value = same;
+			}
+			// maintain reverse index: this upsilon's value changed from _phi to same.
+			if (same.isPhi())
+			{
+				if (same.value() >= m_reversePhiUpsilonValues.size())
+					m_reversePhiUpsilonValues.resize(same.value() + 1);
+				m_reversePhiUpsilonValues[same.value()].push_back(targetPhi);
+			}
+			phiUses.push_back(targetPhi);
+		}
+		m_reversePhiUpsilonValues[phiIdx].clear();
+	}
+
+	// now erase all upsilons targeting _phi
+	// m_upsilonValuesForPhi[phiIdx] is now stale but _phi is gone and never consulted again.
+	if (phiIdx < m_phiTargetBlocks.size())
+	{
+		for (auto const blockId: m_phiTargetBlocks[phiIdx])
+			std::erase_if(m_graph.block(blockId).upsilons, [_phi](auto const& u) { return u.phi == _phi; });
+		m_phiTargetBlocks[phiIdx].clear();
+	}
+
+	// op.inputs, block exits, and m_currentDef are updated lazily:
+	//   - readVariable() calls canonicalize() before returning any phi def.
+	//   - applyPhiSubstitutions() does a single O(B×(U+O×I)) sweep at the end of build.
+
+	for (auto const phiUse: phiUses)
 		tryRemoveTrivialPhi(phiUse);
 
 	return same;
@@ -192,6 +213,7 @@ void SSACFGBuilder::cleanUnreachable()
 	//   - upsilons in unreachable blocks (their block will never execute), or
 	//   - upsilons with an unreachable value (product of earlier trivial-phi removal).
 	// Collect the affected target phis so we can attempt trivial-phi removal afterward.
+	// Also remove the corresponding entries from the index to keep it consistent.
 	std::vector<SSACFG::ValueId> maybeTrivialPhi;
 	for (SSACFG::BlockId blockId{0}; blockId.value < m_graph.numBlocks(); ++blockId.value)
 	{
@@ -200,7 +222,29 @@ void SSACFGBuilder::cleanUnreachable()
 
 		for (auto const& u: block.upsilons)
 			if (!isReachable || u.value.isUnreachable())
+			{
 				maybeTrivialPhi.push_back(u.phi);
+				auto const phiIdx = u.phi.value();
+				if (phiIdx < m_upsilonValuesForPhi.size())
+				{
+					auto& vals = m_upsilonValuesForPhi[phiIdx];
+					auto const it = ranges::find(vals, u.value);
+					if (it != ranges::end(vals))
+						vals.erase(it);
+				}
+				// maintain reverse index: remove this upsilon from the reverse mapping
+				if (u.value.isPhi())
+				{
+					auto const valIdx = u.value.value();
+					if (valIdx < m_reversePhiUpsilonValues.size())
+					{
+						auto& rev = m_reversePhiUpsilonValues[valIdx];
+						auto const it = ranges::find(rev, u.phi);
+						if (it != ranges::end(rev))
+							rev.erase(it);
+					}
+				}
+			}
 
 		std::erase_if(block.upsilons, [&](SSACFG::Upsilon const& u) {
 			return !isReachable || u.value.isUnreachable();
@@ -256,6 +300,7 @@ void SSACFGBuilder::buildFunctionGraph(
 	// Artificial explicit function exit (`leave`) at the end of the body.
 	builder(Leave{debugDataOf(*_functionDefinition)});
 	builder.cleanUnreachable();
+	builder.applyPhiSubstitutions();
 }
 
 void SSACFGBuilder::operator()(ExpressionStatement const& _expressionStatement)
@@ -610,8 +655,9 @@ SSACFG::ValueId SSACFGBuilder::zero()
 
 SSACFG::ValueId SSACFGBuilder::readVariable(Scope::Variable const& _variable, SSACFG::BlockId _block)
 {
-	if (auto const& def = currentDef(_variable, _block))
-		return *def;
+	auto const& def = currentDef(_variable, _block);
+	if (def.hasValue())
+		return canonicalize(def);
 	return readVariableRecursive(_variable, _block);
 }
 
@@ -659,6 +705,67 @@ void SSACFGBuilder::emitUpsilon(SSACFG::BlockId _block, SSACFG::ValueId _value, 
 {
 	yulAssert(_phi.isPhi());
 	m_graph.block(_block).upsilons.emplace_back(SSACFG::Upsilon{_value, _phi});
+
+	// maintain m_upsilonValuesForPhi (triviality check index)
+	auto const phiIdx = _phi.value();
+	if (phiIdx >= m_upsilonValuesForPhi.size())
+		m_upsilonValuesForPhi.resize(phiIdx + 1);
+	m_upsilonValuesForPhi[phiIdx].push_back(_value);
+
+	// maintain m_phiTargetBlocks (to erase upsilons targeting _phi)
+	if (phiIdx >= m_phiTargetBlocks.size())
+		m_phiTargetBlocks.resize(phiIdx + 1);
+	m_phiTargetBlocks[phiIdx].push_back(_block);
+
+	// maintain m_reversePhiUpsilonValues (find dependency chains from _value)
+	if (_value.isPhi())
+	{
+		auto const valIdx = _value.value();
+		if (valIdx >= m_reversePhiUpsilonValues.size())
+			m_reversePhiUpsilonValues.resize(valIdx + 1);
+		m_reversePhiUpsilonValues[valIdx].push_back(_phi);
+	}
+}
+
+SSACFG::ValueId SSACFGBuilder::canonicalize(SSACFG::ValueId _v)
+{
+	if (!_v.isPhi())
+		return _v;
+	auto const idx = _v.value();
+	if (idx >= m_phiSubstitution.size())
+		return _v;
+	auto& sub = m_phiSubstitution[idx];
+	if (!sub.hasValue())
+		return _v;
+	sub = canonicalize(sub);
+	return sub;
+}
+
+void SSACFGBuilder::applyPhiSubstitutions()
+{
+	if (m_phiSubstitution.empty())
+		return;
+
+	for (SSACFG::BlockId blockId{0}; blockId.value < m_graph.numBlocks(); ++blockId.value)
+	{
+		auto& block = m_graph.block(blockId);
+		for (auto& u: block.upsilons)
+			u.value = canonicalize(u.value);
+		for (auto const opId: block.operations)
+			for (auto& input: m_graph.operation(opId).inputs)
+				input = canonicalize(input);
+		std::visit(util::GenericVisitor{
+			[&](SSACFG::BasicBlock::FunctionReturn& r)
+			{
+				for (auto& v: r.returnValues)
+					v = canonicalize(v);
+			},
+			[&](SSACFG::BasicBlock::ConditionalJump& c) { c.condition = canonicalize(c.condition); },
+			[](SSACFG::BasicBlock::Jump&) {},
+			[](SSACFG::BasicBlock::MainExit&) {},
+			[](SSACFG::BasicBlock::Terminated&) {}
+		}, block.exit);
+	}
 }
 
 void SSACFGBuilder::writeVariable(Scope::Variable const& _variable, SSACFG::BlockId _block, SSACFG::ValueId _value)

--- a/libyul/backends/evm/ssa/SSACFGBuilder.cpp
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.cpp
@@ -20,6 +20,7 @@
  */
 
 #include <libyul/backends/evm/ssa/SSACFGBuilder.h>
+#include <libyul/backends/evm/ssa/SSACFGTrivialPhiEliminator.h>
 
 #include <libyul/backends/evm/ssa/ControlFlow.h>
 
@@ -32,7 +33,6 @@
 #include <libsolutil/StringUtils.h>
 #include <libsolutil/Visitor.h>
 
-#include <range/v3/algorithm/find.hpp>
 #include <range/v3/range/conversion.hpp>
 #include <range/v3/view/drop_last.hpp>
 #include <range/v3/view/enumerate.hpp>
@@ -87,173 +87,10 @@ std::unique_ptr<ControlFlow> SSACFGBuilder::build(
 	if (!builder.blockInfo(builder.m_currentBlock).sealed)
 		builder.sealBlock(builder.m_currentBlock);
 	mainGraph.block(builder.m_currentBlock).exit = SSACFG::BasicBlock::MainExit{};
-	builder.cleanUnreachable();
-	builder.applyPhiSubstitutions();
+	eliminateTrivialPhis(mainGraph);
 	return controlFlow;
 }
 
-SSACFG::ValueId SSACFGBuilder::tryRemoveTrivialPhi(SSACFG::ValueId _phi)
-{
-	auto const& phiInfo = m_graph.phiInfo(_phi);
-	yulAssert(blockInfo(phiInfo.block).sealed);
-
-	auto const phiIdx = _phi.value();
-
-	// early exit if this phi was already processed
-	if (phiIdx < m_phiSubstitution.size() && m_phiSubstitution[phiIdx].hasValue())
-		return canonicalize(m_phiSubstitution[phiIdx]);
-
-	// check triviality
-	SSACFG::ValueId same;
-	if (phiIdx < m_upsilonValuesForPhi.size())
-		for (auto const arg: m_upsilonValuesForPhi[phiIdx])
-		{
-			if (arg == same || arg == _phi)
-				continue;  // duplicate or self-reference
-			if (same.hasValue())
-				return _phi;  // two distinct values -> non-trivial
-			same = arg;
-		}
-
-	if (!same.hasValue())
-		// phi has only self-references (unreachable cycle), or no upsilons at all
-		same = m_graph.unreachableValue();
-
-	// remove the phi from its defining block
-	std::erase(m_graph.block(phiInfo.block).phis, _phi);
-
-	// record the substitution for deferred application to op.inputs / block exits.
-	if (phiIdx >= m_phiSubstitution.size())
-		m_phiSubstitution.resize(phiIdx + 1);
-	m_phiSubstitution[phiIdx] = same;
-
-	// update upsilon.value fields and `m_upsilonValuesForPhi` for all phis whose upsilons reference `_phi` as a value
-	std::vector<SSACFG::ValueId> phiUses;
-	if (phiIdx < m_reversePhiUpsilonValues.size())
-	{
-		for (auto const targetPhi: m_reversePhiUpsilonValues[phiIdx])
-		{
-			// update m_upsilonValuesForPhi[targetPhi]: _phi with same.
-			{
-				auto& vals = m_upsilonValuesForPhi[targetPhi.value()];
-				if (
-					auto it = ranges::find(vals, _phi);
-					it != ranges::end(vals)
-				)
-					*it = same;
-			}
-			// update the actual upsilon.value fields in targetPhi's predecessor blocks, needed for `cleanUnreachable`
-			if (targetPhi.value() < m_phiTargetBlocks.size())
-			{
-				for (auto const blockId: m_phiTargetBlocks[targetPhi.value()])
-					for (auto& u: m_graph.block(blockId).upsilons)
-						if (u.phi == targetPhi && u.value == _phi)
-							u.value = same;
-			}
-			// maintain reverse index: this upsilon's value changed from _phi to same.
-			if (same.isPhi())
-			{
-				if (same.value() >= m_reversePhiUpsilonValues.size())
-					m_reversePhiUpsilonValues.resize(same.value() + 1);
-				m_reversePhiUpsilonValues[same.value()].push_back(targetPhi);
-			}
-			phiUses.push_back(targetPhi);
-		}
-		m_reversePhiUpsilonValues[phiIdx].clear();
-	}
-
-	// now erase all upsilons targeting _phi
-	// m_upsilonValuesForPhi[phiIdx] is now stale but _phi is gone and never consulted again.
-	if (phiIdx < m_phiTargetBlocks.size())
-	{
-		for (auto const blockId: m_phiTargetBlocks[phiIdx])
-			std::erase_if(m_graph.block(blockId).upsilons, [_phi](auto const& u) { return u.phi == _phi; });
-		m_phiTargetBlocks[phiIdx].clear();
-	}
-
-	// op.inputs, block exits, and m_currentDef are updated lazily:
-	//   - readVariable() calls canonicalize() before returning any phi def.
-	//   - applyPhiSubstitutions() does a single O(B×(U+O×I)) sweep at the end of build.
-
-	for (auto const phiUse: phiUses)
-		tryRemoveTrivialPhi(phiUse);
-
-	return same;
-}
-
-/// Removes edges to blocks that are not reachable.
-void SSACFGBuilder::cleanUnreachable()
-{
-	// Determine which blocks are reachable from the entry.
-	util::BreadthFirstSearch<SSACFG::BlockId> reachabilityCheck{{m_graph.entry}};
-	reachabilityCheck.run([&](SSACFG::BlockId _blockId, auto&& _addChild) {
-		auto const& block = m_graph.block(_blockId);
-		visit(util::GenericVisitor{
-				[&](SSACFG::BasicBlock::Jump const& _jump) {
-					_addChild(_jump.target);
-				},
-				[&](SSACFG::BasicBlock::ConditionalJump const& _jump) {
-					_addChild(_jump.zero);
-					_addChild(_jump.nonZero);
-				},
-				[](SSACFG::BasicBlock::FunctionReturn const&) {},
-				[](SSACFG::BasicBlock::Terminated const&) {},
-				[](SSACFG::BasicBlock::MainExit const&) {}
-			}, block.exit);
-	});
-
-	// Remove unreachable predecessor entries.
-	for (SSACFG::BlockId blockId: reachabilityCheck.visited)
-	{
-		auto& block = m_graph.block(blockId);
-		std::erase_if(block.entries, [&](auto const& entry) { return !reachabilityCheck.visited.contains(entry); });
-	}
-
-	// Remove upsilons that are now invalid:
-	//   - upsilons in unreachable blocks (their block will never execute), or
-	//   - upsilons with an unreachable value (product of earlier trivial-phi removal).
-	// Collect the affected target phis so we can attempt trivial-phi removal afterward.
-	// Also remove the corresponding entries from the index to keep it consistent.
-	std::vector<SSACFG::ValueId> maybeTrivialPhi;
-	for (SSACFG::BlockId blockId{0}; blockId.value < m_graph.numBlocks(); ++blockId.value)
-	{
-		auto& block = m_graph.block(blockId);
-		bool const isReachable = reachabilityCheck.visited.contains(blockId);
-
-		for (auto const& u: block.upsilons)
-			if (!isReachable || u.value.isUnreachable())
-			{
-				maybeTrivialPhi.push_back(u.phi);
-				auto const phiIdx = u.phi.value();
-				if (phiIdx < m_upsilonValuesForPhi.size())
-				{
-					auto& vals = m_upsilonValuesForPhi[phiIdx];
-					auto const it = ranges::find(vals, u.value);
-					if (it != ranges::end(vals))
-						vals.erase(it);
-				}
-				// maintain reverse index: remove this upsilon from the reverse mapping
-				if (u.value.isPhi())
-				{
-					auto const valIdx = u.value.value();
-					if (valIdx < m_reversePhiUpsilonValues.size())
-					{
-						auto& rev = m_reversePhiUpsilonValues[valIdx];
-						auto const it = ranges::find(rev, u.phi);
-						if (it != ranges::end(rev))
-							rev.erase(it);
-					}
-				}
-			}
-
-		std::erase_if(block.upsilons, [&](SSACFG::Upsilon const& u) {
-			return !isReachable || u.value.isUnreachable();
-		});
-	}
-
-	for (auto const phi: maybeTrivialPhi)
-		tryRemoveTrivialPhi(phi);
-}
 
 void SSACFGBuilder::buildFunctionGraph(
 	Scope::Function const* _function,
@@ -299,8 +136,7 @@ void SSACFGBuilder::buildFunctionGraph(
 	cfg.exits.insert(builder.m_currentBlock);
 	// Artificial explicit function exit (`leave`) at the end of the body.
 	builder(Leave{debugDataOf(*_functionDefinition)});
-	builder.cleanUnreachable();
-	builder.applyPhiSubstitutions();
+	eliminateTrivialPhis(cfg);
 }
 
 void SSACFGBuilder::operator()(ExpressionStatement const& _expressionStatement)
@@ -657,7 +493,7 @@ SSACFG::ValueId SSACFGBuilder::readVariable(Scope::Variable const& _variable, SS
 {
 	auto const& def = currentDef(_variable, _block);
 	if (def.hasValue())
-		return canonicalize(def);
+		return def;
 	return readVariableRecursive(_variable, _block);
 }
 
@@ -683,10 +519,7 @@ SSACFG::ValueId SSACFGBuilder::readVariableRecursive(Scope::Variable const& _var
 		val = m_graph.newPhi(_block);
 		block.phis.push_back(val);
 		writeVariable(_variable, _block, val);
-		// we call tryRemoveTrivialPhi explicitly opposed to what is presented in Algorithm 2, as our implementation
-		// does not call it in addPhiOperands to avoid removing phis in unsealed blocks
 		addPhiOperands(_variable, val);
-		val = tryRemoveTrivialPhi(val);
 	}
 	writeVariable(_variable, _block, val);
 	return val;
@@ -705,67 +538,6 @@ void SSACFGBuilder::emitUpsilon(SSACFG::BlockId _block, SSACFG::ValueId _value, 
 {
 	yulAssert(_phi.isPhi());
 	m_graph.block(_block).upsilons.emplace_back(SSACFG::Upsilon{_value, _phi});
-
-	// maintain m_upsilonValuesForPhi (triviality check index)
-	auto const phiIdx = _phi.value();
-	if (phiIdx >= m_upsilonValuesForPhi.size())
-		m_upsilonValuesForPhi.resize(phiIdx + 1);
-	m_upsilonValuesForPhi[phiIdx].push_back(_value);
-
-	// maintain m_phiTargetBlocks (to erase upsilons targeting _phi)
-	if (phiIdx >= m_phiTargetBlocks.size())
-		m_phiTargetBlocks.resize(phiIdx + 1);
-	m_phiTargetBlocks[phiIdx].push_back(_block);
-
-	// maintain m_reversePhiUpsilonValues (find dependency chains from _value)
-	if (_value.isPhi())
-	{
-		auto const valIdx = _value.value();
-		if (valIdx >= m_reversePhiUpsilonValues.size())
-			m_reversePhiUpsilonValues.resize(valIdx + 1);
-		m_reversePhiUpsilonValues[valIdx].push_back(_phi);
-	}
-}
-
-SSACFG::ValueId SSACFGBuilder::canonicalize(SSACFG::ValueId _v)
-{
-	if (!_v.isPhi())
-		return _v;
-	auto const idx = _v.value();
-	if (idx >= m_phiSubstitution.size())
-		return _v;
-	auto& sub = m_phiSubstitution[idx];
-	if (!sub.hasValue())
-		return _v;
-	sub = canonicalize(sub);
-	return sub;
-}
-
-void SSACFGBuilder::applyPhiSubstitutions()
-{
-	if (m_phiSubstitution.empty())
-		return;
-
-	for (SSACFG::BlockId blockId{0}; blockId.value < m_graph.numBlocks(); ++blockId.value)
-	{
-		auto& block = m_graph.block(blockId);
-		for (auto& u: block.upsilons)
-			u.value = canonicalize(u.value);
-		for (auto const opId: block.operations)
-			for (auto& input: m_graph.operation(opId).inputs)
-				input = canonicalize(input);
-		std::visit(util::GenericVisitor{
-			[&](SSACFG::BasicBlock::FunctionReturn& r)
-			{
-				for (auto& v: r.returnValues)
-					v = canonicalize(v);
-			},
-			[&](SSACFG::BasicBlock::ConditionalJump& c) { c.condition = canonicalize(c.condition); },
-			[](SSACFG::BasicBlock::Jump&) {},
-			[](SSACFG::BasicBlock::MainExit&) {},
-			[](SSACFG::BasicBlock::Terminated&) {}
-		}, block.exit);
-	}
 }
 
 void SSACFGBuilder::writeVariable(Scope::Variable const& _variable, SSACFG::BlockId _block, SSACFG::ValueId _value)
@@ -804,15 +576,12 @@ Scope::Variable const& SSACFGBuilder::lookupVariable(YulName _name) const
 
 void SSACFGBuilder::sealBlock(SSACFG::BlockId _block)
 {
-	// this method deviates from Algorithm 4 in the reference paper,
-	// as it would lead to tryRemoveTrivialPhi being called on unsealed blocks
 	auto& info = blockInfo(_block);
 	yulAssert(!info.sealed, "Trying to seal already sealed block.");
+	// emit upsilons for all incomplete phis before marking the block as sealed
 	for (auto&& [phi, variable] : info.incompletePhis)
 		addPhiOperands(variable, phi);
 	info.sealed = true;
-	for (auto& [phi, _]: info.incompletePhis)
-		phi = tryRemoveTrivialPhi(phi);
 }
 
 

--- a/libyul/backends/evm/ssa/SSACFGBuilder.h
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.h
@@ -40,6 +40,7 @@
 #include <libyul/ControlFlowSideEffectsCollector.h>
 #include <libyul/backends/evm/ssa/SSACFG.h>
 #include <stack>
+#include <unordered_map>
 
 namespace solidity::yul::ssa
 {
@@ -91,6 +92,11 @@ private:
 	std::vector<SSACFG::ValueId> visitFunctionCall(FunctionCall const& _call);
 	void registerFunctionDefinition(FunctionDefinition const& _functionDefinition);
 	void buildFunctionGraph(Scope::Function const* _function, FunctionDefinition const* _functionDefinition);
+	// performs path compression on substitution chains: phi1->phi2->literal becomes phi1->literal
+	SSACFG::ValueId canonicalize(SSACFG::ValueId _v);
+	// replaces phi references in operation inputs, block exits, and upsilon values with their final substitution
+	// targets in a single pass over the graph, after all trivial phi removals are complete
+	void applyPhiSubstitutions();
 
 	SSACFG::ValueId zero();
 	SSACFG::ValueId readVariable(Scope::Variable const& _variable, SSACFG::BlockId _block);
@@ -133,10 +139,24 @@ private:
 	}
 	void sealBlock(SSACFG::BlockId _block);
 
-	std::map<
+	std::unordered_map<
 		Scope::Variable const*,
-		std::vector<std::optional<SSACFG::ValueId>>
+		std::vector<SSACFG::ValueId>
 	> m_currentDef;
+
+	/// Values of upsilons targeting phi_id: m_upsilonValuesForPhi[phi_id] = {upsilon1, upsilon2, ...},
+	/// populated by calls to `emitUpsilon`
+	std::vector<std::vector<SSACFG::ValueId>> m_upsilonValuesForPhi;
+
+	/// phi_id -> canonical replacement (empty/default if not yet substituted)
+	std::vector<SSACFG::ValueId> m_phiSubstitution;
+
+	/// phi_id -> block IDs that contain upsilons targeting this phi
+	std::vector<std::vector<SSACFG::BlockId>> m_phiTargetBlocks;
+
+	/// phi_id -> phis whose upsilon values include this phi_id, e.g.:
+	/// m_reversePhiUpsilonValues[phi_A] = {phi_X, phi_Y, ...}; phi_X and phi_Y have upsilons whose value is phi_A
+	std::vector<std::vector<SSACFG::ValueId>> m_reversePhiUpsilonValues;
 
 	struct ForLoopInfo {
 		SSACFG::BlockId breakBlock;
@@ -144,7 +164,7 @@ private:
 	};
 	std::stack<ForLoopInfo> m_forLoopInfo;
 
-	std::optional<SSACFG::ValueId>& currentDef(Scope::Variable const& _variable, SSACFG::BlockId _block)
+	SSACFG::ValueId& currentDef(Scope::Variable const& _variable, SSACFG::BlockId _block)
 	{
 		auto& varDefs = m_currentDef[&_variable];
 		if (varDefs.size() <= _block.value)

--- a/libyul/backends/evm/ssa/SSACFGBuilder.h
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.h
@@ -86,17 +86,10 @@ public:
 	SSACFG::ValueId operator()(Literal const& _literal);
 
 private:
-	void cleanUnreachable();
-	SSACFG::ValueId tryRemoveTrivialPhi(SSACFG::ValueId _phi);
 	void assign(std::vector<std::reference_wrapper<Scope::Variable const>> _variables, Expression const* _expression);
 	std::vector<SSACFG::ValueId> visitFunctionCall(FunctionCall const& _call);
 	void registerFunctionDefinition(FunctionDefinition const& _functionDefinition);
 	void buildFunctionGraph(Scope::Function const* _function, FunctionDefinition const* _functionDefinition);
-	// performs path compression on substitution chains: phi1->phi2->literal becomes phi1->literal
-	SSACFG::ValueId canonicalize(SSACFG::ValueId _v);
-	// replaces phi references in operation inputs, block exits, and upsilon values with their final substitution
-	// targets in a single pass over the graph, after all trivial phi removals are complete
-	void applyPhiSubstitutions();
 
 	SSACFG::ValueId zero();
 	SSACFG::ValueId readVariable(Scope::Variable const& _variable, SSACFG::BlockId _block);
@@ -143,20 +136,6 @@ private:
 		Scope::Variable const*,
 		std::vector<SSACFG::ValueId>
 	> m_currentDef;
-
-	/// Values of upsilons targeting phi_id: m_upsilonValuesForPhi[phi_id] = {upsilon1, upsilon2, ...},
-	/// populated by calls to `emitUpsilon`
-	std::vector<std::vector<SSACFG::ValueId>> m_upsilonValuesForPhi;
-
-	/// phi_id -> canonical replacement (empty/default if not yet substituted)
-	std::vector<SSACFG::ValueId> m_phiSubstitution;
-
-	/// phi_id -> block IDs that contain upsilons targeting this phi
-	std::vector<std::vector<SSACFG::BlockId>> m_phiTargetBlocks;
-
-	/// phi_id -> phis whose upsilon values include this phi_id, e.g.:
-	/// m_reversePhiUpsilonValues[phi_A] = {phi_X, phi_Y, ...}; phi_X and phi_Y have upsilons whose value is phi_A
-	std::vector<std::vector<SSACFG::ValueId>> m_reversePhiUpsilonValues;
 
 	struct ForLoopInfo {
 		SSACFG::BlockId breakBlock;

--- a/libyul/backends/evm/ssa/SSACFGTrivialPhiEliminator.cpp
+++ b/libyul/backends/evm/ssa/SSACFGTrivialPhiEliminator.cpp
@@ -1,0 +1,285 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libyul/backends/evm/ssa/SSACFGTrivialPhiEliminator.h>
+
+#include <libyul/backends/evm/ssa/SSACFG.h>
+
+#include <libsolutil/Algorithms.h>
+#include <libsolutil/Visitor.h>
+
+#include <range/v3/algorithm/any_of.hpp>
+#include <range/v3/algorithm/count_if.hpp>
+#include <range/v3/algorithm/replace.hpp>
+
+#include <algorithm>
+#include <vector>
+
+using namespace solidity;
+using namespace solidity::yul;
+using namespace solidity::yul::ssa;
+
+namespace
+{
+
+struct TrivialPhiEliminator
+{
+	SSACFG& cfg;
+
+	// phi_id -> values of upsilons targeting this phi
+	std::vector<std::vector<SSACFG::ValueId>> upsilonValuesForPhi;
+	// phi_id -> blocks containing upsilons targeting this phi
+	std::vector<std::vector<SSACFG::BlockId>> phiTargetBlocks;
+	// phi_id -> phis whose upsilon values reference this phi
+	std::vector<std::vector<SSACFG::ValueId>> reversePhiUpsilonValues;
+	// phi_id -> canonical replacement (default = no substitution)
+	std::vector<SSACFG::ValueId> substitution;
+
+	explicit TrivialPhiEliminator(SSACFG& _cfg): cfg(_cfg) {}
+
+	void run()
+	{
+		cleanUnreachable();
+		buildIndices();
+		substituteDeadPhis();
+
+		// run elimination repeatedly until convergence
+		auto substitutionsBeforeEliminateAll = static_cast<std::size_t>(ranges::count_if(substitution, [](auto const& s) { return s.hasValue(); }));
+		auto substitutionsAfterEliminateAll = substitutionsBeforeEliminateAll;
+		do
+		{
+			substitutionsBeforeEliminateAll = substitutionsAfterEliminateAll;
+			eliminateAll();
+			substitutionsAfterEliminateAll = static_cast<std::size_t>(ranges::count_if(substitution, [](auto const& s) { return s.hasValue(); }));
+		} while (substitutionsAfterEliminateAll > substitutionsBeforeEliminateAll);
+		applySubstitutions();
+	}
+
+private:
+	void cleanUnreachable()
+	{
+		util::BreadthFirstSearch<SSACFG::BlockId> reachabilityCheck{{cfg.entry}};
+		reachabilityCheck.run([&](SSACFG::BlockId _blockId, auto&& _addChild) {
+			auto const& block = cfg.block(_blockId);
+			visit(util::GenericVisitor{
+				[&](SSACFG::BasicBlock::Jump const& _jump) { _addChild(_jump.target); },
+				[&](SSACFG::BasicBlock::ConditionalJump const& _jump) {
+					_addChild(_jump.zero);
+					_addChild(_jump.nonZero);
+				},
+				[](SSACFG::BasicBlock::FunctionReturn const&) {},
+				[](SSACFG::BasicBlock::Terminated const&) {},
+				[](SSACFG::BasicBlock::MainExit const&) {}
+			}, block.exit);
+		});
+
+		for (SSACFG::BlockId blockId: reachabilityCheck.visited)
+		{
+			auto& block = cfg.block(blockId);
+			std::erase_if(block.entries, [&](auto const& entry) {
+				return !reachabilityCheck.visited.contains(entry);
+			});
+		}
+
+		for (SSACFG::BlockId blockId{0}; blockId.value < cfg.numBlocks(); ++blockId.value)
+		{
+			auto& block = cfg.block(blockId);
+			bool const isReachable = reachabilityCheck.visited.contains(blockId);
+			std::erase_if(block.upsilons, [&](SSACFG::Upsilon const& u) {
+				return !isReachable || u.value.isUnreachable();
+			});
+		}
+	}
+
+	void buildIndices()
+	{
+		for (SSACFG::BlockId blockId{0}; blockId.value < cfg.numBlocks(); ++blockId.value)
+		{
+			auto const& block = cfg.block(blockId);
+			for (auto const& u: block.upsilons)
+			{
+				auto const phiIdx = u.phi.value();
+				if (phiIdx >= upsilonValuesForPhi.size())
+				{
+					upsilonValuesForPhi.resize(phiIdx + 1);
+					phiTargetBlocks.resize(phiIdx + 1);
+				}
+				if (phiIdx >= reversePhiUpsilonValues.size())
+					reversePhiUpsilonValues.resize(phiIdx + 1);
+				upsilonValuesForPhi[phiIdx].push_back(u.value);
+				phiTargetBlocks[phiIdx].push_back(blockId);
+				if (u.value.isPhi())
+				{
+					auto const valIdx = u.value.value();
+					if (valIdx >= reversePhiUpsilonValues.size())
+						reversePhiUpsilonValues.resize(valIdx + 1);
+					reversePhiUpsilonValues[valIdx].push_back(u.phi);
+				}
+			}
+		}
+		substitution.resize(std::max(upsilonValuesForPhi.size(), size_t{1}));
+	}
+
+	/// Phis that have no upsilons targeting them are dead — either in unreachable blocks
+	/// or orphaned from cycle-breaking.
+	/// Replace references to them with unreachableValue in the upsilon value index so they don't block triviality
+	/// detection.
+	void substituteDeadPhis()
+	{
+		auto const unreachable = cfg.unreachableValue();
+		for (auto& upsilonValues: upsilonValuesForPhi)
+			for (auto& val: upsilonValues)
+				if (val.isPhi())
+				{
+					auto const idx = val.value();
+					bool const hasUpsilons = idx < upsilonValuesForPhi.size() && !upsilonValuesForPhi[idx].empty();
+					if (!hasUpsilons)
+						val = unreachable;
+				}
+	}
+
+	void eliminateAll()
+	{
+		for (SSACFG::BlockId blockId{0}; blockId.value < cfg.numBlocks(); ++blockId.value)
+		{
+			auto const phis = cfg.block(blockId).phis;
+			for (auto const phi: phis)
+				tryRemove(phi);
+		}
+	}
+
+	void tryRemove(SSACFG::ValueId _phi)
+	{
+		auto const phiIdx = _phi.value();
+
+		// early exit if this phi was already processed
+		if (phiIdx < substitution.size() && substitution[phiIdx].hasValue())
+			return;
+
+		// check triviality and canonicalize arguments to account for already-substituted phis;
+		// skip self-references and unreachable values
+		SSACFG::ValueId same;
+		if (phiIdx < upsilonValuesForPhi.size())
+			for (auto const arg: upsilonValuesForPhi[phiIdx])
+			{
+				auto const resolved = canonicalize(arg);
+				if (resolved == same || resolved == _phi || resolved.isUnreachable())
+					continue;
+				if (same.hasValue())
+					return; // non-trivial
+				same = resolved;
+			}
+
+		if (!same.hasValue())
+			// phi has only self-references (unreachable cycle), or no upsilons at all
+			same = cfg.unreachableValue();
+
+		// remove the phi from its defining block
+		std::erase(cfg.block(cfg.phiInfo(_phi).block).phis, _phi);
+
+		// record the substitution
+		if (phiIdx >= substitution.size())
+			substitution.resize(phiIdx + 1);
+		substitution[phiIdx] = same;
+
+		// update upsilon.value fields and `upsilonValuesForPhi` for all phis whose upsilons reference `_phi` as a value
+		std::vector<SSACFG::ValueId> cascades;
+		if (phiIdx < reversePhiUpsilonValues.size())
+		{
+			for (auto const targetPhi: reversePhiUpsilonValues[phiIdx])
+			{
+				// update upsilonValuesForPhi[targetPhi]: _phi with same
+				auto& vals = upsilonValuesForPhi[targetPhi.value()];
+				ranges::replace(vals, _phi, same);
+				if (targetPhi.value() < phiTargetBlocks.size())
+					for (auto const blockId: phiTargetBlocks[targetPhi.value()])
+						for (auto& u: cfg.block(blockId).upsilons)
+							if (u.phi == targetPhi && u.value == _phi)
+								u.value = same;
+				// maintain reverse index
+				if (same.isPhi())
+				{
+					if (same.value() >= reversePhiUpsilonValues.size())
+						reversePhiUpsilonValues.resize(same.value() + 1);
+					reversePhiUpsilonValues[same.value()].push_back(targetPhi);
+				}
+				cascades.push_back(targetPhi);
+			}
+			reversePhiUpsilonValues[phiIdx].clear();
+		}
+
+		// erase all upsilons targeting the removed phi.
+		if (phiIdx < phiTargetBlocks.size())
+		{
+			for (auto const blockId: phiTargetBlocks[phiIdx])
+				std::erase_if(cfg.block(blockId).upsilons, [_phi](auto const& u) { return u.phi == _phi; });
+			phiTargetBlocks[phiIdx].clear();
+		}
+
+		for (auto const cascadingPhi: cascades)
+			tryRemove(cascadingPhi);
+	}
+
+	SSACFG::ValueId canonicalize(SSACFG::ValueId const _v)
+	{
+		if (!_v.isPhi())
+			return _v;
+		auto const idx = _v.value();
+		if (idx >= substitution.size())
+			return _v;
+		auto& sub = substitution[idx];
+		if (!sub.hasValue())
+			return _v;
+		// path compression
+		sub = canonicalize(sub);
+		return sub;
+	}
+
+	void applySubstitutions()
+	{
+		if (!ranges::any_of(substitution, [](ValueId const& _sub) { return _sub.hasValue(); }))
+			return;
+
+		for (SSACFG::BlockId blockId{0}; blockId.value < cfg.numBlocks(); ++blockId.value)
+		{
+			auto& block = cfg.block(blockId);
+			for (auto& u: block.upsilons)
+				u.value = canonicalize(u.value);
+			for (auto const opId: block.operations)
+				for (auto& input: cfg.operation(opId).inputs)
+					input = canonicalize(input);
+			std::visit(util::GenericVisitor{
+				[&](SSACFG::BasicBlock::FunctionReturn& r) {
+					for (auto& v: r.returnValues)
+						v = canonicalize(v);
+				},
+				[&](SSACFG::BasicBlock::ConditionalJump& c) { c.condition = canonicalize(c.condition); },
+				[](SSACFG::BasicBlock::Jump&) {},
+				[](SSACFG::BasicBlock::MainExit&) {},
+				[](SSACFG::BasicBlock::Terminated&) {}
+			}, block.exit);
+		}
+	}
+};
+
+}
+
+void ssa::eliminateTrivialPhis(SSACFG& _cfg)
+{
+	TrivialPhiEliminator(_cfg).run();
+}

--- a/libyul/backends/evm/ssa/SSACFGTrivialPhiEliminator.h
+++ b/libyul/backends/evm/ssa/SSACFGTrivialPhiEliminator.h
@@ -1,0 +1,34 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * Removes trivial phis and unreachable blocks from an SSA CFG.
+ *
+ * A phi is trivial if all its upsilon operands provide the same value (modulo self-references).
+ * Removal may cascade: eliminating one trivial phi can make others trivial.
+ */
+#pragma once
+
+namespace solidity::yul::ssa
+{
+
+class SSACFG;
+
+/// Removes unreachable blocks and trivial phis from the SSA CFG
+void eliminateTrivialPhis(SSACFG& _cfg);
+
+}


### PR DESCRIPTION
Extracts the trivial phi removal into a separate step at the very end after the SSA CFG Builder has run.
The removal itself is optimized by replacing the intermittent ad-hoc full-graph scans by building up node index structures and doing the removal in a deferred fashion at the very end.

This can save orders of magnitude of time required to build the SSA CFG, especially relevant for unit tests where there are many `require` statements in solidity leading to many different `revert` paths and consequently phi functions. The ad-hoc removal always scanned the full graph.