### PR TITLE
libsolutil: speed up picosha2::hash256_one_by_one::process

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 Language Features:
 
 Compiler Features:
-* General: Speed up SHA-256 hashing (`picosha2`) by avoiding per-byte `vector::push_back` when consuming input.
+* General: Speed up SHA-256 hashing (`picosha2`).
 
 Bugfixes:
 * NatSpec: Disallow `@return` tag in event documentation.

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Language Features:
 
 Compiler Features:
+* General: Speed up SHA-256 hashing (`picosha2`) by avoiding per-byte `vector::push_back` when consuming input.
 
 Bugfixes:
 * NatSpec: Disallow `@return` tag in event documentation.

--- a/libsolutil/picosha2.h
+++ b/libsolutil/picosha2.h
@@ -193,7 +193,7 @@ class hash256_one_by_one {
     template <typename RaIter>
     void process(RaIter first, RaIter last) {
         add_to_data_length(static_cast<word_t>(std::distance(first, last)));
-        std::copy(first, last, std::back_inserter(buffer_));
+        buffer_.insert(buffer_.end(), first, last);
         std::size_t i = 0;
         for (; i + 64 <= buffer_.size(); i += 64) {
             detail::hash256_block(h_, buffer_.begin() + long(i),


### PR DESCRIPTION
## Description

`picosha2::hash256_one_by_one::process` currently appends its input to the internal buffer via:

```cpp
std::copy(first, last, std::back_inserter(buffer_));
```

For random-access iterators (which is how this template is used) that is equivalent to:

```cpp
buffer_.insert(buffer_.end(), first, last);
```

but expressed as O(N) individual `push_back` calls, each going through the vector capacity check and (in debug/ASan builds) container annotation. The `insert` form computes the distance once, resizes once, and bulk-copies the range.

This is a behavior-preserving change. Existing SHA-256 tests cover the path.

## Checklist

- [x] Code compiles correctly.
- [x] All tests pass.
- [x] New code is covered by tests (no behavior change).
- [x] Documentation is up to date.
- [x] Changelog entry added.