### PR TITLE
Emit PUSH<N> instead of PUSH32 for small immutable types

### DIFF
--- a/docs/contracts/constant-state-variables.rst
+++ b/docs/contracts/constant-state-variables.rst
@@ -21,8 +21,10 @@ Compared to regular state variables, the gas costs of constant and immutable var
 are much lower. For a constant variable, the expression assigned to it is copied to
 all the places where it is accessed and also re-evaluated each time. This allows for local
 optimizations. Immutable variables are evaluated once at construction time and their value
-is copied to all the places in the code where they are accessed. For these values,
-32 bytes are reserved, even if they would fit in fewer bytes. Due to this, constant values
+is copied to all the places in the code where they are accessed. For unsigned integer types
+smaller than 256 bits, address types, contract types, and enums, the compiler reserves only
+as many bytes as the type requires (e.g. 1 byte for ``uint8``, 20 bytes for ``address``).
+For all other types, 32 bytes are reserved. Due to this, constant values
 can sometimes be cheaper than immutable values.
 
 Not all types for constants and immutables are implemented at this time. The only supported types are

--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -100,6 +100,27 @@ private:
 	size_t m_instructionLocationStart{};
 };
 
+/// Parses an immutable identifier that may have a byte width suffix encoded as "@N".
+/// Returns the original identifier and the byte width (defaulting to 32 if no suffix).
+std::pair<std::string, uint8_t> parseImmutableIdentifierWithWidth(std::string const& _identifier)
+{
+	auto atPos = _identifier.rfind('@');
+	if (atPos != std::string::npos && atPos + 1 < _identifier.size())
+	{
+		std::string const widthStr = _identifier.substr(atPos + 1);
+		try
+		{
+			size_t consumed = 0;
+			unsigned long width = std::stoul(widthStr, &consumed);
+			if (consumed == widthStr.size() && width >= 1 && width <= 32)
+				return {_identifier.substr(0, atPos), static_cast<uint8_t>(width)};
+		}
+		catch (std::invalid_argument const&) {}
+		catch (std::out_of_range const&) {}
+	}
+	return {_identifier, 32};
+}
+
 }
 
 std::map<std::string, std::shared_ptr<std::string const>> Assembly::s_sharedSourceNames;
