### PR TITLE
Improve SSA shuffler test interface

### DIFF
--- a/test/libyul/ssa/StackShufflerTest.cpp
+++ b/test/libyul/ssa/StackShufflerTest.cpp
@@ -166,15 +166,20 @@ struct ShuffleTestInput
 {
 	std::optional<TestStack::Data> initial;
 	std::optional<TestStack::Data> targetStackTop;
-	std::optional<Liveness> targetStackTailSet;
+	Liveness targetStackTailSet{};
 	std::optional<size_t> targetStackSize;
 
 	bool valid() const
 	{
-		return initial.has_value() &&
+		bool const fullySpecified =
+			initial.has_value() &&
 			targetStackTop.has_value() &&
-			targetStackTailSet.has_value() &&
 			targetStackSize.has_value();
+		bool const exactMode =
+			initial.has_value() &&
+			targetStackTop.has_value() &&
+			!targetStackSize.has_value();
+		return fullySpecified || exactMode;
 	}
 
 	static ShuffleTestInput parse(std::string_view _source)
@@ -222,6 +227,15 @@ struct ShuffleTestInput
 					throw std::runtime_error(fmt::format("Couldn't parse targetStackSize: {}", value));
 			}
 
+		}
+
+		if (result.valid() && !result.targetStackSize)
+		{
+			yulAssert(
+				result.targetStackTailSet.empty(),
+				"Can only infer target stack size if targetStackTailSet is empty / unset."
+			);
+			result.targetStackSize = result.targetStackTop->size();
 		}
 		return result;
 	}
@@ -399,7 +413,10 @@ Where <slot> is one of:
   lit<N>  - literal
   JUNK    - junk slot
 
-Lines starting with // are comments. Comments at the end of lines are supported, too.)";
+Lines starting with // are comments. Comments at the end of lines are supported, too.
+The targetStackTailSet defaults to empty.
+The targetStackSize defaults to the size of targetStackTop if targetStackTailSet is empty, otherwise it must be
+explicitly provided.)";
 		util::AnsiColorized out(_stream, _formatted, {util::formatting::BOLD, util::formatting::RED});
 		out	<< _linePrefix << fmt::format("Error parsing source. Expected format:") << '\n';
 
@@ -418,13 +435,13 @@ Lines starting with // are comments. Comments at the end of lines are supported,
 	auto stackData = *testConfig.initial;
 	std::ostringstream oss;
 	{
-		TraceRecorder trace(oss, *testConfig.targetStackTop, *testConfig.targetStackTailSet, *testConfig.targetStackSize);
+		TraceRecorder trace(oss, *testConfig.targetStackTop, testConfig.targetStackTailSet, *testConfig.targetStackSize);
 		trace.record("(initial)", *testConfig.initial);
 		TestStack stack(stackData, {.hook = [&](std::string const& op){ trace.record(op, stackData); }});
 		StackShuffler<StackManipulationCallbacks>::shuffle(
 			stack,
 			*testConfig.targetStackTop,
-			*testConfig.targetStackTailSet,
+			testConfig.targetStackTailSet,
 			*testConfig.targetStackSize
 		);
 	}
@@ -433,7 +450,7 @@ Lines starting with // are comments. Comments at the end of lines are supported,
 		yulAssert(*testConfig.targetStackSize >= testConfig.targetStackTop->size());
 		auto const tailSize = *testConfig.targetStackSize - testConfig.targetStackTop->size();
 		yulAssert(stackData.size() == *testConfig.targetStackSize);
-		for (const auto& valueID: *testConfig.targetStackTailSet | ranges::views::keys)
+		for (const auto& valueID: testConfig.targetStackTailSet | ranges::views::keys)
 		{
 			auto const findIt = ranges::find(
 				stackData.begin(),

--- a/test/libyul/ssa/stackShuffler/grow.stack
+++ b/test/libyul/ssa/stackShuffler/grow.stack
@@ -1,8 +1,6 @@
 // need to grow the stack to reach target stack size but still fulfill args requirements
 initial: [JUNK, JUNK, JUNK, v15]
 targetStackTop: [JUNK, JUNK, JUNK, JUNK, v15]
-targetStackTailSet: {}
-targetStackSize: 5
 // ----
 //             |      0      1      2      3      4
 //             +-----------------------------------

--- a/test/libyul/ssa/stackShuffler/introduce_junk.stack
+++ b/test/libyul/ssa/stackShuffler/introduce_junk.stack
@@ -1,8 +1,6 @@
 // some of the slots in the initial stack no longer appear in the target / are junk
 initial: [v189, phi112, JUNK, v204, JUNK, JUNK, JUNK, v185, JUNK, v188, v190, v191, JUNK, v199, phi112, phi112, v205, v206]
 targetStackTop: [v199, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, v185, JUNK, v188, v190, v191, JUNK, v189, JUNK, v206, v205, v204]
-targetStackTailSet: {}
-targetStackSize: 18
 // ----
 //             |      0      1      2      3      4      5      6      7      8      9     10     11     12     13     14     15     16     17
 //             +------------------------------------------------------------------------------------------------------------------------------

--- a/test/libyul/ssa/stackShuffler/replace_junk_with_top_value.stack
+++ b/test/libyul/ssa/stackShuffler/replace_junk_with_top_value.stack
@@ -1,8 +1,6 @@
 // we want to replace JUNK at the bottom of the stack with the top value, all other slots must be preserved exactly
 initial: [JUNK, v2, v1, v0]
 targetStackTop: [v0, v2, v1, v0]
-targetStackTailSet: {}
-targetStackSize: 4
 // ----
 //             |      0      1      2      3 |      4
 //             +---------------------------- +-------

--- a/test/libyul/ssa/stackShuffler/superfluous_top_slots.stack
+++ b/test/libyul/ssa/stackShuffler/superfluous_top_slots.stack
@@ -1,8 +1,6 @@
 // todo: The upper two junk slots should be popped immediately, they are completely superfluous.
 initial: [JUNK, JUNK, v56, v57, JUNK, JUNK]
 targetStackTop: [JUNK, JUNK, v56, v57, lit0, v56, lit11]
-targetStackTailSet: {}
-targetStackSize: 7
 // ----
 //             |      0      1      2      3      4      5      6 |      7
 //             +------------------------------------------------- +-------

--- a/test/libyul/ssa/stackShuffler/swap_junk_over_pop.stack
+++ b/test/libyul/ssa/stackShuffler/swap_junk_over_pop.stack
@@ -1,7 +1,6 @@
 // here, the algorithm should prefer a swap of junk into tail over pop and dup
 initial: [v0, JUNK, v2]
 targetStackTop: [lit2, v2, v0]
-targetStackTailSet: {}
 targetStackSize: 4
 // ----
 //             |      0 |      1      2      3


### PR DESCRIPTION
Relaxes the conditions for valid SSA stack shuffler test definitions by defaulting the target tail set to empty and deriving the target size from the target stack top when unset. Also simplifies the test definitions accordingly.