### PR TITLE
SSACFG: Add run gas-accumulating callback implementation  and add EVMDialect to SSACFG

### DIFF
--- a/libyul/backends/evm/EVMObjectCompiler.cpp
+++ b/libyul/backends/evm/EVMObjectCompiler.cpp
@@ -91,7 +91,7 @@ void EVMObjectCompiler::run(Object const& _object, bool _optimize, bool _viaSSAC
 		{
 			std::unique_ptr<ssa::ControlFlow> controlFlow = ssa::SSACFGBuilder::build(
 				*_object.analysisInfo,
-				*_object.dialect(),
+				*evmDialect,
 				_object.code()->root(),
 				false
 			);

--- a/libyul/backends/evm/ssa/ControlFlow.cpp
+++ b/libyul/backends/evm/ssa/ControlFlow.cpp
@@ -18,6 +18,7 @@
 
 #include <libyul/backends/evm/ssa/ControlFlow.h>
 
+#include <range/v3/view/transform.hpp>
 #include <range/v3/range/conversion.hpp>
 
 using namespace solidity::yul::ssa;

--- a/libyul/backends/evm/ssa/SSACFG.cpp
+++ b/libyul/backends/evm/ssa/SSACFG.cpp
@@ -25,11 +25,9 @@
 #include <libsolutil/StringUtils.h>
 #include <libsolutil/Visitor.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wtautological-compare"
 #include <fmt/ranges.h>
-#pragma GCC diagnostic pop
 
+#include <range/v3/view/transform.hpp>
 #include <range/v3/view/zip.hpp>
 
 using namespace solidity;

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -24,6 +24,8 @@
 #include <libyul/backends/evm/ssa/SSACFGDebugInfo.h>
 #include <libyul/backends/evm/ssa/SSACFGTypes.h>
 
+#include <libyul/backends/evm/EVMDialect.h>
+
 #include <libyul/AST.h>
 #include <libyul/AsmAnalysisInfo.h>
 #include <libyul/Dialect.h>
@@ -47,7 +49,11 @@ class SSACFG
 public:
 	using DebugInfo = SSACFGDebugInfo;
 
-	explicit SSACFG(std::unique_ptr<DebugInfo> _debugInfo = std::make_unique<DebugInfo>()):
+	explicit SSACFG(
+		EVMDialect const& _evmVersion,
+		std::unique_ptr<DebugInfo> _debugInfo = nullptr
+	):
+		evmDialect(_evmVersion),
 		debugInfo(std::move(_debugInfo))
 	{}
 
@@ -266,6 +272,7 @@ private:
 	std::vector<VariableValue> m_variables;
 	std::optional<ValueId> m_unreachableValue;
 public:
+	EVMDialect const& evmDialect;
 	std::unique_ptr<DebugInfo> debugInfo;
 	BlockId entry = BlockId{0};
 	std::set<BlockId> exits;

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -32,8 +32,6 @@
 
 #include <libsolutil/Numeric.h>
 
-#include <range/v3/view/map.hpp>
-
 #include <concepts>
 #include <deque>
 #include <functional>

--- a/libyul/backends/evm/ssa/SSACFGBuilder.cpp
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.cpp
@@ -52,7 +52,7 @@ SSACFGBuilder::SSACFGBuilder(
 	SSACFG& _graph,
 	AsmAnalysisInfo const& _analysisInfo,
 	ControlFlowSideEffectsCollector const& _sideEffects,
-	Dialect const& _dialect,
+	EVMDialect const& _dialect,
 	bool _keepLiteralAssignments,
 	bool _generateDebugInfo
 ):
@@ -68,7 +68,7 @@ SSACFGBuilder::SSACFGBuilder(
 
 std::unique_ptr<ControlFlow> SSACFGBuilder::build(
 	AsmAnalysisInfo const& _analysisInfo,
-	Dialect const& _dialect,
+	EVMDialect const& _dialect,
 	Block const& _block,
 	bool _keepLiteralAssignments,
 	bool _generateDebugInfo
@@ -78,6 +78,7 @@ std::unique_ptr<ControlFlow> SSACFGBuilder::build(
 
 	auto controlFlow = std::make_unique<ControlFlow>();
 	controlFlow->functionGraphs.emplace_back(std::make_unique<SSACFG>(
+		_dialect,
 		_generateDebugInfo ? std::make_unique<SSACFGDebugInfo>() : nullptr
 	));
 	controlFlow->functionGraphMapping.emplace_back(nullptr, controlFlow->functionGraphs.back().get());
@@ -101,6 +102,7 @@ void SSACFGBuilder::buildFunctionGraph(
 )
 {
 	m_controlFlow.functionGraphs.emplace_back(std::make_unique<SSACFG>(
+		m_dialect,
 		m_generateDebugInfo ? std::make_unique<SSACFGDebugInfo>() : nullptr
 	));
 	auto& cfg = *m_controlFlow.functionGraphs.back();

--- a/libyul/backends/evm/ssa/SSACFGBuilder.h
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.h
@@ -36,9 +36,13 @@
 */
 #pragma once
 
-#include <libyul/backends/evm/ssa/ControlFlow.h>
 #include <libyul/ControlFlowSideEffectsCollector.h>
+
+#include <libyul/backends/evm/EVMDialect.h>
+
+#include <libyul/backends/evm/ssa/ControlFlow.h>
 #include <libyul/backends/evm/ssa/SSACFG.h>
+
 #include <stack>
 #include <unordered_map>
 
@@ -52,7 +56,7 @@ class SSACFGBuilder
 		SSACFG& _graph,
 		AsmAnalysisInfo const& _analysisInfo,
 		ControlFlowSideEffectsCollector const& _sideEffects,
-		Dialect const& _dialect,
+		EVMDialect const& _dialect,
 		bool _keepLiteralAssignments,
 		bool _generateDebugInfo
 	);
@@ -61,7 +65,7 @@ public:
 	SSACFGBuilder& operator=(SSACFGBuilder const&) = delete;
 	static std::unique_ptr<ControlFlow> build(
 		AsmAnalysisInfo const& _analysisInfo,
-		Dialect const& _dialect,
+		EVMDialect const& _dialect,
 		Block const& _block,
 		bool _keepLiteralAssignments,
 		bool _generateDebugInfo = true
@@ -104,7 +108,7 @@ private:
 	SSACFG& m_graph;
 	AsmAnalysisInfo const& m_info;
 	ControlFlowSideEffectsCollector const& m_sideEffects;
-	Dialect const& m_dialect;
+	EVMDialect const& m_dialect;
 	bool const m_keepLiteralAssignments;
 	bool const m_generateDebugInfo;
 	std::vector<std::tuple<Scope::Function const*, FunctionDefinition const*>> m_functionDefinitions;

--- a/libyul/backends/evm/ssa/Stack.cpp
+++ b/libyul/backends/evm/ssa/Stack.cpp
@@ -18,6 +18,8 @@
 
 #include <libyul/backends/evm/ssa/Stack.h>
 
+#include <range/v3/view/transform.hpp>
+
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -64,7 +64,7 @@ void handlePhiFunctions(StackData& _stackData, PhiInverse const& _phiInverse, Li
 	}
 }
 
-using StackType = Stack<CountingInstructionsCallbacks>;
+using StackType = Stack<GasAccumulatingCallbacks>;
 
 void declareJunk(StackType& _stack, LivenessAnalysis::LivenessData const& _live)
 {
@@ -184,7 +184,7 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 				continue;
 			proposals[i] = *parentExits[i].second;
 			{
-				StackType stack(proposals[i], {});
+				StackType stack(proposals[i], {.cfg = m_cfg});
 				declareJunk(stack, liveIn);
 			}
 			handlePhiFunctions(proposals[i], PhiInverse(m_cfg, parentExits[i].first, _blockId), liveIn);
@@ -200,14 +200,14 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 				if (j == i || !parentExits[j].second)
 					continue;
 				auto proposalCopy = proposals[j];
-				StackType stack(proposalCopy, {});
+				StackType stack(proposalCopy, {.cfg = m_cfg});
 				StackShuffler<StackType::Callbacks>::shuffle(
 					stack,
 					proposals[i],
 					{},
 					proposals[i].size()
 				);
-				cumulativeCost += stack.callbacks().numOps;
+				cumulativeCost += stack.callbacks().opGas;
 			}
 			cumulativeCosts[i] = cumulativeCost;
 		}
@@ -229,7 +229,7 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 	SSACFG::BasicBlock const& block = m_cfg.block(_blockId);
 
 	StackData currentStackData = blockLayout.stackIn;
-	StackType stack(currentStackData, {});
+	StackType stack(currentStackData, {.cfg = m_cfg});
 	bool const junkCanBeAdded = m_junkAdmittingBlocksFinder->allowsAdditionOfJunk(_blockId);
 
 	auto const& operationsLiveOut = m_liveness.operationsLiveOut(_blockId);
@@ -260,7 +260,13 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 			)
 				stack.declareJunk(depth);
 
-		std::size_t const targetSize = findOptimalTargetSize(stack.data(), requiredStackTop, opLiveOutWithoutOutputs, junkCanBeAdded, m_hasFunctionReturnLabel);
+		std::size_t const targetSize = findOptimalTargetSize(
+			stack.data(),
+			requiredStackTop,
+			opLiveOutWithoutOutputs,
+			junkCanBeAdded,
+			m_hasFunctionReturnLabel
+		);
 		StackShuffler<StackType::Callbacks>::shuffle(
 			stack,
 			requiredStackTop,
@@ -270,9 +276,9 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 
 		blockLayout.operationIn.push_back(currentStackData);
 		for (std::size_t i = 0; i < requiredStackTop.size(); ++i)
-			stack.pop();
+			stack.pop<false>();
 		for (auto const& val: operation.outputs)
-			stack.push(Slot::makeValueID(val));
+			stack.push<false>(Slot::makeValueID(val));
 	}
 
 	if (auto const* cjump = std::get_if<SSACFG::BasicBlock::ConditionalJump>(&block.exit))
@@ -288,7 +294,13 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 		if (!conditionSlotAlreadyFinal)
 		{
 			auto const condition = Slot::makeValueID(cjump->condition);
-			auto const targetSize = findOptimalTargetSize(stack.data(), {condition}, blockLiveOut, false, m_hasFunctionReturnLabel);
+			auto const targetSize = findOptimalTargetSize(
+				stack.data(),
+				{condition},
+				blockLiveOut,
+				false,
+				m_hasFunctionReturnLabel
+			);
 			StackShuffler<StackType::Callbacks>::shuffle(
 				stack, {condition}, blockLiveOut, targetSize
 			);
@@ -314,7 +326,7 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 				// same as nonzero stack in initially
 				zeroLayout = nonZeroLayout;
 				handlePhiFunctions(zeroLayout->stackIn, PhiInverse(m_cfg, _blockId, cjump->zero), zeroLiveIn);
-				StackType zeroStack(zeroLayout->stackIn, {});
+				StackType zeroStack(zeroLayout->stackIn, {.cfg = m_cfg});
 				declareJunk(zeroStack, zeroLiveIn);
 			}
 		}

--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -24,6 +24,8 @@
 #include <boost/container/flat_map.hpp>
 
 #include <range/v3/view/iota.hpp>
+#include <range/v3/view/map.hpp>
+#include <range/v3/view/transform.hpp>
 
 #include <cstddef>
 #include <optional>

--- a/libyul/backends/evm/ssa/StackUtils.cpp
+++ b/libyul/backends/evm/ssa/StackUtils.cpp
@@ -20,6 +20,8 @@
 
 #include <libyul/backends/evm/ssa/StackShuffler.h>
 
+#include <libevmasm/GasMeter.h>
+
 #include <range/v3/numeric/accumulate.hpp>
 #include <range/v3/view/iota.hpp>
 #include <range/v3/view/zip.hpp>
@@ -29,6 +31,42 @@
 #include <fmt/ranges.h>
 
 using namespace solidity::yul::ssa;
+
+void GasAccumulatingCallbacks::swap(StackDepth _depth)
+{
+	opGas += evmasm::GasMeter::swapGas(_depth.value, cfg.evmDialect.evmVersion());
+}
+
+void GasAccumulatingCallbacks::dup(StackDepth _depth)
+{
+	opGas += evmasm::GasMeter::dupGas(_depth.value, cfg.evmDialect.evmVersion());
+}
+
+void GasAccumulatingCallbacks::push(StackSlot const& _slot)
+{
+	if (_slot.isLiteralValueID())
+	{
+		auto const size = numberEncodingSize(cfg.literalInfo(_slot.valueID()).value);
+		opGas += evmasm::GasMeter::runGas(evmasm::pushInstruction(size), cfg.evmDialect.evmVersion());
+	}
+	else if (_slot.isJunk())
+	{
+		auto const op = cfg.evmDialect.evmVersion().hasPush0() ? evmasm::Instruction::PUSH0 : evmasm::Instruction::CODESIZE;
+		opGas += evmasm::GasMeter::runGas(op, cfg.evmDialect.evmVersion());
+	}
+	else
+	{
+		yulAssert(_slot.isFunctionCallReturnLabel(), "we can only push literals, junk, and function call return labels");
+		// this is a jump dest, we don't really know yet how big it is going to be, just assume that it fits into
+		// a 2-byte number
+		opGas += evmasm::GasMeter::runGas(evmasm::Instruction::PUSH2, cfg.evmDialect.evmVersion());
+	}
+}
+
+void GasAccumulatingCallbacks::pop()
+{
+	opGas += evmasm::GasMeter::runGas(evmasm::Instruction::POP, cfg.evmDialect.evmVersion());
+}
 
 StackData solidity::yul::ssa::stackPreImage(StackData _stack, PhiInverse const& _phiInverse)
 {
@@ -67,8 +105,8 @@ std::size_t solidity::yul::ssa::findOptimalTargetSize
 	auto const evaluateCost = [&](std::size_t const _targetSize) -> std::size_t
 	{
 		data = _stackData;
-		Stack<CountingInstructionsCallbacks> countOpsStack(data, {});
-		StackShuffler<CountingInstructionsCallbacks>::shuffle(countOpsStack, _targetArgs, _targetLiveOut, _targetSize);
+		Stack<OpsCountingCallbacks> countOpsStack(data, {});
+		StackShuffler<OpsCountingCallbacks>::shuffle(countOpsStack, _targetArgs, _targetLiveOut, _targetSize);
 		yulAssert(countOpsStack.size() == _targetSize);
 		return countOpsStack.callbacks().numOps;
 	};

--- a/libyul/backends/evm/ssa/StackUtils.h
+++ b/libyul/backends/evm/ssa/StackUtils.h
@@ -38,19 +38,37 @@ private:
 	std::vector<std::string> m_errors;
 };
 
-struct CountingInstructionsCallbacks
+struct OpsCountingCallbacks
 {
 	std::size_t numOps = 0;
-	void swap(StackDepth) { ++numOps; }
-	void dup(StackDepth) { ++numOps; }
-	void push(StackSlot const&) { ++numOps; }
-	void pop() { ++numOps; }
+
+	void swap(StackDepth) {numOps++;}
+	void dup(StackDepth) {numOps++;}
+	void push(StackSlot const&) {numOps++;}
+	void pop() {numOps++;}
+};
+
+struct GasAccumulatingCallbacks
+{
+	SSACFG const& cfg;
+	std::size_t opGas = 0;
+
+	void swap(StackDepth _depth);
+	void dup(StackDepth _depth);
+	void push(StackSlot const& _slot);
+	void pop();
 };
 
 /// Transform stack data by replacing all its phi variables with their respective preimages.
 StackData stackPreImage(StackData _stack, PhiInverse const& _phiInverse);
 
-std::size_t findOptimalTargetSize(StackData const& _stackData, StackData const& _targetArgs, LivenessAnalysis::LivenessData const& _targetLiveOut, bool _canIntroduceJunk, bool _hasFunctionReturnLabel);
+std::size_t findOptimalTargetSize(
+	StackData const& _stackData,
+	StackData const& _targetArgs,
+	LivenessAnalysis::LivenessData const& _targetLiveOut,
+	bool _canIntroduceJunk,
+	bool _hasFunctionReturnLabel
+);
 
 CallSites gatherCallSites(SSACFG const& _cfg);
 

--- a/libyul/backends/evm/ssa/io/DotExporterBase.cpp
+++ b/libyul/backends/evm/ssa/io/DotExporterBase.cpp
@@ -21,6 +21,8 @@
 #include <libsolutil/Numeric.h>
 #include <libsolutil/Visitor.h>
 
+#include <range/v3/view/transform.hpp>
+
 #include <fmt/ranges.h>
 
 #include <deque>

--- a/test/libyul/ssa/ControlFlowGraphTest.cpp
+++ b/test/libyul/ssa/ControlFlowGraphTest.cpp
@@ -70,9 +70,12 @@ TestCase::TestResult ControlFlowGraphTest::run(std::ostream& _stream, std::strin
 		return TestResult::FatalError;
 	}
 
+	auto const* evmDialect = dynamic_cast<EVMDialect const*>(&yulStack.dialect());
+	yulAssert(evmDialect);
+
 	std::unique_ptr<yul::ssa::ControlFlow> controlFlow = yul::ssa::SSACFGBuilder::build(
 		*yulStack.parserResult()->analysisInfo,
-		yulStack.dialect(),
+		*evmDialect,
 		yulStack.parserResult()->code()->root(),
 		true
 	);

--- a/test/libyul/ssa/StackLayoutGeneratorTest.cpp
+++ b/test/libyul/ssa/StackLayoutGeneratorTest.cpp
@@ -145,9 +145,12 @@ frontend::test::TestCase::TestResult StackLayoutGeneratorTest::run(std::ostream&
 		auto const& object = *toVisit.back();
 		toVisit.pop_back();
 
+		auto const* evmDialect = dynamic_cast<EVMDialect const*>(object.dialect());
+		yulAssert(evmDialect);
+
 		std::unique_ptr<ControlFlow> const controlFlow = SSACFGBuilder::build(
 			*object.analysisInfo,
-			*object.dialect(),
+			*evmDialect,
 			object.code()->root(),
 			false
 		);

--- a/test/libyul/ssa/stackLayoutGenerator/switch.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/switch.yul
@@ -62,13 +62,13 @@
 // Block0_3Exit:0 -> Block0_5 [style="solid"];
 // Block0_3Exit:1 -> Block0_4 [style="solid"];
 // Block0_1 [label="\
-// IN: [JUNK, phi0]\l\
+// IN: [phi0]\l\
 // \l\
-// [JUNK, phi0, lit6]\l\
+// [phi0, lit6]\l\
 // sstore\l\
-// [JUNK]\l\
+// []\l\
 // \l\
-// OUT: [JUNK]\l\
+// OUT: []\l\
 // "];
 // Block0_1Exit [label="MainExit"];
 // Block0_1 -> Block0_1Exit;


### PR DESCRIPTION
This PR:
- stores the `EVMDialect` that belongs to the SSA CFG in the SSA CFG
- uses op counts to select target stack size