### PR TITLE
Parser: reject invalid UTF-8 in NatSpec doc comments

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ Compiler Features:
 
 Bugfixes:
 * NatSpec: Disallow `@return` tag in event documentation.
+* Parser: Reject invalid UTF-8 byte sequences in NatSpec documentation comments instead of crashing during metadata serialization.
 
 
 ### 0.8.35 (2026-04-29)

--- a/liblangutil/Scanner.cpp
+++ b/liblangutil/Scanner.cpp
@@ -53,6 +53,7 @@
 #include <liblangutil/Common.h>
 #include <liblangutil/Exceptions.h>
 #include <liblangutil/Scanner.h>
+#include <libsolutil/UTF8.h>
 
 #include <boost/algorithm/string/classification.hpp>
 
@@ -84,6 +85,7 @@ std::string to_string(ScannerError _errorCode)
 		case ScannerError::OctalNotAllowed: return "Octal numbers not allowed.";
 		case ScannerError::DirectionalOverrideUnderflow: return "Unicode direction override underflow in comment or string literal.";
 		case ScannerError::DirectionalOverrideMismatch: return "Mismatching directional override markers in comment or string literal.";
+		case ScannerError::IllegalCharacterInComment: return "Invalid UTF-8 sequence in documentation comment.";
 		default:
 			solAssert(false, "Unhandled case in to_string(ScannerError)");
 			return "";
@@ -488,6 +490,8 @@ Token Scanner::scanSlash()
 			m_skippedComments[NextNext].location.sourceName = m_sourceName;
 			m_skippedComments[NextNext].token = Token::CommentLiteral;
 			m_skippedComments[NextNext].location.end = static_cast<int>(scanSingleLineDocComment());
+			if (!util::validateUTF8(m_skippedComments[NextNext].literal))
+				return setError(ScannerError::IllegalCharacterInComment);
 			return Token::Whitespace;
 		}
 		else
@@ -520,8 +524,9 @@ Token Scanner::scanSlash()
 			m_skippedComments[NextNext].token = comment;
 			if (comment == Token::Illegal)
 				return Token::Illegal; // error already set
-			else
-				return Token::Whitespace;
+			if (!util::validateUTF8(m_skippedComments[NextNext].literal))
+				return setError(ScannerError::IllegalCharacterInComment);
+			return Token::Whitespace;
 		}
 		else
 			return skipMultiLineComment();

--- a/liblangutil/Scanner.h
+++ b/liblangutil/Scanner.h
@@ -90,6 +90,8 @@ enum class ScannerError
 	DirectionalOverrideMismatch,
 
 	OctalNotAllowed,
+
+	IllegalCharacterInComment,
 };
 
 std::string to_string(ScannerError _errorCode);

