### PR TITLE
Add parser tests for experimental EVM version

### DIFF
--- a/test/solc/CommandLineParser.cpp
+++ b/test/solc/CommandLineParser.cpp
@@ -719,6 +719,25 @@ BOOST_AUTO_TEST_CASE(experimental_features_without_experimental_flag)
 	BOOST_CHECK_EXCEPTION(parseCommandLine(commandLineOptions), CommandLineValidationError, hasCorrectMessage);
 }
 
+BOOST_AUTO_TEST_CASE(experimental_evm_version_without_experimental_flag)
+{
+	std::string const expectedErrorMessage =
+		"EVM version '@future' is experimental and can only be selected in experimental mode. "
+		"To enable experimental mode, use the --experimental flag.";
+
+	auto hasCorrectMessage = [&](CommandLineValidationError const& _exception) { return _exception.what() == expectedErrorMessage; };
+
+	std::vector<std::string> const commandLineOptions{"solc", "--evm-version=@future", "contract.sol"};
+	BOOST_CHECK_EXCEPTION(parseCommandLine(commandLineOptions), CommandLineValidationError, hasCorrectMessage);
+}
+
+BOOST_AUTO_TEST_CASE(experimental_evm_version_with_experimental_flag)
+{
+	auto const commandLineOptions = parseCommandLine({"solc", "--experimental", "--evm-version=@future", "contract.sol"});
+	BOOST_CHECK_EQUAL(commandLineOptions.experimental, true);
+	BOOST_CHECK(commandLineOptions.output.evmVersion == EVMVersion::future());
+}
+
 BOOST_AUTO_TEST_CASE(via_ssa_cfg_smoke)
 {
 	auto const commandLineOptions = parseCommandLine({"solc", "--experimental", "--via-ssa-cfg", "contract.sol"});


### PR DESCRIPTION

  ## Summary

  This PR only adds test coverage.

  It adds `CommandLineParser` tests for the experimental `@future` EVM version to cover:
  - rejection when `--experimental` is not enabled
  - successful parsing when `--experimental` is enabled

  ## Notes

  There is no functional or logic change in compiler behavior.
  This only extends parser-level test coverage for behavior that is already implemented.

  ## Testing

  - built `soltest`
  - ran `./scripts/soltest.sh -t "CommandLineParserTest/*" --no-semantic-tests`