### PR TITLE
NatSpec: Disallow `@return` tag on events

### DIFF
--- a/libsolidity/analysis/DocStringTagParser.cpp
+++ b/libsolidity/analysis/DocStringTagParser.cpp
@@ -285,7 +285,7 @@ void DocStringTagParser::handleCallable(
 	StructurallyDocumentedAnnotation& _annotation
 )
 {
-	static std::set<std::string> const validEventTags = std::set<std::string>{"dev", "notice", "return", "param"};
+	static std::set<std::string> const validEventTags = std::set<std::string>{"dev", "notice", "param"};
 	static std::set<std::string> const validErrorTags = std::set<std::string>{"dev", "notice", "param"};
 	static std::set<std::string> const validModifierTags = std::set<std::string>{"dev", "notice", "param", "inheritdoc"};
 	static std::set<std::string> const validTags = std::set<std::string>{"dev", "notice", "return", "param", "inheritdoc"};


### PR DESCRIPTION
## Summary

Events do not expose return parameters, but NatSpec parsing for events still allowed `@return` because event documentation used a callable-facing tag whitelist that included `return`. Drop `return` from `validEventTags` so validation matches `errors` ( `dev` / `notice` / `param` only).

## Rationale

- Avoid misleading documentation markup and mismatches for extractors that treat events like errors for tag rules.

## Change

- `DocStringTagParser::handleCallable()`: update `validEventTags`.

If an earlier PR with the same behavior is still open, feel free to close either one (this branch is fresh from current `develop`).