@@ -307,12 +328,16 @@ AssemblyItem Assembly::createAssemblyItemFromJSON(Json const& _json, std::vector
 		else if (name == "PUSHIMMUTABLE")
 		{
 			requireValueDefinedForInstruction(name, value);
-			result = {AssemblyItemType::PushImmutable, storeImmutableHash(value)};
+			auto [identifier, byteWidth] = parseImmutableIdentifierWithWidth(value);
+			result = {AssemblyItemType::PushImmutable, storeImmutableHash(identifier)};
+			result.setImmutableByteWidth(byteWidth);
 		}
 		else if (name == "ASSIGNIMMUTABLE")
 		{
 			requireValueDefinedForInstruction(name, value);
-			result = {AssemblyItemType::AssignImmutable, storeImmutableHash(value)};
+			auto [identifier, byteWidth] = parseImmutableIdentifierWithWidth(value);
+			result = {AssemblyItemType::AssignImmutable, storeImmutableHash(identifier)};
+			result.setImmutableByteWidth(byteWidth);
 		}
 		else if (name == "tag")
 		{
@@ -527,7 +552,11 @@ Json Assembly::assemblyJSON(std::map<std::string, unsigned> const& _sourceIndice
 		if (name == "PUSHLIB")
 			data = m_libraries.at(h256(data));
 		else if (name == "PUSHIMMUTABLE" || name == "ASSIGNIMMUTABLE")
+		{
 			data = m_immutables.at(h256(data));
+			if (item.immutableByteWidth() != 32)
+				data += "@" + std::to_string(item.immutableByteWidth());
+		}
 		if (!data.empty())
 			jsonItem["value"] = data;
 		jsonItem["source"] = sourceIndex;
@@ -802,18 +831,22 @@ AssemblyItem Assembly::newPushLibraryAddress(std::string const& _identifier)
 	return AssemblyItem{PushLibraryAddress, h};
 }
 
-AssemblyItem Assembly::newPushImmutable(std::string const& _identifier)
+AssemblyItem Assembly::newPushImmutable(std::string const& _identifier, uint8_t _byteWidth)
 {
 	h256 h(util::keccak256(_identifier));
 	m_immutables[h] = _identifier;
-	return AssemblyItem{PushImmutable, h};
+	AssemblyItem item{PushImmutable, h};
+	item.setImmutableByteWidth(_byteWidth);
+	return item;
 }
 
-AssemblyItem Assembly::newImmutableAssignment(std::string const& _identifier)
+AssemblyItem Assembly::newImmutableAssignment(std::string const& _identifier, uint8_t _byteWidth)
 {
 	h256 h(util::keccak256(_identifier));
 	m_immutables[h] = _identifier;
-	return AssemblyItem{AssignImmutable, h};
+	AssemblyItem item{AssignImmutable, h};
+	item.setImmutableByteWidth(_byteWidth);
+	return item;
 }
 
 AssemblyItem Assembly::newAuxDataLoadN(size_t _offset) const
@@ -1287,7 +1320,9 @@ LinkerObject const& Assembly::assembleLegacy() const
 	for (auto const& item: items)
 		if (item.type() == AssignImmutable)
 		{
-			item.setImmutableOccurrences(immutableReferencesBySub[item.data()].second.size());
+			auto const& ref = immutableReferencesBySub[item.data()];
+			item.setImmutableOccurrences(ref.offsets.size());
+			item.setImmutableByteWidth(ref.length);
 			setsImmutables = true;
 		}
 		else if (item.type() == PushImmutable)
@@ -1389,21 +1424,30 @@ LinkerObject const& Assembly::assembleLegacy() const
 			break;
 		}
 		case PushImmutable:
-			ret.bytecode.push_back(static_cast<uint8_t>(Instruction::PUSH32));
-			// Maps keccak back to the "identifier" std::string of that immutable.
-			ret.immutableReferences[item.data()].first = m_immutables.at(item.data());
-			// Record the bytecode offset of the PUSH32 argument.
-			ret.immutableReferences[item.data()].second.emplace_back(ret.bytecode.size());
-			// Advance bytecode by 32 bytes (default initialized).
-			ret.bytecode.resize(ret.bytecode.size() + 32);
+		{
+			auto const width = item.immutableByteWidth();
+			ret.bytecode.push_back(static_cast<uint8_t>(pushInstruction(width)));
+			auto& ref = ret.immutableReferences[item.data()];
+			if (ref.offsets.empty())
+			{
+				ref.identifier = m_immutables.at(item.data());
+				ref.length = width;
+			}
+			else
+				solAssert(ref.length == width, "Inconsistent immutable byte width.");
+			ref.offsets.emplace_back(ret.bytecode.size());
+			ret.bytecode.resize(ret.bytecode.size() + width);
 			break;
+		}
 		case VerbatimBytecode:
 			ret.bytecode += assembleVerbatimBytecode(item);
 			break;
 		case AssignImmutable:
 		{
-			// Expect 2 elements on stack (source, dest_base)
-			auto const& offsets = immutableReferencesBySub[item.data()].second;
+			// Expect 2 elements on stack (value, dest_base)
+			auto const& immutableRef = immutableReferencesBySub[item.data()];
+			auto const& offsets = immutableRef.offsets;
+			auto const width = immutableRef.length;
 			for (size_t i = 0; i < offsets.size(); ++i)
 			{
 				if (i != offsets.size() - 1)
@@ -1415,13 +1459,129 @@ LinkerObject const& Assembly::assembleLegacy() const
 					instructionLocationEmitter.emit();
 				}
 				// TODO: should we make use of the constant optimizer methods for pushing the offsets?
-				bytes offsetBytes = toCompactBigEndian(u256(offsets[i]));
-				ret.bytecode.push_back(static_cast<uint8_t>(pushInstruction(static_cast<unsigned>(offsetBytes.size()))));
-				ret.bytecode += offsetBytes;
-				instructionLocationEmitter.emit();
-				ret.bytecode.push_back(static_cast<uint8_t>(Instruction::ADD));
-				instructionLocationEmitter.emit();
-				ret.bytecode.push_back(static_cast<uint8_t>(Instruction::MSTORE));
+				if (width == 32)
+				{
+					// Full-width: simple MSTORE.
+					bytes offsetBytes = toCompactBigEndian(u256(offsets[i]));
+					ret.bytecode.push_back(static_cast<uint8_t>(pushInstruction(static_cast<unsigned>(offsetBytes.size()))));
+					ret.bytecode += offsetBytes;
+					instructionLocationEmitter.emit();
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::ADD));
+					instructionLocationEmitter.emit();
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::MSTORE));
+				}
+				else if (width == 1)
+				{
+					// Single byte: use MSTORE8.
+					bytes offsetBytes = toCompactBigEndian(u256(offsets[i]));
+					ret.bytecode.push_back(static_cast<uint8_t>(pushInstruction(static_cast<unsigned>(offsetBytes.size()))));
+					ret.bytecode += offsetBytes;
+					instructionLocationEmitter.emit();
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::ADD));
+					instructionLocationEmitter.emit();
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::MSTORE8));
+				}
+				else if (offsets[i] >= static_cast<size_t>(32 - width))
+				{
+					// Partial width (2-31 bytes): read-modify-write.
+					// MSTORE always writes 32 bytes, so we offset the write by (width - 32) and
+					// use a mask to preserve the (32 - width) preceding bytes.
+					// addr = dest_base + offset + width - 32
+					// keepMask = ~((1 << (width * 8)) - 1)   (preserves high bytes, clears low `width` bytes)
+					//
+					// Stack in: [value, dest_base]  (dest_base on top)
+					// PUSH adjOff ADD: [value, addr]
+					// SWAP1:           [addr, value]
+					// DUP2:            [addr, value, addr]
+					// MLOAD:           [addr, value, old]
+					// PUSH mask AND:   [addr, value, masked]
+					// OR:              [addr, patched]
+					// SWAP1:           [patched, addr]
+					// MSTORE:          []
+					size_t adjustedOffset = offsets[i] + width - 32;
+					u256 keepMask = ~((u256(1) << (width * 8)) - 1);
+
+					bytes offsetBytes = toCompactBigEndian(u256(adjustedOffset));
+					ret.bytecode.push_back(static_cast<uint8_t>(pushInstruction(static_cast<unsigned>(offsetBytes.size()))));
+					ret.bytecode += offsetBytes;
+					instructionLocationEmitter.emit();
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::ADD));
+					instructionLocationEmitter.emit();
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::SWAP1));
+					instructionLocationEmitter.emit();
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::DUP2));
+					instructionLocationEmitter.emit();
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::MLOAD));
+					instructionLocationEmitter.emit();
+					bytes maskBytes = toCompactBigEndian(keepMask);
+					ret.bytecode.push_back(static_cast<uint8_t>(pushInstruction(static_cast<unsigned>(maskBytes.size()))));
+					ret.bytecode += maskBytes;
+					instructionLocationEmitter.emit();
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::AND));
+					instructionLocationEmitter.emit();
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::OR));
+					instructionLocationEmitter.emit();
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::SWAP1));
+					instructionLocationEmitter.emit();
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::MSTORE));
+				}
+				else
+				{
+					// Partial width (2-31 bytes) at an early offset where offset < 32 - width:
+					// the read-modify-write address adjustment would underflow, so fall back
+					// to byte-by-byte MSTORE8.
+					// Stack in: [value, dest_base]  (dest_base on top)
+					for (size_t byteIdx = 0; byteIdx < width; ++byteIdx)
+					{
+						bool last = (byteIdx == static_cast<size_t>(width) - 1);
+						// Duplicate value and dest_base for all but the last byte.
+						if (!last)
+						{
+							ret.bytecode.push_back(static_cast<uint8_t>(Instruction::DUP2));
+							instructionLocationEmitter.emit();
+							ret.bytecode.push_back(static_cast<uint8_t>(Instruction::DUP2));
+							instructionLocationEmitter.emit();
+						}
+						// Stack: [value, dest_base] (either originals or copies)
+						// Compute dest_base + offsets[i] + byteIdx
+						size_t byteOffset = offsets[i] + byteIdx;
+						bytes offsetBytes = toCompactBigEndian(u256(byteOffset));
+						ret.bytecode.push_back(static_cast<uint8_t>(pushInstruction(static_cast<unsigned>(offsetBytes.size()))));
+						ret.bytecode += offsetBytes;
+						instructionLocationEmitter.emit();
+						ret.bytecode.push_back(static_cast<uint8_t>(Instruction::ADD));
+						instructionLocationEmitter.emit();
+						// Stack: [value, addr]
+						ret.bytecode.push_back(static_cast<uint8_t>(Instruction::SWAP1));
+						instructionLocationEmitter.emit();
+						// Stack: [addr, value]
+						// Extract the byte: divide by 256^(width - 1 - byteIdx) to shift right.
+						// Uses DIV instead of SHR for EVM version compatibility.
+						unsigned shiftBytes_ = static_cast<unsigned>(width - 1 - byteIdx);
+						if (shiftBytes_ > 0)
+						{
+							u256 divisor = u256(1) << (shiftBytes_ * 8);
+							bytes divisorBytes = toCompactBigEndian(divisor);
+							ret.bytecode.push_back(static_cast<uint8_t>(pushInstruction(static_cast<unsigned>(divisorBytes.size()))));
+							ret.bytecode += divisorBytes;
+							instructionLocationEmitter.emit();
+							// Stack: [addr, value, divisor]
+							ret.bytecode.push_back(static_cast<uint8_t>(Instruction::SWAP1));
+							instructionLocationEmitter.emit();
+							// Stack: [addr, divisor, value]
+							ret.bytecode.push_back(static_cast<uint8_t>(Instruction::DIV));
+							instructionLocationEmitter.emit();
+							// Stack: [addr, value / divisor]
+						}
+						// Stack: [addr, byte_value] (low byte is what we want)
+						// MSTORE8(offset, value): pops offset first, then value.
+						// Need [byte_value, addr] with addr on top.
+						ret.bytecode.push_back(static_cast<uint8_t>(Instruction::SWAP1));
+						instructionLocationEmitter.emit();
+						ret.bytecode.push_back(static_cast<uint8_t>(Instruction::MSTORE8));
+						instructionLocationEmitter.emit();
+					}
+				}
 				// No emit needed here, it's taken care of by the destructor of instructionLocationEmitter.
 			}
 			if (offsets.empty())

--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -1486,52 +1486,51 @@ LinkerObject const& Assembly::assembleLegacy() const
 					// Partial width (2-31 bytes): left-shift read-modify-write.
 					// Left-align the value via MUL, then MSTORE at the original offset.
 					// Uses MUL instead of SHL for pre-Constantinople compatibility.
-					//
-					// multiplier = 1 << ((32 - width) * 8)
-					// keepMask   = multiplier - 1  (preserves trailing 32-width bytes)
-					//
-					// Stack in: [value, dest_base]  (dest_base on top)
-					// PUSH off ADD:          [value, addr]
-					// SWAP1:                 [addr, value]
-					// PUSH multiplier MUL:   [addr, shifted]
-					// DUP2:                  [addr, shifted, addr]
-					// MLOAD:                 [addr, shifted, old]
-					// PUSH keepMask AND:     [addr, shifted, masked]
-					// OR:                    [addr, patched]
-					// SWAP1:                 [patched, addr]
-					// MSTORE:                []
 					u256 multiplier = u256(1) << ((32 - width) * 8);
-					u256 keepMask = multiplier - 1;
+					u256 keepMask = multiplier - 1; // preserves trailing (32 - width) bytes.
 
+					// Stack: [value, dest_base]
 					bytes offsetBytes = toCompactBigEndian(u256(offsets[i]));
 					ret.bytecode.push_back(static_cast<uint8_t>(pushInstruction(static_cast<unsigned>(offsetBytes.size()))));
 					ret.bytecode += offsetBytes;
 					instructionLocationEmitter.emit();
+					// Stack: [value, dest_base, offset]
 					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::ADD));
 					instructionLocationEmitter.emit();
