### PR TITLE
Refactor SSA Stack layout to have an exit stack in

### DIFF
--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -185,7 +185,7 @@ void CodeTransform::operator()(SSACFG::BlockId const _blockId)
 	// Shuffle to the block's exit layout before dispatching the exit.
 	// This ensures the condition is on top for ConditionalJump, phi pre-images are
 	// in the right positions for jumps, and return values are accessible for FunctionReturn.
-	StackShuffler<AssemblyCallbacks>::shuffle(m_stack, blockLayout->stackOut);
+	StackShuffler<AssemblyCallbacks>::shuffle(m_stack, blockLayout->exitIn);
 
 	// handle the block exit
 	std::visit(util::GenericVisitor{ [this, &_blockId](auto const& exit) { (*this)(_blockId, exit); } }, block.exit);

--- a/libyul/backends/evm/ssa/StackLayout.h
+++ b/libyul/backends/evm/ssa/StackLayout.h
@@ -31,8 +31,8 @@ struct BlockLayout
 	StackData stackIn;
 	// stack layout required to execute the i-th operation in the block
 	std::vector<StackData> operationIn;
-	// stack after the block was executed
-	StackData stackOut;
+	// stack layout required to handle the exit of the block
+	StackData exitIn;
 };
 
 /// For each (reachable) block in the SSACFG one block layout

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -64,7 +64,7 @@ void handlePhiFunctions(StackData& _stackData, PhiInverse const& _phiInverse, Li
 	}
 }
 
-using StackType = Stack<GasAccumulatingCallbacks>;
+using StackType = Stack<>;
 
 void declareJunk(StackType& _stack, LivenessAnalysis::LivenessData const& _live)
 {
@@ -185,7 +185,7 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 			proposals[i] = *parentExits[i].second;
 			handlePhiFunctions(proposals[i], PhiInverse(m_cfg, parentExits[i].first, _blockId), liveIn);
 			{
-				StackType stack(proposals[i], {.cfg = m_cfg});
+				StackType stack(proposals[i], {});
 				declareJunk(stack, liveIn);
 			}
 		}
@@ -200,8 +200,8 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 				if (j == i || !parentExits[j].second)
 					continue;
 				auto proposalCopy = proposals[j];
