### PR TITLE
Parser: extend Trojan Source mitigation to NatSpec and bidirectional isolates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Compiler Features:
 
 Bugfixes:
 * NatSpec: Disallow `@return` tag in event documentation.
+* Parser: Validate paired bidirectional formatting and isolate markers (LRI / RLI / FSI / PDI) and apply the validation to NatSpec doc comments (`///` and `/** */`), closing a Trojan Source mitigation gap.
 
 
 ### 0.8.35 (2026-04-29)

--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -267,19 +267,24 @@ bool Scanner::skipWhitespaceExceptUnicodeLinebreak()
 namespace
 {
 
-/// Tries to scan for an RLO/LRO/RLE/LRE/PDF and keeps track of script writing direction override depth.
+/// Tries to scan for directional formatting and isolate markers and keeps track of script
+/// writing direction override depth.
 ///
 /// @returns ScannerError::NoError in case of successful parsing and directional encodings are paired
 ///          and error code in case the input's lexical parser state is invalid and this error should be reported
 ///          to the user.
 static ScannerError validateBiDiMarkup(CharStream& _stream, size_t _startPosition)
 {
-	static std::array<std::pair<std::string_view, int>, 5> constexpr directionalSequences{
+	static std::array<std::pair<std::string_view, int>, 9> constexpr directionalSequences{
 		std::pair<std::string_view, int>{"\xE2\x80\xAD", 1}, // U+202D (LRO - Left-to-Right Override)
 		std::pair<std::string_view, int>{"\xE2\x80\xAE", 1}, // U+202E (RLO - Right-to-Left Override)
 		std::pair<std::string_view, int>{"\xE2\x80\xAA", 1}, // U+202A (LRE - Left-to-Right Embedding)
 		std::pair<std::string_view, int>{"\xE2\x80\xAB", 1}, // U+202B (RLE - Right-to-Left Embedding)
-		std::pair<std::string_view, int>{"\xE2\x80\xAC", -1} // U+202C (PDF - Pop Directional Formatting
+		std::pair<std::string_view, int>{"\xE2\x80\xAC", -1}, // U+202C (PDF - Pop Directional Formatting)
+		std::pair<std::string_view, int>{"\xE2\x81\xA6", 1}, // U+2066 (LRI - Left-to-Right Isolate)
+		std::pair<std::string_view, int>{"\xE2\x81\xA7", 1}, // U+2067 (RLI - Right-to-Left Isolate)
+		std::pair<std::string_view, int>{"\xE2\x81\xA8", 1}, // U+2068 (FSI - First Strong Isolate)
+		std::pair<std::string_view, int>{"\xE2\x81\xA9", -1} // U+2069 (PDI - Pop Directional Isolate)
 	};
 
 	size_t endPosition = _stream.position();
@@ -464,8 +469,7 @@ Token Scanner::scanMultiLineDocComment()
 	literal.complete();
 	if (!endFound)
 		return setError(ScannerError::IllegalCommentTerminator);
-	else
-		return Token::CommentLiteral;
+	return Token::CommentLiteral;
 }
 
 Token Scanner::scanSlash()
@@ -488,6 +492,9 @@ Token Scanner::scanSlash()
 			m_skippedComments[NextNext].location.sourceName = m_sourceName;
 			m_skippedComments[NextNext].token = Token::CommentLiteral;
 			m_skippedComments[NextNext].location.end = static_cast<int>(scanSingleLineDocComment());
+			ScannerError unicodeDirectionError = validateBiDiMarkup(m_source, static_cast<size_t>(firstSlashPosition));
+			if (unicodeDirectionError != ScannerError::NoError)
+				return setError(unicodeDirectionError);
 			return Token::Whitespace;
 		}
 		else
@@ -520,8 +527,10 @@ Token Scanner::scanSlash()
 			m_skippedComments[NextNext].token = comment;
 			if (comment == Token::Illegal)
 				return Token::Illegal; // error already set
-			else
-				return Token::Whitespace;
+			ScannerError unicodeDirectionError = validateBiDiMarkup(m_source, static_cast<size_t>(firstSlashPosition));
+			if (unicodeDirectionError != ScannerError::NoError)
+				return setError(unicodeDirectionError);
+			return Token::Whitespace;
 		}
 		else
 			return skipMultiLineComment();

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -151,6 +151,9 @@ ASTPointer<SourceUnit> Parser::parse(CharStream& _charStream)
 				solAssert(m_experimentalSolidityEnabledInCurrentSourceUnit);
 				nodes.push_back(parseTypeClassInstantiation());
 				break;
+			case Token::Illegal:
+				fatalParserError(1108_error, to_string(m_scanner->currentError()));
+				break;
 			default:
 				if (
 					// Workaround because `error` is not a keyword.
@@ -499,6 +502,8 @@ ASTPointer<ContractDefinition> Parser::parseContractDefinition()
 			subNodes.push_back(parseEventDefinition());
 		else if (currentTokenValue == Token::Using)
 			subNodes.push_back(parseUsingDirective());
+		else if (currentTokenValue == Token::Illegal)
+			fatalParserError(1109_error, to_string(m_scanner->currentError()));
 		else
 			fatalParserError(9182_error, "Function, variable, struct or modifier declaration expected.");
 	}

