### PR TITLE
SSA: Add shuffler test

### DIFF
--- a/test/libyul/ssa/stackShuffler/keep_top_argument.stack
+++ b/test/libyul/ssa/stackShuffler/keep_top_argument.stack
@@ -1,0 +1,14 @@
+// We have arguments in the right order, but we need an extra copy of the top argument in the tail
+initial: [v0, v1]
+targetStackTop: [v0, v1]
+targetStackTailSet: {v1}
+targetStackSize: 3
+// ----
+//             |      0 |      1      2
+//             +------- +--------------
+//    (initial)|     v0 |     v1
+//         DUP1|     v0 |     v1     v1
+//        SWAP2|     v1 |     v1     v0
+//        SWAP1|     v1 |     v0     v1
+//             +------- +--------------
+//     (target)|   {v1} |     v0     v1


### PR DESCRIPTION
This test demonstrates an inefficiency in the shuffler. We we have arguments in the right order but we need an extra copy of the top argument in the tail, the shuffler now creates a sequence of three instructions "DUP1 + SWAP2 + SWAP1" when the same result could be achieved with just two instructions "SWAP1 + DUP2".