### PR TITLE
SMT checker: Fix pop() assertion to match push/pop frame stack

### DIFF
--- a/libsmtutil/SMTLib2Interface.cpp
+++ b/libsmtutil/SMTLib2Interface.cpp
@@ -240,7 +240,7 @@ void SMTLib2Commands::push() {
 }
 
 void SMTLib2Commands::pop() {
-	smtAssert(!m_commands.empty());
+	smtAssert(!m_frameLimits.empty());
 	auto limit = m_frameLimits.back();
 	m_frameLimits.pop_back();
 	while (m_commands.size() > limit)


### PR DESCRIPTION
## Summary

`SMTLib2Commands::pop()` used `smtAssert(!m_commands.empty())` before reading the bookmarked deque size off `m_frameLimits`. That does not mirror what `push()` guarantees: `push()` always pushes the current deque size onto `m_frameLimits`, but the deque may legitimately remain empty across a bracket if no commands were flushed while the inner frame stayed open.

## Fix

Replace the precondition with `smtAssert(!m_frameLimits.empty())`, which validates push/pop bookkeeping and still catches unbalanced pops when the stack is drained.

## References

Touches `libsmtutil/SMTLib2Interface.cpp` only.