### PR TITLE
SSA CFG: lift the memoryguard value out of the instruction argument into the parent ControlFlowGraphs structure

### DIFF
--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -302,6 +302,12 @@ void CodeTransform::operator()(InstId _instId, StackData const& _operationInputL
 		builtin.generateCode(transient, m_assembly, m_builtinContext);
 		break;
 	}
+	case InstOpcode::MemoryGuard:
+	{
+		yulAssert(m_controlFlow.memoryGuard.has_value());
+		m_assembly.appendConstant(*m_controlFlow.memoryGuard);
+		break;
+	}
 	default:
 		yulAssert(false);
 	}
@@ -414,16 +420,19 @@ void CodeTransform::operator()(SSACFG::BlockId const& _blockId, SSACFG::BasicBlo
 			break;
 		}
 	yulAssert(lastOpInstId.hasValue(), "Terminated block must have at least one operation.");
-	if (m_cfg.inst(lastOpInstId).opcode == InstOpcode::BuiltinCall)
+	auto const lastOpcode = m_cfg.inst(lastOpInstId).opcode;
+	if (lastOpcode == InstOpcode::BuiltinCall)
 		yulAssert(
 			m_cfg.evmDialect.builtin(m_cfg.builtinPayload(lastOpInstId).builtin).controlFlowSideEffects.terminatesOrReverts(),
 			"Last operation of Terminated block must terminate or revert."
 		);
-	else
+	else if (lastOpcode == InstOpcode::Call)
 		yulAssert(
 			!m_cfg.callPayload(lastOpInstId).canContinue,
 			"Last operation of Terminated block must be a non-continuable call."
 		);
+	else
+		yulAssert(false, "Last operation of Terminated block must be a non-continuable Call or terminating BuiltinCall.");
 	// To be sure just emit another INVALID - should be removed by optimizer.
 	m_assembly.appendInstruction(evmasm::Instruction::INVALID);
 }

--- a/libyul/backends/evm/ssa/ControlFlowGraphs.h
+++ b/libyul/backends/evm/ssa/ControlFlowGraphs.h
@@ -21,7 +21,9 @@
 #include <libyul/backends/evm/ssa/LivenessAnalysis.h>
 #include <libyul/backends/evm/ssa/SSACFG.h>
 
-#include <libyul/AST.h>
+#include <libsolutil/Numeric.h>
+
+#include <optional>
 
 namespace solidity::yul::ssa
 {
@@ -68,6 +70,11 @@ struct ControlFlowGraphs
 		output << "}\n";
 		return output.str();
 	}
+
+	/// Memoryguard boundary for this subobject.
+	/// - empty: no `memoryguard(N)` call appears in the source
+	/// - set: every MemoryGuard Inst lowers to a `pushN <value>` of this constant
+	std::optional<u256> memoryGuard{};
 
 	std::vector<std::unique_ptr<SSACFG>> functionGraphs{};
 };

--- a/libyul/backends/evm/ssa/InstructionStore.h
+++ b/libyul/backends/evm/ssa/InstructionStore.h
@@ -90,11 +90,15 @@ public:
 		constexpr bool isProjection() const noexcept { return opcode == InstOpcode::Projection; }
 		constexpr bool isIdentity() const noexcept { return opcode == InstOpcode::Identity; }
 		constexpr bool isNop() const noexcept { return opcode == InstOpcode::Nop; }
+		constexpr bool isMemoryGuard() const noexcept { return opcode == InstOpcode::MemoryGuard; }
 		constexpr bool isTombstone() const noexcept { return opcode == InstOpcode::Tombstone; }
-		/// Operation = a Call or BuiltinCall.
+		/// Operation = a Call, BuiltinCall, or MemoryGuard
 		constexpr bool isOperation() const noexcept
 		{
-			return opcode == InstOpcode::Call || opcode == InstOpcode::BuiltinCall;
+			return
+				opcode == InstOpcode::Call ||
+				opcode == InstOpcode::BuiltinCall ||
+				opcode == InstOpcode::MemoryGuard;
 		}
 	};
 
