### PR TITLE
SSA: More controlled stack growing in shuffler

### DIFF
--- a/libyul/backends/evm/ssa/StackShuffler.cpp
+++ b/libyul/backends/evm/ssa/StackShuffler.cpp
@@ -195,3 +195,13 @@ bool State::willRequireShrinking() const
 	}
 	return deficit + size() > target().size;
 }
+
+std::optional<StackDepth> State::findDeepestIncorrectArgSlot() const
+{
+	for (StackOffset const offset: stackArgsRange())
+	{
+		if (!isArgsCompatible(offset, offset))
+			return StackDepth{m_stackData.size() - offset.value};
+	}
+	return std::nullopt;
+}

--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -124,6 +124,9 @@ public:
 		return ranges::views::iota(0u, std::min(m_stackData.size(), m_reachableStackDepth)) | ranges::views::transform([&](auto _i) { return StackOffset{m_stackData.size() - _i - 1}; });
 	}
 
+	/// Depth of the deepest arg slot incompatible with target or Nothing for no incompatibility in current state
+	std::optional<StackDepth> findDeepestIncorrectArgSlot() const;
+
 private:
 	StackData const& m_stackData;
 	Target const& m_target;
@@ -505,6 +508,8 @@ private:
 			if (auto result = dupDeepSlotIfRequired(_stack, _state); result.status != ShuffleHelperResult::Status::NoAction)
 				return result;
 
