### PR TITLE
ethdebug: Improve current testing infra

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1718,6 +1718,37 @@ jobs:
           command: |
             pytest test/ethdebugSchemaTests --solc-binary-path=/tmp/workspace/solc/solc-static-linux -v
 
+  t_ethdebug_overhead:
+    <<: *base_ubuntu2404_large
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - install_python3
+      - run:
+          name: ETHDebug compilation overhead
+          no_output_timeout: 30m
+          command: |
+            git clone --depth 1 --branch feature/ethdebug-overhead https://github.com/walnuthq/solc-bench.git /tmp/solc-bench
+            python3 -m pip install --user --break-system-packages /tmp/solc-bench
+            export PATH="$HOME/.local/bin:$PATH"
+
+            mkdir -p reports/ethdebug-overhead
+            solc-bench run \
+              --solc /tmp/workspace/solc/solc-static-linux \
+              --benchmark-dir /tmp/solc-bench/benchmark_data \
+              --tags med \
+              --iterations 3 \
+              --ethdebug-overhead \
+              --output-dir reports/ethdebug-overhead
+
+            solc-bench compare \
+              reports/ethdebug-overhead/bench-results.json \
+              --pipelines ir-ethdebug:ir \
+              --max-regression cpu_time:50
+      - store_artifacts:
+          path: reports/ethdebug-overhead/
+
   c_ext_benchmarks:
     <<: *base_node_small
     steps:
@@ -2158,6 +2189,9 @@ workflows:
 
       - t_ethdebug_output_validity:
           name: ETHDebug
+          <<: *requires_b_ubu_static
+      - t_ethdebug_overhead:
+          name: ETHDebug overhead
           <<: *requires_b_ubu_static
 
       - c_ext_benchmarks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1710,7 +1710,11 @@ jobs:
       - install_python3:
             packages: pyyaml jsonschema pytest
       - run:
-          name: Ethdebug validity tests
+          name: Initialize ethdebug/format schemas
+          command: |
+            git submodule update --init test/ethdebugSchemaTests/ethdebug-format
+      - run:
+          name: ETHDebug schema validation
           command: |
             pytest test/ethdebugSchemaTests --solc-binary-path=/tmp/workspace/solc/solc-static-linux -v
 
@@ -2153,6 +2157,7 @@ workflows:
       #- t_ext: *job_native_compile_ext_bleeps
 
       - t_ethdebug_output_validity:
+          name: ETHDebug
           <<: *requires_b_ubu_static
 
       - c_ext_benchmarks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1718,37 +1718,6 @@ jobs:
           command: |
             pytest test/ethdebugSchemaTests --solc-binary-path=/tmp/workspace/solc/solc-static-linux -v
 
-  t_ethdebug_overhead:
-    <<: *base_ubuntu2404_large
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /tmp/workspace
-      - install_python3
-      - run:
-          name: ETHDebug compilation overhead
-          no_output_timeout: 30m
-          command: |
-            git clone --depth 1 --branch feature/ethdebug-overhead https://github.com/walnuthq/solc-bench.git /tmp/solc-bench
-            python3 -m pip install --user --break-system-packages /tmp/solc-bench
-            export PATH="$HOME/.local/bin:$PATH"
-
-            mkdir -p reports/ethdebug-overhead
-            solc-bench run \
-              --solc /tmp/workspace/solc/solc-static-linux \
-              --benchmark-dir /tmp/solc-bench/benchmark_data \
-              --tags med \
-              --iterations 3 \
-              --ethdebug-overhead \
-              --output-dir reports/ethdebug-overhead
-
-            solc-bench compare \
-              reports/ethdebug-overhead/bench-results.json \
-              --pipelines ir-ethdebug:ir \
-              --max-regression cpu_time:50
-      - store_artifacts:
-          path: reports/ethdebug-overhead/
-
   c_ext_benchmarks:
     <<: *base_node_small
     steps:
@@ -2189,9 +2158,6 @@ workflows:
 
       - t_ethdebug_output_validity:
           name: ETHDebug
-          <<: *requires_b_ubu_static
-      - t_ethdebug_overhead:
-          name: ETHDebug overhead
           <<: *requires_b_ubu_static
 
       - c_ext_benchmarks:

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "deps/fmtlib"]
 	path = deps/fmtlib
 	url = https://github.com/fmtlib/fmt.git
+[submodule "test/ethdebugSchemaTests/ethdebug-format"]
+	path = test/ethdebugSchemaTests/ethdebug-format
+	url = https://github.com/ethdebug/format.git

--- a/libevmasm/Ethdebug.cpp
+++ b/libevmasm/Ethdebug.cpp
@@ -157,13 +157,13 @@ std::string compilationID(std::vector<Source> const& _sources)
 
 schema::materials::Source materialSource(Source const& _source)
 {
-	return {
-		.id = schema::materials::ID{_source.id},
-		.path = _source.path,
-		.contents = _source.contents,
-		.encoding = std::nullopt,
-		.language = _source.language,
-	};
+	schema::materials::Source result;
+	result.id = schema::materials::ID{_source.id};
+	result.path = _source.path;
+	result.contents = _source.contents;
+	result.encoding = std::nullopt;
+	result.language = _source.language;
+	return result;
 }
 
 schema::materials::Compilation materialCompilation(std::vector<Source> const& _sources, std::string_view _version)
@@ -173,15 +173,13 @@ schema::materials::Compilation materialCompilation(std::vector<Source> const& _s
 	for (auto const& source: _sources)
 		sources.emplace_back(materialSource(source));
 
-	return {
-		.id = schema::materials::ID{compilationID(_sources)},
-		.compiler = {
-			.name = "solc",
-			.version = std::string{_version},
-		},
-		.settings = std::nullopt,
-		.sources = std::move(sources),
-	};
+	schema::materials::Compilation result;
+	result.id = schema::materials::ID{compilationID(_sources)};
+	result.compiler.name = "solc";
+	result.compiler.version = std::string{_version};
+	result.settings = std::nullopt;
+	result.sources = std::move(sources);
+	return result;
 }
 
 } // anonymous namespace

--- a/libevmasm/Ethdebug.cpp
+++ b/libevmasm/Ethdebug.cpp
@@ -20,6 +20,8 @@
 
 #include <libevmasm/EthdebugSchema.h>
 
+#include <libsolutil/Keccak256.h>
+
 #include <range/v3/algorithm/any_of.hpp>
 
 using namespace solidity;
