### PR TITLE
SSA-CFG: Fix stack adjustments for codegen on conditional jump

### DIFF
--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -359,14 +359,13 @@ void CodeTransform::operator()(SSACFG::BlockId const& _currentBlock, SSACFG::Bas
 	}
 	{
 		yulAssert(m_stackLayout[_conditionalJump.nonZero]);
+		m_assembly.setStackHeight(static_cast<int>(m_stack.size()));
 		// transform stack to a state in which we can jump to the nonZero branch
 		prepareBlockExitStack(
 			m_stackLayout[_conditionalJump.nonZero]->stackIn,
 			PhiInverse(m_cfg, _currentBlock, _conditionalJump.nonZero)
 		);
 		assertLayoutCompatibility(m_stack.data(), m_stackLayout[_conditionalJump.nonZero]->stackIn);
-
-		m_assembly.setStackHeight(static_cast<int>(m_stack.size()));
 		if (!m_blockIsTransformed[_conditionalJump.nonZero.value])
 			(*this)(_conditionalJump.nonZero);
 	}


### PR DESCRIPTION
When running codegen on a block which ends in a conditional jump, we save the stack before we continue with zero branch and then we restore it when come back and continue with non-zero branch. Notifying the assebly about the restored stack size is part of resetting the state and needs to happen before we attempt any stack shuffling. `prepareBlockExitStack` might shuffle the stack and so assembly notification must happen before that.