+					// Stack: [value, addr]
 					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::SWAP1));
 					instructionLocationEmitter.emit();
+					// Stack: [addr, value]
 					bytes mulBytes = toCompactBigEndian(multiplier);
 					ret.bytecode.push_back(static_cast<uint8_t>(pushInstruction(static_cast<unsigned>(mulBytes.size()))));
 					ret.bytecode += mulBytes;
 					instructionLocationEmitter.emit();
+					// Stack: [addr, value, multiplier]
 					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::MUL));
 					instructionLocationEmitter.emit();
+					// Stack: [addr, shifted]  (value left-aligned in 32 bytes)
 					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::DUP2));
 					instructionLocationEmitter.emit();
+					// Stack: [addr, shifted, addr]
 					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::MLOAD));
 					instructionLocationEmitter.emit();
+					// Stack: [addr, shifted, old]
 					bytes maskBytes = toCompactBigEndian(keepMask);
 					ret.bytecode.push_back(static_cast<uint8_t>(pushInstruction(static_cast<unsigned>(maskBytes.size()))));
 					ret.bytecode += maskBytes;
 					instructionLocationEmitter.emit();
+					// Stack: [addr, shifted, old, keepMask]
 					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::AND));
 					instructionLocationEmitter.emit();
+					// Stack: [addr, shifted, masked]  (trailing bytes preserved, leading cleared)
 					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::OR));
 					instructionLocationEmitter.emit();
+					// Stack: [addr, patched]
 					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::SWAP1));
 					instructionLocationEmitter.emit();
+					// Stack: [patched, addr]
 					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::MSTORE));
+					// Stack: []
 				}
 				// No emit needed here, it's taken care of by the destructor of instructionLocationEmitter.
 			}

--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -1486,8 +1486,8 @@ LinkerObject const& Assembly::assembleLegacy() const
 					// Partial width (2-31 bytes): left-shift read-modify-write.
 					// Left-align the value via MUL, then MSTORE at the original offset.
 					// Uses MUL instead of SHL for pre-Constantinople compatibility.
+					// keepMask = multiplier - 1 is computed on-stack to avoid a large PUSH.
 					u256 multiplier = u256(1) << ((32 - width) * 8);
-					u256 keepMask = multiplier - 1; // preserves trailing (32 - width) bytes.
 
 					// Stack: [value, dest_base]
 					bytes offsetBytes = toCompactBigEndian(u256(offsets[i]));
@@ -1506,20 +1506,34 @@ LinkerObject const& Assembly::assembleLegacy() const
 					ret.bytecode += mulBytes;
 					instructionLocationEmitter.emit();
 					// Stack: [addr, value, multiplier]
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::DUP1));
+					instructionLocationEmitter.emit();
+					// Stack: [addr, value, multiplier, multiplier]
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::SWAP2));
+					instructionLocationEmitter.emit();
+					// Stack: [addr, multiplier, multiplier, value]
 					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::MUL));
 					instructionLocationEmitter.emit();
-					// Stack: [addr, shifted]  (value left-aligned in 32 bytes)
-					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::DUP2));
+					// Stack: [addr, multiplier, shifted]
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::SWAP1));
 					instructionLocationEmitter.emit();
-					// Stack: [addr, shifted, addr]
+					// Stack: [addr, shifted, multiplier]
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::PUSH1));
+					ret.bytecode.push_back(1);
+					instructionLocationEmitter.emit();
+					// Stack: [addr, shifted, multiplier, 1]
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::SWAP1));
+					instructionLocationEmitter.emit();
+					// Stack: [addr, shifted, 1, multiplier]
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::SUB));
+					instructionLocationEmitter.emit();
+					// Stack: [addr, shifted, keepMask]  (= multiplier - 1)
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::DUP3));
+					instructionLocationEmitter.emit();
+					// Stack: [addr, shifted, keepMask, addr]
 					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::MLOAD));
 					instructionLocationEmitter.emit();
-					// Stack: [addr, shifted, old]
-					bytes maskBytes = toCompactBigEndian(keepMask);
-					ret.bytecode.push_back(static_cast<uint8_t>(pushInstruction(static_cast<unsigned>(maskBytes.size()))));
-					ret.bytecode += maskBytes;
-					instructionLocationEmitter.emit();
-					// Stack: [addr, shifted, old, keepMask]
+					// Stack: [addr, shifted, keepMask, old]
 					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::AND));
 					instructionLocationEmitter.emit();
 					// Stack: [addr, shifted, masked]  (trailing bytes preserved, leading cleared)

--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -1481,33 +1481,41 @@ LinkerObject const& Assembly::assembleLegacy() const
 					instructionLocationEmitter.emit();
 					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::MSTORE8));
 				}
-				else if (offsets[i] >= static_cast<size_t>(32 - width))
+				else
 				{
-					// Partial width (2-31 bytes): read-modify-write.
-					// MSTORE always writes 32 bytes, so we offset the write by (width - 32) and
-					// use a mask to preserve the (32 - width) preceding bytes.
-					// addr = dest_base + offset + width - 32
-					// keepMask = ~((1 << (width * 8)) - 1)   (preserves high bytes, clears low `width` bytes)
+					// Partial width (2-31 bytes): left-shift read-modify-write.
+					// Left-align the value via MUL, then MSTORE at the original offset.
+					// Uses MUL instead of SHL for pre-Constantinople compatibility.
+					//
+					// multiplier = 1 << ((32 - width) * 8)
+					// keepMask   = multiplier - 1  (preserves trailing 32-width bytes)
 					//
 					// Stack in: [value, dest_base]  (dest_base on top)
-					// PUSH adjOff ADD: [value, addr]
-					// SWAP1:           [addr, value]
-					// DUP2:            [addr, value, addr]
-					// MLOAD:           [addr, value, old]
-					// PUSH mask AND:   [addr, value, masked]
-					// OR:              [addr, patched]
-					// SWAP1:           [patched, addr]
-					// MSTORE:          []
-					size_t adjustedOffset = offsets[i] + width - 32;
-					u256 keepMask = ~((u256(1) << (width * 8)) - 1);
+					// PUSH off ADD:          [value, addr]
+					// SWAP1:                 [addr, value]
+					// PUSH multiplier MUL:   [addr, shifted]
+					// DUP2:                  [addr, shifted, addr]
+					// MLOAD:                 [addr, shifted, old]
+					// PUSH keepMask AND:     [addr, shifted, masked]
+					// OR:                    [addr, patched]
+					// SWAP1:                 [patched, addr]
+					// MSTORE:                []
+					u256 multiplier = u256(1) << ((32 - width) * 8);
+					u256 keepMask = multiplier - 1;
 
-					bytes offsetBytes = toCompactBigEndian(u256(adjustedOffset));
+					bytes offsetBytes = toCompactBigEndian(u256(offsets[i]));
 					ret.bytecode.push_back(static_cast<uint8_t>(pushInstruction(static_cast<unsigned>(offsetBytes.size()))));
 					ret.bytecode += offsetBytes;
 					instructionLocationEmitter.emit();
 					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::ADD));
 					instructionLocationEmitter.emit();
 					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::SWAP1));
+					instructionLocationEmitter.emit();
+					bytes mulBytes = toCompactBigEndian(multiplier);
+					ret.bytecode.push_back(static_cast<uint8_t>(pushInstruction(static_cast<unsigned>(mulBytes.size()))));
+					ret.bytecode += mulBytes;
+					instructionLocationEmitter.emit();
+					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::MUL));
 					instructionLocationEmitter.emit();
 					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::DUP2));
 					instructionLocationEmitter.emit();
@@ -1524,63 +1532,6 @@ LinkerObject const& Assembly::assembleLegacy() const
 					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::SWAP1));
 					instructionLocationEmitter.emit();
 					ret.bytecode.push_back(static_cast<uint8_t>(Instruction::MSTORE));
