### PR TITLE
SSA CFG instruction store

### DIFF
--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -91,6 +91,7 @@ add_library(yul
 	backends/evm/ssa/SSACFGBuilder.cpp
 	backends/evm/ssa/SSACFGBuilder.h
 	backends/evm/ssa/SSACFGDebugInfo.h
+	backends/evm/ssa/SSACFGTypes.cpp
 	backends/evm/ssa/SSACFGTypes.h
 	backends/evm/ssa/Stack.cpp
 	backends/evm/ssa/Stack.h

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(yul
 	backends/evm/ssa/CodeTransform.h
 	backends/evm/ssa/ControlFlowGraphs.cpp
 	backends/evm/ssa/ControlFlowGraphs.h
+	backends/evm/ssa/InstructionStore.h
 	backends/evm/ssa/JunkAdmittingBlocksFinder.cpp
 	backends/evm/ssa/JunkAdmittingBlocksFinder.h
 	backends/evm/ssa/LivenessAnalysis.cpp

--- a/libyul/backends/evm/ssa/InstructionStore.h
+++ b/libyul/backends/evm/ssa/InstructionStore.h
@@ -1,0 +1,176 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * Owns the instruction table of an SSACFG: hands out InstIds, stores opcode
+ * payloads, and provides lookups. Has no knowledge of basic blocks or debug
+ * information; SSACFG composes those on top.
+ */
+
+#pragma once
+
+#include <libyul/backends/evm/ssa/SSACFGTypes.h>
+
+#include <libyul/AST.h>
+#include <libyul/Builtins.h>
+#include <libyul/Exceptions.h>
+
+#include <libsolutil/Numeric.h>
+
+#include <limits>
+#include <map>
+#include <optional>
+#include <variant>
+#include <vector>
+
+namespace solidity::yul::ssa
+{
+
+class InstructionStore
+{
+public:
+	struct BuiltinCall
+	{
+		BuiltinHandle builtin;
+		/// Literal-kind arguments
+		std::vector<Literal> literalArguments;
+	};
+	struct Call
+	{
+		FunctionGraphID graphID;
+		bool canContinue;
+	};
+	struct Operation
+	{
+		std::vector<ValueId> outputs{};
+		std::variant<BuiltinCall, Call> kind;
+		BlockId block{};
+		std::vector<ValueId> inputs{};
+	};
+	struct LiteralValue
+	{
+		u256 value;
+	};
+	struct VariableValue
+	{
+		BlockId definingBlock;
+	};
+	struct PhiValue
+	{
+		BlockId block;
+	};
+	struct UnreachableValue {};
+
+	InstructionStore() = default;
+	InstructionStore(InstructionStore const&) = delete;
+	InstructionStore(InstructionStore&&) = default;
+	InstructionStore& operator=(InstructionStore const&) = delete;
+	InstructionStore& operator=(InstructionStore&&) = default;
+	~InstructionStore() = default;
+
+	Operation& operation(InstId const _id) { return m_operations.at(_id.value); }
+	Operation const& operation(InstId const _id) const { return m_operations.at(_id.value); }
+
+	LiteralValue const& literalInfo(ValueId const& _valueId) const
+	{
+		yulAssert(_valueId.hasValue() && _valueId.isLiteral());
+		return m_literals.at(_valueId.value());
+	}
+
+	PhiValue const& phiInfo(ValueId const& _valueId) const
+	{
+		yulAssert(_valueId.hasValue() && _valueId.isPhi());
+		return m_phis.at(_valueId.value());
+	}
+	PhiValue& phiInfo(ValueId const& _valueId)
+	{
+		yulAssert(_valueId.hasValue() && _valueId.isPhi());
+		return m_phis.at(_valueId.value());
+	}
+
+	VariableValue const& variableInfo(ValueId const& _valueId) const
+	{
+		yulAssert(_valueId.hasValue() && _valueId.isVariable());
+		return m_variables.at(_valueId.value());
+	}
+
+	ValueId newPhi(BlockId const _definingBlock)
+	{
+		yulAssert(_definingBlock.hasValue());
+		m_phis.emplace_back(PhiValue{_definingBlock});
+		auto const value = m_phis.size() - 1;
+		yulAssert(value < std::numeric_limits<ValueId::ValueType>::max());
+		return ValueId::makePhi(static_cast<ValueId::ValueType>(value));
+	}
+
+	ValueId newVariable(BlockId const _definingBlock)
+	{
+		yulAssert(_definingBlock.hasValue());
+		m_variables.emplace_back(VariableValue{_definingBlock});
+		auto const value = m_variables.size() - 1;
+		yulAssert(value < std::numeric_limits<ValueId::ValueType>::max());
+		return ValueId::makeVariable(static_cast<ValueId::ValueType>(value));
+	}
+
+	ValueId unreachableValue()
+	{
+		if (!m_unreachableValue)
+			m_unreachableValue = ValueId::makeUnreachable();
+		return *m_unreachableValue;
+	}
+
+	/// Look up or allocate a Literal ValueId for `_value`. Returns the ValueId and
+	/// whether a new entry was allocated (false if it was deduplicated).
+	std::pair<ValueId, bool> newLiteral(u256 _value)
+	{
+		if (auto const it = m_literalMapping.find(_value); it != m_literalMapping.end())
+		{
+			yulAssert(it->second.hasValue() && m_literals[it->second.value()].value == _value);
+			return {it->second, false};
+		}
+		m_literals.emplace_back(LiteralValue{std::move(_value)});
+		auto const idx = m_literals.size() - 1;
+		yulAssert(idx < std::numeric_limits<ValueId::ValueType>::max());
+		auto const id = ValueId::makeLiteral(static_cast<ValueId::ValueType>(idx));
+		m_literalMapping.emplace(m_literals.back().value, id);
+		return {id, true};
+	}
+
+	InstId makeOperation(BlockId const _block, Operation _op)
+	{
+		yulAssert(_block.hasValue());
+		for (ValueId const& output: _op.outputs)
+		{
+			yulAssert(output.isVariable());
+			yulAssert(m_variables.at(output.value()).definingBlock == _block);
+		}
+		_op.block = _block;
+		InstId const id{static_cast<InstId::ValueType>(m_operations.size())};
+		m_operations.emplace_back(std::move(_op));
+		return id;
+	}
+
+private:
+	std::vector<Operation> m_operations;
+	std::vector<LiteralValue> m_literals;
+	std::map<u256, ValueId> m_literalMapping;
+	std::vector<PhiValue> m_phis;
+	std::vector<VariableValue> m_variables;
+	std::optional<ValueId> m_unreachableValue;
+};
+
+}

--- a/libyul/backends/evm/ssa/SSACFG.cpp
+++ b/libyul/backends/evm/ssa/SSACFG.cpp
@@ -149,21 +149,6 @@ private:
 
 }
 
-std::string ValueId::str(SSACFG const& _cfg) const
-{
-	if (!hasValue())
-		return "INVALID";
-	switch (kind())
-	{
-		case Kind::Literal:  return toCompactHexWithPrefix(_cfg.literalInfo(*this).value);
-		case Kind::Variable: return fmt::format("v{}", value());
-		case Kind::Phi: return fmt::format("phi{}", value());
-		case Kind::Unreachable: return "[unreachable]";
-	}
-	unreachable();
-}
-
-
 std::string SSACFG::toDot(
 	bool _includeDiGraphDefinition,
 	std::optional<size_t> _functionIndex,

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -90,6 +90,8 @@ public:
 		std::vector<ValueId> outputs{};
 		std::variant<BuiltinCall, Call> kind;
 		std::vector<ValueId> inputs{};
+		/// Block this operation lives in. Set by `makeOperation`.
+		BlockId block{};
 	};
 	struct BasicBlock
 	{
@@ -162,8 +164,15 @@ public:
 	BasicBlock const& block(BlockId _id) const { return m_blocks.at(_id.value); }
 	size_t numBlocks() const { return m_blocks.size(); }
 
-	InstId makeOperation(Operation _op, langutil::DebugData::ConstPtr _debugData = {})
+	InstId makeOperation(BlockId _block, Operation _op, langutil::DebugData::ConstPtr _debugData = {})
 	{
+		yulAssert(_block.hasValue());
+		for (ValueId const& output: _op.outputs)
+		{
+			yulAssert(output.isVariable());
+			yulAssert(m_variables.at(output.value()).definingBlock == _block);
+		}
+		_op.block = _block;
 		InstId id{static_cast<InstId::ValueType>(m_operations.size())};
 		m_operations.emplace_back(std::move(_op));
 		if (debugInfo && _debugData)

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <libyul/backends/evm/ssa/InstructionStore.h>
 #include <libyul/backends/evm/ssa/SSACFGDebugInfo.h>
 #include <libyul/backends/evm/ssa/SSACFGTypes.h>
 
@@ -65,17 +66,9 @@ public:
 	using InstId = ssa::InstId;
 	using ValueId = ssa::ValueId;
 
-	struct BuiltinCall
-	{
-		BuiltinHandle builtin;
-		/// Literal-kind arguments
-		std::vector<Literal> literalArguments;
-	};
-	struct Call
-	{
-		FunctionGraphID graphID;
-		bool canContinue;
-	};
+	using BuiltinCall = InstructionStore::BuiltinCall;
+	using Call = InstructionStore::Call;
+	using Operation = InstructionStore::Operation;
 
 	/// Upsilon records a phi pre-image at a block exit.
 	/// Upsilon(value, phi) means: the value flowing into `phi` from this block is `value`.
@@ -86,13 +79,6 @@ public:
 		ValueId phi;    ///< target phi
 	};
 
-	struct Operation {
-		std::vector<ValueId> outputs{};
-		std::variant<BuiltinCall, Call> kind;
-		std::vector<ValueId> inputs{};
-		/// Block this operation lives in. Set by `makeOperation`.
-		BlockId block{};
-	};
 	struct BasicBlock
 	{
 		struct MainExit {};
@@ -131,30 +117,17 @@ public:
 			}
 		}
 
-		bool isMainExitBlock() const
-		{
-			return std::holds_alternative<MainExit>(exit);
-		}
-
-		bool isTerminationBlock() const
-		{
-			return std::holds_alternative<Terminated>(exit);
-		}
-
-		bool isFunctionReturnBlock() const
-		{
-			return std::holds_alternative<FunctionReturn>(exit);
-		}
-
-		bool isJumpBlock() const
-		{
-			return std::holds_alternative<Jump>(exit);
-		}
+		bool isMainExitBlock() const { return std::holds_alternative<MainExit>(exit); }
+		bool isTerminationBlock() const { return std::holds_alternative<Terminated>(exit); }
+		bool isFunctionReturnBlock() const { return std::holds_alternative<FunctionReturn>(exit); }
+		bool isJumpBlock() const { return std::holds_alternative<Jump>(exit); }
 	};
 
 	BlockId makeBlock(langutil::DebugData::ConstPtr _debugData)
 	{
-		BlockId blockId { static_cast<BlockId::ValueType>(m_blocks.size()) };
+		// max itself is reserved for the 'empty' block
+		yulAssert(m_blocks.size() < std::numeric_limits<BlockId::ValueType>::max());
+		BlockId const blockId{static_cast<BlockId::ValueType>(m_blocks.size())};
 		m_blocks.emplace_back(BasicBlock{{}, {}, {}, {}, BasicBlock::Terminated{}});
 		if (debugInfo)
 			debugInfo->setBlockDebugData(blockId, std::move(_debugData));
@@ -164,84 +137,49 @@ public:
 	BasicBlock const& block(BlockId _id) const { return m_blocks.at(_id.value); }
 	size_t numBlocks() const { return m_blocks.size(); }
 
-	InstId makeOperation(BlockId _block, Operation _op, langutil::DebugData::ConstPtr _debugData = {})
-	{
-		yulAssert(_block.hasValue());
-		for (ValueId const& output: _op.outputs)
-		{
-			yulAssert(output.isVariable());
-			yulAssert(m_variables.at(output.value()).definingBlock == _block);
-		}
-		_op.block = _block;
-		InstId id{static_cast<InstId::ValueType>(m_operations.size())};
-		m_operations.emplace_back(std::move(_op));
-		if (debugInfo && _debugData)
-			debugInfo->setOperationDebugData(id, std::move(_debugData));
-		return id;
-	}
-	Operation& operation(InstId _id) { return m_operations.at(_id.value); }
-	Operation const& operation(InstId _id) const { return m_operations.at(_id.value); }
+	InstructionStore& instructionStore() { return m_instructions; }
+	InstructionStore const& instructionStore() const { return m_instructions; }
 
-private:
-	std::vector<BasicBlock> m_blocks;
-	std::vector<Operation> m_operations;
-public:
-	struct LiteralValue {
-		u256 value;
-	};
-	struct VariableValue {
-		BlockId definingBlock;
-	};
-	struct PhiValue {
-		BlockId block;
-	};
-	struct UnreachableValue {};
+	Operation& operation(InstId _id) { return m_instructions.operation(_id); }
+	Operation const& operation(InstId _id) const { return m_instructions.operation(_id); }
+
+	InstructionStore::LiteralValue const& literalInfo(ValueId const& _valueId) const { return m_instructions.literalInfo(_valueId); }
+	InstructionStore::PhiValue const& phiInfo(ValueId const& _valueId) const { return m_instructions.phiInfo(_valueId); }
+	InstructionStore::PhiValue& phiInfo(ValueId const& _valueId) { return m_instructions.phiInfo(_valueId); }
+	InstructionStore::VariableValue const& variableInfo(ValueId const& _valueId) const { return m_instructions.variableInfo(_valueId); }
+
 	ValueId newPhi(BlockId const _definingBlock)
 	{
-		m_phis.emplace_back(PhiValue{_definingBlock});
-		auto const value = m_phis.size() - 1;
-		yulAssert(value < std::numeric_limits<ValueId::ValueType>::max());
-		auto const id = ValueId::makePhi(static_cast<ValueId::ValueType>(value));
-		if (debugInfo)
-			debugInfo->setValueDebugData(id, debugInfo->blockDebugData(_definingBlock));
-		return id;
-	}
-	ValueId newVariable(BlockId const _definingBlock)
-	{
-		m_variables.emplace_back(VariableValue{_definingBlock});
-		auto const value = m_variables.size() - 1;
-		yulAssert(value < std::numeric_limits<ValueId::ValueType>::max());
-		auto const id = ValueId::makeVariable(static_cast<ValueId::ValueType>(value));
+		auto const id = m_instructions.newPhi(_definingBlock);
 		if (debugInfo)
 			debugInfo->setValueDebugData(id, debugInfo->blockDebugData(_definingBlock));
 		return id;
 	}
 
-	ValueId unreachableValue()
+	ValueId newVariable(BlockId const _definingBlock)
 	{
-		if (!m_unreachableValue)
-			m_unreachableValue = ValueId::makeUnreachable();
-		return *m_unreachableValue;
+		auto const id = m_instructions.newVariable(_definingBlock);
+		if (debugInfo)
+			debugInfo->setValueDebugData(id, debugInfo->blockDebugData(_definingBlock));
+		return id;
 	}
+
+	ValueId unreachableValue() { return m_instructions.unreachableValue(); }
 
 	ValueId newLiteral(langutil::DebugData::ConstPtr _debugData, u256 _value)
 	{
-		auto const it = m_literalMapping.find(_value);
-		if (it != m_literalMapping.end())
-		{
-			ValueId const& valueId = it->second;
-			yulAssert(valueId.hasValue() && m_literals[valueId.value()].value == _value);
-			return valueId;
-		}
+		auto const [id, allocated] = m_instructions.newLiteral(std::move(_value));
+		if (debugInfo && allocated)
+			debugInfo->setValueDebugData(id, std::move(_debugData));
+		return id;
+	}
 
-		m_literals.emplace_back(LiteralValue{std::move(_value)});
-		auto const value = m_literals.size() - 1;
-		yulAssert(value < std::numeric_limits<ValueId::ValueType>::max());
-		auto const literalId = ValueId::makeLiteral(static_cast<ValueId::ValueType>(value));
+	InstId makeOperation(BlockId _block, Operation _op, langutil::DebugData::ConstPtr _debugData = {})
+	{
+		auto const id = m_instructions.makeOperation(_block, std::move(_op));
 		if (debugInfo)
-			debugInfo->setValueDebugData(literalId, std::move(_debugData));
-		m_literalMapping.emplace(_value, literalId);
-		return literalId;
+			debugInfo->setOperationDebugData(id, std::move(_debugData));
+		return id;
 	}
 
 	std::string toDot(
@@ -251,33 +189,9 @@ public:
 		ControlFlowGraphs const* _controlFlow=nullptr
 	) const;
 
-	PhiValue const& phiInfo(ValueId const& _valueId) const
-	{
-		yulAssert(_valueId.hasValue() && _valueId.isPhi());
-		return m_phis.at(_valueId.value());
-	}
-	PhiValue& phiInfo(ValueId const& _valueId)
-	{
-		yulAssert(_valueId.hasValue() && _valueId.isPhi());
-		return m_phis.at(_valueId.value());
-	}
-	LiteralValue const& literalInfo(ValueId const& _valueId) const
-	{
-		yulAssert(_valueId.hasValue() && _valueId.isLiteral());
-		return m_literals.at(_valueId.value());
-	}
-	VariableValue const& variableInfo(ValueId const& _valueId) const
-	{
-		yulAssert(_valueId.hasValue() && _valueId.isVariable());
-		return m_variables.at(_valueId.value());
-	}
-
 private:
-	std::vector<LiteralValue> m_literals;
-	std::map<u256, ValueId> m_literalMapping;
-	std::vector<PhiValue> m_phis;
-	std::vector<VariableValue> m_variables;
-	std::optional<ValueId> m_unreachableValue;
+	std::vector<BasicBlock> m_blocks;
+	InstructionStore m_instructions;
 public:
 	EVMDialect const& evmDialect;
 	std::unique_ptr<DebugInfo> debugInfo;

--- a/libyul/backends/evm/ssa/SSACFGBuilder.cpp
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.cpp
@@ -235,7 +235,7 @@ void SSACFGBuilder::operator()(Switch const& _switch)
 
 	auto makeValueCompare = [&](Case const& _case) {
 		auto outputValue = m_graph.newVariable(m_currentBlock);
-		auto opId = m_graph.makeOperation(SSACFG::Operation{
+		auto opId = m_graph.makeOperation(m_currentBlock, SSACFG::Operation{
 			{outputValue},
 			SSACFG::BuiltinCall{*equalityBuiltinHandle, {}},
 			{m_graph.newLiteral(debugDataOf(_case), _case.value->value.value()), expression}
@@ -479,7 +479,7 @@ std::vector<SSACFG::ValueId> SSACFGBuilder::visitFunctionCall(FunctionCall const
 		}
 	}, _call.functionName);
 	auto results = operation.outputs;
-	currentBlock().operations.emplace_back(m_graph.makeOperation(std::move(operation), debugDataOf(_call)));
+	currentBlock().operations.emplace_back(m_graph.makeOperation(m_currentBlock, std::move(operation), debugDataOf(_call)));
 	if (!canContinue)
 	{
 		currentBlock().exit = SSACFG::BasicBlock::Terminated{};

--- a/libyul/backends/evm/ssa/SSACFGBuilder.cpp
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.cpp
@@ -236,9 +236,9 @@ void SSACFGBuilder::operator()(Switch const& _switch)
 	auto makeValueCompare = [&](Case const& _case) {
 		auto outputValue = m_graph.newVariable(m_currentBlock);
 		auto opId = m_graph.makeOperation(m_currentBlock, SSACFG::Operation{
-			{outputValue},
-			SSACFG::BuiltinCall{*equalityBuiltinHandle, {}},
-			{m_graph.newLiteral(debugDataOf(_case), _case.value->value.value()), expression}
+			.outputs = {outputValue},
+			.kind = SSACFG::BuiltinCall{*equalityBuiltinHandle, {}},
+			.inputs = {m_graph.newLiteral(debugDataOf(_case), _case.value->value.value()), expression},
 		}, debugDataOf(_case));
 		currentBlock().operations.emplace_back(opId);
 		return outputValue;
@@ -452,7 +452,7 @@ std::vector<SSACFG::ValueId> SSACFGBuilder::visitFunctionCall(FunctionCall const
 					yulAssert(std::holds_alternative<Literal>(arg));
 					literalArguments.emplace_back(std::get<Literal>(arg));
 				}
-			SSACFG::Operation result{{}, SSACFG::BuiltinCall{_builtinName.handle, std::move(literalArguments)}, {}};
+			SSACFG::Operation result{.kind = SSACFG::BuiltinCall{_builtinName.handle, std::move(literalArguments)}};
 			for (auto&& [idx, arg]: _call.arguments | ranges::views::enumerate | ranges::views::reverse)
 				if (!builtin.literalArgument(idx).has_value())
 					result.inputs.emplace_back(std::visit(*this, arg));
@@ -470,7 +470,7 @@ std::vector<SSACFG::ValueId> SSACFGBuilder::visitFunctionCall(FunctionCall const
 			canContinue = m_sideEffects.functionSideEffects().at(definition).canContinue;
 			auto const calleeIt = m_functionScopeToID.find(&function);
 			yulAssert(calleeIt != m_functionScopeToID.end(), "Called function has no registered graph id.");
-			SSACFG::Operation result{{}, SSACFG::Call{calleeIt->second, canContinue}, {}};
+			SSACFG::Operation result{.kind = SSACFG::Call{calleeIt->second, canContinue}};
 			for (auto const& arg: _call.arguments | ranges::views::reverse)
 				result.inputs.emplace_back(std::visit(*this, arg));
 			for (size_t i = 0; i < function.numReturns; ++i)

--- a/libyul/backends/evm/ssa/SSACFGTypes.cpp
+++ b/libyul/backends/evm/ssa/SSACFGTypes.cpp
@@ -1,0 +1,41 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libyul/backends/evm/ssa/SSACFGTypes.h>
+
+#include <libyul/backends/evm/ssa/SSACFG.h>
+
+#include <libsolutil/CommonData.h>
+#include <libsolutil/Numeric.h>
+
+using namespace solidity::util;
+using namespace solidity::yul::ssa;
+
+std::string ValueId::str(SSACFG const& _cfg) const
+{
+	if (!hasValue())
+		return "INVALID";
+	switch (kind())
+	{
+		case Kind::Literal:  return toCompactHexWithPrefix(_cfg.literalInfo(*this).value);
+		case Kind::Variable: return fmt::format("v{}", value());
+		case Kind::Phi: return fmt::format("phi{}", value());
+		case Kind::Unreachable: return "[unreachable]";
+	}
+	unreachable();
+}


### PR DESCRIPTION
- adds a new `InstructionStore` class that owns an `SSACFG` instances' value storage. with it, the uniformity refactor can swap out the internal per-kind pools by the unified instruction pool without touching too much of the `SSACFG` header
- store the defining block on each Operation, mirroring the upcoming `Instruction` shape from the uniformity refactor
- cleanup: move `ValueId::str` into `SSACFGTypes.cpp` where it belongs