-				StackType stack(proposalCopy, {.cfg = m_cfg});
-				StackShuffler<StackType::Callbacks>::shuffle(
+				Stack<GasAccumulatingCallbacks> stack(proposalCopy, {.cfg = m_cfg});
+				StackShuffler<GasAccumulatingCallbacks>::shuffle(
 					stack,
 					proposals[i],
 					{},
@@ -214,7 +214,6 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 		auto const argMin = static_cast<std::size_t>(
 			std::distance(cumulativeCosts.begin(), ranges::min_element(cumulativeCosts))
 		);
-		yulAssert(parentExits[argMin].second);
 		blockLayout.stackIn = std::move(proposals[argMin]);
 	}
 	m_resultLayout[_blockId] = blockLayout;
@@ -229,7 +228,7 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 	SSACFG::BasicBlock const& block = m_cfg.block(_blockId);
 
 	StackData currentStackData = blockLayout.stackIn;
-	StackType stack(currentStackData, {.cfg = m_cfg});
+	StackType stack(currentStackData, {});
 	bool const junkCanBeAdded = m_junkAdmittingBlocksFinder->allowsAdditionOfJunk(_blockId);
 
 	auto const& operationsLiveOut = m_liveness.operationsLiveOut(_blockId);

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -23,8 +23,9 @@
 #include <libyul/backends/evm/ssa/StackShuffler.h>
 #include <libyul/backends/evm/ssa/StackUtils.h>
 
+#include <libsolutil/Visitor.h>
+
 #include <range/v3/algorithm/count.hpp>
-#include <range/v3/algorithm/min_element.hpp>
 #include <range/v3/algorithm/replace.hpp>
 #include <range/v3/view/transform.hpp>
 #include <range/v3/to_container.hpp>
@@ -98,6 +99,7 @@ StackLayoutGenerator::StackLayoutGenerator(
 	m_graphID(_graphID),
 	m_hasFunctionReturnLabel(_liveness.cfg().function && _liveness.cfg().canContinue),
 	m_junkAdmittingBlocksFinder(std::make_unique<JunkAdmittingBlocksFinder>(_liveness.cfg(), _liveness.topologicalSort())),
+	m_inputStackProposalsPerBlock(m_cfg.numBlocks()),
 	m_resultLayout(m_cfg.numBlocks())
 {
 	// traverse the cfg layer-wise using Kahn's algorithm:
@@ -156,49 +158,37 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 
 	auto const& block = m_cfg.block(_blockId);
 
-	std::vector<std::pair<SSACFG::BlockId, StackData const*>> parentExits;
-	for (auto const& entry: block.entries)
-		if (m_resultLayout[entry])
-			parentExits.emplace_back(entry, &m_resultLayout[entry]->stackOut);
-
-	yulAssert(!parentExits.empty(), fmt::format("None of the parents of block {} were generated", _blockId));
+	auto const& stackInProposals = m_inputStackProposalsPerBlock[_blockId.value];
+	yulAssert(!stackInProposals.empty(), fmt::format("None of the parents of block {} were generated", _blockId));
 
 	if (block.entries.size() == 1)
 	{
 		// pass through
-		yulAssert(parentExits.size() == 1);
-		blockLayout.stackIn = *parentExits[0].second;
-
-		if (!block.phis.empty())
-			handlePhiFunctions(blockLayout.stackIn, PhiInverse(m_cfg, parentExits[0].first, _blockId), m_liveness.liveIn(_blockId));
+		yulAssert(stackInProposals.size() == 1);
+		blockLayout.stackIn = stackInProposals[0].second;
+		handlePhiFunctions(blockLayout.stackIn, PhiInverse(m_cfg, stackInProposals[0].first, _blockId), m_liveness.liveIn(_blockId));
 	}
 	else
 	{
 		// we have more than one entry and need to unify or at the very least apply phi fct.
 		auto const& liveIn = m_liveness.liveIn(_blockId);
 		// Pre-compute each parent's proposal
-		std::vector<StackData> proposals(parentExits.size());
-		for (std::size_t i = 0; i < parentExits.size(); ++i)
+		std::vector<StackData> proposals(stackInProposals.size());
+		for (std::size_t i = 0; i < stackInProposals.size(); ++i)
 		{
-			if (!parentExits[i].second)
-				continue;
-			proposals[i] = *parentExits[i].second;
-			handlePhiFunctions(proposals[i], PhiInverse(m_cfg, parentExits[i].first, _blockId), liveIn);
+			proposals[i] = stackInProposals[i].second;
+			handlePhiFunctions(proposals[i], PhiInverse(m_cfg, stackInProposals[i].first, _blockId), liveIn);
 			{
 				StackType stack(proposals[i], {});
 				declareJunk(stack, liveIn);
 			}
 		}
-		std::vector cumulativeCosts(parentExits.size(), std::numeric_limits<std::size_t>::max());
-		for (std::size_t i = 0; i < parentExits.size(); ++i)
+		std::vector cumulativeCosts(stackInProposals.size(), std::numeric_limits<std::size_t>::max());
+		for (std::size_t i = 0; i < stackInProposals.size(); ++i)
 		{
-			if (!parentExits[i].second)
-				continue;
 			std::size_t cumulativeCost = 0;
-			for (std::size_t j = 0; j < parentExits.size(); ++j)
+			for (std::size_t j = 0; j < stackInProposals.size(); ++j)
 			{
-				if (j == i || !parentExits[j].second)
-					continue;
 				auto proposalCopy = proposals[j];
 				Stack<GasAccumulatingCallbacks> stack(proposalCopy, {.cfg = m_cfg});
 				StackShuffler<GasAccumulatingCallbacks>::shuffle(
@@ -211,10 +201,12 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 			}
 			cumulativeCosts[i] = cumulativeCost;
 		}
-		auto const argMin = static_cast<std::size_t>(
-			std::distance(cumulativeCosts.begin(), ranges::min_element(cumulativeCosts))
-		);
-		blockLayout.stackIn = std::move(proposals[argMin]);
+		// Pick the proposal with the lowest cost; break ties by preferring smaller stacks
+		std::size_t best = 0;
+		for (std::size_t i = 1; i < stackInProposals.size(); ++i)
+			if (std::make_pair(cumulativeCosts[i], proposals[i].size()) < std::make_pair(cumulativeCosts[best], proposals[best].size()))
+				best = i;
+		blockLayout.stackIn = std::move(proposals[best]);
 	}
 	m_resultLayout[_blockId] = blockLayout;
 }
@@ -280,65 +272,82 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 			stack.push<false>(Slot::makeValueID(val));
 	}
 
-	if (auto const* cjump = std::get_if<SSACFG::BasicBlock::ConditionalJump>(&block.exit))
-	{
-		auto const& zeroLiveIn = m_liveness.liveIn(cjump->zero);
-		auto const& blockLiveOut = m_liveness.liveOut(_blockId);
+	std::visit(
+		util::GenericVisitor{
+			[&](SSACFG::BasicBlock::ConditionalJump const& _cJump) {
+				auto const& zeroLiveIn = m_liveness.liveIn(_cJump.zero);
+				auto const& blockLiveOut = m_liveness.liveOut(_blockId);
 
-		// check if we have to do anything (dup the condition, bring it to the top etc)
-		bool const conditionSlotAlreadyFinal =
-			!blockLiveOut.contains(cjump->condition) &&  // if our live out does not contain the condition (ie we dont have to dup it)
-			!stack.empty() &&   // our stack is not empty
-			stack.top().isValueID() && stack.top().valueID() == cjump->condition;  // and the condition is already on top
-		if (!conditionSlotAlreadyFinal)
-		{
-			auto const condition = Slot::makeValueID(cjump->condition);
-			auto const targetSize = findOptimalTargetSize(
-				stack.data(),
-				{condition},
-				blockLiveOut,
-				false,
-				m_hasFunctionReturnLabel
-			);
-			StackShuffler<StackType::Callbacks>::shuffle(
-				stack, {condition}, blockLiveOut, targetSize
-			);
-		}
+				// check if we have to do anything (dup the condition, bring it to the top etc)
+				bool const conditionSlotAlreadyFinal =
+					!blockLiveOut.contains(_cJump.condition) &&  // if our live out does not contain the condition (ie we dont have to dup it)
+					!stack.empty() &&   // our stack is not empty
+					stack.top().isValueID() && stack.top().valueID() == _cJump.condition;  // and the condition is already on top
+				if (!conditionSlotAlreadyFinal)
+				{
+					auto const condition = Slot::makeValueID(_cJump.condition);
+					auto const targetSize = findOptimalTargetSize(
+						stack.data(),
+						{condition},
+						blockLiveOut,
+						false,
+						m_hasFunctionReturnLabel
+					);
+					StackShuffler<StackType::Callbacks>::shuffle(
+						stack, {condition}, blockLiveOut, targetSize
+					);
+				}
 
-		yulAssert(!stack.empty() && stack.top().isValueID() && stack.top().valueID() == cjump->condition);
-		yulAssert(m_cfg.block(cjump->nonZero).phis.empty());
+				yulAssert(!stack.empty() && stack.top().isValueID() && stack.top().valueID() == _cJump.condition);
+				yulAssert(m_cfg.block(_cJump.nonZero).phis.empty());
 
-		// define zero and non-zero stack in layouts
-		{
-			std::optional<BlockLayout>& nonZeroLayout = m_resultLayout[cjump->nonZero];
-			yulAssert(!nonZeroLayout, "There should be no way to reach this block other than by going through the parent.");
-			nonZeroLayout = BlockLayout{};
-			nonZeroLayout->stackIn = currentStackData;
-			// Remove condition; consumed by JUMPI
-			nonZeroLayout->stackIn.pop_back();
+				// exitIn = pre-JUMPI state (condition on top) for CodeTransform
+				blockLayout.exitIn = currentStackData;
 
-			if (
-				std::optional<BlockLayout>& zeroLayout = m_resultLayout[cjump->zero];
-				!zeroLayout
-			)
-			{
-				// same as nonzero stack in initially
-				zeroLayout = nonZeroLayout;
-				handlePhiFunctions(zeroLayout->stackIn, PhiInverse(m_cfg, _blockId, cjump->zero), zeroLiveIn);
-				StackType zeroStack(zeroLayout->stackIn, {.cfg = m_cfg});
-				declareJunk(zeroStack, zeroLiveIn);
+				// Pop condition from symbolic stack (consumed by JUMPI).
+				// After this, currentStackData reflects the post-JUMPI stack.
+				stack.pop<false>();
+
+				// Define successor stack-in layouts
+				{
+					// nonZero is always single-entry
+					std::optional<BlockLayout>& nonZeroLayout = m_resultLayout[_cJump.nonZero];
+					yulAssert(!nonZeroLayout, "There should be no way to reach this block other than by going through the parent.");
+					nonZeroLayout = BlockLayout{};
+					nonZeroLayout->stackIn = currentStackData;
+
+					if (
+						std::optional<BlockLayout>& zeroLayout = m_resultLayout[_cJump.zero];
+						!zeroLayout
+					)
+					{
+						zeroLayout = BlockLayout{};
+						zeroLayout->stackIn = currentStackData;
+						handlePhiFunctions(zeroLayout->stackIn, PhiInverse(m_cfg, _blockId, _cJump.zero), zeroLiveIn);
+						StackType zeroStack(zeroLayout->stackIn, {});
+						declareJunk(zeroStack, zeroLiveIn);
+					}
+				}
+			},
+			[&](SSACFG::BasicBlock::FunctionReturn const& _functionReturn) {
+				yulAssert(m_hasFunctionReturnLabel, "When there is a proper function return, we need to have a label for it");
+				// in case there are return values, let's bring the function return label to the top
+				StackData returnStack = _functionReturn.returnValues | ranges::views::transform(StackSlot::makeValueID) | ranges::to<std::vector>;
+				returnStack.push_back(StackSlot::makeFunctionReturnLabel(m_graphID));
+				StackShuffler<StackType::Callbacks>::shuffle(stack, returnStack);
+				blockLayout.exitIn = currentStackData;
+			},
+			[&](SSACFG::BasicBlock::Jump const& _jump) {
+				blockLayout.exitIn = currentStackData;
+				m_inputStackProposalsPerBlock[_jump.target.value].emplace_back(_blockId, currentStackData);
+			},
+			[&](SSACFG::BasicBlock::MainExit const&) {
+				blockLayout.exitIn = currentStackData;
+			},
+			[&](SSACFG::BasicBlock::Terminated const&) {
+				blockLayout.exitIn = currentStackData;
 			}
-		}
-	}
-
-	if (auto const* functionReturn = std::get_if<SSACFG::BasicBlock::FunctionReturn>(&block.exit))
-	{
-		yulAssert(m_hasFunctionReturnLabel, "When there is a proper function return, we need to have a label for it");
-		// in case there are return values, let's bring the function return label to the top
-		StackData returnStack = functionReturn->returnValues | ranges::views::transform(StackSlot::makeValueID) | ranges::to<std::vector>;
-		returnStack.push_back(StackSlot::makeFunctionReturnLabel(m_graphID));
-		StackShuffler<StackType::Callbacks>::shuffle(stack, returnStack);
-	}
-
-	blockLayout.stackOut = currentStackData;
+		},
+		block.exit
+	);
 }

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.h
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.h
@@ -55,6 +55,10 @@ private:
 	bool m_hasFunctionReturnLabel;
 
 	std::unique_ptr<JunkAdmittingBlocksFinder> m_junkAdmittingBlocksFinder;
+	// Per-edge stack proposals for defineStackIn.
+	// m_inputStackProposalsPerBlock[blockId] contains (predecessorId, edgeStack) pairs
+	// representing the stack state flowing from each predecessor into the block.
+	std::vector<std::vector<std::pair<SSACFG::BlockId, StackData>>> m_inputStackProposalsPerBlock;
 	SSACFGStackLayout m_resultLayout;
 };
 

--- a/scripts/codespell_whitelist.txt
+++ b/scripts/codespell_whitelist.txt
@@ -3,3 +3,4 @@ compilability
 keypair
 wast
 slippy
+exitIn

--- a/test/libsolidity/semanticTests/externalContracts/prbmath_signed.sol
+++ b/test/libsolidity/semanticTests/externalContracts/prbmath_signed.sol
@@ -57,8 +57,8 @@ contract test {
 // gas legacy code: 2205000
 // gas legacyOptimized: 178012
 // gas legacyOptimized code: 1669600
-// gas ssaCFGOptimized: 175048
-// gas ssaCFGOptimized code: 1639600
+// gas ssaCFGOptimized: 175028
+// gas ssaCFGOptimized code: 1639200
 // div(int256,int256): 3141592653589793238, 88714123 -> 35412542528203691288251815328
 // gas irOptimized: 22045
 // gas legacy: 22736

--- a/test/libsolidity/semanticTests/externalContracts/ramanujan_pi.sol
+++ b/test/libsolidity/semanticTests/externalContracts/ramanujan_pi.sol
@@ -42,8 +42,8 @@ contract test {
 // gas legacy code: 523600
 // gas legacyOptimized: 82667
 // gas legacyOptimized code: 369200
-// gas ssaCFGOptimized: 77958
-// gas ssaCFGOptimized code: 313800
+// gas ssaCFGOptimized: 77956
+// gas ssaCFGOptimized code: 313400
 // prb_pi() -> 3141592656369545286
 // gas irOptimized: 55036
 // gas legacy: 100657

--- a/test/libyul/ssa/StackLayoutGeneratorTest.cpp
+++ b/test/libyul/ssa/StackLayoutGeneratorTest.cpp
@@ -104,7 +104,7 @@ protected:
 		}
 
 		_out << "\\l\\\n";
-		_out << "OUT: " << stackToString(blockLayout->stackOut) << "\\l\\\n";
+		_out << "OUT: " << stackToString(blockLayout->exitIn) << "\\l\\\n";
 	}
 
 private:


### PR DESCRIPTION
- Renames `stackOut` to `exitIn` in `BlockLayout` and stores per-edge successor stack proposals: instead of recording the stack state after a block executes, the layout now captures the stack state required to handle the block's exit 
- successor input-stack proposals are tracked per-edge in a new `m_inputStackProposalsPerBlock` member rather than being derived from the parent's `stackOut` on the fly