### PR TITLE
Enforce that gas expectations match enabled pipelines

### DIFF
--- a/test/libsolidity/SemanticTest.cpp
+++ b/test/libsolidity/SemanticTest.cpp
@@ -118,6 +118,41 @@ SemanticTest::SemanticTest(
 	parseExpectations(m_reader.stream());
 	soltestAssert(!m_tests.empty(), "No tests specified in " + _filename);
 
+	// Validate that gas expectations only reference pipelines the test actually runs.
+	// E.g. a test with compileViaYul: true should not have gas legacy: expectations.
+	for (auto const& test: m_tests)
+	{
+		auto checkNoStaleGasKey = [&](std::string const& _key)
+		{
+			if (
+				test.call().expectations.gasUsedExcludingCode.count(_key) ||
+				test.call().expectations.gasUsedForCodeDeposit.count(_key)
+			)
+				BOOST_THROW_EXCEPTION(std::runtime_error(
+					"Test has gas expectation for \"" + _key + "\", "
+					"but the corresponding pipeline is not enabled "
+					"(compileViaYul: " + compileViaYul +
+					", compileViaSSACFG: " + (m_testCaseWantsSSACFGRun ? "true" : "false") + ")."
+				));
+		};
+
+		if (!m_testCaseWantsLegacyRun)
+		{
+			checkNoStaleGasKey("legacy");
+			checkNoStaleGasKey("legacyOptimized");
+		}
+		if (!m_testCaseWantsYulRun)
+		{
+			checkNoStaleGasKey("ir");
+			checkNoStaleGasKey("irOptimized");
+		}
+		if (!m_testCaseWantsSSACFGRun)
+		{
+			checkNoStaleGasKey("ssaCFG");
+			checkNoStaleGasKey("ssaCFGOptimized");
+		}
+	}
+
 	if (m_enforceGasCost)
 	{
 		m_compiler.setMetadataFormat(CompilerStack::MetadataFormat::NoMetadata);

--- a/test/libsolidity/semanticTests/array/copying/nested_dynamic_array_element_calldata_to_storage.sol
+++ b/test/libsolidity/semanticTests/array/copying/nested_dynamic_array_element_calldata_to_storage.sol
@@ -33,4 +33,3 @@ contract C {
 // gas irOptimized: 137891
 // test2(uint8[][]): 0x20, 2, 0x40, 0x80, 1, 7, 2, 8, 9
 // gas irOptimized: 164249
-// gas legacyOptimized: 120228

--- a/test/libsolidity/semanticTests/functionCall/return_size_bigger_than_expected.sol
+++ b/test/libsolidity/semanticTests/functionCall/return_size_bigger_than_expected.sol
@@ -28,4 +28,3 @@ contract Test {
 // compileViaYul: true
 // ----
 // test() -> 0x20
-// gas legacy: 131966

--- a/test/libsolidity/semanticTests/functionCall/return_size_shorter_than_expected.sol
+++ b/test/libsolidity/semanticTests/functionCall/return_size_shorter_than_expected.sol
@@ -29,4 +29,3 @@ contract Test {
 // compileViaYul: true
 // ----
 // test() -> 0x0500
-// gas legacy: 131966

--- a/test/libsolidity/semanticTests/functionCall/return_size_shorter_than_expected_evm_version_after_homestead.sol
+++ b/test/libsolidity/semanticTests/functionCall/return_size_shorter_than_expected_evm_version_after_homestead.sol
@@ -31,4 +31,3 @@ contract Test {
 // compileViaYul: true
 // ----
 // test() -> FAILURE
-// gas legacy: 131966

--- a/test/libsolidity/semanticTests/immutable/immutable_tag_too_large_bug.sol
+++ b/test/libsolidity/semanticTests/immutable/immutable_tag_too_large_bug.sol
@@ -43,6 +43,4 @@ contract C {
 // constructor() ->
 // gas irOptimized: 73171
 // gas irOptimized code: 291200
-// gas legacy: 83499
-// gas legacy code: 408800
 // f() -> -1, 1


### PR DESCRIPTION
## Description

Addresses #16461.

Adds validation in the `SemanticTest` constructor to ensure that test files do not carry gas expectations for pipelines that are not enabled by their settings.

The validation checks:
- Tests with `compileViaYul: true` must not have `gas legacy:` or `gas legacyOptimized:` expectations
- Tests with `compileViaYul: false` must not have `gas ir:` or `gas irOptimized:` expectations
- Tests without `compileViaSSACFG: true` must not have `gas ssaCFG:` or `gas ssaCFGOptimized:` expectations

If a stale gas expectation is found, a clear `runtime_error` is thrown identifying the offending key and the current pipeline settings.

Also removes stale gas expectations from 5 test files:
- `semanticTests/functionCall/return_size_shorter_than_expected.sol` — removed `gas legacy: 131966`
- `semanticTests/functionCall/return_size_shorter_than_expected_evm_version_after_homestead.sol` — removed `gas legacy: 131966`
- `semanticTests/functionCall/return_size_bigger_than_expected.sol` — removed `gas legacy: 131966`
- `semanticTests/immutable/immutable_tag_too_large_bug.sol` — removed `gas legacy: 83499` and `gas legacy code: 408800`
- `semanticTests/array/copying/nested_dynamic_array_element_calldata_to_storage.sol` — removed `gas legacyOptimized: 120228`

## Testing

- Built `soltest` and ran the full semantic test suite (1636 tests) — all pass
- Created a temporary test file with a stale `gas legacy:` line on a `compileViaYul: true` test — validation correctly rejects it with a clear error message
- Ran syntax tests (3551) and ASTJSON tests (72) — all pass
- Code style check (`scripts/check_style.sh`) passes