### PR TITLE
SSA shuffler: "all necessary slots reachable" should ignore junk

### DIFF
--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -807,12 +807,18 @@ private:
 		{
 			if (_state.isArgsCompatible(offset, offset))
 				continue;
+
+			auto const& targetArg = _state.targetArg(offset);
+			// if the target arg is junk, we can simply push0 and it's fine
+			if (targetArg.isJunk())
+				continue;
+
 			// find first occurrence of the slot
-			std::optional<StackDepth> depth = _stack.findSlotDepth(_state.targetArg(offset));
+			std::optional<StackDepth> const depth = _stack.findSlotDepth(targetArg);
 			if (!depth)
 			{
 				// if there is no occurrence of the slot anywhere, we must be able to freely generate it
-				yulAssert(_stack.canBeFreelyGenerated(_state.targetArg(offset)));
+				yulAssert(_stack.canBeFreelyGenerated(targetArg));
 			}
 			else
 			{

--- a/test/libyul/ssa/stackShuffler/stack_top_is_junk.stack
+++ b/test/libyul/ssa/stackShuffler/stack_top_is_junk.stack
@@ -1,0 +1,41 @@
+initial: [JUNK, JUNK, v0, v0, lit0, v0, lit0, v0, v0, v0, lit0, v0, v0, v0, lit0, v0, lit0, lit0, v0]
+targetStackTop: [JUNK, lit0, v0, lit0, v0, JUNK, v0, lit0, JUNK, v0, v0, lit0, v0, JUNK, lit0, v0, JUNK]
+targetStackTailSet: {v0}
+targetStackSize: 20
+// ----
+//             |      0      1      2 |      3      4      5      6      7      8      9     10     11     12     13     14     15     16     17     18     19
+//             +--------------------- +-----------------------------------------------------------------------------------------------------------------------
+//    (initial)|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0
+//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
+//          POP|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0
+//         DUP2|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
+//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0
+//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
+//          POP|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0
+//         DUP2|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
+//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0
+//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
+//          POP|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0
+//         DUP2|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
+//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0
+//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
+//          POP|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0
+//         DUP2|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
+//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0
+//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
+//          POP|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0
+//         DUP2|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
+//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0
+//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
+//          POP|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0
+//         DUP2|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
+//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0
+//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
+//          POP|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0
+//         DUP2|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
+//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0
+//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
+//          ...|
+//             +--------------------- +-----------------------------------------------------------------------------------------------------------------------
+//     (target)|                 {v0} |      *   lit0     v0   lit0     v0      *     v0   lit0      *     v0     v0   lit0     v0      *   lit0     v0      *
+// Status: MaxIterationsReached

--- a/test/libyul/ssa/stackShuffler/stack_top_is_junk.stack
+++ b/test/libyul/ssa/stackShuffler/stack_top_is_junk.stack
@@ -6,36 +6,7 @@ targetStackSize: 20
 //             |      0      1      2 |      3      4      5      6      7      8      9     10     11     12     13     14     15     16     17     18     19
 //             +--------------------- +-----------------------------------------------------------------------------------------------------------------------
 //    (initial)|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0
-//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
-//          POP|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0
-//         DUP2|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
-//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0
-//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
-//          POP|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0
-//         DUP2|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
-//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0
-//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
-//          POP|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0
-//         DUP2|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
-//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0
-//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
-//          POP|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0
-//         DUP2|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
-//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0
-//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
-//          POP|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0
-//         DUP2|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
-//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0
-//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
-//          POP|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0
-//         DUP2|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
-//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0
-//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
-//          POP|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0
-//         DUP2|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
-//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0
-//        SWAP1|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
-//          ...|
+//    PUSH JUNK|      *      *     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0      *
 //             +--------------------- +-----------------------------------------------------------------------------------------------------------------------
 //     (target)|                 {v0} |      *   lit0     v0   lit0     v0      *     v0   lit0      *     v0     v0   lit0     v0      *   lit0     v0      *
-// Status: MaxIterationsReached
+// Status: Admissible

--- a/test/libyul/ssa/stackShuffler/stack_top_is_lit.stack
+++ b/test/libyul/ssa/stackShuffler/stack_top_is_lit.stack
@@ -1,0 +1,18 @@
+initial: [lit1, lit1, v0, v0, lit0, v0, lit0, v0, v0, v0, lit0, v0, v0, v0, lit0, v0, lit0, lit0, v0]
+targetStackTop: [JUNK, lit0, v0, lit0, v0, JUNK, v0, lit0, JUNK, v0, v0, lit0, v0, JUNK, lit0, v0, lit1]
+targetStackTailSet: {v0}
+targetStackSize: 20
+// ----
+//             |      0      1      2 |      3      4      5      6      7      8      9     10     11     12     13     14     15     16     17     18     19
+//             +--------------------- +-----------------------------------------------------------------------------------------------------------------------
+//    (initial)|   lit1   lit1     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0
+//        SWAP1|   lit1   lit1     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
+//          POP|   lit1   lit1     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0
+//       SWAP16|   lit1     v0     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit1
+//         DUP2|   lit1     v0     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit1   lit0
+//        SWAP1|   lit1     v0     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0   lit1
+//         DUP4|   lit1     v0     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0   lit1     v0
+//        SWAP1|   lit1     v0     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0   lit1
+//             +--------------------- +-----------------------------------------------------------------------------------------------------------------------
+//     (target)|                 {v0} |      *   lit0     v0   lit0     v0      *     v0   lit0      *     v0     v0   lit0     v0      *   lit0     v0   lit1
+// Status: Admissible

--- a/test/libyul/ssa/stackShuffler/stack_top_is_var.stack
+++ b/test/libyul/ssa/stackShuffler/stack_top_is_var.stack
@@ -1,0 +1,18 @@
+initial: [v1, v1, v0, v0, lit0, v0, lit0, v0, v0, v0, lit0, v0, v0, v0, lit0, v0, lit0, lit0, v0]
+targetStackTop: [JUNK, lit0, v0, lit0, v0, JUNK, v0, lit0, JUNK, v0, v0, lit0, v0, JUNK, lit0, v0, v1]
+targetStackTailSet: {v0}
+targetStackSize: 20
+// ----
+//             |      0      1      2 |      3      4      5      6      7      8      9     10     11     12     13     14     15     16     17     18     19
+//             +--------------------- +-----------------------------------------------------------------------------------------------------------------------
+//    (initial)|     v1     v1     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0
+//        SWAP1|     v1     v1     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0   lit0
+//          POP|     v1     v1     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v0
+//       SWAP16|     v1     v0     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v1
+//         DUP2|     v1     v0     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0     v1   lit0
+//        SWAP1|     v1     v0     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v1
+//         DUP4|     v1     v0     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v1     v0
+//        SWAP1|     v1     v0     v0 |     v0   lit0     v0   lit0     v0     v0     v0   lit0     v0     v0     v0   lit0     v0   lit0   lit0     v0     v1
+//             +--------------------- +-----------------------------------------------------------------------------------------------------------------------
+//     (target)|                 {v0} |      *   lit0     v0   lit0     v0      *     v0   lit0      *     v0     v0   lit0     v0      *   lit0     v0     v1
+// Status: Admissible


### PR DESCRIPTION
Added three tests, where the stack top is either a variable, a lit, or junk and the stack has to grow by one to populate it. For the first two, the shuffler pulls the var/lit out of the tail by shrinking and then growing back; for junk it should simply push0 (when it was previously oscillating).