### PR TITLE
Purity flag: Rework native members

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -4052,12 +4052,7 @@ void TypeChecker::endVisit(UsingForDirective const& _usingFor)
 		FunctionDefinition const& functionDefinition =
 			dynamic_cast<FunctionDefinition const&>(*path->annotation().referencedDeclaration);
 
-		FunctionType const* functionType = dynamic_cast<FunctionType const*>(
-			functionDefinition.libraryFunction() ?
-				functionDefinition.typeViaContractName(Declaration::ContractNameAccessKind::Library) :
-				functionDefinition.type()
-			);
-
+		FunctionType const* functionType = dynamic_cast<FunctionType const*>(functionDefinition.typeWhenAttached());
 		solAssert(functionType);
 
 		if (functionDefinition.parameters().empty())

--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -4054,7 +4054,7 @@ void TypeChecker::endVisit(UsingForDirective const& _usingFor)
 
 		FunctionType const* functionType = dynamic_cast<FunctionType const*>(
 			functionDefinition.libraryFunction() ?
-				functionDefinition.typeViaContractName() :
+				functionDefinition.typeViaContractName(Declaration::ContractNameAccessKind::Library) :
 				functionDefinition.type()
 			);
 

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -493,11 +493,13 @@ Type const* FunctionDefinition::type() const
 
 Type const* FunctionDefinition::typeViaContractName(ContractNameAccessKind const _accessKind) const
 {
+	// TODO: Fails because private library functions are attachable but not visible (issue #16721)
+	//solAssert(isVisibleViaContractName(_accessKind));
 	switch (_accessKind)
 	{
 		case ContractNameAccessKind::Local:
 		{
-			solAssert(!libraryFunction(), "Library member cannot be accessed from local/deriving scope");
+			solAssert(!libraryFunction(), "Library members can only be accessed via library name.");
 			solAssert(visibility() > Visibility::Private, "Private non-library member is not visible via contract type name");
 
 			if (!Declaration::isVisibleInContract() || !isImplemented())
@@ -513,7 +515,7 @@ Type const* FunctionDefinition::typeViaContractName(ContractNameAccessKind const
 		case ContractNameAccessKind::Foreign:
 		{
 			solAssert(!libraryFunction(), "Library members can only be accessed via library name.");
-			solAssert(isVisibleViaContractTypeAccess(), "Externally invisible member accessed via contract name.");
+			solAssert(isVisibleViaContractTypeAccess(), "Invisible member accessed via contract name.");
 			// Foreign contract member function being accessed via contract type name, cannot be called.
 			return TypeProvider::function(*this, FunctionType::Kind::Declaration);
 		}

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -538,6 +538,12 @@ Type const* FunctionDefinition::typeViaContractName(ContractNameAccessKind const
 	util::unreachable();
 }
 
+Type const* FunctionDefinition::typeWhenAttached() const
+{
+	solAssert(isFree() || libraryFunction());
+	return libraryFunction() ? typeViaContractName(ContractNameAccessKind::Library) : type();
+}
+
 std::string FunctionDefinition::externalSignature() const
 {
 	return TypeProvider::function(*this)->externalSignature();
@@ -984,11 +990,7 @@ FunctionType const* UnaryOperation::userDefinedFunctionType() const
 		return nullptr;
 
 	FunctionDefinition const* userDefinedFunction = *annotation().userDefinedFunction;
-	return dynamic_cast<FunctionType const*>(
-		userDefinedFunction->libraryFunction() ?
-		userDefinedFunction->typeViaContractName(Declaration::ContractNameAccessKind::Library) :
-		userDefinedFunction->type()
-	);
+	return dynamic_cast<FunctionType const*>(userDefinedFunction->typeWhenAttached());
 }
 
 FunctionType const* BinaryOperation::userDefinedFunctionType() const
@@ -997,11 +999,7 @@ FunctionType const* BinaryOperation::userDefinedFunctionType() const
 		return nullptr;
 
 	FunctionDefinition const* userDefinedFunction = *annotation().userDefinedFunction;
-	return dynamic_cast<FunctionType const*>(
-		userDefinedFunction->libraryFunction() ?
-		userDefinedFunction->typeViaContractName(Declaration::ContractNameAccessKind::Library) :
-		userDefinedFunction->type()
-	);
+	return dynamic_cast<FunctionType const*>(userDefinedFunction->typeWhenAttached());
 }
 
 BinaryOperationAnnotation& BinaryOperation::annotation() const

--- a/libsolidity/ast/AST.cpp
+++ b/libsolidity/ast/AST.cpp
@@ -491,17 +491,51 @@ Type const* FunctionDefinition::type() const
 	return TypeProvider::function(*this, FunctionType::Kind::Internal);
 }
 
-Type const* FunctionDefinition::typeViaContractName() const
+Type const* FunctionDefinition::typeViaContractName(ContractNameAccessKind const _accessKind) const
 {
-	if (libraryFunction())
+	switch (_accessKind)
 	{
-		if (isPublic())
-			return FunctionType(*this).asExternallyCallableFunction(true);
-		else
-			return TypeProvider::function(*this, FunctionType::Kind::Internal);
+		case ContractNameAccessKind::Local:
+		{
+			solAssert(!libraryFunction(), "Library member cannot be accessed from local/deriving scope");
+			solAssert(visibility() > Visibility::Private, "Private non-library member is not visible via contract type name");
+
+			if (!Declaration::isVisibleInContract() || !isImplemented())
+				// If is external or has no implementation, it cannot be called using contract type name. In case of accessing
+				// via contract type name, only declaration is available, to be used in non calling context. I.e. to access
+				// function selector `C.foo.selector` where foo has external visibility.
+				return TypeProvider::function(*this, FunctionType::Kind::Declaration);
+			else
+				// If call is in local (or deriving) scope, function is visible in contract (non-external) and it has an
+				// implementation, internal call is used.
+				return type();
+		}
+		case ContractNameAccessKind::Foreign:
+		{
+			solAssert(!libraryFunction(), "Library members can only be accessed via library name.");
+			solAssert(isVisibleViaContractTypeAccess(), "Externally invisible member accessed via contract name.");
+			// Foreign contract member function being accessed via contract type name, cannot be called.
+			return TypeProvider::function(*this, FunctionType::Kind::Declaration);
+		}
+		case ContractNameAccessKind::Library:
+		{
+			// We could theoretically distinguish local and foreign scope for libraries but it does not affect the type,
+			// so we don't. Access to private members from foreign scopes is not allowed by the type checker, so if we
+			// get such a function here, we assume the scope is local. Note that access to private library members via
+			// library name is not allowed, but you can (sometimes, see issue [#16721](#16721)) attach them via `using`
+			// statement.
+			solAssert(libraryFunction(), "Non-library members cannot be accessed via library name.");
+			// In case of library contract, member call kind depends on its visibility.
+			if (isPublic())
+				// When Lib.foo is public or external, an external call (delegate call) is used.
+				return FunctionType(*this).asExternallyCallableFunction(true /* _inLibrary */);
+			else
+				// For private or internal visibility, internal call is used.
+				// Private library members can be accessed in context of `using` statement.
+				return type();
+		}
 	}
-	else
-		return TypeProvider::function(*this, FunctionType::Kind::Declaration);
+	util::unreachable();
 }
 
 std::string FunctionDefinition::externalSignature() const
@@ -952,7 +986,7 @@ FunctionType const* UnaryOperation::userDefinedFunctionType() const
 	FunctionDefinition const* userDefinedFunction = *annotation().userDefinedFunction;
 	return dynamic_cast<FunctionType const*>(
 		userDefinedFunction->libraryFunction() ?
-		userDefinedFunction->typeViaContractName() :
+		userDefinedFunction->typeViaContractName(Declaration::ContractNameAccessKind::Library) :
 		userDefinedFunction->type()
 	);
 }
@@ -965,7 +999,7 @@ FunctionType const* BinaryOperation::userDefinedFunctionType() const
 	FunctionDefinition const* userDefinedFunction = *annotation().userDefinedFunction;
 	return dynamic_cast<FunctionType const*>(
 		userDefinedFunction->libraryFunction() ?
-		userDefinedFunction->typeViaContractName() :
+		userDefinedFunction->typeViaContractName(Declaration::ContractNameAccessKind::Library) :
 		userDefinedFunction->type()
 	);
 }

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -306,10 +306,28 @@ public:
 		Library, ///< Via library name (no distinction between local or foreign access).
 	};
 
