### PR TITLE
Preserve failAfter directive in isoltest ASTJSON reformatting

### DIFF
--- a/test/libsolidity/ASTJSONTest.cpp
+++ b/test/libsolidity/ASTJSONTest.cpp
@@ -295,6 +295,9 @@ void ASTJSONTest::printSource(std::ostream& _stream, std::string const& _linePre
 		printPrefixed(_stream, source.second, _linePrefix);
 		_stream << std::endl;
 	}
+
+	if (m_expectedFailAfter.has_value())
+		printPrefixed(_stream, "// failAfter: " + compilerStateToString(m_expectedFailAfter.value()) + "\n", _linePrefix);
 }
 
 void ASTJSONTest::printUpdatedExpectations(std::ostream&, std::string const&) const


### PR DESCRIPTION
## Description

Fixes #14093.

When `isoltest` updates test expectations for ASTJSON tests (via `--accept-updates`), it calls `ASTJSONTest::printSource()` to rewrite the `.sol` input file. The function was not outputting the `failAfter` directive that was parsed and stored in `m_expectedFailAfter`, causing the directive to be silently dropped during reformatting.

### The Fix

Added output of the `failAfter` directive in `ASTJSONTest::printSource()` when `m_expectedFailAfter` has a value. The directive is written in the same format that `fillSources()` parses: `// failAfter: <CompilerState>`.

### Changes

- `test/libsolidity/ASTJSONTest.cpp`: Add `failAfter` output to `printSource()` (3 lines)

## Testing

- Built and ran ASTJSON tests (72 pass)
- Built and ran syntax tests (3551 pass)
- Code style check passes
- The fix is minimal and directly addresses the parsing/output asymmetry identified in the issue