### PR TITLE
Fix segfault when emiting warning for empty contracts with custom layout near the end of storage

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@ Compiler Features:
 
 Bugfixes:
 * Constant Evaluator: Fix ICE when evaluating `erc7201` builtin with wrong number of arguments.
+* Custom Storage Layout: Fix segfault when emitting the "too close to end of storage" warning for contracts with no storage variables.
 * NatSpec: Disallow `@return` tag in event documentation.
 * SMTChecker: Fix incorrect handling of constant operands of unary operations.
 * Standard JSON Interface: Fix incorrect serialization of `optimizer.runs` setting for values in the interval [INT64_MAX, UINT64_MAX].

--- a/libsolidity/analysis/PostTypeContractLevelChecker.cpp
+++ b/libsolidity/analysis/PostTypeContractLevelChecker.cpp
@@ -30,7 +30,6 @@
 #include <libsolutil/FunctionSelector.h>
 #include <liblangutil/ErrorReporter.h>
 
-#include <range/v3/action/reverse.hpp>
 #include <range/v3/view/reverse.hpp>
 
 #include <limits>
@@ -211,10 +210,17 @@ namespace
 
 VariableDeclaration const* findLastStorageVariable(ContractDefinition const& _contract)
 {
-	for (ContractDefinition const* baseContract: ranges::views::reverse(_contract.annotation().linearizedBaseContracts))
-		for (VariableDeclaration const* stateVariable: ranges::actions::reverse(baseContract->stateVariables()))
-			if (stateVariable->referenceLocation() == VariableDeclaration::Location::Unspecified)
+	for (ContractDefinition const* baseContract: _contract.annotation().linearizedBaseContracts)
+	{
+		auto const stateVariables = baseContract->stateVariables();
+		for (VariableDeclaration const* stateVariable: stateVariables | ranges::views::reverse)
+			if (
+				stateVariable->referenceLocation() == VariableDeclaration::Location::Unspecified &&
+				!stateVariable->isConstant() &&
+				!stateVariable->immutable()
+			)
 				return stateVariable;
+	}
 
 	return nullptr;
 }

--- a/test/cmdlineTests/storage_layout_specifier_with_inheritance/err
+++ b/test/cmdlineTests/storage_layout_specifier_with_inheritance/err
@@ -4,7 +4,7 @@ Warning: This contract is very close to the end of storage. This limits its futu
 6 | contract C is B layout at 2**256 - 2**40 { uint z; }
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^
 Note: There are 0xffFFFFfffc storage slots between this state variable and the end of storage.
- --> <stdin>:4:14:
+ --> <stdin>:6:44:
   |
-4 | contract A { uint x; }
-  |              ^^^^^^
+6 | contract C is B layout at 2**256 - 2**40 { uint z; }
+  |                                            ^^^^^^

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/no_variables_contract_near_storage_end.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/no_variables_contract_near_storage_end.sol
@@ -1,0 +1,3 @@
+contract C layout at 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF {}
+// ----
+// Warning 3495: (11-87): This contract is very close to the end of storage. This limits its future upgradability.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/no_variables_contract_near_storage_end_multibase.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/no_variables_contract_near_storage_end_multibase.sol
@@ -1,0 +1,6 @@
+contract A {}
+contract B is A {}
+contract C {}
+contract D is A, C layout at 2**256 - 2**64 {}
+// ----
+// Warning 3495: (66-90): This contract is very close to the end of storage. This limits its future upgradability.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/warning_near_the_storage_end.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/warning_near_the_storage_end.sol
@@ -1,8 +1,13 @@
 contract A layout at 2**256 - 2**64 {}
-contract C layout at 2**256 - 2**65 {
-    uint[2**63] x;
-    uint[2**63] y;
+
+contract B {
+    uint baseVar;
+}
+contract C is B layout at 2**256 - 3 {
+    uint x;
+    uint constant CONST_VAR = 2;
+    int immutable immutableVar = 3;
 }
 // ----
 // Warning 3495: (11-35): This contract is very close to the end of storage. This limits its future upgradability.
-// Warning 3495: (50-74): This contract is very close to the end of storage. This limits its future upgradability.
+// Warning 3495: (89-109): This contract is very close to the end of storage. This limits its future upgradability.


### PR DESCRIPTION
Fix #16681.
Fix #16678.
Fix #16784.