### PR TITLE
Purity flag: Fix purity flag for struct instance member access.

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -3333,9 +3333,44 @@ bool TypeChecker::visit(MemberAccess const& _memberAccess)
 	{
 	case Type::Category::Struct:
 	{
-		auto const* owningObjectStructType = dynamic_cast<StructType const*>(owningObjectType);
-		solAssert(owningObjectStructType);
-		_memberAccess.annotation().isLValue = !owningObjectStructType->dataStoredIn(DataLocation::CallData);
+		_memberAccess.annotation().isLValue = !static_cast<StructType const*>(owningObjectType)->dataStoredIn(DataLocation::CallData);
+
+		if (
+			auto const* accessedVariableDeclaration =
+				dynamic_cast<VariableDeclaration const*>(_memberAccess.annotation().referencedDeclaration)
+		)
+		{
+			_memberAccess.annotation().isPure =
+				*_memberAccess.expression().annotation().isPure ||
+				accessedVariableDeclaration->isConstant(); // It is always false. See below.
+
+			solUnimplementedAssert(
+				!accessedVariableDeclaration->isConstant(),
+				"Constant struct members are not yet implemented."
+			);
+		}
+		else if (dynamic_cast<FunctionDefinition const*>(_memberAccess.annotation().referencedDeclaration))
+		{
+			solAssert(_memberAccess.annotation().type->category() == Type::Category::Function);
+			auto const* accessedMemberFunctionType = static_cast<FunctionType const*>(_memberAccess.annotation().type);
+			// It is not possible to define a function inside a struct definition, but a library function can be
+			// attached to a struct with the `using` keyword. In this case the function invoke kind can be only
+			// `internal` or `delegate`.
+			solAssert(
+				accessedMemberFunctionType->kind() == FunctionType::Kind::Internal ||
+				accessedMemberFunctionType->kind() == FunctionType::Kind::DelegateCall,
+				"Impossible function call kind for struct type member."
+			);
+
+			// When struct is constant its members are also constant.
+			_memberAccess.annotation().isPure = *_memberAccess.expression().annotation().isPure;
+		}
+		else
+			solAssert(
+				false,
+				"Struct must have all members defined and they must be variables declarations or functions definitions"
+			);
+
 		break;
 	}
 	case Type::Category::Function:

--- a/test/libsolidity/syntaxTests/purity/member_access/struct/attached_function_is_not_constant.sol
+++ b/test/libsolidity/syntaxTests/purity/member_access/struct/attached_function_is_not_constant.sol
@@ -1,0 +1,22 @@
+struct S {
+    uint256 v;
+}
+
+library L {
+    function double(S memory s) pure public returns(uint256) {
+        return 2 * s.v;
+    }
+}
+
+using L for S;
+
+contract C
+{
+    S private s;
+    function test() pure private {
+        s.double;
+    }
+}
+// ----
+// TypeError 2527: (226-227): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".
+// TypeError 2527: (226-234): Function declared as pure, but this expression (potentially) reads from the environment or state and thus requires "view".

--- a/test/libsolidity/syntaxTests/purity/member_access/struct/inline_struct_creation_is_constant.sol
+++ b/test/libsolidity/syntaxTests/purity/member_access/struct/inline_struct_creation_is_constant.sol
@@ -1,0 +1,38 @@
+struct S {
+    uint256 v;
+}
+
+library L {
+    function doubleInternal(S memory s) pure internal returns(uint256) {
+        return 2 * s.v;
+    }
+
+    function doubleExternal(S memory s) pure external returns(uint256) {
+        return 2 * s.v;
+    }
+
+    function doublePublic(S memory s) pure public returns(uint256) {
+        return 2 * s.v;
+    }
+}
+
+using L for S;
+
+contract C
+{
+    uint256 constant s = S(1).v;
+
+    function test() pure private {
+        S(1);
+        S(1).v;
+        S(1).doubleInternal;
+        S(1).doubleExternal;
+        S(1).doublePublic;
+    }
+}
+// ----
+// Warning 6133: (457-461): Statement has no effect.
+// Warning 6133: (471-477): Statement has no effect.
+// Warning 6133: (487-506): Statement has no effect.
+// Warning 6133: (516-535): Statement has no effect.
+// Warning 6133: (545-562): Statement has no effect.

--- a/test/libsolidity/syntaxTests/purity/member_access/struct/struct_field_is_not_constant.sol
+++ b/test/libsolidity/syntaxTests/purity/member_access/struct/struct_field_is_not_constant.sol
@@ -1,0 +1,12 @@
+struct S {
+    uint256 v;
+}
+
+contract C
+{
+    S private s;
+    uint256 v = s.v;
+    uint256 constant vConst = s.v;
+}
+// ----
+// TypeError 8349: (110-113): Initial value for constant variable has to be compile-time constant.


### PR DESCRIPTION
This is a part of bigger [Rework purity flag setting for constant variables accessed via member access.](https://github.com/argotorg/solidity/pull/16376) which was splitted into a couple of smaller PRs.

This PR sets purity flag for constant struct instance.

Struct instance member can be only variable or a library function attached to the struct. For now the only possible way to have constant/pure struct instance is by inline declaration i.e. `S(1).v`

~Depends on: https://github.com/argotorg/solidity/pull/16625~