### PR TITLE
SSA CFG: extract liveness counts data structure

### DIFF
--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -101,6 +101,7 @@ add_library(yul
 	backends/evm/ssa/StackLayoutGenerator.h
 	backends/evm/ssa/StackShuffler.cpp
 	backends/evm/ssa/StackShuffler.h
+	backends/evm/ssa/StackSlotLiveness.h
 	backends/evm/ssa/StackToMemorySpilling.h
 	backends/evm/ssa/util/UseCountSet.h
 	backends/evm/ssa/StackUtils.cpp

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -102,6 +102,7 @@ add_library(yul
 	backends/evm/ssa/StackShuffler.cpp
 	backends/evm/ssa/StackShuffler.h
 	backends/evm/ssa/StackToMemorySpilling.h
+	backends/evm/ssa/util/UseCountSet.h
 	backends/evm/ssa/StackUtils.cpp
 	backends/evm/ssa/StackUtils.h
 	backends/evm/ssa/io/DotExporterBase.cpp

--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -196,7 +196,7 @@ void CodeTransform::operator()(SSACFG::BlockId const _blockId)
 	yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 
 	// handle the block exit
-	std::visit(util::GenericVisitor{ [this, &_blockId](auto const& exit) { (*this)(_blockId, exit); } }, block.exit);
+	std::visit(solidity::util::GenericVisitor{ [this, &_blockId](auto const& exit) { (*this)(_blockId, exit); } }, block.exit);
 }
 
 void CodeTransform::operator()(SSACFG::InstId _opId, StackData const& _operationInputLayout)
@@ -259,7 +259,7 @@ void CodeTransform::operator()(SSACFG::InstId _opId, StackData const& _operation
 	}();
 
 	// generate code for the operation
-	std::visit(util::GenericVisitor{
+	std::visit(solidity::util::GenericVisitor{
 		[&](SSACFG::BuiltinCall const& _builtin) {
 			m_assembly.setSourceLocation(opOriginLocation);
 			auto const& builtin = m_cfg.evmDialect.builtin(_builtin.builtin);
@@ -276,7 +276,7 @@ void CodeTransform::operator()(SSACFG::InstId _opId, StackData const& _operation
 			builtin.generateCode(transient, m_assembly, m_builtinContext);
 		},
 		[&](SSACFG::Call const& _call) {
-			auto const* returnLabel = util::valueOrNullptr(m_returnLabels, _opId);
+			auto const* returnLabel = solidity::util::valueOrNullptr(m_returnLabels, _opId);
 			// check that if we have a return label, the call can continue
 			yulAssert(!!returnLabel == _call.canContinue);
 			m_assembly.setSourceLocation(opOriginLocation);
@@ -394,7 +394,7 @@ void CodeTransform::operator()(SSACFG::BlockId const& _blockId, SSACFG::BasicBlo
 	yulAssert(static_cast<int>(m_stack.size()) == m_assembly.stackHeight());
 	auto const& block = m_cfg.block(_blockId);
 	yulAssert(!block.operations.empty(), "Terminated block must have at least one operation.");
-	std::visit(util::GenericVisitor{
+	std::visit(solidity::util::GenericVisitor{
 		[&](SSACFG::BuiltinCall const& _builtin) {
 			yulAssert(m_cfg.evmDialect.builtin(_builtin.builtin).controlFlowSideEffects.terminatesOrReverts(), "Last operation of Terminated block must terminate or revert.");
 		},

--- a/libyul/backends/evm/ssa/LivenessAnalysis.cpp
+++ b/libyul/backends/evm/ssa/LivenessAnalysis.cpp
@@ -20,8 +20,6 @@
 
 #include <libsolutil/Visitor.h>
 
-#include <range/v3/algorithm/find.hpp>
-#include <range/v3/algorithm/find_if.hpp>
 #include <range/v3/range/conversion.hpp>
 
 #include <range/v3/view/filter.hpp>
@@ -33,112 +31,17 @@ namespace
 {
 constexpr auto excludingLiteralsFilter()
 {
-	return [](LivenessAnalysis::LivenessData::Value const& _valueId) -> bool
+	return [](SSACFG::ValueId const& _valueId) -> bool
 	{
 		return !_valueId.isLiteral();
 	};
 }
 }
 
-bool LivenessAnalysis::LivenessData::contains(Value const& _valueId) const
-{
-	return findEntry(_valueId) != m_liveCounts.end();
-}
-
-LivenessAnalysis::LivenessData::Count LivenessAnalysis::LivenessData::count(Value const& _valueId) const
-{
-	if (
-		auto const it = findEntry(_valueId);
-		it != m_liveCounts.end()
-	)
-		return it->second;
-	return 0;
-}
-
-LivenessAnalysis::LivenessData::LiveCounts::const_iterator LivenessAnalysis::LivenessData::begin() const
-{
-	return m_liveCounts.begin();
-}
-
-LivenessAnalysis::LivenessData::LiveCounts::const_iterator LivenessAnalysis::LivenessData::end() const
-{
-	return m_liveCounts.end();
-}
-
-LivenessAnalysis::LivenessData::LiveCounts::size_type LivenessAnalysis::LivenessData::size() const
-{
-	return m_liveCounts.size();
-}
-
-bool LivenessAnalysis::LivenessData::empty() const { return m_liveCounts.empty(); }
-
-void LivenessAnalysis::LivenessData::insert(Value const& _value, Count _count)
-{
-	if (_count == 0)
-		return;
-
-	auto it = findEntry(_value);
-	if (it != m_liveCounts.end())
-		it->second += _count;
-	else
-		m_liveCounts.emplace_back(_value, _count);
-}
-
-LivenessAnalysis::LivenessData& LivenessAnalysis::LivenessData::maxUnion(LivenessData const& _other)
-{
-	for (auto const& [value, count]: _other.m_liveCounts)
-	{
-		auto it = findEntry(value);
-		if (it != m_liveCounts.end())
-			it->second = std::max(it->second, count);
-		else
-			m_liveCounts.emplace_back(value, count);
-	}
-	return *this;
-}
-
-LivenessAnalysis::LivenessData& LivenessAnalysis::LivenessData::operator+=(LivenessData const& _other)
-{
-	for (auto const& [valueId, count]: _other.m_liveCounts)
-		insert(valueId, count);
-	return *this;
-}
-
-LivenessAnalysis::LivenessData& LivenessAnalysis::LivenessData::operator-=(LivenessData const& _other)
-{
-	std::erase_if(m_liveCounts, [&](auto const& entry) { return _other.contains(entry.first); });
-	return *this;
-}
-
-void LivenessAnalysis::LivenessData::erase(Value const& _value)
-{
-	if (
-		auto const it = findEntry(_value);
-		it != m_liveCounts.end()
-	)
-		m_liveCounts.erase(it);
-}
-
-void LivenessAnalysis::LivenessData::remove(Value const& _value, Count _count)
-{
-	if (_count == 0)
-		return;
-
-	auto it = findEntry(_value);
-	if (it != m_liveCounts.end())
-	{
-		if (it->second <= _count)
-			m_liveCounts.erase(it);
-		else
-			it->second -= _count;
-	}
-}
-
-
 LivenessAnalysis::LivenessData LivenessAnalysis::blockExitValues(SSACFG::BlockId const& _blockId) const
 {
 	LivenessData result;
-	util::GenericVisitor exitVisitor{
+	solidity::util::GenericVisitor exitVisitor{
 		[](SSACFG::BasicBlock::MainExit const&) {},
 		[&](SSACFG::BasicBlock::FunctionReturn const& _functionReturn)
 		{
@@ -154,17 +57,6 @@ LivenessAnalysis::LivenessData LivenessAnalysis::blockExitValues(SSACFG::BlockId
 		[](SSACFG::BasicBlock::Terminated const&) {}};
 	std::visit(exitVisitor, m_cfg.block(_blockId).exit);
 	return result;
-}
-
-
-LivenessAnalysis::LivenessData::LiveCounts::iterator LivenessAnalysis::LivenessData::findEntry(Value const& _value)
-{
-	return ranges::find_if(m_liveCounts, [&](auto const& _entry) { return _entry.first == _value; });
-}
-
-LivenessAnalysis::LivenessData::LiveCounts::const_iterator LivenessAnalysis::LivenessData::findEntry(Value const& _value) const
-{
-	return ranges::find_if(m_liveCounts, [&](auto const& _entry) { return _entry.first == _value; });
 }
 
 LivenessAnalysis::LivenessAnalysis(SSACFG const& _cfg):

--- a/libyul/backends/evm/ssa/LivenessAnalysis.h
+++ b/libyul/backends/evm/ssa/LivenessAnalysis.h
@@ -34,8 +34,8 @@ namespace solidity::yul::ssa
 class LivenessAnalysis
 {
 public:
-	/// Per-program-point liveness: each value's use count is the total number
-	/// of times the value will be read along all paths downstream of that point.
+	/// Per-program-point liveness, each value's use count is the max number of times the value will be read along
+	/// all paths downstream of that point
 	using LivenessData = util::UseCountSet<SSACFG::ValueId>;
 
 	explicit LivenessAnalysis(SSACFG const& _cfg);

--- a/libyul/backends/evm/ssa/LivenessAnalysis.h
+++ b/libyul/backends/evm/ssa/LivenessAnalysis.h
@@ -21,6 +21,7 @@
 #include <libyul/backends/evm/ssa/traversal/ForwardTopologicalSort.h>
 #include <libyul/backends/evm/ssa/SSACFG.h>
 #include <libyul/backends/evm/ssa/SSACFGLoopNestingForest.h>
+#include <libyul/backends/evm/ssa/util/UseCountSet.h>
 
 #include <vector>
 
@@ -33,74 +34,10 @@ namespace solidity::yul::ssa
 class LivenessAnalysis
 {
 public:
-	class LivenessData
-	{
-	public:
-		using Count = std::uint32_t;
-		using Value = SSACFG::ValueId;
-		using LiveCounts = std::vector<std::pair<Value, Count>>;
+	/// Per-program-point liveness: each value's use count is the total number
+	/// of times the value will be read along all paths downstream of that point.
+	using LivenessData = util::UseCountSet<SSACFG::ValueId>;
 
-		LivenessData() = default;
-		template<std::input_iterator Iter, std::sentinel_for<Iter> Sentinel>
-		LivenessData(Iter begin, Sentinel end): m_liveCounts(begin, end) {}
-		explicit LivenessData(LiveCounts&& _liveCounts): m_liveCounts(std::move(_liveCounts)) {}
-
-		bool contains(Value const& _valueId) const;
-		Count count(Value const& _valueId) const;
-		LiveCounts::const_iterator begin() const;
-		LiveCounts::const_iterator end() const;
-		LiveCounts::size_type size() const;
-		bool empty() const;
-
-		// Core modification
-		/// Add value with count (default 1), incrementing if already present
-		void insert(Value const& _value, Count _count = 1);
-		/// Remove value completely regardless of count
-		void erase(Value const& _value);
-		/// Decrement value count, removing if count reaches zero
-		void remove(Value const& _value, Count _count = 1);
-
-		// Set operations
-		/// Add all entries from other, summing counts
-		LivenessData& operator+=(LivenessData const& _other);
-		/// Remove all values present in other
-		LivenessData& operator-=(LivenessData const& _other);
-		/// Union with other, taking max count for each value
-		LivenessData& maxUnion(LivenessData const& _other);
-
-		// Bulk operations
-		/// Insert all values from range with count 1 each
-		template<typename Range>
-		void insertAll(Range const& _values)
-		{
-			for (auto const& value: _values)
-				insert(value);
-		}
-
-		/// Erase all values from range
-		template<typename Range>
-		void eraseAll(Range const& _values)
-		{
-			for (auto const& value: _values)
-				erase(value);
-		}
-
-		// Conditional removal
-		/// Remove all entries matching predicate
-		template<typename Predicate>
-		void eraseIf(Predicate&& _predicate)
-		{
-			std::erase_if(m_liveCounts, std::forward<Predicate>(_predicate));
-		}
-
-	private:
-		LiveCounts::iterator findEntry(Value const& _value);
-		LiveCounts::const_iterator findEntry(Value const& _value) const;
-
-		/// Usage counts represent the total number of times each variable will be used
-		/// downstream across all possible execution paths from this program point.
-		LiveCounts m_liveCounts;
-	};
 	explicit LivenessAnalysis(SSACFG const& _cfg);
 
 	LivenessData const& liveIn(SSACFG::BlockId const _blockId) const { return m_liveIns[_blockId.value]; }

--- a/libyul/backends/evm/ssa/PhiInverse.cpp
+++ b/libyul/backends/evm/ssa/PhiInverse.cpp
@@ -34,7 +34,7 @@ bool PhiInverse::noOp() const
 
 SSACFG::ValueId PhiInverse::operator()(SSACFG::ValueId _valueId) const
 {
-	return util::valueOrDefault(m_phiToPreImage, _valueId, _valueId);
+	return solidity::util::valueOrDefault(m_phiToPreImage, _valueId, _valueId);
 }
 
 std::map<SSACFG::ValueId, SSACFG::ValueId> const& PhiInverse::data() const

--- a/libyul/backends/evm/ssa/SSACFGBuilder.cpp
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.cpp
@@ -440,7 +440,7 @@ void SSACFGBuilder::assign(std::vector<std::reference_wrapper<Scope::Variable co
 std::vector<SSACFG::ValueId> SSACFGBuilder::visitFunctionCall(FunctionCall const& _call)
 {
 	bool canContinue = true;
-	SSACFG::Operation operation = std::visit(util::GenericVisitor{
+	SSACFG::Operation operation = std::visit(solidity::util::GenericVisitor{
 		[&](BuiltinName const& _builtinName)
 		{
 			auto const& builtin = m_dialect.builtin(_builtinName.handle);
@@ -553,7 +553,7 @@ void SSACFGBuilder::writeVariable(Scope::Variable const& _variable, SSACFG::Bloc
 Scope::Function const& SSACFGBuilder::lookupFunction(YulName _name) const
 {
 	Scope::Function const* function = nullptr;
-	yulAssert(m_scope->lookup(_name, util::GenericVisitor{
+	yulAssert(m_scope->lookup(_name, solidity::util::GenericVisitor{
 		[](Scope::Variable&) { yulAssert(false, "Expected function name."); },
 		[&](Scope::Function& _function) { function = &_function; }
 	}), "Function name not found.");
@@ -565,7 +565,7 @@ Scope::Variable const& SSACFGBuilder::lookupVariable(YulName _name) const
 {
 	yulAssert(m_scope, "");
 	Scope::Variable const* var = nullptr;
-	if (m_scope->lookup(_name, util::GenericVisitor{
+	if (m_scope->lookup(_name, solidity::util::GenericVisitor{
 		[&](Scope::Variable const& _var) { var = &_var; },
 		[](Scope::Function const&)
 		{

--- a/libyul/backends/evm/ssa/Stack.cpp
+++ b/libyul/backends/evm/ssa/Stack.cpp
@@ -39,7 +39,7 @@ std::string slotToString(StackSlot const& _slot)
 	case StackSlot::Kind::FunctionReturnLabel:
 		return fmt::format("ReturnLabel[{}]", _slot.functionReturnLabel());
 	}
-	util::unreachable();
+	solidity::util::unreachable();
 }
 
 std::string stackToString(StackData const& _stackData)

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -253,10 +253,11 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 			)
 				stack.declareJunk(depth);
 
+		StackSlotLiveness const opLiveOutSlots = toStackSlotLiveness(opLiveOutWithoutOutputs);
 		std::size_t const targetSize = findOptimalTargetSize(
 			stack.data(),
 			requiredStackTop,
-			opLiveOutWithoutOutputs,
+			opLiveOutSlots,
 			junkCanBeAdded,
 			m_hasFunctionReturnLabel
 		);
@@ -264,7 +265,7 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 			auto const shuffleResult = StackShuffler<StackType::Callbacks>::shuffle(
 				stack,
 				requiredStackTop,
-				opLiveOutWithoutOutputs,
+				opLiveOutSlots,
 				targetSize
 			);
 			yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
@@ -290,15 +291,16 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 				if (!conditionSlotAlreadyFinal)
 				{
 					auto const condition = Slot::makeValueID(_cJump.condition);
+					StackSlotLiveness const blockLiveOutSlots = toStackSlotLiveness(blockLiveOut);
 					auto const targetSize = findOptimalTargetSize(
 						stack.data(),
 						{condition},
-						blockLiveOut,
+						blockLiveOutSlots,
 						false,
 						m_hasFunctionReturnLabel
 					);
 					auto const shuffleResult = StackShuffler<StackType::Callbacks>::shuffle(
-						stack, {condition}, blockLiveOut, targetSize
+						stack, {condition}, blockLiveOutSlots, targetSize
 					);
 					yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 				}

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -278,7 +278,7 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 	}
 
 	std::visit(
-		util::GenericVisitor{
+		solidity::util::GenericVisitor{
 			[&](SSACFG::BasicBlock::ConditionalJump const& _cJump) {
 				auto const& blockLiveOut = m_liveness.liveOut(_blockId);
 

--- a/libyul/backends/evm/ssa/StackShuffler.cpp
+++ b/libyul/backends/evm/ssa/StackShuffler.cpp
@@ -26,7 +26,7 @@ using namespace solidity::yul::ssa::detail;
 
 Target::Target(
 	StackData const& _args,
-	LivenessAnalysis::LivenessData const& _liveOut,
+	StackSlotLiveness const& _liveOut,
 	std::size_t const _targetSize,
 	SpilledVariables const* _spilledVariables
 ):
@@ -40,9 +40,9 @@ Target::Target(
 	for (auto const& arg: _args)
 		if (!arg.isJunk() && !slotIsSpilled(arg, _spilledVariables))
 			++minCount[arg];
-	for (auto const& liveValueId: _liveOut | ranges::views::keys)
-		if (!(_spilledVariables && _spilledVariables->isSpilled(liveValueId)))
-			++minCount[StackSlot::makeValueID(liveValueId)];
+	for (auto const& liveSlot: _liveOut | ranges::views::keys)
+		if (!slotIsSpilled(liveSlot, _spilledVariables))
+			++minCount[liveSlot];
 }
 
 State::State(StackData const& _stackData, Target const& _target, SpilledVariables const* const _spilledVariables, std::size_t const _reachableStackDepth):
@@ -133,7 +133,7 @@ bool State::requiredInArgs(StackSlot const& _slot) const
 
 bool State::requiredInTail(StackSlot const& _slot) const
 {
-	if (!_slot.isValueID() || !m_target.liveOut.contains(_slot.valueID()))
+	if (!_slot.isValueID() || !m_target.liveOut.contains(_slot))
 		return false;
 	// Spilled values can be rematerialized, so they need not occupy a tail slot.
 	return !slotIsSpilled(_slot);

--- a/libyul/backends/evm/ssa/StackShuffler.cpp
+++ b/libyul/backends/evm/ssa/StackShuffler.cpp
@@ -81,27 +81,27 @@ std::size_t State::size() const
 
 std::size_t State::count(StackSlot const& _slot) const
 {
-	return util::valueOrDefault(m_histogram, _slot, static_cast<size_t>(0));
+	return solidity::util::valueOrDefault(m_histogram, _slot, static_cast<size_t>(0));
 }
 
 std::size_t State::countInArgs(StackSlot const& _slot) const
 {
-	return util::valueOrDefault(m_histogramArgs, _slot, static_cast<size_t>(0));
+	return solidity::util::valueOrDefault(m_histogramArgs, _slot, static_cast<size_t>(0));
 }
 
 std::size_t State::countInTail(StackSlot const& _slot) const
 {
-	return util::valueOrDefault(m_histogramTail, _slot, static_cast<size_t>(0));
+	return solidity::util::valueOrDefault(m_histogramTail, _slot, static_cast<size_t>(0));
 }
 
 std::size_t State::countReachable(StackSlot const& _slot) const
 {
-	return util::valueOrDefault(m_histogramReachable, _slot, static_cast<size_t>(0));
+	return solidity::util::valueOrDefault(m_histogramReachable, _slot, static_cast<size_t>(0));
 }
 
 std::size_t State::targetMinCount(StackSlot const& _slot) const
 {
-	return util::valueOrDefault(m_target.minCount, _slot, static_cast<size_t>(0));
+	return solidity::util::valueOrDefault(m_target.minCount, _slot, static_cast<size_t>(0));
 }
 
 std::size_t State::targetArgsCount(StackSlot const& _slot) const

--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <libyul/backends/evm/ssa/LivenessAnalysis.h>
+#include <libyul/backends/evm/ssa/StackSlotLiveness.h>
 #include <libyul/backends/evm/ssa/StackToMemorySpilling.h>
 #include <libyul/backends/evm/ssa/Stack.h>
 
@@ -54,13 +54,13 @@ struct Target
 {
 	Target(
 		StackData const& _args,
-		LivenessAnalysis::LivenessData const& _liveOut,
+		StackSlotLiveness const& _liveOut,
 		std::size_t _targetSize,
 		SpilledVariables const* _spilledVariables = nullptr
 	);
 
 	StackData const& args;
-	LivenessAnalysis::LivenessData const& liveOut;
+	StackSlotLiveness const& liveOut;
 	SpilledVariables const* const spilledVariables;
 	std::size_t const size;
 	std::size_t const tailSize;
@@ -184,7 +184,7 @@ public:
 	[[nodiscard]] static StackShufflerResult shuffle(
 		Stack<Callback>& _stack,
 		StackData const& _args,
-		LivenessAnalysis::LivenessData const& _liveOut,
+		StackSlotLiveness const& _liveOut,
 		std::size_t _targetStackSize,
 		SpilledVariables const* const _spilledVariables = nullptr
 	)
@@ -197,10 +197,10 @@ public:
 		{
 			// check that all required values are on stack
 			detail::State const state(_stack.data(), target, _spilledVariables, ReachableStackDepth);
-			for (auto const& liveVariable: _liveOut | ranges::views::keys | ranges::views::transform(Slot::makeValueID))
+			for (auto const& liveSlot: _liveOut | ranges::views::keys)
 				yulAssert(
-					!_stack.canBeFreelyGenerated(liveVariable) &&
-					(ranges::contains(_stack.data(), liveVariable) || detail::slotIsSpilled(liveVariable, _spilledVariables))
+					!_stack.canBeFreelyGenerated(liveSlot) &&
+					(ranges::contains(_stack.data(), liveSlot) || detail::slotIsSpilled(liveSlot, _spilledVariables))
 				);
 			for (auto const& arg: _args)
 				yulAssert(detail::slotCanBeLoadedOrPushed(arg, _spilledVariables) || ranges::contains(_stack.data(), arg));
@@ -346,8 +346,8 @@ private:
 			int currentCount = static_cast<int>(_state.count(slot));
 
 			int liveOutCount = 0;
-			if (slot.isValueID() && _state.target().liveOut.contains(slot.valueID()))
-				liveOutCount = static_cast<int>(_state.target().liveOut.count(slot.valueID()));
+			if (slot.isValueID() && _state.target().liveOut.contains(slot))
+				liveOutCount = static_cast<int>(_state.target().liveOut.count(slot));
 			int deficit = liveOutCount - currentCount;
 
 			// Update best if this deficit is higher

--- a/libyul/backends/evm/ssa/StackSlotLiveness.h
+++ b/libyul/backends/evm/ssa/StackSlotLiveness.h
@@ -1,0 +1,40 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libyul/backends/evm/ssa/LivenessAnalysis.h>
+#include <libyul/backends/evm/ssa/Stack.h>
+#include <libyul/backends/evm/ssa/util/UseCountSet.h>
+
+namespace solidity::yul::ssa
+{
+
+/// Liveness counts keyed on StackSlot
+using StackSlotLiveness = util::UseCountSet<StackSlot>;
+
+inline StackSlotLiveness toStackSlotLiveness(LivenessAnalysis::LivenessData const& _liveness)
+{
+	StackSlotLiveness::Entries entries;
+	entries.reserve(_liveness.size());
+	for (auto const& [valueId, count]: _liveness)
+		entries.emplace_back(StackSlot::makeValueID(valueId), count);
+	return StackSlotLiveness{std::move(entries)};
+}
+
+}

--- a/libyul/backends/evm/ssa/StackUtils.cpp
+++ b/libyul/backends/evm/ssa/StackUtils.cpp
@@ -81,15 +81,15 @@ std::size_t solidity::yul::ssa::findOptimalTargetSize
 (
 	StackData const& _stackData,
 	StackData const& _targetArgs,
-	LivenessAnalysis::LivenessData const& _targetLiveOut,
+	StackSlotLiveness const& _targetLiveOut,
 	bool const _canIntroduceJunk,
 	bool const _hasFunctionReturnLabel
 )
 {
 	std::size_t const minSize = _targetLiveOut.size() + _targetArgs.size() + (_hasFunctionReturnLabel ? 1 : 0);
 	boost::container::flat_map<StackSlot, std::size_t> deficit;
-	for (auto const& v: _targetLiveOut | ranges::views::keys)
-		deficit[StackSlot::makeValueID(v)]++;
+	for (auto const& slot: _targetLiveOut | ranges::views::keys)
+		deficit[slot]++;
 	for (auto const& arg: _targetArgs)
 		deficit[arg]++;
 	for (auto const& slot: _stackData)

--- a/libyul/backends/evm/ssa/StackUtils.h
+++ b/libyul/backends/evm/ssa/StackUtils.h
@@ -20,6 +20,7 @@
 
 #include <libyul/backends/evm/ssa/PhiInverse.h>
 #include <libyul/backends/evm/ssa/Stack.h>
+#include <libyul/backends/evm/ssa/StackSlotLiveness.h>
 
 #include <string>
 #include <vector>
@@ -65,7 +66,7 @@ StackData stackPreImage(StackData _stack, PhiInverse const& _phiInverse);
 std::size_t findOptimalTargetSize(
 	StackData const& _stackData,
 	StackData const& _targetArgs,
-	LivenessAnalysis::LivenessData const& _targetLiveOut,
+	StackSlotLiveness const& _targetLiveOut,
 	bool _canIntroduceJunk,
 	bool _hasFunctionReturnLabel
 );

--- a/libyul/backends/evm/ssa/io/JSONExporter.cpp
+++ b/libyul/backends/evm/ssa/io/JSONExporter.cpp
@@ -46,7 +46,7 @@ Json toJson(SSACFG const& _cfg, std::vector<SSACFG::ValueId> const& _values)
 Json toJson(Json& _ret, SSACFG const& _cfg, SSACFG::Operation const& _operation, ControlFlowGraphs const& _controlFlow)
 {
 	Json opJson = Json::object();
-	std::visit(util::GenericVisitor{
+	std::visit(solidity::util::GenericVisitor{
 		[&](SSACFG::Call const& _call) {
 			_ret["type"] = "FunctionCall";
 			opJson["op"] = _controlFlow.functionGraph(_call.graphID)->name;
@@ -72,7 +72,7 @@ Json toJson(Json& _ret, SSACFG const& _cfg, SSACFG::Operation const& _operation,
 
 Json toJson(SSACFG const& _cfg, SSACFG::BlockId _blockId, LivenessAnalysis const* _liveness, ControlFlowGraphs const& _controlFlow)
 {
-	auto const valueToString = [&](LivenessAnalysis::LivenessData::LiveCounts::value_type const& _live) { return _live.first.str(_cfg); };
+	auto const valueToString = [&](auto const& _live) { return _live.first.str(_cfg); };
 
 	Json blockJson = Json::object();
 	auto const& block = _cfg.block(_blockId);
@@ -122,12 +122,12 @@ Json toJson(SSACFG const& _cfg, SSACFG::BlockId _blockId, LivenessAnalysis const
 Json exportBlock(SSACFG const& _cfg, SSACFG::BlockId _entryId, LivenessAnalysis const* _liveness, ControlFlowGraphs const& _controlFlow)
 {
 	Json blocksJson = Json::array();
-	util::BreadthFirstSearch<SSACFG::BlockId> bfs{{{_entryId}}};
+	solidity::util::BreadthFirstSearch<SSACFG::BlockId> bfs{{{_entryId}}};
 	bfs.run([&](SSACFG::BlockId _blockId, auto _addChild) {
 		Json blockJson = toJson(_cfg, _blockId, _liveness, _controlFlow);
 
 		Json exitBlockJson = Json::object();
-		std::visit(util::GenericVisitor{
+		std::visit(solidity::util::GenericVisitor{
 			[&](SSACFG::BasicBlock::MainExit const&) {
 				exitBlockJson["type"] = "MainExit";
 			},

--- a/libyul/backends/evm/ssa/transform/TrivialPhiEliminator.cpp
+++ b/libyul/backends/evm/ssa/transform/TrivialPhiEliminator.cpp
@@ -235,7 +235,7 @@ private:
 			for (auto const opId: block.operations)
 				for (auto& input: cfg.operation(opId).inputs)
 					input = canonicalize(input);
-			std::visit(util::GenericVisitor{
+			std::visit(solidity::util::GenericVisitor{
 				[&](SSACFG::BasicBlock::FunctionReturn& r) {
 					for (auto& v: r.returnValues)
 						v = canonicalize(v);

--- a/libyul/backends/evm/ssa/util/UseCountSet.h
+++ b/libyul/backends/evm/ssa/util/UseCountSet.h
@@ -1,0 +1,150 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <algorithm>
+#include <concepts>
+#include <cstdint>
+#include <iterator>
+#include <utility>
+#include <vector>
+
+namespace solidity::yul::ssa::util
+{
+
+/// Vector-backed reference-counted set keyed on `Key`. Each entry carries a non-zero use count; absent keys have
+/// effective count 0. Designed for small working sets such that linear scan beats the constant overhead
+/// of a hashed or tree-based associative container.
+template <std::equality_comparable Key>
+class UseCountSet
+{
+public:
+	using Value = Key;
+	using Count = std::uint32_t;
+	using Entries = std::vector<std::pair<Key, Count>>;
+
+	UseCountSet() = default;
+	template<std::input_iterator Iter, std::sentinel_for<Iter> Sentinel>
+	UseCountSet(Iter _begin, Sentinel _end): m_entries(_begin, _end) {}
+	explicit UseCountSet(Entries _entries): m_entries(std::move(_entries)) {}
+
+	bool contains(Key const& _key) const
+	{
+		return findEntry(_key) != m_entries.end();
+	}
+	Count count(Key const& _key) const
+	{
+		auto const it = findEntry(_key);
+		return it == m_entries.end() ? Count{0} : it->second;
+	}
+	typename Entries::const_iterator begin() const { return m_entries.begin(); }
+	typename Entries::const_iterator end() const { return m_entries.end(); }
+	typename Entries::size_type size() const { return m_entries.size(); }
+	bool empty() const { return m_entries.empty(); }
+
+	/// Add `_count` to existing entry or insert a new one. No-op if `_count == 0`.
+	void insert(Key const& _key, Count _count = 1)
+	{
+		if (_count == 0)
+			return;
+		auto it = findEntry(_key);
+		if (it != m_entries.end())
+			it->second += _count;
+		else
+			m_entries.emplace_back(_key, _count);
+	}
+
+	/// Remove the entry for `_key` if present.
+	void erase(Key const& _key)
+	{
+		if (auto const it = findEntry(_key); it != m_entries.end())
+			m_entries.erase(it);
+	}
+
+	/// Subtract `_count` from the entry for `_key`, removing it if the count
+	/// drops to zero. No-op if `_key` is absent or `_count == 0`.
+	void remove(Key const& _key, Count _count = 1)
+	{
+		if (_count == 0)
+			return;
+		auto it = findEntry(_key);
+		if (it == m_entries.end())
+			return;
+		if (it->second <= _count)
+			m_entries.erase(it);
+		else
+			it->second -= _count;
+	}
+
+	/// Sum-merge counts from `_other` into this.
+	UseCountSet& operator+=(UseCountSet const& _other)
+	{
+		for (auto const& [key, count]: _other.m_entries)
+			insert(key, count);
+		return *this;
+	}
+
+	/// Union with `_other`, taking max count per key.
+	UseCountSet& maxUnion(UseCountSet const& _other)
+	{
+		for (auto const& [key, count]: _other.m_entries)
+		{
+			auto it = findEntry(key);
+			if (it != m_entries.end())
+				it->second = std::max(it->second, count);
+			else
+				m_entries.emplace_back(key, count);
+		}
+		return *this;
+	}
+
+	template<typename Range>
+	void insertAll(Range const& _values)
+	{
+		for (auto const& value: _values)
+			insert(value);
+	}
+
+	template<typename Range>
+	void eraseAll(Range const& _values)
+	{
+		for (auto const& value: _values)
+			erase(value);
+	}
+
+	template<typename Predicate>
+	void eraseIf(Predicate&& _predicate)
+	{
+		std::erase_if(m_entries, std::forward<Predicate>(_predicate));
+	}
+
+private:
+	typename Entries::iterator findEntry(Key const& _key)
+	{
+		return std::find_if(m_entries.begin(), m_entries.end(), [&](auto const& _entry) { return _entry.first == _key; });
+	}
+	typename Entries::const_iterator findEntry(Key const& _key) const
+	{
+		return std::find_if(m_entries.begin(), m_entries.end(), [&](auto const& _entry) { return _entry.first == _key; });
+	}
+
+	Entries m_entries;
+};
+
+}

--- a/test/libyul/ssa/StackShufflerTest.cpp
+++ b/test/libyul/ssa/StackShufflerTest.cpp
@@ -99,21 +99,21 @@ Slot parseSlot(std::string_view token)
 
 	if (token.starts_with("v"))
 	{
-		if (auto const num = util::parseArithmetic<ValueId::ValueType>(token.substr(1)))
+		if (auto const num = solidity::util::parseArithmetic<ValueId::ValueType>(token.substr(1)))
 			return Slot::makeValueID(ValueId::makeVariable(*num));
 		throw std::runtime_error(fmt::format("Couldn't parse variable token: {}", token));
 	}
 
 	if (token.starts_with("phi"))
 	{
-		if (auto const num = util::parseArithmetic<ValueId::ValueType>(token.substr(3)))
+		if (auto const num = solidity::util::parseArithmetic<ValueId::ValueType>(token.substr(3)))
 			return Slot::makeValueID(ValueId::makePhi(*num));
 		throw std::runtime_error(fmt::format("Couldn't parse phi token: {}", token));
 	}
 
 	if (token.starts_with("lit"))
 	{
-		if (auto const num = util::parseArithmetic<ValueId::ValueType>(token.substr(3)))
+		if (auto const num = solidity::util::parseArithmetic<ValueId::ValueType>(token.substr(3)))
 			return Slot::makeValueID(ValueId::makeLiteral(*num));
 		throw std::runtime_error(fmt::format("Couldn't parse literal token: {}", token));
 	}
@@ -122,7 +122,7 @@ Slot parseSlot(std::string_view token)
 	if (token.starts_with(returnLabelPrefix) && token.ends_with("]"))
 	{
 		auto const inner = token.substr(returnLabelPrefix.size(), token.size() - returnLabelPrefix.size() - 1);
-		if (auto const num = util::parseArithmetic<ControlFlowGraphs::FunctionGraphID>(inner))
+		if (auto const num = solidity::util::parseArithmetic<ControlFlowGraphs::FunctionGraphID>(inner))
 			return Slot::makeFunctionReturnLabel(*num);
 		throw std::runtime_error(fmt::format("Couldn't parse ReturnLabel token: {}", token));
 	}
@@ -235,7 +235,7 @@ struct ShuffleTestInput
 				result.targetStackTailSet = parseLiveness(value);
 			else if (key == parserKeyStackSize)
 			{
-				if (auto num = util::parseArithmetic<std::size_t>(value))
+				if (auto num = solidity::util::parseArithmetic<std::size_t>(value))
 					result.targetStackSize = *num;
 				else
 					throw std::runtime_error(fmt::format("Couldn't parse targetStackSize: {}", value));

--- a/test/libyul/ssa/StackShufflerTest.cpp
+++ b/test/libyul/ssa/StackShufflerTest.cpp
@@ -18,9 +18,9 @@
 
 #include <test/libyul/ssa/StackShufflerTest.h>
 
-#include <libyul/backends/evm/ssa/LivenessAnalysis.h>
 #include <libyul/backends/evm/ssa/Stack.h>
 #include <libyul/backends/evm/ssa/StackShuffler.h>
+#include <libyul/backends/evm/ssa/StackSlotLiveness.h>
 
 #include <range/v3/view/split.hpp>
 
@@ -53,7 +53,6 @@ std::string_view constexpr parserKeyStackSize {"targetStackSize"};
 std::string_view constexpr parserKeyAllowSpilling {"allowSpilling"};
 std::string_view constexpr parserKeyInitialSpilled {"initialSpilledSet"};
 
-using Liveness = LivenessAnalysis::LivenessData;
 using Slot = StackSlot;
 using ValueId = SSACFG::ValueId;
 struct StackManipulationCallbacks
@@ -160,25 +159,25 @@ TestStack::Data parseSlots(std::string_view _input, char const brackBegin = '[',
 }
 
 /// Parse liveness like "{phi109, phi150, v172}"
-/// Returns Liveness with reference count 1 for each value
-Liveness parseLiveness(std::string_view _input)
+/// Returns StackSlotLiveness with reference count 1 for each value
+StackSlotLiveness parseLiveness(std::string_view _input)
 {
 	auto const slots = parseSlots(_input, '{', '}');
-	std::vector<std::pair<ValueId, uint32_t>> liveCounts;
-	liveCounts.reserve(slots.size());
+	StackSlotLiveness::Entries entries;
+	entries.reserve(slots.size());
 	for (auto const& slot: slots)
 	{
 		yulAssert(slot.isValueID(), "Only value IDs are permitted in liveness definition.");
-		liveCounts.emplace_back(slot.valueID(), 1);
+		entries.emplace_back(slot, 1u);
 	}
-	return {liveCounts.begin(), liveCounts.end()};
+	return StackSlotLiveness{std::move(entries)};
 }
 
 struct ShuffleTestInput
 {
 	std::optional<TestStack::Data> initial;
 	std::optional<TestStack::Data> targetStackTop;
-	Liveness targetStackTailSet{};
+	StackSlotLiveness targetStackTailSet{};
 	std::optional<size_t> targetStackSize;
 	bool allowSpilling = false;
 	SpilledVariables initialSpilledSet{};
@@ -250,8 +249,14 @@ struct ShuffleTestInput
 					throw std::runtime_error(fmt::format("Couldn't parse allowSpilling: {}", value));
 			}
 			else if (key == parserKeyInitialSpilled)
-				for (auto const& [valueId, _]: parseLiveness(value))
-					result.initialSpilledSet.spill(valueId);
+			{
+				auto const spillSet = parseLiveness(value);
+				for (auto const& slot: spillSet | ranges::views::keys)
+				{
+					yulAssert(slot.isValueID());
+					result.initialSpilledSet.spill(slot.valueID());
+				}
+			}
 
 		}
 
@@ -278,7 +283,7 @@ public:
 	TraceRecorder(
 		std::ostream& _out,
 		TestStack::Data const& _targetArgs,
-		Liveness const& _targetTail,
+		StackSlotLiveness const& _targetTail,
 		size_t _targetStackSize,
 		SpilledVariables const& _spillSet
 	):
@@ -298,9 +303,9 @@ public:
 				"{{{}}}",
 				fmt::join(
 					m_targetTail | ranges::views::keys | ranges::views::transform(
-						[this](auto const& id) {
-							std::string const suffix = m_spillSet.isSpilled(id) ? "*" : "";
-							return slotToString(Slot::makeValueID(id)) + suffix;
+						[this](Slot const& _slot) {
+							std::string const suffix = (_slot.isValueID() && m_spillSet.isSpilled(_slot.valueID())) ? "*" : "";
+							return slotToString(_slot) + suffix;
 						}
 					),
 					", "
@@ -377,7 +382,7 @@ private:
 	std::vector<TraceEntry> m_entries;
 	bool m_truncated = false;
 	TestStack::Data const& m_targetArgs;
-	Liveness const& m_targetTail;
+	StackSlotLiveness const& m_targetTail;
 	SpilledVariables const& m_spillSet;
 	size_t const m_targetStackSize;
 	size_t const m_targetTailSize;
@@ -601,14 +606,14 @@ explicitly provided.)";
 		yulAssert(*testConfig.targetStackSize >= testConfig.targetStackTop->size());
 		auto const tailSize = *testConfig.targetStackSize - testConfig.targetStackTop->size();
 		yulAssert(stackData.size() == *testConfig.targetStackSize);
-		for (const auto& valueID: testConfig.targetStackTailSet | ranges::views::keys)
+		for (const auto& slot: testConfig.targetStackTailSet | ranges::views::keys)
 		{
-			if (spillSet.isSpilled(valueID))
+			if (slot.isValueID() && spillSet.isSpilled(slot.valueID()))
 				continue;
 			auto const findIt = ranges::find(
 				stackData.begin(),
 				stackData.begin() + static_cast<std::ptrdiff_t>(tailSize),
-				StackSlot::makeValueID(valueID)
+				slot
 			);
 			yulAssert(findIt != ranges::end(stackData));
 		}


### PR DESCRIPTION
- introduce `ssa::util::UseCountSet` which, in effect, is the underlying datastructure of the liveness data
- introduce `StackSlotLiveness`, which is the same data but on stack slots. this will help the stack shuffler stay as decoupled as possible from the SSACFG post unification, as there, the value id no longer carries the type of operation it was emitted from