### PR TITLE
Fix docs stating incorrect version for the introduction of `--experimental`

### DIFF
--- a/docs/using-the-compiler.rst
+++ b/docs/using-the-compiler.rst
@@ -753,7 +753,7 @@ Note that the use of this mode is recorded in the metadata:
 - ``settings.experimental`` in JSON metadata is set to ``true``,
 
 .. note::
-    Prior to version 0.8.34, most of the experimental features were usable without any extra safeguards.
+    Prior to version 0.8.35, most of the experimental features were usable without any extra safeguards.
     Some were gated behind ``pragma experimental``, but this was not done consistently.
     The information about them was also only recorded in CBOR metadata and even then not always.
     The main goal of the experimental mode is to systematize this and make users fully aware when relying on features which are unfinished or not production-ready.


### PR DESCRIPTION
## Description

Docs on "using the compiler" mentions 0.8.34 as the release introducing `--experimental`, this is not correct.

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and
      the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
<!--
See our contributing guidelines for the full AI usage policy:
https://docs.soliditylang.org/en/latest/contributing.html#ai-assisted-contributions

If you used AI tools in any part of this PR you MUST disclose it below.
-->

- [x] No AI tools were used
- [ ] AI tools were used (details below)

<!-- If AI tools were used, describe which tools and for which parts here. -->
