### PR TITLE
Allow signed expressions in storage layout specifier

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.8.37 (unreleased)
 
 Language Features:
+* Custom Storage Layout: Allow signed positive expressions.
 
 Compiler Features:
 * SMTChecker: Emit a deprecation warning for the BMC engine.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.8.35 (unreleased)
 
 Language Features:
+* Custom Storage Layout: Allow signed positive expressions.
 * General: Add a builtin that computes the base slot of a storage namespace using the `erc7201` formula from ERC-7201.
 
 Compiler Features:

--- a/libsolidity/analysis/PostTypeContractLevelChecker.cpp
+++ b/libsolidity/analysis/PostTypeContractLevelChecker.cpp
@@ -181,18 +181,6 @@ void PostTypeContractLevelChecker::checkStorageLayoutSpecifier(ContractDefinitio
 		return;
 	}
 
-	if (!baseSlotExpressionType->isImplicitlyConvertibleTo(*TypeProvider::uint256()))
-	{
-		m_errorReporter.typeError(
-			1481_error,
-			baseSlotExpression.location(),
-			fmt::format(
-				"Base slot expression of type '{}' is not convertible to uint256.",
-				baseSlotExpressionType->humanReadableName()
-			)
-		);
-		return;
-	}
 	storageLayoutSpecifier->annotation().baseSlot = u256(baseSlot);
 
 	bigint size = contractStorageSizeUpperBound(_contract, VariableDeclaration::Location::Unspecified);

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/int_constant.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/int_constant.sol
@@ -1,7 +1,0 @@
-int constant x = -42;
-int constant y = 64;
-contract C layout at x {}
-contract D layout at y {}
-// ----
-// TypeError 6753: (64-65): The base slot of the storage layout evaluates to -42, which is outside the range of type uint256.
-// TypeError 1481: (90-91): Base slot expression of type 'int256' is not convertible to uint256.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/int_constant_negative.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/int_constant_negative.sol
@@ -1,0 +1,13 @@
+int constant INT256 = -42;
+int8 constant INT8 = -64;
+int constant EXPRESSION = INT256 * 2;
+int constant COMPLEX = EXPRESSION * -2 + EXPRESSION * 4;
+contract A layout at INT256 {}
+contract B layout at INT8 {}
+contract C layout at EXPRESSION {}
+contract D layout at COMPLEX {}
+// ----
+// TypeError 6753: (169-175): The base slot of the storage layout evaluates to -42, which is outside the range of type uint256.
+// TypeError 6753: (200-204): The base slot of the storage layout evaluates to -64, which is outside the range of type uint256.
+// TypeError 6753: (229-239): The base slot of the storage layout evaluates to -84, which is outside the range of type uint256.
+// TypeError 6753: (264-271): The base slot of the storage layout evaluates to -168, which is outside the range of type uint256.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/int_constant_positive.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/int_constant_positive.sol
@@ -1,0 +1,5 @@
+int constant x = 42;
+int16 constant y = 64;
+contract C layout at x {}
+contract D layout at y {}
+// ----

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/signed_expressions.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/signed_expressions.sol
@@ -1,0 +1,11 @@
+int constant SIGNED2 = 2;
+int constant SIGNED2_NEGATIVE = -2;
+uint constant UNSIGNED2 = 2;
+
+contract A layout at SIGNED2 * 1 {}
+contract B layout at SIGNED2_NEGATIVE * -1 {}
+contract C layout at SIGNED2_NEGATIVE * SIGNED2_NEGATIVE {}
+contract D layout at 2 * -1 * -1 {}
+contract E layout at 2 * SIGNED2 {}
+contract F layout at 2 * -1 * SIGNED2_NEGATIVE {}
+// ----


### PR DESCRIPTION
Suggested in https://github.com/argotorg/solidity/pull/16456#discussion_r2859936488

We intended to reject signed expressions for layout specifier, but since array lengths do accept them, this makes the handling consistent between both.
I guess not a bug then.