### PR TITLE
Improve evmasm block deduplicator performance

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Language Features:
 
 Compiler Features:
+* EVM-ASM Optimizer: Improve performance of block deduplicator.
 * SMTChecker: Emit a deprecation warning for the BMC engine.
 
 Bugfixes:

--- a/libevmasm/AssemblyItem.h
+++ b/libevmasm/AssemblyItem.h
@@ -30,9 +30,13 @@
 #include <libsolutil/Common.h>
 #include <libsolutil/Numeric.h>
 #include <libsolutil/Assertions.h>
+
+#include <boost/container_hash/hash.hpp>
+
 #include <optional>
 #include <iostream>
 #include <sstream>
+#include <type_traits>
 
 namespace solidity::evmasm
 {
@@ -158,6 +162,19 @@ public:
 			return data() == _other.data();
 	}
 	bool operator!=(AssemblyItem const& _other) const { return !operator==(_other); }
+	/// Hash function compatible with `operator==`. Found via ADL by `boost::hash`.
+	friend std::size_t hash_value(AssemblyItem const& _item)
+	{
+		std::size_t hash = 0;
+		boost::hash_combine(hash, static_cast<std::underlying_type_t<AssemblyItemType>>(_item.m_type));
+		if (_item.m_type == Operation)
+			boost::hash_combine(hash, static_cast<std::underlying_type_t<Instruction>>(_item.instruction()));
+		else if (_item.m_type == VerbatimBytecode)
+			boost::hash_combine(hash, *_item.m_verbatimBytecode);
+		else
+			boost::hash_combine(hash, _item.data());
+		return hash;
+	}
 	/// Less-than operator compatible with operator==.
 	bool operator<(AssemblyItem const& _other) const
 	{

--- a/libevmasm/BlockDeduplicator.cpp
+++ b/libevmasm/BlockDeduplicator.cpp
@@ -27,6 +27,8 @@
 #include <libevmasm/AssemblyItem.h>
 #include <libevmasm/SemanticInformation.h>
 
+#include <range/v3/algorithm/any_of.hpp>
+
 #include <functional>
 #include <set>
 
@@ -39,14 +41,14 @@ bool BlockDeduplicator::deduplicate()
 	// Compares indices based on the suffix that starts there, ignoring tags and stopping at
 	// opcodes that stop the control flow.
 
-	// Virtual tag that signifies "the current block" and which is used to optimise loops.
+	// Virtual tag that signifies "the current block" and which is used to optimize loops.
 	// We abort if this virtual tag actually exists.
-	AssemblyItem pushSelf{PushTag, u256(-4)};
-	if (
-		std::count(m_items.cbegin(), m_items.cend(), pushSelf.tag()) ||
-		std::count(m_items.cbegin(), m_items.cend(), pushSelf.pushTag())
-	)
-		return false;
+	AssemblyItem const pushSelf{PushTag, u256(-4)};
+	{
+		AssemblyItem const selfTag = pushSelf.tag();
+		if (ranges::any_of(m_items, [&](AssemblyItem const& _item) { return _item == selfTag || _item == pushSelf; }))
+			return false;
+	}
 
 	std::function<bool(size_t, size_t)> comparator = [&](size_t _i, size_t _j)
 	{

--- a/libevmasm/BlockDeduplicator.cpp
+++ b/libevmasm/BlockDeduplicator.cpp
@@ -27,10 +27,12 @@
 #include <libevmasm/AssemblyItem.h>
 #include <libevmasm/SemanticInformation.h>
 
-#include <range/v3/algorithm/any_of.hpp>
+#include <boost/container_hash/hash.hpp>
 
-#include <functional>
-#include <set>
+#include <range/v3/algorithm/any_of.hpp>
+#include <range/v3/algorithm/equal.hpp>
+
+#include <unordered_set>
 
 using namespace solidity;
 using namespace solidity::evmasm;
@@ -38,8 +40,10 @@ using namespace solidity::evmasm;
 
 bool BlockDeduplicator::deduplicate()
 {
-	// Compares indices based on the suffix that starts there, ignoring tags and stopping at
-	// opcodes that stop the control flow.
+	// Group basic blocks by a content hash and dedup within each bucket.
+	// The hash and equality both walk a BlockIterator that ignores tags and stops at
+	// opcodes that terminate control flow, replacing the block's own self-push by a
+	// virtual tag so that recursive loops match.
 
 	// Virtual tag that signifies "the current block" and which is used to optimize loops.
 	// We abort if this virtual tag actually exists.
@@ -50,48 +54,45 @@ bool BlockDeduplicator::deduplicate()
 			return false;
 	}
 
-	std::function<bool(size_t, size_t)> comparator = [&](size_t _i, size_t _j)
+	BlockIterator const end{m_items.end(), m_items.end()};
+
+	// yields a block iterator into the body of a block (skips `Tag` typed assembly items at `_blockBegin`)
+	auto const blockBodyBegin = [&](std::size_t const _blockBegin, AssemblyItem const& _selfTagPush)
 	{
-		if (_i == _j)
-			return false;
-
-		// To compare recursive loops, we have to already unify PushTag opcodes of the
-		// block's own tag.
-		AssemblyItem pushFirstTag{pushSelf};
-		AssemblyItem pushSecondTag{pushSelf};
-
-		if (_i < m_items.size() && m_items.at(_i).type() == Tag)
-			pushFirstTag = m_items.at(_i).pushTag();
-		if (_j < m_items.size() && m_items.at(_j).type() == Tag)
-			pushSecondTag = m_items.at(_j).pushTag();
-
-		using diff_type = BlockIterator::difference_type;
-		BlockIterator first{m_items.begin() + diff_type(_i), m_items.end(), &pushFirstTag, &pushSelf};
-		BlockIterator second{m_items.begin() + diff_type(_j), m_items.end(), &pushSecondTag, &pushSelf};
-		BlockIterator end{m_items.end(), m_items.end()};
-
-		if (first != end && (*first).type() == Tag)
-			++first;
-		if (second != end && (*second).type() == Tag)
-			++second;
-
-		return std::lexicographical_compare(first, end, second, end);
+		BlockIterator it{
+			m_items.begin() + static_cast<BlockIterator::difference_type>(_blockBegin),
+			m_items.end(),
+			&_selfTagPush,
+			&pushSelf
+		};
+		if (it != end && (*it).type() == Tag)
+			++it;
+		return it;
 	};
 
-	size_t iterations = 0;
+	auto const hashBlockAt = [&](std::size_t const _i)
+	{
+		return boost::hash_range(blockBodyBegin(_i, m_items[_i].pushTag()), end);
+	};
+	auto const blocksAtEqual = [&](std::size_t const _i, std::size_t const _j)
+	{
+		return ranges::equal(
+			blockBodyBegin(_i, m_items[_i].pushTag()), end,
+			blockBodyBegin(_j, m_items[_j].pushTag()), end
+		);
+	};
+
+	std::size_t iterations = 0;
 	for (; ; ++iterations)
 	{
-		//@todo this should probably be optimized.
-		std::set<size_t, std::function<bool(size_t, size_t)>> blocksSeen(comparator);
-		for (size_t i = 0; i < m_items.size(); ++i)
+		std::unordered_set<std::size_t, decltype(hashBlockAt), decltype(blocksAtEqual)> seen(0, hashBlockAt, blocksAtEqual);
+		for (std::size_t i = 0; i < m_items.size(); ++i)
 		{
-			if (m_items.at(i).type() != Tag)
+			if (m_items[i].type() != Tag)
 				continue;
-			auto it = blocksSeen.find(i);
-			if (it == blocksSeen.end())
-				blocksSeen.insert(i);
-			else
-				m_replacedTags[m_items.at(i).data()] = m_items.at(*it).data();
+			auto const [it, inserted] = seen.insert(i);
+			if (!inserted)
+				m_replacedTags[m_items[i].data()] = m_items[*it].data();
 		}
 
 		if (!applyTagReplacement(m_items, m_replacedTags))

--- a/libevmasm/BlockDeduplicator.h
+++ b/libevmasm/BlockDeduplicator.h
@@ -75,6 +75,7 @@ private:
 		using difference_type = std::ptrdiff_t;
 		using pointer = AssemblyItem const*;
 		using reference = AssemblyItem const&;
+		BlockIterator() = default;
 		BlockIterator(
 			AssemblyItems::const_iterator _it,
 			AssemblyItems::const_iterator _end,
@@ -83,13 +84,14 @@ private:
 		):
 			it(_it), end(_end), replaceItem(_replaceItem), replaceWith(_replaceWith) {}
 		BlockIterator& operator++();
+		BlockIterator operator++(int) { auto tmp = *this; ++*this; return tmp; }
 		bool operator==(BlockIterator const& _other) const { return it == _other.it; }
 		bool operator!=(BlockIterator const& _other) const { return it != _other.it; }
 		AssemblyItem const& operator*() const;
 		AssemblyItems::const_iterator it;
 		AssemblyItems::const_iterator end;
-		AssemblyItem const* replaceItem;
-		AssemblyItem const* replaceWith;
+		AssemblyItem const* replaceItem = nullptr;
+		AssemblyItem const* replaceWith = nullptr;
 	};
 
 	std::map<u256, u256> m_replacedTags;

--- a/libevmasm/CMakeLists.txt
+++ b/libevmasm/CMakeLists.txt
@@ -48,4 +48,4 @@ set(sources
 )
 
 add_library(evmasm ${sources})
-target_link_libraries(evmasm PUBLIC solutil fmt::fmt-header-only)
+target_link_libraries(evmasm PUBLIC solutil langutil fmt::fmt-header-only)

--- a/test/fuzztest/CMakeLists.txt
+++ b/test/fuzztest/CMakeLists.txt
@@ -38,7 +38,16 @@ add_executable(yul_fuzztest ${yul_fuzztest_sources})
 target_link_libraries(yul_fuzztest PRIVATE yul)
 link_fuzztest(yul_fuzztest)
 
+set(evmasm_fuzztest_sources
+	libevmasm/BlockDeduplicatorPropertyTest.cpp
+)
+detect_stray_source_files("${evmasm_fuzztest_sources}" "libevmasm/")
+
+add_executable(evmasm_fuzztest ${evmasm_fuzztest_sources})
+target_link_libraries(evmasm_fuzztest PRIVATE evmasm)
+link_fuzztest(evmasm_fuzztest)
+
 # Convenience target to build all per-library property-test executables at once (e.g. in CI).
 # New <lib>_fuzztest targets should add themselves here.
 add_custom_target(property_tests)
-add_dependencies(property_tests yul_fuzztest)
+add_dependencies(property_tests yul_fuzztest evmasm_fuzztest)

--- a/test/fuzztest/libevmasm/BlockDeduplicatorPropertyTest.cpp
+++ b/test/fuzztest/libevmasm/BlockDeduplicatorPropertyTest.cpp
@@ -1,0 +1,411 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+/**
+ * Property test for the evmasm BlockDeduplicator.
+ *
+ * For a random program of tagged blocks, executing the original and the deduplicated items must produce the same
+ * observable outcome, meaning the same result state when interpreting through the items including the state of the
+ * stack modulo jump tag values (which can change due to deduplication).
+ */
+
+#include <libevmasm/AssemblyItem.h>
+#include <libevmasm/BlockDeduplicator.h>
+#include <libevmasm/Instruction.h>
+
+#include <fuzztest/fuzztest.h>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <map>
+#include <ostream>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+using namespace solidity;
+using namespace solidity::evmasm;
+
+namespace solidity::evmasm::test
+{
+
+namespace
+{
+
+std::size_t constexpr maxBlocks = 6;
+std::size_t constexpr maxBodyLength = 8;
+std::size_t constexpr stepLimit = 1000;
+
+/// Counts how often deduplication actually changed a fuzzed program and reports it once at teardown.
+class DeduplicationStats: public testing::Environment
+{
+public:
+	static void record(bool const _changed)
+	{
+		++s_total;
+		s_merged += static_cast<std::size_t>(_changed);
+	}
+
+	void TearDown() override
+	{
+		if (s_total > 0)
+			std::cout << "BlockDeduplicator changed " << s_merged << " of " << s_total << " fuzzed programs." << std::endl;
+	}
+
+private:
+	static std::size_t s_total;
+	static std::size_t s_merged;
+};
+std::size_t DeduplicationStats::s_total = 0;
+std::size_t DeduplicationStats::s_merged = 0;
+
+[[maybe_unused]] testing::Environment* const g_deduplicationStats = testing::AddGlobalTestEnvironment(new DeduplicationStats);
+
+/// Item of the symbolic representation of the symbolic stack
+struct StackValue
+{
+	u256 data;
+	bool isTag = false;  // indicates whether the stack value corresponds to a PushTag item
+};
+
+enum class HaltReason
+{
+	Stop,
+	Return,
+	Revert,
+	Failure,
+	UndefinedTagUse,  // tag value used as anything but a jump destination (or via DUP/SWAP/POP)
+	StepLimit  // execution did not halt within stepLimit steps
+};
+
+struct ExecutionOutcome
+{
+	std::vector<StackValue> stack;
+	std::map<u256, u256> memory;
+	std::size_t steps = 0;
+	HaltReason reason = HaltReason::Stop;
+	std::vector<u256> haltArgs;  // offset and size popped by RETURN/REVERT
+};
+
+std::ostream& operator<<(std::ostream& _out, ExecutionOutcome const& _outcome)
+{
+	_out << "reason=" << static_cast<int>(_outcome.reason) << " steps=" << _outcome.steps << " haltArgs=[";
+	for (u256 const& arg: _outcome.haltArgs)
+		_out << " " << arg;
+	_out << " ] memory={";
+	for (auto const& [offset, value]: _outcome.memory)
+		_out << " " << offset << ":" << value;
+	_out << " } stack=[";
+	for (StackValue const& slot: _outcome.stack)
+		if (slot.isTag)
+			_out << " tag:" << slot.data;
+		else
+			_out << " " << slot.data;
+	return _out << " ]";
+}
+
+ExecutionOutcome execute(AssemblyItems const& _items)
+{
+	std::map<u256, std::size_t> tagPositions;
+	for (std::size_t i = 0; i < _items.size(); ++i)
+		if (_items[i].type() == Tag)
+			tagPositions.emplace(_items[i].data(), i);
+
+	std::vector<StackValue> stack;
+	std::map<u256, u256> memory;
+	std::size_t steps = 0;
+
+	auto const pop = [&]() {
+		StackValue const value = stack.back();
+		stack.pop_back();
+		return value;
+	};
+
+	std::size_t pc = 0;
+	while (true)
+	{
+		if (pc >= _items.size())
+			return {.stack = stack, .memory = memory, .steps = steps, .reason = HaltReason::Stop};  // running past the last item is an implicit STOP
+		AssemblyItem const& item = _items[pc++];
+		if (item.type() == Tag)
+			continue;
+		if (++steps > stepLimit)
+			return {.reason = HaltReason::StepLimit};
+
+		if (item.type() == Push)
+		{
+			stack.push_back({item.data(), false});
+			continue;
+		}
+		if (item.type() == PushTag)
+		{
+			stack.push_back({item.data(), true});
+			continue;
+		}
+		if (item.type() != Operation)
+			return {.reason = HaltReason::Failure};
+
+		Instruction const instruction = item.instruction();
+		if (Instruction::DUP1 <= instruction && instruction <= Instruction::DUP16)
+		{
+			std::size_t const depth = static_cast<std::size_t>(instruction) - static_cast<std::size_t>(Instruction::DUP1) + 1;
+			if (stack.size() < depth)
+				return {.reason = HaltReason::Failure};
+			stack.push_back(stack[stack.size() - depth]);
+			continue;
+		}
+		if (Instruction::SWAP1 <= instruction && instruction <= Instruction::SWAP16)
+		{
+			std::size_t const depth = static_cast<std::size_t>(instruction) - static_cast<std::size_t>(Instruction::SWAP1) + 1;
+			if (stack.size() < depth + 1)
+				return {.reason = HaltReason::Failure};
+			std::swap(stack.back(), stack[stack.size() - depth - 1]);
+			continue;
+		}
+
+		switch (instruction)
+		{
+		case Instruction::STOP:
+			return {.stack = stack, .memory = memory, .steps = steps, .reason = HaltReason::Stop};
+		case Instruction::ADD:
+		{
+			if (stack.size() < 2)
+				return {.reason = HaltReason::Failure};
+			StackValue const a = pop();
+			StackValue const b = pop();
+			if (a.isTag || b.isTag)
+				return {.reason = HaltReason::UndefinedTagUse};
+			stack.push_back({a.data + b.data, false});
+			break;
+		}
+		case Instruction::POP:
+			if (stack.empty())
+				return {.reason = HaltReason::Failure};
+			pop();
+			break;
+		case Instruction::MLOAD:
+		{
+			if (stack.empty())
+				return {.reason = HaltReason::Failure};
+			StackValue const offset = pop();
+			if (offset.isTag)
+				return {.reason = HaltReason::UndefinedTagUse};
+			auto const cell = memory.find(offset.data);
+			stack.push_back({.data = cell == memory.end() ? u256(0) : cell->second, .isTag = false});
+			break;
+		}
+		case Instruction::MSTORE:
+		{
+			if (stack.size() < 2)
+				return {.reason = HaltReason::Failure};
+			StackValue const offset = pop();
+			StackValue const value = pop();
+			if (offset.isTag || value.isTag)
+				return {.reason = HaltReason::UndefinedTagUse};
+			memory[offset.data] = value.data;
+			break;
+		}
+		case Instruction::JUMP:
+		{
+			if (stack.empty())
+				return {.reason = HaltReason::Failure};
+			StackValue const destination = pop();
+			auto const target = destination.isTag ? tagPositions.find(destination.data) : tagPositions.end();
+			if (target == tagPositions.end())
+				return {.reason = HaltReason::Failure};
+			pc = target->second;
+			break;
+		}
+		case Instruction::JUMPI:
+		{
+			if (stack.size() < 2)
+				return {.reason = HaltReason::Failure};
+			StackValue const destination = pop();
+			StackValue const condition = pop();
+			if (condition.isTag)
+				return {.reason = HaltReason::UndefinedTagUse};
+			if (condition.data != 0)
+			{
+				auto const target = destination.isTag ? tagPositions.find(destination.data) : tagPositions.end();
+				if (target == tagPositions.end())
+					return {.reason = HaltReason::Failure};
+				pc = target->second;
+			}
+			break;
+		}
+		case Instruction::RETURN:
+		case Instruction::REVERT:
+		{
+			if (stack.size() < 2)
+				return {.reason = HaltReason::Failure};
+			StackValue const offset = pop();
+			StackValue const size = pop();
+			if (offset.isTag || size.isTag)
+				return {.reason = HaltReason::UndefinedTagUse};
+			return {
+				.stack = stack,
+				.memory = memory,
+				.steps = steps,
+				.reason = instruction == Instruction::RETURN ? HaltReason::Return : HaltReason::Revert,
+				.haltArgs = {offset.data, size.data}
+			};
+		}
+		default:
+			return {.reason = HaltReason::Failure}; // outside the modeled alphabet
+		}
+	}
+}
+
+/// Domain of single body items for a program with tags 1..._numBlocks
+fuzztest::Domain<AssemblyItem> bodyItemDomain(std::size_t const _numBlocks)
+{
+	return fuzztest::OneOf(
+		fuzztest::ElementOf<AssemblyItem>({
+			Instruction::STOP,
+			Instruction::ADD,
+			Instruction::POP,
+			Instruction::MLOAD,
+			Instruction::MSTORE,
+			Instruction::JUMP,
+			Instruction::JUMPI,
+			Instruction::DUP1,
+			Instruction::DUP2,
+			Instruction::SWAP1,
+			Instruction::RETURN,
+			Instruction::REVERT,
+		}),
+		fuzztest::Map(
+			[](std::uint64_t const _constant) { return AssemblyItem{u256(_constant)}; },
+			fuzztest::InRange<std::uint64_t>(0, 3)
+		),
+		fuzztest::Map(
+			[](std::uint64_t const _tag) { return AssemblyItem{PushTag, u256(_tag)}; },
+			fuzztest::InRange<std::uint64_t>(1, _numBlocks)
+		)
+	);
+}
+
+/// Concatenates blocks Tag(1) body_1 ... Tag(n) body_n into one item sequence.
+AssemblyItems concatenateBodies(std::vector<AssemblyItems> const& _bodies)
+{
+	AssemblyItems items;
+	for (std::size_t i = 0; i < _bodies.size(); ++i)
+	{
+		items.emplace_back(Tag, u256(i + 1));
+		items.insert(items.end(), _bodies[i].begin(), _bodies[i].end());
+	}
+	return items;
+}
+
+/// Copies one whole block body over another so that the deduplicator finds a mergeable pair
+AssemblyItems withDuplicateBlock(std::vector<AssemblyItems> _bodies, std::size_t const _source, std::size_t const _destination)
+{
+	std::size_t const sourceIndex = _source % _bodies.size();
+	std::size_t const destinationIndex = _destination % _bodies.size();
+	// terminate block to denote its end with respect to the equality operator
+	_bodies[sourceIndex].emplace_back(Instruction::STOP);
+	_bodies[destinationIndex] = _bodies[sourceIndex];
+	AssemblyItems program{AssemblyItem{PushTag, u256(std::max(sourceIndex, destinationIndex) + 1)}};
+	AssemblyItems const blocks = concatenateBodies(_bodies);
+	program.insert(program.end(), blocks.begin(), blocks.end());
+	return program;
+}
+
+fuzztest::Domain<AssemblyItems> programDomain()
+{
+	return fuzztest::FlatMap(
+		[](std::size_t const _numBlocks) {
+			auto const bodiesDomain =
+				fuzztest::VectorOf(fuzztest::VectorOf(bodyItemDomain(_numBlocks)).WithMaxSize(maxBodyLength)).WithSize(_numBlocks);
+			return fuzztest::OneOf(
+				fuzztest::Map(concatenateBodies, bodiesDomain),
+				fuzztest::Map(
+					withDuplicateBlock,
+					bodiesDomain,
+					fuzztest::InRange<std::size_t>(0, maxBlocks - 1),
+					fuzztest::InRange<std::size_t>(0, maxBlocks - 1)
+				)
+			);
+		},
+		fuzztest::InRange<std::size_t>(1, maxBlocks)
+	);
+}
+
+}
+
+static void DeduplicationPreservesBehavior(AssemblyItems const& _program)
+{
+	AssemblyItems optimized = _program;
+	bool const changed = BlockDeduplicator{optimized}.deduplicate();
+	DeduplicationStats::record(changed);
+
+	// Unchanged program implies identical items
+	if (!changed)
+		return;
+
+	ExecutionOutcome const original = execute(_program);
+	ExecutionOutcome const deduplicated = execute(optimized);
+
+	std::ostringstream context;
+	context << "program: " << _program << " original: " << original << " deduplicated: " << deduplicated;
+	SCOPED_TRACE(context.str());
+
+	ASSERT_EQ(original.reason, deduplicated.reason);
+	ASSERT_EQ(original.haltArgs, deduplicated.haltArgs);
+	ASSERT_EQ(original.memory, deduplicated.memory);
+	ASSERT_EQ(original.steps, deduplicated.steps);
+
+	// The stacks are compared modulo tag identity as deduplication redirects tags
+	ASSERT_EQ(original.stack.size(), deduplicated.stack.size());
+	for (std::size_t i = 0; i < original.stack.size(); ++i)
+	{
+		ASSERT_EQ(original.stack[i].isTag, deduplicated.stack[i].isTag) << "stack slot " << i;
+		if (!original.stack[i].isTag)
+			ASSERT_EQ(original.stack[i].data, deduplicated.stack[i].data) << "stack slot " << i;
+	}
+}
+
+FUZZ_TEST(BlockDeduplicatorProperty, DeduplicationPreservesBehavior).WithDomains(programDomain());
+
+static void DeduplicationInvariants(AssemblyItems const& _program)
+{
+	AssemblyItems optimized = _program;
+	bool const changed = BlockDeduplicator{optimized}.deduplicate();
+
+	// deduplicate() reports a change iff the items actually changed.
+	ASSERT_EQ(changed, optimized != _program);
+
+	// Deduplication only redirects PushTags; it never adds, removes or otherwise alters items.
+	ASSERT_EQ(optimized.size(), _program.size());
+	for (std::size_t i = 0; i < optimized.size(); ++i)
+		if (_program[i].type() == PushTag)
+			ASSERT_EQ(optimized[i].type(), PushTag);
+		else
+			ASSERT_EQ(optimized[i], _program[i]);
+
+	// Immediate fixed point: a second run finds nothing left to do.
+	AssemblyItems rerun = optimized;
+	ASSERT_FALSE(BlockDeduplicator{rerun}.deduplicate()) << "second run changed: " << optimized;
+	ASSERT_EQ(rerun, optimized);
+}
+
+FUZZ_TEST(BlockDeduplicatorProperty, DeduplicationInvariants).WithDomains(programDomain());
+
+}

--- a/test/fuzztest/libevmasm/BlockDeduplicatorPropertyTest.cpp
+++ b/test/fuzztest/libevmasm/BlockDeduplicatorPropertyTest.cpp
@@ -27,15 +27,20 @@
 #include <libevmasm/AssemblyItem.h>
 #include <libevmasm/BlockDeduplicator.h>
 #include <libevmasm/Instruction.h>
+#include <libevmasm/SemanticInformation.h>
 
 #include <fuzztest/fuzztest.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <iostream>
+#include <iterator>
 #include <map>
 #include <ostream>
+#include <set>
 #include <sstream>
 #include <utility>
 #include <vector>
@@ -348,6 +353,125 @@ fuzztest::Domain<AssemblyItems> programDomain()
 	);
 }
 