+	bool isVisibleViaContractName(ContractNameAccessKind const _accessKind) const
+	{
+		switch (_accessKind)
+		{
+		case ContractNameAccessKind::Local:
+			return visibility() > Visibility::Private;
+		case ContractNameAccessKind::Foreign:
+			return isVisibleViaContractTypeAccess();
+		case ContractNameAccessKind::Library:
+			return isVisibleAsLibraryMember();
+		}
+
+		util::unreachable();
+	}
 	/// @returns the type for members of the containing contract type that refer to this declaration. Depends on access
 	/// context defined by `ContractNameAccessKind`.
 	/// This can only be called once types of variable declarations have already been resolved.
-	virtual Type const* typeViaContractName(ContractNameAccessKind const) const { return type(); }
+	virtual Type const* typeViaContractName(ContractNameAccessKind const _accessKind) const
+	{
+		solAssert(isVisibleViaContractName(_accessKind));
+		return type();
+	}
 
 	/// @param _internal false indicates external interface is concerned, true indicates internal interface is concerned.
 	/// @returns null when it is not accessible as a function.

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -1064,6 +1064,7 @@ public:
 
 	Type const* type() const override;
 	Type const* typeViaContractName(ContractNameAccessKind const _accessKind) const override;
+	Type const* typeWhenAttached() const;
 
 	/// @param _internal false indicates external interface is concerned, true indicates internal interface is concerned.
 	/// @returns null when it is not accessible as a function.