@@ -127,6 +129,59 @@ std::vector<schema::program::Instruction> programInstructions(Assembly const& _a
 	return instructionInfo;
 }
 
+void appendLengthPrefixed(std::string& _target, std::string_view _value)
+{
+	_target += std::to_string(_value.size());
+	_target += ":";
+	_target += _value;
+}
+
+std::string compilationID(std::vector<Source> const& _sources)
+{
+	// Keep this independent from VersionString build metadata.
+	// TODO: take compilation flags into account. Once compiler settings are threaded
+	// into ETHDebug resources, include a normalized settings object here.
+	std::string rawIDInput = "ethdebug-solc-compilation-v1";
+	appendLengthPrefixed(rawIDInput, std::to_string(_sources.size()));
+
+	for (auto const& source: _sources)
+	{
+		appendLengthPrefixed(rawIDInput, std::to_string(source.id));
+		appendLengthPrefixed(rawIDInput, source.path);
+		appendLengthPrefixed(rawIDInput, source.contents);
+		appendLengthPrefixed(rawIDInput, source.language);
+	}
+
+	return "solc-" + util::keccak256(rawIDInput).hex();
+}
+
+schema::materials::Source materialSource(Source const& _source)
+{
+	schema::materials::Source result;
+	result.id = schema::materials::ID{_source.id};
+	result.path = _source.path;
+	result.contents = _source.contents;
+	result.encoding = std::nullopt;
+	result.language = _source.language;
+	return result;
+}
+
+schema::materials::Compilation materialCompilation(std::vector<Source> const& _sources, std::string_view _version)
+{
+	std::vector<schema::materials::Source> sources;
+	sources.reserve(_sources.size());
+	for (auto const& source: _sources)
+		sources.emplace_back(materialSource(source));
+
+	schema::materials::Compilation result;
+	result.id = schema::materials::ID{compilationID(_sources)};
+	result.compiler.name = "solc";
+	result.compiler.version = std::string{_version};
+	result.settings = std::nullopt;
+	result.sources = std::move(sources);
+	return result;
+}
+
 } // anonymous namespace
 
 Json ethdebug::program(std::string_view _name, unsigned _sourceID, Assembly const& _assembly, LinkerObject const& _linkerObject)
@@ -149,27 +204,16 @@ Json ethdebug::program(std::string_view _name, unsigned _sourceID, Assembly cons
 	};
 }
 
-Json ethdebug::resources(std::vector<std::string> const& _sources, std::string const& _version)
+Json ethdebug::resources(std::vector<Source> const& _sources, std::string_view _version)
 {
-	Json sources = Json::array();
-	for (size_t id = 0; id < _sources.size(); ++id)
-	{
-		Json source = Json::object();
-		source["id"] = id;
-		source["path"] = _sources[id];
-		sources.push_back(source);
-	}
-	Json result = Json::object();
-	result["compilation"] = compilation(_version);
-	result["compilation"]["sources"] = sources;
+	schema::info::Resources result;
+	result.compilation = materialCompilation(_sources, _version);
+	result.types = Json::object();
+	result.pointers = Json::object();
 	return result;
 }
 
-Json ethdebug::compilation(std::string_view _version)
+Json ethdebug::compilation(std::vector<Source> const& _sources, std::string_view _version)
 {
-	Json result = Json::object();
-	result["compiler"] = Json::object();
-	result["compiler"]["name"] = "solc";
-	result["compiler"]["version"] = _version;
-	return result;
+	return materialCompilation(_sources, _version);
 }

--- a/libevmasm/Ethdebug.cpp
+++ b/libevmasm/Ethdebug.cpp
@@ -22,6 +22,8 @@
 
 #include <libsolutil/Keccak256.h>
 
+#include <fmt/format.h>
+
 #include <range/v3/algorithm/any_of.hpp>
 
 using namespace solidity;
@@ -129,11 +131,9 @@ std::vector<schema::program::Instruction> programInstructions(Assembly const& _a
 	return instructionInfo;
 }
 
-void appendLengthPrefixed(std::string& _target, std::string_view _value)
+std::string lengthPrefixed(std::string_view _value)
 {
-	_target += std::to_string(_value.size());
-	_target += ":";
-	_target += _value;
+	return fmt::format("{}:{}", _value.size(), _value);
 }
 
 std::string compilationID(std::vector<Source> const& _sources)
@@ -142,28 +142,28 @@ std::string compilationID(std::vector<Source> const& _sources)
 	// TODO: take compilation flags into account. Once compiler settings are threaded
 	// into ETHDebug resources, include a normalized settings object here.
 	std::string rawIDInput = "ethdebug-solc-compilation-v1";
-	appendLengthPrefixed(rawIDInput, std::to_string(_sources.size()));
+	rawIDInput += lengthPrefixed(std::to_string(_sources.size()));
 
 	for (auto const& source: _sources)
 	{
-		appendLengthPrefixed(rawIDInput, std::to_string(source.id));
-		appendLengthPrefixed(rawIDInput, source.path);
-		appendLengthPrefixed(rawIDInput, source.contents);
-		appendLengthPrefixed(rawIDInput, source.language);
+		rawIDInput += lengthPrefixed(std::to_string(source.id));
+		rawIDInput += lengthPrefixed(source.path);
+		rawIDInput += lengthPrefixed(source.contents);
+		rawIDInput += lengthPrefixed(source.language);
 	}
 
-	return "solc-" + util::keccak256(rawIDInput).hex();
+	return fmt::format("solc-{}", util::keccak256(rawIDInput).hex());
 }
 
 schema::materials::Source materialSource(Source const& _source)
 {
-	schema::materials::Source result;
-	result.id = schema::materials::ID{_source.id};
-	result.path = _source.path;
-	result.contents = _source.contents;
-	result.encoding = std::nullopt;
-	result.language = _source.language;
-	return result;
+	return {
+		.id = schema::materials::ID{_source.id},
+		.path = _source.path,
+		.contents = _source.contents,
+		.encoding = std::nullopt,
+		.language = _source.language,
+	};
 }
 
 schema::materials::Compilation materialCompilation(std::vector<Source> const& _sources, std::string_view _version)
