### PR TITLE
SSA CFG: rename OperationId to InstId

### DIFF
--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -199,7 +199,7 @@ void CodeTransform::operator()(SSACFG::BlockId const _blockId)
 	std::visit(util::GenericVisitor{ [this, &_blockId](auto const& exit) { (*this)(_blockId, exit); } }, block.exit);
 }
 
-void CodeTransform::operator()(SSACFG::OperationId _opId, StackData const& _operationInputLayout)
+void CodeTransform::operator()(SSACFG::InstId _opId, StackData const& _operationInputLayout)
 {
 	SSACFG::Operation const& _operation = m_cfg.operation(_opId);
 	bool const hasReturnLabel =

--- a/libyul/backends/evm/ssa/CodeTransform.h
+++ b/libyul/backends/evm/ssa/CodeTransform.h
@@ -86,7 +86,7 @@ struct AssemblyCallbacks
 	SSACFG const* cfg{};
 	AbstractAssembly* assembly{};
 	CallSites const* callSites{};
-	std::map<SSACFG::OperationId, AbstractAssembly::LabelID> const* returnLabels{};
+	std::map<SSACFG::InstId, AbstractAssembly::LabelID> const* returnLabels{};
 };
 static_assert(StackManipulationCallbackConcept<AssemblyCallbacks>);
 
@@ -118,7 +118,7 @@ private:
 		ControlFlowGraphs::FunctionGraphID _graphID);
 
 	void operator()(SSACFG::BlockId _blockId);
-	void operator()(SSACFG::OperationId _opId, StackData const& _operationInputLayout);
+	void operator()(SSACFG::InstId _opId, StackData const& _operationInputLayout);
 	void operator()(SSACFG::BlockId const& _currentBlock, SSACFG::BasicBlock::MainExit const& _mainExit);
 	void operator()(SSACFG::BlockId const& _currentBlock, SSACFG::BasicBlock::ConditionalJump const& _conditionalJump);
 	void operator()(SSACFG::BlockId const& _currentBlock, SSACFG::BasicBlock::Jump const& _jump);
@@ -141,7 +141,7 @@ private:
 	AssemblyCallbacks m_assemblyCallbacks;
 	StackData m_stackData;
 	Stack<AssemblyCallbacks> m_stack;
-	std::map<SSACFG::OperationId, AbstractAssembly::LabelID> m_returnLabels;
+	std::map<SSACFG::InstId, AbstractAssembly::LabelID> m_returnLabels;
 };
 
 }

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -62,7 +62,7 @@ public:
 	~SSACFG() = default;
 
 	using BlockId = ssa::BlockId;
-	using OperationId = ssa::OperationId;
+	using InstId = ssa::InstId;
 	using ValueId = ssa::ValueId;
 
 	struct BuiltinCall
@@ -111,7 +111,7 @@ public:
 		struct Terminated {};
 		std::vector<BlockId> entries;
 		std::vector<ValueId> phis;
-		std::vector<OperationId> operations;
+		std::vector<InstId> operations;
 		/// Upsilon assignments placed at the block exit (before the terminator).
 		/// They record the phi pre-images for successor blocks.
 		std::vector<Upsilon> upsilons;
@@ -162,16 +162,16 @@ public:
 	BasicBlock const& block(BlockId _id) const { return m_blocks.at(_id.value); }
 	size_t numBlocks() const { return m_blocks.size(); }
 
-	OperationId makeOperation(Operation _op, langutil::DebugData::ConstPtr _debugData = {})
+	InstId makeOperation(Operation _op, langutil::DebugData::ConstPtr _debugData = {})
 	{
-		OperationId id{static_cast<OperationId::ValueType>(m_operations.size())};
+		InstId id{static_cast<InstId::ValueType>(m_operations.size())};
 		m_operations.emplace_back(std::move(_op));
 		if (debugInfo && _debugData)
 			debugInfo->setOperationDebugData(id, std::move(_debugData));
 		return id;
 	}
-	Operation& operation(OperationId _id) { return m_operations.at(_id.value); }
-	Operation const& operation(OperationId _id) const { return m_operations.at(_id.value); }
+	Operation& operation(InstId _id) { return m_operations.at(_id.value); }
+	Operation const& operation(InstId _id) const { return m_operations.at(_id.value); }
 
 private:
 	std::vector<BasicBlock> m_blocks;

