### PR TITLE
SSA CFG: Make basic blocks optional and add a free list to them

### DIFF
--- a/libyul/backends/evm/ssa/LivenessAnalysis.cpp
+++ b/libyul/backends/evm/ssa/LivenessAnalysis.cpp
@@ -153,24 +153,22 @@ void LivenessAnalysis::runLoopTreeDfs(SSACFG::BlockId::ValueType const _loopHead
 		// must be live out of header if live in of children
 		m_liveOuts[_loopHeader].maxUnion(liveLoop);
 		// for each blockId \in children(loopHeader)
-		for (SSACFG::BlockId::ValueType blockIdValue = 0u; blockIdValue < m_cfg.numBlocks(); ++blockIdValue)
-			if (m_cfg.hasBlock(SSACFG::BlockId{blockIdValue}) && m_loopNestingForest.loopParents()[blockIdValue] == _loopHeader)
+		for (SSACFG::BlockId const blockId: m_cfg.liveBlocks())
+			if (m_loopNestingForest.loopParents()[blockId.value] == _loopHeader)
 			{
 				// propagate loop liveness information down to the loop header's children
-				m_liveIns[blockIdValue].maxUnion(liveLoop);
-				m_liveOuts[blockIdValue].maxUnion(liveLoop);
+				m_liveIns[blockId.value].maxUnion(liveLoop);
+				m_liveOuts[blockId.value].maxUnion(liveLoop);
 
-				runLoopTreeDfs(blockIdValue);
+				runLoopTreeDfs(blockId.value);
 			}
 	}
 }
 
 void LivenessAnalysis::fillOperationsLiveOut()
 {
-	for (SSACFG::BlockId blockId{0}; blockId.value < m_cfg.numBlocks(); ++blockId.value)
+	for (SSACFG::BlockId const blockId: m_cfg.liveBlocks())
 	{
-		if (!m_cfg.hasBlock(blockId))
-			continue;
 		auto const& block = m_cfg.block(blockId);
 		auto const opCount = static_cast<std::size_t>(ranges::count_if(
 			block.instructions,

--- a/libyul/backends/evm/ssa/LivenessAnalysis.cpp
+++ b/libyul/backends/evm/ssa/LivenessAnalysis.cpp
@@ -154,7 +154,7 @@ void LivenessAnalysis::runLoopTreeDfs(SSACFG::BlockId::ValueType const _loopHead
 		m_liveOuts[_loopHeader].maxUnion(liveLoop);
 		// for each blockId \in children(loopHeader)
 		for (SSACFG::BlockId::ValueType blockIdValue = 0u; blockIdValue < m_cfg.numBlocks(); ++blockIdValue)
-			if (m_loopNestingForest.loopParents()[blockIdValue] == _loopHeader)
+			if (m_cfg.hasBlock(SSACFG::BlockId{blockIdValue}) && m_loopNestingForest.loopParents()[blockIdValue] == _loopHeader)
 			{
 				// propagate loop liveness information down to the loop header's children
 				m_liveIns[blockIdValue].maxUnion(liveLoop);
@@ -169,6 +169,8 @@ void LivenessAnalysis::fillOperationsLiveOut()
 {
 	for (SSACFG::BlockId blockId{0}; blockId.value < m_cfg.numBlocks(); ++blockId.value)
 	{
+		if (!m_cfg.hasBlock(blockId))
+			continue;
 		auto const& block = m_cfg.block(blockId);
 		auto const opCount = static_cast<std::size_t>(ranges::count_if(
 			block.instructions,

--- a/libyul/backends/evm/ssa/SSACFG.cpp
+++ b/libyul/backends/evm/ssa/SSACFG.cpp
@@ -45,17 +45,13 @@ std::string formatPhi(SSACFG const& _cfg, InstId _phiId)
 {
 	// Collect all upsilons targeting _phiId from the whole CFG.
 	std::vector<std::string> formattedUpsilons;
-	for (BlockId::ValueType bv = 0; bv < _cfg.numBlocks(); ++bv)
-	{
-		if (!_cfg.hasBlock(BlockId{bv}))
-			continue;
-		_cfg.forEachUpsilon(_cfg.block(BlockId{bv}), [&](InstId const instId, SSACFG::Inst const& inst) {
+	for (BlockId const blockId: _cfg.liveBlocks())
+		_cfg.forEachUpsilon(_cfg.block(blockId), [&](InstId const instId, SSACFG::Inst const& inst) {
 			if (_cfg.upsilonPhi(instId) == _phiId)
 				formattedUpsilons.push_back(
-					fmt::format("Block {} => {}", bv, inst.inputs.at(0).str(_cfg))
+					fmt::format("Block {} => {}", blockId.value, inst.inputs.at(0).str(_cfg))
 				);
 		});
-	}
 	if (!formattedUpsilons.empty())
 		return fmt::format("φ(\\l\\\n\t{}\\l\\\n)", fmt::join(formattedUpsilons, ",\\l\\\n\t"));
 	return "φ()";

--- a/libyul/backends/evm/ssa/SSACFG.cpp
+++ b/libyul/backends/evm/ssa/SSACFG.cpp
@@ -46,12 +46,16 @@ std::string formatPhi(SSACFG const& _cfg, InstId _phiId)
 	// Collect all upsilons targeting _phiId from the whole CFG.
 	std::vector<std::string> formattedUpsilons;
 	for (BlockId::ValueType bv = 0; bv < _cfg.numBlocks(); ++bv)
+	{
+		if (!_cfg.hasBlock(BlockId{bv}))
+			continue;
 		_cfg.forEachUpsilon(_cfg.block(BlockId{bv}), [&](InstId const instId, SSACFG::Inst const& inst) {
 			if (_cfg.upsilonPhi(instId) == _phiId)
 				formattedUpsilons.push_back(
 					fmt::format("Block {} => {}", bv, inst.inputs.at(0).str(_cfg))
 				);
 		});
+	}
 	if (!formattedUpsilons.empty())
 		return fmt::format("φ(\\l\\\n\t{}\\l\\\n)", fmt::join(formattedUpsilons, ",\\l\\\n\t"));
 	return "φ()";

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -36,6 +36,7 @@
 #include <range/v3/range/concepts.hpp>
 #include <range/v3/range/conversion.hpp>
 #include <range/v3/range/traits.hpp>
+#include <range/v3/view/filter.hpp>
 #include <range/v3/view/iota.hpp>
 #include <range/v3/view/transform.hpp>
 
@@ -165,6 +166,14 @@ public:
 		);
 		block.reset();
 		m_freeBlocks.push_back(_id);
+	}
+
+	InputRangeOf<BlockId> auto liveBlocks() const
+	{
+		return
+			ranges::views::iota(BlockId::ValueType{0}, static_cast<BlockId::ValueType>(m_blocks.size())) |
+			ranges::views::filter([this](BlockId::ValueType const _v) { return m_blocks[_v].has_value(); }) |
+			ranges::views::transform([](BlockId::ValueType const _v) { return BlockId{_v}; });
 	}
 
 	InstructionStore& instructionStore() { return m_instructions; }

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -32,6 +32,7 @@
 
 #include <libsolutil/Numeric.h>
 
+#include <range/v3/algorithm/all_of.hpp>
 #include <range/v3/range/concepts.hpp>
 #include <range/v3/range/conversion.hpp>
 #include <range/v3/range/traits.hpp>
@@ -40,6 +41,7 @@
 
 #include <concepts>
 #include <functional>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -118,17 +120,52 @@ public:
 
 	BlockId makeBlock(langutil::DebugData::ConstPtr _debugData)
 	{
-		// max itself is reserved for the 'empty' block
-		yulAssert(m_blocks.size() < std::numeric_limits<BlockId::ValueType>::max());
-		BlockId const blockId{static_cast<BlockId::ValueType>(m_blocks.size())};
-		m_blocks.emplace_back(BasicBlock{{}, {}, BasicBlock::Terminated{}});
+		BlockId blockId;
+		if (!m_freeBlocks.empty())
+		{
+			blockId = m_freeBlocks.back();
+			yulAssert(blockId.value < m_freeBlocks.size());
+			std::optional<BasicBlock>& block = m_blocks[blockId.value];
+			yulAssert(!block.has_value());
+			m_freeBlocks.pop_back();
+			block.emplace(BasicBlock{{}, {}, BasicBlock::Terminated{}});
+		}
+		else
+		{
+			yulAssert(m_blocks.size() < std::numeric_limits<BlockId::ValueType>::max());
+			blockId = BlockId{static_cast<BlockId::ValueType>(m_blocks.size())};
+			m_blocks.emplace_back(BasicBlock{{}, {}, BasicBlock::Terminated{}});
+		}
 		if (debugInfo)
 			debugInfo->setBlockDebugData(blockId, std::move(_debugData));
 		return blockId;
 	}
-	BasicBlock& block(BlockId _id) { return m_blocks.at(_id.value); }
-	BasicBlock const& block(BlockId _id) const { return m_blocks.at(_id.value); }
+	BasicBlock& block(BlockId _id)
+	{
+		auto& slot = m_blocks.at(_id.value);
+		yulAssert(slot.has_value(), fmt::format("Access of dead block #{}", _id.value));
+		return *slot;
+	}
+	BasicBlock const& block(BlockId _id) const
+	{
+		auto const& slot = m_blocks.at(_id.value);
+		yulAssert(slot.has_value(), fmt::format("Access of dead block #{}", _id.value));
+		return *slot;
+	}
 	size_t numBlocks() const { return m_blocks.size(); }
+	bool hasBlock(BlockId const _id) const { return _id.value < m_blocks.size() && m_blocks[_id.value].has_value(); }
+	void resetBlock(BlockId const _id)
+	{
+		yulAssert(_id.value < m_blocks.size());
+		auto& block = m_blocks[_id.value];
+		yulAssert(block.has_value(), "double reset");
+		yulAssert(
+			ranges::all_of(block->instructions, [this](InstId const _instId) { return isTombstone(_instId); }),
+			"can only reset blocks that have no live instructions left"
+		);
+		block.reset();
+		m_freeBlocks.push_back(_id);
+	}
 
 	InstructionStore& instructionStore() { return m_instructions; }
 	InstructionStore const& instructionStore() const { return m_instructions; }
@@ -328,11 +365,13 @@ public:
 private:
 	InstId scheduleInBlock(InstId const _id, BlockId const _block)
 	{
-		m_blocks.at(_block.value).instructions.push_back(_id);
+		block(_block).instructions.push_back(_id);
 		return _id;
 	}
 
-	std::vector<BasicBlock> m_blocks;
+	std::vector<std::optional<BasicBlock>> m_blocks;
+	// free list of blocks
+	std::vector<BlockId> m_freeBlocks;
 	InstructionStore m_instructions;
 public:
 	EVMDialect const& evmDialect;

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -113,9 +113,13 @@ StackLayoutGenerator::StackLayoutGenerator(
 		std::vector<std::size_t> inDegreesIgnoringBackedges(m_cfg.numBlocks(), 0);
 
 		for (SSACFG::BlockId id{0}; id.value < m_cfg.numBlocks(); ++id.value)
+		{
+			if (!m_cfg.hasBlock(id))
+				continue;
 			for (auto const& entry: m_cfg.block(id).entries)
 				if (!m_liveness.topologicalSort().backEdge(entry, id))
 					inDegreesIgnoringBackedges[id.value] += 1;
+		}
 
 		std::queue<SSACFG::BlockId> traversalQueue;
 		traversalQueue.push(m_cfg.entry);

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -112,14 +112,10 @@ StackLayoutGenerator::StackLayoutGenerator(
 		// Future optimization: it might be beneficial to revisit the loop heads (back edge targets) after the first iteration
 		std::vector<std::size_t> inDegreesIgnoringBackedges(m_cfg.numBlocks(), 0);
 
-		for (SSACFG::BlockId id{0}; id.value < m_cfg.numBlocks(); ++id.value)
-		{
-			if (!m_cfg.hasBlock(id))
-				continue;
+		for (SSACFG::BlockId const id: m_cfg.liveBlocks())
 			for (auto const& entry: m_cfg.block(id).entries)
 				if (!m_liveness.topologicalSort().backEdge(entry, id))
 					inDegreesIgnoringBackedges[id.value] += 1;
-		}
 
 		std::queue<SSACFG::BlockId> traversalQueue;
 		traversalQueue.push(m_cfg.entry);

--- a/libyul/backends/evm/ssa/transform/IdentityAndNopRemover.cpp
+++ b/libyul/backends/evm/ssa/transform/IdentityAndNopRemover.cpp
@@ -78,6 +78,9 @@ void transform::removeIdentitiesAndNops(SSACFG& _cfg)
 
 	// Rewrite block-exit references that name InstIds outside `inst.inputs`.
 	for (BlockId blockId{0}; blockId.value < _cfg.numBlocks(); ++blockId.value)
+	{
+		if (!_cfg.hasBlock(blockId))
+			continue;
 		std::visit(solidity::util::GenericVisitor{
 			[&](SSACFG::BasicBlock::ConditionalJump& c) { c.condition = _cfg.resolveIdentity(c.condition); },
 			[&](SSACFG::BasicBlock::FunctionReturn& r) { rewriteInputs(_cfg, r.returnValues); },
@@ -85,11 +88,14 @@ void transform::removeIdentitiesAndNops(SSACFG& _cfg)
 			[](SSACFG::BasicBlock::MainExit&) {},
 			[](SSACFG::BasicBlock::Terminated&) {}
 		}, _cfg.block(blockId).exit);
+	}
 
 	// Drop Identity / Nop entries from each block and tombstone their slots. No live reference reads through any of
 	// these slots, so reusing them is safe.
 	for (BlockId blockId{0}; blockId.value < _cfg.numBlocks(); ++blockId.value)
 	{
+		if (!_cfg.hasBlock(blockId))
+			continue;
 		auto& block = _cfg.block(blockId);
 		std::vector<InstId> toTombstone;
 		std::erase_if(block.instructions, [&](InstId const _id) {

--- a/libyul/backends/evm/ssa/transform/IdentityAndNopRemover.cpp
+++ b/libyul/backends/evm/ssa/transform/IdentityAndNopRemover.cpp
@@ -77,10 +77,7 @@ void transform::removeIdentitiesAndNops(SSACFG& _cfg)
 	}
 
 	// Rewrite block-exit references that name InstIds outside `inst.inputs`.
-	for (BlockId blockId{0}; blockId.value < _cfg.numBlocks(); ++blockId.value)
-	{
-		if (!_cfg.hasBlock(blockId))
-			continue;
+	for (BlockId const blockId: _cfg.liveBlocks())
 		std::visit(solidity::util::GenericVisitor{
 			[&](SSACFG::BasicBlock::ConditionalJump& c) { c.condition = _cfg.resolveIdentity(c.condition); },
 			[&](SSACFG::BasicBlock::FunctionReturn& r) { rewriteInputs(_cfg, r.returnValues); },
@@ -88,14 +85,11 @@ void transform::removeIdentitiesAndNops(SSACFG& _cfg)
 			[](SSACFG::BasicBlock::MainExit&) {},
 			[](SSACFG::BasicBlock::Terminated&) {}
 		}, _cfg.block(blockId).exit);
-	}
 
 	// Drop Identity / Nop entries from each block and tombstone their slots. No live reference reads through any of
 	// these slots, so reusing them is safe.
-	for (BlockId blockId{0}; blockId.value < _cfg.numBlocks(); ++blockId.value)
+	for (BlockId const blockId: _cfg.liveBlocks())
 	{
-		if (!_cfg.hasBlock(blockId))
-			continue;
 		auto& block = _cfg.block(blockId);
 		std::vector<InstId> toTombstone;
 		std::erase_if(block.instructions, [&](InstId const _id) {

--- a/libyul/backends/evm/ssa/transform/TrivialPhiEliminator.cpp
+++ b/libyul/backends/evm/ssa/transform/TrivialPhiEliminator.cpp
@@ -32,12 +32,16 @@ void transform::eliminateTrivialPhis(SSACFG& _cfg)
 {
 	// Drop upsilons whose value is Unreachable (dead control-flow predecessor)
 	for (BlockId blockId{0}; blockId.value < _cfg.numBlocks(); ++blockId.value)
+	{
+		if (!_cfg.hasBlock(blockId))
+			continue;
 		for (InstId const id: _cfg.block(blockId).instructions)
 		{
 			auto const& inst = _cfg.inst(id);
 			if (inst.isUpsilon() && _cfg.isUnreachable(inst.inputs[0]))
 				_cfg.replaceWithNop(id);
 		}
+	}
 
 	// Build per-phi indices
 	std::map<InstId, std::vector<InstId>> upsilonsTargeting;

--- a/libyul/backends/evm/ssa/transform/TrivialPhiEliminator.cpp
+++ b/libyul/backends/evm/ssa/transform/TrivialPhiEliminator.cpp
@@ -31,17 +31,13 @@ using namespace solidity::yul::ssa;
 void transform::eliminateTrivialPhis(SSACFG& _cfg)
 {
 	// Drop upsilons whose value is Unreachable (dead control-flow predecessor)
-	for (BlockId blockId{0}; blockId.value < _cfg.numBlocks(); ++blockId.value)
-	{
-		if (!_cfg.hasBlock(blockId))
-			continue;
+	for (BlockId const blockId: _cfg.liveBlocks())
 		for (InstId const id: _cfg.block(blockId).instructions)
 		{
 			auto const& inst = _cfg.inst(id);
 			if (inst.isUpsilon() && _cfg.isUnreachable(inst.inputs[0]))
 				_cfg.replaceWithNop(id);
 		}
-	}
 
 	// Build per-phi indices
 	std::map<InstId, std::vector<InstId>> upsilonsTargeting;

--- a/libyul/backends/evm/ssa/transform/UnreachableBlockCleaner.cpp
+++ b/libyul/backends/evm/ssa/transform/UnreachableBlockCleaner.cpp
@@ -37,8 +37,9 @@ void transform::cleanUnreachableBlocks(SSACFG& _cfg)
 	{
 		auto const blockId = worklist.front();
 		worklist.pop_front();
-		auto const& block = _cfg.block(blockId);
-		block.forEachExit([&](BlockId const _exitBlock) {
+		if (!_cfg.hasBlock(blockId))
+			continue;
+		_cfg.block(blockId).forEachExit([&](BlockId const _exitBlock) {
 			if (!reachable[_exitBlock.value])
 			{
 				reachable[_exitBlock.value] = true;
@@ -50,14 +51,15 @@ void transform::cleanUnreachableBlocks(SSACFG& _cfg)
 	auto& store = _cfg.instructionStore();
 	for (SSACFG::BlockId blockId{0}; blockId.value < _cfg.numBlocks(); ++blockId.value)
 	{
-		auto& block = _cfg.block(blockId);
+		if (!_cfg.hasBlock(blockId))
+			continue;
 		if (reachable[blockId.value])
-			std::erase_if(block.entries, [&](auto const& entry) { return !reachable[entry.value]; });
+			std::erase_if(_cfg.block(blockId).entries, [&](auto const& entry) { return !reachable[entry.value]; });
 		else
 		{
-			for (InstId const id: block.instructions)
+			for (InstId const id: _cfg.block(blockId).instructions)
 				store.tombstone(id);
-			block = {};
+			_cfg.resetBlock(blockId);
 		}
 	}
 }

--- a/libyul/backends/evm/ssa/transform/UnreachableBlockCleaner.cpp
+++ b/libyul/backends/evm/ssa/transform/UnreachableBlockCleaner.cpp
@@ -49,10 +49,8 @@ void transform::cleanUnreachableBlocks(SSACFG& _cfg)
 	}
 
 	auto& store = _cfg.instructionStore();
-	for (SSACFG::BlockId blockId{0}; blockId.value < _cfg.numBlocks(); ++blockId.value)
+	for (SSACFG::BlockId const blockId: _cfg.liveBlocks())
 	{
-		if (!_cfg.hasBlock(blockId))
-			continue;
 		if (reachable[blockId.value])
 			std::erase_if(_cfg.block(blockId).entries, [&](auto const& entry) { return !reachable[entry.value]; });
 		else


### PR DESCRIPTION
It occurred to me that we don't have an invalid/deleted state for basic blocks yet. This adds that state by changing the `vector<BasicBlock>` to a `vector<optional<BasicBlock>>`. If we end up removing and adding many blocks this on its own will lead to fragmentation. Therefore this also adds a free list that repurposes previously freed blocks.