### PR TITLE
Tests: Run SSA-CFG on external contracts in semantic tests

### DIFF
--- a/test/libsolidity/semanticTests/externalContracts/FixedFeeRegistrar.sol
+++ b/test/libsolidity/semanticTests/externalContracts/FixedFeeRegistrar.sol
@@ -72,6 +72,9 @@ contract FixedFeeRegistrar is Registrar {
 	}
 	uint constant c_fee = 69 ether;
 }
+// ====
+// compileViaSSACFG: true
+// experimental: true
 // ----
 // constructor()
 // gas irOptimized: 78076
@@ -80,6 +83,8 @@ contract FixedFeeRegistrar is Registrar {
 // gas legacy code: 792400
 // gas legacyOptimized: 84598
 // gas legacyOptimized code: 388000
+// gas ssaCFGOptimized: 80860
+// gas ssaCFGOptimized code: 345400
 // reserve(string), 69 ether: 0x20, 3, "abc" ->
 // ~ emit Changed(string): #0x4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45
 // gas irOptimized: 45741

--- a/test/libsolidity/semanticTests/externalContracts/base64.sol
+++ b/test/libsolidity/semanticTests/externalContracts/base64.sol
@@ -31,6 +31,8 @@ contract test {
 //
 // ====
 // EVMVersion: >=constantinople
+// compileViaSSACFG: true
+// experimental: true
 // ----
 // constructor()
 // gas irOptimized: 79076
@@ -39,6 +41,8 @@ contract test {
 // gas legacy code: 629800
 // gas legacyOptimized: 87926
 // gas legacyOptimized code: 429800
+// gas ssaCFGOptimized: 80162
+// gas ssaCFGOptimized code: 334800
 // encode_inline_asm(bytes): 0x20, 0 -> 0x20, 0
 // encode_inline_asm(bytes): 0x20, 1, "f" -> 0x20, 4, "Zg=="
 // encode_inline_asm(bytes): 0x20, 2, "fo" -> 0x20, 4, "Zm8="
@@ -57,7 +61,9 @@ contract test {
 // gas irOptimized: 1406025
 // gas legacy: 1554038
 // gas legacyOptimized: 1132031
+// gas ssaCFGOptimized: 1391028
 // encode_no_asm_large()
 // gas irOptimized: 3512081
 // gas legacy: 4600082
 // gas legacyOptimized: 2813075
+// gas ssaCFGOptimized: 3097084

--- a/test/libsolidity/semanticTests/externalContracts/prbmath_signed.sol
+++ b/test/libsolidity/semanticTests/externalContracts/prbmath_signed.sol
@@ -46,6 +46,9 @@ contract test {
         assert(z1 == z2);
     }
 }
+// ====
+// compileViaSSACFG: true
+// experimental: true
 // ----
 // constructor()
 // gas irOptimized: 177903
@@ -54,6 +57,8 @@ contract test {
 // gas legacy code: 2205000
 // gas legacyOptimized: 178012
 // gas legacyOptimized code: 1669600
+// gas ssaCFGOptimized: 177301
+// gas ssaCFGOptimized code: 1666800
 // div(int256,int256): 3141592653589793238, 88714123 -> 35412542528203691288251815328
 // gas irOptimized: 22045
 // gas legacy: 22736

--- a/test/libsolidity/semanticTests/externalContracts/prbmath_unsigned.sol
+++ b/test/libsolidity/semanticTests/externalContracts/prbmath_unsigned.sol
@@ -46,6 +46,9 @@ contract test {
         assert(z1 == z2);
     }
 }
+// ====
+// compileViaSSACFG: true
+// experimental: true
 // ----
 // constructor()
 // gas irOptimized: 170626
@@ -54,6 +57,8 @@ contract test {
 // gas legacy code: 1999000
 // gas legacyOptimized: 168857
 // gas legacyOptimized code: 1556200
+// gas ssaCFGOptimized: 168323
+// gas ssaCFGOptimized code: 1553000
 // div(uint256,uint256): 3141592653589793238, 88714123 -> 35412542528203691288251815328
 // gas irOptimized: 21912
 // gas legacy: 22475

--- a/test/libsolidity/semanticTests/externalContracts/ramanujan_pi.sol
+++ b/test/libsolidity/semanticTests/externalContracts/ramanujan_pi.sol
@@ -31,6 +31,9 @@ contract test {
         ret = prb_scale(1).div(ret);
     }
 }
+// ====
+// compileViaSSACFG: true
+// experimental: true
 // ----
 // constructor()
 // gas irOptimized: 77816
@@ -39,6 +42,8 @@ contract test {
 // gas legacy code: 523600
 // gas legacyOptimized: 82667
 // gas legacyOptimized code: 369200
+// gas ssaCFGOptimized: 80456
+// gas ssaCFGOptimized code: 344400
 // prb_pi() -> 3141592656369545286
 // gas irOptimized: 55036
 // gas legacy: 100657

--- a/test/libsolidity/semanticTests/externalContracts/strings.sol
+++ b/test/libsolidity/semanticTests/externalContracts/strings.sol
@@ -47,6 +47,9 @@ contract test {
         return d.toSlice().len();
     }
 }
+// ====
+// compileViaSSACFG: true
+// experimental: true
 // ----
 // constructor()
 // gas irOptimized: 95303
@@ -55,6 +58,8 @@ contract test {
 // gas legacy code: 932600
 // gas legacyOptimized: 102639
 // gas legacyOptimized code: 612400
+// gas ssaCFGOptimized: 97417
+// gas ssaCFGOptimized code: 547000
 // toSlice(string): 0x20, 11, "hello world" -> 11, 0xa0
 // gas irOptimized: 22646
 // gas legacy: 23168
@@ -75,3 +80,4 @@ contract test {
 // gas irOptimized: 1976778
 // gas legacy: 4234020
 // gas legacyOptimized: 2318668
+// gas ssaCFGOptimized: 2080148


### PR DESCRIPTION
With (possible) upcoming changes in the SSA-CFG pipeline, it is beneficial to see some of the effects on gas statistics directly in the PRs. We are not running SSA-CFG by default yet, but we can at least run it on all external contracts, which are most relevant for us.