--- a/libyul/backends/evm/ssa/SSACFGDebugInfo.h
+++ b/libyul/backends/evm/ssa/SSACFGDebugInfo.h
@@ -55,14 +55,14 @@ struct SSACFGDebugInfo
 		return getOrEmpty(m_exitDebugData, _id.value);
 	}
 
-	void setOperationDebugData(OperationId _id, langutil::DebugData::ConstPtr _data)
+	void setOperationDebugData(InstId _id, langutil::DebugData::ConstPtr _data)
 	{
 		yulAssert(_id.hasValue());
 		ensureSize(m_operationDebugData, _id.value);
 		m_operationDebugData[_id.value] = std::move(_data);
 	}
 
-	langutil::DebugData::ConstPtr const& operationDebugData(OperationId _id) const
+	langutil::DebugData::ConstPtr const& operationDebugData(InstId _id) const
 	{
 		return getOrEmpty(m_operationDebugData, _id.value);
 	}

--- a/libyul/backends/evm/ssa/SSACFGTypes.h
+++ b/libyul/backends/evm/ssa/SSACFGTypes.h
@@ -44,12 +44,12 @@ struct BlockId
 	auto operator<=>(BlockId const&) const = default;
 };
 
-struct OperationId
+struct InstId
 {
 	using ValueType = std::uint32_t;
 	ValueType value = std::numeric_limits<ValueType>::max();
 	bool hasValue() const { return value != std::numeric_limits<ValueType>::max(); }
-	auto operator<=>(OperationId const&) const = default;
+	auto operator<=>(InstId const&) const = default;
 };
 
 class ValueId
@@ -112,12 +112,12 @@ struct fmt::formatter<solidity::yul::ssa::BlockId>
 };
 
 template<>
-struct fmt::formatter<solidity::yul::ssa::OperationId>
+struct fmt::formatter<solidity::yul::ssa::InstId>
 {
 	static auto constexpr parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
 
 	template<typename FormatContext>
-	auto format(solidity::yul::ssa::OperationId const& _opId, FormatContext& _ctx) const -> decltype(_ctx.out())
+	auto format(solidity::yul::ssa::InstId const& _opId, FormatContext& _ctx) const -> decltype(_ctx.out())
 	{
 		if (!_opId.hasValue())
 			return fmt::format_to(_ctx.out(), "empty");

--- a/libyul/backends/evm/ssa/Stack.h
+++ b/libyul/backends/evm/ssa/Stack.h
@@ -39,20 +39,20 @@ class CallSites
 public:
 	using CallSiteID = std::uint32_t;
 
-	std::optional<CallSiteID> callSiteID(OperationId _op) const
+	std::optional<CallSiteID> callSiteID(InstId _op) const
 	{
 		if (auto const it = ranges::find(m_data, _op); it != m_data.end())
 			return static_cast<CallSiteID>(std::distance(m_data.begin(), it));
 		return std::nullopt;
 	}
 
-	OperationId operationId(CallSiteID _callSite) const
+	InstId operationId(CallSiteID _callSite) const
 	{
 		yulAssert(_callSite < m_data.size());
 		return m_data[_callSite];
 	}
 
-	CallSiteID addCallSite(OperationId _op)
+	CallSiteID addCallSite(InstId _op)
 	{
 		if (auto const id = callSiteID(_op))
 			return *id;
@@ -61,7 +61,7 @@ public:
 		return static_cast<CallSiteID>(m_data.size() - 1);
 	}
 private:
-	std::vector<OperationId> m_data;
+	std::vector<InstId> m_data;
 };
 
 /// A discriminated union corresponding to a single EVM stack slot.

--- a/libyul/backends/evm/ssa/transform/UnreachableBlockCleaner.h
+++ b/libyul/backends/evm/ssa/transform/UnreachableBlockCleaner.h
@@ -17,7 +17,7 @@
 // SPDX-License-Identifier: GPL-3.0
 /**
  * Removes unreachable blocks from an SSA CFG and cleans up entry lists referencing them.
- * Note that this invalidates ValueIds and OperationIds pointing into the (unreachable) blocks.
+ * Note that this invalidates ValueIds and InstIds pointing into the (unreachable) blocks.
  */
 #pragma once
 


### PR DESCRIPTION
Pure type rename. Method names (`operation()`, `makeOperation`, `operationId`, `setOperationDebugData`, etc.) and the formatter's `op{}` output are left unchanged. This is preparation for the Operation/Phi/Literal/Upsilon unification under a single Inst type.