@@ -173,13 +173,15 @@ schema::materials::Compilation materialCompilation(std::vector<Source> const& _s
 	for (auto const& source: _sources)
 		sources.emplace_back(materialSource(source));
 
-	schema::materials::Compilation result;
-	result.id = schema::materials::ID{compilationID(_sources)};
-	result.compiler.name = "solc";
-	result.compiler.version = std::string{_version};
-	result.settings = std::nullopt;
-	result.sources = std::move(sources);
-	return result;
+	return {
+		.id = schema::materials::ID{compilationID(_sources)},
+		.compiler = {
+			.name = "solc",
+			.version = std::string{_version},
+		},
+		.settings = std::nullopt,
+		.sources = std::move(sources),
+	};
 }
 
 } // anonymous namespace

--- a/libevmasm/Ethdebug.h
+++ b/libevmasm/Ethdebug.h
@@ -26,13 +26,21 @@
 namespace solidity::evmasm::ethdebug
 {
 
+struct Source
+{
+	unsigned id;
+	std::string path;
+	std::string contents;
+	std::string language;
+};
+
 // returns ethdebug/format/program.
 Json program(std::string_view _name, unsigned _sourceID, Assembly const& _assembly, LinkerObject const& _linkerObject);
 
 // returns ethdebug/format/info/resources
-Json resources(std::vector<std::string> const& _sources, std::string const& _version);
+Json resources(std::vector<Source> const& _sources, std::string_view _version);
 
 // returns the 'compilation' object from ethdebug/format/info/resources
-Json compilation(std::string_view _version);
+Json compilation(std::vector<Source> const& _sources, std::string_view _version);
 
 } // namespace solidity::evmasm::ethdebug

--- a/libevmasm/EthdebugSchema.cpp
+++ b/libevmasm/EthdebugSchema.cpp
@@ -66,6 +66,31 @@ void schema::materials::to_json(Json& _json, SourceRange const& _sourceRange)
 		_json["range"] = *_sourceRange.range;
 }
 
+void schema::materials::to_json(Json& _json, Source const& _source)
+{
+	_json["id"] = _source.id;
+	_json["path"] = _source.path;
+	_json["contents"] = _source.contents;
+	if (_source.encoding)
+		_json["encoding"] = *_source.encoding;
+	_json["language"] = _source.language;
+}
+
+void schema::materials::to_json(Json& _json, Compilation::Compiler const& _compiler)
+{
+	_json["name"] = _compiler.name;
+	_json["version"] = _compiler.version;
+}
+
+void schema::materials::to_json(Json& _json, Compilation const& _compilation)
+{
+	_json["id"] = _compilation.id;
+	_json["compiler"] = _compilation.compiler;
+	if (_compilation.settings)
+		_json["settings"] = *_compilation.settings;
+	_json["sources"] = _compilation.sources;
+}
+
 void schema::to_json(Json& _json, Program::Contract const& _contract)
 {
 	if (_contract.name)
@@ -140,4 +165,11 @@ void schema::to_json(Json& _json, Program::Environment const& _environment)
 		_json = "create";
 		break;
 	}
+}
+
+void schema::info::to_json(Json& _json, Resources const& _resources)
+{
+	_json["compilation"] = _resources.compilation;
+	_json["types"] = _resources.types;
+	_json["pointers"] = _resources.pointers;
 }

--- a/libevmasm/EthdebugSchema.h
+++ b/libevmasm/EthdebugSchema.h
@@ -23,6 +23,7 @@
 
 #include <concepts>
 #include <optional>
+#include <string>
 #include <variant>
 #include <vector>
 
@@ -88,6 +89,29 @@ struct SourceRange
 	std::optional<Range> range;
 };
 
+struct Source
+{
+	ID id;
+	std::string path;
+	std::string contents;
+	std::optional<std::string> encoding;
+	std::string language;
+};
+
+struct Compilation
+{
+	struct Compiler
+	{
+		std::string name;
+		std::string version;
+	};
+
+	ID id;
+	Compiler compiler;
+	std::optional<Json> settings;
+	std::vector<Source> sources;
+};
+
 }
 
 namespace program
@@ -143,6 +167,18 @@ struct Program
 	std::vector<program::Instruction> instructions;
 };
 
+namespace info
+{
+
+struct Resources
+{
+	materials::Compilation compilation;
+	Json types;
+	Json pointers;
+};
+
+}
+
 namespace data
 {
 void to_json(Json& _json, HexValue const& _hexValue);
@@ -155,6 +191,9 @@ void to_json(Json& _json, ID const& _id);
 void to_json(Json& _json, Reference const& _source);
 void to_json(Json& _json, SourceRange::Range const& _range);
 void to_json(Json& _json, SourceRange const& _sourceRange);
+void to_json(Json& _json, Source const& _source);
+void to_json(Json& _json, Compilation::Compiler const& _compiler);
+void to_json(Json& _json, Compilation const& _compilation);
 }
 
 namespace program
@@ -168,5 +207,10 @@ void to_json(Json& _json, Instruction const& _instruction);
 void to_json(Json& _json, Program::Contract const& _contract);
 void to_json(Json& _json, Program::Environment const& _environment);
 void to_json(Json& _json, Program const& _program);
+
+namespace info
+{
+void to_json(Json& _json, Resources const& _resources);
+}
 
 }

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -1234,12 +1234,28 @@ Json CompilerStack::interfaceSymbols(std::string const& _contractName) const
 Json CompilerStack::ethdebug() const
 {
 	solAssert(m_stackState >= AnalysisSuccessful, "Analysis was not successful.");
-	return evmasm::ethdebug::resources(sourceNames(), VersionString);
+	return evmasm::ethdebug::resources(ethdebugSources(), VersionString);
 }
 
 Json CompilerStack::ethdebugCompilation() const
 {
-	return evmasm::ethdebug::compilation(VersionString);
+	solAssert(m_stackState >= AnalysisSuccessful, "Analysis was not successful.");
+	return evmasm::ethdebug::compilation(ethdebugSources(), VersionString);
+}
+
+std::vector<evmasm::ethdebug::Source> CompilerStack::ethdebugSources() const
+{
+	auto const sourceIDs = sourceIndices();
+	std::vector<evmasm::ethdebug::Source> sources;
+	sources.reserve(m_sources.size());
+	for (auto const& [sourceName, source]: m_sources)
+		sources.push_back({
+			.id = sourceIDs.at(sourceName),
+			.path = sourceName,
+			.contents = source.charStream->source(),
+			.language = "Solidity"
+		});
+	return sources;
 }
 
 Json CompilerStack::ethdebug(std::string const& _contractName) const

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -69,6 +69,11 @@ namespace solidity::evmasm
 class Assembly;
 class AssemblyItem;
 using AssemblyItems = std::vector<AssemblyItem>;
