### PR TITLE
Type Checker: skip zero-param bindings in operatorDefinitions matching scan

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -404,7 +404,13 @@ std::set<FunctionDefinition const*, ASTNode::CompareByID> Type::operatorDefiniti
 				*identifierPath->annotation().referencedDeclaration
 			);
 			auto const* functionType = dynamic_cast<FunctionType const*>(functionDefinition.typeWhenAttached());
-			solAssert(functionType && !functionType->parameterTypes().empty());
+			solAssert(functionType);
+			// Zero-parameter functions are rejected by TypeChecker::endVisit(UsingForDirective)
+			// with error 4731, but that fatal fires per-binding and the matching scan below
+			// still revisits sibling bindings. Skip them here so that we do not assert on an
+			// already-reported invalid binding (#16613).
+			if (functionType->parameterTypes().empty())
+				continue;
 
 			size_t parameterCount = functionDefinition.parameterList().parameters().size();
 			if (*this == *functionType->parameterTypes().front() && (_unary ? parameterCount == 1 : parameterCount == 2))

--- a/test/libsolidity/syntaxTests/operators/userDefined/operator_zero_param_alongside_valid_binding_no_ice.sol
+++ b/test/libsolidity/syntaxTests/operators/userDefined/operator_zero_param_alongside_valid_binding_no_ice.sol
@@ -1,0 +1,6 @@
+type T is int256;
+function f(T a, T b) pure returns (T) {}
+function g() pure returns (T) {}
+using {f as -, g as -} for T global;
+// ----
+// TypeError 4731: (107-108): The function "g" does not have any parameters, and therefore cannot be attached to the type "T".


### PR DESCRIPTION
## Description

Fixes #16613.

In a global `using { ..., g as <op> } for T` directive that mixes a valid binding (`f as -`, two parameters of `T`) with a zero-parameter binding (`g as -`), `solc --bin` panics with an internal compiler error before the user-visible 4731 (`The function "g" does not have any parameters...`) is emitted:

```
Internal compiler error:
libsolidity/ast/Types.cpp(409): Throw in function ... operatorDefinitions(...)
Solidity assertion failed
```

`TypeChecker::endVisit(UsingForDirective)` walks the bindings in order. For `f` it reaches the per-binding cross-scan at `libsolidity/analysis/TypeChecker.cpp:4224` and calls `Type::operatorDefinitions(_token, _scope, _unary)`. That helper iterates every binding of every using-for directive on `T` (including `g`), and asserted on `!functionType->parameterTypes().empty()`. The fatal 4731 for `g` is only fired later, when the outer loop reaches it.

This change keeps the assertion that the binding still maps to a `FunctionType`, but treats the empty-parameter case as a no-op for the matching scan. The TypeChecker still emits 4731 from `endVisit(UsingForDirective)`, so the user-visible diagnostic is unchanged for the well-typed binding paths and for the standalone zero-parameter case (`operator_taking_no_parameters_unary.sol` is unaffected).

## Tests

- New `test/libsolidity/syntaxTests/operators/userDefined/operator_zero_param_alongside_valid_binding_no_ice.sol` reproduces the issue MRE (one valid `-` binding + one zero-parameter `-` binding) and asserts the expected `TypeError 4731` instead of the prior ICE.

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
- [x] No AI tools were used
- [ ] AI tools were used (details below)