--- a/libsolidity/ast/AST.h
+++ b/libsolidity/ast/AST.h
@@ -297,9 +297,19 @@ public:
 	/// This can only be called once types of variable declarations have already been resolved.
 	virtual Type const* type() const = 0;
 
-	/// @returns the type for members of the containing contract type that refer to this declaration.
+	/// Additional context for expressions that refer to contract members via the contract name.
+	/// Indicates whether the contract is a contract/interface or a library
+	/// and whether the access happens in a scope that belongs to that contract or outside (which affects visibility of members).
+	enum class ContractNameAccessKind {
+		Local,   ///< Via contract name, from within that contract or one deriving from it.
+		Foreign, ///< Via contract name, from foreign (unrelated) contract.
+		Library, ///< Via library name (no distinction between local or foreign access).
+	};
+
+	/// @returns the type for members of the containing contract type that refer to this declaration. Depends on access
+	/// context defined by `ContractNameAccessKind`.
 	/// This can only be called once types of variable declarations have already been resolved.
-	virtual Type const* typeViaContractName() const { return type(); }
+	virtual Type const* typeViaContractName(ContractNameAccessKind const) const { return type(); }
 
 	/// @param _internal false indicates external interface is concerned, true indicates internal interface is concerned.
 	/// @returns null when it is not accessible as a function.
@@ -1040,7 +1050,7 @@ public:
 	bool isVisibleViaContractTypeAccess() const override
 	{
 		solAssert(!isFree(), "");
-		return isOrdinary() && visibility() >= Visibility::Public;
+		return isPartOfExternalInterface();
 	}
 	bool isPartOfExternalInterface() const override { return isOrdinary() && isPublic(); }
 
