### PR TITLE
Type Checker: skip zero-param free functions in attachedFunctions resolution

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -457,10 +457,16 @@ MemberList::MemberMap Type::attachedFunctions(Type const& _type, ASTNode const& 
 				}
 			}
 			else
-				addFunction(
-					dynamic_cast<FunctionDefinition const&>(*declaration),
-					identifierPath->path().back()
-				);
+			{
+				auto const& functionDefinition = dynamic_cast<FunctionDefinition const&>(*declaration);
+				// Zero-parameter functions are rejected by TypeChecker::endVisit(UsingForDirective)
+				// with error 4731, but member resolution can run before the directive is visited
+				// when the call site precedes the directive in the contract body. Skip these here
+				// so addFunction() does not assert in withBoundFirstArgument() (#16610).
+				if (functionDefinition.parameters().empty())
+					continue;
+				addFunction(functionDefinition, identifierPath->path().back());
+			}
 		}
 
 	return members;

--- a/test/libsolidity/syntaxTests/using/using_free_no_parameters_call_site_before_directive.sol
+++ b/test/libsolidity/syntaxTests/using/using_free_no_parameters_call_site_before_directive.sol
@@ -1,0 +1,11 @@
+function zero() pure returns (uint) { return 0; }
+
+contract C {
+    function f(uint z) pure external returns (uint) {
+        return z.zero();
+    }
+    using {zero} for uint;
+}
+// ----
+// TypeError 9582: (133-139): Member "zero" not found or not visible after argument-dependent lookup in uint256.
+// TypeError 4731: (160-164): The function "zero" does not have any parameters, and therefore cannot be attached to the type "uint256".


### PR DESCRIPTION
## Description

Fixes #16610.

`solc --bin` panics with an internal compiler error when a `using { zero } for T` directive binds a zero-parameter free function and the call site (`x.zero()`) appears in the contract body **before** the directive:

```solidity
function zero() pure returns (uint) { return 0; }

contract C {
    function f(uint z) external pure returns (uint) {
        return z.zero();
    }
    using {zero} for uint;
}
```

```
Internal compiler error:
libsolidity/ast/Types.cpp(3753): Throw in function ... withBoundFirstArgument()
Solidity assertion failed
```

`Type::attachedFunctions()` is called from member resolution while typechecking `z.zero()`. For library-bound entries it already filters out functions with no parameters at `Types.cpp:460`, but the non-library branch (free functions bound via `using { zero } for T`) calls `addFunction()` unconditionally, which asserts in `FunctionType::withBoundFirstArgument()`. The fatal `4731` ("does not have any parameters") in `TypeChecker::endVisit(UsingForDirective)` only fires later, when the directive itself is visited.

This change mirrors the existing library-binding filter for free-function bindings: empty-parameter entries are skipped during attached-function resolution. The TypeChecker still emits the 4731 error from the directive, and the call site separately emits a `9582` "member not found" error, matching the diagnostics surface that users would see for any other unattached function.

## Tests

- New `test/libsolidity/syntaxTests/using/using_free_no_parameters_call_site_before_directive.sol` reproduces the issue MRE and asserts both expected `TypeError 9582` and `TypeError 4731` instead of the prior ICE.
- Existing `using_free_no_parameters_err.sol` (directive without call site) is unaffected.

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
- [x] No AI tools were used
- [ ] AI tools were used (details below)
