### PR TITLE
SMT checker: Fix pop() assertion to match push/pop frame stack.

### DIFF
--- a/libsmtutil/SMTLib2Interface.cpp
+++ b/libsmtutil/SMTLib2Interface.cpp
@@ -240,7 +240,7 @@ void SMTLib2Commands::push() {
 }
 
 void SMTLib2Commands::pop() {
-	smtAssert(!m_commands.empty());
+	smtAssert(!m_frameLimits.empty());
 	auto limit = m_frameLimits.back();
 	m_frameLimits.pop_back();
 	while (m_commands.size() > limit)


### PR DESCRIPTION
<!--
Thank you for your contribution to the Solidity compiler! A team member will follow up shortly.

If you have any questions or need our help, feel free to post them in the PR or talk to us directly on the
[#solidity-dev](https://matrix.to/#/#ethereum_solidity-dev:gitter.im) channel on Matrix.
-->

## Description

<!-- Describe the purpose of this PR. -->
push() bookmarks the active command deque size in m_frameLimits; pop() must restore trailing commands relative to that limit. Checking m_commands.empty() could fail right after opening a stack frame during which nothing was asserted yet—the deque can legitimately remain empty across push/pop boundaries. Replace the guard with a non-empty m_frameLimits check instead so stray pop calls are still diagnosed without blocking valid checker sessions.

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
<!--
See our contributing guidelines for the full AI usage policy:
https://docs.soliditylang.org/en/latest/contributing.html#ai-assisted-contributions

If you used AI tools in any part of this PR you MUST disclose it below.
-->

- [x] No AI tools were used
- [x] AI tools were used (details below)

<!-- If AI tools were used, describe which tools and for which parts here. -->
