### PR TITLE
SSA: Do not dup prematurely in shuffler

### DIFF
--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -603,16 +603,6 @@ private:
 				_state.countInTail(slotAtOffset) == 0  // if we don't have the slot in tail right now
 			)
 			{
-				// If we don't have enough copies of this slot, dup first instead of swapping.
-				if (_state.count(slotAtOffset) < _state.targetMinCount(slotAtOffset))
-				{
-					if (_stack.dupReachable(offset))
-					{
-						_stack.dup(offset);
-						return true;
-					}
-				}
-
 				// find the lowest swappable slot in tail that needs to go to args, swap
 				for (StackOffset tailOffset: _state.stackTailRange())
 				{

--- a/test/libyul/ssa/stackShuffler/keep_top_argument.stack
+++ b/test/libyul/ssa/stackShuffler/keep_top_argument.stack
@@ -7,8 +7,7 @@ targetStackSize: 3
 //             |      0 |      1      2
 //             +------- +--------------
 //    (initial)|     v0 |     v1
-//         DUP1|     v0 |     v1     v1
-//        SWAP2|     v1 |     v1     v0
-//        SWAP1|     v1 |     v0     v1
+//        SWAP1|     v1 |     v0
+//         DUP2|     v1 |     v0     v1
 //             +------- +--------------
 //     (target)|   {v1} |     v0     v1

--- a/test/libyul/ssa/stackShuffler/satisfy_tail_requirements.stack
+++ b/test/libyul/ssa/stackShuffler/satisfy_tail_requirements.stack
@@ -7,24 +7,22 @@ targetStackSize: 17
 //             |      0      1      2      3      4      5      6 |      7      8      9     10     11     12     13     14     15     16
 //             +------------------------------------------------- +----------------------------------------------------------------------
 //    (initial)|     v2     v3     v4     v5     v6     v7     v8 |     v9    v10
-//         DUP1|     v2     v3     v4     v5     v6     v7     v8 |     v9    v10    v10
-//        SWAP9|    v10     v3     v4     v5     v6     v7     v8 |     v9    v10     v2
-//        SWAP2|    v10     v3     v4     v5     v6     v7     v8 |     v2    v10     v9
-//        SWAP1|    v10     v3     v4     v5     v6     v7     v8 |     v2     v9    v10
-//    PUSH lit3|    v10     v3     v4     v5     v6     v7     v8 |     v2     v9    v10   lit3
-//        SWAP3|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9    v10     v2
-//         DUP5|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9    v10     v2     v8
-//        SWAP2|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v2    v10
-//         DUP7|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v2    v10     v7
-//        SWAP2|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7    v10     v2
-//         DUP9|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7    v10     v2     v6
-//        SWAP2|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7     v6     v2    v10
-//        DUP11|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7     v6     v2    v10     v5
-//        SWAP2|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7     v6     v5    v10     v2
-//        DUP13|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7     v6     v5    v10     v2     v4
-//        SWAP2|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7     v6     v5     v4     v2    v10
-//        DUP15|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7     v6     v5     v4     v2    v10     v3
-//        SWAP2|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7     v6     v5     v4     v3    v10     v2
-//        SWAP1|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7     v6     v5     v4     v3     v2    v10
+//        SWAP8|    v10     v3     v4     v5     v6     v7     v8 |     v9     v2
+//    PUSH lit3|    v10     v3     v4     v5     v6     v7     v8 |     v9     v2   lit3
+//        SWAP2|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v2     v9
+//        SWAP1|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v2
+//         DUP4|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v2     v8
+//        SWAP1|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v2
+//         DUP6|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v2     v7
+//        SWAP1|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7     v2
+//         DUP8|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7     v2     v6
+//        SWAP1|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7     v6     v2
+//        DUP10|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7     v6     v2     v5
+//        SWAP1|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7     v6     v5     v2
+//        DUP12|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7     v6     v5     v2     v4
+//        SWAP1|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7     v6     v5     v4     v2
+//        DUP14|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7     v6     v5     v4     v2     v3
+//        SWAP1|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7     v6     v5     v4     v3     v2
+//        DUP16|    v10     v3     v4     v5     v6     v7     v8 |   lit3     v9     v8     v7     v6     v5     v4     v3     v2    v10
 //             +------------------------------------------------- +----------------------------------------------------------------------
 //     (target)|                                            {v10} |   lit3     v9     v8     v7     v6     v5     v4     v3     v2    v10


### PR DESCRIPTION
It seems that we do not need to dup slots we will need in advance. We can first swap them into tail, and only dup them later when we have more information.