### PR TITLE
SMTChecker: Fix SMT Encoder mishandling of constant operands of unary operations.

### DIFF
--- a/libsolidity/formal/SMTEncoder.cpp
+++ b/libsolidity/formal/SMTEncoder.cpp
@@ -451,9 +451,10 @@ void SMTEncoder::endVisit(TupleExpression const& _tuple)
 
 void SMTEncoder::endVisit(UnaryOperation const& _op)
 {
-	/// We need to shortcut here due to potentially unknown
-	/// rational number sizes.
-	if (_op.annotation().type->category() == Type::Category::RationalNumber)
+	/// For constant expressions, we need to shortcut here
+	/// due to potentially unknown rational number sizes that
+	/// can appear in intermediary operations, e.g., ~(2**256 - 1).
+	if (isConstant(_op))
 		return;
 
 	if (TokenTraits::isBitOp(_op.getOperator()) && !*_op.annotation().userDefinedFunction)

--- a/test/libsolidity/smtCheckerTests/operators/constant_evaluation_unary_minus_bmc.sol
+++ b/test/libsolidity/smtCheckerTests/operators/constant_evaluation_unary_minus_bmc.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity *;
+contract C {
+    int256 constant signedConstant = 42;
+
+    function testComptime() public pure {
+        assert(-signedConstant == -42);
+    }
+}
+// ====
+// SMTEngine: bmc
+// ----
+// Info 6002: BMC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/operators/constant_evaluation_unary_minus_chc.sol
+++ b/test/libsolidity/smtCheckerTests/operators/constant_evaluation_unary_minus_chc.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity *;
+contract C {
+    int256 constant signedConstant = 42;
+
+    function testComptime() public pure {
+        assert(-signedConstant == -42);
+    }
+}
+// ====
+// SMTEngine: chc
+// ----
+// Info 1391: CHC: 3 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.

--- a/test/libsolidity/smtCheckerTests/operators/constant_evaluation_unary_operations_compound.sol
+++ b/test/libsolidity/smtCheckerTests/operators/constant_evaluation_unary_operations_compound.sol
@@ -1,0 +1,10 @@
+contract C {
+    int256 constant CONST = 42;
+    function test() public pure {
+        assert(~-CONST == ~-42);
+    }
+}
+// ====
+// SMTEngine: chc
+// ----
+// Info 1391: CHC: 1 verification condition(s) proved safe! Enable the model checker option "show proved safe" to see all of them.


### PR DESCRIPTION
fix #16653.