-				}
-				else
-				{
-					// Partial width (2-31 bytes) at an early offset where offset < 32 - width:
-					// the read-modify-write address adjustment would underflow, so fall back
-					// to byte-by-byte MSTORE8.
-					// Stack in: [value, dest_base]  (dest_base on top)
-					for (size_t byteIdx = 0; byteIdx < width; ++byteIdx)
-					{
-						bool last = (byteIdx == static_cast<size_t>(width) - 1);
-						// Duplicate value and dest_base for all but the last byte.
-						if (!last)
-						{
-							ret.bytecode.push_back(static_cast<uint8_t>(Instruction::DUP2));
-							instructionLocationEmitter.emit();
-							ret.bytecode.push_back(static_cast<uint8_t>(Instruction::DUP2));
-							instructionLocationEmitter.emit();
-						}
-						// Stack: [value, dest_base] (either originals or copies)
-						// Compute dest_base + offsets[i] + byteIdx
-						size_t byteOffset = offsets[i] + byteIdx;
-						bytes offsetBytes = toCompactBigEndian(u256(byteOffset));
-						ret.bytecode.push_back(static_cast<uint8_t>(pushInstruction(static_cast<unsigned>(offsetBytes.size()))));
-						ret.bytecode += offsetBytes;
-						instructionLocationEmitter.emit();
-						ret.bytecode.push_back(static_cast<uint8_t>(Instruction::ADD));
-						instructionLocationEmitter.emit();
-						// Stack: [value, addr]
-						ret.bytecode.push_back(static_cast<uint8_t>(Instruction::SWAP1));
-						instructionLocationEmitter.emit();
-						// Stack: [addr, value]
-						// Extract the byte: divide by 256^(width - 1 - byteIdx) to shift right.
-						// Uses DIV instead of SHR for EVM version compatibility.
-						unsigned shiftBytes_ = static_cast<unsigned>(width - 1 - byteIdx);
-						if (shiftBytes_ > 0)
-						{
-							u256 divisor = u256(1) << (shiftBytes_ * 8);
-							bytes divisorBytes = toCompactBigEndian(divisor);
-							ret.bytecode.push_back(static_cast<uint8_t>(pushInstruction(static_cast<unsigned>(divisorBytes.size()))));
-							ret.bytecode += divisorBytes;
-							instructionLocationEmitter.emit();
-							// Stack: [addr, value, divisor]
-							ret.bytecode.push_back(static_cast<uint8_t>(Instruction::SWAP1));
-							instructionLocationEmitter.emit();
-							// Stack: [addr, divisor, value]
-							ret.bytecode.push_back(static_cast<uint8_t>(Instruction::DIV));
-							instructionLocationEmitter.emit();
-							// Stack: [addr, value / divisor]
-						}
-						// Stack: [addr, byte_value] (low byte is what we want)
-						// MSTORE8(offset, value): pops offset first, then value.
-						// Need [byte_value, addr] with addr on top.
-						ret.bytecode.push_back(static_cast<uint8_t>(Instruction::SWAP1));
-						instructionLocationEmitter.emit();
-						ret.bytecode.push_back(static_cast<uint8_t>(Instruction::MSTORE8));
-						instructionLocationEmitter.emit();
-					}
 				}
 				// No emit needed here, it's taken care of by the destructor of instructionLocationEmitter.
 			}

--- a/libevmasm/Assembly.h
+++ b/libevmasm/Assembly.h
@@ -87,8 +87,8 @@ public:
 	size_t numSubs() const { return m_subs.size(); }
 	AssemblyItem newPushSubSize(u256 const& _subId) { return AssemblyItem(PushSubSize, _subId); }
 	AssemblyItem newPushLibraryAddress(std::string const& _identifier);
-	AssemblyItem newPushImmutable(std::string const& _identifier);
-	AssemblyItem newImmutableAssignment(std::string const& _identifier);
+	AssemblyItem newPushImmutable(std::string const& _identifier, uint8_t _byteWidth = 32);
+	AssemblyItem newImmutableAssignment(std::string const& _identifier, uint8_t _byteWidth = 32);
 	AssemblyItem newAuxDataLoadN(size_t offset) const;
 	AssemblyItem newSwapN(size_t _depth) const;
 	AssemblyItem newDupN(size_t _depth) const;
@@ -102,8 +102,8 @@ public:
 	/// after compilation and CODESIZE is not an option.
 	void appendProgramSize() { append(AssemblyItem(PushProgramSize)); }
 	void appendLibraryAddress(std::string const& _identifier) { append(newPushLibraryAddress(_identifier)); }
-	void appendImmutable(std::string const& _identifier) { append(newPushImmutable(_identifier)); }
-	void appendImmutableAssignment(std::string const& _identifier) { append(newImmutableAssignment(_identifier)); }
+	void appendImmutable(std::string const& _identifier, uint8_t _byteWidth = 32) { append(newPushImmutable(_identifier, _byteWidth)); }
+	void appendImmutableAssignment(std::string const& _identifier, uint8_t _byteWidth = 32) { append(newImmutableAssignment(_identifier, _byteWidth)); }
 	void appendAuxDataLoadN(uint16_t _offset) { append(newAuxDataLoadN(_offset));}
 	void appendSwapN(size_t _depth) { append(newSwapN(_depth)); }
 	void appendDupN(size_t _depth) { append(newDupN(_depth)); }