+
+namespace ethdebug
+{
+struct Source;
+}
 }
 
 namespace solidity::yul
@@ -460,6 +465,8 @@ private:
 		util::h256 const& swarmHash() const;
 		std::string const& ipfsUrl() const;
 	};
+
+	std::vector<evmasm::ethdebug::Source> ethdebugSources() const;
 
 	/// The state per contract. Filled gradually during compilation.
 	struct Contract

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -1908,12 +1908,18 @@ Json StandardCompiler::compileYul(InputsAndSettings _inputsAndSettings)
 	if (isEthdebugGlobalOutputRequested(_inputsAndSettings.outputSelection, "ethdebug.resources"))
 	{
 		solAssert(_inputsAndSettings.experimental, "");
-		output["ethdebug"]["resources"] = evmasm::ethdebug::resources({sourceName}, VersionString);
+		output["ethdebug"]["resources"] = evmasm::ethdebug::resources(
+			{{.id = 0, .path = sourceName, .contents = sourceContents, .language = "Yul"}},
+			VersionString
+		);
 	}
 	if (isEthdebugGlobalOutputRequested(_inputsAndSettings.outputSelection, "ethdebug.compilation"))
 	{
 		solAssert(_inputsAndSettings.experimental, "");
-		output["ethdebug"]["compilation"] = evmasm::ethdebug::compilation(VersionString);
+		output["ethdebug"]["compilation"] = evmasm::ethdebug::compilation(
+			{{.id = 0, .path = sourceName, .contents = sourceContents, .language = "Yul"}},
+			VersionString
+		);
 	}
 	return output;
 }

--- a/solc/CommandLineInterface.cpp
+++ b/solc/CommandLineInterface.cpp
@@ -1371,7 +1371,10 @@ void CommandLineInterface::assembleYul(yul::YulStack::Machine _targetMachine)
 		{
 			sout() << "======= Debug Data (ethdebug/format/info/resources) =======" << std::endl;
 			sout() << util::jsonPrint(
-					evmasm::ethdebug::resources({{sourceUnitName}}, VersionString),
+					evmasm::ethdebug::resources(
+						{{.id = 0, .path = sourceUnitName, .contents = yulSource, .language = "Yul"}},
+						VersionString
+					),
 					m_options.formatting.json
 			) << std::endl;
 		}
@@ -1379,7 +1382,10 @@ void CommandLineInterface::assembleYul(yul::YulStack::Machine _targetMachine)
 		{
 			sout() << "======= Debug Data (ethdebug compilation) =======" << std::endl;
 			sout() << util::jsonPrint(
-					evmasm::ethdebug::compilation(VersionString),
+					evmasm::ethdebug::compilation(
+						{{.id = 0, .path = sourceUnitName, .contents = yulSource, .language = "Yul"}},
+						VersionString
+					),
 					m_options.formatting.json
 			) << std::endl;
 		}

--- a/test/cmdlineTests/ethdebug_eof_container_osaka/output
+++ b/test/cmdlineTests/ethdebug_eof_container_osaka/output
@@ -3,7 +3,16 @@
     "compiler": {
         "name": "solc",
         "version": "<VERSION REMOVED>"
-    }
+    },
+    "id": "solc-cb8d51a34a3cd68eeec8de2d8c4c7910b9c29d2d66fd8f74d4bfa4010bbf3e48",
+    "sources": [
+        {
+            "contents": "// SPDX-License-Identifier: GPL-2.0\npragma solidity >=0.0;\n\ncontract C {\n    function f() public {}\n}\n",
+            "id": 0,
+            "language": "Solidity",
+            "path": "input.sol"
+        }
+    ]
 }
 
 ======= input.sol:C =======

--- a/test/cmdlineTests/ethdebug_on_abstract/output
+++ b/test/cmdlineTests/ethdebug_on_abstract/output
@@ -3,7 +3,16 @@
     "compiler": {
         "name": "solc",
         "version": "<VERSION REMOVED>"
-    }
+    },
+    "id": "solc-1fb1a811d53b0858c48a4da75091cdc547267ca7eb5bd7ad2d386d171a88cf5d",
+    "sources": [
+        {
+            "contents": "// SPDX-License-Identifier: GPL-2.0\npragma solidity >=0.0;\n\nabstract contract C {\n    function f() public virtual returns (bytes32);\n}\n",
+            "id": 0,
+            "language": "Solidity",
+            "path": "input.sol"
+        }
+    ]
 }
 
 ======= input.sol:C =======

--- a/test/cmdlineTests/ethdebug_on_interface/output
+++ b/test/cmdlineTests/ethdebug_on_interface/output
@@ -3,7 +3,16 @@
     "compiler": {
         "name": "solc",
         "version": "<VERSION REMOVED>"
-    }
+    },
+    "id": "solc-8c97f795bcc636a608a944de3973c486ddf6992c4c401297f58aee68f41b243b",
+    "sources": [
+        {
+            "contents": "// SPDX-License-Identifier: GPL-2.0\npragma solidity >=0.0;\n\ninterface C {\n    function f() external;\n}\n",
+            "id": 0,
+            "language": "Solidity",
+            "path": "input.sol"
+        }
+    ]
 }
 
 ======= input.sol:C =======

--- a/test/cmdlineTests/ethdebug_resources/output
+++ b/test/cmdlineTests/ethdebug_resources/output
@@ -5,13 +5,18 @@
             "name": "solc",
             "version": "<VERSION REMOVED>"
         },
+        "id": "solc-cb8d51a34a3cd68eeec8de2d8c4c7910b9c29d2d66fd8f74d4bfa4010bbf3e48",
         "sources": [
             {
+                "contents": "// SPDX-License-Identifier: GPL-2.0\npragma solidity >=0.0;\n\ncontract C {\n    function f() public {}\n}\n",
                 "id": 0,
+                "language": "Solidity",
                 "path": "input.sol"
             }
         ]
-    }
+    },
+    "pointers": {},
+    "types": {}
 }
 
 ======= input.sol:C =======