+			auto const maybeIncorrectArgSlotDepth = _state.findDeepestIncorrectArgSlot();
+			if (!maybeIncorrectArgSlotDepth || maybeIncorrectArgSlotDepth->value < ReachableStackDepth - 1)
 			{
 				StackOffset const targetOffset{_stack.size()};
 				if (_state.count(_state.targetArg(targetOffset)) < _state.targetMinCount(_state.targetArg(targetOffset)))

--- a/test/libyul/ssa/stackShuffler/deep_values_grow_to_args.stack
+++ b/test/libyul/ssa/stackShuffler/deep_values_grow_to_args.stack
@@ -8,33 +8,12 @@ targetStackTop: [JUNK, v2, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK,
 //          POP|      *      *      *      *      *      *      *      *      *      *      *      *      *     v1     v2
 //    PUSH lit2|      *      *      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2
 //         DUP2|      *      *      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2
-//    PUSH lit3|      *      *      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2   lit3
-//         DUP2|      *      *      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2   lit3     v2
-//    PUSH lit1|      *      *      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2   lit3     v2   lit1
-//        SWAP6|      *      *      *      *      *      *      *      *      *      *      *      *      *   lit1     v2   lit2     v2   lit3     v2     v1
-//        SWAP1|      *      *      *      *      *      *      *      *      *      *      *      *      *   lit1     v2   lit2     v2   lit3     v1     v2
-//        SWAP7|      *      *      *      *      *      *      *      *      *      *      *      *     v2   lit1     v2   lit2     v2   lit3     v1      *
-//          POP|      *      *      *      *      *      *      *      *      *      *      *      *     v2   lit1     v2   lit2     v2   lit3     v1
-//         DUP3|      *      *      *      *      *      *      *      *      *      *      *      *     v2   lit1     v2   lit2     v2   lit3     v1     v2
-//        SWAP8|      *      *      *      *      *      *      *      *      *      *      *     v2     v2   lit1     v2   lit2     v2   lit3     v1      *
-//          POP|      *      *      *      *      *      *      *      *      *      *      *     v2     v2   lit1     v2   lit2     v2   lit3     v1
-//         DUP3|      *      *      *      *      *      *      *      *      *      *      *     v2     v2   lit1     v2   lit2     v2   lit3     v1     v2
-//        SWAP9|      *      *      *      *      *      *      *      *      *      *     v2     v2     v2   lit1     v2   lit2     v2   lit3     v1      *
-//          POP|      *      *      *      *      *      *      *      *      *      *     v2     v2     v2   lit1     v2   lit2     v2   lit3     v1
-//         DUP3|      *      *      *      *      *      *      *      *      *      *     v2     v2     v2   lit1     v2   lit2     v2   lit3     v1     v2
-//       SWAP10|      *      *      *      *      *      *      *      *      *     v2     v2     v2     v2   lit1     v2   lit2     v2   lit3     v1      *
-//          POP|      *      *      *      *      *      *      *      *      *     v2     v2     v2     v2   lit1     v2   lit2     v2   lit3     v1
-//         DUP3|      *      *      *      *      *      *      *      *      *     v2     v2     v2     v2   lit1     v2   lit2     v2   lit3     v1     v2
-//       SWAP11|      *      *      *      *      *      *      *      *     v2     v2     v2     v2     v2   lit1     v2   lit2     v2   lit3     v1      *
-//          POP|      *      *      *      *      *      *      *      *     v2     v2     v2     v2     v2   lit1     v2   lit2     v2   lit3     v1
-//         DUP3|      *      *      *      *      *      *      *      *     v2     v2     v2     v2     v2   lit1     v2   lit2     v2   lit3     v1     v2
-//       SWAP12|      *      *      *      *      *      *      *     v2     v2     v2     v2     v2     v2   lit1     v2   lit2     v2   lit3     v1      *
-//          POP|      *      *      *      *      *      *      *     v2     v2     v2     v2     v2     v2   lit1     v2   lit2     v2   lit3     v1
-//         DUP3|      *      *      *      *      *      *      *     v2     v2     v2     v2     v2     v2   lit1     v2   lit2     v2   lit3     v1     v2
-//       SWAP13|      *      *      *      *      *      *     v2     v2     v2     v2     v2     v2     v2   lit1     v2   lit2     v2   lit3     v1      *
-//          POP|      *      *      *      *      *      *     v2     v2     v2     v2     v2     v2     v2   lit1     v2   lit2     v2   lit3     v1
-//         DUP3|      *      *      *      *      *      *     v2     v2     v2     v2     v2     v2     v2   lit1     v2   lit2     v2   lit3     v1     v2
-//          ...|
+//         DUP1|      *      *      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2     v2
+//       SWAP16|      *     v2      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2      *
+//    PUSH lit1|      *     v2      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2      *   lit1
+//        SWAP5|      *     v2      *      *      *      *      *      *      *      *      *      *      *   lit1     v2   lit2     v2      *     v1
+//    PUSH lit3|      *     v2      *      *      *      *      *      *      *      *      *      *      *   lit1     v2   lit2     v2      *     v1   lit3
+//        SWAP2|      *     v2      *      *      *      *      *      *      *      *      *      *      *   lit1     v2   lit2     v2   lit3     v1      *
 //             +--------------------------------------------------------------------------------------------------------------------------------------------
 //     (target)|      *     v2      *      *      *      *      *      *      *      *      *      *      *   lit1     v2   lit2     v2   lit3     v1      *
-// Status: MaxIterationsReached
+// Status: Admissible

--- a/test/libyul/ssa/stackShuffler/dup_value_into_args_with_grow_1.stack
+++ b/test/libyul/ssa/stackShuffler/dup_value_into_args_with_grow_1.stack
@@ -9,10 +9,7 @@ targetStackTop: [v2, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, phi1,
 //          POP|     v3      *      *      *      *      *      *      *      *      *   phi1      *     v1     v2
 //    PUSH lit2|     v3      *      *      *      *      *      *      *      *      *   phi1      *     v1     v2   lit2
 //         DUP2|     v3      *      *      *      *      *      *      *      *      *   phi1      *     v1     v2   lit2     v2
-//    PUSH lit1|     v3      *      *      *      *      *      *      *      *      *   phi1      *     v1     v2   lit2     v2   lit1
-//         DUP2|     v3      *      *      *      *      *      *      *      *      *   phi1      *     v1     v2   lit2     v2   lit1     v2
-//        SWAP1|     v3      *      *      *      *      *      *      *      *      *   phi1      *     v1     v2   lit2     v2     v2   lit1
-//          POP|     v3      *      *      *      *      *      *      *      *      *   phi1      *     v1     v2   lit2     v2     v2
+//         DUP1|     v3      *      *      *      *      *      *      *      *      *   phi1      *     v1     v2   lit2     v2     v2
 //       SWAP16|     v2      *      *      *      *      *      *      *      *      *   phi1      *     v1     v2   lit2     v2     v3
 //    PUSH lit1|     v2      *      *      *      *      *      *      *      *      *   phi1      *     v1     v2   lit2     v2     v3   lit1
 //        SWAP5|     v2      *      *      *      *      *      *      *      *      *   phi1      *   lit1     v2   lit2     v2     v3     v1

--- a/test/libyul/ssa/stackShuffler/dup_value_into_tail_and_args.stack
+++ b/test/libyul/ssa/stackShuffler/dup_value_into_tail_and_args.stack
@@ -9,10 +9,7 @@ targetStackTop: [JUNK, JUNK, v2, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK,
 //          POP|      *      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2
 //    PUSH lit2|      *      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2
 //         DUP2|      *      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2
-//    PUSH lit3|      *      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2   lit3
-//         DUP2|      *      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2   lit3     v2
-//        SWAP1|      *      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2     v2   lit3
-//          POP|      *      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2     v2
+//         DUP1|      *      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2     v2
 //       SWAP16|      *      *     v2      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2     v3
 //    PUSH lit1|      *      *     v2      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2     v3   lit1
 //        SWAP5|      *      *     v2      *      *      *      *      *      *      *      *      *      *      *   lit1     v2   lit2     v2     v3     v1

--- a/test/libyul/ssa/stackShuffler/multi_dup_with_phi_in_tail.stack
+++ b/test/libyul/ssa/stackShuffler/multi_dup_with_phi_in_tail.stack
@@ -9,10 +9,7 @@ targetStackTop: [JUNK, v5, JUNK, v1, v2, JUNK, JUNK, JUNK, JUNK, phi1, JUNK, v3,
 //          POP|      *     v6      *     v1     v2      *      *      *      *   phi1      *     v3   phi2     v4     v5
 //    PUSH lit2|      *     v6      *     v1     v2      *      *      *      *   phi1      *     v3   phi2     v4     v5   lit2
 //         DUP2|      *     v6      *     v1     v2      *      *      *      *   phi1      *     v3   phi2     v4     v5   lit2     v5
-//    PUSH lit3|      *     v6      *     v1     v2      *      *      *      *   phi1      *     v3   phi2     v4     v5   lit2     v5   lit3
-//         DUP2|      *     v6      *     v1     v2      *      *      *      *   phi1      *     v3   phi2     v4     v5   lit2     v5   lit3     v5
-//        SWAP1|      *     v6      *     v1     v2      *      *      *      *   phi1      *     v3   phi2     v4     v5   lit2     v5     v5   lit3
-//          POP|      *     v6      *     v1     v2      *      *      *      *   phi1      *     v3   phi2     v4     v5   lit2     v5     v5
+//         DUP1|      *     v6      *     v1     v2      *      *      *      *   phi1      *     v3   phi2     v4     v5   lit2     v5     v5
 //       SWAP16|      *     v5      *     v1     v2      *      *      *      *   phi1      *     v3   phi2     v4     v5   lit2     v5     v6
 //    PUSH lit1|      *     v5      *     v1     v2      *      *      *      *   phi1      *     v3   phi2     v4     v5   lit2     v5     v6   lit1
 //        SWAP5|      *     v5      *     v1     v2      *      *      *      *   phi1      *     v3   phi2   lit1     v5   lit2     v5     v6     v4

--- a/test/libyul/ssa/stackShuffler/return_label_with_dup_and_grow.stack
+++ b/test/libyul/ssa/stackShuffler/return_label_with_dup_and_grow.stack
@@ -20,10 +20,7 @@ targetStackTop: [ReturnLabel[1], JUNK, JUNK, v2, JUNK, JUNK, JUNK, JUNK, JUNK, J
 //          POP| ReturnLabel[1]      *      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2
 //    PUSH lit2| ReturnLabel[1]      *      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2
 //         DUP2| ReturnLabel[1]      *      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2
-//    PUSH lit1| ReturnLabel[1]      *      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2   lit1
-//         DUP2| ReturnLabel[1]      *      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2   lit1     v2
-//        SWAP1| ReturnLabel[1]      *      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2     v2   lit1
-//          POP| ReturnLabel[1]      *      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2     v2
+//         DUP1| ReturnLabel[1]      *      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2     v2
 //       SWAP16| ReturnLabel[1]      *      *     v2      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2     v3
 //    PUSH lit1| ReturnLabel[1]      *      *     v2      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2     v3   lit1
 //        SWAP5| ReturnLabel[1]      *      *     v2      *      *      *      *      *      *      *      *      *      *      *   lit1     v2   lit2     v2     v3     v1

--- a/test/libyul/ssa/stackShuffler/triple_dup_no_phi.stack
+++ b/test/libyul/ssa/stackShuffler/triple_dup_no_phi.stack
@@ -9,10 +9,7 @@ targetStackTop: [JUNK, v2, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK,
 //          POP|      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2
 //    PUSH lit2|      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2
 //         DUP2|      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2
-//    PUSH lit3|      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2   lit3
-//         DUP2|      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2   lit3     v2
-//        SWAP1|      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2     v2   lit3
-//          POP|      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2     v2
+//         DUP1|      *     v3      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2     v2
 //       SWAP16|      *     v2      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2     v3
 //    PUSH lit1|      *     v2      *      *      *      *      *      *      *      *      *      *      *     v1     v2   lit2     v2     v3   lit1
 //        SWAP5|      *     v2      *      *      *      *      *      *      *      *      *      *      *   lit1     v2   lit2     v2     v3     v1

--- a/test/libyul/ssa/stackShuffler/triple_dup_with_phi.stack
+++ b/test/libyul/ssa/stackShuffler/triple_dup_with_phi.stack
@@ -9,10 +9,7 @@ targetStackTop: [JUNK, v2, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, phi1, JUNK, JUNK,
 //          POP|      *     v3      *      *      *      *      *      *   phi1      *      *      *      *     v1     v2
 //    PUSH lit2|      *     v3      *      *      *      *      *      *   phi1      *      *      *      *     v1     v2   lit2
 //         DUP2|      *     v3      *      *      *      *      *      *   phi1      *      *      *      *     v1     v2   lit2     v2
-//    PUSH lit3|      *     v3      *      *      *      *      *      *   phi1      *      *      *      *     v1     v2   lit2     v2   lit3
-//         DUP2|      *     v3      *      *      *      *      *      *   phi1      *      *      *      *     v1     v2   lit2     v2   lit3     v2
-//        SWAP1|      *     v3      *      *      *      *      *      *   phi1      *      *      *      *     v1     v2   lit2     v2     v2   lit3
-//          POP|      *     v3      *      *      *      *      *      *   phi1      *      *      *      *     v1     v2   lit2     v2     v2
+//         DUP1|      *     v3      *      *      *      *      *      *   phi1      *      *      *      *     v1     v2   lit2     v2     v2
 //       SWAP16|      *     v2      *      *      *      *      *      *   phi1      *      *      *      *     v1     v2   lit2     v2     v3
 //    PUSH lit1|      *     v2      *      *      *      *      *      *   phi1      *      *      *      *     v1     v2   lit2     v2     v3   lit1
 //        SWAP5|      *     v2      *      *      *      *      *      *   phi1      *      *      *      *   lit1     v2   lit2     v2     v3     v1


### PR DESCRIPTION
Previously, when growing the current stack, we would always grow if we can put a slot on top that is expected there in the target.

However, if we have something in the args that still need to be fixed and would go out of reach, we should skip this step and focus on fixing the deep arg first.

This also fixes the last cycling behaviour in our tests.