### PR TITLE
SSA: Strengthen shuffler requirements

### DIFF
--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -162,7 +162,7 @@ public:
 			// check that all required values are on stack
 			detail::State const state(_stack.data(), target, ReachableStackDepth);
 			for (auto const& liveVariable: _liveOut | ranges::views::keys | ranges::views::transform(Slot::makeValueID))
-				yulAssert(_stack.canBeFreelyGenerated(liveVariable) || ranges::contains(_stack.data(), liveVariable));
+				yulAssert(!_stack.canBeFreelyGenerated(liveVariable) && ranges::contains(_stack.data(), liveVariable));
 			for (auto const& arg: _args)
 				yulAssert(_stack.canBeFreelyGenerated(arg) || ranges::contains(_stack.data(), arg));
 		}

--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -23,6 +23,7 @@
 
 #include <boost/container/flat_map.hpp>
 
+#include <range/v3/algorithm/contains.hpp>
 #include <range/v3/view/iota.hpp>
 #include <range/v3/view/map.hpp>
 #include <range/v3/view/transform.hpp>
@@ -161,9 +162,9 @@ public:
 			// check that all required values are on stack
 			detail::State const state(_stack.data(), target, ReachableStackDepth);
 			for (auto const& liveVariable: _liveOut | ranges::views::keys | ranges::views::transform(Slot::makeValueID))
-				yulAssert(_stack.canBeFreelyGenerated(liveVariable) || ranges::find(_stack.data(), liveVariable) != ranges::end(_stack.data()));
+				yulAssert(_stack.canBeFreelyGenerated(liveVariable) || ranges::contains(_stack.data(), liveVariable));
 			for (auto const& arg: _args)
-				yulAssert(_stack.canBeFreelyGenerated(arg) || ranges::find(_stack.data(), arg) != ranges::end(_stack.data()));
+				yulAssert(_stack.canBeFreelyGenerated(arg) || ranges::contains(_stack.data(), arg));
 		}
 
 		static std::size_t constexpr maxIterations = 1000;


### PR DESCRIPTION
First, we use `ranges::contains` to make the code a bit more concise.
Afterwards, we strengthen the requirements on what task can be passed to a shuffler.

Without this requirement, I was able to create a test case on which the shuffler was looping.
However, in that case, I was requiring that a literal (not present in the input stack) must be present in the tail (the liveness data). Then I realized that such a case should actually not be allowed. If a value can be freely generated, we should not track it in the liveness data.
Note that this might need to change for the values spilled into memory.

For context, this is a test example that would currently loop, but would be rejected with the proposed change:
```
initial: [v1, v3, v2]
targetStackTop: [v2, v3]
targetStackTailSet: {v1, lit0}
targetStackSize: 4
```