### PR TITLE
NatSpec: Disallow `@return` tag on events

### DIFF
--- a/libsolidity/analysis/DocStringTagParser.cpp
+++ b/libsolidity/analysis/DocStringTagParser.cpp
@@ -285,7 +285,7 @@ void DocStringTagParser::handleCallable(
 	StructurallyDocumentedAnnotation& _annotation
 )
 {
-	static std::set<std::string> const validEventTags = std::set<std::string>{"dev", "notice", "return", "param"};
+	static std::set<std::string> const validEventTags = std::set<std::string>{"dev", "notice", "param"};
 	static std::set<std::string> const validErrorTags = std::set<std::string>{"dev", "notice", "param"};
 	static std::set<std::string> const validModifierTags = std::set<std::string>{"dev", "notice", "param", "inheritdoc"};
 	static std::set<std::string> const validTags = std::set<std::string>{"dev", "notice", "return", "param", "inheritdoc"};


### PR DESCRIPTION
## Summary

Events in Solidity cannot return values, but NatSpec parsing for events still allowed the `@return` tag because events were validated with tags meant for callable declarations that include returns. Align event documentation validation with errors (only `dev`, `notice`, `param`).

## Motivation

- Events have no return parameters; documenting `@return` is misleading and inconsistent with tooling that treats events like errors for tag validation.

## Implementation

Remove `return` from `validEventTags` in `DocStringTagParser::handleCallable()`.

Contributing guideline: commit message explains why, not only what.