### PR TITLE
SSA CFG Stack layout generator: Determine optimal target (not just size)

### DIFF
--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -258,19 +258,14 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 
 		StackSlotLiveness const opLiveOutSlots = toStackSlotLiveness(m_cfg, opLiveOutWithoutOutputs);
 		{
-			std::size_t const targetSize = findOptimalTargetSize(
+			StackData const target = findOptimalTarget(
 				stack.data(),
 				requiredStackTop,
 				opLiveOutSlots,
 				junkCanBeAdded,
 				m_hasFunctionReturnLabel
 			);
-			auto const shuffleResult = StackShuffler<StackType::Callbacks>::shuffle(
-				stack,
-				requiredStackTop,
-				opLiveOutSlots,
-				targetSize
-			);
+			auto const shuffleResult = StackShuffler<StackType::Callbacks>::shuffle(stack, target);
 			yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 		}
 
@@ -298,16 +293,14 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 				{
 					auto const condition = Slot::makeValue(m_cfg, _cJump.condition);
 					StackSlotLiveness const blockLiveOutSlots = toStackSlotLiveness(m_cfg, blockLiveOut);
-					auto const targetSize = findOptimalTargetSize(
+					StackData const target = findOptimalTarget(
 						stack.data(),
 						{condition},
 						blockLiveOutSlots,
 						false,
 						m_hasFunctionReturnLabel
 					);
-					auto const shuffleResult = StackShuffler<StackType::Callbacks>::shuffle(
-						stack, {condition}, blockLiveOutSlots, targetSize
-					);
+					auto const shuffleResult = StackShuffler<StackType::Callbacks>::shuffle(stack, target);
 					yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 				}
 

--- a/libyul/backends/evm/ssa/StackUtils.cpp
+++ b/libyul/backends/evm/ssa/StackUtils.cpp
@@ -80,7 +80,7 @@ StackData solidity::yul::ssa::stackPreImage(SSACFG const& _cfg, StackData _stack
 	return _stack;
 }
 
-std::size_t solidity::yul::ssa::findOptimalTargetSize
+StackData solidity::yul::ssa::findOptimalTarget
 (
 	StackData const& _stackData,
 	StackData const& _targetArgs,
@@ -141,7 +141,7 @@ std::size_t solidity::yul::ssa::findOptimalTargetSize
 	};
 
 	std::size_t bestCost = evaluateCost(startSize);
-	auto result = startSize;
+	StackData bestData = data;
 
 	// On non-reverting paths, only search downward from pivot to avoid growing the stack.
 	// On reverting paths, search in both directions since stack cleanup doesn't matter.
@@ -157,7 +157,7 @@ std::size_t solidity::yul::ssa::findOptimalTargetSize
 			if (cost <= bestCost)
 			{
 				bestCost = cost;
-				result = size;
+				bestData = data;
 				consecutiveIncreases = 0;
 			}
 			else if (++consecutiveIncreases >= stopAfter)
@@ -174,14 +174,15 @@ std::size_t solidity::yul::ssa::findOptimalTargetSize
 			if (cost < bestCost)
 			{
 				bestCost = cost;
-				result = size;
+				bestData = data;
 				consecutiveIncreases = 0;
 			}
 			else if (++consecutiveIncreases >= stopAfter)
 				break;
 		}
 	}
-	return result;
+
+	return bestData;
 }
 
 CallSites solidity::yul::ssa::gatherCallSites(SSACFG const& _cfg)

--- a/libyul/backends/evm/ssa/StackUtils.h
+++ b/libyul/backends/evm/ssa/StackUtils.h
@@ -63,7 +63,10 @@ struct GasAccumulatingCallbacks
 /// Transform stack data by replacing all its phi variables with their respective preimages.
 StackData stackPreImage(SSACFG const& _cfg, StackData _stack, PhiInverse const& _phiInverse);
 
-std::size_t findOptimalTargetSize(
+/// Searches for the cheapest target stack size for shuffling _stackData towards
+/// (_targetArgs on top, _targetLiveOut anywhere in the tail), then realizes that size and
+/// returns the resolved post-shuffle StackData
+StackData findOptimalTarget(
 	StackData const& _stackData,
 	StackData const& _targetArgs,
 	StackSlotLiveness const& _targetLiveOut,

--- a/test/libyul/ssa/stackLayoutGenerator/nested_for.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/nested_for.yul
@@ -107,11 +107,11 @@
 // Block0_3 [label="\
 // IN: [phi2, phi8, JUNK]\l\
 // \l\
-// [JUNK, phi8, lit10, phi2]\l\
+// [phi2, phi8, lit10, phi2]\l\
 // add\l\
-// [JUNK, phi8, v19]\l\
+// [phi2, phi8, v19]\l\
 // \l\
-// OUT: [JUNK, phi8, v19]\l\
+// OUT: [phi2, phi8, v19]\l\
 // "];
 // Block0_3 -> Block0_3Exit [arrowhead=none];
 // Block0_3Exit [label="Jump" shape=oval];


### PR DESCRIPTION
Instead of reporting the target size, we now find the optimal target stack data. That way the stack layout generator operates on the exact target data and doesn't do the flexible-tail shuffle. This is consistent with what code transform does.