### PR TITLE
NatSpec: Restrict @param validation to input parameters.

### DIFF
--- a/libsolidity/analysis/DocStringTagParser.cpp
+++ b/libsolidity/analysis/DocStringTagParser.cpp
@@ -253,9 +253,6 @@ void DocStringTagParser::checkParameters(
 	std::set<std::string> validParams;
 	for (auto const& p: _callable.parameters())
 		validParams.insert(p->name());
-	if (_callable.returnParameterList())
-		for (auto const& p: _callable.returnParameterList()->parameters())
-			validParams.insert(p->name());
 	auto paramRange = _annotation.docTags.equal_range("param");
 	for (auto i = paramRange.first; i != paramRange.second; ++i)
 		if (!validParams.count(i->second.paramName))


### PR DESCRIPTION
<!--
Thank you for your contribution to the Solidity compiler! A team member will follow up shortly.

If you have any questions or need our help, feel free to post them in the PR or talk to us directly on the
[#solidity-dev](https://matrix.to/#/#ethereum_solidity-dev:gitter.im) channel on Matrix.
-->

## Description

<!-- Describe the purpose of this PR. -->

Named return bindings are surfaced through @return documentation, whereas @param historically also accepted those identifiers and blurred the distinction. By mirroring downstream NatSpec tooling expectations, exclude return parameter names when checking DocString @param tags so only inbound arguments count as documented parameters rather than permitting duplicate coverage paths.

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
<!--
See our contributing guidelines for the full AI usage policy:
https://docs.soliditylang.org/en/latest/contributing.html#ai-assisted-contributions

If you used AI tools in any part of this PR you MUST disclose it below.
-->

- [x] No AI tools were used
- [x] AI tools were used (details below)

<!-- If AI tools were used, describe which tools and for which parts here. -->
