### PR TITLE
SSA CFG: remove Yul Scope::Function and Yul Scope::Variable

### DIFF
--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -76,8 +76,8 @@ add_library(yul
 	backends/evm/ssa/BridgeFinder.h
 	backends/evm/ssa/CodeTransform.cpp
 	backends/evm/ssa/CodeTransform.h
-	backends/evm/ssa/ControlFlow.cpp
-	backends/evm/ssa/ControlFlow.h
+	backends/evm/ssa/ControlFlowGraphs.cpp
+	backends/evm/ssa/ControlFlowGraphs.h
 	backends/evm/ssa/JunkAdmittingBlocksFinder.cpp
 	backends/evm/ssa/JunkAdmittingBlocksFinder.h
 	backends/evm/ssa/LivenessAnalysis.cpp

--- a/libyul/YulStack.cpp
+++ b/libyul/YulStack.cpp
@@ -396,14 +396,14 @@ Json YulStack::cfgJson() const
 		// operations to the control flow graphs
 		bool constexpr keepLiteralAssignments = true;
 		// NOTE: The block Ids are reset for each object
-		std::unique_ptr<ssa::ControlFlow> controlFlow = ssa::SSACFGBuilder::build(
+		std::unique_ptr<ssa::ControlFlowGraphs> controlFlowGraphs = ssa::SSACFGBuilder::build(
 			*_object.analysisInfo,
 			EVMDialect::strictAssemblyForEVMObjects(m_evmVersion, m_eofVersion),
 			_object.code()->root(),
 			keepLiteralAssignments
 		);
-		std::unique_ptr<ssa::ControlFlowLiveness> liveness = std::make_unique<ssa::ControlFlowLiveness>(*controlFlow);
-		return ssa::io::json::exportControlFlow(*controlFlow, liveness.get());
+		std::unique_ptr<ssa::ControlFlowGraphsLiveness> liveness = std::make_unique<ssa::ControlFlowGraphsLiveness>(*controlFlowGraphs);
+		return ssa::io::json::exportControlFlow(*controlFlowGraphs, liveness.get());
 	};
 
 	std::function<Json(std::vector<std::shared_ptr<ObjectNode>>)> exportCFGFromSubObjects;

--- a/libyul/backends/evm/EVMObjectCompiler.cpp
+++ b/libyul/backends/evm/EVMObjectCompiler.cpp
@@ -23,7 +23,7 @@
 
 #include <libyul/backends/evm/ssa/CodeTransform.h>
 #include <libyul/backends/evm/ssa/SSACFGBuilder.h>
-#include <libyul/backends/evm/ssa/ControlFlow.h>
+#include <libyul/backends/evm/ssa/ControlFlowGraphs.h>
 
 #include <libyul/backends/evm/EVMCodeTransform.h>
 #include <libyul/backends/evm/EVMDialect.h>
@@ -89,13 +89,13 @@ void EVMObjectCompiler::run(Object const& _object, bool _optimize, bool _viaSSAC
 	{
 		if (_viaSSACFG)
 		{
-			std::unique_ptr<ssa::ControlFlow> controlFlow = ssa::SSACFGBuilder::build(
+			std::unique_ptr<ssa::ControlFlowGraphs> controlFlowGraphs = ssa::SSACFGBuilder::build(
 				*_object.analysisInfo,
 				*evmDialect,
 				_object.code()->root(),
 				false
 			);
-			ssa::ControlFlowLiveness const liveness(*controlFlow);
+			ssa::ControlFlowGraphsLiveness const liveness(*controlFlowGraphs);
 			ssa::CodeTransform::run(
 				m_assembly,
 				liveness,

--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -101,7 +101,7 @@ CodeTransform::FunctionLabels CodeTransform::registerFunctionLabels(
 			_assembly.namedLabel(
 				functionGraph.name,
 				functionGraph.arguments.size(),
-				functionGraph.returns.size(),
+				functionGraph.numReturns,
 				sourceID
 			) :
 			_assembly.newLabelId();
@@ -161,7 +161,7 @@ CodeTransform::CodeTransform(
 	expectedStackTop.reserve(m_cfg.arguments.size() + (isFunctionGraph && m_cfg.canContinue ? 1 : 0));
 	if (isFunctionGraph && m_cfg.canContinue)
 		expectedStackTop.push_back(StackSlot::makeFunctionReturnLabel(m_graphID));
-	for (auto const& [_, valueID]: m_cfg.arguments | ranges::views::reverse)
+	for (auto const& valueID: m_cfg.arguments | ranges::views::reverse)
 		expectedStackTop.push_back(StackSlot::makeValueID(valueID));
 	assertLayoutCompatibility(m_stack.data(), expectedStackTop);
 }
@@ -367,7 +367,7 @@ void CodeTransform::operator()(SSACFG::BlockId const&, SSACFG::BasicBlock::Funct
 {
 	yulAssert(static_cast<int>(m_stack.size()) == m_assembly.stackHeight());
 	// Each CodeTransform instance handles exactly one function's CFG, so a FunctionReturn exit
-	// here necessarily belongs to m_cfg.function. No identity cross-check is needed.
+	// here necessarily belongs to a function graph. No identity cross-check is needed.
 	yulAssert(!m_cfg.isMainGraph());
 	yulAssert(m_cfg.canContinue);
 	yulAssert(m_stack.size() == _functionReturn.returnValues.size() + 1, "There must be at least the function return label element on stack");

--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -53,11 +53,12 @@ void CodeTransform::run
 	yulAssert(controlFlow.functionGraphs.size() == _controlFlowLiveness.cfgLiveness.size());
 	FunctionLabels const functionLabels = registerFunctionLabels(_assembly, controlFlow);
 
-	for (std::size_t functionIndex = 0; functionIndex < controlFlow.functionGraphMapping.size(); ++functionIndex)
+	for (std::size_t functionIndex = 0; functionIndex < controlFlow.functionGraphs.size(); ++functionIndex)
 	{
-		auto const& [function, cfg] = controlFlow.functionGraphMapping[functionIndex];
-		yulAssert(cfg);
-		auto const callSites = gatherCallSites(*cfg);
+		std::unique_ptr<SSACFG> const& functionGraphPtr = controlFlow.functionGraphs[functionIndex];
+		yulAssert(functionGraphPtr);
+		SSACFG const& cfg = *functionGraphPtr;
+		auto const callSites = gatherCallSites(cfg);
 		auto const& liveness = _controlFlowLiveness.cfgLiveness[functionIndex];
 		yulAssert(liveness);
 		auto const graphID = static_cast<ControlFlow::FunctionGraphID>(functionIndex);
@@ -65,14 +66,14 @@ void CodeTransform::run
 		CodeTransform transform(
 			_assembly,
 			_builtinContext,
+			controlFlow,
 			functionLabels,
 			callSites,
-			*cfg,
+			cfg,
 			stackLayout,
-			function,
 			graphID
 		);
-		transform(cfg->entry);
+		transform(cfg.entry);
 	}
 }
 
@@ -80,23 +81,27 @@ CodeTransform::FunctionLabels CodeTransform::registerFunctionLabels(
 	AbstractAssembly& _assembly, ControlFlow const& _controlFlow)
 {
 	FunctionLabels functionLabels;
-	std::set<YulString> assignedFunctionNames;
+	std::set<std::string> assignedFunctionNames;
 
-	for (auto const& [_function, _functionGraph]: _controlFlow.functionGraphMapping)
+	for (std::size_t index = 0; index < _controlFlow.functionGraphs.size(); ++index)
 	{
-		if (!_function)
+		std::unique_ptr<SSACFG> const& functionGraphPtr = _controlFlow.functionGraphs[index];
+		yulAssert(functionGraphPtr);
+		SSACFG const& functionGraph = *functionGraphPtr;
+		if (functionGraph.isMainGraph())
 			continue;
-		bool nameAlreadySeen = !assignedFunctionNames.insert(_function->name).second;
+		auto const graphID = static_cast<ControlFlow::FunctionGraphID>(index);
+		bool const nameAlreadySeen = !assignedFunctionNames.insert(functionGraph.name).second;
 		auto const sourceID = [&]() -> std::optional<std::size_t> {
-			if (_functionGraph->debugInfo && _functionGraph->debugInfo->graphDebugData)
-				return _functionGraph->debugInfo->graphDebugData->astID;
+			if (functionGraph.debugInfo && functionGraph.debugInfo->graphDebugData)
+				return functionGraph.debugInfo->graphDebugData->astID;
 			return std::nullopt;
 		}();
-		functionLabels[_function] = !nameAlreadySeen ?
+		functionLabels[graphID] = !nameAlreadySeen ?
 			_assembly.namedLabel(
-				_function->name.str(),
-				_functionGraph->arguments.size(),
-				_functionGraph->returns.size(),
+				functionGraph.name,
+				functionGraph.arguments.size(),
+				functionGraph.returns.size(),
 				sourceID
 			) :
 			_assembly.newLabelId();
@@ -107,15 +112,16 @@ CodeTransform::FunctionLabels CodeTransform::registerFunctionLabels(
 CodeTransform::CodeTransform(
 	AbstractAssembly& _assembly,
 	BuiltinContext& _builtinContext,
+	ControlFlow const& _controlFlow,
 	FunctionLabels const& _functionLabels,
 	CallSites const& _callSites,
 	SSACFG const& _cfg,
 	SSACFGStackLayout const& _stackLayout,
-	Scope::Function const* _function,
 	ControlFlow::FunctionGraphID _graphID
 ):
 	m_assembly(_assembly),
 	m_builtinContext(_builtinContext),
+	m_controlFlow(_controlFlow),
 	m_functionLabels(_functionLabels),
 	m_callSites(_callSites),
 	m_cfg(_cfg),
@@ -143,17 +149,18 @@ CodeTransform::CodeTransform(
 	}()),
 	m_stack(m_stackData, m_assemblyCallbacks)
 {
-	if (_function)
+	bool const isFunctionGraph = !m_cfg.isMainGraph();
+	if (isFunctionGraph)
 	{
-		auto const findIt = m_functionLabels.find(_function);
+		auto const findIt = m_functionLabels.find(_graphID);
 		yulAssert(findIt != m_functionLabels.end());
 		m_assembly.appendLabel(findIt->second);
-		m_assembly.setStackHeight(static_cast<int>(_function->numArguments) + (m_cfg.canContinue ? 1 : 0));
+		m_assembly.setStackHeight(static_cast<int>(m_cfg.arguments.size()) + (m_cfg.canContinue ? 1 : 0));
 	}
 	StackData expectedStackTop;
-	expectedStackTop.reserve(m_cfg.arguments.size() + (!m_cfg.isMainGraph() && m_cfg.canContinue ? 1 : 0));
-		if (!m_cfg.isMainGraph() && m_cfg.canContinue)
-			expectedStackTop.push_back(StackSlot::makeFunctionReturnLabel(m_graphID));
+	expectedStackTop.reserve(m_cfg.arguments.size() + (isFunctionGraph && m_cfg.canContinue ? 1 : 0));
+	if (isFunctionGraph && m_cfg.canContinue)
+		expectedStackTop.push_back(StackSlot::makeFunctionReturnLabel(m_graphID));
 	for (auto const& [_, valueID]: m_cfg.arguments | ranges::views::reverse)
 		expectedStackTop.push_back(StackSlot::makeValueID(valueID));
 	assertLayoutCompatibility(m_stack.data(), expectedStackTop);
@@ -266,9 +273,11 @@ void CodeTransform::operator()(SSACFG::OperationId _opId, StackData const& _oper
 			// check that if we have a return label, the call can continue
 			yulAssert(!!returnLabel == _call.canContinue);
 			m_assembly.setSourceLocation(opOriginLocation);
+			SSACFG const* calleeCFG  = m_controlFlow.functionGraph(_call.graphID);
+			yulAssert(calleeCFG);
 			m_assembly.appendJumpTo(
-				m_functionLabels.at(&_call.function.get()),
-				static_cast<int>(_call.function.get().numReturns - _call.function.get().numArguments) - (_call.canContinue ? 1 : 0),
+				m_functionLabels.at(_call.graphID),
+				static_cast<int>(calleeCFG->numReturns) - static_cast<int>(calleeCFG->arguments.size()) - (_call.canContinue ? 1 : 0),
 				AbstractAssembly::JumpType::IntoFunction
 			);
 			// if we have a return label, append it to assembly and pop the label from the stack

--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -44,29 +44,29 @@ void assertLayoutCompatibility(StackData const& _layout1, StackData const& _layo
 void CodeTransform::run
 (
 	AbstractAssembly& _assembly,
-	ControlFlowLiveness const& _controlFlowLiveness,
+	ControlFlowGraphsLiveness const& _controlFlowLiveness,
 	BuiltinContext& _builtinContext
 )
 {
 	yulAssert(!_controlFlowLiveness.cfgLiveness.empty());
-	ControlFlow const& controlFlow = _controlFlowLiveness.controlFlow.get();
-	yulAssert(controlFlow.functionGraphs.size() == _controlFlowLiveness.cfgLiveness.size());
-	FunctionLabels const functionLabels = registerFunctionLabels(_assembly, controlFlow);
+	ControlFlowGraphs const& controlFlowGraphs = _controlFlowLiveness.controlFlowGraphs.get();
+	yulAssert(controlFlowGraphs.functionGraphs.size() == _controlFlowLiveness.cfgLiveness.size());
+	FunctionLabels const functionLabels = registerFunctionLabels(_assembly, controlFlowGraphs);
 
-	for (std::size_t functionIndex = 0; functionIndex < controlFlow.functionGraphs.size(); ++functionIndex)
+	for (std::size_t functionIndex = 0; functionIndex < controlFlowGraphs.functionGraphs.size(); ++functionIndex)
 	{
-		std::unique_ptr<SSACFG> const& functionGraphPtr = controlFlow.functionGraphs[functionIndex];
+		std::unique_ptr<SSACFG> const& functionGraphPtr = controlFlowGraphs.functionGraphs[functionIndex];
 		yulAssert(functionGraphPtr);
 		SSACFG const& cfg = *functionGraphPtr;
 		auto const callSites = gatherCallSites(cfg);
 		auto const& liveness = _controlFlowLiveness.cfgLiveness[functionIndex];
 		yulAssert(liveness);
-		auto const graphID = static_cast<ControlFlow::FunctionGraphID>(functionIndex);
+		auto const graphID = static_cast<ControlFlowGraphs::FunctionGraphID>(functionIndex);
 		auto const& stackLayout = StackLayoutGenerator::generate(*liveness, callSites, graphID);
 		CodeTransform transform(
 			_assembly,
 			_builtinContext,
-			controlFlow,
+			controlFlowGraphs,
 			functionLabels,
 			callSites,
 			cfg,
@@ -78,7 +78,7 @@ void CodeTransform::run
 }
 
 CodeTransform::FunctionLabels CodeTransform::registerFunctionLabels(
-	AbstractAssembly& _assembly, ControlFlow const& _controlFlow)
+	AbstractAssembly& _assembly, ControlFlowGraphs const& _controlFlow)
 {
 	FunctionLabels functionLabels;
 	std::set<std::string> assignedFunctionNames;
@@ -90,7 +90,7 @@ CodeTransform::FunctionLabels CodeTransform::registerFunctionLabels(
 		SSACFG const& functionGraph = *functionGraphPtr;
 		if (functionGraph.isMainGraph())
 			continue;
-		auto const graphID = static_cast<ControlFlow::FunctionGraphID>(index);
+		auto const graphID = static_cast<ControlFlowGraphs::FunctionGraphID>(index);
 		bool const nameAlreadySeen = !assignedFunctionNames.insert(functionGraph.name).second;
 		auto const sourceID = [&]() -> std::optional<std::size_t> {
 			if (functionGraph.debugInfo && functionGraph.debugInfo->graphDebugData)
@@ -112,12 +112,12 @@ CodeTransform::FunctionLabels CodeTransform::registerFunctionLabels(
 CodeTransform::CodeTransform(
 	AbstractAssembly& _assembly,
 	BuiltinContext& _builtinContext,
-	ControlFlow const& _controlFlow,
+	ControlFlowGraphs const& _controlFlow,
 	FunctionLabels const& _functionLabels,
 	CallSites const& _callSites,
 	SSACFG const& _cfg,
 	SSACFGStackLayout const& _stackLayout,
-	ControlFlow::FunctionGraphID _graphID
+	ControlFlowGraphs::FunctionGraphID _graphID
 ):
 	m_assembly(_assembly),
 	m_builtinContext(_builtinContext),

--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -151,8 +151,8 @@ CodeTransform::CodeTransform(
 		m_assembly.setStackHeight(static_cast<int>(_function->numArguments) + (m_cfg.canContinue ? 1 : 0));
 	}
 	StackData expectedStackTop;
-	expectedStackTop.reserve(m_cfg.arguments.size() + (m_cfg.function && m_cfg.canContinue ? 1 : 0));
-		if (m_cfg.function && m_cfg.canContinue)
+	expectedStackTop.reserve(m_cfg.arguments.size() + (!m_cfg.isMainGraph() && m_cfg.canContinue ? 1 : 0));
+		if (!m_cfg.isMainGraph() && m_cfg.canContinue)
 			expectedStackTop.push_back(StackSlot::makeFunctionReturnLabel(m_graphID));
 	for (auto const& [_, valueID]: m_cfg.arguments | ranges::views::reverse)
 		expectedStackTop.push_back(StackSlot::makeValueID(valueID));
@@ -359,7 +359,7 @@ void CodeTransform::operator()(SSACFG::BlockId const&, SSACFG::BasicBlock::Funct
 	yulAssert(static_cast<int>(m_stack.size()) == m_assembly.stackHeight());
 	// Each CodeTransform instance handles exactly one function's CFG, so a FunctionReturn exit
 	// here necessarily belongs to m_cfg.function. No identity cross-check is needed.
-	yulAssert(m_cfg.function);
+	yulAssert(!m_cfg.isMainGraph());
 	yulAssert(m_cfg.canContinue);
 	yulAssert(m_stack.size() == _functionReturn.returnValues.size() + 1, "There must be at least the function return label element on stack");
 	yulAssert(m_stack.top().isFunctionReturnLabel());

--- a/libyul/backends/evm/ssa/CodeTransform.h
+++ b/libyul/backends/evm/ssa/CodeTransform.h
@@ -100,7 +100,7 @@ public:
 	);
 
 private:
-	using FunctionLabels = std::map<Scope::Function const*, AbstractAssembly::LabelID>;
+	using FunctionLabels = std::map<ControlFlow::FunctionGraphID, AbstractAssembly::LabelID>;
 
 	static FunctionLabels registerFunctionLabels(
 		AbstractAssembly& _assembly,
@@ -110,11 +110,11 @@ private:
 	CodeTransform(
 		AbstractAssembly& _assembly,
 		BuiltinContext& _builtinContext,
+		ControlFlow const& _controlFlow,
 		FunctionLabels const& _functionLabels,
 		CallSites const& _callSites,
 		SSACFG const& _cfg,
 		SSACFGStackLayout const& _stackLayout,
-		Scope::Function const* _function,
 		ControlFlow::FunctionGraphID _graphID);
 
 	void operator()(SSACFG::BlockId _blockId);
@@ -129,6 +129,7 @@ private:
 
 	AbstractAssembly& m_assembly;
 	BuiltinContext& m_builtinContext;
+	ControlFlow const& m_controlFlow;
 	FunctionLabels const& m_functionLabels;
 	CallSites const& m_callSites;
 	SSACFG const& m_cfg;

--- a/libyul/backends/evm/ssa/CodeTransform.h
+++ b/libyul/backends/evm/ssa/CodeTransform.h
@@ -95,27 +95,27 @@ class CodeTransform
 public:
 	static void run(
 		AbstractAssembly& _assembly,
-		ControlFlowLiveness const& _liveness,
+		ControlFlowGraphsLiveness const& _liveness,
 		BuiltinContext& _builtinContext
 	);
 
 private:
-	using FunctionLabels = std::map<ControlFlow::FunctionGraphID, AbstractAssembly::LabelID>;
+	using FunctionLabels = std::map<ControlFlowGraphs::FunctionGraphID, AbstractAssembly::LabelID>;
 
 	static FunctionLabels registerFunctionLabels(
 		AbstractAssembly& _assembly,
-		ControlFlow const& _controlFlow
+		ControlFlowGraphs const& _controlFlow
 	);
 
 	CodeTransform(
 		AbstractAssembly& _assembly,
 		BuiltinContext& _builtinContext,
-		ControlFlow const& _controlFlow,
+		ControlFlowGraphs const& _controlFlow,
 		FunctionLabels const& _functionLabels,
 		CallSites const& _callSites,
 		SSACFG const& _cfg,
 		SSACFGStackLayout const& _stackLayout,
-		ControlFlow::FunctionGraphID _graphID);
+		ControlFlowGraphs::FunctionGraphID _graphID);
 
 	void operator()(SSACFG::BlockId _blockId);
 	void operator()(SSACFG::OperationId _opId, StackData const& _operationInputLayout);
@@ -129,12 +129,12 @@ private:
 
 	AbstractAssembly& m_assembly;
 	BuiltinContext& m_builtinContext;
-	ControlFlow const& m_controlFlow;
+	ControlFlowGraphs const& m_controlFlow;
 	FunctionLabels const& m_functionLabels;
 	CallSites const& m_callSites;
 	SSACFG const& m_cfg;
 	SSACFGStackLayout const& m_stackLayout;
-	ControlFlow::FunctionGraphID const m_graphID;
+	ControlFlowGraphs::FunctionGraphID const m_graphID;
 
 	std::vector<std::uint8_t> m_blockIsTransformed;
 	std::vector<AbstractAssembly::LabelID> m_blockLabels;

--- a/libyul/backends/evm/ssa/ControlFlow.h
+++ b/libyul/backends/evm/ssa/ControlFlow.h
@@ -22,9 +22,6 @@
 #include <libyul/backends/evm/ssa/SSACFG.h>
 
 #include <libyul/AST.h>
-#include <libyul/Scope.h>
-
-#include <range/v3/algorithm/find_if.hpp>
 
 namespace solidity::yul::ssa
 {
@@ -48,14 +45,6 @@ struct ControlFlow
 
 	SSACFG const* mainGraph() const { return functionGraph(mainGraphID()); }
 
-	SSACFG const* functionGraph(Scope::Function const* _function) const
-	{
-		auto it = ranges::find_if(functionGraphMapping, [_function](auto const& tup) { return _function == std::get<0>(tup); });
-		if (it != functionGraphMapping.end())
-			return std::get<1>(*it);
-		return nullptr;
-	}
-
 	SSACFG const* functionGraph(FunctionGraphID const _id) const
 	{
 		return functionGraphs.at(_id).get();
@@ -72,7 +61,8 @@ struct ControlFlow
 			output << functionGraphs[index]->toDot(
 				false,
 				index,
-				_liveness ? _liveness->cfgLiveness[index].get() : nullptr
+				_liveness ? _liveness->cfgLiveness[index].get() : nullptr,
+				this
 			);
 
 		output << "}\n";
@@ -80,7 +70,6 @@ struct ControlFlow
 	}
 
 	std::vector<std::unique_ptr<SSACFG>> functionGraphs{};
-	std::vector<std::tuple<Scope::Function const*, SSACFG const*>> functionGraphMapping{};
 };
 
 }

--- a/libyul/backends/evm/ssa/ControlFlow.h
+++ b/libyul/backends/evm/ssa/ControlFlow.h
@@ -42,7 +42,7 @@ struct ControlFlowLiveness{
 
 struct ControlFlow
 {
-	using FunctionGraphID = std::uint32_t;
+	using FunctionGraphID = ssa::FunctionGraphID;
 
 	static FunctionGraphID constexpr mainGraphID() noexcept { return 0; }
 

--- a/libyul/backends/evm/ssa/ControlFlowGraphs.cpp
+++ b/libyul/backends/evm/ssa/ControlFlowGraphs.cpp
@@ -16,19 +16,19 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
-#include <libyul/backends/evm/ssa/ControlFlow.h>
+#include <libyul/backends/evm/ssa/ControlFlowGraphs.h>
 
 #include <range/v3/view/transform.hpp>
 #include <range/v3/range/conversion.hpp>
 
 using namespace solidity::yul::ssa;
 
-ControlFlowLiveness::ControlFlowLiveness(ControlFlow const& _controlFlow):
-	controlFlow(_controlFlow),
+ControlFlowGraphsLiveness::ControlFlowGraphsLiveness(ControlFlowGraphs const& _controlFlow):
+	controlFlowGraphs(_controlFlow),
 	cfgLiveness(_controlFlow.functionGraphs | ranges::views::transform([](auto const& _cfg) { return std::make_unique<LivenessAnalysis>(*_cfg); }) | ranges::to<std::vector>)
 { }
 
-std::string ControlFlowLiveness::toDot() const
+std::string ControlFlowGraphsLiveness::toDot() const
 {
-	return controlFlow.get().toDot(this);
+	return controlFlowGraphs.get().toDot(this);
 }

--- a/libyul/backends/evm/ssa/ControlFlowGraphs.h
+++ b/libyul/backends/evm/ssa/ControlFlowGraphs.h
@@ -26,18 +26,18 @@
 namespace solidity::yul::ssa
 {
 
-struct ControlFlow;
+struct ControlFlowGraphs;
 
-struct ControlFlowLiveness{
-	explicit ControlFlowLiveness(ControlFlow const& _controlFlow);
+struct ControlFlowGraphsLiveness{
+	explicit ControlFlowGraphsLiveness(ControlFlowGraphs const& _controlFlow);
 
-	std::reference_wrapper<ControlFlow const> controlFlow;
+	std::reference_wrapper<ControlFlowGraphs const> controlFlowGraphs;
 	std::vector<std::unique_ptr<LivenessAnalysis>> cfgLiveness;
 
 	std::string toDot() const;
 };
 
-struct ControlFlow
+struct ControlFlowGraphs
 {
 	using FunctionGraphID = ssa::FunctionGraphID;
 
@@ -50,10 +50,10 @@ struct ControlFlow
 		return functionGraphs.at(_id).get();
 	}
 
-	std::string toDot(ControlFlowLiveness const* _liveness=nullptr) const
+	std::string toDot(ControlFlowGraphsLiveness const* _liveness=nullptr) const
 	{
 		if (_liveness)
-			yulAssert(&_liveness->controlFlow.get() == this);
+			yulAssert(&_liveness->controlFlowGraphs.get() == this);
 		std::ostringstream output;
 		output << "digraph SSACFG {\nnodesep=0.7;\ngraph[fontname=\"DejaVu Sans\"]\nnode[shape=box,fontname=\"DejaVu Sans\"];\n\n";
 

--- a/libyul/backends/evm/ssa/SSACFG.cpp
+++ b/libyul/backends/evm/ssa/SSACFG.cpp
@@ -18,7 +18,7 @@
 
 #include <libyul/backends/evm/ssa/SSACFG.h>
 
-#include <libyul/backends/evm/ssa/ControlFlow.h>
+#include <libyul/backends/evm/ssa/ControlFlowGraphs.h>
 #include <libyul/backends/evm/ssa/LivenessAnalysis.h>
 #include <libyul/backends/evm/ssa/JunkAdmittingBlocksFinder.h>
 #include <libyul/backends/evm/ssa/io/DotExporterBase.h>
@@ -59,7 +59,7 @@ std::string formatPhi(SSACFG const& _cfg, SSACFG::ValueId _phiId)
 class SSACFGDotExporter: public io::DotExporterBase
 {
 public:
-	SSACFGDotExporter(SSACFG const& _cfg, size_t _functionIndex, LivenessAnalysis const* _liveness, ControlFlow const* _controlFlow):
+	SSACFGDotExporter(SSACFG const& _cfg, size_t _functionIndex, LivenessAnalysis const* _liveness, ControlFlowGraphs const* _controlFlow):
 		DotExporterBase(_cfg, _functionIndex),
 		m_liveness(_liveness),
 		m_controlFlow(_controlFlow)
@@ -143,7 +143,7 @@ protected:
 
 private:
 	LivenessAnalysis const* m_liveness;
-	ControlFlow const* m_controlFlow;
+	ControlFlowGraphs const* m_controlFlow;
 	std::unique_ptr<JunkAdmittingBlocksFinder> m_junkAdmittingBlocks;
 };
 
@@ -168,7 +168,7 @@ std::string SSACFG::toDot(
 	bool _includeDiGraphDefinition,
 	std::optional<size_t> _functionIndex,
 	LivenessAnalysis const* _liveness,
-	ControlFlow const* _controlFlow
+	ControlFlowGraphs const* _controlFlow
 ) const
 {
 	SSACFGDotExporter exporter(*this, _functionIndex.value_or(isMainGraph() ? 0 : 1), _liveness, _controlFlow);

--- a/libyul/backends/evm/ssa/SSACFG.cpp
+++ b/libyul/backends/evm/ssa/SSACFG.cpp
@@ -18,6 +18,7 @@
 
 #include <libyul/backends/evm/ssa/SSACFG.h>
 
+#include <libyul/backends/evm/ssa/ControlFlow.h>
 #include <libyul/backends/evm/ssa/LivenessAnalysis.h>
 #include <libyul/backends/evm/ssa/JunkAdmittingBlocksFinder.h>
 #include <libyul/backends/evm/ssa/io/DotExporterBase.h>
@@ -58,9 +59,10 @@ std::string formatPhi(SSACFG const& _cfg, SSACFG::ValueId _phiId)
 class SSACFGDotExporter: public io::DotExporterBase
 {
 public:
-	SSACFGDotExporter(SSACFG const& _cfg, size_t _functionIndex, LivenessAnalysis const* _liveness):
+	SSACFGDotExporter(SSACFG const& _cfg, size_t _functionIndex, LivenessAnalysis const* _liveness, ControlFlow const* _controlFlow):
 		DotExporterBase(_cfg, _functionIndex),
-		m_liveness(_liveness)
+		m_liveness(_liveness),
+		m_controlFlow(_controlFlow)
 	{
 		if (_liveness)
 			m_junkAdmittingBlocks = std::make_unique<JunkAdmittingBlocksFinder>(_cfg, _liveness->topologicalSort());
@@ -103,10 +105,12 @@ protected:
 		{
 			auto const& operation = m_cfg.operation(opId);
 			std::string const label = std::visit(GenericVisitor{
-				[&](SSACFG::Call const& _call) {
-					return _call.function.get().name.str();
+				[&](SSACFG::Call const& _call) -> std::string {
+					if (m_controlFlow)
+						return m_controlFlow->functionGraph(_call.graphID)->name;
+					return fmt::format("func{}", _call.graphID);
 				},
-				[&](SSACFG::BuiltinCall const& _call) {
+				[&](SSACFG::BuiltinCall const& _call) -> std::string {
 					return _call.builtin.get().name;
 				}
 			}, operation.kind);
@@ -139,6 +143,7 @@ protected:
 
 private:
 	LivenessAnalysis const* m_liveness;
+	ControlFlow const* m_controlFlow;
 	std::unique_ptr<JunkAdmittingBlocksFinder> m_junkAdmittingBlocks;
 };
 
@@ -162,10 +167,11 @@ std::string ValueId::str(SSACFG const& _cfg) const
 std::string SSACFG::toDot(
 	bool _includeDiGraphDefinition,
 	std::optional<size_t> _functionIndex,
-	LivenessAnalysis const* _liveness
+	LivenessAnalysis const* _liveness,
+	ControlFlow const* _controlFlow
 ) const
 {
-	SSACFGDotExporter exporter(*this, _functionIndex.value_or(isMainGraph() ? 0 : 1), _liveness);
+	SSACFGDotExporter exporter(*this, _functionIndex.value_or(isMainGraph() ? 0 : 1), _liveness, _controlFlow);
 	if (!isMainGraph())
 		return exporter.exportFunction(*function, _includeDiGraphDefinition);
 	else

--- a/libyul/backends/evm/ssa/SSACFG.cpp
+++ b/libyul/backends/evm/ssa/SSACFG.cpp
@@ -165,8 +165,8 @@ std::string SSACFG::toDot(
 	LivenessAnalysis const* _liveness
 ) const
 {
-	SSACFGDotExporter exporter(*this, _functionIndex.value_or(function ? 1 : 0), _liveness);
-	if (function)
+	SSACFGDotExporter exporter(*this, _functionIndex.value_or(isMainGraph() ? 0 : 1), _liveness);
+	if (!isMainGraph())
 		return exporter.exportFunction(*function, _includeDiGraphDefinition);
 	else
 		return exporter.exportBlocks(entry, _includeDiGraphDefinition);

--- a/libyul/backends/evm/ssa/SSACFG.cpp
+++ b/libyul/backends/evm/ssa/SSACFG.cpp
@@ -173,7 +173,7 @@ std::string SSACFG::toDot(
 {
 	SSACFGDotExporter exporter(*this, _functionIndex.value_or(isMainGraph() ? 0 : 1), _liveness, _controlFlow);
 	if (!isMainGraph())
-		return exporter.exportFunction(*function, _includeDiGraphDefinition);
+		return exporter.exportFunction(*this, _includeDiGraphDefinition);
 	else
 		return exporter.exportBlocks(entry, _includeDiGraphDefinition);
 }

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -43,7 +43,7 @@
 namespace solidity::yul::ssa
 {
 class LivenessAnalysis;
-struct ControlFlow;
+struct ControlFlowGraphs;
 
 class SSACFG
 {
@@ -242,7 +242,7 @@ public:
 		bool _includeDiGraphDefinition=true,
 		std::optional<size_t> _functionIndex=std::nullopt,
 		LivenessAnalysis const* _liveness=nullptr,
-		ControlFlow const* _controlFlow=nullptr
+		ControlFlowGraphs const* _controlFlow=nullptr
 	) const;
 
 	PhiValue const& phiInfo(ValueId const& _valueId) const

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -30,7 +30,6 @@
 #include <libyul/AsmAnalysisInfo.h>
 #include <libyul/Dialect.h>
 #include <libyul/Exceptions.h>
-#include <libyul/Scope.h>
 
 #include <libsolutil/Numeric.h>
 
@@ -38,6 +37,7 @@
 #include <deque>
 #include <functional>
 #include <list>
+#include <string>
 #include <vector>
 
 namespace solidity::yul::ssa
@@ -279,8 +279,8 @@ public:
 	std::set<BlockId> exits;
 	std::string name{};
 	bool canContinue = true;
-	std::vector<std::tuple<std::reference_wrapper<Scope::Variable const>, ValueId>> arguments;
-	std::vector<std::reference_wrapper<Scope::Variable const>> returns;
+	std::vector<ValueId> arguments;
+	std::size_t numReturns = 0;
 	// Container for artificial calls generated for switch statements.
 	std::list<FunctionCall> ghostCalls;
 

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -43,6 +43,7 @@
 namespace solidity::yul::ssa
 {
 class LivenessAnalysis;
+struct ControlFlow;
 
 class SSACFG
 {
@@ -74,7 +75,7 @@ public:
 	};
 	struct Call
 	{
-		std::reference_wrapper<Scope::Function const> function;
+		FunctionGraphID graphID;
 		std::reference_wrapper<FunctionCall const> call;
 		bool canContinue;
 	};
@@ -240,7 +241,8 @@ public:
 	std::string toDot(
 		bool _includeDiGraphDefinition=true,
 		std::optional<size_t> _functionIndex=std::nullopt,
-		LivenessAnalysis const* _liveness=nullptr
+		LivenessAnalysis const* _liveness=nullptr,
+		ControlFlow const* _controlFlow=nullptr
 	) const;
 
 	PhiValue const& phiInfo(ValueId const& _valueId) const

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -281,7 +281,6 @@ public:
 	bool canContinue = true;
 	std::vector<std::tuple<std::reference_wrapper<Scope::Variable const>, ValueId>> arguments;
 	std::vector<std::reference_wrapper<Scope::Variable const>> returns;
-	std::vector<std::reference_wrapper<Scope::Function const>> functions;
 	// Container for artificial calls generated for switch statements.
 	std::list<FunctionCall> ghostCalls;
 

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -275,13 +275,15 @@ public:
 	std::unique_ptr<DebugInfo> debugInfo;
 	BlockId entry = BlockId{0};
 	std::set<BlockId> exits;
-	Scope::Function const* function = nullptr;
+	std::string name{};
 	bool canContinue = true;
 	std::vector<std::tuple<std::reference_wrapper<Scope::Variable const>, ValueId>> arguments;
 	std::vector<std::reference_wrapper<Scope::Variable const>> returns;
 	std::vector<std::reference_wrapper<Scope::Function const>> functions;
 	// Container for artificial calls generated for switch statements.
 	std::list<FunctionCall> ghostCalls;
+
+	bool isMainGraph() const { return name.empty(); }
 };
 
 }

--- a/libyul/backends/evm/ssa/SSACFGBuilder.cpp
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.cpp
@@ -122,6 +122,7 @@ void SSACFGBuilder::buildFunctionGraph(
 	if (cfg.debugInfo)
 		cfg.debugInfo->graphDebugData = _functionDefinition->debugData;
 	cfg.function = _function;
+	cfg.name = _function->name.str();
 	cfg.canContinue = m_sideEffects.functionSideEffects().at(_functionDefinition).canContinue;
 	cfg.arguments = arguments;
 	cfg.returns = returns;

--- a/libyul/backends/evm/ssa/SSACFGBuilder.cpp
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.cpp
@@ -35,6 +35,7 @@
 #include <libsolutil/StringUtils.h>
 #include <libsolutil/Visitor.h>
 
+#include <range/v3/algorithm/find_if.hpp>
 #include <range/v3/range/conversion.hpp>
 #include <range/v3/view/drop_last.hpp>
 #include <range/v3/view/enumerate.hpp>
@@ -78,7 +79,6 @@ std::unique_ptr<ControlFlow> SSACFGBuilder::build(
 		_dialect,
 		_generateDebugInfo ? std::make_unique<SSACFGDebugInfo>() : nullptr
 	));
-	controlFlow->functionGraphMapping.emplace_back(nullptr, controlFlow->functionGraphs.back().get());
 	SSACFG& mainGraph = *controlFlow->functionGraphs.back();
 	SSACFGBuilder builder(*controlFlow, mainGraph, _analysisInfo, sideEffects, _dialect, _generateDebugInfo);
 	builder.m_currentBlock = mainGraph.makeBlock(debugDataOf(_block));
@@ -98,12 +98,11 @@ void SSACFGBuilder::buildFunctionGraph(
 	FunctionDefinition const* _functionDefinition
 )
 {
-	m_controlFlow.functionGraphs.emplace_back(std::make_unique<SSACFG>(
-		m_dialect,
-		m_generateDebugInfo ? std::make_unique<SSACFGDebugInfo>() : nullptr
-	));
-	auto& cfg = *m_controlFlow.functionGraphs.back();
-	m_controlFlow.functionGraphMapping.emplace_back(_function, &cfg);
+	// The graph slot and the FunctionGraphID have already been allocated in
+	// `registerFunctionDefinition`; this call builds the body into that slot.
+	auto const graphIt = m_functionScopeToID.find(_function);
+	yulAssert(graphIt != m_functionScopeToID.end(), "Function graph must be registered before building.");
+	auto& cfg = *m_controlFlow.functionGraphs[graphIt->second];
 
 	yulAssert(m_info.scopes.at(&_functionDefinition->body), "");
 	Scope* virtualFunctionScope = m_info.scopes.at(m_info.virtualBlocks.at(_functionDefinition).get()).get();
@@ -122,7 +121,6 @@ void SSACFGBuilder::buildFunctionGraph(
 	if (cfg.debugInfo)
 		cfg.debugInfo->graphDebugData = _functionDefinition->debugData;
 	cfg.function = _function;
-	cfg.name = _function->name.str();
 	cfg.canContinue = m_sideEffects.functionSideEffects().at(_functionDefinition).canContinue;
 	cfg.arguments = arguments;
 	cfg.returns = returns;
@@ -130,6 +128,7 @@ void SSACFGBuilder::buildFunctionGraph(
 	SSACFGBuilder builder(m_controlFlow, cfg, m_info, m_sideEffects, m_dialect, m_generateDebugInfo);
 	builder.m_currentBlock = cfg.entry;
 	builder.m_functionDefinitions = m_functionDefinitions;
+	builder.m_functionScopeToID = m_functionScopeToID;
 	for (auto&& [var, varId]: cfg.arguments)
 		builder.currentDef(var, cfg.entry) = varId;
 	for (auto const& var: cfg.returns)
@@ -382,6 +381,17 @@ void SSACFGBuilder::registerFunctionDefinition(FunctionDefinition const& _functi
 	auto& function = std::get<Scope::Function>(m_scope->identifiers.at(_functionDefinition.name));
 	m_graph.functions.emplace_back(function);
 	m_functionDefinitions.emplace_back(&function, &_functionDefinition);
+
+	// Allocate the graph slot up front so sibling functions (and mutually-recursive pairs) can
+	// reference this function by its FunctionGraphID when their bodies are built later.
+	m_controlFlow.functionGraphs.emplace_back(std::make_unique<SSACFG>(
+		m_dialect,
+		m_generateDebugInfo ? std::make_unique<SSACFGDebugInfo>() : nullptr
+	));
+	auto const graphID = static_cast<FunctionGraphID>(m_controlFlow.functionGraphs.size() - 1);
+	auto& cfg = *m_controlFlow.functionGraphs.back();
+	cfg.name = function.name.str();
+	m_functionScopeToID[&function] = graphID;
 }
 
 void SSACFGBuilder::operator()(Block const& _block)
@@ -457,7 +467,9 @@ std::vector<SSACFG::ValueId> SSACFGBuilder::visitFunctionCall(FunctionCall const
 			auto const* definition = findFunctionDefinition(&function);
 			yulAssert(definition);
 			canContinue = m_sideEffects.functionSideEffects().at(definition).canContinue;
-			SSACFG::Operation result{{}, SSACFG::Call{function, _call, canContinue}, {}};
+			auto const calleeIt = m_functionScopeToID.find(&function);
+			yulAssert(calleeIt != m_functionScopeToID.end(), "Called function has no registered graph id.");
+			SSACFG::Operation result{{}, SSACFG::Call{calleeIt->second, _call, canContinue}, {}};
 			for (auto const& arg: _call.arguments | ranges::views::reverse)
 				result.inputs.emplace_back(std::visit(*this, arg));
 			for (size_t i = 0; i < function.numReturns; ++i)

--- a/libyul/backends/evm/ssa/SSACFGBuilder.cpp
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.cpp
@@ -109,29 +109,30 @@ void SSACFGBuilder::buildFunctionGraph(
 	yulAssert(virtualFunctionScope, "");
 
 	cfg.entry = cfg.makeBlock(debugDataOf(_functionDefinition->body));
-	auto arguments = _functionDefinition->parameters | ranges::views::transform([&](auto const& _param) {
+	auto argumentBindings = _functionDefinition->parameters | ranges::views::transform([&](auto const& _param) {
 		auto const& var = std::get<Scope::Variable>(virtualFunctionScope->identifiers.at(_param.name));
 		// Note: cannot use std::make_tuple since it unwraps reference wrappers.
 		return std::tuple{std::cref(var), cfg.newVariable(cfg.entry)};
 	}) | ranges::to<std::vector>;
-	auto returns = _functionDefinition->returnVariables | ranges::views::transform([&](auto const& _param) {
+	auto returnVars = _functionDefinition->returnVariables | ranges::views::transform([&](auto const& _param) {
 		return std::cref(std::get<Scope::Variable>(virtualFunctionScope->identifiers.at(_param.name)));
-	}) | ranges::to<std::vector>;
+	}) | ranges::to<std::vector<std::reference_wrapper<Scope::Variable const>>>();
 
 	if (cfg.debugInfo)
 		cfg.debugInfo->graphDebugData = _functionDefinition->debugData;
-	cfg.function = _function;
 	cfg.canContinue = m_sideEffects.functionSideEffects().at(_functionDefinition).canContinue;
-	cfg.arguments = arguments;
-	cfg.returns = returns;
+	cfg.arguments = argumentBindings
+		| ranges::views::transform([](auto const& _binding) { return std::get<1>(_binding); })
+		| ranges::to<std::vector>;
 
 	SSACFGBuilder builder(m_controlFlow, cfg, m_info, m_sideEffects, m_dialect, m_generateDebugInfo);
 	builder.m_currentBlock = cfg.entry;
 	builder.m_functionDefinitions = m_functionDefinitions;
 	builder.m_functionScopeToID = m_functionScopeToID;
-	for (auto&& [var, varId]: cfg.arguments)
+	builder.m_currentReturnVars = returnVars;
+	for (auto&& [var, varId]: argumentBindings)
 		builder.currentDef(var, cfg.entry) = varId;
-	for (auto const& var: cfg.returns)
+	for (auto const& var: returnVars)
 		builder.currentDef(var.get(), cfg.entry) = builder.zero();
 	builder.sealBlock(cfg.entry);
 	builder(_functionDefinition->body);
@@ -366,7 +367,7 @@ void SSACFGBuilder::operator()(Leave const& _leaveStatement)
 	if (m_graph.debugInfo)
 		m_graph.debugInfo->setExitDebugData(m_currentBlock, debugDataOf(_leaveStatement));
 	currentBlock().exit = SSACFG::BasicBlock::FunctionReturn{
-		m_graph.returns | ranges::views::transform([&](auto _var) {
+		m_currentReturnVars | ranges::views::transform([&](auto _var) {
 			return readVariable(_var, m_currentBlock);
 		}) | ranges::to<std::vector>
 	};
@@ -390,6 +391,7 @@ void SSACFGBuilder::registerFunctionDefinition(FunctionDefinition const& _functi
 	auto const graphID = static_cast<FunctionGraphID>(m_controlFlow.functionGraphs.size() - 1);
 	auto& cfg = *m_controlFlow.functionGraphs.back();
 	cfg.name = function.name.str();
+	cfg.numReturns = _functionDefinition.returnVariables.size();
 	m_functionScopeToID[&function] = graphID;
 }
 

--- a/libyul/backends/evm/ssa/SSACFGBuilder.cpp
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.cpp
@@ -24,7 +24,7 @@
 #include <libyul/backends/evm/ssa/transform/TrivialPhiEliminator.h>
 #include <libyul/backends/evm/ssa/transform/UnreachableBlockCleaner.h>
 
-#include <libyul/backends/evm/ssa/ControlFlow.h>
+#include <libyul/backends/evm/ssa/ControlFlowGraphs.h>
 
 #include <libyul/AST.h>
 #include <libyul/ControlFlowSideEffectsCollector.h>
@@ -49,7 +49,7 @@ using namespace solidity::yul;
 using namespace solidity::yul::ssa;
 
 SSACFGBuilder::SSACFGBuilder(
-	ControlFlow& _controlFlow,
+	ControlFlowGraphs& _controlFlow,
 	SSACFG& _graph,
 	AsmAnalysisInfo const& _analysisInfo,
 	ControlFlowSideEffectsCollector const& _sideEffects,
@@ -65,7 +65,7 @@ SSACFGBuilder::SSACFGBuilder(
 {
 }
 
-std::unique_ptr<ControlFlow> SSACFGBuilder::build(
+std::unique_ptr<ControlFlowGraphs> SSACFGBuilder::build(
 	AsmAnalysisInfo const& _analysisInfo,
 	EVMDialect const& _dialect,
 	Block const& _block,
@@ -74,13 +74,13 @@ std::unique_ptr<ControlFlow> SSACFGBuilder::build(
 {
 	ControlFlowSideEffectsCollector sideEffects(_dialect, _block);
 
-	auto controlFlow = std::make_unique<ControlFlow>();
-	controlFlow->functionGraphs.emplace_back(std::make_unique<SSACFG>(
+	auto controlFlowGraphs = std::make_unique<ControlFlowGraphs>();
+	controlFlowGraphs->functionGraphs.emplace_back(std::make_unique<SSACFG>(
 		_dialect,
 		_generateDebugInfo ? std::make_unique<SSACFGDebugInfo>() : nullptr
 	));
-	SSACFG& mainGraph = *controlFlow->functionGraphs.back();
-	SSACFGBuilder builder(*controlFlow, mainGraph, _analysisInfo, sideEffects, _dialect, _generateDebugInfo);
+	SSACFG& mainGraph = *controlFlowGraphs->functionGraphs.back();
+	SSACFGBuilder builder(*controlFlowGraphs, mainGraph, _analysisInfo, sideEffects, _dialect, _generateDebugInfo);
 	builder.m_currentBlock = mainGraph.makeBlock(debugDataOf(_block));
 	builder.sealBlock(builder.m_currentBlock);
 	builder(_block);
@@ -89,7 +89,7 @@ std::unique_ptr<ControlFlow> SSACFGBuilder::build(
 	mainGraph.block(builder.m_currentBlock).exit = SSACFG::BasicBlock::MainExit{};
 	transform::cleanUnreachableBlocks(mainGraph);
 	transform::eliminateTrivialPhis(mainGraph);
-	return controlFlow;
+	return controlFlowGraphs;
 }
 
 

--- a/libyul/backends/evm/ssa/SSACFGBuilder.cpp
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.cpp
@@ -379,7 +379,6 @@ void SSACFGBuilder::registerFunctionDefinition(FunctionDefinition const& _functi
 	yulAssert(m_scope, "");
 	yulAssert(m_scope->identifiers.count(_functionDefinition.name), "");
 	auto& function = std::get<Scope::Function>(m_scope->identifiers.at(_functionDefinition.name));
-	m_graph.functions.emplace_back(function);
 	m_functionDefinitions.emplace_back(&function, &_functionDefinition);
 
 	// Allocate the graph slot up front so sibling functions (and mutually-recursive pairs) can

--- a/libyul/backends/evm/ssa/SSACFGBuilder.h
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.h
@@ -112,6 +112,8 @@ private:
 	std::vector<std::tuple<Scope::Function const*, FunctionDefinition const*>> m_functionDefinitions;
 	/// Translation map from Yul-AST function scopes to their corresponding FunctionGraphIDs
 	std::map<Scope::Function const*, FunctionGraphID> m_functionScopeToID;
+	/// Return variable scopes of the function currently being built
+	std::vector<std::reference_wrapper<Scope::Variable const>> m_currentReturnVars;
 	SSACFG::BlockId m_currentBlock;
 	SSACFG::BasicBlock& currentBlock() { return m_graph.block(m_currentBlock); }
 	langutil::DebugData::ConstPtr currentBlockDebugData() const

--- a/libyul/backends/evm/ssa/SSACFGBuilder.h
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.h
@@ -43,6 +43,7 @@
 #include <libyul/backends/evm/ssa/ControlFlow.h>
 #include <libyul/backends/evm/ssa/SSACFG.h>
 
+#include <map>
 #include <stack>
 #include <unordered_map>
 
@@ -109,6 +110,8 @@ private:
 	EVMDialect const& m_dialect;
 	bool const m_generateDebugInfo;
 	std::vector<std::tuple<Scope::Function const*, FunctionDefinition const*>> m_functionDefinitions;
+	/// Translation map from Yul-AST function scopes to their corresponding FunctionGraphIDs
+	std::map<Scope::Function const*, FunctionGraphID> m_functionScopeToID;
 	SSACFG::BlockId m_currentBlock;
 	SSACFG::BasicBlock& currentBlock() { return m_graph.block(m_currentBlock); }
 	langutil::DebugData::ConstPtr currentBlockDebugData() const

--- a/libyul/backends/evm/ssa/SSACFGBuilder.h
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.h
@@ -40,7 +40,7 @@
 
 #include <libyul/backends/evm/EVMDialect.h>
 
-#include <libyul/backends/evm/ssa/ControlFlow.h>
+#include <libyul/backends/evm/ssa/ControlFlowGraphs.h>
 #include <libyul/backends/evm/ssa/SSACFG.h>
 
 #include <map>
@@ -53,7 +53,7 @@ namespace solidity::yul::ssa
 class SSACFGBuilder
 {
 	SSACFGBuilder(
-		ControlFlow& _controlFlow,
+		ControlFlowGraphs& _controlFlow,
 		SSACFG& _graph,
 		AsmAnalysisInfo const& _analysisInfo,
 		ControlFlowSideEffectsCollector const& _sideEffects,
@@ -63,7 +63,7 @@ class SSACFGBuilder
 public:
 	SSACFGBuilder(SSACFGBuilder const&) = delete;
 	SSACFGBuilder& operator=(SSACFGBuilder const&) = delete;
-	static std::unique_ptr<ControlFlow> build(
+	static std::unique_ptr<ControlFlowGraphs> build(
 		AsmAnalysisInfo const& _analysisInfo,
 		EVMDialect const& _dialect,
 		Block const& _block,
@@ -103,7 +103,7 @@ private:
 	void emitUpsilon(SSACFG::BlockId _block, SSACFG::ValueId _value, SSACFG::ValueId _phi);
 	void writeVariable(Scope::Variable const& _variable, SSACFG::BlockId _block, SSACFG::ValueId _value);
 
-	ControlFlow& m_controlFlow;
+	ControlFlowGraphs& m_controlFlow;
 	SSACFG& m_graph;
 	AsmAnalysisInfo const& m_info;
 	ControlFlowSideEffectsCollector const& m_sideEffects;

--- a/libyul/backends/evm/ssa/SSACFGTypes.h
+++ b/libyul/backends/evm/ssa/SSACFGTypes.h
@@ -34,6 +34,8 @@ namespace solidity::yul::ssa
 
 class SSACFG;
 
+using FunctionGraphID = std::uint32_t;
+
 struct BlockId
 {
 	using ValueType = std::uint32_t;

--- a/libyul/backends/evm/ssa/Stack.h
+++ b/libyul/backends/evm/ssa/Stack.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <libyul/backends/evm/ssa/ControlFlow.h>
+#include <libyul/backends/evm/ssa/ControlFlowGraphs.h>
 #include <libyul/backends/evm/ssa/SSACFG.h>
 
 #include <range/v3/algorithm/find.hpp>
@@ -85,7 +85,7 @@ public:
 		ValueID, // u32
 		Junk, // empty
 		FunctionCallReturnLabel, // index into corresponding stack layout's call sites
-		FunctionReturnLabel // identifying the function graph via ControlFlow
+		FunctionReturnLabel // identifying the function graph via ControlFlowGraphs
 	};
 
 	constexpr StackSlot() = default;
@@ -101,13 +101,13 @@ public:
 	constexpr bool isJunk() const noexcept { return kind() == Kind::Junk; }
 	constexpr Kind kind() const noexcept { return m_kind; }
 
-	ControlFlow::FunctionGraphID functionReturnLabel() const { yulAssert(isFunctionReturnLabel()); return m_payload; }
+	ControlFlowGraphs::FunctionGraphID functionReturnLabel() const { yulAssert(isFunctionReturnLabel()); return m_payload; }
 	CallSites::CallSiteID functionCallReturnLabel() const { yulAssert(isFunctionCallReturnLabel()); return m_payload; }
 	SSACFG::ValueId valueID() const { yulAssert(isValueID()); return {m_payload, m_valueIdKind}; }
 
 	static constexpr StackSlot makeJunk() { return {0, Kind::Junk}; }
 	static constexpr StackSlot makeValueID(SSACFG::ValueId const& _valueID) { return {_valueID.value(), Kind::ValueID, _valueID.kind()}; }
-	static constexpr StackSlot makeFunctionReturnLabel(ControlFlow::FunctionGraphID const _graphID) { return {_graphID, Kind::FunctionReturnLabel}; }
+	static constexpr StackSlot makeFunctionReturnLabel(ControlFlowGraphs::FunctionGraphID const _graphID) { return {_graphID, Kind::FunctionReturnLabel}; }
 	static constexpr StackSlot makeFunctionCallReturnLabel(CallSites::CallSiteID const _callSiteID) { return {_callSiteID, Kind::FunctionCallReturnLabel};	}
 
 	auto operator<=>(StackSlot const&) const = default;

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -82,7 +82,7 @@ void declareJunk(StackType& _stack, LivenessAnalysis::LivenessData const& _live)
 SSACFGStackLayout StackLayoutGenerator::generate(
 	LivenessAnalysis const& _liveness,
 	CallSites const& _callSites,
-	ControlFlow::FunctionGraphID const _graphID
+	ControlFlowGraphs::FunctionGraphID const _graphID
 )
 {
 	return StackLayoutGenerator(_liveness, _callSites, _graphID).m_resultLayout;
@@ -91,7 +91,7 @@ SSACFGStackLayout StackLayoutGenerator::generate(
 StackLayoutGenerator::StackLayoutGenerator(
 	LivenessAnalysis const& _liveness,
 	CallSites const& _callSites,
-	ControlFlow::FunctionGraphID const _graphID
+	ControlFlowGraphs::FunctionGraphID const _graphID
 ):
 	m_cfg(_liveness.cfg()),
 	m_liveness(_liveness),

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -149,7 +149,7 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 			blockLayout.stackIn.reserve(m_cfg.arguments.size() + (m_hasFunctionReturnLabel ? 1u : 0u));
 			if (m_hasFunctionReturnLabel)
 				blockLayout.stackIn.push_back(Slot::makeFunctionReturnLabel(m_graphID));
-			for (auto const& [_, valueID]: m_cfg.arguments | ranges::views::reverse)
+			for (auto const& valueID: m_cfg.arguments | ranges::views::reverse)
 				blockLayout.stackIn.push_back(Slot::makeValueID(valueID));
 		}
 		m_resultLayout[_blockId] = blockLayout;

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -97,7 +97,7 @@ StackLayoutGenerator::StackLayoutGenerator(
 	m_liveness(_liveness),
 	m_callSites(_callSites),
 	m_graphID(_graphID),
-	m_hasFunctionReturnLabel(_liveness.cfg().function && _liveness.cfg().canContinue),
+	m_hasFunctionReturnLabel(!_liveness.cfg().isMainGraph() && _liveness.cfg().canContinue),
 	m_junkAdmittingBlocksFinder(std::make_unique<JunkAdmittingBlocksFinder>(_liveness.cfg(), _liveness.topologicalSort())),
 	m_inputStackProposalsPerBlock(m_cfg.numBlocks()),
 	m_resultLayout(m_cfg.numBlocks())
@@ -144,7 +144,7 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 
 	if (_blockId == m_cfg.entry)
 	{
-		if (m_cfg.function)
+		if (!m_cfg.isMainGraph())
 		{
 			blockLayout.stackIn.reserve(m_cfg.arguments.size() + (m_hasFunctionReturnLabel ? 1u : 0u));
 			if (m_hasFunctionReturnLabel)

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.h
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.h
@@ -35,14 +35,14 @@ public:
 	static SSACFGStackLayout generate(
 		LivenessAnalysis const& _liveness,
 		CallSites const& _callSites,
-		ControlFlow::FunctionGraphID _graphID
+		ControlFlowGraphs::FunctionGraphID _graphID
 	);
 
 private:
 	explicit StackLayoutGenerator(
 		LivenessAnalysis const& _liveness,
 		CallSites const& _callSites,
-		ControlFlow::FunctionGraphID _graphID
+		ControlFlowGraphs::FunctionGraphID _graphID
 	);
 
 	void defineStackIn(SSACFG::BlockId const& _blockId);
@@ -51,7 +51,7 @@ private:
 	SSACFG const& m_cfg;
 	LivenessAnalysis const& m_liveness;
 	CallSites const& m_callSites;
-	ControlFlow::FunctionGraphID m_graphID;
+	ControlFlowGraphs::FunctionGraphID m_graphID;
 	bool m_hasFunctionReturnLabel;
 
 	std::unique_ptr<JunkAdmittingBlocksFinder> m_junkAdmittingBlocksFinder;

--- a/libyul/backends/evm/ssa/io/DotExporterBase.cpp
+++ b/libyul/backends/evm/ssa/io/DotExporterBase.cpp
@@ -171,28 +171,27 @@ std::string DotExporterBase::exportBlocks(SSACFG::BlockId _entry, bool _wrapInDi
 	return out.str();
 }
 
-std::string DotExporterBase::exportFunction(Scope::Function const& _function, bool _wrapInDigraph)
+std::string DotExporterBase::exportFunction(SSACFG const& _function, bool _wrapInDigraph)
 {
 	std::ostringstream out;
 	if (_wrapInDigraph)
 		out << fmt::format("digraph SSACFG {{\nnodesep=0.7;\ngraph[fontname=\"DejaVu Sans\", rankdir={}]\nnode[shape=box,fontname=\"DejaVu Sans\"];\n\n", m_rankDir);
 
-	static auto constexpr returnsTransform = [](auto const& functionReturnValue) { return escapeLabel(functionReturnValue.get().name.str()); };
-	static auto constexpr argsTransform = [](auto const& arg) { return fmt::format("v{}", std::get<1>(arg).value()); };
-	auto const entryHandle = fmt::format("FunctionEntry_{}_{}", escapeId(_function.name.str()), m_cfg.entry.value);
-	if (!m_cfg.returns.empty())
-		out << fmt::format("{} [label=\"function {}:\n {} := {}({})\"];\n",
-			entryHandle, escapeLabel(_function.name.str()),
-			fmt::join(m_cfg.returns | ranges::views::transform(returnsTransform), ", "),
-			escapeLabel(_function.name.str()),
-			fmt::join(m_cfg.arguments | ranges::views::transform(argsTransform), ", "));
+	static auto constexpr argsTransform = [](auto const& arg) { return fmt::format("v{}", arg.value()); };
+	auto const entryHandle = fmt::format("FunctionEntry_{}_{}", escapeId(_function.name), _function.entry.value);
+	if (_function.numReturns > 0)
+		out << fmt::format("{} [label=\"function {}:\n [{} returns] := {}({})\"];\n",
+			entryHandle, escapeLabel(_function.name),
+			_function.numReturns,
+			escapeLabel(_function.name),
+			fmt::join(_function.arguments | ranges::views::transform(argsTransform), ", "));
 	else
 		out << fmt::format("{} [label=\"function {}:\n {}({})\"];\n",
-			entryHandle, escapeLabel(_function.name.str()),
-			escapeLabel(_function.name.str()),
-			fmt::join(m_cfg.arguments | ranges::views::transform(argsTransform), ", "));
-	out << fmt::format("{} -> {};\n", entryHandle, formatBlockHandle(m_cfg.entry));
-	traverse(out, m_cfg.entry);
+			entryHandle, escapeLabel(_function.name),
+			escapeLabel(_function.name),
+			fmt::join(_function.arguments | ranges::views::transform(argsTransform), ", "));
+	out << fmt::format("{} -> {};\n", entryHandle, formatBlockHandle(_function.entry));
+	traverse(out, _function.entry);
 
 	if (_wrapInDigraph)
 		out << "}\n";

--- a/libyul/backends/evm/ssa/io/DotExporterBase.h
+++ b/libyul/backends/evm/ssa/io/DotExporterBase.h
@@ -43,7 +43,7 @@ public:
 	virtual ~DotExporterBase() = default;
 
 	std::string exportBlocks(SSACFG::BlockId _entry, bool _wrapInDigraph = true);
-	std::string exportFunction(Scope::Function const& _function, bool _wrapInDigraph = true);
+	std::string exportFunction(SSACFG const& _function, bool _wrapInDigraph = true);
 
 protected:
 	/// Override to write the content inside a block's dot label.

--- a/libyul/backends/evm/ssa/io/JSONExporter.cpp
+++ b/libyul/backends/evm/ssa/io/JSONExporter.cpp
@@ -177,9 +177,9 @@ Json exportFunction(SSACFG const& _cfg, LivenessAnalysis const* _liveness, Contr
 	Json functionJson = Json::object();
 	functionJson["type"] = "Function";
 	functionJson["entry"] = "Block" + std::to_string(_cfg.entry.value);
-	static auto constexpr argsTransform = [](auto const& _arg) { return fmt::format("v{}", std::get<1>(_arg).value()); };
+	static auto constexpr argsTransform = [](auto const& _arg) { return fmt::format("v{}", _arg.value()); };
 	functionJson["arguments"] = _cfg.arguments | ranges::views::transform(argsTransform) | ranges::to<std::vector>;
-	functionJson["numReturns"] = _cfg.returns.size();
+	functionJson["numReturns"] = _cfg.numReturns;
 	functionJson["blocks"] = exportBlock(_cfg, _cfg.entry, _liveness, _controlFlow);
 	return functionJson;
 }

--- a/libyul/backends/evm/ssa/io/JSONExporter.cpp
+++ b/libyul/backends/evm/ssa/io/JSONExporter.cpp
@@ -43,13 +43,13 @@ Json toJson(SSACFG const& _cfg, std::vector<SSACFG::ValueId> const& _values)
 	return ret;
 }
 
-Json toJson(Json& _ret, SSACFG const& _cfg, SSACFG::Operation const& _operation)
+Json toJson(Json& _ret, SSACFG const& _cfg, SSACFG::Operation const& _operation, ControlFlow const& _controlFlow)
 {
 	Json opJson = Json::object();
 	std::visit(util::GenericVisitor{
 		[&](SSACFG::Call const& _call) {
 			_ret["type"] = "FunctionCall";
-			opJson["op"] = _call.function.get().name.str();
+			opJson["op"] = _controlFlow.functionGraph(_call.graphID)->name;
 		},
 		[&](SSACFG::BuiltinCall const& _call) {
 			_ret["type"] = "BuiltinCall";
@@ -83,7 +83,7 @@ Json toJson(Json& _ret, SSACFG const& _cfg, SSACFG::Operation const& _operation)
 	return opJson;
 }
 
-Json toJson(SSACFG const& _cfg, SSACFG::BlockId _blockId, LivenessAnalysis const* _liveness)
+Json toJson(SSACFG const& _cfg, SSACFG::BlockId _blockId, LivenessAnalysis const* _liveness, ControlFlow const& _controlFlow)
 {
 	auto const valueToString = [&](LivenessAnalysis::LivenessData::LiveCounts::value_type const& _live) { return _live.first.str(_cfg); };
 
@@ -127,17 +127,17 @@ Json toJson(SSACFG const& _cfg, SSACFG::BlockId _blockId, LivenessAnalysis const
 		}
 	}
 	for (auto const opId: block.operations)
-		blockJson["instructions"].push_back(toJson(blockJson, _cfg, _cfg.operation(opId)));
+		blockJson["instructions"].push_back(toJson(blockJson, _cfg, _cfg.operation(opId), _controlFlow));
 
 	return blockJson;
 }
 
-Json exportBlock(SSACFG const& _cfg, SSACFG::BlockId _entryId, LivenessAnalysis const* _liveness)
+Json exportBlock(SSACFG const& _cfg, SSACFG::BlockId _entryId, LivenessAnalysis const* _liveness, ControlFlow const& _controlFlow)
 {
 	Json blocksJson = Json::array();
 	util::BreadthFirstSearch<SSACFG::BlockId> bfs{{{_entryId}}};
 	bfs.run([&](SSACFG::BlockId _blockId, auto _addChild) {
-		Json blockJson = toJson(_cfg, _blockId, _liveness);
+		Json blockJson = toJson(_cfg, _blockId, _liveness, _controlFlow);
 
 		Json exitBlockJson = Json::object();
 		std::visit(util::GenericVisitor{
@@ -172,7 +172,7 @@ Json exportBlock(SSACFG const& _cfg, SSACFG::BlockId _entryId, LivenessAnalysis 
 	return blocksJson;
 }
 
-Json exportFunction(SSACFG const& _cfg, LivenessAnalysis const* _liveness)
+Json exportFunction(SSACFG const& _cfg, LivenessAnalysis const* _liveness, ControlFlow const& _controlFlow)
 {
 	Json functionJson = Json::object();
 	functionJson["type"] = "Function";
@@ -180,7 +180,7 @@ Json exportFunction(SSACFG const& _cfg, LivenessAnalysis const* _liveness)
 	static auto constexpr argsTransform = [](auto const& _arg) { return fmt::format("v{}", std::get<1>(_arg).value()); };
 	functionJson["arguments"] = _cfg.arguments | ranges::views::transform(argsTransform) | ranges::to<std::vector>;
 	functionJson["numReturns"] = _cfg.returns.size();
-	functionJson["blocks"] = exportBlock(_cfg, _cfg.entry, _liveness);
+	functionJson["blocks"] = exportBlock(_cfg, _cfg.entry, _liveness, _controlFlow);
 	return functionJson;
 }
 
@@ -192,13 +192,22 @@ Json io::json::exportControlFlow(ControlFlow const& _controlFlow, ControlFlowLiv
 		yulAssert(&_liveness->controlFlow.get() == &_controlFlow);
 
 	Json yulObjectJson = Json::object();
-	yulObjectJson["blocks"] = exportBlock(*_controlFlow.mainGraph(), SSACFG::BlockId{0}, _liveness ? _liveness->cfgLiveness.front().get() : nullptr);
+	yulObjectJson["blocks"] = exportBlock(
+		*_controlFlow.mainGraph(),
+		SSACFG::BlockId{0},
+		_liveness ? _liveness->cfgLiveness.front().get() : nullptr,
+		_controlFlow
+	);
 
 	Json functionsJson = Json::object();
-	size_t index = 1;
-	for (auto const& [function, functionGraph]: _controlFlow.functionGraphMapping | ranges::views::drop(1))
+	for (std::size_t index = 1; index < _controlFlow.functionGraphs.size(); ++index)
 	{
-		functionsJson[function->name.str()] = exportFunction(*functionGraph, _liveness ? _liveness->cfgLiveness[index++].get() : nullptr);
+		SSACFG const& functionGraph = *_controlFlow.functionGraphs[index];
+		functionsJson[functionGraph.name] = exportFunction(
+			functionGraph,
+			_liveness ? _liveness->cfgLiveness[index].get() : nullptr,
+			_controlFlow
+		);
 	}
 	yulObjectJson["functions"] = functionsJson;
 

--- a/libyul/backends/evm/ssa/io/JSONExporter.cpp
+++ b/libyul/backends/evm/ssa/io/JSONExporter.cpp
@@ -43,7 +43,7 @@ Json toJson(SSACFG const& _cfg, std::vector<SSACFG::ValueId> const& _values)
 	return ret;
 }
 
-Json toJson(Json& _ret, SSACFG const& _cfg, SSACFG::Operation const& _operation, ControlFlow const& _controlFlow)
+Json toJson(Json& _ret, SSACFG const& _cfg, SSACFG::Operation const& _operation, ControlFlowGraphs const& _controlFlow)
 {
 	Json opJson = Json::object();
 	std::visit(util::GenericVisitor{
@@ -83,7 +83,7 @@ Json toJson(Json& _ret, SSACFG const& _cfg, SSACFG::Operation const& _operation,
 	return opJson;
 }
 
-Json toJson(SSACFG const& _cfg, SSACFG::BlockId _blockId, LivenessAnalysis const* _liveness, ControlFlow const& _controlFlow)
+Json toJson(SSACFG const& _cfg, SSACFG::BlockId _blockId, LivenessAnalysis const* _liveness, ControlFlowGraphs const& _controlFlow)
 {
 	auto const valueToString = [&](LivenessAnalysis::LivenessData::LiveCounts::value_type const& _live) { return _live.first.str(_cfg); };
 
@@ -132,7 +132,7 @@ Json toJson(SSACFG const& _cfg, SSACFG::BlockId _blockId, LivenessAnalysis const
 	return blockJson;
 }
 
-Json exportBlock(SSACFG const& _cfg, SSACFG::BlockId _entryId, LivenessAnalysis const* _liveness, ControlFlow const& _controlFlow)
+Json exportBlock(SSACFG const& _cfg, SSACFG::BlockId _entryId, LivenessAnalysis const* _liveness, ControlFlowGraphs const& _controlFlow)
 {
 	Json blocksJson = Json::array();
 	util::BreadthFirstSearch<SSACFG::BlockId> bfs{{{_entryId}}};
@@ -172,7 +172,7 @@ Json exportBlock(SSACFG const& _cfg, SSACFG::BlockId _entryId, LivenessAnalysis 
 	return blocksJson;
 }
 
-Json exportFunction(SSACFG const& _cfg, LivenessAnalysis const* _liveness, ControlFlow const& _controlFlow)
+Json exportFunction(SSACFG const& _cfg, LivenessAnalysis const* _liveness, ControlFlowGraphs const& _controlFlow)
 {
 	Json functionJson = Json::object();
 	functionJson["type"] = "Function";
@@ -186,10 +186,10 @@ Json exportFunction(SSACFG const& _cfg, LivenessAnalysis const* _liveness, Contr
 
 }
 
-Json io::json::exportControlFlow(ControlFlow const& _controlFlow, ControlFlowLiveness const* _liveness)
+Json io::json::exportControlFlow(ControlFlowGraphs const& _controlFlow, ControlFlowGraphsLiveness const* _liveness)
 {
 	if (_liveness)
-		yulAssert(&_liveness->controlFlow.get() == &_controlFlow);
+		yulAssert(&_liveness->controlFlowGraphs.get() == &_controlFlow);
 
 	Json yulObjectJson = Json::object();
 	yulObjectJson["blocks"] = exportBlock(

--- a/libyul/backends/evm/ssa/io/JSONExporter.h
+++ b/libyul/backends/evm/ssa/io/JSONExporter.h
@@ -18,12 +18,12 @@
 
 #pragma once
 
-#include <libyul/backends/evm/ssa/ControlFlow.h>
+#include <libyul/backends/evm/ssa/ControlFlowGraphs.h>
 #include <libsolutil/JSON.h>
 
 namespace solidity::yul::ssa::io::json
 {
 
-Json exportControlFlow(ControlFlow const& _controlFlow, ControlFlowLiveness const* _liveness);
+Json exportControlFlow(ControlFlowGraphs const& _controlFlow, ControlFlowGraphsLiveness const* _liveness);
 
 }

--- a/test/libyul/ssa/ControlFlowGraphTest.cpp
+++ b/test/libyul/ssa/ControlFlowGraphTest.cpp
@@ -73,14 +73,14 @@ TestCase::TestResult ControlFlowGraphTest::run(std::ostream& _stream, std::strin
 	auto const* evmDialect = dynamic_cast<EVMDialect const*>(&yulStack.dialect());
 	yulAssert(evmDialect);
 
-	std::unique_ptr<yul::ssa::ControlFlow> controlFlow = yul::ssa::SSACFGBuilder::build(
+	std::unique_ptr<yul::ssa::ControlFlowGraphs> controlFlowGraphs = yul::ssa::SSACFGBuilder::build(
 		*yulStack.parserResult()->analysisInfo,
 		*evmDialect,
 		yulStack.parserResult()->code()->root(),
 		true
 	);
-	yul::ssa::ControlFlowLiveness liveness(*controlFlow);
-	m_obtainedResult = controlFlow->toDot(&liveness);
+	yul::ssa::ControlFlowGraphsLiveness liveness(*controlFlowGraphs);
+	m_obtainedResult = controlFlowGraphs->toDot(&liveness);
 
 	auto result = checkResult(_stream, _linePrefix, _formatted);
 

--- a/test/libyul/ssa/StackLayoutGeneratorTest.cpp
+++ b/test/libyul/ssa/StackLayoutGeneratorTest.cpp
@@ -56,9 +56,15 @@ namespace
 class StackLayoutDotExporter: public io::DotExporterBase
 {
 public:
-	StackLayoutDotExporter(SSACFG const& _cfg, std::size_t _functionIndex, SSACFGStackLayout const& _layout):
+	StackLayoutDotExporter(
+		SSACFG const& _cfg,
+		std::size_t _functionIndex,
+		SSACFGStackLayout const& _layout,
+		ControlFlow const& _controlFlow
+	):
 		DotExporterBase(_cfg, _functionIndex),
-		m_layout(_layout)
+		m_layout(_layout),
+		m_controlFlow(_controlFlow)
 	{
 	}
 
@@ -83,7 +89,7 @@ protected:
 
 			std::visit(GenericVisitor{
 				[&](SSACFG::Call const& _call) {
-					_out << escapeLabel(_call.function.get().name.str());
+					_out << escapeLabel(m_controlFlow.functionGraph(_call.graphID)->name);
 				},
 				[&](SSACFG::BuiltinCall const& _call) {
 					_out << escapeLabel(_call.builtin.get().name);
@@ -105,6 +111,7 @@ protected:
 
 private:
 	SSACFGStackLayout const& m_layout;
+	ControlFlow const& m_controlFlow;
 };
 
 }
@@ -164,8 +171,8 @@ frontend::test::TestCase::TestResult StackLayoutGeneratorTest::run(std::ostream&
 				gatherCallSites(cfg),
 				static_cast<ControlFlow::FunctionGraphID>(index)
 			);
-			StackLayoutDotExporter exporter(cfg, index, layout);
-			if (cfg.function)
+			StackLayoutDotExporter exporter(cfg, index, layout, *controlFlow);
+			if (!cfg.isMainGraph())
 				m_obtainedResult += exporter.exportFunction(*cfg.function, false);
 			else
 				m_obtainedResult += exporter.exportBlocks(cfg.entry, false);

--- a/test/libyul/ssa/StackLayoutGeneratorTest.cpp
+++ b/test/libyul/ssa/StackLayoutGeneratorTest.cpp
@@ -19,7 +19,7 @@
 #include <test/libyul/ssa/StackLayoutGeneratorTest.h>
 
 #include <libyul/backends/evm/ssa/io/DotExporterBase.h>
-#include <libyul/backends/evm/ssa/ControlFlow.h>
+#include <libyul/backends/evm/ssa/ControlFlowGraphs.h>
 #include <libyul/backends/evm/ssa/SSACFGBuilder.h>
 #include <libyul/backends/evm/ssa/Stack.h>
 #include <libyul/backends/evm/ssa/StackLayout.h>
@@ -60,7 +60,7 @@ public:
 		SSACFG const& _cfg,
 		std::size_t _functionIndex,
 		SSACFGStackLayout const& _layout,
-		ControlFlow const& _controlFlow
+		ControlFlowGraphs const& _controlFlow
 	):
 		DotExporterBase(_cfg, _functionIndex),
 		m_layout(_layout),
@@ -111,7 +111,7 @@ protected:
 
 private:
 	SSACFGStackLayout const& m_layout;
-	ControlFlow const& m_controlFlow;
+	ControlFlowGraphs const& m_controlFlow;
 };
 
 }
@@ -151,7 +151,7 @@ frontend::test::TestCase::TestResult StackLayoutGeneratorTest::run(std::ostream&
 		auto const* evmDialect = dynamic_cast<EVMDialect const*>(object.dialect());
 		yulAssert(evmDialect);
 
-		std::unique_ptr<ControlFlow> const controlFlow = SSACFGBuilder::build(
+		std::unique_ptr<ControlFlowGraphs> const controlFlowGraphs = SSACFGBuilder::build(
 			*object.analysisInfo,
 			*evmDialect,
 			object.code()->root(),
@@ -163,15 +163,15 @@ frontend::test::TestCase::TestResult StackLayoutGeneratorTest::run(std::ostream&
 
 		m_obtainedResult += "digraph SSACFG {\nnodesep=0.7;\ngraph[fontname=\"DejaVu Sans\", rankdir=LR]\nnode[shape=box,fontname=\"DejaVu Sans\"];\n\n";
 
-		for (std::size_t index = 0; index < controlFlow->functionGraphs.size(); ++index)
+		for (std::size_t index = 0; index < controlFlowGraphs->functionGraphs.size(); ++index)
 		{
-			auto const& cfg = *controlFlow->functionGraphs[index];
+			auto const& cfg = *controlFlowGraphs->functionGraphs[index];
 			SSACFGStackLayout const layout = StackLayoutGenerator::generate(
 				LivenessAnalysis(cfg),
 				gatherCallSites(cfg),
-				static_cast<ControlFlow::FunctionGraphID>(index)
+				static_cast<ControlFlowGraphs::FunctionGraphID>(index)
 			);
-			StackLayoutDotExporter exporter(cfg, index, layout, *controlFlow);
+			StackLayoutDotExporter exporter(cfg, index, layout, *controlFlowGraphs);
 			if (!cfg.isMainGraph())
 				m_obtainedResult += exporter.exportFunction(cfg, false);
 			else

--- a/test/libyul/ssa/StackLayoutGeneratorTest.cpp
+++ b/test/libyul/ssa/StackLayoutGeneratorTest.cpp
@@ -173,7 +173,7 @@ frontend::test::TestCase::TestResult StackLayoutGeneratorTest::run(std::ostream&
 			);
 			StackLayoutDotExporter exporter(cfg, index, layout, *controlFlow);
 			if (!cfg.isMainGraph())
-				m_obtainedResult += exporter.exportFunction(*cfg.function, false);
+				m_obtainedResult += exporter.exportFunction(cfg, false);
 			else
 				m_obtainedResult += exporter.exportBlocks(cfg.entry, false);
 		}

--- a/test/libyul/ssa/StackShufflerTest.cpp
+++ b/test/libyul/ssa/StackShufflerTest.cpp
@@ -122,7 +122,7 @@ Slot parseSlot(std::string_view token)
 	if (token.starts_with(returnLabelPrefix) && token.ends_with("]"))
 	{
 		auto const inner = token.substr(returnLabelPrefix.size(), token.size() - returnLabelPrefix.size() - 1);
-		if (auto const num = util::parseArithmetic<ControlFlow::FunctionGraphID>(inner))
+		if (auto const num = util::parseArithmetic<ControlFlowGraphs::FunctionGraphID>(inner))
 			return Slot::makeFunctionReturnLabel(*num);
 		throw std::runtime_error(fmt::format("Couldn't parse ReturnLabel token: {}", token));
 	}

--- a/test/libyul/ssa/controlFlowGraph/complex.yul
+++ b/test/libyul/ssa/controlFlowGraph/complex.yul
@@ -59,7 +59,7 @@
 // Block0_0Exit [label="MainExit"];
 // Block0_0 -> Block0_0Exit;
 // FunctionEntry_f_0 [label="function f:
-//  c := f(v0, v1)"];
+//  [1 returns] := f(v0, v1)"];
 // FunctionEntry_f_0 -> Block1_0;
 // Block1_0 [label="\
 // Block 0; (0, max 17)\nLiveIn: v1[1], v0[1]\l\

--- a/test/libyul/ssa/controlFlowGraph/complex2.yul
+++ b/test/libyul/ssa/controlFlowGraph/complex2.yul
@@ -75,7 +75,7 @@
 // Block0_0Exit [label="MainExit"];
 // Block0_0 -> Block0_0Exit;
 // FunctionEntry_f_0 [label="function f:
-//  c := f(v0, v1)"];
+//  [1 returns] := f(v0, v1)"];
 // FunctionEntry_f_0 -> Block1_0;
 // Block1_0 [label="\
 // Block 0; (0, max 17)\nLiveIn: v1[1], v0[1]\l\

--- a/test/libyul/ssa/controlFlowGraph/function.yul
+++ b/test/libyul/ssa/controlFlowGraph/function.yul
@@ -34,7 +34,7 @@
 // Block0_0Exit [label="Terminated"];
 // Block0_0 -> Block0_0Exit;
 // FunctionEntry_f_0 [label="function f:
-//  r := f(v0, v1)"];
+//  [1 returns] := f(v0, v1)"];
 // FunctionEntry_f_0 -> Block1_0;
 // Block1_0 [label="\
 // Block 0; (0, max 0)\nLiveIn: v0[2], v1[1]\l\
@@ -63,7 +63,7 @@
 // Block3_0Exit [label="Terminated"];
 // Block3_0 -> Block3_0Exit;
 // FunctionEntry_i_0 [label="function i:
-//  v, w := i()"];
+//  [2 returns] := i()"];
 // FunctionEntry_i_0 -> Block4_0;
 // Block4_0 [label="\
 // Block 0; (0, max 0)\nLiveIn: \l\

--- a/test/libyul/ssa/controlFlowGraph/nested_function.yul
+++ b/test/libyul/ssa/controlFlowGraph/nested_function.yul
@@ -64,92 +64,92 @@
 // "];
 // Block2_0Exit [label="FunctionReturn[]"];
 // Block2_0 -> Block2_0Exit;
+// FunctionEntry_cycle1_0 [label="function cycle1:
+//  r := cycle1()"];
+// FunctionEntry_cycle1_0 -> Block3_0;
+// Block3_0 [label="\
+// Block 0; (0, max 2)\nLiveIn: \l\
+// LiveOut: \l\nUsed: \l\nv0 := mload(0x03)\l\
+// "];
+// Block3_0 -> Block3_0Exit;
+// Block3_0Exit [label="{ If v0 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block3_0Exit:0 -> Block3_2 [style="solid"];
+// Block3_0Exit:1 -> Block3_1 [style="solid"];
+// Block3_1 [label="\
+// Block 1; (1, max 2)\nLiveIn: \l\
+// LiveOut: v1[1]\l\nUsed: \l\nv1 := cycle2()\l\
+// "];
+// Block3_1 -> Block3_1Exit [arrowhead=none];
+// Block3_1Exit [label="Jump" shape=oval];
+// Block3_1Exit -> Block3_2 [style="solid"];
+// Block3_2 [label="\
+// Block 2; (2, max 2)\nLiveIn: phi0[3]\l\
+// LiveOut: phi0[1]\l\nUsed: phi0[2]\l\nphi0 := φ(\l\
+// 	Block 0 => 0x00,\l\
+// 	Block 1 => v1\l\
+// )\l\
+// "];
+// Block3_2Exit [label="FunctionReturn[phi0]"];
+// Block3_2 -> Block3_2Exit;
+// FunctionEntry_cycle2_0 [label="function cycle2:
+//  r := cycle2()"];
+// FunctionEntry_cycle2_0 -> Block4_0;
+// Block4_0 [label="\
+// Block 0; (0, max 2)\nLiveIn: \l\
+// LiveOut: \l\nUsed: \l\nv0 := mload(0x04)\l\
+// "];
+// Block4_0 -> Block4_0Exit;
+// Block4_0Exit [label="{ If v0 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
+// Block4_0Exit:0 -> Block4_2 [style="solid"];
+// Block4_0Exit:1 -> Block4_1 [style="solid"];
+// Block4_1 [label="\
+// Block 1; (1, max 2)\nLiveIn: \l\
+// LiveOut: v1[1]\l\nUsed: \l\nv1 := cycle1()\l\
+// "];
+// Block4_1 -> Block4_1Exit [arrowhead=none];
+// Block4_1Exit [label="Jump" shape=oval];
+// Block4_1Exit -> Block4_2 [style="solid"];
+// Block4_2 [label="\
+// Block 2; (2, max 2)\nLiveIn: phi0[3]\l\
+// LiveOut: phi0[1]\l\nUsed: phi0[2]\l\nphi0 := φ(\l\
+// 	Block 0 => 0x00,\l\
+// 	Block 1 => v1\l\
+// )\l\
+// "];
+// Block4_2Exit [label="FunctionReturn[phi0]"];
+// Block4_2 -> Block4_2Exit;
 // FunctionEntry_z_0 [label="function z:
 //  r := z()"];
-// FunctionEntry_z_0 -> Block3_0;
-// Block3_0 [label="\
-// Block 0; (0, max 0)\nLiveIn: \l\
-// LiveOut: v0[1]\l\nUsed: \l\nv0 := w()\l\
-// "];
-// Block3_0Exit [label="FunctionReturn[v0]"];
-// Block3_0 -> Block3_0Exit;
-// FunctionEntry_w_0 [label="function w:
-//  rw1 := w()"];
-// FunctionEntry_w_0 -> Block4_0;
-// Block4_0 [label="\
-// Block 0; (0, max 0)\nLiveIn: \l\
-// LiveOut: \l\nUsed: \l\n"];
-// Block4_0Exit [label="FunctionReturn[0x01]"];
-// Block4_0 -> Block4_0Exit;
-// FunctionEntry_v_0 [label="function v:
-//  r := v()"];
-// FunctionEntry_v_0 -> Block5_0;
+// FunctionEntry_z_0 -> Block5_0;
 // Block5_0 [label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
 // LiveOut: v0[1]\l\nUsed: \l\nv0 := w()\l\
 // "];
 // Block5_0Exit [label="FunctionReturn[v0]"];
 // Block5_0 -> Block5_0Exit;
-// FunctionEntry_w_0 [label="function w:
-//  rw2 := w()"];
-// FunctionEntry_w_0 -> Block6_0;
+// FunctionEntry_v_0 [label="function v:
+//  r := v()"];
+// FunctionEntry_v_0 -> Block6_0;
 // Block6_0 [label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
-// LiveOut: \l\nUsed: \l\n"];
-// Block6_0Exit [label="FunctionReturn[0x11]"];
+// LiveOut: v0[1]\l\nUsed: \l\nv0 := w()\l\
+// "];
+// Block6_0Exit [label="FunctionReturn[v0]"];
 // Block6_0 -> Block6_0Exit;
-// FunctionEntry_cycle1_0 [label="function cycle1:
-//  r := cycle1()"];
-// FunctionEntry_cycle1_0 -> Block7_0;
+// FunctionEntry_w_0 [label="function w:
+//  rw1 := w()"];
+// FunctionEntry_w_0 -> Block7_0;
 // Block7_0 [label="\
-// Block 0; (0, max 2)\nLiveIn: \l\
-// LiveOut: \l\nUsed: \l\nv0 := mload(0x03)\l\
-// "];
+// Block 0; (0, max 0)\nLiveIn: \l\
+// LiveOut: \l\nUsed: \l\n"];
+// Block7_0Exit [label="FunctionReturn[0x01]"];
 // Block7_0 -> Block7_0Exit;
-// Block7_0Exit [label="{ If v0 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
-// Block7_0Exit:0 -> Block7_2 [style="solid"];
-// Block7_0Exit:1 -> Block7_1 [style="solid"];
-// Block7_1 [label="\
-// Block 1; (1, max 2)\nLiveIn: \l\
-// LiveOut: v1[1]\l\nUsed: \l\nv1 := cycle2()\l\
-// "];
-// Block7_1 -> Block7_1Exit [arrowhead=none];
-// Block7_1Exit [label="Jump" shape=oval];
-// Block7_1Exit -> Block7_2 [style="solid"];
-// Block7_2 [label="\
-// Block 2; (2, max 2)\nLiveIn: phi0[3]\l\
-// LiveOut: phi0[1]\l\nUsed: phi0[2]\l\nphi0 := φ(\l\
-// 	Block 0 => 0x00,\l\
-// 	Block 1 => v1\l\
-// )\l\
-// "];
-// Block7_2Exit [label="FunctionReturn[phi0]"];
-// Block7_2 -> Block7_2Exit;
-// FunctionEntry_cycle2_0 [label="function cycle2:
-//  r := cycle2()"];
-// FunctionEntry_cycle2_0 -> Block8_0;
+// FunctionEntry_w_0 [label="function w:
+//  rw2 := w()"];
+// FunctionEntry_w_0 -> Block8_0;
 // Block8_0 [label="\
-// Block 0; (0, max 2)\nLiveIn: \l\
-// LiveOut: \l\nUsed: \l\nv0 := mload(0x04)\l\
-// "];
+// Block 0; (0, max 0)\nLiveIn: \l\
+// LiveOut: \l\nUsed: \l\n"];
+// Block8_0Exit [label="FunctionReturn[0x11]"];
 // Block8_0 -> Block8_0Exit;
-// Block8_0Exit [label="{ If v0 | { <0> Zero | <1> NonZero }}" shape=Mrecord];
-// Block8_0Exit:0 -> Block8_2 [style="solid"];
-// Block8_0Exit:1 -> Block8_1 [style="solid"];
-// Block8_1 [label="\
-// Block 1; (1, max 2)\nLiveIn: \l\
-// LiveOut: v1[1]\l\nUsed: \l\nv1 := cycle1()\l\
-// "];
-// Block8_1 -> Block8_1Exit [arrowhead=none];
-// Block8_1Exit [label="Jump" shape=oval];
-// Block8_1Exit -> Block8_2 [style="solid"];
-// Block8_2 [label="\
-// Block 2; (2, max 2)\nLiveIn: phi0[3]\l\
-// LiveOut: phi0[1]\l\nUsed: phi0[2]\l\nphi0 := φ(\l\
-// 	Block 0 => 0x00,\l\
-// 	Block 1 => v1\l\
-// )\l\
-// "];
-// Block8_2Exit [label="FunctionReturn[phi0]"];
-// Block8_2 -> Block8_2Exit;
 // }

--- a/test/libyul/ssa/controlFlowGraph/nested_function.yul
+++ b/test/libyul/ssa/controlFlowGraph/nested_function.yul
@@ -43,7 +43,7 @@
 // Block0_0Exit [label="MainExit"];
 // Block0_0 -> Block0_0Exit;
 // FunctionEntry_f_0 [label="function f:
-//  r := f(v0, v1)"];
+//  [1 returns] := f(v0, v1)"];
 // FunctionEntry_f_0 -> Block1_0;
 // Block1_0 [label="\
 // Block 0; (0, max 0)\nLiveIn: v0[2], v1[1]\l\
@@ -65,7 +65,7 @@
 // Block2_0Exit [label="FunctionReturn[]"];
 // Block2_0 -> Block2_0Exit;
 // FunctionEntry_cycle1_0 [label="function cycle1:
-//  r := cycle1()"];
+//  [1 returns] := cycle1()"];
 // FunctionEntry_cycle1_0 -> Block3_0;
 // Block3_0 [label="\
 // Block 0; (0, max 2)\nLiveIn: \l\
@@ -92,7 +92,7 @@
 // Block3_2Exit [label="FunctionReturn[phi0]"];
 // Block3_2 -> Block3_2Exit;
 // FunctionEntry_cycle2_0 [label="function cycle2:
-//  r := cycle2()"];
+//  [1 returns] := cycle2()"];
 // FunctionEntry_cycle2_0 -> Block4_0;
 // Block4_0 [label="\
 // Block 0; (0, max 2)\nLiveIn: \l\
@@ -119,7 +119,7 @@
 // Block4_2Exit [label="FunctionReturn[phi0]"];
 // Block4_2 -> Block4_2Exit;
 // FunctionEntry_z_0 [label="function z:
-//  r := z()"];
+//  [1 returns] := z()"];
 // FunctionEntry_z_0 -> Block5_0;
 // Block5_0 [label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
@@ -128,7 +128,7 @@
 // Block5_0Exit [label="FunctionReturn[v0]"];
 // Block5_0 -> Block5_0Exit;
 // FunctionEntry_v_0 [label="function v:
-//  r := v()"];
+//  [1 returns] := v()"];
 // FunctionEntry_v_0 -> Block6_0;
 // Block6_0 [label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
@@ -137,7 +137,7 @@
 // Block6_0Exit [label="FunctionReturn[v0]"];
 // Block6_0 -> Block6_0Exit;
 // FunctionEntry_w_0 [label="function w:
-//  rw1 := w()"];
+//  [1 returns] := w()"];
 // FunctionEntry_w_0 -> Block7_0;
 // Block7_0 [label="\
 // Block 0; (0, max 0)\nLiveIn: \l\
@@ -145,7 +145,7 @@
 // Block7_0Exit [label="FunctionReturn[0x01]"];
 // Block7_0 -> Block7_0Exit;
 // FunctionEntry_w_0 [label="function w:
-//  rw2 := w()"];
+//  [1 returns] := w()"];
 // FunctionEntry_w_0 -> Block8_0;
 // Block8_0 [label="\
 // Block 0; (0, max 0)\nLiveIn: \l\

--- a/test/libyul/ssa/stackLayoutGenerator/function.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/function.yul
@@ -44,7 +44,7 @@
 // Block0_0Exit [label="Terminated"];
 // Block0_0 -> Block0_0Exit;
 // FunctionEntry_f_0 [label="function f:
-//  r := f(v0, v1)"];
+//  [1 returns] := f(v0, v1)"];
 // FunctionEntry_f_0 -> Block1_0;
 // Block1_0 [label="\
 // IN: [ReturnLabel[1], v1, v0]\l\
@@ -94,7 +94,7 @@
 // Block3_0Exit [label="Terminated"];
 // Block3_0 -> Block3_0Exit;
 // FunctionEntry_i_0 [label="function i:
-//  v, w := i()"];
+//  [2 returns] := i()"];
 // FunctionEntry_i_0 -> Block4_0;
 // Block4_0 [label="\
 // IN: [ReturnLabel[4]]\l\

--- a/test/libyul/ssa/stackLayoutGenerator/multi_return.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/multi_return.yul
@@ -39,7 +39,7 @@
 // Block0_0Exit [label="MainExit"];
 // Block0_0 -> Block0_0Exit;
 // FunctionEntry_pair_0 [label="function pair:
-//  x, y := pair(v0)"];
+//  [2 returns] := pair(v0)"];
 // FunctionEntry_pair_0 -> Block1_0;
 // Block1_0 [label="\
 // IN: [ReturnLabel[1], v0]\l\

--- a/test/libyul/ssa/stackLayoutGenerator/recursion.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/recursion.yul
@@ -30,7 +30,7 @@
 // Block0_0Exit [label="MainExit"];
 // Block0_0 -> Block0_0Exit;
 // FunctionEntry_sum_0 [label="function sum:
-//  s := sum(v0)"];
+//  [1 returns] := sum(v0)"];
 // FunctionEntry_sum_0 -> Block1_0;
 // Block1_0 [label="\
 // IN: [ReturnLabel[1], v0]\l\

--- a/test/libyul/ssa/stackLayoutGenerator/simple_if.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/simple_if.yul
@@ -32,7 +32,7 @@
 // Block0_0Exit [label="MainExit"];
 // Block0_0 -> Block0_0Exit;
 // FunctionEntry_f_0 [label="function f:
-//  c := f(v0, v1)"];
+//  [1 returns] := f(v0, v1)"];
 // FunctionEntry_f_0 -> Block1_0;
 // Block1_0 [label="\
 // IN: [ReturnLabel[1], v1, v0]\l\


### PR DESCRIPTION
This PR removes the `Scope::Function` and `Scope::Variable` references from the SSA CFG to the original Yul AST and introduces mechanisms that make the SSA CFG more self-sufficient. Scope lookups are confined to the `SSACFGBuilder`.