### PR TITLE
Code Generator: treat `abi.encodeCall` as no-op when referenced as a bare member

### DIFF
--- a/libsolidity/codegen/ExpressionCompiler.cpp
+++ b/libsolidity/codegen/ExpressionCompiler.cpp
@@ -2050,7 +2050,7 @@ bool ExpressionCompiler::visit(MemberAccess const& _memberAccess)
 				solAssert(false, "min/max not available for the given type.");
 
 		}
-		else if ((std::set<std::string>{"encode", "encodePacked", "encodeWithSelector", "encodeWithSignature", "decode"}).count(member))
+		else if ((std::set<std::string>{"encode", "encodePacked", "encodeCall", "encodeWithSelector", "encodeWithSignature", "decode"}).count(member))
 		{
 			// no-op
 		}

--- a/test/libsolidity/semanticTests/specialFunctions/abi_functions_member_access.sol
+++ b/test/libsolidity/semanticTests/specialFunctions/abi_functions_member_access.sol
@@ -2,6 +2,7 @@ contract C {
     function f() public pure {
         abi.encode;
         abi.encodePacked;
+        abi.encodeCall;
         abi.encodeWithSelector;
         abi.encodeWithSignature;
         abi.decode;

--- a/test/libsolidity/syntaxTests/specialFunctions/abi_encodeCall_member_access.sol
+++ b/test/libsolidity/syntaxTests/specialFunctions/abi_encodeCall_member_access.sol
@@ -1,0 +1,7 @@
+contract C {
+    function f() public pure {
+        abi.encodeCall;
+    }
+}
+// ----
+// Warning 6133: (52-66): Statement has no effect.


### PR DESCRIPTION
## Description

Fixes #16612.

`solc --bin` panics with an internal compiler error when `abi.encodeCall` is referenced as a bare member expression (not called):

```solidity
contract C { function f() public { abi.encodeCall; } }
```

```
Internal compiler error:
libsolidity/codegen/ExpressionCompiler.cpp(2058): Throw in function ... visit(MemberAccess&)
Unknown magic member.
```

The `abi.*` member access branch in `ExpressionCompiler::visit(MemberAccess const&)` carries a hard-coded set of members that are silently dropped when referenced without a call: `encode`, `encodePacked`, `encodeWithSelector`, `encodeWithSignature`, `decode`. `encodeCall` is missing from this set, so its bare reference falls through to the `solAssert(false, "Unknown magic member.")` guard. The other members in the same family already no-op without bytecode side effects; this change adds `encodeCall` to match.

The TypeChecker continues to flag the bare reference with `Warning 6133` ("Statement has no effect"), preserving the existing user-visible diagnostic surface.

## Tests

- New `test/libsolidity/syntaxTests/specialFunctions/abi_encodeCall_member_access.sol` exercises the bare `abi.encodeCall;` reference and asserts the expected `Warning 6133` instead of the prior ICE.
- Existing `test/libsolidity/semanticTests/specialFunctions/abi_functions_member_access.sol` extended to include `abi.encodeCall;` so the codegen no-op branch is exercised as part of the same semantic round-trip that already covers the rest of the family.

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
- [x] No AI tools were used
- [ ] AI tools were used (details below)