@@ -1053,7 +1063,7 @@ public:
 	std::string externalIdentifierHex() const;
 
 	Type const* type() const override;
-	Type const* typeViaContractName() const override;
+	Type const* typeViaContractName(ContractNameAccessKind const _accessKind) const override;
 
 	/// @param _internal false indicates external interface is concerned, true indicates internal interface is concerned.
 	/// @returns null when it is not accessible as a function.

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -403,11 +403,7 @@ std::set<FunctionDefinition const*, ASTNode::CompareByID> Type::operatorDefiniti
 			auto const& functionDefinition = dynamic_cast<FunctionDefinition const&>(
 				*identifierPath->annotation().referencedDeclaration
 			);
-			auto const* functionType = dynamic_cast<FunctionType const*>(
-				functionDefinition.libraryFunction() ?
-				functionDefinition.typeViaContractName(Declaration::ContractNameAccessKind::Library) :
-				functionDefinition.type()
-			);
+			auto const* functionType = dynamic_cast<FunctionType const*>(functionDefinition.typeWhenAttached());
 			solAssert(functionType && !functionType->parameterTypes().empty());
 
 			size_t parameterCount = functionDefinition.parameterList().parameters().size();
@@ -427,8 +423,7 @@ MemberList::MemberMap Type::attachedFunctions(Type const& _type, ASTNode const& 
 	{
 		if (!_name)
 			_name = _function.name();
-		Type const* functionType =
-			_function.libraryFunction() ? _function.typeViaContractName(Declaration::ContractNameAccessKind::Library) : _function.type();
+		Type const* functionType = _function.typeWhenAttached();
 		solAssert(functionType, "");
 		FunctionType const* withBoundFirstArgument =
 			dynamic_cast<FunctionType const&>(*functionType).withBoundFirstArgument();

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -3975,32 +3975,37 @@ MemberList::MemberMap TypeType::nativeMembers(ASTNode const* _currentScope) cons
 				if (declaration->name().empty())
 					continue;
 
-				if (contract.isLibrary() && declaration->isVisibleAsLibraryMember())
+				if (!contract.isLibrary())
 				{
-					// In case the contract is library, add only visible library members. visibility >= Internal.
-					members.emplace_back(
-						declaration,
-						declaration->typeViaContractName(Declaration::ContractNameAccessKind::Library)
-					);
+					if (inDerivingScope)
+					{
+						if (declaration->isVisibleViaContractName(Declaration::ContractNameAccessKind::Local))
+						{
+							members.emplace_back(
+								declaration,
+								declaration->typeViaContractName(Declaration::ContractNameAccessKind::Local));
+						}
+					}
+					else // !inDerivingScope
+					{
+						if (declaration->isVisibleViaContractName(Declaration::ContractNameAccessKind::Foreign))
+						{
+							members.emplace_back(
+								declaration,
+								declaration->typeViaContractName(Declaration::ContractNameAccessKind::Foreign)
+							);
+						}
+					}
 				}
-				else if (!contract.isLibrary() && inDerivingScope && declaration->visibility() > Visibility::Private)
+				else // isLibrary
 				{
-					// In case of regular contract (not library) and member is in the same deriving scope, add all
-					// members which are not private. Private members cannot be accessed via contract type name
-					// i.e C.fooPrivate.
-					members.emplace_back(
-						declaration,
-						declaration->typeViaContractName(Declaration::ContractNameAccessKind::Local)
-					);
-				}
-				else if (!contract.isLibrary() && !inDerivingScope && declaration->isVisibleViaContractTypeAccess())
-				{
-					// In case of regular contract (not library) being accessed from foreign contract (not in deriving
-					// scope), add only externally visible members.
-					members.emplace_back(
-						declaration,
-						declaration->typeViaContractName(Declaration::ContractNameAccessKind::Foreign)
-					);
+					if (declaration->isVisibleViaContractName(Declaration::ContractNameAccessKind::Library))
+					{
+						members.emplace_back(
+							declaration,
+							declaration->typeViaContractName(Declaration::ContractNameAccessKind::Library)
+						);
+					}
 				}
 			}
 		}

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -404,7 +404,9 @@ std::set<FunctionDefinition const*, ASTNode::CompareByID> Type::operatorDefiniti
 				*identifierPath->annotation().referencedDeclaration
 			);
 			auto const* functionType = dynamic_cast<FunctionType const*>(
-				functionDefinition.libraryFunction() ? functionDefinition.typeViaContractName() : functionDefinition.type()
+				functionDefinition.libraryFunction() ?
+				functionDefinition.typeViaContractName(Declaration::ContractNameAccessKind::Library) :
+				functionDefinition.type()
 			);
 			solAssert(functionType && !functionType->parameterTypes().empty());
 