+/// Reference implementation of BlockDeduplicator::deduplicate() from commit 70198f157: an ordered set with a
+/// lexicographic suffix comparator over a copy of the block iterator.
+namespace reference
+{
+
+struct BlockIterator
+{
+	using iterator_category = std::forward_iterator_tag;
+	using value_type = AssemblyItem const;
+	using difference_type = std::ptrdiff_t;
+	using pointer = AssemblyItem const*;
+	using reference = AssemblyItem const&;
+
+	BlockIterator(
+		AssemblyItems::const_iterator _it,
+		AssemblyItems::const_iterator _end,
+		AssemblyItem const* _replaceItem = nullptr,
+		AssemblyItem const* _replaceWith = nullptr
+	):
+		it(_it), end(_end), replaceItem(_replaceItem), replaceWith(_replaceWith) {}
+
+	BlockIterator& operator++()
+	{
+		if (it == end)
+			return *this;
+		if (SemanticInformation::altersControlFlow(*it) && *it != AssemblyItem{Instruction::JUMPI})
+			it = end;
+		else
+		{
+			++it;
+			while (it != end && it->type() == Tag)
+				++it;
+		}
+		return *this;
+	}
+
+	bool operator==(BlockIterator const& _other) const { return it == _other.it; }
+	bool operator!=(BlockIterator const& _other) const { return it != _other.it; }
+
+	AssemblyItem const& operator*() const
+	{
+		if (replaceItem && replaceWith && *it == *replaceItem)
+			return *replaceWith;
+		else
+			return *it;
+	}
+
+	AssemblyItems::const_iterator it;
+	AssemblyItems::const_iterator end;
+	AssemblyItem const* replaceItem = nullptr;
+	AssemblyItem const* replaceWith = nullptr;
+};
+
+bool deduplicate(AssemblyItems& _items)
+{
+	// Compares indices based on the suffix that starts there, ignoring tags and stopping at
+	// opcodes that stop the control flow.
+
+	// Virtual tag that signifies "the current block" and which is used to optimize loops.
+	// We abort if this virtual tag actually exists.
+	AssemblyItem const pushSelf{PushTag, u256(-4)};
+	if (
+		std::count(_items.cbegin(), _items.cend(), pushSelf.tag()) ||
+		std::count(_items.cbegin(), _items.cend(), pushSelf.pushTag())
+	)
+			return false;
+
+	std::function<bool(std::size_t, std::size_t)> comparator = [&](std::size_t _i, std::size_t _j)
+	{
+		if (_i == _j)
+			return false;
+
+		// To compare recursive loops, we have to already unify PushTag opcodes of the
+		// block's own tag.
+		AssemblyItem pushFirstTag{pushSelf};
+		AssemblyItem pushSecondTag{pushSelf};
+
+		if (_i < _items.size() && _items.at(_i).type() == Tag)
+			pushFirstTag = _items.at(_i).pushTag();
+		if (_j < _items.size() && _items.at(_j).type() == Tag)
+			pushSecondTag = _items.at(_j).pushTag();
+
+		using diff_type = BlockIterator::difference_type;
+		BlockIterator first{_items.begin() + static_cast<diff_type>(_i), _items.end(), &pushFirstTag, &pushSelf};
+		BlockIterator second{_items.begin() + static_cast<diff_type>(_j), _items.end(), &pushSecondTag, &pushSelf};
+		BlockIterator end{_items.end(), _items.end()};
+
+		if (first != end && (*first).type() == Tag)
+			++first;
+		if (second != end && (*second).type() == Tag)
+			++second;
+
+		return std::lexicographical_compare(first, end, second, end);
+	};
+
+	std::map<u256, u256> replacedTags;
+	std::size_t iterations = 0;
+	for (; ; ++iterations)
+	{
+		std::set<std::size_t, std::function<bool(std::size_t, std::size_t)>> blocksSeen(comparator);
+		for (std::size_t i = 0; i < _items.size(); ++i)
+		{
+			if (_items.at(i).type() != Tag)
+				continue;
+			auto it = blocksSeen.find(i);
+			if (it == blocksSeen.end())
+				blocksSeen.insert(i);
+			else
+				replacedTags[_items.at(i).data()] = _items.at(*it).data();
+		}
+
+		if (!BlockDeduplicator::applyTagReplacement(_items, replacedTags))
+			break;
+	}
+	return iterations > 0;
+}
+
+}
+
 }
 
 static void DeduplicationPreservesBehavior(AssemblyItems const& _program)