--- a/test/cmdlineTests/metadata_experimental/output
+++ b/test/cmdlineTests/metadata_experimental/output
@@ -3,7 +3,16 @@
     "compiler": {
         "name": "solc",
         "version": "<VERSION REMOVED>"
-    }
+    },
+    "id": "solc-4743915c828ac077c907e396c21c675b200f1fd5faefcab84ccd46bb7d5cd48b",
+    "sources": [
+        {
+            "contents": "// SPDX-License-Identifier: GPL-3.0\npragma solidity *;\n\ncontract C {}\n",
+            "id": 0,
+            "language": "Solidity",
+            "path": "input.sol"
+        }
+    ]
 }
 
 ======= input.sol:C =======

--- a/test/cmdlineTests/standard_output_debuginfo_ethdebug_with_interfaces_and_abstracts/output.json
+++ b/test/cmdlineTests/standard_output_debuginfo_ethdebug_with_interfaces_and_abstracts/output.json
@@ -32,17 +32,36 @@
                     "name": "solc",
                     "version": "<VERSION REMOVED>"
                 },
+                "id": "solc-598eebe605bc597ddb6fccd6a05fff13cb70c3dca35a634a51bb02f8c3291ad8",
                 "sources": [
                     {
+                        "contents": "// SPDX-License-Identifier: GPL-2.0
+pragma solidity >=0.0;
+
+abstract contract C {
+    function f() public virtual returns (bytes32);
+}
+",
                         "id": 0,
+                        "language": "Solidity",
                         "path": "a.sol"
                     },
                     {
+                        "contents": "// SPDX-License-Identifier: GPL-2.0
+pragma solidity >=0.0;
+
+interface C {
+    function f() external;
+}
+",
                         "id": 1,
+                        "language": "Solidity",
                         "path": "b.sol"
                     }
                 ]
-            }
+            },
+            "pointers": {},
+            "types": {}
         }
     },
     "sources": {

--- a/test/cmdlineTests/standard_output_ethdebug_selection_compilation/output.json
+++ b/test/cmdlineTests/standard_output_ethdebug_selection_compilation/output.json
@@ -4,7 +4,18 @@
             "compiler": {
                 "name": "solc",
                 "version": "<VERSION REMOVED>"
-            }
+            },
+            "id": "solc-16f212cfefc133646daa9c29bfe430dea2930e5128748cca05a6e47d4c72e51e",
+            "sources": [
+                {
+                    "contents": "//SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+contract C { function f() public pure {} }",
+                    "id": 0,
+                    "language": "Solidity",
+                    "path": "a.sol"
+                }
+            ]
         }
     },
     "sources": {

--- a/test/cmdlineTests/standard_output_ethdebug_selection_resources/output.json
+++ b/test/cmdlineTests/standard_output_ethdebug_selection_resources/output.json
@@ -6,13 +6,20 @@
                     "name": "solc",
                     "version": "<VERSION REMOVED>"
                 },
+                "id": "solc-16f212cfefc133646daa9c29bfe430dea2930e5128748cca05a6e47d4c72e51e",
                 "sources": [
                     {
+                        "contents": "//SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+contract C { function f() public pure {} }",
                         "id": 0,
+                        "language": "Solidity",
                         "path": "a.sol"
                     }
                 ]
-            }
+            },
+            "pointers": {},
+            "types": {}
         }
     },
     "sources": {

--- a/test/cmdlineTests/standard_yul_ethdebug_assign_immutable/output.json
+++ b/test/cmdlineTests/standard_yul_ethdebug_assign_immutable/output.json
@@ -117,13 +117,24 @@
                     "name": "solc",
                     "version": "<VERSION REMOVED>"
                 },
+                "id": "solc-b25a00fbb503b1ec21ab2c73518834633c063188f521655e16df0205086472dc",
                 "sources": [
                     {
+                        "contents": "object \"a\" {
+    code {
+        {
+            setimmutable(0, \"long___name___that___definitely___exceeds___the___thirty___two___byte___limit\", 0x1234567890123456789012345678901234567890)
+        }
+    }
+}",
                         "id": 0,
+                        "language": "Yul",
                         "path": "C"
                     }
                 ]
-            }
+            },
+            "pointers": {},
+            "types": {}
         }
     }
 }

--- a/test/cmdlineTests/standard_yul_ethdebug_compilation/output.json
+++ b/test/cmdlineTests/standard_yul_ethdebug_compilation/output.json
@@ -4,7 +4,33 @@
             "compiler": {
                 "name": "solc",
                 "version": "<VERSION REMOVED>"
-            }
+            },
+            "id": "solc-3a049701c860c06be82a623ac416ee6504d093aa0293cec7f49b67373f4aeb7a",
+            "sources": [
+                {
+                    "contents": "/// @use-src 0:\"input.sol\"
+object \"C_6_deployed\" {
+    code {
+        /// @src 0:60:101  \"contract C {...\"
+        mstore(64, 128)
+
+        // f()
+        fun_f_5()
+
+        /// @src 0:77:99  \"function f() public {}\"
+        function fun_f_5() {
+            sstore(0, 42)
+        }
+        /// @src 0:60:101  \"contract C {...\"
+    }
+}
+
+",
+                    "id": 0,
+                    "language": "Yul",
+                    "path": "C"
+                }
+            ]
         }
     }
 }

--- a/test/cmdlineTests/standard_yul_ethdebug_resources/output.json
+++ b/test/cmdlineTests/standard_yul_ethdebug_resources/output.json
@@ -6,13 +6,35 @@
                     "name": "solc",
                     "version": "<VERSION REMOVED>"
                 },
+                "id": "solc-3a049701c860c06be82a623ac416ee6504d093aa0293cec7f49b67373f4aeb7a",
                 "sources": [
                     {
+                        "contents": "/// @use-src 0:\"input.sol\"
+object \"C_6_deployed\" {
+    code {
+        /// @src 0:60:101  \"contract C {...\"
+        mstore(64, 128)
+
+        // f()
+        fun_f_5()
+
+        /// @src 0:77:99  \"function f() public {}\"
+        function fun_f_5() {
+            sstore(0, 42)
+        }
+        /// @src 0:60:101  \"contract C {...\"
+    }
+}
+
+",
                         "id": 0,
+                        "language": "Yul",
                         "path": "C"
                     }
                 ]
-            }
+            },
+            "pointers": {},
+            "types": {}
         }
     }
 }

