### PR TITLE
Report proper error for named arguments in string/bytes.concat()

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -2348,7 +2348,16 @@ void TypeChecker::typeCheckStringConcatFunction(
 {
 	solAssert(_functionType);
 	solAssert(_functionType->kind() == FunctionType::Kind::StringConcat);
-	solAssert(_functionCall.names().empty());
+
+	if (!_functionCall.names().empty())
+	{
+		m_errorReporter.typeError(
+			4903_error,
+			_functionCall.location(),
+			"Named arguments cannot be used with string.concat()."
+		);
+		return;
+	}
 
 	typeCheckFunctionGeneralChecks(_functionCall, _functionType);
 
@@ -2375,7 +2384,16 @@ void TypeChecker::typeCheckBytesConcatFunction(
 {
 	solAssert(_functionType);
 	solAssert(_functionType->kind() == FunctionType::Kind::BytesConcat);
-	solAssert(_functionCall.names().empty());
+
+	if (!_functionCall.names().empty())
+	{
+		m_errorReporter.typeError(
+			8145_error,
+			_functionCall.location(),
+			"Named arguments cannot be used with bytes.concat()."
+		);
+		return;
+	}
 
 	typeCheckFunctionGeneralChecks(_functionCall, _functionType);
 

--- a/test/libsolidity/syntaxTests/array/concat/bytes_concat_named_args.sol
+++ b/test/libsolidity/syntaxTests/array/concat/bytes_concat_named_args.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        bytes.concat({x: "abc", y: hex"00"});
+    }
+}
+// ----
+// TypeError 8145: (52-88): Named arguments cannot be used with bytes.concat().

--- a/test/libsolidity/syntaxTests/string/concat/string_concat_named_args.sol
+++ b/test/libsolidity/syntaxTests/string/concat/string_concat_named_args.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        string.concat({x: "abc", y: "def"});
+    }
+}
+// ----
+// TypeError 4903: (52-87): Named arguments cannot be used with string.concat().


### PR DESCRIPTION
## Description

Fixes #15735.

Using named arguments with `string.concat()` or `bytes.concat()` previously triggered an internal compiler error (ICE) due to a `solAssert(_functionCall.names().empty())` assertion. This replaces the assertions with proper `TypeError` diagnostics so the user gets a clear error message instead of a crash.

### Reproduction (from the issue)

```solidity
contract C {
    function f() public {
        string.concat({x: .3, y: "abc", z: true});
    }
}
```

**Before:** `Internal compiler error: Solidity assertion failed` at TypeChecker.cpp
**After:** `TypeError: Named arguments cannot be used with string.concat().`

The same fix is applied to `bytes.concat()` which had the identical assertion.

### Changes

- `libsolidity/analysis/TypeChecker.cpp`: Replace `solAssert` with `typeError` + `return` in both `typeCheckStringConcatFunction` (error 4903) and `typeCheckBytesConcatFunction` (error 8145)
- Add syntax tests: `string_concat_named_args.sol` and `bytes_concat_named_args.sol`

## Testing

- Built and ran syntax tests (3553 pass, including 2 new tests)
- Built and ran semantic tests (1636 pass)
- Verified the exact reproduction case from the issue produces a clean error instead of an ICE
- Code style check passes