--- a/libsolidity/parsing/Parser.cpp
+++ b/libsolidity/parsing/Parser.cpp
@@ -107,6 +107,9 @@ ASTPointer<SourceUnit> Parser::parse(CharStream& _charStream)
 		{
 			switch (m_scanner->currentToken())
 			{
+			case Token::Illegal:
+				fatalParserError(5985_error, to_string(m_scanner->currentError()));
+				break;
 			case Token::Pragma:
 				nodes.push_back(parsePragmaDirective(true));
 				break;
@@ -464,6 +467,8 @@ ASTPointer<ContractDefinition> Parser::parseContractDefinition()
 		Token currentTokenValue = m_scanner->currentToken();
 		if (currentTokenValue == Token::RBrace)
 			break;
+		else if (currentTokenValue == Token::Illegal)
+			fatalParserError(5100_error, to_string(m_scanner->currentError()));
 		else if (
 			(currentTokenValue == Token::Function && m_scanner->peekNextToken() != Token::LParen) ||
 			currentTokenValue == Token::Constructor ||

--- a/scripts/error_codes.py
+++ b/scripts/error_codes.py
@@ -13,7 +13,12 @@ SOURCE_FILE_PATTERN = r"\b\d+_error\b"
 def read_file(file_name):
     content = None
     _, tail = path.split(file_name)
-    is_latin = tail == "invalid_utf8_sequence.sol"
+    is_latin = tail in (
+        "invalid_utf8_sequence.sol",
+        "singleline_doc_invalid_utf8.sol",
+        "multiline_doc_invalid_utf8.sol",
+        "contract_body_doc_invalid_utf8.sol",
+    )
     try:
         with open(file_name, "r", encoding="latin-1" if is_latin else ENCODING) as f:
             content = f.read()

--- a/scripts/isolate_tests.py
+++ b/scripts/isolate_tests.py
@@ -158,8 +158,14 @@ if __name__ == '__main__':
                 subdirs.remove('_build')
             if 'compilationTests' in subdirs:
                 subdirs.remove('compilationTests')
+            invalid_utf8_files = {
+                "invalid_utf8_sequence.sol",
+                "singleline_doc_invalid_utf8.sol",
+                "multiline_doc_invalid_utf8.sol",
+                "contract_body_doc_invalid_utf8.sol",
+            }
             for f in files:
-                if basename(f) == "invalid_utf8_sequence.sol":
-                    continue  # ignore the test with broken utf-8 encoding
+                if basename(f) in invalid_utf8_files:
+                    continue  # ignore tests with broken utf-8 encoding
                 path = join(root, f)
                 extract_and_write(path, options.language)

--- a/scripts/test_antlr_grammar.sh
+++ b/scripts/test_antlr_grammar.sh
@@ -63,6 +63,9 @@ done < <(
       # Skipping the unicode tests as I couldn't adapt the lexical grammar to recursively counting RLO/LRO/PDF's.
       grep -v -E 'comments/.*_direction_override.*.sol' |
       grep -v -E 'literals/.*_direction_override.*.sol' |
+      # Skipping doc-comment tests that contain raw invalid UTF-8 bytes,
+      # which ANTLR's lexer cannot tokenize.
+      grep -v -E 'comments/(singleline|multiline|contract_body)_doc_invalid_utf8\.sol' |
       # Skipping a test with "revert E;" because ANTLR cannot distinguish it from
       # a variable declaration.
       grep -v -E 'revertStatement/non_called.sol' |

--- a/test/liblangutil/Scanner.cpp
+++ b/test/liblangutil/Scanner.cpp
@@ -797,6 +797,20 @@ BOOST_AUTO_TEST_CASE(multiline_comment_at_eos)
 	BOOST_CHECK_EQUAL(scanner.next(), Token::EOS);
 }
 
+BOOST_AUTO_TEST_CASE(invalid_utf8_in_single_line_doc_comment)
+{
+	TestScanner scanner(std::string("/// invalid \xF7\n"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
+	BOOST_CHECK_EQUAL(scanner.currentError(), ScannerError::IllegalCharacterInComment);
+}
+
+BOOST_AUTO_TEST_CASE(invalid_utf8_in_multi_line_doc_comment)
+{
+	TestScanner scanner(std::string("/** invalid \xF7 */"));
+	BOOST_CHECK_EQUAL(scanner.currentToken(), Token::Illegal);
+	BOOST_CHECK_EQUAL(scanner.currentError(), ScannerError::IllegalCharacterInComment);
+}
+
 BOOST_AUTO_TEST_CASE(regular_line_break_in_single_line_comment)
 {
 	for (auto const& nl: {"\r", "\n", "\r\n"})

--- a/test/libsolidity/syntaxTests/comments/contract_body_doc_invalid_utf8.sol
+++ b/test/libsolidity/syntaxTests/comments/contract_body_doc_invalid_utf8.sol
@@ -1,0 +1,6 @@
+contract C {
+    /// inside÷ doc
+    function f() public {}
+}
+// ----
+// ParserError 5100: (17-37): Invalid UTF-8 sequence in documentation comment.

--- a/test/libsolidity/syntaxTests/comments/multiline_doc_invalid_utf8.sol
+++ b/test/libsolidity/syntaxTests/comments/multiline_doc_invalid_utf8.sol
@@ -1,0 +1,6 @@
+/**
+ * invalid ÷ byte
+ */
+contract C {}
+// ----
+// ParserError 5985: (0-25): Invalid UTF-8 sequence in documentation comment.

--- a/test/libsolidity/syntaxTests/comments/singleline_doc_invalid_utf8.sol
+++ b/test/libsolidity/syntaxTests/comments/singleline_doc_invalid_utf8.sol
@@ -1,0 +1,4 @@
+contract C {}
+/// invalid utf-8: ÷
+// ----
+// ParserError 5985: (14-35): Invalid UTF-8 sequence in documentation comment.


### PR DESCRIPTION
## Description

Fixes #16519.

`solc --optimize --ir` crashes with an uncaught `nlohmann::json` `type_error 316: invalid UTF-8 byte at index 0: 0xF7` when a NatSpec documentation comment contains an invalid UTF-8 byte sequence. The bad bytes flow from the scanner's comment literal into the NatSpec text and from there into the metadata JSON (and the AST JSON / userdoc / devdoc outputs), where `nlohmann::json::dump` rejects them.

Minimal repro from the issue:

```
$ xxd minimized
00000000: 2f2f 2ff7 0a63 6f6e 7472 6163 7420 677b  ///..contract g{
00000010: 7d                                       }
$ solc --optimize --ir minimized
Uncaught exception:
[json.exception.type_error.316] invalid UTF-8 byte at index 0: 0xF7
```

## Fix

The scanner now validates the literal of every `///` and `/** */` documentation comment via `util::validateUTF8` and raises `ScannerError::IllegalCharacterInComment` on a malformed byte sequence.

The resulting `Token::Illegal` is surfaced by the parser at:

* the top-level source-unit switch in `Parser::parse` (new `5985_error`), which previously fell through to the generic `7858` "expected pragma" message and swallowed the scanner error;
* the contract-body member loop in `Parser::parseContractDefinition` (new `5100_error`), which previously fell through to the generic `9182` "function, variable, struct or modifier declaration expected" message.

After the fix, the same input now exits cleanly:

```
Error: Invalid UTF-8 sequence in documentation comment.
 --> minimized:1:1:
  |
1 | ///
  | ^ (Relevant source part starts here and spans across multiple lines).
```

Validating at the scanner is the right chokepoint: doc-comment text reaches the metadata JSON, devdoc, userdoc and AST JSON exclusively via `m_skippedComments[].literal`, so rejecting bad bytes at scan time poisons every downstream consumer with a parser error before any JSON serialization is attempted. Non-doc `//` and `/* */` comments are not stored, so they don't need validation.

## Tests

* `test/libsolidity/syntaxTests/comments/singleline_doc_invalid_utf8.sol`
* `test/libsolidity/syntaxTests/comments/multiline_doc_invalid_utf8.sol`
* `test/libsolidity/syntaxTests/comments/contract_body_doc_invalid_utf8.sol`
* `test/liblangutil/Scanner.cpp`: `invalid_utf8_in_single_line_doc_comment`, `invalid_utf8_in_multi_line_doc_comment`

`scripts/error_codes.py` is taught about the three new fixtures so that the `--check` step can read them with a `latin-1` fallback (matching the existing `invalid_utf8_sequence.sol` exception). `python3 scripts/error_codes.py --check` passes; `--next` reports `1572`.

Full `ScannerTest` (82 cases), `SolidityParser` (25 cases) and the syntax-test corpus pass locally.

## Test plan

- [x] Repro from #16519 no longer crashes; exits with `ParserError 5985`.
- [x] In-body NatSpec with invalid UTF-8 produces `ParserError 5100` instead of crashing or emitting a generic message.
- [x] Valid multi-byte UTF-8 NatSpec (`wörld 你好`) still parses cleanly.
- [x] `python3 scripts/error_codes.py --check` succeeds.
- [x] `isoltest --no-semantic-tests --no-smt` reports no failures.
- [x] `soltest --run_test='ScannerTest'` reports no failures.

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
- [x] No AI tools were used
- [ ] AI tools were used (details below)