--- a/test/ethdebugSchemaTests/README.md
+++ b/test/ethdebugSchemaTests/README.md
@@ -1,0 +1,21 @@
+# ETHDebug schema tests
+
+These tests validate Solidity's ETHDebug output against a pinned checkout of the upstream `ethdebug/format` JSON Schemas.
+
+The schema checkout is a git submodule at `test/ethdebugSchemaTests/ethdebug-format`. Initialize it with:
+
+```bash
+git submodule update --init test/ethdebugSchemaTests/ethdebug-format
+```
+
+Run the tests with:
+
+```bash
+pytest test/ethdebugSchemaTests --solc-binary-path=build/solc/solc -v
+```
+
+The JSON inputs use `contentFile` entries to keep Solidity examples in regular
+`.sol` fixture files under `sources/`. The pytest harness expands those entries
+to Standard JSON `content` before invoking `solc`.
+
+To update the schema version, bump the submodule commit and rerun this suite.

--- a/test/ethdebugSchemaTests/conftest.py
+++ b/test/ethdebugSchemaTests/conftest.py
@@ -1,5 +1,3 @@
-import shutil
-import subprocess
 from pathlib import Path
 
 import pytest
@@ -21,24 +19,19 @@ def solc_path(request):
 
 
 @pytest.fixture(scope="module")
-def ethdebug_clone_dir(tmpdir_factory):
-    temporary_dir = Path(tmpdir_factory.mktemp("data"))
-    yield temporary_dir
-    shutil.rmtree(temporary_dir)
+def ethdebug_schema_dir():
+    schema_dir = Path(__file__).parent / "ethdebug-format" / "schemas"
+    assert schema_dir.is_dir(), (
+        "ethdebug/format schemas are missing. "
+        "Run `git submodule update --init test/ethdebugSchemaTests/ethdebug-format`."
+    )
+    return schema_dir
 
 
 @pytest.fixture(scope="module")
-def ethdebug_schema_repository(ethdebug_clone_dir):
-    process = subprocess.run(
-        ["git", "clone", "https://github.com/ethdebug/format.git", ethdebug_clone_dir],
-        encoding="utf8",
-        capture_output=True,
-        check=True
-    )
-    assert process.returncode == 0
-
+def ethdebug_schema_repository(ethdebug_schema_dir):
     registry = referencing.Registry()
-    for path in (ethdebug_clone_dir / "schemas").rglob("*.yaml"):
+    for path in ethdebug_schema_dir.rglob("*.yaml"):
         with open(path, "r", encoding="utf8") as f:
             schema = yaml.safe_load(f)
             if "$id" in schema:

--- a/test/ethdebugSchemaTests/input_file.json
+++ b/test/ethdebugSchemaTests/input_file.json
@@ -2,10 +2,10 @@
   "language": "Solidity",
   "sources": {
     "a.sol": {
-      "content": "//SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0;\ncontract A1 { function a(uint x) public pure { assert(x > 0); } } contract A2 { function a(uint x) public pure { assert(x > 0); } }"
+      "contentFile": "sources/a.sol"
     },
     "b.sol": {
-      "content": "//SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0;\ncontract A1 { function b(uint x) public pure { assert(x > 0); } } contract B2 { function b(uint x) public pure { assert(x > 0); } }"
+      "contentFile": "sources/b.sol"
     }
   },
   "settings": {
@@ -20,7 +20,9 @@
       "*": {
         "*": [
           "evm.bytecode.ethdebug",
-          "evm.deployedBytecode.ethdebug"
+          "evm.deployedBytecode.ethdebug",
+          "ethdebug.resources",
+          "ethdebug.compilation"
         ]
       }
     }

--- a/test/ethdebugSchemaTests/input_file_eof.json
+++ b/test/ethdebugSchemaTests/input_file_eof.json
@@ -2,10 +2,10 @@
   "language": "Solidity",
   "sources": {
     "a.sol": {
-      "content": "//SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0;\ncontract A1 { function a(uint x) public pure { assert(x > 0); } } contract A2 { function a(uint x) public pure { assert(x > 0); } }"
+      "contentFile": "sources/a.sol"
     },
     "b.sol": {
-      "content": "//SPDX-License-Identifier: GPL-3.0\npragma solidity >=0.0;\ncontract A1 { function b(uint x) public pure { assert(x > 0); } } contract B2 { function b(uint x) public pure { assert(x > 0); } }"
+      "contentFile": "sources/b.sol"
     }
   },
   "settings": {
@@ -22,7 +22,9 @@
       "*": {
         "*": [
           "evm.bytecode.ethdebug",
-          "evm.deployedBytecode.ethdebug"
+          "evm.deployedBytecode.ethdebug",
+          "ethdebug.resources",
+          "ethdebug.compilation"
         ]
       }
     }

--- a/test/ethdebugSchemaTests/sources/a.sol
+++ b/test/ethdebugSchemaTests/sources/a.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+
+contract A1 {
+	function a(uint x) public pure {
+		assert(x > 0);
+	}
+}
+
+contract A2 {
+	function a(uint x) public pure {
+		assert(x > 0);
+	}
+}

--- a/test/ethdebugSchemaTests/sources/b.sol
+++ b/test/ethdebugSchemaTests/sources/b.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0;
+
+contract A1 {
+	function b(uint x) public pure {
+		assert(x > 0);
+	}
+}
+
+contract B2 {
+	function b(uint x) public pure {
+		assert(x > 0);
+	}
+}

--- a/test/ethdebugSchemaTests/test_ethdebug_schema_conformity.py
+++ b/test/ethdebugSchemaTests/test_ethdebug_schema_conformity.py
@@ -14,15 +14,43 @@ def get_nested_value(dictionary, *keys):
     return dictionary
 
 
-@pytest.fixture(params=["input_file.json", "input_file_eof.json"])
-def solc_output(request, solc_path):
-    testfile_dir = Path(__file__).parent
-    with open(testfile_dir / request.param, "r", encoding="utf8") as f:
-        source = json.load(f)
+def validator(schema_id, ethdebug_schema_repository):
+    return jsonschema.Draft202012Validator(
+        schema={"$ref": schema_id},
+        registry=ethdebug_schema_repository
+    )
 
