### PR TITLE
feat: Add benchmarking infrastructure for ethdebug (Part 1 of #16537)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,12 @@ emscripten_build/
 /reports/
 /benchmarks/
 
+# Generated Solidity sources produced by the benchmarking infrastructure
+/test/benchmarks/generated/
+
+# Real-world standard-JSON input files (downloaded separately, not committed)
+test/benchmarks/real-world/*.json
+
 # vim stuff
 [._]*.sw[a-p]
 [._]sw[a-p]

--- a/test/benchmarks/__init__.py
+++ b/test/benchmarks/__init__.py
@@ -1,0 +1,2 @@
+# Benchmarking infrastructure for the Solidity compiler.
+# See test/benchmarks/run.py for the entry point.

--- a/test/benchmarks/contract_generator.py
+++ b/test/benchmarks/contract_generator.py
@@ -1,0 +1,368 @@
+"""
+Synthetic Solidity contract generator for the solc benchmarking infrastructure.
+
+Produces parameterised .sol files covering five stress categories that exercise
+distinct compiler subsystems.  All code uses Python stdlib only.
+
+Usage:
+    from pathlib import Path
+    from contract_generator import StressCategory, generate
+
+    path = generate(StressCategory.DEEP_NESTING, size=10, output_dir=Path("generated"))
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+_SPDX = "// SPDX-License-Identifier: GPL-3.0"
+_PRAGMA = "pragma solidity ^0.8.0;"
+_DEFAULT_SIZE = 10
+
+
+class StressCategory(Enum):
+    """The five synthetic contract families."""
+
+    DEEP_NESTING = "deep-nesting"
+    WIDE_CONTRACT = "wide-contract"
+    HEAVY_ABI = "heavy-abi"
+    COMPLEX_CONTROL_FLOW = "complex-control-flow"
+    HEAVY_STORAGE = "heavy-storage"
+
+
+def generate(
+    category: StressCategory,
+    size: int = _DEFAULT_SIZE,
+    output_dir: Path = Path("generated"),
+) -> Path:
+    """Generate a .sol file for *category* at the given *size*.
+
+    Creates *output_dir* (including parents) if it does not exist, writes the
+    Solidity source, and returns the path to the written file.
+
+    Args:
+        category:   Which stress category to generate.
+        size:       Positive integer that scales contract complexity.
+        output_dir: Directory in which to write the .sol file.
+
+    Returns:
+        Path to the generated .sol file.
+    """
+    if size < 1:
+        raise ValueError(f"size must be a positive integer, got {size!r}")
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    _generators = {
+        StressCategory.DEEP_NESTING: _generate_deep_nesting,
+        StressCategory.WIDE_CONTRACT: _generate_wide_contract,
+        StressCategory.HEAVY_ABI: _generate_heavy_abi,
+        StressCategory.COMPLEX_CONTROL_FLOW: _generate_complex_control_flow,
+        StressCategory.HEAVY_STORAGE: _generate_heavy_storage,
+    }
+
+    source = _generators[category](size)
+    filename = f"{category.value}.sol"
+    out_path = output_dir / filename
+    out_path.write_text(source, encoding="utf-8")
+    return out_path
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+def _header(contract_name: str) -> str:
+    """Return the standard file header (SPDX + pragma + contract opening)."""
+    return f"{_SPDX}\n{_PRAGMA}\n\ncontract {contract_name} {{\n"
+
+
+def _footer() -> str:
+    return "}\n"
+
+
+# ---------------------------------------------------------------------------
+# Category generators
+# ---------------------------------------------------------------------------
+
+def _generate_deep_nesting(size: int) -> str:
+    """Nested structs, mappings, and functions scaled by *size*.
+
+    Generates *size* levels of nested struct definitions and a set of
+    functions that read/write them, exercising the type checker and ABI
+    encoder.
+    """
+    lines: list[str] = []
+    lines.append(_SPDX)
+    lines.append(_PRAGMA)
+    lines.append("")
+    lines.append("contract DeepNesting {")
+    lines.append("")
+
+    # Generate nested struct definitions: S1 contains S2, S2 contains S3, …
+    # The innermost struct holds a uint256 value field.
+    for i in range(size, 0, -1):
+        lines.append(f"    struct S{i} {{")
+        if i < size:
+            lines.append(f"        S{i + 1} inner;")
+        lines.append(f"        uint256 val{i};")
+        lines.append("    }")
+        lines.append("")
+
+    # A mapping from uint256 to the outermost struct
+    lines.append("    mapping(uint256 => S1) public store;")
+    lines.append("")
+
+    # Nested mappings: map1 -> map2 -> … -> uint256
+    for i in range(1, size + 1):
+        mapping_type = "uint256"
+        for _ in range(i):
+            mapping_type = f"mapping(uint256 => {mapping_type})"
+        lines.append(f"    {mapping_type} public nestedMap{i};")
+    lines.append("")
+
+    # Functions that set/get the nested struct
+    lines.append("    function setVal(uint256 key, uint256 v) public {")
+    lines.append("        store[key].val1 = v;")
+    lines.append("    }")
+    lines.append("")
+    lines.append("    function getVal(uint256 key) public view returns (uint256) {")
+    lines.append("        return store[key].val1;")
+    lines.append("    }")
+    lines.append("")
+
+    # One function per nesting level that traverses the chain
+    for i in range(1, size + 1):
+        lines.append(f"    function readLevel{i}(uint256 key) public view returns (uint256) {{")
+        # Build accessor chain: store[key].inner.inner…val
+        chain = "store[key]"
+        for _ in range(i - 1):
+            chain += ".inner"
+        chain += f".val{i}"
+        lines.append(f"        return {chain};")
+        lines.append("    }")
+        lines.append("")
+
+    lines.append("}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _generate_wide_contract(size: int) -> str:
+    """*size* state variables and *size* public functions.
+
+    Exercises symbol-table construction and dispatch-table generation.
+    """
+    lines: list[str] = []
+    lines.append(_SPDX)
+    lines.append(_PRAGMA)
+    lines.append("")
+    lines.append("contract WideContract {")
+    lines.append("")
+
+    # State variables
+    for i in range(1, size + 1):
+        lines.append(f"    uint256 public var{i};")
+    lines.append("")
+
+    # Public setter/getter function pairs
+    for i in range(1, size + 1):
+        lines.append(f"    function set{i}(uint256 v) public {{")
+        lines.append(f"        var{i} = v;")
+        lines.append("    }")
+        lines.append("")
+        lines.append(f"    function get{i}() public view returns (uint256) {{")
+        lines.append(f"        return var{i};")
+        lines.append("    }")
+        lines.append("")
+
+    lines.append("}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _generate_heavy_abi(size: int) -> str:
+    """Functions with complex tuple/array parameters scaled by *size*.
+
+    Exercises ABI encoding and decoding generation.
+    """
+    lines: list[str] = []
+    lines.append(_SPDX)
+    lines.append(_PRAGMA)
+    lines.append("")
+    lines.append("contract HeavyABI {")
+    lines.append("")
+
+    # Generate *size* struct types used as tuple parameters
+    for i in range(1, size + 1):
+        lines.append(f"    struct Param{i} {{")
+        lines.append(f"        uint256 a{i};")
+        lines.append(f"        address b{i};")
+        lines.append(f"        bytes32 c{i};")
+        lines.append(f"        uint256[] arr{i};")
+        lines.append("    }")
+        lines.append("")
+
+    # Functions that accept and return these structs
+    for i in range(1, size + 1):
+        lines.append(
+            f"    function process{i}(Param{i} calldata p, uint256[] calldata extra)"
+            f" external pure returns (Param{i} memory, uint256) {{"
+        )
+        lines.append(f"        uint256 sum = p.a{i};")
+        lines.append("        for (uint256 k = 0; k < extra.length; k++) {")
+        lines.append("            sum += extra[k];")
+        lines.append("        }")
+        lines.append(f"        return (p, sum);")
+        lines.append("    }")
+        lines.append("")
+
+    # Functions with nested array parameters
+    for i in range(1, size + 1):
+        lines.append(
+            f"    function multiArray{i}(uint256[][] calldata matrix, bytes[] calldata data)"
+            f" external pure returns (uint256) {{"
+        )
+        lines.append("        uint256 total = 0;")
+        lines.append("        for (uint256 r = 0; r < matrix.length; r++) {")
+        lines.append("            for (uint256 c = 0; c < matrix[r].length; c++) {")
+        lines.append("                total += matrix[r][c];")
+        lines.append("            }")
+        lines.append("        }")
+        lines.append("        total += data.length;")
+        lines.append("        return total;")
+        lines.append("    }")
+        lines.append("")
+
+    lines.append("}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _generate_complex_control_flow(size: int) -> str:
+    """Deeply nested conditionals, loops, and internal calls scaled by *size*.
+
+    Exercises the control-flow graph builder and optimizer.
+    """
+    lines: list[str] = []
+    lines.append(_SPDX)
+    lines.append(_PRAGMA)
+    lines.append("")
+    lines.append("contract ComplexControlFlow {")
+    lines.append("")
+
+    # Internal helper functions that call each other
+    for i in range(1, size + 1):
+        lines.append(f"    function _helper{i}(uint256 x) internal pure returns (uint256) {{")
+        lines.append("        uint256 result = x;")
+        # Nested if/else chain
+        for j in range(1, i + 1):
+            indent = "        " + "    " * (j - 1)
+            lines.append(f"{indent}if (result % {j + 1} == 0) {{")
+            lines.append(f"{indent}    result = result / {j + 1} + {j};")
+        # Close all the ifs
+        for j in range(i, 0, -1):
+            indent = "        " + "    " * (j - 1)
+            lines.append(f"{indent}}}")
+        lines.append("        return result;")
+        lines.append("    }")
+        lines.append("")
+
+    # Public functions with nested loops and internal calls
+    for i in range(1, size + 1):
+        lines.append(f"    function compute{i}(uint256 n) public pure returns (uint256) {{")
+        lines.append("        uint256 acc = 0;")
+        # Nested for loops
+        for j in range(1, min(i + 1, 4)):  # cap nesting at 3 to keep valid Solidity
+            indent = "        " + "    " * (j - 1)
+            lines.append(f"{indent}for (uint256 i{j} = 0; i{j} < n; i{j}++) {{")
+        inner_indent = "        " + "    " * min(i, 3)
+        lines.append(f"{inner_indent}acc += _helper{i}(acc);")
+        for j in range(min(i, 3), 0, -1):
+            indent = "        " + "    " * (j - 1)
+            lines.append(f"{indent}}}")
+        lines.append("        return acc;")
+        lines.append("    }")
+        lines.append("")
+
+    lines.append("}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _generate_heavy_storage(size: int) -> str:
+    """Complex storage variables (mappings-of-mappings, dynamic arrays of structs).
+
+    Exercises storage layout computation and slot assignment.
+    """
+    lines: list[str] = []
+    lines.append(_SPDX)
+    lines.append(_PRAGMA)
+    lines.append("")
+    lines.append("contract HeavyStorage {")
+    lines.append("")
+
+    # Struct types used in dynamic arrays
+    for i in range(1, size + 1):
+        lines.append(f"    struct Record{i} {{")
+        lines.append(f"        uint256 id{i};")
+        lines.append(f"        address owner{i};")
+        lines.append(f"        bytes32 data{i};")
+        lines.append("    }")
+        lines.append("")
+
+    # Mapping-of-mapping declarations (depth scales with index, capped at 4 to
+    # avoid stack-too-deep in legacy codegen without optimizer)
+    _MAX_DEPTH = 4
+    for i in range(1, size + 1):
+        depth = min(i, _MAX_DEPTH)
+        inner = "uint256"
+        for _ in range(depth):
+            inner = f"mapping(address => {inner})"
+        outer = f"mapping(uint256 => {inner})"
+        lines.append(f"    {outer} public deepMap{i};")
+    lines.append("")
+
+    # Dynamic arrays of structs
+    for i in range(1, size + 1):
+        lines.append(f"    Record{i}[] public records{i};")
+    lines.append("")
+
+    # Accessor / mutator functions
+    for i in range(1, size + 1):
+        lines.append(f"    function addRecord{i}(uint256 id, address owner, bytes32 data) public {{")
+        lines.append(f"        Record{i} storage r = records{i}.push();")
+        lines.append(f"        r.id{i} = id;")
+        lines.append(f"        r.owner{i} = owner;")
+        lines.append(f"        r.data{i} = data;")
+        lines.append("    }")
+        lines.append("")
+        lines.append(f"    function getRecordCount{i}() public view returns (uint256) {{")
+        lines.append(f"        return records{i}.length;")
+        lines.append("    }")
+        lines.append("")
+
+    # Mapping write/read helpers
+    # deepMap{i} has depth min(i, _MAX_DEPTH): one uint256 key then depth address keys
+    for i in range(1, size + 1):
+        depth = min(i, _MAX_DEPTH)
+        addr_params = ", ".join(f"address a{j}" for j in range(1, depth + 1))
+        addr_keys = "".join(f"[a{j}]" for j in range(1, depth + 1))
+        lines.append(f"    function setDeep{i}(uint256 k, {addr_params}, uint256 v) public {{")
+        lines.append(f"        deepMap{i}[k]{addr_keys} = v;")
+        lines.append("    }")
+        lines.append("")
+        lines.append(f"    function getDeep{i}(uint256 k, {addr_params}) public view returns (uint256) {{")
+        lines.append(f"        return deepMap{i}[k]{addr_keys};")
+        lines.append("    }")
+        lines.append("")
+
+    lines.append("}")
+    lines.append("")
+    return "\n".join(lines)

--- a/test/benchmarks/models.py
+++ b/test/benchmarks/models.py
@@ -1,0 +1,78 @@
+"""
+Shared data model dataclasses for the solc benchmarking infrastructure.
+
+These types flow through the pipeline:
+  BenchmarkCase  ->  runner.py  ->  Sample  ->  reporter.py  ->  CaseStats
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class BenchmarkCase:
+    """A single compilation task to be benchmarked.
+
+    Attributes:
+        case_id:          Unique identifier, e.g. "deep-nesting-legacy-off".
+        source_path:      Path to the .sol source or standard-JSON input file.
+        pipeline:         Compiler code-generation path: "legacy" or "ir".
+        debug_info_mode:  Whether ethdebug info is emitted: "on" or "off".
+        use_standard_json: When True the input is passed via --standard-json.
+    """
+
+    case_id: str
+    source_path: Path
+    pipeline: str           # "legacy" | "ir"
+    debug_info_mode: str    # "on" | "off"
+    use_standard_json: bool = False
+
+
+@dataclass
+class Sample:
+    """One wall-clock time and peak-RSS measurement for a single BenchmarkCase run.
+
+    Attributes:
+        case_id:       Identifies which BenchmarkCase produced this sample.
+        elapsed_s:     Wall-clock elapsed time in seconds (≥ 0).
+        peak_rss_mib:  Peak resident-set size in mebibytes (> 0 on success).
+        exit_code:     Exit code of the solc invocation (0 = success).
+    """
+
+    case_id: str
+    elapsed_s: float
+    peak_rss_mib: float
+    exit_code: int
+
+
+@dataclass
+class CaseStats:
+    """Aggregated statistics for all Samples belonging to one BenchmarkCase.
+
+    Attributes:
+        case_id:           Identifies the BenchmarkCase.
+        pipeline:          "legacy" or "ir".
+        debug_info_mode:   "on" or "off".
+        repeat_count:      Total number of samples collected (including failures).
+        time_median_s:     Median of elapsed_s across all samples.
+        time_mean_s:       Arithmetic mean of elapsed_s across all samples.
+        time_variance_s2:  Sample variance of elapsed_s (ddof=1; 0.0 for single sample).
+        rss_median_mib:    Median of peak_rss_mib across all samples.
+        rss_mean_mib:      Arithmetic mean of peak_rss_mib across all samples.
+        rss_variance_mib2: Sample variance of peak_rss_mib (ddof=1; 0.0 for single sample).
+        failed_count:      Number of samples whose exit_code was non-zero.
+    """
+
+    case_id: str
+    pipeline: str
+    debug_info_mode: str
+    repeat_count: int
+    time_median_s: float
+    time_mean_s: float
+    time_variance_s2: float
+    rss_median_mib: float
+    rss_mean_mib: float
+    rss_variance_mib2: float
+    failed_count: int

--- a/test/benchmarks/real-world/README.md
+++ b/test/benchmarks/real-world/README.md
@@ -1,0 +1,111 @@
+# Real-World Benchmark Inputs
+
+This directory holds **standard-JSON input files** used by the `real-world` benchmark suite.
+Each file is a complete `--standard-json` payload that can be fed directly to `solc`, covering
+a realistic, large-scale Solidity codebase.
+
+---
+
+## Purpose
+
+Synthetic contracts exercise specific compiler subsystems in isolation, but they cannot capture
+the full complexity of real-world projects. This suite compiles well-known open-source projects
+to measure how large pull requests (e.g. ethdebug support) affect compilation time and memory
+usage against realistic inputs.
+
+---
+
+## Provenance
+
+The table below records the origin of every standard-JSON file that belongs in this directory.
+Keep this table up to date whenever a new file is added or an existing one is updated.
+
+| Project | Version | Source URL | Extracted From |
+|---------|---------|------------|----------------|
+| *(no files yet — see instructions below)* | | | |
+
+---
+
+## Adding a New Real-World Benchmark
+
+To add a new project to the suite:
+
+1. **Obtain the project source.** Clone or download the release tarball of the project at the
+   desired version, e.g.:
+   ```
+   git clone --depth 1 --branch v5.0.2 https://github.com/OpenZeppelin/openzeppelin-contracts.git
+   ```
+
+2. **Compile the project once with Hardhat or Foundry** to let the build tool resolve imports
+   and produce a compilation artifact. For Hardhat:
+   ```
+   npm install
+   npx hardhat compile --config hardhat.config.js
+   ```
+   For Foundry:
+   ```
+   forge build
+   ```
+
+3. **Extract the standard-JSON input.** The easiest method is to run `solc` with
+   `--standard-json` and capture the input that the build tool would pass. With Hardhat you can
+   inspect `artifacts/build-info/*.json` — each file contains an `input` key that is the
+   standard-JSON payload. Extract it:
+   ```python
+   import json, pathlib
+   build_info = json.loads(pathlib.Path("artifacts/build-info/<hash>.json").read_text())
+   pathlib.Path("openzeppelin-5.0.2.json").write_text(json.dumps(build_info["input"], indent=2))
+   ```
+   With Foundry, the equivalent lives in `out/<ContractName>.sol/<ContractName>.json` under the
+   `metadata.settings` key, but the simplest approach is to run:
+   ```
+   forge build --extra-output-files ir
+   ```
+   and reconstruct the standard-JSON manually, or use a helper script.
+
+4. **Name the file** using the convention `<project>-<version>.json`, e.g.
+   `openzeppelin-5.0.2.json`.
+
+5. **Place the file in this directory** (`test/benchmarks/real-world/`).
+
+6. **Update the Provenance table** above with the project name, version, source URL, and where
+   the standard-JSON was extracted from (e.g. "Hardhat build-info artifact").
+
+7. **Verify** the file works with the benchmark runner:
+   ```
+   python test/benchmarks/run.py --suite real-world --solc <path-to-solc>
+   ```
+
+---
+
+## Important: JSON Files Are Not Committed
+
+`.json` files in this directory are **not committed to the repository**. They can be large
+(several megabytes) and are downloaded or generated separately before running the real-world
+suite. Only this `README.md` is tracked by git.
+
+If the benchmark runner cannot find a `.json` file it expects, it will emit a warning and skip
+that case rather than aborting the run.
+
+---
+
+## Running the Real-World Suite
+
+To run only the real-world benchmarks:
+
+```
+python test/benchmarks/run.py --suite real-world --solc <path-to-solc>
+```
+
+Additional options:
+
+```
+# Specify number of measurement repeats (default: 3)
+python test/benchmarks/run.py --suite real-world --solc <path> --repeats 5
+
+# Save the JSON report to a file
+python test/benchmarks/run.py --suite real-world --solc <path> --output report.json
+
+# Compare against a previous run
+python test/benchmarks/run.py --suite real-world --solc <path> --baseline previous-report.json
+```

--- a/test/benchmarks/reporter.py
+++ b/test/benchmarks/reporter.py
@@ -1,0 +1,387 @@
+"""
+Statistical reporter for the solc benchmarking infrastructure.
+
+Computes statistics over raw Sample objects, formats results as console tables,
+JSON reports, and Markdown comparison diffs.
+
+Can also be run as a standalone script:
+    python reporter.py <baseline.json> <current.json>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Dict, List
+
+from models import CaseStats, Sample
+
+
+class Reporter:
+    """Stateless reporter: all methods are @staticmethod."""
+
+    # ------------------------------------------------------------------
+    # Task 6.1 — compute_stats
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def compute_stats(samples: List[Sample]) -> List[CaseStats]:
+        """Group samples by case_id and compute aggregated statistics.
+
+        For each group the following are computed using the ``statistics``
+        stdlib module:
+          - median, arithmetic mean, and sample variance (ddof=1) for
+            elapsed_s and peak_rss_mib.
+          - failed_count: number of samples whose exit_code != 0.
+
+        A single-sample group has variance 0.0 (statistics.variance would
+        raise StatisticsError for n < 2, so we handle that explicitly).
+
+        Returns a list of CaseStats, one per unique case_id, in the order
+        the case_ids are first encountered.
+        """
+        # Preserve insertion order of case_ids.
+        groups: Dict[str, List[Sample]] = defaultdict(list)
+        for s in samples:
+            groups[s.case_id].append(s)
+
+        # We need pipeline / debug_info_mode per case_id.  These come from
+        # the BenchmarkCase that produced the samples; the runner embeds
+        # them in the Sample's case_id string but does NOT store them on
+        # Sample directly.  The runner.py module exposes build_synthetic_cases
+        # and build_real_world_cases, but the reporter must not depend on the
+        # runner.  Instead we accept that the caller may pass a parallel list
+        # of BenchmarkCase objects — however the current interface only takes
+        # List[Sample].
+        #
+        # The design doc says CaseStats has pipeline and debug_info_mode, but
+        # Sample does not carry those fields.  We therefore derive them from
+        # the case_id convention "{source}-{pipeline}-{debug_info_mode}" by
+        # splitting on the last two "-" separated tokens.  This is consistent
+        # with the case-ID convention documented in design.md.
+
+        result: List[CaseStats] = []
+        for case_id, grp in groups.items():
+            times = [s.elapsed_s for s in grp]
+            rss = [s.peak_rss_mib for s in grp]
+            failed = sum(1 for s in grp if s.exit_code != 0)
+
+            t_median = statistics.median(times)
+            t_mean = statistics.mean(times)
+            t_var = statistics.variance(times) if len(times) > 1 else 0.0
+
+            r_median = statistics.median(rss)
+            r_mean = statistics.mean(rss)
+            r_var = statistics.variance(rss) if len(rss) > 1 else 0.0
+
+            # Derive pipeline and debug_info_mode from case_id convention.
+            # Convention: "...-{pipeline}-{debug_info_mode}"
+            # pipeline ∈ {"legacy", "ir"}, debug_info_mode ∈ {"on", "off"}
+            parts = case_id.split("-")
+            pipeline = "unknown"
+            debug_info_mode = "unknown"
+            if len(parts) >= 2:
+                candidate_dim = parts[-1]
+                candidate_pipeline = parts[-2]
+                if candidate_dim in ("on", "off"):
+                    debug_info_mode = candidate_dim
+                if candidate_pipeline in ("legacy", "ir"):
+                    pipeline = candidate_pipeline
+
+            result.append(
+                CaseStats(
+                    case_id=case_id,
+                    pipeline=pipeline,
+                    debug_info_mode=debug_info_mode,
+                    repeat_count=len(grp),
+                    time_median_s=t_median,
+                    time_mean_s=t_mean,
+                    time_variance_s2=t_var,
+                    rss_median_mib=r_median,
+                    rss_mean_mib=r_mean,
+                    rss_variance_mib2=r_var,
+                    failed_count=failed,
+                )
+            )
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Task 6.2 — to_json
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def to_json(stats: List[CaseStats], solc_version: str = "unknown") -> dict:
+        """Produce a JSON-serialisable dict matching the report schema.
+
+        Schema:
+          {
+            "schema_version": "1",
+            "generated_at": "<ISO 8601 UTC>",
+            "solc_version": "<str>",
+            "cases": [ { ...all 11 CaseStats fields... }, ... ]
+          }
+        """
+        generated_at = datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        cases = []
+        for cs in stats:
+            cases.append(
+                {
+                    "case_id": cs.case_id,
+                    "pipeline": cs.pipeline,
+                    "debug_info_mode": cs.debug_info_mode,
+                    "repeat_count": cs.repeat_count,
+                    "failed_count": cs.failed_count,
+                    "time_median_s": cs.time_median_s,
+                    "time_mean_s": cs.time_mean_s,
+                    "time_variance_s2": cs.time_variance_s2,
+                    "rss_median_mib": cs.rss_median_mib,
+                    "rss_mean_mib": cs.rss_mean_mib,
+                    "rss_variance_mib2": cs.rss_variance_mib2,
+                }
+            )
+
+        return {
+            "schema_version": "1",
+            "generated_at": generated_at,
+            "solc_version": solc_version,
+            "cases": cases,
+        }
+
+    # ------------------------------------------------------------------
+    # Task 6.3 — format_table
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def format_table(stats: List[CaseStats]) -> str:
+        """Render a plain-text console table.
+
+        Columns (fixed-width):
+          case_id | pipeline | debug_info_mode | median_time_s | median_rss_mib | samples
+        """
+        # Column headers
+        headers = [
+            "case_id",
+            "pipeline",
+            "debug_info_mode",
+            "median_time_s",
+            "median_rss_mib",
+            "samples",
+        ]
+
+        # Build rows as strings first so we can compute column widths.
+        rows = []
+        for cs in stats:
+            rows.append(
+                [
+                    cs.case_id,
+                    cs.pipeline,
+                    cs.debug_info_mode,
+                    f"{cs.time_median_s:.2f}",
+                    str(int(cs.rss_median_mib)),
+                    str(cs.repeat_count),
+                ]
+            )
+
+        # Compute column widths (max of header and all row values).
+        col_widths = [len(h) for h in headers]
+        for row in rows:
+            for i, cell in enumerate(row):
+                col_widths[i] = max(col_widths[i], len(cell))
+
+        def fmt_row(cells: List[str]) -> str:
+            return "  ".join(cell.ljust(col_widths[i]) for i, cell in enumerate(cells))
+
+        separator = "  ".join("-" * w for w in col_widths)
+
+        lines = [fmt_row(headers), separator]
+        for row in rows:
+            lines.append(fmt_row(row))
+
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Task 6.4 — compare
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def compare(baseline: dict, current: dict) -> str:
+        """Produce a Markdown-formatted regression comparison.
+
+        For each case in *current*:
+          - Compute relative % diff vs baseline for median time and RSS.
+          - Mark cases absent from baseline as ``!B``.
+          - Highlight (⚠) cases where debug_info_mode=="off" and either
+            relative time or RSS diff exceeds 5%.
+
+        Also includes a "Debug Info Overhead" section showing
+        (debug_on - debug_off) / debug_off * 100% for each case in the
+        current run.
+
+        Returns a Markdown string.
+        """
+        # Index baseline cases by case_id.
+        baseline_by_id: Dict[str, dict] = {
+            c["case_id"]: c for c in baseline.get("cases", [])
+        }
+        current_cases: List[dict] = current.get("cases", [])
+
+        # ---- Regression comparison table --------------------------------
+        comp_header = (
+            "| case_id | pipeline | debug_info_mode "
+            "| Δ time % | Δ RSS % | note |"
+        )
+        comp_sep = "|---|---|---|---|---|---|"
+        comp_rows = []
+
+        for cc in current_cases:
+            cid = cc["case_id"]
+            pipeline = cc.get("pipeline", "")
+            dim = cc.get("debug_info_mode", "")
+            bc = baseline_by_id.get(cid)
+
+            if bc is None:
+                comp_rows.append(
+                    f"| {cid} | {pipeline} | {dim} | !B | !B | no baseline |"
+                )
+                continue
+
+            # Relative % differences.
+            def rel_pct(base_val: float, curr_val: float) -> str:
+                if base_val == 0:
+                    return "N/A"
+                pct = (curr_val - base_val) / base_val * 100.0
+                sign = "+" if pct >= 0 else ""
+                return f"{sign}{pct:.1f}%"
+
+            t_pct_str = rel_pct(bc["time_median_s"], cc["time_median_s"])
+            r_pct_str = rel_pct(bc["rss_median_mib"], cc["rss_median_mib"])
+
+            # Determine if we should highlight (⚠).
+            warn = ""
+            if dim == "off":
+                try:
+                    t_pct_val = (
+                        (cc["time_median_s"] - bc["time_median_s"])
+                        / bc["time_median_s"]
+                        * 100.0
+                    )
+                    r_pct_val = (
+                        (cc["rss_median_mib"] - bc["rss_median_mib"])
+                        / bc["rss_median_mib"]
+                        * 100.0
+                    )
+                    if abs(t_pct_val) > 5.0 or abs(r_pct_val) > 5.0:
+                        warn = "⚠"
+                except ZeroDivisionError:
+                    pass
+
+            comp_rows.append(
+                f"| {cid} | {pipeline} | {dim} "
+                f"| {t_pct_str} | {r_pct_str} | {warn} |"
+            )
+
+        # ---- Debug Info Overhead section --------------------------------
+        # Group current cases by (source_prefix, pipeline) to pair off/on.
+        # The case_id convention is "{source}-{pipeline}-{debug_info_mode}".
+        # We strip the last token to get the "base" key.
+        def _base_key(case_id: str) -> str:
+            """Return case_id without the trailing '-on' or '-off'."""
+            parts = case_id.rsplit("-", 1)
+            return parts[0] if len(parts) == 2 and parts[1] in ("on", "off") else case_id
+
+        current_by_id: Dict[str, dict] = {c["case_id"]: c for c in current_cases}
+
+        # Build a map: base_key -> {"off": case_dict, "on": case_dict}
+        overhead_map: Dict[str, Dict[str, dict]] = defaultdict(dict)
+        for cc in current_cases:
+            dim = cc.get("debug_info_mode", "")
+            if dim in ("on", "off"):
+                overhead_map[_base_key(cc["case_id"])][dim] = cc
+
+        overhead_header = (
+            "| base_case | pipeline "
+            "| time overhead % | RSS overhead % |"
+        )
+        overhead_sep = "|---|---|---|---|"
+        overhead_rows = []
+
+        for base_key in sorted(overhead_map.keys()):
+            pair = overhead_map[base_key]
+            off_case = pair.get("off")
+            on_case = pair.get("on")
+            if off_case is None or on_case is None:
+                continue
+
+            pipeline = off_case.get("pipeline", "")
+
+            def overhead_pct(off_val: float, on_val: float) -> str:
+                if off_val == 0:
+                    return "N/A"
+                pct = (on_val - off_val) / off_val * 100.0
+                sign = "+" if pct >= 0 else ""
+                return f"{sign}{pct:.1f}%"
+
+            t_oh = overhead_pct(off_case["time_median_s"], on_case["time_median_s"])
+            r_oh = overhead_pct(off_case["rss_median_mib"], on_case["rss_median_mib"])
+            overhead_rows.append(
+                f"| {base_key} | {pipeline} | {t_oh} | {r_oh} |"
+            )
+
+        # ---- Assemble Markdown output -----------------------------------
+        current_ver = current.get("solc_version", "unknown")
+        baseline_ver = baseline.get("solc_version", "unknown")
+
+        lines = [
+            "## Benchmark Regression Report",
+            "",
+            f"**Baseline:** `{baseline_ver}`  ",
+            f"**Current:** `{current_ver}`",
+            "",
+            "### Regression Comparison",
+            "",
+            comp_header,
+            comp_sep,
+        ]
+        lines.extend(comp_rows)
+
+        lines += [
+            "",
+            "### Debug Info Overhead",
+            "",
+            "_Overhead of enabling `debug_info_mode=on` relative to `off` in the current run._",
+            "",
+            overhead_header,
+            overhead_sep,
+        ]
+        lines.extend(overhead_rows)
+
+        return "\n".join(lines)
+
+
+# ------------------------------------------------------------------
+# Task 6.5 — standalone CLI
+# ------------------------------------------------------------------
+
+def _main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compare two solc benchmark JSON reports and print a Markdown diff."
+    )
+    parser.add_argument("baseline_json", help="Path to the baseline JSON report file.")
+    parser.add_argument("current_json", help="Path to the current JSON report file.")
+    args = parser.parse_args()
+
+    with open(args.baseline_json, encoding="utf-8") as fh:
+        baseline = json.load(fh)
+    with open(args.current_json, encoding="utf-8") as fh:
+        current = json.load(fh)
+
+    print(Reporter.compare(baseline, current))
+
+
+if __name__ == "__main__":
+    _main()

--- a/test/benchmarks/run.py
+++ b/test/benchmarks/run.py
@@ -1,0 +1,235 @@
+"""
+Entry point for the solc benchmarking infrastructure.
+
+Usage:
+    python run.py [--suite {synthetic,real-world,all}]
+                  [--solc PATH]
+                  [--repeats N]
+                  [--output PATH]
+                  [--baseline PATH]
+
+All code uses Python stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+# run.py lives at test/benchmarks/run.py; repo root is 2 levels up.
+_HERE = Path(__file__).resolve().parent          # test/benchmarks/
+_REPO_ROOT = _HERE.parent.parent                 # <repo-root>/
+
+# Allow importing sibling modules when run directly.
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from models import Sample  # noqa: E402
+from runner import BenchmarkRunner, build_synthetic_cases, build_real_world_cases  # noqa: E402
+from reporter import Reporter  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Task 8.1 — CLI argument parsing
+# ---------------------------------------------------------------------------
+
+def _default_solc_path() -> Path:
+    """Return the default solc binary path.
+
+    Resolves ``${SOLIDITY_BUILD_DIR}/solc/solc``, where ``SOLIDITY_BUILD_DIR``
+    defaults to ``<repo-root>/build``.
+    """
+    build_dir = os.environ.get("SOLIDITY_BUILD_DIR", str(_REPO_ROOT / "build"))
+    return Path(build_dir) / "solc" / "solc"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Construct and return the argument parser for run.py."""
+    parser = argparse.ArgumentParser(
+        prog="run.py",
+        description="Run solc benchmarks and report results.",
+    )
+    parser.add_argument(
+        "--suite",
+        choices=["synthetic", "real-world", "all"],
+        default="all",
+        help="Which benchmark suite to run (default: all).",
+    )
+    parser.add_argument(
+        "--solc",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Path to the solc binary. "
+            "Defaults to ${SOLIDITY_BUILD_DIR}/solc/solc "
+            "(SOLIDITY_BUILD_DIR defaults to <repo-root>/build)."
+        ),
+    )
+    parser.add_argument(
+        "--repeats",
+        metavar="N",
+        type=int,
+        default=3,
+        help="Number of times each benchmark case is compiled (default: 3).",
+    )
+    parser.add_argument(
+        "--output",
+        metavar="PATH",
+        default=None,
+        help="Path for the JSON report file. If omitted, the report is written to stdout.",
+    )
+    parser.add_argument(
+        "--baseline",
+        metavar="PATH",
+        default=None,
+        help="Path to a baseline JSON report for regression comparison.",
+    )
+    return parser
+
+
+def _validate_args(args: argparse.Namespace) -> Path:
+    """Validate parsed arguments and return the resolved solc Path.
+
+    Prints a descriptive error to stderr and calls sys.exit(1) if the solc
+    binary is not executable.
+
+    Args:
+        args: Parsed namespace from argparse.
+
+    Returns:
+        Resolved Path to the solc binary.
+    """
+    solc_path = Path(args.solc) if args.solc is not None else _default_solc_path()
+
+    if not os.access(solc_path, os.X_OK):
+        print(
+            f"error: solc binary '{solc_path}' is not executable or does not exist.\n"
+            f"  Specify a valid path with --solc, or set the SOLIDITY_BUILD_DIR "
+            f"environment variable.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return solc_path
+
+
+# ---------------------------------------------------------------------------
+# Task 8.2 — Wire runner and reporter together
+# ---------------------------------------------------------------------------
+
+def _get_solc_version(solc_path: Path) -> str:
+    """Run ``solc --version`` and return the version string.
+
+    Parses the first line containing "Version:" and returns the text after
+    the colon.  Falls back to "unknown" on any error.
+
+    Args:
+        solc_path: Path to the solc binary.
+
+    Returns:
+        Version string, e.g. ``"0.8.30+commit.abc123"``.
+    """
+    try:
+        result = subprocess.run(
+            [str(solc_path), "--version"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        for line in result.stdout.splitlines():
+            if "Version:" in line:
+                # e.g. "Version: 0.8.30+commit.abc123"
+                return line.split("Version:", 1)[1].strip()
+    except Exception:
+        pass
+    return "unknown"
+
+
+def _build_cases(suite: str) -> list:
+    """Build the list of BenchmarkCase objects for the requested suite.
+
+    Paths are resolved relative to the repo root (2 levels up from run.py).
+
+    Args:
+        suite: One of ``"synthetic"``, ``"real-world"``, or ``"all"``.
+
+    Returns:
+        List of BenchmarkCase objects.
+    """
+    output_dir = _REPO_ROOT / "test" / "benchmarks" / "generated"
+    real_world_dir = _REPO_ROOT / "test" / "benchmarks" / "real-world"
+
+    if suite == "synthetic":
+        return build_synthetic_cases(output_dir=output_dir)
+    elif suite == "real-world":
+        return build_real_world_cases(real_world_dir=real_world_dir)
+    else:  # "all"
+        synthetic = build_synthetic_cases(output_dir=output_dir)
+        real_world = build_real_world_cases(real_world_dir=real_world_dir)
+        return synthetic + real_world
+
+
+def main() -> None:
+    """Parse arguments, run benchmarks, and report results.
+
+    Always exits with status code 0 (Requirement 8.1).  Individual case
+    failures are recorded in the report but do not abort the run.
+    """
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    try:
+        solc_path = _validate_args(args)
+
+        # Resolve solc version for the report header.
+        solc_version = _get_solc_version(solc_path)
+
+        # Build the case list.
+        cases = _build_cases(args.suite)
+
+        # Run the suite.
+        runner = BenchmarkRunner(solc_path=solc_path, repeats=args.repeats)
+        samples: list[Sample] = runner.run_suite(cases)
+
+        # Compute statistics and produce JSON report.
+        stats = Reporter.compute_stats(samples)
+        report = Reporter.to_json(stats, solc_version=solc_version)
+
+        # Write JSON report to file or stdout.
+        report_json = json.dumps(report, indent=2)
+        if args.output:
+            output_path = Path(args.output)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(report_json, encoding="utf-8")
+        else:
+            print(report_json)
+
+        # Always print the human-readable console table to stdout.
+        print(Reporter.format_table(stats))
+
+        # If a baseline was provided, print the regression comparison.
+        if args.baseline:
+            baseline_path = Path(args.baseline)
+            with open(baseline_path, encoding="utf-8") as fh:
+                baseline = json.load(fh)
+            print(Reporter.compare(baseline, report))
+
+    except SystemExit:
+        # Re-raise SystemExit from _validate_args (non-zero exit for bad solc).
+        raise
+    except Exception as exc:  # noqa: BLE001
+        print(f"error: {exc}", file=sys.stderr)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/benchmarks/runner.py
+++ b/test/benchmarks/runner.py
@@ -1,0 +1,316 @@
+"""
+Benchmark runner for the solc benchmarking infrastructure.
+
+Orchestrates benchmark execution: builds case lists, invokes solc, collects
+Sample objects, and returns them for downstream statistical reporting.
+
+All code uses Python stdlib only.
+
+Usage:
+    from pathlib import Path
+    from runner import BenchmarkRunner, build_synthetic_cases, build_real_world_cases
+
+    runner = BenchmarkRunner(solc_path=Path("/usr/bin/solc"), repeats=3)
+    cases = build_synthetic_cases(output_dir=Path("test/benchmarks/generated"))
+    samples = runner.run_suite(cases)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone, UTC
+from pathlib import Path
+from typing import List
+
+# Allow running from repo root or from test/benchmarks/ directly.
+_HERE = Path(__file__).parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from models import BenchmarkCase, Sample  # noqa: E402
+from contract_generator import StressCategory, generate  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Module-level logger (used as fallback; log() is the primary output function)
+# ---------------------------------------------------------------------------
+_logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Task 4.1 — RSS measurement and CI logging helpers
+# ---------------------------------------------------------------------------
+
+def _measure_peak_rss_mib() -> float:
+    """Return the peak RSS of the most recently waited-for child process in MiB.
+
+    Uses ``resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss``.
+
+    Platform normalisation:
+    - Linux:  ru_maxrss is in kilobytes  → divide by 1 024
+    - macOS:  ru_maxrss is in bytes      → divide by 1 048 576
+    - Other:  logs a warning and returns 0.0
+    """
+    try:
+        import resource  # not available on Windows
+    except ImportError:
+        log("WARNING: resource module not available on this platform; RSS will be 0.0")
+        return 0.0
+
+    usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    raw = usage.ru_maxrss
+
+    if sys.platform == "darwin":
+        # macOS returns bytes
+        return raw / (1024 * 1024)
+    elif sys.platform.startswith("linux"):
+        # Linux returns kilobytes
+        return raw / 1024
+    else:
+        log(f"WARNING: unsupported platform '{sys.platform}' for RSS measurement; returning 0.0")
+        return 0.0
+
+
+def log(msg: str) -> None:
+    """Print *msg* to stdout, always flushing.
+
+    When the ``CI`` environment variable is set to a non-empty value, each
+    line is prefixed with an ISO 8601 UTC timestamp (e.g.
+    ``2025-01-01T12:00:00.000000Z``).
+    """
+    if os.environ.get("CI"):
+        timestamp = datetime.now(UTC).isoformat(timespec="seconds") + "Z"
+        print(f"{timestamp} {msg}", flush=True)
+    else:
+        print(msg, flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Task 4.2 — BenchmarkRunner.run_case()
+# ---------------------------------------------------------------------------
+
+class BenchmarkRunner:
+    """Orchestrates benchmark execution against a solc binary.
+
+    Args:
+        solc_path: Path to the solc binary to benchmark.
+        repeats:   Number of times each BenchmarkCase is compiled.
+    """
+
+    def __init__(self, solc_path: Path, repeats: int) -> None:
+        self.solc_path = Path(solc_path)
+        self.repeats = repeats
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def run_case(self, case: BenchmarkCase) -> List[Sample]:
+        """Invoke solc *repeats* times for *case* and return the samples.
+
+        One warmup invocation is performed first (discarded) to prime the OS
+        page cache and CPU branch predictor before measurements begin.
+
+        Returns:
+            A list of exactly ``self.repeats`` Sample objects.
+        """
+        samples: List[Sample] = []
+
+        # Warmup run — result discarded
+        if case.use_standard_json:
+            cmd, stdin_data = self._build_standard_json_cmd(case)
+        else:
+            cmd, stdin_data = self._build_regular_cmd(case)
+        subprocess.run(cmd, input=stdin_data, capture_output=True)
+
+        for _ in range(self.repeats):
+            if case.use_standard_json:
+                cmd, stdin_data = self._build_standard_json_cmd(case)
+            else:
+                cmd, stdin_data = self._build_regular_cmd(case)
+
+            t_start = time.perf_counter()
+            result = subprocess.run(
+                cmd,
+                input=stdin_data,
+                capture_output=True,
+            )
+            t_end = time.perf_counter()
+
+            elapsed_s = t_end - t_start
+            peak_rss_mib = _measure_peak_rss_mib()
+            exit_code = result.returncode
+
+            if exit_code != 0:
+                log(
+                    f"WARNING: solc exited with code {exit_code} for case '{case.case_id}'; "
+                    "recording failure and continuing"
+                )
+
+            samples.append(
+                Sample(
+                    case_id=case.case_id,
+                    elapsed_s=elapsed_s,
+                    peak_rss_mib=peak_rss_mib,
+                    exit_code=exit_code,
+                )
+            )
+
+        return samples
+
+    # ------------------------------------------------------------------
+    # Task 4.3 — run_suite()
+    # ------------------------------------------------------------------
+
+    def run_suite(self, cases: List[BenchmarkCase]) -> List[Sample]:
+        """Run all *cases* and return the accumulated list of samples.
+
+        Args:
+            cases: Ordered list of BenchmarkCase objects to execute.
+
+        Returns:
+            All Sample objects collected across every case.
+        """
+        all_samples: List[Sample] = []
+        for case in cases:
+            log(f"Running case: {case.case_id}")
+            samples = self.run_case(case)
+            all_samples.extend(samples)
+        return all_samples
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _build_regular_cmd(self, case: BenchmarkCase):
+        """Build the command list for a non-standard-json case.
+
+        Returns:
+            (cmd: list[str], stdin_data: None)
+        """
+        cmd = [str(self.solc_path), str(case.source_path), "--bin"]
+
+        # --optimize is not compatible with ethdebug (experimental); omit it
+        # when debug info is on.
+        if case.debug_info_mode == "off":
+            cmd.append("--optimize")
+
+        if case.pipeline == "ir":
+            cmd.append("--via-ir")
+
+        if case.debug_info_mode == "on":
+            cmd.extend(["--debug-info", "ethdebug", "--experimental"])
+
+        return cmd, None
+
+    def _build_standard_json_cmd(self, case: BenchmarkCase):
+        """Build the command list for a standard-json case.
+
+        The source file content is read and passed via stdin.
+
+        Returns:
+            (cmd: list[str], stdin_data: bytes)
+        """
+        cmd = [str(self.solc_path), "--standard-json"]
+
+        if case.pipeline == "ir":
+            cmd.append("--via-ir")
+
+        if case.debug_info_mode == "on":
+            cmd.extend(["--debug-info", "ethdebug", "--experimental"])
+
+        stdin_data = case.source_path.read_bytes()
+        return cmd, stdin_data
+
+
+# ---------------------------------------------------------------------------
+# Task 4.3 — Case-list builders
+# ---------------------------------------------------------------------------
+
+def build_synthetic_cases(output_dir: Path) -> List[BenchmarkCase]:
+    """Generate synthetic .sol files and return the full list of BenchmarkCases.
+
+    Produces all combinations of:
+    - 5 StressCategory values
+    - 2 pipelines: "legacy", "ir"
+    - 2 debug modes: "off", "on"
+
+    Total: 5 × 2 × 2 = 20 cases.
+
+    Args:
+        output_dir: Directory where generated .sol files are written.
+
+    Returns:
+        List of 20 BenchmarkCase objects.
+    """
+    output_dir = Path(output_dir)
+    cases: List[BenchmarkCase] = []
+
+    pipelines = ["legacy", "ir"]
+    debug_modes = ["off", "on"]
+
+    for category in StressCategory:
+        source_path = generate(category, output_dir=output_dir)
+        for pipeline in pipelines:
+            for debug_mode in debug_modes:
+                case_id = f"{category.value}-{pipeline}-{debug_mode}"
+                cases.append(
+                    BenchmarkCase(
+                        case_id=case_id,
+                        source_path=source_path,
+                        pipeline=pipeline,
+                        debug_info_mode=debug_mode,
+                        use_standard_json=False,
+                    )
+                )
+
+    return cases
+
+
+def build_real_world_cases(real_world_dir: Path) -> List[BenchmarkCase]:
+    """Scan *real_world_dir* for *.json files and return BenchmarkCases.
+
+    Each JSON file becomes one BenchmarkCase with ``use_standard_json=True``.
+    If the directory does not exist or contains no JSON files, a warning is
+    logged and an empty list is returned.
+
+    Args:
+        real_world_dir: Directory containing standard-JSON input files.
+
+    Returns:
+        List of BenchmarkCase objects (may be empty).
+    """
+    real_world_dir = Path(real_world_dir)
+
+    if not real_world_dir.exists():
+        log(f"WARNING: real-world directory '{real_world_dir}' does not exist; skipping")
+        return []
+
+    json_files = sorted(real_world_dir.glob("*.json"))
+
+    if not json_files:
+        log(f"WARNING: no *.json files found in '{real_world_dir}'; skipping real-world suite")
+        return []
+
+    cases: List[BenchmarkCase] = []
+    pipelines = ["legacy", "ir"]
+    debug_modes = ["off", "on"]
+
+    for json_file in json_files:
+        stem = json_file.stem  # e.g. "openzeppelin-5.0.2"
+        for pipeline in pipelines:
+            for debug_mode in debug_modes:
+                case_id = f"{stem}-{pipeline}-{debug_mode}"
+                cases.append(
+                    BenchmarkCase(
+                        case_id=case_id,
+                        source_path=json_file,
+                        pipeline=pipeline,
+                        debug_info_mode=debug_mode,
+                        use_standard_json=True,
+                    )
+                )
+
+    return cases

--- a/test/benchmarks/test_contract_generator.py
+++ b/test/benchmarks/test_contract_generator.py
@@ -1,0 +1,305 @@
+"""
+Unit tests for contract_generator.py.
+
+Covers:
+- Each category generates a file at default size
+- SPDX and pragma present in all generated files
+- Output directory is created if absent
+- Line count at size 20 >= 1.5x line count at size 10 for each category
+- Structural keywords present per category
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from contract_generator import StressCategory, generate  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _line_count(text: str) -> int:
+    """Return the number of non-empty lines in *text*."""
+    return sum(1 for line in text.splitlines() if line.strip())
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGenerateDispatcher(unittest.TestCase):
+    """Tests for the generate() dispatcher and file I/O."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.out = Path(self._tmpdir.name)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_returns_path_object(self):
+        path = generate(StressCategory.WIDE_CONTRACT, size=10, output_dir=self.out)
+        self.assertIsInstance(path, Path)
+
+    def test_file_exists_after_generate(self):
+        path = generate(StressCategory.WIDE_CONTRACT, size=10, output_dir=self.out)
+        self.assertTrue(path.exists(), f"Expected file at {path}")
+
+    def test_filename_matches_category_value(self):
+        for cat in StressCategory:
+            with self.subTest(category=cat):
+                path = generate(cat, size=10, output_dir=self.out)
+                self.assertEqual(path.name, f"{cat.value}.sol")
+
+    def test_creates_output_dir_if_absent(self):
+        nested = self.out / "a" / "b" / "c"
+        self.assertFalse(nested.exists())
+        generate(StressCategory.WIDE_CONTRACT, size=5, output_dir=nested)
+        self.assertTrue(nested.exists())
+
+    def test_creates_output_dir_if_absent_deep_nesting(self):
+        nested = self.out / "new_dir"
+        generate(StressCategory.DEEP_NESTING, size=5, output_dir=nested)
+        self.assertTrue(nested.exists())
+
+    def test_invalid_size_raises(self):
+        with self.assertRaises((ValueError, Exception)):
+            generate(StressCategory.WIDE_CONTRACT, size=0, output_dir=self.out)
+
+
+class TestSpdxAndPragma(unittest.TestCase):
+    """Every generated file must contain SPDX identifier and pragma solidity."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.out = Path(self._tmpdir.name)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def test_spdx_present_all_categories(self):
+        for cat in StressCategory:
+            with self.subTest(category=cat):
+                path = generate(cat, size=10, output_dir=self.out)
+                source = path.read_text(encoding="utf-8")
+                self.assertIn("// SPDX-License-Identifier:", source,
+                              f"SPDX missing in {cat.value}")
+
+    def test_pragma_present_all_categories(self):
+        for cat in StressCategory:
+            with self.subTest(category=cat):
+                path = generate(cat, size=10, output_dir=self.out)
+                source = path.read_text(encoding="utf-8")
+                self.assertIn("pragma solidity", source,
+                              f"pragma solidity missing in {cat.value}")
+
+    def test_spdx_gpl_30(self):
+        """Spec requires GPL-3.0 specifically."""
+        for cat in StressCategory:
+            with self.subTest(category=cat):
+                path = generate(cat, size=10, output_dir=self.out)
+                source = path.read_text(encoding="utf-8")
+                self.assertIn("GPL-3.0", source)
+
+    def test_pragma_version_080(self):
+        for cat in StressCategory:
+            with self.subTest(category=cat):
+                path = generate(cat, size=10, output_dir=self.out)
+                source = path.read_text(encoding="utf-8")
+                self.assertIn("^0.8.0", source)
+
+
+class TestEachCategoryDefaultSize(unittest.TestCase):
+    """Each category generates a non-empty file at default size (10)."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.out = Path(self._tmpdir.name)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def _generate_source(self, cat: StressCategory, size: int = 10) -> str:
+        path = generate(cat, size=size, output_dir=self.out)
+        return path.read_text(encoding="utf-8")
+
+    def test_deep_nesting_generates_file(self):
+        source = self._generate_source(StressCategory.DEEP_NESTING)
+        self.assertGreater(len(source), 0)
+
+    def test_wide_contract_generates_file(self):
+        source = self._generate_source(StressCategory.WIDE_CONTRACT)
+        self.assertGreater(len(source), 0)
+
+    def test_heavy_abi_generates_file(self):
+        source = self._generate_source(StressCategory.HEAVY_ABI)
+        self.assertGreater(len(source), 0)
+
+    def test_complex_control_flow_generates_file(self):
+        source = self._generate_source(StressCategory.COMPLEX_CONTROL_FLOW)
+        self.assertGreater(len(source), 0)
+
+    def test_heavy_storage_generates_file(self):
+        source = self._generate_source(StressCategory.HEAVY_STORAGE)
+        self.assertGreater(len(source), 0)
+
+
+class TestLineCountScaling(unittest.TestCase):
+    """Line count at size 20 must be >= 1.5x line count at size 10 (Req 5.6)."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.out = Path(self._tmpdir.name)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def _line_count_for(self, cat: StressCategory, size: int) -> int:
+        path = generate(cat, size=size, output_dir=self.out)
+        return _line_count(path.read_text(encoding="utf-8"))
+
+    def test_deep_nesting_scales(self):
+        lc10 = self._line_count_for(StressCategory.DEEP_NESTING, 10)
+        lc20 = self._line_count_for(StressCategory.DEEP_NESTING, 20)
+        self.assertGreaterEqual(lc20, 1.5 * lc10,
+            f"deep-nesting: size-20 lines={lc20}, size-10 lines={lc10}, ratio={lc20/lc10:.2f}")
+
+    def test_wide_contract_scales(self):
+        lc10 = self._line_count_for(StressCategory.WIDE_CONTRACT, 10)
+        lc20 = self._line_count_for(StressCategory.WIDE_CONTRACT, 20)
+        self.assertGreaterEqual(lc20, 1.5 * lc10,
+            f"wide-contract: size-20 lines={lc20}, size-10 lines={lc10}, ratio={lc20/lc10:.2f}")
+
+    def test_heavy_abi_scales(self):
+        lc10 = self._line_count_for(StressCategory.HEAVY_ABI, 10)
+        lc20 = self._line_count_for(StressCategory.HEAVY_ABI, 20)
+        self.assertGreaterEqual(lc20, 1.5 * lc10,
+            f"heavy-abi: size-20 lines={lc20}, size-10 lines={lc10}, ratio={lc20/lc10:.2f}")
+
+    def test_complex_control_flow_scales(self):
+        lc10 = self._line_count_for(StressCategory.COMPLEX_CONTROL_FLOW, 10)
+        lc20 = self._line_count_for(StressCategory.COMPLEX_CONTROL_FLOW, 20)
+        self.assertGreaterEqual(lc20, 1.5 * lc10,
+            f"complex-control-flow: size-20 lines={lc20}, size-10 lines={lc10}, ratio={lc20/lc10:.2f}")
+
+    def test_heavy_storage_scales(self):
+        lc10 = self._line_count_for(StressCategory.HEAVY_STORAGE, 10)
+        lc20 = self._line_count_for(StressCategory.HEAVY_STORAGE, 20)
+        self.assertGreaterEqual(lc20, 1.5 * lc10,
+            f"heavy-storage: size-20 lines={lc20}, size-10 lines={lc10}, ratio={lc20/lc10:.2f}")
+
+
+class TestStructuralKeywords(unittest.TestCase):
+    """Each category must contain category-appropriate structural keywords."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.out = Path(self._tmpdir.name)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def _source(self, cat: StressCategory, size: int = 10) -> str:
+        return generate(cat, size=size, output_dir=self.out).read_text(encoding="utf-8")
+
+    def test_deep_nesting_contains_struct(self):
+        source = self._source(StressCategory.DEEP_NESTING)
+        self.assertIn("struct", source)
+
+    def test_deep_nesting_contains_nested_struct(self):
+        """Should have at least two struct definitions (S1, S2, …)."""
+        source = self._source(StressCategory.DEEP_NESTING)
+        self.assertGreaterEqual(source.count("struct S"), 2)
+
+    def test_deep_nesting_contains_mapping(self):
+        source = self._source(StressCategory.DEEP_NESTING)
+        self.assertIn("mapping", source)
+
+    def test_wide_contract_contains_state_variables(self):
+        source = self._source(StressCategory.WIDE_CONTRACT)
+        # Should have multiple uint256 public var declarations
+        self.assertGreaterEqual(source.count("uint256 public var"), 10)
+
+    def test_wide_contract_contains_public_functions(self):
+        source = self._source(StressCategory.WIDE_CONTRACT)
+        self.assertGreaterEqual(source.count("function"), 10)
+
+    def test_heavy_abi_contains_struct(self):
+        source = self._source(StressCategory.HEAVY_ABI)
+        self.assertIn("struct", source)
+
+    def test_heavy_abi_contains_array_params(self):
+        source = self._source(StressCategory.HEAVY_ABI)
+        self.assertIn("[]", source)
+
+    def test_heavy_abi_contains_calldata(self):
+        source = self._source(StressCategory.HEAVY_ABI)
+        self.assertIn("calldata", source)
+
+    def test_complex_control_flow_contains_if(self):
+        source = self._source(StressCategory.COMPLEX_CONTROL_FLOW)
+        self.assertIn("if", source)
+
+    def test_complex_control_flow_contains_for(self):
+        source = self._source(StressCategory.COMPLEX_CONTROL_FLOW)
+        self.assertIn("for", source)
+
+    def test_complex_control_flow_contains_internal_calls(self):
+        source = self._source(StressCategory.COMPLEX_CONTROL_FLOW)
+        # Internal helper functions should be called
+        self.assertIn("_helper", source)
+
+    def test_heavy_storage_contains_mapping(self):
+        source = self._source(StressCategory.HEAVY_STORAGE)
+        self.assertIn("mapping", source)
+
+    def test_heavy_storage_contains_mapping_of_mapping(self):
+        """Should have nested mappings (mapping inside mapping)."""
+        source = self._source(StressCategory.HEAVY_STORAGE)
+        # A mapping-of-mapping has "mapping" appearing inside another mapping's value type
+        self.assertGreaterEqual(source.count("mapping("), 2)
+
+    def test_heavy_storage_contains_dynamic_array_of_struct(self):
+        source = self._source(StressCategory.HEAVY_STORAGE)
+        # Dynamic array of struct: Record1[] public records1
+        self.assertIn("Record", source)
+        self.assertIn("[]", source)
+
+    def test_heavy_storage_contains_struct(self):
+        source = self._source(StressCategory.HEAVY_STORAGE)
+        self.assertIn("struct", source)
+
+
+class TestStressCategoryEnum(unittest.TestCase):
+    """Tests for the StressCategory enum itself."""
+
+    def test_all_five_values_present(self):
+        values = {cat.value for cat in StressCategory}
+        expected = {
+            "deep-nesting",
+            "wide-contract",
+            "heavy-abi",
+            "complex-control-flow",
+            "heavy-storage",
+        }
+        self.assertEqual(values, expected)
+
+    def test_enum_members_by_name(self):
+        self.assertEqual(StressCategory.DEEP_NESTING.value, "deep-nesting")
+        self.assertEqual(StressCategory.WIDE_CONTRACT.value, "wide-contract")
+        self.assertEqual(StressCategory.HEAVY_ABI.value, "heavy-abi")
+        self.assertEqual(StressCategory.COMPLEX_CONTROL_FLOW.value, "complex-control-flow")
+        self.assertEqual(StressCategory.HEAVY_STORAGE.value, "heavy-storage")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/benchmarks/test_models.py
+++ b/test/benchmarks/test_models.py
@@ -1,0 +1,197 @@
+"""Unit tests for the shared data model dataclasses in models.py."""
+
+import sys
+import unittest
+from pathlib import Path
+
+# Allow running from repo root or from test/benchmarks/ directly.
+_HERE = Path(__file__).parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from models import BenchmarkCase, CaseStats, Sample  # noqa: E402
+
+
+class TestBenchmarkCase(unittest.TestCase):
+    """Tests for BenchmarkCase dataclass."""
+
+    def test_instantiation_required_fields(self):
+        case = BenchmarkCase(
+            case_id="deep-nesting-legacy-off",
+            source_path=Path("test/benchmarks/generated/deep_nesting.sol"),
+            pipeline="legacy",
+            debug_info_mode="off",
+        )
+        self.assertEqual(case.case_id, "deep-nesting-legacy-off")
+        self.assertEqual(case.source_path, Path("test/benchmarks/generated/deep_nesting.sol"))
+        self.assertEqual(case.pipeline, "legacy")
+        self.assertEqual(case.debug_info_mode, "off")
+        self.assertFalse(case.use_standard_json)
+
+    def test_use_standard_json_default_is_false(self):
+        case = BenchmarkCase(
+            case_id="x",
+            source_path=Path("x.sol"),
+            pipeline="legacy",
+            debug_info_mode="off",
+        )
+        self.assertFalse(case.use_standard_json)
+
+    def test_use_standard_json_can_be_set_true(self):
+        case = BenchmarkCase(
+            case_id="rw-legacy-off",
+            source_path=Path("real-world/input.json"),
+            pipeline="legacy",
+            debug_info_mode="off",
+            use_standard_json=True,
+        )
+        self.assertTrue(case.use_standard_json)
+
+    def test_ir_pipeline(self):
+        case = BenchmarkCase(
+            case_id="wide-contract-ir-on",
+            source_path=Path("wide.sol"),
+            pipeline="ir",
+            debug_info_mode="on",
+        )
+        self.assertEqual(case.pipeline, "ir")
+        self.assertEqual(case.debug_info_mode, "on")
+
+    def test_source_path_is_path_object(self):
+        case = BenchmarkCase(
+            case_id="c",
+            source_path=Path("/abs/path/contract.sol"),
+            pipeline="legacy",
+            debug_info_mode="off",
+        )
+        self.assertIsInstance(case.source_path, Path)
+
+    def test_equality(self):
+        a = BenchmarkCase("id", Path("a.sol"), "legacy", "off")
+        b = BenchmarkCase("id", Path("a.sol"), "legacy", "off")
+        self.assertEqual(a, b)
+
+    def test_inequality_different_case_id(self):
+        a = BenchmarkCase("id-a", Path("a.sol"), "legacy", "off")
+        b = BenchmarkCase("id-b", Path("a.sol"), "legacy", "off")
+        self.assertNotEqual(a, b)
+
+
+class TestSample(unittest.TestCase):
+    """Tests for Sample dataclass."""
+
+    def test_instantiation(self):
+        s = Sample(
+            case_id="deep-nesting-legacy-off",
+            elapsed_s=1.234,
+            peak_rss_mib=42.5,
+            exit_code=0,
+        )
+        self.assertEqual(s.case_id, "deep-nesting-legacy-off")
+        self.assertAlmostEqual(s.elapsed_s, 1.234)
+        self.assertAlmostEqual(s.peak_rss_mib, 42.5)
+        self.assertEqual(s.exit_code, 0)
+
+    def test_non_zero_exit_code(self):
+        s = Sample(case_id="failing-case", elapsed_s=0.1, peak_rss_mib=10.0, exit_code=1)
+        self.assertEqual(s.exit_code, 1)
+
+    def test_zero_elapsed_time_allowed(self):
+        s = Sample(case_id="c", elapsed_s=0.0, peak_rss_mib=1.0, exit_code=0)
+        self.assertEqual(s.elapsed_s, 0.0)
+
+    def test_equality(self):
+        a = Sample("c", 1.0, 2.0, 0)
+        b = Sample("c", 1.0, 2.0, 0)
+        self.assertEqual(a, b)
+
+    def test_inequality_different_elapsed(self):
+        a = Sample("c", 1.0, 2.0, 0)
+        b = Sample("c", 2.0, 2.0, 0)
+        self.assertNotEqual(a, b)
+
+    def test_fields_are_correct_types(self):
+        s = Sample(case_id="c", elapsed_s=0.5, peak_rss_mib=100.0, exit_code=0)
+        self.assertIsInstance(s.case_id, str)
+        self.assertIsInstance(s.elapsed_s, float)
+        self.assertIsInstance(s.peak_rss_mib, float)
+        self.assertIsInstance(s.exit_code, int)
+
+
+class TestCaseStats(unittest.TestCase):
+    """Tests for CaseStats dataclass."""
+
+    def _make_stats(self, **overrides):
+        defaults = dict(
+            case_id="deep-nesting-legacy-off",
+            pipeline="legacy",
+            debug_info_mode="off",
+            repeat_count=3,
+            time_median_s=1.2,
+            time_mean_s=1.25,
+            time_variance_s2=0.01,
+            rss_median_mib=42.0,
+            rss_mean_mib=43.0,
+            rss_variance_mib2=0.5,
+            failed_count=0,
+        )
+        defaults.update(overrides)
+        return CaseStats(**defaults)
+
+    def test_instantiation_all_fields(self):
+        stats = self._make_stats()
+        self.assertEqual(stats.case_id, "deep-nesting-legacy-off")
+        self.assertEqual(stats.pipeline, "legacy")
+        self.assertEqual(stats.debug_info_mode, "off")
+        self.assertEqual(stats.repeat_count, 3)
+        self.assertAlmostEqual(stats.time_median_s, 1.2)
+        self.assertAlmostEqual(stats.time_mean_s, 1.25)
+        self.assertAlmostEqual(stats.time_variance_s2, 0.01)
+        self.assertAlmostEqual(stats.rss_median_mib, 42.0)
+        self.assertAlmostEqual(stats.rss_mean_mib, 43.0)
+        self.assertAlmostEqual(stats.rss_variance_mib2, 0.5)
+        self.assertEqual(stats.failed_count, 0)
+
+    def test_failed_count_nonzero(self):
+        stats = self._make_stats(failed_count=2)
+        self.assertEqual(stats.failed_count, 2)
+
+    def test_ir_pipeline_debug_on(self):
+        stats = self._make_stats(
+            case_id="wide-contract-ir-on",
+            pipeline="ir",
+            debug_info_mode="on",
+        )
+        self.assertEqual(stats.pipeline, "ir")
+        self.assertEqual(stats.debug_info_mode, "on")
+
+    def test_equality(self):
+        a = self._make_stats()
+        b = self._make_stats()
+        self.assertEqual(a, b)
+
+    def test_inequality_different_pipeline(self):
+        a = self._make_stats(pipeline="legacy")
+        b = self._make_stats(pipeline="ir")
+        self.assertNotEqual(a, b)
+
+    def test_all_field_names_present(self):
+        stats = self._make_stats()
+        expected_fields = {
+            "case_id", "pipeline", "debug_info_mode", "repeat_count",
+            "time_median_s", "time_mean_s", "time_variance_s2",
+            "rss_median_mib", "rss_mean_mib", "rss_variance_mib2",
+            "failed_count",
+        }
+        actual_fields = set(stats.__dataclass_fields__.keys())
+        self.assertEqual(actual_fields, expected_fields)
+
+    def test_variance_zero_for_single_sample(self):
+        # Represents a run with a single repeat where variance is 0.0
+        stats = self._make_stats(repeat_count=1, time_variance_s2=0.0, rss_variance_mib2=0.0)
+        self.assertEqual(stats.time_variance_s2, 0.0)
+        self.assertEqual(stats.rss_variance_mib2, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/benchmarks/test_reporter.py
+++ b/test/benchmarks/test_reporter.py
@@ -1,0 +1,589 @@
+"""
+Unit tests for reporter.py — covering Reporter.compute_stats(), to_json(),
+format_table(), compare(), and the standalone CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Ensure the benchmarks package is importable when running from repo root.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from models import CaseStats, Sample
+from reporter import Reporter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_sample(case_id: str, elapsed_s: float, peak_rss_mib: float, exit_code: int = 0) -> Sample:
+    return Sample(case_id=case_id, elapsed_s=elapsed_s, peak_rss_mib=peak_rss_mib, exit_code=exit_code)
+
+
+def _make_case_stats(
+    case_id: str = "foo-legacy-off",
+    pipeline: str = "legacy",
+    debug_info_mode: str = "off",
+    repeat_count: int = 3,
+    time_median_s: float = 1.0,
+    time_mean_s: float = 1.0,
+    time_variance_s2: float = 0.0,
+    rss_median_mib: float = 100.0,
+    rss_mean_mib: float = 100.0,
+    rss_variance_mib2: float = 0.0,
+    failed_count: int = 0,
+) -> CaseStats:
+    return CaseStats(
+        case_id=case_id,
+        pipeline=pipeline,
+        debug_info_mode=debug_info_mode,
+        repeat_count=repeat_count,
+        time_median_s=time_median_s,
+        time_mean_s=time_mean_s,
+        time_variance_s2=time_variance_s2,
+        rss_median_mib=rss_median_mib,
+        rss_mean_mib=rss_mean_mib,
+        rss_variance_mib2=rss_variance_mib2,
+        failed_count=failed_count,
+    )
+
+
+# ---------------------------------------------------------------------------
+# compute_stats — grouping
+# ---------------------------------------------------------------------------
+
+class TestComputeStatsGrouping:
+    def test_groups_samples_by_case_id(self):
+        samples = [
+            _make_sample("a-legacy-off", 1.0, 10.0),
+            _make_sample("a-legacy-off", 2.0, 20.0),
+            _make_sample("b-ir-on", 3.0, 30.0),
+        ]
+        result = Reporter.compute_stats(samples)
+        ids = [cs.case_id for cs in result]
+        assert "a-legacy-off" in ids
+        assert "b-ir-on" in ids
+        assert len(result) == 2
+
+    def test_repeat_count_equals_group_size(self):
+        samples = [_make_sample("x-legacy-off", float(i), float(i)) for i in range(5)]
+        result = Reporter.compute_stats(samples)
+        assert len(result) == 1
+        assert result[0].repeat_count == 5
+
+    def test_empty_input_returns_empty_list(self):
+        assert Reporter.compute_stats([]) == []
+
+
+# ---------------------------------------------------------------------------
+# compute_stats — median / mean / variance
+# ---------------------------------------------------------------------------
+
+class TestComputeStatsValues:
+    def test_median_odd_count(self):
+        samples = [
+            _make_sample("c-legacy-off", 1.0, 10.0),
+            _make_sample("c-legacy-off", 3.0, 30.0),
+            _make_sample("c-legacy-off", 2.0, 20.0),
+        ]
+        cs = Reporter.compute_stats(samples)[0]
+        assert cs.time_median_s == pytest.approx(2.0)
+        assert cs.rss_median_mib == pytest.approx(20.0)
+
+    def test_mean_correct(self):
+        samples = [
+            _make_sample("d-legacy-off", 1.0, 10.0),
+            _make_sample("d-legacy-off", 3.0, 30.0),
+        ]
+        cs = Reporter.compute_stats(samples)[0]
+        assert cs.time_mean_s == pytest.approx(2.0)
+        assert cs.rss_mean_mib == pytest.approx(20.0)
+
+    def test_variance_two_samples(self):
+        # For [1, 3]: sample variance = ((1-2)^2 + (3-2)^2) / (2-1) = 2.0
+        samples = [
+            _make_sample("e-legacy-off", 1.0, 10.0),
+            _make_sample("e-legacy-off", 3.0, 30.0),
+        ]
+        cs = Reporter.compute_stats(samples)[0]
+        assert cs.time_variance_s2 == pytest.approx(2.0)
+        assert cs.rss_variance_mib2 == pytest.approx(200.0)
+
+    def test_variance_three_samples(self):
+        import statistics as _stats
+        times = [1.0, 2.0, 4.0]
+        rss = [10.0, 20.0, 40.0]
+        samples = [_make_sample("f-legacy-off", t, r) for t, r in zip(times, rss)]
+        cs = Reporter.compute_stats(samples)[0]
+        assert cs.time_variance_s2 == pytest.approx(_stats.variance(times))
+        assert cs.rss_variance_mib2 == pytest.approx(_stats.variance(rss))
+
+
+# ---------------------------------------------------------------------------
+# compute_stats — single sample (variance = 0.0)
+# ---------------------------------------------------------------------------
+
+class TestComputeStatsSingleSample:
+    def test_single_sample_variance_is_zero(self):
+        samples = [_make_sample("g-legacy-off", 5.0, 50.0)]
+        cs = Reporter.compute_stats(samples)[0]
+        assert cs.time_variance_s2 == 0.0
+        assert cs.rss_variance_mib2 == 0.0
+
+    def test_single_sample_median_equals_value(self):
+        samples = [_make_sample("h-ir-on", 7.5, 75.0)]
+        cs = Reporter.compute_stats(samples)[0]
+        assert cs.time_median_s == pytest.approx(7.5)
+        assert cs.rss_median_mib == pytest.approx(75.0)
+
+    def test_single_sample_mean_equals_value(self):
+        samples = [_make_sample("i-legacy-on", 3.3, 33.0)]
+        cs = Reporter.compute_stats(samples)[0]
+        assert cs.time_mean_s == pytest.approx(3.3)
+        assert cs.rss_mean_mib == pytest.approx(33.0)
+
+
+# ---------------------------------------------------------------------------
+# compute_stats — failed_count
+# ---------------------------------------------------------------------------
+
+class TestComputeStatsFailedCount:
+    def test_no_failures(self):
+        samples = [_make_sample("j-legacy-off", 1.0, 10.0, exit_code=0) for _ in range(3)]
+        cs = Reporter.compute_stats(samples)[0]
+        assert cs.failed_count == 0
+
+    def test_all_failures(self):
+        samples = [_make_sample("k-legacy-off", 1.0, 10.0, exit_code=1) for _ in range(3)]
+        cs = Reporter.compute_stats(samples)[0]
+        assert cs.failed_count == 3
+
+    def test_mixed_failures(self):
+        samples = [
+            _make_sample("l-legacy-off", 1.0, 10.0, exit_code=0),
+            _make_sample("l-legacy-off", 1.0, 10.0, exit_code=1),
+            _make_sample("l-legacy-off", 1.0, 10.0, exit_code=0),
+        ]
+        cs = Reporter.compute_stats(samples)[0]
+        assert cs.failed_count == 1
+
+    def test_non_one_exit_code_counts_as_failure(self):
+        samples = [
+            _make_sample("m-legacy-off", 1.0, 10.0, exit_code=0),
+            _make_sample("m-legacy-off", 1.0, 10.0, exit_code=2),
+        ]
+        cs = Reporter.compute_stats(samples)[0]
+        assert cs.failed_count == 1
+
+
+# ---------------------------------------------------------------------------
+# to_json — required fields
+# ---------------------------------------------------------------------------
+
+class TestToJson:
+    def _make_report(self, n: int = 2) -> dict:
+        stats = [
+            _make_case_stats(
+                case_id=f"case{i}-legacy-off",
+                pipeline="legacy",
+                debug_info_mode="off",
+                repeat_count=3,
+                time_median_s=float(i),
+                time_mean_s=float(i),
+                rss_median_mib=float(i * 10),
+                rss_mean_mib=float(i * 10),
+            )
+            for i in range(1, n + 1)
+        ]
+        return Reporter.to_json(stats)
+
+    def test_schema_version_is_one(self):
+        report = self._make_report()
+        assert report["schema_version"] == "1"
+
+    def test_generated_at_present(self):
+        report = self._make_report()
+        assert "generated_at" in report
+        # Should be a non-empty ISO 8601 string ending with Z.
+        assert report["generated_at"].endswith("Z")
+
+    def test_solc_version_default(self):
+        report = self._make_report()
+        assert report["solc_version"] == "unknown"
+
+    def test_solc_version_custom(self):
+        stats = [_make_case_stats()]
+        report = Reporter.to_json(stats, solc_version="0.8.30+commit.abc")
+        assert report["solc_version"] == "0.8.30+commit.abc"
+
+    def test_cases_array_length(self):
+        report = self._make_report(n=3)
+        assert len(report["cases"]) == 3
+
+    def test_all_required_fields_present(self):
+        required = {
+            "case_id", "pipeline", "debug_info_mode", "repeat_count",
+            "failed_count", "time_median_s", "time_mean_s", "time_variance_s2",
+            "rss_median_mib", "rss_mean_mib", "rss_variance_mib2",
+        }
+        report = self._make_report(n=1)
+        case = report["cases"][0]
+        assert required.issubset(case.keys())
+
+    def test_field_values_match_stats(self):
+        cs = _make_case_stats(
+            case_id="test-legacy-off",
+            pipeline="legacy",
+            debug_info_mode="off",
+            repeat_count=5,
+            time_median_s=1.23,
+            time_mean_s=1.25,
+            time_variance_s2=0.001,
+            rss_median_mib=42.0,
+            rss_mean_mib=43.0,
+            rss_variance_mib2=0.5,
+            failed_count=1,
+        )
+        report = Reporter.to_json([cs])
+        c = report["cases"][0]
+        assert c["case_id"] == "test-legacy-off"
+        assert c["pipeline"] == "legacy"
+        assert c["debug_info_mode"] == "off"
+        assert c["repeat_count"] == 5
+        assert c["failed_count"] == 1
+        assert c["time_median_s"] == pytest.approx(1.23)
+        assert c["time_mean_s"] == pytest.approx(1.25)
+        assert c["time_variance_s2"] == pytest.approx(0.001)
+        assert c["rss_median_mib"] == pytest.approx(42.0)
+        assert c["rss_mean_mib"] == pytest.approx(43.0)
+        assert c["rss_variance_mib2"] == pytest.approx(0.5)
+
+    def test_json_serialisable(self):
+        report = self._make_report()
+        # Should not raise.
+        serialised = json.dumps(report)
+        assert isinstance(serialised, str)
+
+
+# ---------------------------------------------------------------------------
+# format_table
+# ---------------------------------------------------------------------------
+
+class TestFormatTable:
+    def _table(self) -> str:
+        stats = [
+            _make_case_stats(
+                case_id="deep-nesting-legacy-off",
+                pipeline="legacy",
+                debug_info_mode="off",
+                repeat_count=3,
+                time_median_s=1.23,
+                rss_median_mib=42.7,
+            ),
+            _make_case_stats(
+                case_id="wide-contract-ir-on",
+                pipeline="ir",
+                debug_info_mode="on",
+                repeat_count=5,
+                time_median_s=0.50,
+                rss_median_mib=100.0,
+            ),
+        ]
+        return Reporter.format_table(stats)
+
+    def test_contains_case_id(self):
+        table = self._table()
+        assert "deep-nesting-legacy-off" in table
+        assert "wide-contract-ir-on" in table
+
+    def test_contains_pipeline(self):
+        table = self._table()
+        assert "legacy" in table
+        assert "ir" in table
+
+    def test_contains_debug_info_mode(self):
+        table = self._table()
+        assert "off" in table
+        assert "on" in table
+
+    def test_median_time_two_decimal_places(self):
+        table = self._table()
+        # 1.23 formatted to 2 dp
+        assert "1.23" in table
+        # 0.50 formatted to 2 dp
+        assert "0.50" in table
+
+    def test_median_rss_integer(self):
+        table = self._table()
+        # 42.7 → 42 (int truncation via int())
+        assert "42" in table
+        # 100.0 → 100
+        assert "100" in table
+
+    def test_sample_count_present(self):
+        table = self._table()
+        assert "3" in table
+        assert "5" in table
+
+    def test_header_row_present(self):
+        table = self._table()
+        assert "case_id" in table
+        assert "pipeline" in table
+        assert "debug_info_mode" in table
+        assert "median_time_s" in table
+        assert "median_rss_mib" in table
+        assert "samples" in table
+
+    def test_empty_stats_returns_header_only(self):
+        table = Reporter.format_table([])
+        assert "case_id" in table
+
+
+# ---------------------------------------------------------------------------
+# compare — missing baseline (!B)
+# ---------------------------------------------------------------------------
+
+def _make_json_report(cases: list[dict], solc_version: str = "test") -> dict:
+    return {
+        "schema_version": "1",
+        "generated_at": "2025-01-01T00:00:00Z",
+        "solc_version": solc_version,
+        "cases": cases,
+    }
+
+
+def _case_dict(
+    case_id: str,
+    pipeline: str = "legacy",
+    debug_info_mode: str = "off",
+    time_median_s: float = 1.0,
+    rss_median_mib: float = 100.0,
+    repeat_count: int = 3,
+    failed_count: int = 0,
+) -> dict:
+    return {
+        "case_id": case_id,
+        "pipeline": pipeline,
+        "debug_info_mode": debug_info_mode,
+        "repeat_count": repeat_count,
+        "failed_count": failed_count,
+        "time_median_s": time_median_s,
+        "time_mean_s": time_median_s,
+        "time_variance_s2": 0.0,
+        "rss_median_mib": rss_median_mib,
+        "rss_mean_mib": rss_median_mib,
+        "rss_variance_mib2": 0.0,
+    }
+
+
+class TestCompareMissingBaseline:
+    def test_missing_case_marked_as_no_baseline(self):
+        baseline = _make_json_report([])
+        current = _make_json_report([_case_dict("new-case-legacy-off")])
+        output = Reporter.compare(baseline, current)
+        assert "!B" in output
+
+    def test_present_case_not_marked_as_no_baseline(self):
+        case = _case_dict("existing-legacy-off")
+        baseline = _make_json_report([case])
+        current = _make_json_report([case])
+        output = Reporter.compare(baseline, current)
+        # The !B marker should not appear for a case that exists in baseline.
+        # (It may appear in the header row label, so check the data rows.)
+        lines = output.splitlines()
+        data_lines = [l for l in lines if "existing-legacy-off" in l]
+        assert data_lines, "Expected a row for existing-legacy-off"
+        assert "!B" not in data_lines[0]
+
+
+# ---------------------------------------------------------------------------
+# compare — relative % differences
+# ---------------------------------------------------------------------------
+
+class TestCompareRelativeDiff:
+    def test_time_increase_positive_pct(self):
+        baseline = _make_json_report([_case_dict("a-legacy-off", time_median_s=1.0)])
+        current = _make_json_report([_case_dict("a-legacy-off", time_median_s=1.1)])
+        output = Reporter.compare(baseline, current)
+        assert "+10.0%" in output
+
+    def test_time_decrease_negative_pct(self):
+        baseline = _make_json_report([_case_dict("b-legacy-off", time_median_s=2.0)])
+        current = _make_json_report([_case_dict("b-legacy-off", time_median_s=1.0)])
+        output = Reporter.compare(baseline, current)
+        assert "-50.0%" in output
+
+    def test_rss_increase_positive_pct(self):
+        baseline = _make_json_report([_case_dict("c-legacy-off", rss_median_mib=100.0)])
+        current = _make_json_report([_case_dict("c-legacy-off", rss_median_mib=110.0)])
+        output = Reporter.compare(baseline, current)
+        assert "+10.0%" in output
+
+    def test_no_change_zero_pct(self):
+        case = _case_dict("d-legacy-off", time_median_s=1.0, rss_median_mib=100.0)
+        baseline = _make_json_report([case])
+        current = _make_json_report([case])
+        output = Reporter.compare(baseline, current)
+        assert "+0.0%" in output or "-0.0%" in output or "0.0%" in output
+
+
+# ---------------------------------------------------------------------------
+# compare — ⚠ highlighting for >5% regression on debug_info_mode=="off"
+# ---------------------------------------------------------------------------
+
+class TestCompareHighlighting:
+    def test_warn_symbol_when_time_exceeds_5pct(self):
+        baseline = _make_json_report([_case_dict("e-legacy-off", time_median_s=1.0, debug_info_mode="off")])
+        current = _make_json_report([_case_dict("e-legacy-off", time_median_s=1.06, debug_info_mode="off")])
+        output = Reporter.compare(baseline, current)
+        assert "⚠" in output
+
+    def test_warn_symbol_when_rss_exceeds_5pct(self):
+        baseline = _make_json_report([_case_dict("f-legacy-off", rss_median_mib=100.0, debug_info_mode="off")])
+        current = _make_json_report([_case_dict("f-legacy-off", rss_median_mib=106.0, debug_info_mode="off")])
+        output = Reporter.compare(baseline, current)
+        assert "⚠" in output
+
+    def test_no_warn_when_within_5pct(self):
+        baseline = _make_json_report([_case_dict("g-legacy-off", time_median_s=1.0, rss_median_mib=100.0, debug_info_mode="off")])
+        current = _make_json_report([_case_dict("g-legacy-off", time_median_s=1.04, rss_median_mib=104.0, debug_info_mode="off")])
+        output = Reporter.compare(baseline, current)
+        # No warning for ≤5% diff.
+        lines = [l for l in output.splitlines() if "g-legacy-off" in l]
+        assert lines
+        assert "⚠" not in lines[0]
+
+    def test_no_warn_for_debug_info_on_cases(self):
+        # Regression highlighting only applies to debug_info_mode=="off".
+        baseline = _make_json_report([_case_dict("h-legacy-on", time_median_s=1.0, debug_info_mode="on")])
+        current = _make_json_report([_case_dict("h-legacy-on", time_median_s=2.0, debug_info_mode="on")])
+        output = Reporter.compare(baseline, current)
+        lines = [l for l in output.splitlines() if "h-legacy-on" in l]
+        assert lines
+        assert "⚠" not in lines[0]
+
+    def test_no_warn_just_below_5pct(self):
+        # 4% increase should NOT trigger warning (must be strictly > 5%).
+        baseline = _make_json_report([_case_dict("i-legacy-off", time_median_s=1.0, debug_info_mode="off")])
+        current = _make_json_report([_case_dict("i-legacy-off", time_median_s=1.04, debug_info_mode="off")])
+        output = Reporter.compare(baseline, current)
+        lines = [l for l in output.splitlines() if "i-legacy-off" in l]
+        assert lines
+        assert "⚠" not in lines[0]
+
+
+# ---------------------------------------------------------------------------
+# compare — debug overhead section
+# ---------------------------------------------------------------------------
+
+class TestCompareDebugOverhead:
+    def _report_with_pair(
+        self,
+        base_name: str = "deep-nesting-legacy",
+        time_off: float = 1.0,
+        time_on: float = 1.2,
+        rss_off: float = 100.0,
+        rss_on: float = 110.0,
+    ) -> dict:
+        return _make_json_report(
+            [
+                _case_dict(f"{base_name}-off", time_median_s=time_off, rss_median_mib=rss_off, debug_info_mode="off"),
+                _case_dict(f"{base_name}-on", time_median_s=time_on, rss_median_mib=rss_on, debug_info_mode="on"),
+            ]
+        )
+
+    def test_debug_overhead_section_present(self):
+        report = self._report_with_pair()
+        output = Reporter.compare(report, report)
+        assert "Debug Info Overhead" in output
+
+    def test_debug_overhead_shows_correct_time_pct(self):
+        # time_on=1.2, time_off=1.0 → overhead = +20.0%
+        baseline = self._report_with_pair(time_off=1.0, time_on=1.2)
+        current = self._report_with_pair(time_off=1.0, time_on=1.2)
+        output = Reporter.compare(baseline, current)
+        assert "+20.0%" in output
+
+    def test_debug_overhead_shows_correct_rss_pct(self):
+        # rss_on=110, rss_off=100 → overhead = +10.0%
+        baseline = self._report_with_pair(rss_off=100.0, rss_on=110.0)
+        current = self._report_with_pair(rss_off=100.0, rss_on=110.0)
+        output = Reporter.compare(baseline, current)
+        assert "+10.0%" in output
+
+    def test_debug_overhead_section_absent_when_no_pairs(self):
+        # Only off cases, no on counterpart.
+        report = _make_json_report([_case_dict("solo-legacy-off", debug_info_mode="off")])
+        output = Reporter.compare(report, report)
+        # Section header should still be present but table body should be empty.
+        assert "Debug Info Overhead" in output
+
+
+# ---------------------------------------------------------------------------
+# compare — Markdown table lines
+# ---------------------------------------------------------------------------
+
+class TestCompareMarkdown:
+    def _output(self) -> str:
+        case = _case_dict("j-legacy-off")
+        report = _make_json_report([case])
+        return Reporter.compare(report, report)
+
+    def test_output_contains_markdown_table_lines(self):
+        output = self._output()
+        table_lines = [l for l in output.splitlines() if l.startswith("|")]
+        assert len(table_lines) >= 1, "Expected at least one Markdown table line starting with '|'"
+
+    def test_output_contains_header_separator(self):
+        output = self._output()
+        sep_lines = [l for l in output.splitlines() if l.startswith("|---")]
+        assert len(sep_lines) >= 1
+
+    def test_output_is_string(self):
+        output = self._output()
+        assert isinstance(output, str)
+        assert len(output) > 0
+
+
+# ---------------------------------------------------------------------------
+# Standalone CLI
+# ---------------------------------------------------------------------------
+
+class TestStandaloneCLI:
+    def _write_report(self, path: Path, cases: list[dict]) -> None:
+        report = _make_json_report(cases)
+        path.write_text(json.dumps(report), encoding="utf-8")
+
+    def test_cli_prints_markdown_output(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_path = Path(tmpdir) / "baseline.json"
+            curr_path = Path(tmpdir) / "current.json"
+            self._write_report(base_path, [_case_dict("cli-test-legacy-off")])
+            self._write_report(curr_path, [_case_dict("cli-test-legacy-off")])
+
+            reporter_path = Path(__file__).parent / "reporter.py"
+            result = subprocess.run(
+                [sys.executable, str(reporter_path), str(base_path), str(curr_path)],
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0
+            assert "|" in result.stdout  # Markdown table lines present
+
+    def test_cli_missing_args_exits_nonzero(self):
+        reporter_path = Path(__file__).parent / "reporter.py"
+        result = subprocess.run(
+            [sys.executable, str(reporter_path)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0

--- a/test/benchmarks/test_run.py
+++ b/test/benchmarks/test_run.py
@@ -1,0 +1,563 @@
+"""
+Unit tests for run.py — covering CLI argument parsing and the wiring of
+BenchmarkRunner + Reporter.
+
+Tests use subprocess to invoke run.py for CLI-level checks, and
+unittest.mock for unit-level wiring tests.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+import unittest.mock
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Ensure the benchmarks package is importable when running from repo root.
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+import run  # noqa: E402 — the module under test
+from models import CaseStats, Sample  # noqa: E402
+
+# Path to run.py for subprocess invocations.
+_RUN_PY = str(_HERE / "run.py")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_sample(case_id: str = "a-legacy-off", elapsed_s: float = 1.0,
+                 peak_rss_mib: float = 10.0, exit_code: int = 0) -> Sample:
+    return Sample(case_id=case_id, elapsed_s=elapsed_s,
+                  peak_rss_mib=peak_rss_mib, exit_code=exit_code)
+
+
+def _make_case_stats(case_id: str = "a-legacy-off") -> CaseStats:
+    return CaseStats(
+        case_id=case_id,
+        pipeline="legacy",
+        debug_info_mode="off",
+        repeat_count=3,
+        time_median_s=1.0,
+        time_mean_s=1.0,
+        time_variance_s2=0.0,
+        rss_median_mib=10.0,
+        rss_mean_mib=10.0,
+        rss_variance_mib2=0.0,
+        failed_count=0,
+    )
+
+
+def _make_report_dict(cases: list | None = None) -> dict:
+    return {
+        "schema_version": "1",
+        "generated_at": "2025-01-01T00:00:00Z",
+        "solc_version": "test",
+        "cases": cases or [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI tests via subprocess
+# ---------------------------------------------------------------------------
+
+class TestCLIInvalidSuite(unittest.TestCase):
+    """Invalid --suite value causes non-zero exit (argparse handles this)."""
+
+    def test_invalid_suite_exits_nonzero(self):
+        result = subprocess.run(
+            [sys.executable, _RUN_PY, "--suite", "invalid-suite"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_invalid_suite_prints_to_stderr(self):
+        result = subprocess.run(
+            [sys.executable, _RUN_PY, "--suite", "bogus"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        # argparse prints usage/error to stderr
+        self.assertTrue(
+            len(result.stderr) > 0,
+            "Expected error output on stderr for invalid --suite",
+        )
+
+    def test_invalid_suite_mentions_valid_choices(self):
+        result = subprocess.run(
+            [sys.executable, _RUN_PY, "--suite", "nope"],
+            capture_output=True,
+            text=True,
+        )
+        # argparse includes the valid choices in the error message
+        combined = result.stderr + result.stdout
+        self.assertTrue(
+            any(choice in combined for choice in ("synthetic", "real-world", "all")),
+            "Expected valid choices to appear in error output",
+        )
+
+
+class TestCLIValidSuites(unittest.TestCase):
+    """Valid --suite values are accepted by argparse (no parse error)."""
+
+    def _parse_only(self, suite: str) -> argparse.Namespace:
+        """Parse args without running the full main() to avoid needing solc."""
+        import argparse
+        parser = run._build_parser()
+        return parser.parse_args(["--suite", suite, "--solc", "/nonexistent"])
+
+    def test_synthetic_accepted(self):
+        import argparse
+        parser = run._build_parser()
+        args = parser.parse_args(["--suite", "synthetic", "--solc", "/x"])
+        self.assertEqual(args.suite, "synthetic")
+
+    def test_real_world_accepted(self):
+        import argparse
+        parser = run._build_parser()
+        args = parser.parse_args(["--suite", "real-world", "--solc", "/x"])
+        self.assertEqual(args.suite, "real-world")
+
+    def test_all_accepted(self):
+        import argparse
+        parser = run._build_parser()
+        args = parser.parse_args(["--suite", "all", "--solc", "/x"])
+        self.assertEqual(args.suite, "all")
+
+
+class TestCLIDefaults(unittest.TestCase):
+    """Default argument values are correct."""
+
+    def _parse(self, extra_args: list | None = None) -> object:
+        parser = run._build_parser()
+        return parser.parse_args(extra_args or [])
+
+    def test_repeats_default_is_3(self):
+        args = self._parse()
+        self.assertEqual(args.repeats, 3)
+
+    def test_suite_default_is_all(self):
+        args = self._parse()
+        self.assertEqual(args.suite, "all")
+
+    def test_output_default_is_none(self):
+        args = self._parse()
+        self.assertIsNone(args.output)
+
+    def test_baseline_default_is_none(self):
+        args = self._parse()
+        self.assertIsNone(args.baseline)
+
+    def test_solc_default_is_none_before_resolution(self):
+        # The parser stores None; resolution happens in _validate_args.
+        args = self._parse()
+        self.assertIsNone(args.solc)
+
+
+class TestCLIMissingOrNonExecutableSolc(unittest.TestCase):
+    """Missing/non-executable solc binary causes exit(1) with error to stderr."""
+
+    def test_nonexistent_solc_exits_1(self):
+        result = subprocess.run(
+            [sys.executable, _RUN_PY, "--solc", "/nonexistent/path/to/solc"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 1)
+
+    def test_nonexistent_solc_prints_error_to_stderr(self):
+        result = subprocess.run(
+            [sys.executable, _RUN_PY, "--solc", "/nonexistent/path/to/solc"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("error", result.stderr.lower())
+
+    def test_nonexistent_solc_error_mentions_path(self):
+        result = subprocess.run(
+            [sys.executable, _RUN_PY, "--solc", "/nonexistent/path/to/solc"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("/nonexistent/path/to/solc", result.stderr)
+
+    def test_non_executable_file_exits_1(self):
+        with tempfile.NamedTemporaryFile(suffix=".sh", delete=False) as f:
+            f.write(b"#!/bin/sh\necho hello\n")
+            tmp_path = f.name
+        try:
+            # Remove execute permission.
+            os.chmod(tmp_path, stat.S_IRUSR | stat.S_IWUSR)
+            result = subprocess.run(
+                [sys.executable, _RUN_PY, "--solc", tmp_path],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("error", result.stderr.lower())
+        finally:
+            os.unlink(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _validate_args
+# ---------------------------------------------------------------------------
+
+class TestValidateArgs(unittest.TestCase):
+    """Unit tests for _validate_args() using mock filesystem checks."""
+
+    def _make_args(self, solc: str | None = None) -> object:
+        parser = run._build_parser()
+        argv = []
+        if solc is not None:
+            argv += ["--solc", solc]
+        return parser.parse_args(argv)
+
+    def test_executable_solc_returns_path(self):
+        with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
+            tmp_path = f.name
+        try:
+            os.chmod(tmp_path, os.stat(tmp_path).st_mode | stat.S_IXUSR)
+            args = self._make_args(solc=tmp_path)
+            result = run._validate_args(args)
+            self.assertEqual(result, Path(tmp_path))
+        finally:
+            os.unlink(tmp_path)
+
+    def test_non_executable_solc_calls_sys_exit_1(self):
+        with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
+            tmp_path = f.name
+        try:
+            os.chmod(tmp_path, stat.S_IRUSR | stat.S_IWUSR)
+            args = self._make_args(solc=tmp_path)
+            with self.assertRaises(SystemExit) as ctx:
+                run._validate_args(args)
+            self.assertEqual(ctx.exception.code, 1)
+        finally:
+            os.unlink(tmp_path)
+
+    def test_missing_solc_calls_sys_exit_1(self):
+        args = self._make_args(solc="/does/not/exist/solc")
+        with self.assertRaises(SystemExit) as ctx:
+            run._validate_args(args)
+        self.assertEqual(ctx.exception.code, 1)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _get_solc_version
+# ---------------------------------------------------------------------------
+
+class TestGetSolcVersion(unittest.TestCase):
+    def test_parses_version_line(self):
+        mock_result = MagicMock()
+        mock_result.stdout = "solc, the solidity compiler commandline interface\nVersion: 0.8.30+commit.abc\n"
+        with patch("subprocess.run", return_value=mock_result):
+            version = run._get_solc_version(Path("/fake/solc"))
+        self.assertEqual(version, "0.8.30+commit.abc")
+
+    def test_returns_unknown_on_exception(self):
+        with patch("subprocess.run", side_effect=Exception("boom")):
+            version = run._get_solc_version(Path("/fake/solc"))
+        self.assertEqual(version, "unknown")
+
+    def test_returns_unknown_when_no_version_line(self):
+        mock_result = MagicMock()
+        mock_result.stdout = "some other output\nno version here\n"
+        with patch("subprocess.run", return_value=mock_result):
+            version = run._get_solc_version(Path("/fake/solc"))
+        self.assertEqual(version, "unknown")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _build_cases
+# ---------------------------------------------------------------------------
+
+class TestBuildCases(unittest.TestCase):
+    def test_synthetic_calls_build_synthetic_cases(self):
+        with patch("run.build_synthetic_cases", return_value=[]) as mock_syn, \
+             patch("run.build_real_world_cases", return_value=[]) as mock_rw:
+            result = run._build_cases("synthetic")
+            mock_syn.assert_called_once()
+            mock_rw.assert_not_called()
+            self.assertEqual(result, [])
+
+    def test_real_world_calls_build_real_world_cases(self):
+        with patch("run.build_synthetic_cases", return_value=[]) as mock_syn, \
+             patch("run.build_real_world_cases", return_value=[]) as mock_rw:
+            result = run._build_cases("real-world")
+            mock_rw.assert_called_once()
+            mock_syn.assert_not_called()
+            self.assertEqual(result, [])
+
+    def test_all_calls_both_builders(self):
+        fake_syn = [MagicMock()]
+        fake_rw = [MagicMock()]
+        with patch("run.build_synthetic_cases", return_value=fake_syn), \
+             patch("run.build_real_world_cases", return_value=fake_rw):
+            result = run._build_cases("all")
+            self.assertEqual(len(result), 2)
+
+    def test_synthetic_output_dir_is_under_repo_root(self):
+        captured = {}
+        def capture_syn(output_dir):
+            captured["output_dir"] = output_dir
+            return []
+        with patch("run.build_synthetic_cases", side_effect=capture_syn), \
+             patch("run.build_real_world_cases", return_value=[]):
+            run._build_cases("synthetic")
+        # output_dir should be inside the repo root
+        self.assertIn("test", str(captured["output_dir"]))
+        self.assertIn("benchmarks", str(captured["output_dir"]))
+        self.assertIn("generated", str(captured["output_dir"]))
+
+    def test_real_world_dir_is_under_repo_root(self):
+        captured = {}
+        def capture_rw(real_world_dir):
+            captured["real_world_dir"] = real_world_dir
+            return []
+        with patch("run.build_real_world_cases", side_effect=capture_rw):
+            run._build_cases("real-world")
+        self.assertIn("real-world", str(captured["real_world_dir"]))
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for main() wiring — always exits 0
+# ---------------------------------------------------------------------------
+
+class TestMainAlwaysExitsZero(unittest.TestCase):
+    """Always exits 0 even when cases fail (mock runner raises exception)."""
+
+    def _run_main_with_mocks(
+        self,
+        suite: str = "synthetic",
+        runner_side_effect=None,
+        extra_argv: list | None = None,
+    ) -> int:
+        """Run main() with a fake executable solc and mocked runner/reporter.
+
+        Returns the exit code (0 on normal completion, or the SystemExit code).
+        """
+        with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
+            tmp_solc = f.name
+        try:
+            os.chmod(tmp_solc, os.stat(tmp_solc).st_mode | stat.S_IXUSR)
+
+            argv = [
+                "--solc", tmp_solc,
+                "--suite", suite,
+            ]
+            if extra_argv:
+                argv += extra_argv
+
+            fake_samples = [_make_sample()]
+            fake_stats = [_make_case_stats()]
+            fake_report = _make_report_dict()
+
+            mock_runner_instance = MagicMock()
+            if runner_side_effect is not None:
+                mock_runner_instance.run_suite.side_effect = runner_side_effect
+            else:
+                mock_runner_instance.run_suite.return_value = fake_samples
+
+            with patch("sys.argv", ["run.py"] + argv), \
+                 patch("run.BenchmarkRunner", return_value=mock_runner_instance), \
+                 patch("run.build_synthetic_cases", return_value=[]), \
+                 patch("run.build_real_world_cases", return_value=[]), \
+                 patch("run.Reporter.compute_stats", return_value=fake_stats), \
+                 patch("run.Reporter.to_json", return_value=fake_report), \
+                 patch("run.Reporter.format_table", return_value="table"), \
+                 patch("run._get_solc_version", return_value="0.8.0"), \
+                 patch("builtins.print"):
+                try:
+                    run.main()
+                    return 0
+                except SystemExit as e:
+                    return e.code if e.code is not None else 0
+        finally:
+            os.unlink(tmp_solc)
+
+    def test_exits_0_on_normal_run(self):
+        code = self._run_main_with_mocks()
+        self.assertEqual(code, 0)
+
+    def test_exits_0_when_runner_raises_exception(self):
+        """Even if the runner raises, main() should exit 0."""
+        code = self._run_main_with_mocks(
+            runner_side_effect=RuntimeError("solc crashed unexpectedly")
+        )
+        self.assertEqual(code, 0)
+
+    def test_exits_0_for_synthetic_suite(self):
+        code = self._run_main_with_mocks(suite="synthetic")
+        self.assertEqual(code, 0)
+
+    def test_exits_0_for_real_world_suite(self):
+        code = self._run_main_with_mocks(suite="real-world")
+        self.assertEqual(code, 0)
+
+    def test_exits_0_for_all_suite(self):
+        code = self._run_main_with_mocks(suite="all")
+        self.assertEqual(code, 0)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for main() — JSON output routing
+# ---------------------------------------------------------------------------
+
+class TestMainOutputRouting(unittest.TestCase):
+    """JSON report goes to --output file when specified, else to stdout."""
+
+    def _run_main_capturing(self, extra_argv: list | None = None) -> tuple[str, str]:
+        """Run main() and return (stdout_output, written_file_content)."""
+        with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
+            tmp_solc = f.name
+        try:
+            os.chmod(tmp_solc, os.stat(tmp_solc).st_mode | stat.S_IXUSR)
+
+            argv = ["--solc", tmp_solc, "--suite", "synthetic"]
+            if extra_argv:
+                argv += extra_argv
+
+            fake_stats = [_make_case_stats()]
+            fake_report = _make_report_dict()
+
+            mock_runner_instance = MagicMock()
+            mock_runner_instance.run_suite.return_value = [_make_sample()]
+
+            printed_lines: list[str] = []
+
+            def fake_print(*args, **kwargs):
+                printed_lines.append(" ".join(str(a) for a in args))
+
+            with patch("sys.argv", ["run.py"] + argv), \
+                 patch("run.BenchmarkRunner", return_value=mock_runner_instance), \
+                 patch("run.build_synthetic_cases", return_value=[]), \
+                 patch("run.build_real_world_cases", return_value=[]), \
+                 patch("run.Reporter.compute_stats", return_value=fake_stats), \
+                 patch("run.Reporter.to_json", return_value=fake_report), \
+                 patch("run.Reporter.format_table", return_value="TABLE"), \
+                 patch("run._get_solc_version", return_value="0.8.0"), \
+                 patch("builtins.print", side_effect=fake_print):
+                try:
+                    run.main()
+                except SystemExit:
+                    pass
+
+            return "\n".join(printed_lines)
+        finally:
+            os.unlink(tmp_solc)
+
+    def test_json_written_to_output_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_path = Path(tmpdir) / "report.json"
+            with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
+                tmp_solc = f.name
+            try:
+                os.chmod(tmp_solc, os.stat(tmp_solc).st_mode | stat.S_IXUSR)
+
+                fake_stats = [_make_case_stats()]
+                fake_report = _make_report_dict()
+                mock_runner_instance = MagicMock()
+                mock_runner_instance.run_suite.return_value = [_make_sample()]
+
+                with patch("sys.argv", ["run.py", "--solc", tmp_solc,
+                                        "--suite", "synthetic",
+                                        "--output", str(out_path)]), \
+                     patch("run.BenchmarkRunner", return_value=mock_runner_instance), \
+                     patch("run.build_synthetic_cases", return_value=[]), \
+                     patch("run.build_real_world_cases", return_value=[]), \
+                     patch("run.Reporter.compute_stats", return_value=fake_stats), \
+                     patch("run.Reporter.to_json", return_value=fake_report), \
+                     patch("run.Reporter.format_table", return_value="TABLE"), \
+                     patch("run._get_solc_version", return_value="0.8.0"), \
+                     patch("builtins.print"):
+                    try:
+                        run.main()
+                    except SystemExit:
+                        pass
+
+                self.assertTrue(out_path.exists(), "Expected output file to be created")
+                content = json.loads(out_path.read_text())
+                self.assertIn("schema_version", content)
+            finally:
+                os.unlink(tmp_solc)
+
+    def test_table_always_printed_to_stdout(self):
+        stdout = self._run_main_capturing()
+        self.assertIn("TABLE", stdout)
+
+    def test_baseline_comparison_printed_when_provided(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            baseline_path = Path(tmpdir) / "baseline.json"
+            baseline_path.write_text(json.dumps(_make_report_dict()), encoding="utf-8")
+
+            with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
+                tmp_solc = f.name
+            try:
+                os.chmod(tmp_solc, os.stat(tmp_solc).st_mode | stat.S_IXUSR)
+
+                fake_stats = [_make_case_stats()]
+                fake_report = _make_report_dict()
+                mock_runner_instance = MagicMock()
+                mock_runner_instance.run_suite.return_value = [_make_sample()]
+
+                printed_lines: list[str] = []
+
+                def fake_print(*args, **kwargs):
+                    printed_lines.append(" ".join(str(a) for a in args))
+
+                with patch("sys.argv", ["run.py", "--solc", tmp_solc,
+                                        "--suite", "synthetic",
+                                        "--baseline", str(baseline_path)]), \
+                     patch("run.BenchmarkRunner", return_value=mock_runner_instance), \
+                     patch("run.build_synthetic_cases", return_value=[]), \
+                     patch("run.build_real_world_cases", return_value=[]), \
+                     patch("run.Reporter.compute_stats", return_value=fake_stats), \
+                     patch("run.Reporter.to_json", return_value=fake_report), \
+                     patch("run.Reporter.format_table", return_value="TABLE"), \
+                     patch("run.Reporter.compare", return_value="## Comparison") as mock_compare, \
+                     patch("run._get_solc_version", return_value="0.8.0"), \
+                     patch("builtins.print", side_effect=fake_print):
+                    try:
+                        run.main()
+                    except SystemExit:
+                        pass
+
+                mock_compare.assert_called_once()
+                combined = "\n".join(printed_lines)
+                self.assertIn("## Comparison", combined)
+            finally:
+                os.unlink(tmp_solc)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _default_solc_path
+# ---------------------------------------------------------------------------
+
+class TestDefaultSolcPath(unittest.TestCase):
+    def test_uses_solidity_build_dir_env(self):
+        with patch.dict(os.environ, {"SOLIDITY_BUILD_DIR": "/custom/build"}):
+            path = run._default_solc_path()
+        self.assertEqual(path, Path("/custom/build/solc/solc"))
+
+    def test_falls_back_to_repo_root_build(self):
+        env = {k: v for k, v in os.environ.items() if k != "SOLIDITY_BUILD_DIR"}
+        with patch.dict(os.environ, env, clear=True):
+            path = run._default_solc_path()
+        # Should end with build/solc/solc
+        self.assertTrue(str(path).endswith("build/solc/solc"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/benchmarks/test_runner.py
+++ b/test/benchmarks/test_runner.py
@@ -1,0 +1,685 @@
+"""
+Unit tests for runner.py.
+
+Covers:
+- Command construction for all pipeline/debug_info_mode combinations (mock subprocess)
+- run_case returns exactly N samples for N repeats (mock subprocess)
+- build_synthetic_cases returns 20 cases (5 categories × 2 pipelines × 2 debug modes)
+- Each source/pipeline combo has both debug modes (off and on)
+- Missing real-world dir logs warning and returns empty list
+- CI log lines have ISO 8601 timestamp prefix when CI env var is set
+- log() without CI env var does not add timestamp
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import re
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_HERE = Path(__file__).parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from models import BenchmarkCase, Sample  # noqa: E402
+from contract_generator import StressCategory  # noqa: E402
+import runner as runner_module  # noqa: E402
+from runner import (  # noqa: E402
+    BenchmarkRunner,
+    _measure_peak_rss_mib,
+    build_real_world_cases,
+    build_synthetic_cases,
+    log,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_SOLC = Path("/usr/bin/solc")
+_ISO8601_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
+
+
+def _make_case(
+    case_id: str = "test-legacy-off",
+    source_path: Path = Path("test.sol"),
+    pipeline: str = "legacy",
+    debug_info_mode: str = "off",
+    use_standard_json: bool = False,
+) -> BenchmarkCase:
+    return BenchmarkCase(
+        case_id=case_id,
+        source_path=source_path,
+        pipeline=pipeline,
+        debug_info_mode=debug_info_mode,
+        use_standard_json=use_standard_json,
+    )
+
+
+def _fake_completed_process(returncode: int = 0):
+    """Return a mock CompletedProcess-like object."""
+    mock = MagicMock()
+    mock.returncode = returncode
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Tests: log() — CI timestamp behaviour
+# ---------------------------------------------------------------------------
+
+class TestLog(unittest.TestCase):
+    """Tests for the log() helper function."""
+
+    def _capture_log(self, msg: str, ci_value: str | None) -> str:
+        """Call log(msg) with CI env var set/unset and capture stdout."""
+        env_patch = {}
+        if ci_value is not None:
+            env_patch["CI"] = ci_value
+        else:
+            # Ensure CI is absent
+            env_patch.pop("CI", None)
+
+        buf = io.StringIO()
+        with patch.dict(os.environ, env_patch, clear=False):
+            # Remove CI if we want it absent
+            if ci_value is None and "CI" in os.environ:
+                with patch.dict(os.environ, {}, clear=False):
+                    os.environ.pop("CI", None)
+                    with patch("sys.stdout", buf):
+                        log(msg)
+                    return buf.getvalue()
+            with patch("sys.stdout", buf):
+                log(msg)
+        return buf.getvalue()
+
+    def test_ci_set_adds_timestamp_prefix(self):
+        """When CI is non-empty, output should start with ISO 8601 timestamp."""
+        buf = io.StringIO()
+        with patch.dict(os.environ, {"CI": "true"}, clear=False):
+            with patch("sys.stdout", buf):
+                log("hello")
+        output = buf.getvalue()
+        self.assertTrue(
+            _ISO8601_RE.match(output),
+            f"Expected ISO 8601 prefix, got: {output!r}",
+        )
+
+    def test_ci_set_message_follows_timestamp(self):
+        """The original message should appear after the timestamp."""
+        buf = io.StringIO()
+        with patch.dict(os.environ, {"CI": "1"}, clear=False):
+            with patch("sys.stdout", buf):
+                log("my message")
+        output = buf.getvalue()
+        self.assertIn("my message", output)
+
+    def test_ci_empty_string_no_timestamp(self):
+        """When CI is set to empty string, no timestamp should be added."""
+        buf = io.StringIO()
+        with patch.dict(os.environ, {"CI": ""}, clear=False):
+            with patch("sys.stdout", buf):
+                log("plain message")
+        output = buf.getvalue().strip()
+        self.assertEqual(output, "plain message")
+
+    def test_no_ci_no_timestamp(self):
+        """When CI is absent, output should be the message only."""
+        buf = io.StringIO()
+        env_without_ci = {k: v for k, v in os.environ.items() if k != "CI"}
+        with patch.dict(os.environ, env_without_ci, clear=True):
+            with patch("sys.stdout", buf):
+                log("plain message")
+        output = buf.getvalue().strip()
+        self.assertEqual(output, "plain message")
+
+    def test_ci_timestamp_format_contains_t_separator(self):
+        """ISO 8601 timestamps use 'T' as date/time separator."""
+        buf = io.StringIO()
+        with patch.dict(os.environ, {"CI": "true"}, clear=False):
+            with patch("sys.stdout", buf):
+                log("check format")
+        output = buf.getvalue()
+        # Should contain the 'T' separator and end with 'Z'
+        self.assertIn("T", output)
+        self.assertIn("Z", output)
+
+
+# ---------------------------------------------------------------------------
+# Tests: command construction
+# ---------------------------------------------------------------------------
+
+class TestCommandConstruction(unittest.TestCase):
+    """Tests for _build_regular_cmd and _build_standard_json_cmd."""
+
+    def setUp(self):
+        self.runner = BenchmarkRunner(solc_path=_FAKE_SOLC, repeats=1)
+
+    def test_legacy_off_contains_optimize_and_bin(self):
+        case = _make_case(pipeline="legacy", debug_info_mode="off")
+        cmd, _ = self.runner._build_regular_cmd(case)
+        self.assertIn("--optimize", cmd)
+        self.assertIn("--bin", cmd)
+
+    def test_debug_on_omits_optimize(self):
+        # --optimize is incompatible with ethdebug (experimental)
+        case = _make_case(pipeline="legacy", debug_info_mode="on")
+        cmd, _ = self.runner._build_regular_cmd(case)
+        self.assertNotIn("--optimize", cmd)
+        self.assertIn("--bin", cmd)
+
+    def test_debug_on_adds_experimental_flag(self):
+        case = _make_case(pipeline="legacy", debug_info_mode="on")
+        cmd, _ = self.runner._build_regular_cmd(case)
+        self.assertIn("--experimental", cmd)
+
+    def test_legacy_off_no_via_ir(self):
+        case = _make_case(pipeline="legacy", debug_info_mode="off")
+        cmd, _ = self.runner._build_regular_cmd(case)
+        self.assertNotIn("--via-ir", cmd)
+
+    def test_legacy_off_no_debug_info(self):
+        case = _make_case(pipeline="legacy", debug_info_mode="off")
+        cmd, _ = self.runner._build_regular_cmd(case)
+        self.assertNotIn("--debug-info", cmd)
+        self.assertNotIn("ethdebug", cmd)
+
+    def test_ir_pipeline_adds_via_ir(self):
+        case = _make_case(pipeline="ir", debug_info_mode="off")
+        cmd, _ = self.runner._build_regular_cmd(case)
+        self.assertIn("--via-ir", cmd)
+
+    def test_debug_on_adds_debug_info_ethdebug(self):
+        case = _make_case(pipeline="legacy", debug_info_mode="on")
+        cmd, _ = self.runner._build_regular_cmd(case)
+        self.assertIn("--debug-info", cmd)
+        self.assertIn("ethdebug", cmd)
+
+    def test_ir_debug_on_has_both_flags(self):
+        case = _make_case(pipeline="ir", debug_info_mode="on")
+        cmd, _ = self.runner._build_regular_cmd(case)
+        self.assertIn("--via-ir", cmd)
+        self.assertIn("--debug-info", cmd)
+        self.assertIn("ethdebug", cmd)
+
+    def test_ir_debug_off_no_debug_info(self):
+        case = _make_case(pipeline="ir", debug_info_mode="off")
+        cmd, _ = self.runner._build_regular_cmd(case)
+        self.assertIn("--via-ir", cmd)
+        self.assertNotIn("--debug-info", cmd)
+
+    def test_regular_cmd_includes_source_path(self):
+        source = Path("/tmp/test.sol")
+        case = _make_case(source_path=source)
+        cmd, _ = self.runner._build_regular_cmd(case)
+        self.assertIn(str(source), cmd)
+
+    def test_regular_cmd_starts_with_solc_path(self):
+        case = _make_case()
+        cmd, _ = self.runner._build_regular_cmd(case)
+        self.assertEqual(cmd[0], str(_FAKE_SOLC))
+
+    def test_standard_json_cmd_contains_standard_json_flag(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            f.write(b'{"language": "Solidity"}')
+            tmp_path = Path(f.name)
+        try:
+            case = _make_case(source_path=tmp_path, use_standard_json=True)
+            cmd, stdin_data = self.runner._build_standard_json_cmd(case)
+            self.assertIn("--standard-json", cmd)
+        finally:
+            tmp_path.unlink()
+
+    def test_standard_json_cmd_no_bin_flag(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            f.write(b'{"language": "Solidity"}')
+            tmp_path = Path(f.name)
+        try:
+            case = _make_case(source_path=tmp_path, use_standard_json=True)
+            cmd, _ = self.runner._build_standard_json_cmd(case)
+            self.assertNotIn("--bin", cmd)
+        finally:
+            tmp_path.unlink()
+
+    def test_standard_json_cmd_passes_file_content_as_stdin(self):
+        content = b'{"language": "Solidity", "sources": {}}'
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            f.write(content)
+            tmp_path = Path(f.name)
+        try:
+            case = _make_case(source_path=tmp_path, use_standard_json=True)
+            _, stdin_data = self.runner._build_standard_json_cmd(case)
+            self.assertEqual(stdin_data, content)
+        finally:
+            tmp_path.unlink()
+
+    def test_standard_json_ir_pipeline_adds_via_ir(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            f.write(b"{}")
+            tmp_path = Path(f.name)
+        try:
+            case = _make_case(source_path=tmp_path, pipeline="ir", use_standard_json=True)
+            cmd, _ = self.runner._build_standard_json_cmd(case)
+            self.assertIn("--via-ir", cmd)
+        finally:
+            tmp_path.unlink()
+
+    def test_standard_json_debug_on_adds_debug_info(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            f.write(b"{}")
+            tmp_path = Path(f.name)
+        try:
+            case = _make_case(
+                source_path=tmp_path, debug_info_mode="on", use_standard_json=True
+            )
+            cmd, _ = self.runner._build_standard_json_cmd(case)
+            self.assertIn("--debug-info", cmd)
+            self.assertIn("ethdebug", cmd)
+        finally:
+            tmp_path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Tests: run_case returns exactly N samples
+# ---------------------------------------------------------------------------
+
+class TestRunCase(unittest.TestCase):
+    """Tests for BenchmarkRunner.run_case()."""
+
+    def _run_case_mocked(
+        self,
+        repeats: int,
+        returncode: int = 0,
+        pipeline: str = "legacy",
+        debug_info_mode: str = "off",
+        use_standard_json: bool = False,
+    ) -> list[Sample]:
+        """Run run_case() with subprocess.run mocked out."""
+        with tempfile.NamedTemporaryFile(suffix=".sol", delete=False) as f:
+            f.write(b"// dummy")
+            source_path = Path(f.name)
+
+        try:
+            bench_runner = BenchmarkRunner(solc_path=_FAKE_SOLC, repeats=repeats)
+            case = _make_case(
+                source_path=source_path,
+                pipeline=pipeline,
+                debug_info_mode=debug_info_mode,
+                use_standard_json=use_standard_json,
+            )
+
+            mock_result = _fake_completed_process(returncode=returncode)
+
+            with patch("runner.subprocess.run", return_value=mock_result):
+                with patch("runner._measure_peak_rss_mib", return_value=42.0):
+                    samples = bench_runner.run_case(case)
+        finally:
+            source_path.unlink()
+
+        return samples
+
+    def test_returns_exactly_1_sample_for_repeats_1(self):
+        samples = self._run_case_mocked(repeats=1)
+        self.assertEqual(len(samples), 1)
+
+    def test_returns_exactly_3_samples_for_repeats_3(self):
+        samples = self._run_case_mocked(repeats=3)
+        self.assertEqual(len(samples), 3)
+
+    def test_returns_exactly_5_samples_for_repeats_5(self):
+        samples = self._run_case_mocked(repeats=5)
+        self.assertEqual(len(samples), 5)
+
+    def test_returns_exactly_10_samples_for_repeats_10(self):
+        samples = self._run_case_mocked(repeats=10)
+        self.assertEqual(len(samples), 10)
+
+    def test_sample_has_correct_case_id(self):
+        samples = self._run_case_mocked(repeats=1)
+        self.assertEqual(samples[0].case_id, "test-legacy-off")
+
+    def test_sample_elapsed_s_is_non_negative(self):
+        samples = self._run_case_mocked(repeats=3)
+        for s in samples:
+            self.assertGreaterEqual(s.elapsed_s, 0.0)
+
+    def test_sample_peak_rss_mib_is_mocked_value(self):
+        samples = self._run_case_mocked(repeats=2)
+        for s in samples:
+            self.assertAlmostEqual(s.peak_rss_mib, 42.0)
+
+    def test_sample_exit_code_zero_on_success(self):
+        samples = self._run_case_mocked(repeats=1, returncode=0)
+        self.assertEqual(samples[0].exit_code, 0)
+
+    def test_sample_exit_code_nonzero_on_failure(self):
+        samples = self._run_case_mocked(repeats=1, returncode=1)
+        self.assertEqual(samples[0].exit_code, 1)
+
+    def test_continues_after_nonzero_exit(self):
+        """run_case should return all repeats even when solc fails."""
+        samples = self._run_case_mocked(repeats=3, returncode=1)
+        self.assertEqual(len(samples), 3)
+
+    def test_ir_pipeline_run_case_returns_correct_count(self):
+        samples = self._run_case_mocked(repeats=2, pipeline="ir")
+        self.assertEqual(len(samples), 2)
+
+    def test_debug_on_run_case_returns_correct_count(self):
+        samples = self._run_case_mocked(repeats=2, debug_info_mode="on")
+        self.assertEqual(len(samples), 2)
+
+    def test_standard_json_run_case_returns_correct_count(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            f.write(b'{"language": "Solidity"}')
+            source_path = Path(f.name)
+        try:
+            bench_runner = BenchmarkRunner(solc_path=_FAKE_SOLC, repeats=3)
+            case = _make_case(source_path=source_path, use_standard_json=True)
+            mock_result = _fake_completed_process(returncode=0)
+            with patch("runner.subprocess.run", return_value=mock_result):
+                with patch("runner._measure_peak_rss_mib", return_value=10.0):
+                    samples = bench_runner.run_case(case)
+        finally:
+            source_path.unlink()
+        self.assertEqual(len(samples), 3)
+
+
+# ---------------------------------------------------------------------------
+# Tests: build_synthetic_cases
+# ---------------------------------------------------------------------------
+
+class TestBuildSyntheticCases(unittest.TestCase):
+    """Tests for build_synthetic_cases()."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.out = Path(self._tmpdir.name)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def _cases(self) -> list[BenchmarkCase]:
+        return build_synthetic_cases(self.out)
+
+    def test_returns_exactly_20_cases(self):
+        cases = self._cases()
+        self.assertEqual(len(cases), 20)
+
+    def test_all_five_categories_present(self):
+        cases = self._cases()
+        category_values = {c.case_id.rsplit("-", 2)[0] for c in cases}
+        expected = {cat.value for cat in StressCategory}
+        self.assertEqual(category_values, expected)
+
+    def test_both_pipelines_present(self):
+        cases = self._cases()
+        pipelines = {c.pipeline for c in cases}
+        self.assertEqual(pipelines, {"legacy", "ir"})
+
+    def test_both_debug_modes_present(self):
+        cases = self._cases()
+        debug_modes = {c.debug_info_mode for c in cases}
+        self.assertEqual(debug_modes, {"off", "on"})
+
+    def test_each_category_has_4_cases(self):
+        """Each category × 2 pipelines × 2 debug modes = 4 cases."""
+        cases = self._cases()
+        for cat in StressCategory:
+            cat_cases = [c for c in cases if c.case_id.startswith(cat.value)]
+            self.assertEqual(
+                len(cat_cases), 4,
+                f"Expected 4 cases for {cat.value}, got {len(cat_cases)}",
+            )
+
+    def test_each_source_pipeline_combo_has_both_debug_modes(self):
+        """For every (source, pipeline) pair, both 'off' and 'on' must exist."""
+        cases = self._cases()
+        # Group by (source_path, pipeline)
+        combos: dict[tuple, set] = {}
+        for c in cases:
+            key = (str(c.source_path), c.pipeline)
+            combos.setdefault(key, set()).add(c.debug_info_mode)
+        for key, modes in combos.items():
+            self.assertEqual(
+                modes, {"off", "on"},
+                f"Combo {key} missing a debug mode: {modes}",
+            )
+
+    def test_use_standard_json_is_false_for_all_synthetic(self):
+        cases = self._cases()
+        for c in cases:
+            self.assertFalse(c.use_standard_json, f"Case {c.case_id} should not use standard-json")
+
+    def test_source_files_exist(self):
+        cases = self._cases()
+        seen_paths = set()
+        for c in cases:
+            if c.source_path not in seen_paths:
+                self.assertTrue(
+                    c.source_path.exists(),
+                    f"Source file missing: {c.source_path}",
+                )
+                seen_paths.add(c.source_path)
+
+    def test_case_ids_follow_naming_convention(self):
+        """Case IDs should follow pattern: {category}-{pipeline}-{debug_mode}."""
+        cases = self._cases()
+        valid_pipelines = {"legacy", "ir"}
+        valid_debug_modes = {"off", "on"}
+        for c in cases:
+            parts = c.case_id.rsplit("-", 2)
+            self.assertEqual(len(parts), 3, f"Unexpected case_id format: {c.case_id}")
+            _, pipeline, debug_mode = parts
+            self.assertIn(pipeline, valid_pipelines)
+            self.assertIn(debug_mode, valid_debug_modes)
+
+
+# ---------------------------------------------------------------------------
+# Tests: build_real_world_cases
+# ---------------------------------------------------------------------------
+
+class TestBuildRealWorldCases(unittest.TestCase):
+    """Tests for build_real_world_cases()."""
+
+    def test_missing_dir_returns_empty_list(self):
+        non_existent = Path("/tmp/does_not_exist_benchmark_test_xyz_12345")
+        cases = build_real_world_cases(non_existent)
+        self.assertEqual(cases, [])
+
+    def test_missing_dir_logs_warning(self):
+        non_existent = Path("/tmp/does_not_exist_benchmark_test_xyz_12345")
+        buf = io.StringIO()
+        env_without_ci = {k: v for k, v in os.environ.items() if k != "CI"}
+        with patch.dict(os.environ, env_without_ci, clear=True):
+            with patch("sys.stdout", buf):
+                build_real_world_cases(non_existent)
+        output = buf.getvalue()
+        self.assertIn("WARNING", output)
+
+    def test_empty_dir_returns_empty_list(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cases = build_real_world_cases(Path(tmpdir))
+        self.assertEqual(cases, [])
+
+    def test_empty_dir_logs_warning(self):
+        buf = io.StringIO()
+        env_without_ci = {k: v for k, v in os.environ.items() if k != "CI"}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, env_without_ci, clear=True):
+                with patch("sys.stdout", buf):
+                    build_real_world_cases(Path(tmpdir))
+        output = buf.getvalue()
+        self.assertIn("WARNING", output)
+
+    def test_json_files_produce_cases(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rw_dir = Path(tmpdir)
+            (rw_dir / "project-1.0.json").write_text('{"language": "Solidity"}')
+            cases = build_real_world_cases(rw_dir)
+        self.assertGreater(len(cases), 0)
+
+    def test_each_json_file_produces_4_cases(self):
+        """Each JSON file × 2 pipelines × 2 debug modes = 4 cases."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rw_dir = Path(tmpdir)
+            (rw_dir / "project-a.json").write_text("{}")
+            (rw_dir / "project-b.json").write_text("{}")
+            cases = build_real_world_cases(rw_dir)
+        self.assertEqual(len(cases), 8)
+
+    def test_real_world_cases_use_standard_json(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rw_dir = Path(tmpdir)
+            (rw_dir / "project.json").write_text("{}")
+            cases = build_real_world_cases(rw_dir)
+        for c in cases:
+            self.assertTrue(c.use_standard_json, f"Case {c.case_id} should use standard-json")
+
+    def test_real_world_cases_have_both_debug_modes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rw_dir = Path(tmpdir)
+            (rw_dir / "project.json").write_text("{}")
+            cases = build_real_world_cases(rw_dir)
+        debug_modes = {c.debug_info_mode for c in cases}
+        self.assertEqual(debug_modes, {"off", "on"})
+
+    def test_real_world_cases_have_both_pipelines(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rw_dir = Path(tmpdir)
+            (rw_dir / "project.json").write_text("{}")
+            cases = build_real_world_cases(rw_dir)
+        pipelines = {c.pipeline for c in cases}
+        self.assertEqual(pipelines, {"legacy", "ir"})
+
+    def test_non_json_files_are_ignored(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rw_dir = Path(tmpdir)
+            (rw_dir / "project.json").write_text("{}")
+            (rw_dir / "readme.txt").write_text("ignore me")
+            (rw_dir / "data.sol").write_text("// ignore")
+            cases = build_real_world_cases(rw_dir)
+        # Only the .json file should produce cases
+        self.assertEqual(len(cases), 4)
+
+
+# ---------------------------------------------------------------------------
+# Tests: run_suite
+# ---------------------------------------------------------------------------
+
+class TestRunSuite(unittest.TestCase):
+    """Tests for BenchmarkRunner.run_suite()."""
+
+    def test_run_suite_accumulates_all_samples(self):
+        """run_suite with 3 cases × 2 repeats should return 6 samples."""
+        bench_runner = BenchmarkRunner(solc_path=_FAKE_SOLC, repeats=2)
+
+        with tempfile.NamedTemporaryFile(suffix=".sol", delete=False) as f:
+            f.write(b"// dummy")
+            source_path = Path(f.name)
+
+        try:
+            cases = [
+                _make_case(case_id=f"case-{i}", source_path=source_path)
+                for i in range(3)
+            ]
+            mock_result = _fake_completed_process(returncode=0)
+            with patch("runner.subprocess.run", return_value=mock_result):
+                with patch("runner._measure_peak_rss_mib", return_value=10.0):
+                    samples = bench_runner.run_suite(cases)
+        finally:
+            source_path.unlink()
+
+        self.assertEqual(len(samples), 6)
+
+    def test_run_suite_empty_cases_returns_empty(self):
+        bench_runner = BenchmarkRunner(solc_path=_FAKE_SOLC, repeats=3)
+        samples = bench_runner.run_suite([])
+        self.assertEqual(samples, [])
+
+    def test_run_suite_preserves_case_ids(self):
+        bench_runner = BenchmarkRunner(solc_path=_FAKE_SOLC, repeats=1)
+
+        with tempfile.NamedTemporaryFile(suffix=".sol", delete=False) as f:
+            f.write(b"// dummy")
+            source_path = Path(f.name)
+
+        try:
+            cases = [
+                _make_case(case_id="alpha", source_path=source_path),
+                _make_case(case_id="beta", source_path=source_path),
+            ]
+            mock_result = _fake_completed_process(returncode=0)
+            with patch("runner.subprocess.run", return_value=mock_result):
+                with patch("runner._measure_peak_rss_mib", return_value=5.0):
+                    samples = bench_runner.run_suite(cases)
+        finally:
+            source_path.unlink()
+
+        case_ids = [s.case_id for s in samples]
+        self.assertIn("alpha", case_ids)
+        self.assertIn("beta", case_ids)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _measure_peak_rss_mib
+# ---------------------------------------------------------------------------
+
+class TestMeasurePeakRssMib(unittest.TestCase):
+    """Tests for _measure_peak_rss_mib()."""
+
+    def test_linux_divides_by_1024(self):
+        mock_usage = MagicMock()
+        mock_usage.ru_maxrss = 102400  # 100 MiB in KB
+
+        with patch("runner.sys.platform", "linux"):
+            with patch("resource.getrusage", return_value=mock_usage):
+                result = _measure_peak_rss_mib()
+
+        self.assertAlmostEqual(result, 100.0)
+
+    def test_macos_divides_by_1048576(self):
+        mock_usage = MagicMock()
+        mock_usage.ru_maxrss = 104857600  # 100 MiB in bytes
+
+        with patch("runner.sys.platform", "darwin"):
+            with patch("resource.getrusage", return_value=mock_usage):
+                result = _measure_peak_rss_mib()
+
+        self.assertAlmostEqual(result, 100.0)
+
+    def test_unsupported_platform_returns_zero(self):
+        mock_usage = MagicMock()
+        mock_usage.ru_maxrss = 999999
+
+        buf = io.StringIO()
+        env_without_ci = {k: v for k, v in os.environ.items() if k != "CI"}
+        with patch("runner.sys.platform", "win32"):
+            with patch("resource.getrusage", return_value=mock_usage):
+                with patch.dict(os.environ, env_without_ci, clear=True):
+                    with patch("sys.stdout", buf):
+                        result = _measure_peak_rss_mib()
+
+        self.assertEqual(result, 0.0)
+
+    def test_unsupported_platform_logs_warning(self):
+        mock_usage = MagicMock()
+        mock_usage.ru_maxrss = 1
+
+        buf = io.StringIO()
+        env_without_ci = {k: v for k, v in os.environ.items() if k != "CI"}
+        with patch("runner.sys.platform", "win32"):
+            with patch("resource.getrusage", return_value=mock_usage):
+                with patch.dict(os.environ, env_without_ci, clear=True):
+                    with patch("sys.stdout", buf):
+                        _measure_peak_rss_mib()
+
+        self.assertIn("WARNING", buf.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR implements the benchmarking infrastructure described in issue #16537. The goal is to ensure that adding ethdebug debug-info support does not regress compilation performance when debug info is switched off.
## What's added (test/benchmarks/):

All new files live under `test/benchmarks/` and require no dependencies
beyond Python stdlib and the `solc` binary.

| File | Purpose |
|---|---|
| `contract_generator.py` | Generates synthetic Solidity contracts across 5 stress categories, parameterised by `size` |
| `runner.py` | Invokes `solc`, measures wall-clock time and peak RSS, supports legacy/IR pipelines and ethdebug on/off |
| `reporter.py` | Computes median/mean/variance, outputs JSON reports and Markdown regression comparison tables |
| `run.py` | Single entry point; always exits 0 for CI artifact upload compatibility |
| `real-world/README.md` | Documents how to extract standard-JSON inputs from real-world projects |
| `test_*.py` | 203 unit tests |

### Stress categories

- `deep-nesting` — nested structs and mappings; exercises type checker and ABI encoder
- `wide-contract` — many state variables and public functions; exercises symbol table and dispatch
- `heavy-abi` — complex tuple/array parameters; exercises ABI encoding/decoding
- `complex-control-flow` — nested conditionals, loops, internal calls; exercises CFG builder and optimizer
- `heavy-storage` — mapping-of-mapping and dynamic arrays of structs; exercises storage layout

### Measurement approach

Each case runs one silent warmup invocation followed by `--repeats` timed
invocations. Wall-clock time is measured with `time.perf_counter()` and
peak RSS with `resource.getrusage(RUSAGE_CHILDREN)`. Every case runs in
both `debug_info_mode=off` (with `--optimize`) and `debug_info_mode=on`
(with `--debug-info ethdebug --experimental`), across both `legacy` and
`ir` pipelines.

The reporter highlights any `debug_info_mode=off` case that regresses more
than 5% in time or RSS relative to a baseline with a ⚠ marker, and
includes a dedicated section showing the overhead of enabling ethdebug.

## Usage

```bash
# Run synthetic suite
python test/benchmarks/run.py --solc build/solc/solc --suite synthetic

# Run all benchmarks, save report, compare against baseline
python test/benchmarks/run.py \
  --solc build/solc/solc \
  --suite all \
  --repeats 5 \
  --output report.json \
  --baseline previous.json

# Compare two existing reports
python test/benchmarks/reporter.py baseline.json current.json

# Run tests
python3 -m pytest test/benchmarks/
```
## Example output

```
case_id                          pipeline  debug_info_mode  median_time_s  median_rss_mib  samples
-------------------------------  --------  ---------------  -------------  --------------  -------
deep-nesting-legacy-off          legacy    off              0.08           18              3
deep-nesting-legacy-on           legacy    on               0.02           18              3
complex-control-flow-ir-off      ir        off              0.43           34              3
complex-control-flow-ir-on       ir        on               0.11           34              3
heavy-storage-ir-off             ir        off              0.40           34              3
heavy-storage-ir-on              ir        on               0.18           34              3
```

## Not included (Part 2)

CI job configuration and real-world standard-JSON inputs depend on the
dedicated machine being provisioned in argotorg/tofu#28. The runner
already supports real-world inputs via `--suite real-world` once `.json`
files are placed in `test/benchmarks/real-world/`.
