### PR TITLE
TypeChecker: skip external free functions in `using for` resolution

### DIFF
--- a/libsolidity/analysis/TypeChecker.cpp
+++ b/libsolidity/analysis/TypeChecker.cpp
@@ -4052,6 +4052,20 @@ void TypeChecker::endVisit(UsingForDirective const& _usingFor)
 		FunctionDefinition const& functionDefinition =
 			dynamic_cast<FunctionDefinition const&>(*path->annotation().referencedDeclaration);
 
+		// Free functions with an explicit visibility were already flagged by the
+		// SyntaxChecker (error 4126). That error is not fatal, so resolution
+		// continues into this directive and calls `functionDefinition.type()`,
+		// which asserts non-external. Skip the entry to avoid the ICE; the user
+		// will still see the visibility error from the function definition.
+		if (
+			!functionDefinition.libraryFunction() &&
+			functionDefinition.visibility() == Visibility::External
+		)
+		{
+			solAssert(m_errorReporter.hasErrors());
+			continue;
+		}
+
 		FunctionType const* functionType = dynamic_cast<FunctionType const*>(
 			functionDefinition.libraryFunction() ?
 				functionDefinition.typeViaContractName() :

--- a/test/libsolidity/syntaxTests/using/external_free_function.sol
+++ b/test/libsolidity/syntaxTests/using/external_free_function.sol
@@ -1,0 +1,7 @@
+// Used to cause ICE in FunctionDefinition::type() when an external free
+// function (already a syntax error) was bound via `using for`.
+function f(int) external;
+using {f} for int global;
+// ----
+// SyntaxError 4126: (0-26): Free functions cannot have visibility.
+// TypeError 4668: (0-26): Free functions must be implemented.


### PR DESCRIPTION
## Summary

When a free function declared \`external\` is referenced from a \`using for\` directive, SyntaxChecker emits error 4126 (\"Free functions cannot have visibility.\") but the error is **not fatal**, so type checking continues into \`endVisit(UsingForDirective)\`. The resolution there calls \`FunctionDefinition::type()\` on the non-library branch, which asserts \`visibility() != External\` and triggers an ICE.

Skip such entries explicitly under \`solAssert(hasErrors())\`. The user still receives the visibility error from the function definition itself, and the directive no longer reaches the assertion.

Fixes #16620

## Test plan

- [x] Added \`test/libsolidity/syntaxTests/using/external_free_function.sol\` covering the MRE from the issue. Expects the existing SyntaxError 4126 / TypeError 4668 messages and no longer crashes.
- [ ] Full \`make test\` not run locally (no build environment); relying on CI.