+
+def ethdebug_programs(solc_output, output_selection):
+    assert "contracts" in solc_output
+    for source_name, source_contracts in solc_output["contracts"].items():
+        assert len(source_contracts) > 0
+        for contract_name, contract_output in source_contracts.items():
+            yield source_name, contract_name, get_nested_value(contract_output, *(output_selection.split(".")))
+
+
+def load_standard_json_input(path):
+    with open(path, "r", encoding="utf8") as f:
+        standard_json_input = json.load(f)
+
+    for source in standard_json_input["sources"].values():
+        if "contentFile" in source:
+            source["content"] = (path.parent / source.pop("contentFile")).read_text(encoding="utf8")
+
+    return standard_json_input
+
+
+@pytest.fixture(params=["input_file.json", "input_file_eof.json"])
+def standard_json_input(request):
+    testfile_dir = Path(__file__).parent
+    return load_standard_json_input(testfile_dir / request.param)
+
+
+@pytest.fixture
+def solc_output(standard_json_input, solc_path):
     process = subprocess.run(
         [solc_path, "--standard-json"],
-        input=json.dumps(source),
+        input=json.dumps(standard_json_input),
         encoding="utf8",
         capture_output=True,
         check=True,
@@ -37,15 +65,70 @@ def test_program_schema(
     ethdebug_schema_repository,
     solc_output
 ):
-    validator = jsonschema.Draft202012Validator(
-        schema={"$ref": "schema:ethdebug/format/program"},
-        registry=ethdebug_schema_repository
-    )
-    assert "contracts" in solc_output
-    for contract in solc_output["contracts"].keys():
-        contract_output = solc_output["contracts"][contract]
-        assert len(contract_output) > 0
-        for source in contract_output.keys():
-            source_output = contract_output[source]
-            ethdebug_data = get_nested_value(source_output, *(output_selection.split(".")))
-            validator.validate(ethdebug_data)
+    program_validator = validator("schema:ethdebug/format/program", ethdebug_schema_repository)
+    for _, _, ethdebug_data in ethdebug_programs(solc_output, output_selection):
+        program_validator.validate(ethdebug_data)
+
+
+def test_resources_schema(ethdebug_schema_repository, solc_output):
+    resources_validator = validator("schema:ethdebug/format/info/resources", ethdebug_schema_repository)
+    resources_validator.validate(solc_output["ethdebug"]["resources"])
+
+
+def test_compilation_schema(ethdebug_schema_repository, solc_output):
+    compilation_validator = validator("schema:ethdebug/format/materials/compilation", ethdebug_schema_repository)
+    compilation_validator.validate(solc_output["ethdebug"]["compilation"])
+
+
+@pytest.mark.parametrize(
+    ("output_selection", "environment"),
+    [
+        ("evm.bytecode.ethdebug", "create"),
+        ("evm.deployedBytecode.ethdebug", "call"),
+    ],
+    ids=str
+)
+def test_program_sanity(output_selection, environment, solc_output):
+    source_ids = {source_name: source["id"] for source_name, source in solc_output["sources"].items()}
+
+    for source_name, contract_name, ethdebug_data in ethdebug_programs(solc_output, output_selection):
+        assert ethdebug_data["environment"] == environment
+        assert ethdebug_data["contract"]["name"] == contract_name
+        assert ethdebug_data["contract"]["definition"]["source"]["id"] == source_ids[source_name]
+
+        instructions = ethdebug_data["instructions"]
+        assert len(instructions) > 0
+        assert [instruction["offset"] for instruction in instructions] == sorted(
+            instruction["offset"] for instruction in instructions
+        )
+        assert all(instruction["operation"]["mnemonic"] for instruction in instructions)
+
+
+def test_resources_match_standard_json_sources(solc_output):
+    standard_json_sources = {source_name: source["id"] for source_name, source in solc_output["sources"].items()}
+    ethdebug_sources = {
+        source["path"]: source["id"]
+        for source in solc_output["ethdebug"]["resources"]["compilation"]["sources"]
+    }
+    assert ethdebug_sources == standard_json_sources
+
+
+def test_resources_include_standard_json_source_contents(standard_json_input, solc_output):
+    ethdebug_sources = {
+        source["path"]: source
+        for source in solc_output["ethdebug"]["resources"]["compilation"]["sources"]
+    }
+
+    assert set(ethdebug_sources) == set(standard_json_input["sources"])
+    for source_name, source_input in standard_json_input["sources"].items():
+        assert ethdebug_sources[source_name]["contents"] == source_input["content"]
+        assert ethdebug_sources[source_name]["language"] == "Solidity"
+
+
+def test_resources_include_empty_type_and_pointer_tables(solc_output):
+    assert solc_output["ethdebug"]["resources"]["types"] == {}
+    assert solc_output["ethdebug"]["resources"]["pointers"] == {}
+
+
+def test_resources_and_compilation_share_compilation(solc_output):
+    assert solc_output["ethdebug"]["resources"]["compilation"] == solc_output["ethdebug"]["compilation"]

--- a/test/libevmasm/Assembler.cpp
+++ b/test/libevmasm/Assembler.cpp
@@ -456,14 +456,46 @@ BOOST_AUTO_TEST_CASE(ethdebug_program_last_instruction_with_immediate_arguments)
 
 BOOST_AUTO_TEST_CASE(ethdebug_resources)
 {
-	Json const resources = ethdebug::resources({"sourceA", "sourceB"}, "version1");
+	Json const resources = ethdebug::resources(
+		{
+			{.id = 0, .path = "sourceA", .contents = "contentsA", .language = "Solidity"},
+			{.id = 1, .path = "sourceB", .contents = "contentsB", .language = "Yul"}
+		},
+		"version1"
+	);
+	std::string const compilationID = resources["compilation"]["id"];
+	BOOST_REQUIRE(compilationID.substr(0, 5) == "solc-");
+	std::string const repeatedCompilationID = ethdebug::resources(
+		{
+			{.id = 0, .path = "sourceA", .contents = "contentsA", .language = "Solidity"},
+			{.id = 1, .path = "sourceB", .contents = "contentsB", .language = "Yul"}
+		},
+		"version1"
+	)["compilation"]["id"];
+	BOOST_REQUIRE(compilationID == repeatedCompilationID);
+	std::string const changedCompilationID = ethdebug::resources(
+		{
+			{.id = 0, .path = "sourceA", .contents = "changedContentsA", .language = "Solidity"},
+			{.id = 1, .path = "sourceB", .contents = "contentsB", .language = "Yul"}
+		},
+		"version1"
+	)["compilation"]["id"];
+	BOOST_REQUIRE(compilationID != changedCompilationID);
+	BOOST_REQUIRE(resources["types"].is_object());
+	BOOST_REQUIRE(resources["types"].empty());
+	BOOST_REQUIRE(resources["pointers"].is_object());
+	BOOST_REQUIRE(resources["pointers"].empty());
 	BOOST_REQUIRE(resources["compilation"]["compiler"]["name"] == "solc");
 	BOOST_REQUIRE(resources["compilation"]["compiler"]["version"] == "version1");
 	BOOST_REQUIRE(resources["compilation"]["sources"].size() == 2);
 	BOOST_REQUIRE(resources["compilation"]["sources"][0]["id"] == 0);
 	BOOST_REQUIRE(resources["compilation"]["sources"][0]["path"] == "sourceA");
+	BOOST_REQUIRE(resources["compilation"]["sources"][0]["contents"] == "contentsA");
+	BOOST_REQUIRE(resources["compilation"]["sources"][0]["language"] == "Solidity");
 	BOOST_REQUIRE(resources["compilation"]["sources"][1]["id"] == 1);
 	BOOST_REQUIRE(resources["compilation"]["sources"][1]["path"] == "sourceB");
+	BOOST_REQUIRE(resources["compilation"]["sources"][1]["contents"] == "contentsB");
+	BOOST_REQUIRE(resources["compilation"]["sources"][1]["language"] == "Yul");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/libsolidity/ethdebugTests/basic_contract.sol
+++ b/test/libsolidity/ethdebugTests/basic_contract.sol
@@ -9,8 +9,16 @@ contract C {
 }
 // ----
 // .compilation.compiler.name: solc
+// .compilation.id: <IGNORE>
+// .compilation.sources | length: 1
+// .compilation.sources[0].id: 0
+// .compilation.sources[0].path: <IGNORE>
+// .compilation.sources[0].contents: <IGNORE>
+// .compilation.sources[0].language: Solidity
+// .resources.compilation.id: <IGNORE>
 // .resources.compilation.sources | length: 1
 // .resources.compilation.sources[0].id: 0
+// .resources.compilation.sources[0].language: Solidity
 //
 // C.contract.name: C
 // C.creation.environment: create

--- a/test/libsolidity/ethdebugTests/isoltestTesting/compilation_metadata.sol
+++ b/test/libsolidity/ethdebugTests/isoltestTesting/compilation_metadata.sol
@@ -5,10 +5,25 @@ contract C {
 // .compilation.compiler.name: solc
 // .compilation.compiler | type: object
 // .compilation.compiler | keys: ["name", "version"]
+// .compilation.id: <IGNORE>
+// .compilation.sources | length: 1
+// .compilation.sources[0].id: 0
+// .compilation.sources[0].path: <IGNORE>
+// .compilation.sources[0].contents: <IGNORE>
+// .compilation.sources[0].language: Solidity
 // .compilation:
 // {
 //     "compiler": {
 //         "name": "solc",
 //         "version": "<IGNORE>"
-//     }
+//     },
+//     "id": "<IGNORE>",
+//     "sources": [
+//         {
+//             "contents": "<IGNORE>",
+//             "id": 0,
+//             "language": "Solidity",
+//             "path": "<IGNORE>"
+//         }
+//     ]
 // }

--- a/test/libsolidity/ethdebugTests/isoltestTesting/resources_only.sol
+++ b/test/libsolidity/ethdebugTests/isoltestTesting/resources_only.sol
@@ -4,5 +4,15 @@ contract C {
 // ----
 // .compilation.compiler.name: solc
 // .compilation.compiler.version: <IGNORE>
+// .compilation.id: <IGNORE>
+// .compilation.sources | length: 1
+// .compilation.sources[0].id: 0
+// .compilation.sources[0].path: <IGNORE>
+// .compilation.sources[0].contents: <IGNORE>
+// .compilation.sources[0].language: Solidity
+// .resources.compilation.id: <IGNORE>
 // .resources.compilation.sources | length: 1
 // .resources.compilation.sources[0].id: 0
+// .resources.compilation.sources[0].path: <IGNORE>
+// .resources.compilation.sources[0].contents: <IGNORE>
+// .resources.compilation.sources[0].language: Solidity

--- a/test/libsolidity/ethdebugTests/multi_source.sol
+++ b/test/libsolidity/ethdebugTests/multi_source.sol
@@ -8,7 +8,16 @@ contract Main {
     function f() public pure returns (uint) { return 42; }
 }
 // ----
+// .compilation.sources | length: 2
+// .compilation.sources[0].id: 0
+// .compilation.sources[0].path: lib.sol
+// .compilation.sources[1].id: 1
+// .compilation.sources[1].path: main.sol
 // .resources.compilation.sources | length: 2
+// .resources.compilation.sources[0].id: 0
+// .resources.compilation.sources[0].path: lib.sol
+// .resources.compilation.sources[1].id: 1
+// .resources.compilation.sources[1].path: main.sol
 // Lib.contract.name: Lib
 // Main.contract.name: Main
 // Lib.creation.environment: create

--- a/test/libsolidity/ethdebugTests/multi_source_name_collision.sol
+++ b/test/libsolidity/ethdebugTests/multi_source_name_collision.sol
@@ -10,7 +10,16 @@ contract C {
     function fromB() public pure returns (uint) { return 2; }
 }
 // ----
+// .compilation.sources | length: 2
+// .compilation.sources[0].id: 0
+// .compilation.sources[0].path: a.sol
+// .compilation.sources[1].id: 1
+// .compilation.sources[1].path: b.sol
 // .resources.compilation.sources | length: 2
+// .resources.compilation.sources[0].id: 0
+// .resources.compilation.sources[0].path: a.sol
+// .resources.compilation.sources[1].id: 1
+// .resources.compilation.sources[1].path: b.sol
 // a.sol:C.contract.name: C
 // b.sol:C.contract.name: C
 // a.sol:C.creation.environment: create


### PR DESCRIPTION
Handle multiple things `ethdebug` related:

- Add LLVM lit tests (this could be interesting for `codegen` tests as well)
  ```bash
  $ lit -sv test/lit --param solc=build/solc/solc
  ```
- Emit schema-compliant compilation resources so we can execute first "round-trip-tests" in producer (here) and in consumer `soldb` via `conformance` tests added into the `format` repo
- Validate ETHDebug output against pinned schemas
