### PR TITLE
SSA: Update assumptions made by CodeTransform about stack layouts

### DIFF
--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -359,6 +359,11 @@ void CodeTransform::operator()(SSACFG::BlockId const& _currentBlock, SSACFG::Bas
 	}
 	{
 		yulAssert(m_stackLayout[_conditionalJump.nonZero]);
+		// transform stack to a state in which we can jump to the nonZero branch
+		prepareBlockExitStack(
+			m_stackLayout[_conditionalJump.nonZero]->stackIn,
+			PhiInverse(m_cfg, _currentBlock, _conditionalJump.nonZero)
+		);
 		assertLayoutCompatibility(m_stack.data(), m_stackLayout[_conditionalJump.nonZero]->stackIn);
 
 		m_assembly.setStackHeight(static_cast<int>(m_stack.size()));

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -312,9 +312,6 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 				}
 
 				yulAssert(!stack.empty() && stack.top().isValue() && stack.top().value() == _cJump.condition);
-				yulAssert(ranges::none_of(m_cfg.block(_cJump.nonZero).instructions, [this](InstId const _id) {
-					return m_cfg.isPhi(_id);
-				}));
 
 				// exitIn = pre-JUMPI state (condition on top) for CodeTransform
 				blockLayout.exitIn = currentStackData;


### PR DESCRIPTION
Code transform has still been assuming that non-zero successor of a conditional jump does not have any other predecessor. It has been assuming that no modification was needed when moving from the out layout of the predecessor to the in layout of the non-zero successor. This assumption does not necessarily hold when non-zero successor can have other predecessors.

We have dropped the assumption about single predecessor of a non-zero successor elsewhere. As we want to enable trasformations that will not uphold this assumption, we should update the code transformation as well. The fix is to ensure the stack is updated, if necessary, when moving from the predecessor to the non-zero successor. We already do the same in case of the zero successor.

In addition, we also drop an assertion in StackLayoutGenerator that non-zero successor has no phi instructions. This is not an invariant of the CFG we want to maintain.