@@ -407,5 +531,19 @@ static void DeduplicationInvariants(AssemblyItems const& _program)
 }
 
 FUZZ_TEST(BlockDeduplicatorProperty, DeduplicationInvariants).WithDomains(programDomain());
+
+static void DeduplicationMatchesReference(AssemblyItems const& _program)
+{
+	AssemblyItems optimized = _program;
+	bool const changed = BlockDeduplicator{optimized}.deduplicate();
+
+	AssemblyItems referenceItems = _program;
+	bool const referenceChanged = reference::deduplicate(referenceItems);
+
+	ASSERT_EQ(changed, referenceChanged);
+	ASSERT_EQ(optimized, referenceItems);
+}
+
+FUZZ_TEST(BlockDeduplicatorProperty, DeduplicationMatchesReference).WithDomains(programDomain());
 
 }


### PR DESCRIPTION
This is mainly a refactor of the `BlockDeduplicator` and no behavior change is intended.

Right now the deduplicator uses a `std::set` with a lexicographical compare over each block's body. Looking up a block is therefore `O(block_size * log N)` per probe and each comparison walks both blocks assembly item by assembly item (worst case the entire block).

The refactor exchanges the `set` with an `unordered_set` provided a specific hash function and a specific equality function. Each block's body is hashed once via `hash_range` and equality checks use `ranges::equal` over the same range. Lookup is then `O(block_size)` amortized.