@@ -426,7 +428,7 @@ MemberList::MemberMap Type::attachedFunctions(Type const& _type, ASTNode const& 
 		if (!_name)
 			_name = _function.name();
 		Type const* functionType =
-			_function.libraryFunction() ? _function.typeViaContractName() : _function.type();
+			_function.libraryFunction() ? _function.typeViaContractName(Declaration::ContractNameAccessKind::Library) : _function.type();
 		solAssert(functionType, "");
 		FunctionType const* withBoundFirstArgument =
 			dynamic_cast<FunctionType const&>(*functionType).withBoundFirstArgument();
@@ -3978,21 +3980,33 @@ MemberList::MemberMap TypeType::nativeMembers(ASTNode const* _currentScope) cons
 				if (declaration->name().empty())
 					continue;
 
-				if (!contract.isLibrary() && inDerivingScope && declaration->isVisibleInDerivedContracts())
+				if (contract.isLibrary() && declaration->isVisibleAsLibraryMember())
 				{
-					if (
-						auto const* functionDefinition = dynamic_cast<FunctionDefinition const*>(declaration);
-						functionDefinition && !functionDefinition->isImplemented()
-					)
-						members.emplace_back(declaration, declaration->typeViaContractName());
-					else
-						members.emplace_back(declaration, declaration->type());
+					// In case the contract is library, add only visible library members. visibility >= Internal.
+					members.emplace_back(
+						declaration,
+						declaration->typeViaContractName(Declaration::ContractNameAccessKind::Library)
+					);
 				}
-				else if (
-					(contract.isLibrary() && declaration->isVisibleAsLibraryMember()) ||
-					declaration->isVisibleViaContractTypeAccess()
-				)
-					members.emplace_back(declaration, declaration->typeViaContractName());
+				else if (!contract.isLibrary() && inDerivingScope && declaration->visibility() > Visibility::Private)
+				{
+					// In case of regular contract (not library) and member is in the same deriving scope, add all
+					// members which are not private. Private members cannot be accessed via contract type name
+					// i.e C.fooPrivate.
+					members.emplace_back(
+						declaration,
+						declaration->typeViaContractName(Declaration::ContractNameAccessKind::Local)
+					);
+				}
+				else if (!contract.isLibrary() && !inDerivingScope && declaration->isVisibleViaContractTypeAccess())
+				{
+					// In case of regular contract (not library) being accessed from foreign contract (not in deriving
+					// scope), add only externally visible members.
+					members.emplace_back(
+						declaration,
+						declaration->typeViaContractName(Declaration::ContractNameAccessKind::Foreign)
+					);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This is a part of bigger [Rework purity flag setting for constant variables accessed via member access.](https://github.com/argotorg/solidity/pull/16376) which was splitted into a couple of smaller PRs.
This PR:
1. Improves a function name to make it consistent with what the function does.
2. Reworks `Declaration::typeViaContractName` implementation to make it easy to integrate by the following PRs.