### PR TITLE
CI: Add explicit boost-libs to Arch Linux build dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1276,7 +1276,7 @@ jobs:
       - run:
           name: Install build dependencies
           command: |
-            pacman --noconfirm -Syu --noprogressbar --needed base-devel boost cmake ccache git openssh tar
+            pacman --noconfirm -Syu --noprogressbar --needed base-devel boost boost-libs cmake ccache git openssh tar
       - checkout
       - run_build
       - store_artifacts_solc


### PR DESCRIPTION
Arch Linux boost 1.90.0 moved static libraries from the `boost` package to `boost-libs` and dropped the dependency between them