### PR TITLE
NatSpec: Disallow `@return` tag on events.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@ Language Features:
 Compiler Features:
 
 Bugfixes:
-* NatSpec: Disallow ``@return`` tags on event documentation; events do not have return parameters (consistent with errors).
+* NatSpec: Disallow `@return` tag in event documentation.
 
 
 ### 0.8.35 (2026-04-29)

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ Language Features:
 Compiler Features:
 
 Bugfixes:
+* NatSpec: Disallow ``@return`` tags on event documentation; events do not have return parameters (consistent with errors).
 
 
 ### 0.8.35 (2026-04-29)

--- a/libsolidity/analysis/DocStringTagParser.cpp
+++ b/libsolidity/analysis/DocStringTagParser.cpp
@@ -285,7 +285,7 @@ void DocStringTagParser::handleCallable(
 	StructurallyDocumentedAnnotation& _annotation
 )
 {
-	static std::set<std::string> const validEventTags = std::set<std::string>{"dev", "notice", "return", "param"};
+	static std::set<std::string> const validEventTags = std::set<std::string>{"dev", "notice", "param"};
 	static std::set<std::string> const validErrorTags = std::set<std::string>{"dev", "notice", "param"};
 	static std::set<std::string> const validModifierTags = std::set<std::string>{"dev", "notice", "param", "inheritdoc"};
 	static std::set<std::string> const validTags = std::set<std::string>{"dev", "notice", "return", "param", "inheritdoc"};

--- a/test/libsolidity/natspecJSON/invalid/docstring_event_return.sol
+++ b/test/libsolidity/natspecJSON/invalid/docstring_event_return.sol
@@ -1,0 +1,6 @@
+contract C {
+	/// @return foo
+	event E(uint x);
+}
+// ----
+// DocstringParsingError 6546: (14-29): Documentation tag @return not valid for events.

--- a/test/libsolidity/natspecJSON/invalid/docstring_event_return_inheritance.sol
+++ b/test/libsolidity/natspecJSON/invalid/docstring_event_return_inheritance.sol
@@ -1,0 +1,10 @@
+interface I {
+	event E(uint x);
+}
+contract C is I {
+	/// @return bar
+	event E(uint x);
+}
+// ----
+// DocstringParsingError 6546: (53-68): Documentation tag @return not valid for events.
+// DeclarationError 5883: (70-86): Event with same name and parameter types defined twice.


### PR DESCRIPTION
<!--
Thank you for your contribution to the Solidity compiler! A team member will follow up shortly.

If you have any questions or need our help, feel free to post them in the PR or talk to us directly on the
[#solidity-dev](https://matrix.to/#/#ethereum_solidity-dev:gitter.im) channel on Matrix.
-->

## Description

<!-- Describe the purpose of this PR. -->
Ethereum events do not declare return parameters, unlike functions. The event branch of callable documentation incorrectly accepted the same tag set as functions, allowing misleading `@return` markup. Restrict event validation to `dev`, `notice`, and `param`, consistent with errors.

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
<!--
See our contributing guidelines for the full AI usage policy:
https://docs.soliditylang.org/en/latest/contributing.html#ai-assisted-contributions

If you used AI tools in any part of this PR you MUST disclose it below.
-->

- [x] No AI tools were used
- [x] AI tools were used (details below)

<!-- If AI tools were used, describe which tools and for which parts here. -->