To achieve this,
- `AssemblyItem` gets a `hash_value` friend so that boost hash can load a hash via ADL
- `BlockIterator` gets default ctor and post-increment to satisfy the range concept (needed for `hash_range` and `ranges::equal`).

Some benchmarks on my machine:

- wall time decreases significantly (4.5 - 10%) for evmasm pipeline
- wall time decreases for solady (5.9%), smaller gains for OZ (1.3%), prb-math and forge-std show a slight increase but both are inside their standard deviations so this is basically noise
- peak RSS is flat so no memory blow up
- instructions drop everywhere, up to 13.6%

```
Benchmark           Pipeline  Metric          Base                             Target                           Delta  
------------------  --------  --------------  -------------------------------  -------------------------------  -------
openzeppelin-5.6.1  evmasm    cpu_time        9.39s ± 0.04s                    8.97s ± 0.05s                    -4.5%  
                              creation_size   725,287 ± 0                      725,287 ± 0                      0.0%   
                              cycles          51,143,785,884 ± 231,191,619     48,970,472,312 ± 237,550,537     -4.25% 
                              instructions    139,854,492,021 ± 2,026,342      129,273,536,861 ± 2,343,796      -7.57% 
                              peak_rss        1079 ± 1 MiB                     1079 ± 1 MiB                     -0.01% 
                              runtime_size    650,752 ± 0                      650,752 ± 0                      0.0%   
                              wall_time       9.44s ± 0.04s                    9.02s ± 0.05s                    -4.47% 
                                                                                                                       
openzeppelin-5.6.1  ir        cpu_time        27.12s ± 0.26s                   26.76s ± 0.04s                   -1.33% 
                              creation_size   675,405 ± 0                      675,405 ± 0                      0.0%   
                              cycles          149,803,686,253 ± 1,129,014,471  148,069,507,225 ± 292,395,229    -1.16% 
                              instructions    320,431,242,127 ± 940,555        313,064,278,224 ± 1,706,536      -2.3%  
                              peak_rss        1469 ± 1 MiB                     1470 ± 1 MiB                     +0.07% 
                              runtime_size    598,355 ± 0                      598,355 ± 0                      0.0%   
                              wall_time       27.23s ± 0.26s                   26.87s ± 0.03s                   -1.34% 
                                                                                                                       
solady-0.1.26       evmasm    cpu_time        13.18s ± 0.04s                   11.89s ± 0.04s                   -9.85% 
                              creation_size   1,514,791 ± 0                    1,514,791 ± 0                    0.0%   
                              cycles          71,650,496,789 ± 154,698,769     64,819,441,832 ± 261,942,806     -9.53% 
                              instructions    214,144,937,711 ± 3,539,478      184,840,171,275 ± 4,082,548      -13.68%
                              peak_rss        1828 ± 1 MiB                     1828 ± 1 MiB                     +0.04% 
                              runtime_size    1,480,154 ± 0                    1,480,154 ± 0                    0.0%   
                              wall_time       13.25s ± 0.05s                   11.95s ± 0.04s                   -9.76% 
                                                                                                                       
solady-0.1.26       ir        cpu_time        70.88s ± 0.42s                   66.68s ± 0.28s                   -5.93% 
                              creation_size   1,681,895 ± 0                    1,681,895 ± 0                    0.0%   
                              cycles          394,580,301,731 ± 2,089,906,480  371,914,985,508 ± 1,503,526,815  -5.74% 
                              instructions    781,103,461,292 ± 2,181,497      677,557,956,149 ± 2,911,948      -13.26%
                              peak_rss        2953 ± 2 MiB                     2954 ± 3 MiB                     +0.02% 
                              runtime_size    1,650,497 ± 0                    1,650,497 ± 0                    0.0%   
                              wall_time       71.13s ± 0.42s                   66.93s ± 0.28s                   -5.91% 
                                                                                                                       
prb-math-4.1.1      evmasm    cpu_time        3.05s ± 0.01s                    2.89s ± 0.02s                    -5.21% 
                              creation_size   252,039 ± 0                      252,039 ± 0                      0.0%   
                              cycles          15,873,797,368 ± 32,906,950      15,114,115,394 ± 90,515,113      -4.79% 
                              instructions    49,362,879,554 ± 98,346          45,721,290,356 ± 71,266          -7.38% 
                              peak_rss        1173 ± 1 MiB                     1173 ± 1 MiB                     +0.01% 
                              runtime_size    250,178 ± 0                      250,178 ± 0                      0.0%   
                              wall_time       3.06s ± 0.01s                    2.90s ± 0.02s                    -5.26% 
                                                                                                                       
prb-math-4.1.1      ir        cpu_time        13.45s ± 0.11s                   13.45s ± 0.02s                   +0.05% 
                              creation_size   262,432 ± 0                      262,432 ± 0                      0.0%   
                              cycles          73,887,147,790 ± 586,549,982     73,871,375,642 ± 171,688,911     -0.02% 
                              instructions    154,542,673,005 ± 321,635        152,792,570,586 ± 478,006        -1.13% 
                              peak_rss        1499 ± 1 MiB                     1492 ± 0 MiB                     -0.51% 
                              runtime_size    260,832 ± 0                      260,832 ± 0                      0.0%   
                              wall_time       13.50s ± 0.12s                   13.50s ± 0.02s                   +0.07% 
                                                                                                                       
forge-std-1.16.1    evmasm    cpu_time        4.13s ± 0.03s                    3.81s ± 0.03s                    -7.75% 
                              creation_size   394,603 ± 0                      394,603 ± 0                      0.0%   
                              cycles          22,359,589,881 ± 114,043,632     20,591,056,394 ± 151,487,100     -7.91% 
                              instructions    63,078,580,181 ± 95,694          56,220,570,242 ± 75,356          -10.87%
                              peak_rss        534 ± 1 MiB                      533 ± 2 MiB                      -0.18% 
                              runtime_size    381,729 ± 0                      381,729 ± 0                      0.0%   
                              wall_time       4.15s ± 0.03s                    3.82s ± 0.03s                    -7.75% 
                                                                                                                       
forge-std-1.16.1    ir        cpu_time        17.70s ± 0.36s                   17.79s ± 0.14s                   +0.47% 
                              creation_size   422,073 ± 0                      422,073 ± 0                      0.0%   
                              cycles          98,206,831,939 ± 1,885,776,060   98,726,395,115 ± 764,655,639     +0.53% 
                              instructions    187,717,062,052 ± 162,869        181,186,753,902 ± 568,894        -3.48% 
                              peak_rss        833 ± 1 MiB                      833 ± 0 MiB                      +0.02% 
                              runtime_size    406,750 ± 0                      406,750 ± 0                      0.0%   
                              wall_time       17.77s ± 0.36s                   17.86s ± 0.14s                   +0.49% 
```

<img width="1995" height="434" alt="plot" src="https://github.com/user-attachments/assets/a4b9e06f-024e-4437-a570-b5751044c74a" />