@@ -171,6 +175,13 @@ public:
 	InstId appendFunctionArg(BlockId const _entryBlock)
 	{
 		return appendInst(Inst{InstOpcode::FunctionArg, _entryBlock, {}, nullptr});
+	}
+
+	/// Allocates a new MemoryGuard Inst defined in `_block`. The boundary value lives in `ControlFlowGraphs::memoryGuard`.
+	InstId appendMemoryGuard(BlockId const _block)
+	{
+		yulAssert(_block.hasValue());
+		return appendInst(Inst{InstOpcode::MemoryGuard, _block, {}, nullptr});
 	}
 
 	/// Allocates a new Unreachable Inst. Not pinned to any block (see class comment).
@@ -308,6 +319,7 @@ public:
 		// every Const InstId is the unique handle for its value, so flipping it to Identity would silently rebind
 		// every other user of that literal to _forward; almost certainly not what was intended
 		yulAssert(!instruction.isLiteral(), "replaceWithIdentity must not morph a deduped Const slot");
+		yulAssert(!instruction.isMemoryGuard(), "replaceWithIdentity must not morph a MemoryGuard slot");
 		yulAssert(
 			numTrailingProjections(_target) == 0,
 			"replaceWithIdentity must not morph a multi-return producer slot"
@@ -323,6 +335,7 @@ public:
 	{
 		yulAssert(_target.hasValue());
 		auto& instruction = inst(_target);
+		yulAssert(!instruction.isMemoryGuard(), "replaceWithConst must not morph a MemoryGuard slot");
 		yulAssert(
 			numTrailingProjections(_target) == 0,
 			"replaceWithConst must not morph a multi-return producer slot"
@@ -349,6 +362,7 @@ public:
 	{
 		yulAssert(_target.hasValue());
 		auto& instruction = inst(_target);
+		yulAssert(!instruction.isMemoryGuard(), "replaceWithNop must not morph a MemoryGuard slot");
 		yulAssert(
 			numTrailingProjections(_target) == 0,
 			"replaceWithNop must not morph a multi-return producer slot"

--- a/libyul/backends/evm/ssa/SSACFG.cpp
+++ b/libyul/backends/evm/ssa/SSACFG.cpp
@@ -108,13 +108,26 @@ protected:
 		});
 		m_cfg.forEachOperation(block, [&](InstId const instId, SSACFG::Inst const& inst) {
 			std::string label;
-			if (inst.opcode == InstOpcode::Call)
+			switch (inst.opcode)
+			{
+			case InstOpcode::Call:
 			{
 				auto const graphID = m_cfg.callPayload(instId).graphID;
 				label = m_controlFlow ? m_controlFlow->functionGraph(graphID)->name : fmt::format("func{}", graphID);
+				break;
 			}
-			else
+			case InstOpcode::BuiltinCall:
 				label = m_cfg.evmDialect.builtin(m_cfg.builtinPayload(instId).builtin).name;
+				break;
+			case InstOpcode::MemoryGuard:
+				if (m_controlFlow && m_controlFlow->memoryGuard)
+					label = fmt::format("memoryguard<{}>", toCompactHexWithPrefix(*m_controlFlow->memoryGuard));
+				else
+					label = "memoryguard";
+				break;
+			default:
+				yulAssert(false);
+			}
 			if (m_cfg.numReturnsOf(instId) >= 1)
 				_out << fmt::format("{} := ", valueToString(instId));
 			_out << fmt::format(

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -149,6 +149,7 @@ public:
 	bool isProjection(InstId const _id) const { return inst(_id).isProjection(); }
 	bool isIdentity(InstId const _id) const { return inst(_id).isIdentity(); }
 	bool isNop(InstId const _id) const { return inst(_id).isNop(); }
+	bool isMemoryGuard(InstId const _id) const { return inst(_id).isMemoryGuard(); }
 	bool isTombstone(InstId const _id) const { return inst(_id).isTombstone(); }
 	bool isOperation(InstId const _id) const { return inst(_id).isOperation(); }
 
@@ -192,6 +193,15 @@ public:
 		InstId const id = scheduleInBlock(m_instructions.appendFunctionArg(entry), entry);
 		if (debugInfo)
 			debugInfo->setValueDebugData(id, debugInfo->blockDebugData(entry));
+		return id;
+	}
+
+	/// Allocates a MemoryGuard Inst at `_block`. The boundary value lives in `ControlFlowGraphs::memoryGuard`.
+	InstId makeMemoryGuard(BlockId const _block, langutil::DebugData::ConstPtr _debugData = {})
+	{
+		InstId const id = scheduleInBlock(m_instructions.appendMemoryGuard(_block), _block);
+		if (debugInfo && _debugData)
+			debugInfo->setValueDebugData(id, std::move(_debugData));
 		return id;
 	}
 
@@ -382,6 +392,8 @@ public:
 			return callPayload(_op).numReturns;
 		case InstOpcode::BuiltinCall:
 			return evmDialect.builtin(builtinPayload(_op).builtin).numReturns;
+		case InstOpcode::MemoryGuard:
+			return 1;
 		default:
 			yulAssert(false, fmt::format("numReturnsOf called on non-operation inst {}", _op));
 		}

--- a/libyul/backends/evm/ssa/SSACFGBuilder.cpp
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.cpp
@@ -59,7 +59,12 @@ SSACFGBuilder::SSACFGBuilder(
 	m_sideEffects(_sideEffects),
 	m_dialect(_dialect),
 	m_generateDebugInfo(_generateDebugInfo),
-	m_functionRegistry(_functionRegistry)
+	m_functionRegistry(_functionRegistry),
+	m_memoryGuardHandle([&] {
+		auto const memoryGuardHandle = m_dialect.findBuiltin("memoryguard");
+		yulAssert(memoryGuardHandle.has_value(), "We only support EVM dialects that contain memoryguard");
+		return *memoryGuardHandle;
+	}())
 {
 }
 
@@ -444,6 +449,25 @@ InstId SSACFGBuilder::visitFunctionCall(FunctionCall const& _call)
 	InstId const id = std::visit(solidity::util::GenericVisitor{
 		[&](BuiltinName const& _builtinName) -> InstId
 		{
+			// memoryguard(N) is represented as a dedicated MemoryGuard Inst; the boundary value lives in the
+			// corresponding ControlFlowGraphs instance
+			if (_builtinName.handle == m_memoryGuardHandle)
+			{
+				yulAssert(_call.arguments.size() == 1);
+				Literal const* literal = std::get_if<Literal>(&_call.arguments.front());
+				yulAssert(literal && literal->kind == LiteralKind::Number);
+				u256 const value = literal->value.value();
+				if (m_controlFlow.memoryGuard)
+					yulAssert(
+						*m_controlFlow.memoryGuard == value,
+						"memoryguard: inconsistent literal across subobject"
+					);
+				else
+					m_controlFlow.memoryGuard = value;
+				canContinue = m_dialect.builtin(m_memoryGuardHandle).controlFlowSideEffects.canContinue;
+				return m_graph.makeMemoryGuard(m_currentBlock, debugDataOf(_call));
+			}
+
 			auto const& builtin = m_dialect.builtin(_builtinName.handle);
 			yulAssert(_call.arguments.size() == builtin.numParameters);
 			std::vector<Literal> literalArguments;

--- a/libyul/backends/evm/ssa/SSACFGBuilder.h
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.h
@@ -127,6 +127,7 @@ private:
 	/// Shared function lookup, populated as `registerFunctionDefinition` is called.
 	/// Owned by the topmost `build()` invocation; nested builders just reference it.
 	FunctionRegistry& m_functionRegistry;
+	BuiltinHandle const m_memoryGuardHandle;
 	/// Return variable scopes of the function currently being built
 	std::vector<std::reference_wrapper<Scope::Variable const>> m_currentReturnVars;
 	SSACFG::BlockId m_currentBlock;

--- a/libyul/backends/evm/ssa/SSACFGTypes.cpp
+++ b/libyul/backends/evm/ssa/SSACFGTypes.cpp
@@ -35,6 +35,7 @@ std::string InstId::str(SSACFG const& _cfg) const
 	case InstOpcode::FunctionArg:
 	case InstOpcode::Projection:
 	case InstOpcode::Identity:
+	case InstOpcode::MemoryGuard:
 		return fmt::format("v{}", value);
 	case InstOpcode::Phi:
 		return fmt::format("phi{}", value);

--- a/libyul/backends/evm/ssa/SSACFGTypes.h
+++ b/libyul/backends/evm/ssa/SSACFGTypes.h
@@ -65,6 +65,7 @@ enum class InstOpcode : std::uint8_t
 	Projection, // projection: single InstId input (multi-output producer) plus immediate index
 	Identity,  // forwards its single input, resolved away by transform::removeIdentities,
 	Nop,  // used to turn a void-typed Inst (eg an upsilon whose phi was eliminated) into a deletable placeholder
+	MemoryGuard,  // emits the subobject's memoryguard boundary; value is held on the enclosing ControlFlowGraphs
 	Tombstone,  // marks a free slot in InstructionStore::m_insts, must never appear in block instructions
 };
 

--- a/libyul/backends/evm/ssa/io/JSONExporter.cpp
+++ b/libyul/backends/evm/ssa/io/JSONExporter.cpp
@@ -48,15 +48,17 @@ Json toJson(Json& _ret, SSACFG const& _cfg, InstId const _instId, ControlFlowGra
 {
 	auto const& inst = _cfg.inst(_instId);
 	Json opJson = Json::object();
-	if (inst.opcode == InstOpcode::Call)
+	switch (inst.opcode)
+	{
+	case InstOpcode::Call:
 	{
 		auto const& callPayload = _cfg.callPayload(_instId);
 		_ret["type"] = "FunctionCall";
 		opJson["op"] = _controlFlow.functionGraph(callPayload.graphID)->name;
+		break;
 	}
-	else
+	case InstOpcode::BuiltinCall:
 	{
-		yulAssert(inst.opcode == InstOpcode::BuiltinCall);
 		auto const& builtinPayload = _cfg.builtinPayload(_instId);
 		_ret["type"] = "BuiltinCall";
 		Json builtinArgsJson = Json::array();
@@ -67,6 +69,14 @@ Json toJson(Json& _ret, SSACFG const& _cfg, InstId const _instId, ControlFlowGra
 			opJson["literalArgs"] = builtinArgsJson;
 
 		opJson["op"] = _cfg.evmDialect.builtin(builtinPayload.builtin).name;
+		break;
+	}
+	case InstOpcode::MemoryGuard:
+		_ret["type"] = "MemoryGuard";
+		opJson["op"] = "memoryguard";
+		break;
+	default:
+		yulAssert(false);
 	}
 
 	opJson["in"] = toJson(_cfg, inst.inputs);
@@ -190,6 +200,8 @@ Json io::json::exportControlFlow(ControlFlowGraphs const& _controlFlow, ControlF
 		yulAssert(&_liveness->controlFlowGraphs.get() == &_controlFlow);
 
 	Json yulObjectJson = Json::object();
+	if (_controlFlow.memoryGuard)
+		yulObjectJson["memoryGuard"] = toCompactHexWithPrefix(*_controlFlow.memoryGuard);
 	yulObjectJson["blocks"] = exportBlock(
 		*_controlFlow.mainGraph(),
 		SSACFG::BlockId{0},

--- a/libyul/backends/evm/ssa/transform/IdentityAndNopRemover.cpp
+++ b/libyul/backends/evm/ssa/transform/IdentityAndNopRemover.cpp
@@ -54,8 +54,9 @@ void transform::removeIdentitiesAndNops(SSACFG& _cfg)
 		case InstOpcode::Phi:
 		case InstOpcode::FunctionArg:
 		case InstOpcode::Unreachable:
+		case InstOpcode::MemoryGuard:
 			// Identity / Nop / Tombstone: rewriting their inputs is pointless as they will be tombstoned
-			// Const / Phi / FunctionArg / Unreachable: can't have identity inputs by construction
+			// Const / Phi / FunctionArg / Unreachable / MemoryGuard: can't have identity inputs by construction
 			break;
 		case InstOpcode::Upsilon:
 		{

--- a/test/cmdlineTests/standard_yul_cfg_json_export/output.json
+++ b/test/cmdlineTests/standard_yul_cfg_json_export/output.json
@@ -18,9 +18,6 @@
                                 "instructions": [
                                     {
                                         "in": [],
-                                        "literalArgs": [
-                                            "0x80"
-                                        ],
                                         "op": "memoryguard",
                                         "out": [
                                             "v0"
@@ -125,6 +122,7 @@
                             }
                         ],
                         "functions": {},
+                        "memoryGuard": "0x80",
                         "subObjects": {
                             "C_19_deployed": {
                                 "blocks": [
@@ -141,9 +139,6 @@
                                         "instructions": [
                                             {
                                                 "in": [],
-                                                "literalArgs": [
-                                                    "0x80"
-                                                ],
                                                 "op": "memoryguard",
                                                 "out": [
                                                     "v0"
@@ -440,6 +435,7 @@
                                     }
                                 ],
                                 "functions": {},
+                                "memoryGuard": "0x80",
                                 "subObjects": {}
                             },
                             "type": "subObject"
@@ -465,9 +461,6 @@
                                 "instructions": [
                                     {
                                         "in": [],
-                                        "literalArgs": [
-                                            "0x80"
-                                        ],
                                         "op": "memoryguard",
                                         "out": [
                                             "v0"
@@ -572,6 +565,7 @@
                             }
                         ],
                         "functions": {},
+                        "memoryGuard": "0x80",
                         "subObjects": {
                             "D_38_deployed": {
                                 "blocks": [
@@ -588,9 +582,6 @@
                                         "instructions": [
                                             {
                                                 "in": [],
-                                                "literalArgs": [
-                                                    "0x80"
-                                                ],
                                                 "op": "memoryguard",
                                                 "out": [
                                                     "v0"
@@ -1675,6 +1666,7 @@
                                     }
                                 ],
                                 "functions": {},
+                                "memoryGuard": "0x80",
                                 "subObjects": {
                                     "C_19": {
                                         "blocks": [
@@ -1691,9 +1683,6 @@
                                                 "instructions": [
                                                     {
                                                         "in": [],
-                                                        "literalArgs": [
-                                                            "0x80"
-                                                        ],
                                                         "op": "memoryguard",
                                                         "out": [
                                                             "v0"
@@ -1798,6 +1787,7 @@
                                             }
                                         ],
                                         "functions": {},
+                                        "memoryGuard": "0x80",
                                         "subObjects": {
                                             "C_19_deployed": {
                                                 "blocks": [
@@ -1814,9 +1804,6 @@
                                                         "instructions": [
                                                             {
                                                                 "in": [],
-                                                                "literalArgs": [
-                                                                    "0x80"
-                                                                ],
                                                                 "op": "memoryguard",
                                                                 "out": [
                                                                     "v0"
@@ -2113,6 +2100,7 @@
                                                     }
                                                 ],
                                                 "functions": {},
+                                                "memoryGuard": "0x80",
                                                 "subObjects": {}
                                             },
                                             "type": "subObject"

--- a/test/cmdlineTests/strict_asm_yul_cfg_json_export/output
+++ b/test/cmdlineTests/strict_asm_yul_cfg_json_export/output
@@ -18,9 +18,6 @@ Yul Control Flow Graph:
                 "instructions": [
                     {
                         "in": [],
-                        "literalArgs": [
-                            "0x80"
-                        ],
                         "op": "memoryguard",
                         "out": [
                             "v0"
@@ -125,6 +122,7 @@ Yul Control Flow Graph:
             }
         ],
         "functions": {},
+        "memoryGuard": "0x80",
         "subObjects": {
             "C_19_deployed": {
                 "blocks": [
@@ -141,9 +139,6 @@ Yul Control Flow Graph:
                         "instructions": [
                             {
                                 "in": [],
-                                "literalArgs": [
-                                    "0x80"
-                                ],
                                 "op": "memoryguard",
                                 "out": [
                                     "v0"
@@ -439,7 +434,8 @@ Yul Control Flow Graph:
                         "type": "BuiltinCall"
                     }
                 ],
-                "functions": {}
+                "functions": {},
+                "memoryGuard": "0x80"
             },
             "type": "subObject"
         }

--- a/test/cmdlineTests/yul_cfg_json_export/output
+++ b/test/cmdlineTests/yul_cfg_json_export/output
@@ -17,9 +17,6 @@ Yul Control Flow Graph:
                 "instructions": [
                     {
                         "in": [],
-                        "literalArgs": [
-                            "0x80"
-                        ],
                         "op": "memoryguard",
                         "out": [
                             "v0"
@@ -124,6 +121,7 @@ Yul Control Flow Graph:
             }
         ],
         "functions": {},
+        "memoryGuard": "0x80",
         "subObjects": {
             "C_19_deployed": {
                 "blocks": [
@@ -140,9 +138,6 @@ Yul Control Flow Graph:
                         "instructions": [
                             {
                                 "in": [],
-                                "literalArgs": [
-                                    "0x80"
-                                ],
                                 "op": "memoryguard",
                                 "out": [
                                     "v0"
@@ -439,6 +434,7 @@ Yul Control Flow Graph:
                     }
                 ],
                 "functions": {},
+                "memoryGuard": "0x80",
                 "subObjects": {}
             },
             "type": "subObject"
@@ -465,9 +461,6 @@ Yul Control Flow Graph:
                 "instructions": [
                     {
                         "in": [],
-                        "literalArgs": [
-                            "0x80"
-                        ],
                         "op": "memoryguard",
                         "out": [
                             "v0"
@@ -572,6 +565,7 @@ Yul Control Flow Graph:
             }
         ],
         "functions": {},
+        "memoryGuard": "0x80",
         "subObjects": {
             "D_38_deployed": {
                 "blocks": [
@@ -588,9 +582,6 @@ Yul Control Flow Graph:
                         "instructions": [
                             {
                                 "in": [],
-                                "literalArgs": [
-                                    "0x80"
-                                ],
                                 "op": "memoryguard",
                                 "out": [
                                     "v0"
@@ -1675,6 +1666,7 @@ Yul Control Flow Graph:
                     }
                 ],
                 "functions": {},
+                "memoryGuard": "0x80",
                 "subObjects": {
                     "C_19": {
                         "blocks": [
@@ -1691,9 +1683,6 @@ Yul Control Flow Graph:
                                 "instructions": [
                                     {
                                         "in": [],
-                                        "literalArgs": [
-                                            "0x80"
-                                        ],
                                         "op": "memoryguard",
                                         "out": [
                                             "v0"
@@ -1798,6 +1787,7 @@ Yul Control Flow Graph:
                             }
                         ],
                         "functions": {},
+                        "memoryGuard": "0x80",
                         "subObjects": {
                             "C_19_deployed": {
                                 "blocks": [
@@ -1814,9 +1804,6 @@ Yul Control Flow Graph:
                                         "instructions": [
                                             {
                                                 "in": [],
-                                                "literalArgs": [
-                                                    "0x80"
-                                                ],
                                                 "op": "memoryguard",
                                                 "out": [
                                                     "v0"
@@ -2113,6 +2100,7 @@ Yul Control Flow Graph:
                                     }
                                 ],
                                 "functions": {},
+                                "memoryGuard": "0x80",
                                 "subObjects": {}
                             },
                             "type": "subObject"

--- a/test/libyul/ssa/controlFlowGraph/memoryguard.yul
+++ b/test/libyul/ssa/controlFlowGraph/memoryguard.yul
@@ -1,0 +1,24 @@
+{
+    let p := memoryguard(0x80)
+    mstore(p, 42)
+    let q := memoryguard(0x80)
+    sstore(q, 1)
+}
+// ----
+// digraph SSACFG {
+// nodesep=0.7;
+// graph[fontname="DejaVu Sans"]
+// node[shape=box,fontname="DejaVu Sans"];
+//
+// Entry [label="Entry"];
+// Entry -> Block0_0;
+// Block0_0 [fillcolor="#FF746C", style=filled, label="\
+// Block 0; (0, max 0)\nLiveIn: \l\
+// LiveOut: \l\nUsed: \l\nv0 := memoryguard<0x80>()\l\
+// mstore(0x2a, v0)\l\
+// v3 := memoryguard<0x80>()\l\
+// sstore(0x01, v3)\l\
+// "];
+// Block0_0Exit [label="MainExit"];
+// Block0_0 -> Block0_0Exit;
+// }


### PR DESCRIPTION
- adds `memoryguard` opcode to ssa cfg
- changes output from `memoryguard(const)` to `memoryguard<const>()`
- value of memoryguard lives on `ControlFlowGraphs` instance
- if there are multiple memoryguards present in the AST, the builder checks for consistency