--- a/scripts/test_antlr_grammar.sh
+++ b/scripts/test_antlr_grammar.sh
@@ -60,9 +60,9 @@ done < <(
     "^\/\/ (Syntax|Type|Declaration)Error|^\/\/ ParserError (1684|2837|3716|3997|5333|6275|6281|6933|7319|8185|7637)|^==== Source:|^pragma experimental solidity;" \
     "${ROOT_DIR}/test/libsolidity/syntaxTests" \
     "${ROOT_DIR}/test/libsolidity/semanticTests" |
-      # Skipping the unicode tests as I couldn't adapt the lexical grammar to recursively counting RLO/LRO/PDF's.
-      grep -v -E 'comments/.*_direction_override.*.sol' |
-      grep -v -E 'literals/.*_direction_override.*.sol' |
+      # Skipping the unicode tests as I couldn't adapt the lexical grammar to recursively counting RLO/LRO/PDF's or LRI/RLI/FSI/PDI's.
+      grep -v -E 'comments/.*_(direction|isolate)_override.*\.sol' |
+      grep -v -E 'literals/.*_(direction|isolate)_override.*\.sol' |
       # Skipping a test with "revert E;" because ANTLR cannot distinguish it from
       # a variable declaration.
       grep -v -E 'revertStatement/non_called.sol' |

--- a/test/libsolidity/syntaxTests/comments/multiline_unicode_isolate_override_1.sol
+++ b/test/libsolidity/syntaxTests/comments/multiline_unicode_isolate_override_1.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() public pure
+    {
+        // PDI
+        /*underflow ⁩*/
+    }
+}
+// ----
+// ParserError 8936: (71-83): Unicode direction override underflow in comment or string literal.

--- a/test/libsolidity/syntaxTests/comments/multiline_unicode_isolate_override_2.sol
+++ b/test/libsolidity/syntaxTests/comments/multiline_unicode_isolate_override_2.sol
@@ -1,0 +1,14 @@
+contract C {
+    function f() public pure
+    {
+        // LRI PDI
+        /*ok ⁦⁩*/
+
+        // LRI LRI PDI PDI
+        /*ok ⁦⁦⁩⁩*/
+
+        // RLI FSI PDI PDI
+        /*ok ⁧⁨⁩⁩*/
+    }
+}
+// ----

--- a/test/libsolidity/syntaxTests/comments/natspec_multiline_direction_override_1.sol
+++ b/test/libsolidity/syntaxTests/comments/natspec_multiline_direction_override_1.sol
@@ -1,0 +1,6 @@
+/** RLO bad ‮ */
+contract C {
+    function f() public pure {}
+}
+// ----
+// ParserError 1108: (0-18): Mismatching directional override markers in comment or string literal.

--- a/test/libsolidity/syntaxTests/comments/natspec_singleline_direction_override_1.sol
+++ b/test/libsolidity/syntaxTests/comments/natspec_singleline_direction_override_1.sol
@@ -1,0 +1,6 @@
+/// RLO bad ‮
+contract C {
+    function f() public pure {}
+}
+// ----
+// ParserError 1108: (0-16): Mismatching directional override markers in comment or string literal.

--- a/test/libsolidity/syntaxTests/comments/natspec_singleline_direction_override_2.sol
+++ b/test/libsolidity/syntaxTests/comments/natspec_singleline_direction_override_2.sol
@@ -1,0 +1,6 @@
+contract C {
+    /// bad ‮
+    function f() public pure {}
+}
+// ----
+// ParserError 1109: (17-33): Mismatching directional override markers in comment or string literal.

--- a/test/libsolidity/syntaxTests/comments/singleline_unicode_isolate_override_1.sol
+++ b/test/libsolidity/syntaxTests/comments/singleline_unicode_isolate_override_1.sol
@@ -1,0 +1,9 @@
+contract C {
+    function f() public pure
+    {
+        // LRI
+        // overflow ⁦
+    }
+}
+// ----
+// ParserError 8936: (71-86): Mismatching directional override markers in comment or string literal.


### PR DESCRIPTION
## Description

The lexer's existing Trojan Source defence (CVE-2021-42574 class) in `liblangutil/Scanner.cpp` had two gaps that this PR closes:

1. **NatSpec doc comments are not validated.** `validateBiDiMarkup` is called from `skipSingleLineComment`, `skipMultiLineComment`, and `scanString`, but never from the doxygen-style `///` and `/** */` paths. Unbalanced override markers (e.g. `U+202E` RLO) hidden inside NatSpec were therefore silently accepted.

2. **The isolate codepoints `U+2066..U+2069` are not in the table.** `validateBiDiMarkup` tracks only the embedding/override set (LRO/RLO/LRE/RLE/PDF). Unicode 6.3 introduced LRI/RLI/FSI/PDI as a separate but visually equivalent mechanism, and unbalanced isolates pass the check even in regular comments and string literals.

This PR:

* adds the four isolate codepoints (LRI = `U+2066`, RLI = `U+2067`, FSI = `U+2068`, PDI = `U+2069`) to the directional sequence table;
* runs `validateBiDiMarkup` on both NatSpec scanner paths via `scanSlash` (so the existing `Token::Illegal` machinery can surface the error);
* extends `Parser::parseSourceUnit` and `Parser::parseContractDefinition` with explicit `Token::Illegal` handling, so the scanner's specific error (`8936`) reaches the user instead of being shadowed by the generic `9182` "Function, variable, struct or modifier declaration expected".

Two new parser error codes (`1108` and `1109`) are introduced for the new `fatalParserError` sites.

Five new syntax tests cover NatSpec single-line / multi-line, isolate overflow / underflow in regular comments, and a balanced-isolate negative case.

Fixes #16500.

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
- [x] No AI tools were used
- [ ] AI tools were used (details below)