--- a/libevmasm/AssemblyItem.cpp
+++ b/libevmasm/AssemblyItem.cpp
@@ -181,10 +181,11 @@ size_t AssemblyItem::bytesRequired(size_t _addressLength, langutil::EVMVersion _
 		if (immutableOccurrences != 0)
 		{
 			if (m_immutableByteWidth >= 2 && m_immutableByteWidth < 32)
-				// Left-shift RMW: PUSH ADD SWAP1 PUSH MUL DUP2 MLOAD PUSH AND OR SWAP1 MSTORE
-				// = 12 opcodes + 3 PUSH immediates (up to 32 bytes each) = 12 + 32*3 = 108
-				// Non-last occurrence adds DUP2 DUP2: +2 = 110
-				return (immutableOccurrences - 1) * (14 + 32 * 3) + (12 + 32 * 3);
+				// Left-shift RMW: PUSH ADD SWAP1 PUSH DUP1 SWAP2 MUL SWAP1 PUSH1 SWAP1 SUB
+				//                 DUP3 MLOAD AND OR SWAP1 MSTORE
+				// = 17 opcodes, 14 single-byte + PUSH<off>(1+32) + PUSH<mul>(1+32) + PUSH1(2)
+				// Non-last occurrence adds DUP2 DUP2: +2
+				return (immutableOccurrences - 1) * (16 + 32 * 2) + (14 + 32 * 2 + 2);
 			else
 				// (DUP DUP PUSH<n> ADD MSTORE[8])* (PUSH<n> ADD MSTORE[8])
 				return (immutableOccurrences - 1) * (5 + 32) + (3 + 32);
@@ -536,9 +537,8 @@ size_t AssemblyItem::opcodeCount() const noexcept
 			if (m_immutableOccurrences.value() != 0)
 			{
 				if (m_immutableByteWidth >= 2 && m_immutableByteWidth < 32)
-					// Left-shift RMW: PUSH ADD SWAP1 PUSH MUL DUP2 MLOAD PUSH AND OR SWAP1 MSTORE = 12.
-					// Non-last occurrence adds DUP2 DUP2 = 14.
-					return (*m_immutableOccurrences - 1) * 14 + 12;
+					// Left-shift RMW: 17 opcodes. Non-last occurrence adds DUP2 DUP2 = 19.
+					return (*m_immutableOccurrences - 1) * 19 + 17;
 				else
 					// Per occurrence: PUSH ADD MSTORE[8] = 3 opcodes.
 					// Non-last add DUP2 DUP2 = 5 opcodes.

--- a/libevmasm/AssemblyItem.cpp
+++ b/libevmasm/AssemblyItem.cpp
@@ -164,7 +164,7 @@ size_t AssemblyItem::bytesRequired(size_t _addressLength, langutil::EVMVersion _
 	case PushDeployTimeAddress:
 		return 1 + 20;
 	case PushImmutable:
-		return 1 + 32;
+		return 1 + m_immutableByteWidth;
 	case AssignImmutable:
 	{
 		unsigned long immutableOccurrences = 0;
@@ -179,8 +179,26 @@ size_t AssemblyItem::bytesRequired(size_t _addressLength, langutil::EVMVersion _
 		}
 
 		if (immutableOccurrences != 0)
-			// (DUP DUP PUSH <n> ADD MSTORE)* (PUSH <n> ADD MSTORE)
-			return (immutableOccurrences - 1) * (5 + 32) + (3 + 32);
+		{
+			if (m_immutableByteWidth >= 2 && m_immutableByteWidth < 32)
+			{
+				// RMW path (normal case, offset >= 32 - width):
+				// Last:     PUSH<n> ADD SWAP1 DUP2 MLOAD PUSH32<mask> AND OR SWAP1 MSTORE = 10 + 32 + 32
+				// Non-last: DUP2 DUP2 + above = 12 + 32 + 32
+				size_t rmwCost = (immutableOccurrences - 1) * (12 + 32 + 32) + (10 + 32 + 32);
+				// Byte-by-byte fallback (early offset, offset < 32 - width):
+				// Non-last byte: DUP2 DUP2 PUSH33 ADD SWAP1 PUSH33 SWAP1 DIV SWAP1 MSTORE8 = 74 bytes
+				// Last byte (no shift/dup): PUSH33 ADD SWAP1 SWAP1 MSTORE8 = 37 bytes
+				// Per occurrence: (width - 1) * 74 + 37
+				// Non-last occurrence adds outer DUP2 DUP2: +2
+				size_t perOccurrence = (static_cast<size_t>(m_immutableByteWidth) - 1) * 74 + 37;
+				size_t byteByByteCost = immutableOccurrences * perOccurrence + (immutableOccurrences - 1) * 2;
+				return std::max(rmwCost, byteByByteCost);
+			}
+			else
+				// (DUP DUP PUSH<n> ADD MSTORE[8])* (PUSH<n> ADD MSTORE[8])
+				return (immutableOccurrences - 1) * (5 + 32) + (3 + 32);
+		}
 		else
 			// POP POP
 			return 2;
@@ -523,14 +541,28 @@ size_t AssemblyItem::opcodeCount() const noexcept
 	switch (m_type)
 	{
 		case AssemblyItemType::AssignImmutable:
-			// Append empty items if this AssignImmutable was referenced more than once.
-			// For n immutable occurrences the first (n - 1) occurrences will
-			// generate 5 opcodes and the last will generate 3 opcodes,
-			// because it is reusing the 2 top-most elements on the stack.
 			solAssert(m_immutableOccurrences, "");
 
 			if (m_immutableOccurrences.value() != 0)
-				return (*m_immutableOccurrences - 1) * 5 + 3;
+			{
+				if (m_immutableByteWidth >= 2 && m_immutableByteWidth < 32)
+				{
+					// RMW path: PUSH ADD SWAP1 DUP2 MLOAD PUSH AND OR SWAP1 MSTORE = 10 opcodes.
+					// Non-last add DUP2 DUP2 = 12 opcodes.
+					size_t rmwCount = (*m_immutableOccurrences - 1) * 12 + 10;
+					// Byte-by-byte fallback:
+					// Non-last byte: DUP2 DUP2 PUSH ADD SWAP1 PUSH SWAP1 DIV SWAP1 MSTORE8 = 10 opcodes.
+					// Last byte (no shift/dup): PUSH ADD SWAP1 SWAP1 MSTORE8 = 5 opcodes.
+					// Per occurrence: (width - 1) * 10 + 5. Non-last occurrence adds outer DUP2 DUP2: +2.
+					size_t perOccurrence = (static_cast<size_t>(m_immutableByteWidth) - 1) * 10 + 5;
+					size_t byteByByteCount = *m_immutableOccurrences * perOccurrence + (*m_immutableOccurrences - 1) * 2;
+					return std::max(rmwCount, byteByByteCount);
+				}
+				else
+					// Per occurrence: PUSH ADD MSTORE[8] = 3 opcodes.
+					// Non-last add DUP2 DUP2 = 5 opcodes.
+					return (*m_immutableOccurrences - 1) * 5 + 3;
+			}
 			else
 				return 2; // two POP's
 		default:

--- a/libevmasm/AssemblyItem.cpp
+++ b/libevmasm/AssemblyItem.cpp
@@ -181,20 +181,10 @@ size_t AssemblyItem::bytesRequired(size_t _addressLength, langutil::EVMVersion _
 		if (immutableOccurrences != 0)
 		{
 			if (m_immutableByteWidth >= 2 && m_immutableByteWidth < 32)
-			{
-				// RMW path (normal case, offset >= 32 - width):
-				// Last:     PUSH<n> ADD SWAP1 DUP2 MLOAD PUSH32<mask> AND OR SWAP1 MSTORE = 10 + 32 + 32
-				// Non-last: DUP2 DUP2 + above = 12 + 32 + 32
-				size_t rmwCost = (immutableOccurrences - 1) * (12 + 32 + 32) + (10 + 32 + 32);
-				// Byte-by-byte fallback (early offset, offset < 32 - width):
-				// Non-last byte: DUP2 DUP2 PUSH33 ADD SWAP1 PUSH33 SWAP1 DIV SWAP1 MSTORE8 = 74 bytes
-				// Last byte (no shift/dup): PUSH33 ADD SWAP1 SWAP1 MSTORE8 = 37 bytes
-				// Per occurrence: (width - 1) * 74 + 37
-				// Non-last occurrence adds outer DUP2 DUP2: +2
-				size_t perOccurrence = (static_cast<size_t>(m_immutableByteWidth) - 1) * 74 + 37;
-				size_t byteByByteCost = immutableOccurrences * perOccurrence + (immutableOccurrences - 1) * 2;
-				return std::max(rmwCost, byteByByteCost);
-			}
+				// Left-shift RMW: PUSH ADD SWAP1 PUSH MUL DUP2 MLOAD PUSH AND OR SWAP1 MSTORE
+				// = 12 opcodes + 3 PUSH immediates (up to 32 bytes each) = 12 + 32*3 = 108
+				// Non-last occurrence adds DUP2 DUP2: +2 = 110
+				return (immutableOccurrences - 1) * (14 + 32 * 3) + (12 + 32 * 3);
 			else
 				// (DUP DUP PUSH<n> ADD MSTORE[8])* (PUSH<n> ADD MSTORE[8])
 				return (immutableOccurrences - 1) * (5 + 32) + (3 + 32);
@@ -546,18 +536,9 @@ size_t AssemblyItem::opcodeCount() const noexcept
 			if (m_immutableOccurrences.value() != 0)
 			{
 				if (m_immutableByteWidth >= 2 && m_immutableByteWidth < 32)
-				{
-					// RMW path: PUSH ADD SWAP1 DUP2 MLOAD PUSH AND OR SWAP1 MSTORE = 10 opcodes.
-					// Non-last add DUP2 DUP2 = 12 opcodes.
-					size_t rmwCount = (*m_immutableOccurrences - 1) * 12 + 10;
-					// Byte-by-byte fallback:
-					// Non-last byte: DUP2 DUP2 PUSH ADD SWAP1 PUSH SWAP1 DIV SWAP1 MSTORE8 = 10 opcodes.
-					// Last byte (no shift/dup): PUSH ADD SWAP1 SWAP1 MSTORE8 = 5 opcodes.
-					// Per occurrence: (width - 1) * 10 + 5. Non-last occurrence adds outer DUP2 DUP2: +2.
-					size_t perOccurrence = (static_cast<size_t>(m_immutableByteWidth) - 1) * 10 + 5;
-					size_t byteByByteCount = *m_immutableOccurrences * perOccurrence + (*m_immutableOccurrences - 1) * 2;
-					return std::max(rmwCount, byteByByteCount);
-				}
+					// Left-shift RMW: PUSH ADD SWAP1 PUSH MUL DUP2 MLOAD PUSH AND OR SWAP1 MSTORE = 12.
+					// Non-last occurrence adds DUP2 DUP2 = 14.
+					return (*m_immutableOccurrences - 1) * 14 + 12;
 				else
 					// Per occurrence: PUSH ADD MSTORE[8] = 3 opcodes.
 					// Non-last add DUP2 DUP2 = 5 opcodes.

--- a/libevmasm/AssemblyItem.h
+++ b/libevmasm/AssemblyItem.h
@@ -308,6 +308,8 @@ public:
 	size_t m_modifierDepth = 0;
 
 	void setImmutableOccurrences(size_t _n) const { m_immutableOccurrences = _n; }
+	void setImmutableByteWidth(uint8_t _width) const { solAssert(_width >= 1 && _width <= 32); m_immutableByteWidth = _width; }
+	uint8_t immutableByteWidth() const { return m_immutableByteWidth; }
 
 	struct FunctionSignature
 	{
@@ -341,6 +343,8 @@ private:
 	mutable std::shared_ptr<u256> m_pushedValue;
 	/// Number of PushImmutable's with the same hash. Only used for AssignImmutable.
 	mutable std::optional<size_t> m_immutableOccurrences;
+	/// Byte width of the immutable value (1-32). Only valid for PushImmutable/AssignImmutable.
+	mutable uint8_t m_immutableByteWidth = 32;
 };
 
 inline size_t bytesRequired(AssemblyItems const& _items, size_t _addressLength, langutil::EVMVersion _evmVersion, Precision _precision = Precision::Precise)

--- a/libevmasm/LinkerObject.h
+++ b/libevmasm/LinkerObject.h
@@ -34,7 +34,18 @@ namespace solidity::evmasm
  */
 struct LinkerObject
 {
-	using ImmutableRefs = std::pair<std::string, std::vector<size_t>>;
+	struct ImmutableRefs
+	{
+		std::string identifier;
+		uint8_t length = 32;
+		std::vector<size_t> offsets;
+
+		bool operator<(ImmutableRefs const& _other) const
+		{
+			return std::tie(identifier, length, offsets) < std::tie(_other.identifier, _other.length, _other.offsets);
+		}
+	};
+
 	/// The bytecode.
 	bytes bytecode;
 

--- a/libsolidity/ast/Types.h
+++ b/libsolidity/ast/Types.h
@@ -1741,4 +1741,23 @@ public:
 	Type const* decodingType() const override;
 };
 
+/// Returns the optimal byte width for an immutable variable of the given type.
+/// Types excluded from the PUSH<N> optimization (returning 32):
+/// - left-aligned types (bytesN)
+/// - signed integer types (intN), including through UserDefinedValueType wrappers
+/// - types already 32 bytes wide
+inline uint8_t immutableByteWidth(Type const& _type)
+{
+	if (_type.leftAligned() || _type.storageBytes() >= 32)
+		return 32;
+	// Check signedness: need to look through UserDefinedValueType to find the underlying IntegerType.
+	Type const* underlying = &_type;
+	if (auto const* udvt = dynamic_cast<UserDefinedValueType const*>(underlying))
+		underlying = &udvt->underlyingType();
+	if (auto const* intType = dynamic_cast<IntegerType const*>(underlying))
+		if (intType->isSigned())
+			return 32;
+	return static_cast<uint8_t>(_type.storageBytes());
+}
+
 }

--- a/libsolidity/codegen/CompilerContext.h
+++ b/libsolidity/codegen/CompilerContext.h
@@ -238,9 +238,9 @@ public:
 	/// Appends the address (virtual, will be filled in by linker) of a library.
 	void appendLibraryAddress(std::string const& _identifier) { m_asm->appendLibraryAddress(_identifier); }
 	/// Appends an immutable variable. The value will be filled in by the constructor.
-	void appendImmutable(std::string const& _identifier) { m_asm->appendImmutable(_identifier); }
+	void appendImmutable(std::string const& _identifier, uint8_t _byteWidth = 32) { m_asm->appendImmutable(_identifier, _byteWidth); }
 	/// Appends an assignment to an immutable variable. Only valid in creation code.
-	void appendImmutableAssignment(std::string const& _identifier) { m_asm->appendImmutableAssignment(_identifier); }
+	void appendImmutableAssignment(std::string const& _identifier, uint8_t _byteWidth = 32) { m_asm->appendImmutableAssignment(_identifier, _byteWidth); }
 	/// Appends a zero-address that can be replaced by something else at deploy time (if the
 	/// position in bytecode is known).
 	void appendDeployTimeAddress() { m_asm->append(evmasm::PushDeployTimeAddress); }

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -207,10 +207,11 @@ SubAssemblyID ContractCompiler::packIntoContractCreator(ContractDefinition const
 	for (auto const& immutable: immutables | ranges::views::reverse)
 	{
 		auto slotNames = m_context.immutableVariableSlotNames(*immutable);
+		uint8_t byteWidth = immutableByteWidth(*immutable->annotation().type);
 		for (auto&& slotName: slotNames | ranges::views::reverse)
 		{
 			m_context << u256(0);
-			m_context.appendImmutableAssignment(slotName);
+			m_context.appendImmutableAssignment(slotName, byteWidth);
 		}
 	}
 	if (!immutables.empty())

--- a/libsolidity/codegen/LValue.cpp
+++ b/libsolidity/codegen/LValue.cpp
@@ -166,7 +166,7 @@ void ImmutableItem::retrieveValue(SourceLocation const&, bool) const
 		);
 	else
 		for (auto&& slotName: m_context.immutableVariableSlotNames(m_variable))
-			m_context.appendImmutable(slotName);
+			m_context.appendImmutable(slotName, immutableByteWidth(*m_dataType));
 }
 
 void ImmutableItem::storeValue(Type const& _sourceType, SourceLocation const&, bool _move) const

--- a/libsolidity/codegen/ir/IRGenerator.cpp
+++ b/libsolidity/codegen/ir/IRGenerator.cpp
@@ -228,7 +228,7 @@ std::string IRGenerator::generate(
 	if (_contract.isLibrary())
 	{
 		if (!eof)
-			t("library_address", IRNames::libraryAddressImmutable());
+			t("library_address", IRNames::libraryAddressImmutable() + "@20");
 		else
 			t("library_address_immutable_offset", std::to_string(m_context.libraryAddressImmutableOffsetRelative()));
 	}
@@ -592,7 +592,13 @@ std::string IRGenerator::generateGetter(VariableDeclaration const& _varDecl)
 			auto const eof = m_context.eofVersion().has_value();
 			t("eof", eof);
 			if (!eof)
-				t("id", std::to_string(_varDecl.id()));
+			{
+				std::string id = std::to_string(_varDecl.id());
+				uint8_t byteWidth = immutableByteWidth(*_varDecl.type());
+				if (byteWidth < 32)
+					id += "@" + std::to_string(byteWidth);
+				t("id", std::move(id));
+			}
 			else
 				t("immutableOffset", std::to_string(m_context.immutableMemoryOffsetRelative(_varDecl)));
 
@@ -1010,7 +1016,7 @@ std::string IRGenerator::deployCode(ContractDefinition const& _contract)
 		solAssert(ContractType(_contract).immutableVariables().empty(), "");
 		if (!eof)
 			immutables.emplace_back(std::map<std::string, std::string>{
-				{"immutableName"s, IRNames::libraryAddressImmutable()},
+				{"immutableName"s, IRNames::libraryAddressImmutable() + "@20"},
 				{"value"s, "address()"}
 			});
 		else
@@ -1023,10 +1029,16 @@ std::string IRGenerator::deployCode(ContractDefinition const& _contract)
 			solUnimplementedAssert(immutable->type()->isValueType());
 			solUnimplementedAssert(immutable->type()->sizeOnStack() == 1);
 			if (!eof)
+			{
+				std::string name = std::to_string(immutable->id());
+				uint8_t byteWidth = immutableByteWidth(*immutable->type());
+				if (byteWidth < 32)
+					name += "@" + std::to_string(byteWidth);
 				immutables.emplace_back(std::map<std::string, std::string>{
-					{"immutableName"s, std::to_string(immutable->id())},
+					{"immutableName"s, std::move(name)},
 					{"value"s, "mload(" + std::to_string(m_context.immutableMemoryOffset(*immutable)) + ")"}
 				});
+			}
 		}
 	}
 

--- a/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
+++ b/libsolidity/codegen/ir/IRGeneratorForStatements.cpp
@@ -3336,7 +3336,13 @@ IRVariable IRGeneratorForStatements::readFromLValue(IRLValue const& _lvalue)
 			else
 			{
 				if (!m_context.eofVersion().has_value())
-					define(result) << "loadimmutable(\"" << std::to_string(_immutable.variable->id()) << "\")\n";
+				{
+					std::string id = std::to_string(_immutable.variable->id());
+					uint8_t byteWidth = immutableByteWidth(*_immutable.variable->type());
+					if (byteWidth < 32)
+						id += "@" + std::to_string(byteWidth);
+					define(result) << "loadimmutable(\"" << id << "\")\n";
+				}
 				else
 					define(result) << "auxdataloadn(" << std::to_string(m_context.immutableMemoryOffsetRelative(*_immutable.variable)) << ")\n";
 			}

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -438,16 +438,16 @@ Json formatImmutableReferences(std::map<u256, evmasm::LinkerObject::ImmutableRef
 
 	for (auto const& immutableReference: _immutableReferences)
 	{
-		auto const& [identifier, byteOffsets] = immutableReference.second;
+		auto const& refs = immutableReference.second;
 		Json array = Json::array();
-		for (size_t byteOffset: byteOffsets)
+		for (size_t byteOffset: refs.offsets)
 		{
 			Json byteRange;
 			byteRange["start"] = Json::number_unsigned_t(byteOffset);
-			byteRange["length"] = Json::number_unsigned_t(32); // immutable references are currently always 32 bytes wide
+			byteRange["length"] = Json::number_unsigned_t(refs.length);
 			array.emplace_back(byteRange);
 		}
-		ret[identifier] = array;
+		ret[refs.identifier] = array;
 	}
 
 	return ret;

--- a/libyul/backends/evm/AbstractAssembly.h
+++ b/libyul/backends/evm/AbstractAssembly.h
@@ -133,9 +133,9 @@ public:
 	virtual SubID appendData(bytes const& _data) = 0;
 
 	/// Appends loading an immutable variable.
-	virtual void appendImmutable(std::string const& _identifier) = 0;
+	virtual void appendImmutable(std::string const& _identifier, uint8_t _byteWidth = 32) = 0;
 	/// Appends an assignment to an immutable variable.
-	virtual void appendImmutableAssignment(std::string const& _identifier) = 0;
+	virtual void appendImmutableAssignment(std::string const& _identifier, uint8_t _byteWidth = 32) = 0;
 
 	/// Appends an operation that loads 32 bytes of data from a known offset relative to the start of the static_aux_data area of the EOF data section.
 	/// Note that static_aux_data is only a part or the data section.

--- a/libyul/backends/evm/EVMBuiltins.cpp
+++ b/libyul/backends/evm/EVMBuiltins.cpp
@@ -34,6 +34,27 @@ using namespace solidity::yul;
 namespace
 {
 
+/// Parses an immutable identifier that may have a byte width suffix encoded as "@N".
+/// Returns the original identifier and the byte width (defaulting to 32 if no suffix).
+std::pair<std::string, uint8_t> parseImmutableIdentifier(std::string const& _identifier)
+{
+	auto atPos = _identifier.rfind('@');
+	if (atPos != std::string::npos && atPos + 1 < _identifier.size())
+	{
+		std::string const widthStr = _identifier.substr(atPos + 1);
+		try
+		{
+			size_t consumed = 0;
+			unsigned long width = std::stoul(widthStr, &consumed);
+			if (consumed == widthStr.size() && width >= 1 && width <= 32)
+				return {_identifier.substr(0, atPos), static_cast<uint8_t>(width)};
+		}
+		catch (std::invalid_argument const&) {}
+		catch (std::out_of_range const&) {}
+	}
+	return {_identifier, 32};
+}
+
 BuiltinFunctionForEVM createFunction(
 	std::string const& _name,
 	size_t _params,
@@ -215,8 +236,9 @@ BuiltinFunctionForEVM setimmutableBuiltin()
 			BuiltinContext&
 		) {
 			yulAssert(_call.arguments.size() == 3, "");
-			auto const identifier = (formatLiteral(std::get<Literal>(_call.arguments[1])));
-			_assembly.appendImmutableAssignment(identifier);
+			auto const rawIdentifier = formatLiteral(std::get<Literal>(_call.arguments[1]));
+			auto const [identifier, byteWidth] = parseImmutableIdentifier(rawIdentifier);
+			_assembly.appendImmutableAssignment(identifier, byteWidth);
 		}
 	);
 }
@@ -236,7 +258,9 @@ BuiltinFunctionForEVM loadimmutableBuiltin()
 			BuiltinContext&
 		) {
 			yulAssert(_call.arguments.size() == 1, "");
-			_assembly.appendImmutable(formatLiteral(std::get<Literal>(_call.arguments.front())));
+			auto const rawIdentifier = formatLiteral(std::get<Literal>(_call.arguments.front()));
+			auto const [identifier, byteWidth] = parseImmutableIdentifier(rawIdentifier);
+			_assembly.appendImmutable(identifier, byteWidth);
 		}
 	);
 }

--- a/libyul/backends/evm/EthAssemblyAdapter.cpp
+++ b/libyul/backends/evm/EthAssemblyAdapter.cpp
@@ -217,14 +217,14 @@ void EthAssemblyAdapter::appendToAuxiliaryData(bytes const& _data)
 	m_assembly.appendToAuxiliaryData(_data);
 }
 
-void EthAssemblyAdapter::appendImmutable(std::string const& _identifier)
+void EthAssemblyAdapter::appendImmutable(std::string const& _identifier, uint8_t _byteWidth)
 {
-	m_assembly.appendImmutable(_identifier);
+	m_assembly.appendImmutable(_identifier, _byteWidth);
 }
 
-void EthAssemblyAdapter::appendImmutableAssignment(std::string const& _identifier)
+void EthAssemblyAdapter::appendImmutableAssignment(std::string const& _identifier, uint8_t _byteWidth)
 {
-	m_assembly.appendImmutableAssignment(_identifier);
+	m_assembly.appendImmutableAssignment(_identifier, _byteWidth);
 }
 
 void EthAssemblyAdapter::appendAuxDataLoadN(uint16_t _offset)

--- a/libyul/backends/evm/EthAssemblyAdapter.h
+++ b/libyul/backends/evm/EthAssemblyAdapter.h
@@ -69,8 +69,8 @@ public:
 
 	void appendToAuxiliaryData(bytes const& _data) override;
 
-	void appendImmutable(std::string const& _identifier) override;
-	void appendImmutableAssignment(std::string const& _identifier) override;
+	void appendImmutable(std::string const& _identifier, uint8_t _byteWidth = 32) override;
+	void appendImmutableAssignment(std::string const& _identifier, uint8_t _byteWidth = 32) override;
 
 	void appendAuxDataLoadN(uint16_t _offset) override;
 

--- a/libyul/backends/evm/NoOutputAssembly.cpp
+++ b/libyul/backends/evm/NoOutputAssembly.cpp
@@ -180,12 +180,12 @@ AbstractAssembly::SubID NoOutputAssembly::appendData(bytes const&)
 }
 
 
-void NoOutputAssembly::appendImmutable(std::string const&)
+void NoOutputAssembly::appendImmutable(std::string const&, uint8_t)
 {
 	yulAssert(false, "loadimmutable not implemented.");
 }
 
-void NoOutputAssembly::appendImmutableAssignment(std::string const&)
+void NoOutputAssembly::appendImmutableAssignment(std::string const&, uint8_t)
 {
 	yulAssert(false, "setimmutable not implemented.");
 }

--- a/libyul/backends/evm/NoOutputAssembly.h
+++ b/libyul/backends/evm/NoOutputAssembly.h
@@ -84,8 +84,8 @@ public:
 
 	void appendToAuxiliaryData(bytes const&) override {}
 
-	void appendImmutable(std::string const& _identifier) override;
-	void appendImmutableAssignment(std::string const& _identifier) override;
+	void appendImmutable(std::string const& _identifier, uint8_t _byteWidth = 32) override;
+	void appendImmutableAssignment(std::string const& _identifier, uint8_t _byteWidth = 32) override;
 
 	void appendAuxDataLoadN(uint16_t) override;
 	void appendEOFCreate(ContainerID) override;

--- a/test/cmdlineTests/standard_immutable_references_small_types/input.json
+++ b/test/cmdlineTests/standard_immutable_references_small_types/input.json
@@ -1,0 +1,18 @@
+{
+ "language": "Solidity",
+ "sources": {
+  "a.sol": {
+   "content": "// SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0;\ncontract A {\n    uint8 immutable x = 42;\n    address immutable y = address(1);\n    function f() public view returns (uint8, address) { return (x, y); }\n}"
+  }
+ },
+ "settings": {
+  "evmVersion": "petersburg",
+  "outputSelection": {
+   "*": {
+    "A": [
+     "evm.deployedBytecode.immutableReferences"
+    ]
+   }
+  }
+ }
+}

--- a/test/cmdlineTests/standard_immutable_references_small_types/output.json
+++ b/test/cmdlineTests/standard_immutable_references_small_types/output.json
@@ -1,0 +1,31 @@
+{
+    "contracts": {
+        "a.sol": {
+            "A": {
+                "evm": {
+                    "deployedBytecode": {
+                        "immutableReferences": {
+                            "10": [
+                                {
+                                    "length": 20,
+                                    "start": 79
+                                }
+                            ],
+                            "4": [
+                                {
+                                    "length": 1,
+                                    "start": 77
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "sources": {
+        "a.sol": {
+            "id": 0
+        }
+    }
+}

--- a/test/libsolidity/semanticTests/immutable/small_immutable_types.sol
+++ b/test/libsolidity/semanticTests/immutable/small_immutable_types.sol
@@ -1,0 +1,17 @@
+contract C {
+	uint8 public immutable a;
+	address public immutable b;
+
+	constructor() {
+		a = 0xff;
+		b = address(0xdEaD);
+	}
+
+	function get() public view returns (uint8, address) {
+		return (a, b);
+	}
+}
+// ----
+// a() -> 0xff
+// b() -> 0xdead
+// get() -> 0xff, 0xdead

--- a/test/libsolidity/semanticTests/immutable/small_immutable_types_signed_udvt.sol
+++ b/test/libsolidity/semanticTests/immutable/small_immutable_types_signed_udvt.sol
@@ -1,0 +1,25 @@
+type MyInt is int16;
+
+contract C {
+	uint8 public immutable a;
+	address public immutable b;
+	MyInt public immutable c;
+	int8 public immutable d;
+
+	constructor() {
+		a = 0xff;
+		b = address(0xdEaD);
+		c = MyInt.wrap(-1);
+		d = -2;
+	}
+
+	function get() public view returns (uint8, address, MyInt, int8) {
+		return (a, b, c, d);
+	}
+}
+// ----
+// a() -> 0xff
+// b() -> 0xdead
+// c() -> -1
+// d() -> -2
+// get() -> 0xff, 0xdead, -1, -2

--- a/test/libyul/objectCompiler/immutable_byte_width.yul
+++ b/test/libyul/objectCompiler/immutable_byte_width.yul
@@ -1,0 +1,50 @@
+object "a" {
+    code {
+        let size := datasize("runtime")
+        datacopy(0, dataoffset("runtime"), size)
+        setimmutable(0, "val@1", 0x42)
+        return(0, size)
+    }
+    object "runtime" {
+        code {
+            sstore(0, loadimmutable("val@1"))
+        }
+    }
+}
+// ====
+// EVMVersion: >=shanghai
+// bytecodeFormat: legacy
+// outputs: Assembly
+// ----
+// Assembly:
+//     /* "source":58:77   */
+//   dataSize(sub_0)
+//     /* "source":102:123   */
+//   dup1
+//   dataOffset(sub_0)
+//     /* "source":99:100   */
+//   0x00
+//     /* "source":90:130   */
+//   codecopy
+//     /* "source":168:172   */
+//   0x42
+//     /* "source":156:157   */
+//   0x00
+//     /* "source":143:173   */
+//   assignImmutable("0x749eb9a32604a1e3d5563e475f22a54221a22999f274fb5acd84a00d16053a11")
+//     /* "source":193:194   */
+//   0x00
+//     /* "source":186:201   */
+//   return
+// stop
+//
+// sub_0: assembly {
+//         /* "source":296:318   */
+//       immutable("0x749eb9a32604a1e3d5563e475f22a54221a22999f274fb5acd84a00d16053a11")
+//         /* "source":293:294   */
+//       0x00
+//         /* "source":286:319   */
+//       sstore
+//         /* "source":254:343   */
+//       stop
+// }

--- a/test/libyul/objectCompiler/immutable_byte_width_20.yul
+++ b/test/libyul/objectCompiler/immutable_byte_width_20.yul
@@ -1,0 +1,50 @@
+object "a" {
+    code {
+        let size := datasize("runtime")
+        datacopy(0, dataoffset("runtime"), size)
+        setimmutable(0, "addr@20", 0xdead)
+        return(0, size)
+    }
+    object "runtime" {
+        code {
+            sstore(0, loadimmutable("addr@20"))
+        }
+    }
+}
+// ====
+// EVMVersion: >=shanghai
+// bytecodeFormat: legacy
+// outputs: Assembly
+// ----
+// Assembly:
+//     /* "source":58:77   */
+//   dataSize(sub_0)
+//     /* "source":102:123   */
+//   dup1
+//   dataOffset(sub_0)
+//     /* "source":99:100   */
+//   0x00
+//     /* "source":90:130   */
+//   codecopy
+//     /* "source":170:176   */
+//   0xdead
+//     /* "source":156:157   */
+//   0x00
+//     /* "source":143:177   */
+//   assignImmutable("0xe5e14487b78f85faa6e1808e89246cf57dd34831548ff2e6097380d98db2504a")
+//     /* "source":197:198   */
+//   0x00
+//     /* "source":190:205   */
+//   return
+// stop
+//
+// sub_0: assembly {
+//         /* "source":300:324   */
+//       immutable("0xe5e14487b78f85faa6e1808e89246cf57dd34831548ff2e6097380d98db2504a")
+//         /* "source":297:298   */
+//       0x00
+//         /* "source":290:325   */
+//       sstore
+//         /* "source":258:349   */
+//       stop
+// }

--- a/test/libyul/objectCompiler/immutable_byte_width_default.yul
+++ b/test/libyul/objectCompiler/immutable_byte_width_default.yul
@@ -1,0 +1,50 @@
+object "a" {
+    code {
+        let size := datasize("runtime")
+        datacopy(0, dataoffset("runtime"), size)
+        setimmutable(0, "val", 0x42)
+        return(0, size)
+    }
+    object "runtime" {
+        code {
+            sstore(0, loadimmutable("val"))
+        }
+    }
+}
+// ====
+// EVMVersion: >=shanghai
+// bytecodeFormat: legacy
+// outputs: Assembly
+// ----
+// Assembly:
+//     /* "source":58:77   */
+//   dataSize(sub_0)
+//     /* "source":102:123   */
+//   dup1
+//   dataOffset(sub_0)
+//     /* "source":99:100   */
+//   0x00
+//     /* "source":90:130   */
+//   codecopy
+//     /* "source":166:170   */
+//   0x42
+//     /* "source":156:157   */
+//   0x00
+//     /* "source":143:171   */
+//   assignImmutable("0x749eb9a32604a1e3d5563e475f22a54221a22999f274fb5acd84a00d16053a11")
+//     /* "source":191:192   */
+//   0x00
+//     /* "source":184:199   */
+//   return
+// stop
+//
+// sub_0: assembly {
+//         /* "source":294:314   */
+//       immutable("0x749eb9a32604a1e3d5563e475f22a54221a22999f274fb5acd84a00d16053a11")
+//         /* "source":291:292   */
+//       0x00
+//         /* "source":284:315   */
+//       sstore
+//         /* "source":252:339   */
+//       stop
+// }


### PR DESCRIPTION
Immutable variables whose type is smaller than 32 bytes now emit `PUSH<N>` where N matches the type's byte width, reducing deployed bytecode size.

Applies to both legacy codegen and via-IR. Excluded types: `bytesN` (left-aligned), signed integers (`intN`, including through `UserDefinedValueType`), and types already 32 bytes wide.

`AssignImmutable` patching strategies by width:
- width 32: `MSTORE`
- width 1: `MSTORE8`
- width 2–31: left-shift value via `MUL`, then read-modify-write at the original offset (keeps mask is computed on-stack as `multiplier - 1` to avoid a large `PUSH`)