### PR TITLE
Fix SSA CFG shuffler oscillation

### DIFF
--- a/libyul/backends/evm/ssa/Stack.h
+++ b/libyul/backends/evm/ssa/Stack.h
@@ -252,6 +252,7 @@ public:
 	bool dupReachable(Depth const& _depth) const noexcept { return _depth < size() && _depth.value + 1 <= reachableStackDepth; }
 	bool isValidSwapTarget(Offset const& _offset) const noexcept { return isValidSwapTarget(offsetToDepth(_offset)); }
 	bool isValidSwapTarget(Depth const& _depth) const noexcept { return _depth < size() && 1 <= _depth.value && _depth.value <= reachableStackDepth; }
+	bool isBeyondSwapRange(Offset const& _offset) const noexcept { return isBeyondSwapRange(offsetToDepth(_offset)); }
 	bool isBeyondSwapRange(Depth const& _depth) const noexcept { return _depth > reachableStackDepth; }
 
 	void declareJunk(Offset const& _offset) { (*m_data)[_offset.value] = Slot::makeJunk(); }

--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -471,7 +471,8 @@ private:
 			// swap up any slot in args that is out of position and has a slot available in args that it can occupy
 			for (StackOffset offset: _state.stackArgsRange())
 			{
-				bool const reachable = _stack.isValidSwapTarget(offset);
+				// when offset is already top no swap-up is needed, so it doesn't have to be a valid swap target itself
+				bool const reachable = !_stack.isBeyondSwapRange(offset);
 				bool const identical = _state.isArgsCompatible(offset, stackTop) && !_state.targetArbitrary(stackTop);
 				if (
 					reachable &&

--- a/test/libyul/ssa/stackShuffler/loop-fuzzer.stack
+++ b/test/libyul/ssa/stackShuffler/loop-fuzzer.stack
@@ -6,36 +6,8 @@ targetStackSize: 7
 //             |      0      1 |      2      3      4      5      6
 //             +-------------- +-----------------------------------
 //    (initial)|     v0   phi0 |   phi0   lit0     v0     v0
-//         DUP4|     v0   phi0 |   phi0   lit0     v0     v0   phi0
-//          POP|     v0   phi0 |   phi0   lit0     v0     v0
-//         DUP4|     v0   phi0 |   phi0   lit0     v0     v0   phi0
-//          POP|     v0   phi0 |   phi0   lit0     v0     v0
-//         DUP4|     v0   phi0 |   phi0   lit0     v0     v0   phi0
-//          POP|     v0   phi0 |   phi0   lit0     v0     v0
-//         DUP4|     v0   phi0 |   phi0   lit0     v0     v0   phi0
-//          POP|     v0   phi0 |   phi0   lit0     v0     v0
-//         DUP4|     v0   phi0 |   phi0   lit0     v0     v0   phi0
-//          POP|     v0   phi0 |   phi0   lit0     v0     v0
-//         DUP4|     v0   phi0 |   phi0   lit0     v0     v0   phi0
-//          POP|     v0   phi0 |   phi0   lit0     v0     v0
-//         DUP4|     v0   phi0 |   phi0   lit0     v0     v0   phi0
-//          POP|     v0   phi0 |   phi0   lit0     v0     v0
-//         DUP4|     v0   phi0 |   phi0   lit0     v0     v0   phi0
-//          POP|     v0   phi0 |   phi0   lit0     v0     v0
-//         DUP4|     v0   phi0 |   phi0   lit0     v0     v0   phi0
-//          POP|     v0   phi0 |   phi0   lit0     v0     v0
-//         DUP4|     v0   phi0 |   phi0   lit0     v0     v0   phi0
-//          POP|     v0   phi0 |   phi0   lit0     v0     v0
-//         DUP4|     v0   phi0 |   phi0   lit0     v0     v0   phi0
-//          POP|     v0   phi0 |   phi0   lit0     v0     v0
-//         DUP4|     v0   phi0 |   phi0   lit0     v0     v0   phi0
-//          POP|     v0   phi0 |   phi0   lit0     v0     v0
-//         DUP4|     v0   phi0 |   phi0   lit0     v0     v0   phi0
-//          POP|     v0   phi0 |   phi0   lit0     v0     v0
-//         DUP4|     v0   phi0 |   phi0   lit0     v0     v0   phi0
-//          POP|     v0   phi0 |   phi0   lit0     v0     v0
-//         DUP4|     v0   phi0 |   phi0   lit0     v0     v0   phi0
-//          ...|
+//        SWAP2|     v0   phi0 |   phi0     v0     v0   lit0
+//         DUP4|     v0   phi0 |   phi0     v0     v0   lit0   phi0
 //             +-------------- +-----------------------------------
 //     (target)|          {v0} |   phi0     v0     v0      *   phi0
-// Status: MaxIterationsReached
+// Status: Admissible


### PR DESCRIPTION
in the ssa shuffler fix args slot, when offset is already top no swap-up is needed, so it doesn't have to be a valid swap target itself