### PR TITLE
SSA-CFG: Introduce a pass to outline specific blocks

### DIFF
--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -120,6 +120,8 @@ add_library(yul
 	backends/evm/ssa/transform/IdentityAndNopRemover.h
 	backends/evm/ssa/transform/OptimizationPipeline.cpp
 	backends/evm/ssa/transform/OptimizationPipeline.h
+	backends/evm/ssa/transform/Outliner.cpp
+	backends/evm/ssa/transform/Outliner.h
 	backends/evm/ssa/transform/TrivialPhiEliminator.cpp
 	backends/evm/ssa/transform/TrivialPhiEliminator.h
 	backends/evm/ssa/transform/UnreachableBlockCleaner.cpp

--- a/libyul/backends/evm/ssa/transform/OptimizationPipeline.cpp
+++ b/libyul/backends/evm/ssa/transform/OptimizationPipeline.cpp
@@ -19,6 +19,7 @@
 #include <libyul/backends/evm/ssa/transform/OptimizationPipeline.h>
 
 #include <libyul/backends/evm/ssa/transform/IdentityAndNopRemover.h>
+#include <libyul/backends/evm/ssa/transform/Outliner.h>
 #include <libyul/backends/evm/ssa/transform/TrivialPhiEliminator.h>
 #include <libyul/backends/evm/ssa/transform/UnreachableBlockCleaner.h>
 
@@ -34,4 +35,5 @@ void transform::optimize(ControlFlowGraphs& _cfgs)
 		transform::eliminateTrivialPhis(*cfg);
 		transform::removeIdentitiesAndNops(*cfg);
 	}
+	transform::runOutliner(_cfgs);
 }

--- a/libyul/backends/evm/ssa/transform/Outliner.cpp
+++ b/libyul/backends/evm/ssa/transform/Outliner.cpp
@@ -1,0 +1,369 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libyul/backends/evm/ssa/transform/Outliner.h>
+
+#include <libyul/backends/evm/ssa/ControlFlowGraphs.h>
+
+#include <range/v3/algorithm/for_each.hpp>
+#include <range/v3/algorithm/transform.hpp>
+#include <range/v3/algorithm/none_of.hpp>
+#include <range/v3/view/enumerate.hpp>
+#include <range/v3/view/map.hpp>
+
+#include <map>
+#include <unordered_set>
+
+
+using namespace solidity;
+using namespace solidity::yul;
+using namespace solidity::yul::ssa;
+
+namespace
+{
+struct BlockIdentifier
+{
+	ControlFlowGraphs::FunctionGraphID graphId;
+	BlockId blockId;
+
+	auto operator<=>(BlockIdentifier const& other) const = default;
+};
+
+class EquivalentBlocksDetector
+{
+public:
+	using EquivalenceClasses = std::map<BlockIdentifier, std::vector<BlockIdentifier>>;
+	explicit EquivalentBlocksDetector(ControlFlowGraphs const& _cfgs) : m_program(_cfgs)
+	{
+		yulAssert(m_program.mainGraph());
+		auto const maybeRevert = m_program.mainGraph()->evmDialect.findBuiltin("revert");
+		yulAssert(maybeRevert.has_value());
+		m_revertBuiltin = maybeRevert.value();
+	}
+	EquivalenceClasses run() &&;
+private:
+	void processBlock(BlockIdentifier _identifier);
+	[[nodiscard]] bool isRevertBlock(BlockIdentifier _identifier) const;
+	[[nodiscard]] bool canOutlineAsFunctionWithNoArguments(BlockIdentifier _identifier) const;
+
+	[[nodiscard]] BlockIdentifier findRepresentative(BlockIdentifier _identifier) const;
+	[[nodiscard]] bool areEquivalent(BlockIdentifier _bid1, BlockIdentifier _bid2) const;
+
+	ControlFlowGraphs const& m_program;
+	EquivalenceClasses m_equivalenceClasses;
+	BuiltinHandle m_revertBuiltin{};
+};
+
+bool EquivalentBlocksDetector::isRevertBlock(BlockIdentifier const _identifier) const
+{
+	auto const& [gid, bid] = _identifier;
+	yulAssert(gid < m_program.functionGraphs.size());
+	auto const& cfg = *m_program.functionGraphs[gid];
+	auto const& block = cfg.block(bid);
+	if (!block.isTerminationBlock())
+		return false;
+	yulAssert(!block.instructions.empty());
+	auto const& inst = cfg.inst(block.instructions.back());
+	if (inst.opcode != InstOpcode::BuiltinCall)
+		return false;
+	return cfg.builtinPayload(block.instructions.back()).builtin == m_revertBuiltin;
+}
+
+/**
+ * Determines if a block can be outlined as a function taking no arguments.
+ * This means it cannot access any (results of) operations that executed before this block.
+ * In other words, as arguments for instructions it can only use constants or values computed in this block.
+ * Note that the block reading/writing from/to both storage and memory is OK (if the previously stated constraint holds).
+ */
+bool EquivalentBlocksDetector::canOutlineAsFunctionWithNoArguments(BlockIdentifier const _identifier) const
+{
+	yulAssert(_identifier.graphId < m_program.functionGraphs.size());
+	auto const& cfg = *m_program.functionGraphs[_identifier.graphId];
+	auto const& block = cfg.block(_identifier.blockId);
+	std::unordered_set<InstId::ValueType> allowed;
+	for (auto const instId: block.instructions)
+	{
+		auto const& instruction = cfg.inst(instId);
+		switch (instruction.opcode)
+		{
+			case InstOpcode::FunctionArg:
+			case InstOpcode::Phi:
+			case InstOpcode::Upsilon:
+				return false;
+			case InstOpcode::Const:
+			case InstOpcode::MemoryGuard:
+			case InstOpcode::Nop:
+			case InstOpcode::Tombstone:
+			case InstOpcode::Unreachable:
+				break; // These instructions have no arguments
+			case InstOpcode::Projection:
+			{
+				allowed.insert(instId.value);
+				break; // Projection are deterministic if the corresponding call is deterministic
+			}
+			case InstOpcode::BuiltinCall:
+			case InstOpcode::Call:
+			case InstOpcode::Identity:
+			{
+				// Check if arguments are constants or instructions we have seen before in this block
+				bool const deterministic = ranges::all_of(instruction.inputs, [&](InstId const arg) {
+					return cfg.isLiteral(arg) || allowed.contains(arg.value);
+				});
+				if (!deterministic)
+					return false;
+				allowed.insert(instId.value);
+				break;
+			}
+		}
+	}
+	return true;
+}
+
+bool EquivalentBlocksDetector::areEquivalent(BlockIdentifier const _bid1, BlockIdentifier const _bid2) const
+{
+	auto const& cfg1 = *m_program.functionGraphs[_bid1.graphId];
+	auto const& cfg2 = *m_program.functionGraphs[_bid2.graphId];
+	auto const& block1 = cfg1.block(_bid1.blockId);
+	auto const& block2 = cfg2.block(_bid2.blockId);
+
+	if (block1.instructions.size() != block2.instructions.size())
+		return false;
+
+	std::unordered_map<InstId::ValueType, InstId::ValueType> instMapping;
+	auto knownToBeEquivalent = [&](auto const& idPair) {
+		auto && [id1, id2] = idPair;
+		if (id1 == id2)
+			return true;
+		auto const it = instMapping.find(id1.value);
+		return it != instMapping.end() && it->second == id2.value;
+	};
+
+	for (auto&& [iid1, iid2] : ranges::views::zip(block1.instructions, block2.instructions))
+	{
+		auto const& inst1 = cfg1.inst(iid1);
+		auto const& inst2 = cfg2.inst(iid2);
+		if (inst1.opcode != inst2.opcode)
+			return false;
+		switch (inst1.opcode)
+		{
+			case InstOpcode::FunctionArg:
+			case InstOpcode::Phi:
+			case InstOpcode::Upsilon:
+				yulAssert(false, "Blocks with these instructions should have been excluded");
+			case InstOpcode::MemoryGuard:
+			case InstOpcode::Nop:
+			case InstOpcode::Tombstone:
+			case InstOpcode::Unreachable:
+			{
+				yulAssert(inst1.inputs.empty());
+				break;
+			}
+			case InstOpcode::Projection:
+			{
+				instMapping.insert({iid1.value, iid2.value});
+				break; /* We check equivalence of the corresponding function call */
+			}
+			case InstOpcode::Const:
+			{
+				if (iid1 != iid2)
+					return false;
+				break;
+			}
+			case InstOpcode::Identity:
+			case InstOpcode::BuiltinCall:
+			case InstOpcode::Call:
+			{
+				if (inst1.opcode == InstOpcode::BuiltinCall && cfg1.builtinPayload(iid1).builtin != cfg2.builtinPayload(iid2).builtin)
+					return false;
+				if (inst1.opcode == InstOpcode::Call && cfg1.callPayload(iid1).graphID != cfg2.callPayload(iid2).graphID)
+					return false;
+				yulAssert(inst1.inputs.size() == inst2.inputs.size());
+				bool const inputsEquiv = ranges::all_of(ranges::views::zip(inst1.inputs, inst2.inputs), knownToBeEquivalent);
+				if (!inputsEquiv)
+					return false;
+				instMapping.insert({iid1.value, iid2.value});
+				break;
+			}
+		}
+	}
+	return true;
+}
+
+BlockIdentifier EquivalentBlocksDetector::findRepresentative(BlockIdentifier const _identifier) const
+{
+	for (BlockIdentifier const other: m_equivalenceClasses | ranges::views::keys)
+	{
+		if (areEquivalent(_identifier, other))
+			return other;
+	}
+	return _identifier;
+}
+
+void EquivalentBlocksDetector::processBlock(BlockIdentifier const _identifier)
+{
+	// For now, we are only interested in reverting blocks
+	if (!isRevertBlock(_identifier))
+		return;
+	// Blocks that depend on the context are harder to outline, we skip them for now
+	if (!canOutlineAsFunctionWithNoArguments(_identifier))
+		return;
+	auto const representative = findRepresentative(_identifier);
+	if (representative == _identifier)
+		m_equivalenceClasses.insert({_identifier, {}});
+	else
+		m_equivalenceClasses.at(representative).push_back(_identifier);
+}
+
+EquivalentBlocksDetector::EquivalenceClasses EquivalentBlocksDetector::run() &&
+{
+	for (auto const& [id, cfg]: m_program.functionGraphs | ranges::views::enumerate)
+	{
+		if (cfg->numBlocks() == 1)
+			continue;
+		auto const graphId = static_cast<ControlFlowGraphs::FunctionGraphID>(id);
+		for (BlockId const blockId: cfg->liveBlocks())
+			processBlock({.graphId = graphId, .blockId = blockId});
+	}
+	return std::move(m_equivalenceClasses);
+}
+
+} // namespace
+
+void transform::runOutliner(ControlFlowGraphs& _cfgs)
+{
+	auto const& equivalenceClasses = EquivalentBlocksDetector(_cfgs).run();
+	for (auto const& equivClass: equivalenceClasses)
+	{
+		if (equivClass.second.empty())
+			continue;
+		auto const& sourceBlockIdentifier = equivClass.first;
+		// Create new CFG and add it to the collection
+		auto const& evmDialect = _cfgs.mainGraph()->evmDialect;
+		auto newCFG = std::make_unique<SSACFG>(evmDialect);
+		auto const entryBlockId = newCFG->makeBlock(nullptr);
+		newCFG->entry = entryBlockId;
+		newCFG->canContinue = false;
+		newCFG->exits.insert(entryBlockId);
+		newCFG->name = "__revert_" + std::to_string(sourceBlockIdentifier.graphId) + "_" + std::to_string(sourceBlockIdentifier.blockId.value);
+		newCFG->numReturns = 0;
+		yulAssert(ranges::none_of(_cfgs.functionGraphs, [&](auto const& cfg) { return cfg->name == newCFG->name; }), "CFG names must be unique!");
+		// copy instructions
+		auto const& sourceCfg = *_cfgs.functionGraphs[sourceBlockIdentifier.graphId];
+		auto const& sourceBlock = sourceCfg.block(sourceBlockIdentifier.blockId);
+		std::unordered_map<InstId::ValueType, InstId::ValueType> instMapping;
+		for (auto const instId: sourceBlock.instructions)
+		{
+			auto const& instruction = sourceCfg.inst(instId);
+			switch (instruction.opcode)
+			{
+				case InstOpcode::Nop:
+				case InstOpcode::Tombstone:
+					break; // No need to copy these
+				case InstOpcode::Projection:
+					break; // Projections are handled together with the corresponding call
+				case InstOpcode::Const:
+					break; // Const instructions are handled on demand
+				case InstOpcode::Unreachable:
+				case InstOpcode::Phi:
+				case InstOpcode::Upsilon:
+				case InstOpcode::FunctionArg:
+				{
+					yulAssert(false, "Instruction should not be present at this stage of outlining");
+				}
+				case InstOpcode::MemoryGuard:
+				{
+					newCFG->makeMemoryGuard(entryBlockId);
+					break;
+				}
+				case InstOpcode::Identity:
+				{
+					// do not copy identity, just point to the argument's translation
+					yulAssert(instruction.inputs.size() == 1);
+					auto arg = instruction.inputs[0];
+					auto it = instMapping.find(arg.value);
+					yulAssert(it != instMapping.end());
+					auto [_, inserted] = instMapping.insert({instId.value, it->second});
+					yulAssert(inserted);
+					break;
+				}
+				case InstOpcode::BuiltinCall:
+				case InstOpcode::Call:
+				{
+					std::vector<InstId> newInputs;
+					newInputs.reserve(instruction.inputs.size());
+					ranges::transform(
+						instruction.inputs,
+						std::back_inserter(newInputs),
+						[&](InstId const originalInput) {
+							if (sourceCfg.isLiteral(originalInput))
+							{
+								auto const& literalPayload = sourceCfg.literalPayload(originalInput);
+								InstId newId = newCFG->newLiteral({}, literalPayload);
+								instMapping.insert({originalInput.value, newId.value});
+							}
+							auto const it = instMapping.find(originalInput.value);
+							yulAssert(it != instMapping.end());
+							return InstId{it->second};
+						}
+					);
+					InstId const newId = [&]()
+					{
+						if (instruction.opcode == InstOpcode::BuiltinCall)
+							return newCFG->makeBuiltinCallWithProjections(
+								entryBlockId,
+								sourceCfg.builtinPayload(instId),
+								std::move(newInputs),
+								static_cast<InstructionStore::NumReturnsSizeType>(evmDialect.builtin(sourceCfg.builtinPayload(instId).builtin).numReturns),
+								{}
+							);
+						else
+							return newCFG->makeCallWithProjections(
+								entryBlockId,
+								sourceCfg.callPayload(instId),
+								std::move(newInputs),
+								static_cast<InstructionStore::NumReturnsSizeType>(sourceCfg.callPayload(instId).numReturns),
+								{}
+							);
+					}();
+					for (auto [srcOut, newOut]: ranges::views::zip(sourceCfg.outputsOf(instId), newCFG->outputsOf(newId)))
+					{
+						auto [_, inserted] = instMapping.insert({srcOut.value, newOut.value});
+						yulAssert(inserted);
+					}
+					break;
+				}
+			}
+		}
+		auto newGraphId = static_cast<FunctionGraphID>(_cfgs.functionGraphs.size());
+		_cfgs.functionGraphs.push_back(std::move(newCFG));
+
+		// Replace all instructions in the corresponding basic block with a function call
+		auto replaceWithCall = [&](BlockIdentifier identifier)
+		{
+			auto&& [graphId, blockId] = identifier;
+			auto& cfg = *_cfgs.functionGraphs.at(graphId);
+			auto& block = cfg.block(blockId);
+			for (InstId const id: cfg.block(blockId).instructions)
+				cfg.tombstone(id);
+			block.instructions.clear();
+			cfg.makeCallWithProjections(blockId, {.graphID = newGraphId, .canContinue = false, .numReturns = 0}, {}, 0);
+		};
+		replaceWithCall(equivClass.first);
+		ranges::for_each(equivClass.second, replaceWithCall);
+	}
+}

--- a/libyul/backends/evm/ssa/transform/Outliner.h
+++ b/libyul/backends/evm/ssa/transform/Outliner.h
@@ -1,0 +1,31 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+namespace solidity::yul::ssa
+{
+
+struct ControlFlowGraphs;
+
+namespace transform
+{
+void runOutliner(ControlFlowGraphs&);
+}
+
+} // namespace solidity::yul::ssa

--- a/test/cmdlineTests/standard_yul_cfg_json_export/output.json
+++ b/test/cmdlineTests/standard_yul_cfg_json_export/output.json
@@ -194,11 +194,8 @@
                                         "id": "Block2",
                                         "instructions": [
                                             {
-                                                "in": [
-                                                    "0x00",
-                                                    "0x00"
-                                                ],
-                                                "op": "revert",
+                                                "in": [],
+                                                "op": "__revert_0_2",
                                                 "out": []
                                             }
                                         ],
@@ -206,7 +203,7 @@
                                             "in": [],
                                             "out": []
                                         },
-                                        "type": "BuiltinCall"
+                                        "type": "FunctionCall"
                                     },
                                     {
                                         "exit": {
@@ -367,11 +364,8 @@
                                         "id": "Block5",
                                         "instructions": [
                                             {
-                                                "in": [
-                                                    "0x00",
-                                                    "0x00"
-                                                ],
-                                                "op": "revert",
+                                                "in": [],
+                                                "op": "__revert_0_2",
                                                 "out": []
                                             }
                                         ],
@@ -379,7 +373,7 @@
                                             "in": [],
                                             "out": []
                                         },
-                                        "type": "BuiltinCall"
+                                        "type": "FunctionCall"
                                     },
                                     {
                                         "exit": {
@@ -419,11 +413,8 @@
                                         "id": "Block8",
                                         "instructions": [
                                             {
-                                                "in": [
-                                                    "0x00",
-                                                    "0x00"
-                                                ],
-                                                "op": "revert",
+                                                "in": [],
+                                                "op": "__revert_0_2",
                                                 "out": []
                                             }
                                         ],
@@ -431,10 +422,40 @@
                                             "in": [],
                                             "out": []
                                         },
-                                        "type": "BuiltinCall"
+                                        "type": "FunctionCall"
                                     }
                                 ],
-                                "functions": {},
+                                "functions": {
+                                    "__revert_0_2": {
+                                        "arguments": [],
+                                        "blocks": [
+                                            {
+                                                "exit": {
+                                                    "type": "Terminated"
+                                                },
+                                                "id": "Block0",
+                                                "instructions": [
+                                                    {
+                                                        "in": [
+                                                            "0x00",
+                                                            "0x00"
+                                                        ],
+                                                        "op": "revert",
+                                                        "out": []
+                                                    }
+                                                ],
+                                                "liveness": {
+                                                    "in": [],
+                                                    "out": []
+                                                },
+                                                "type": "BuiltinCall"
+                                            }
+                                        ],
+                                        "entry": "Block0",
+                                        "numReturns": 0,
+                                        "type": "Function"
+                                    }
+                                },
                                 "memoryGuard": "0x80",
                                 "subObjects": {}
                             },
@@ -637,11 +658,8 @@
                                         "id": "Block2",
                                         "instructions": [
                                             {
-                                                "in": [
-                                                    "0x00",
-                                                    "0x00"
-                                                ],
-                                                "op": "revert",
+                                                "in": [],
+                                                "op": "__revert_0_2",
                                                 "out": []
                                             }
                                         ],
@@ -649,7 +667,7 @@
                                             "in": [],
                                             "out": []
                                         },
-                                        "type": "BuiltinCall"
+                                        "type": "FunctionCall"
                                     },
                                     {
                                         "exit": {
@@ -810,11 +828,8 @@
                                         "id": "Block5",
                                         "instructions": [
                                             {
-                                                "in": [
-                                                    "0x00",
-                                                    "0x00"
-                                                ],
-                                                "op": "revert",
+                                                "in": [],
+                                                "op": "__revert_0_2",
                                                 "out": []
                                             }
                                         ],
@@ -822,7 +837,7 @@
                                             "in": [],
                                             "out": []
                                         },
-                                        "type": "BuiltinCall"
+                                        "type": "FunctionCall"
                                     },
                                     {
                                         "exit": {
@@ -905,11 +920,8 @@
                                         "id": "Block8",
                                         "instructions": [
                                             {
-                                                "in": [
-                                                    "0x00",
-                                                    "0x00"
-                                                ],
-                                                "op": "revert",
+                                                "in": [],
+                                                "op": "__revert_0_2",
                                                 "out": []
                                             }
                                         ],
@@ -917,7 +929,7 @@
                                             "in": [],
                                             "out": []
                                         },
-                                        "type": "BuiltinCall"
+                                        "type": "FunctionCall"
                                     },
                                     {
                                         "exit": {
@@ -999,37 +1011,8 @@
                                         "id": "Block11",
                                         "instructions": [
                                             {
-                                                "in": [
-                                                    "0x4e487b71",
-                                                    "0xe0"
-                                                ],
-                                                "op": "shl",
-                                                "out": [
-                                                    "v38"
-                                                ]
-                                            },
-                                            {
-                                                "in": [
-                                                    "v38",
-                                                    "0x00"
-                                                ],
-                                                "op": "mstore",
-                                                "out": []
-                                            },
-                                            {
-                                                "in": [
-                                                    "0x41",
-                                                    "0x04"
-                                                ],
-                                                "op": "mstore",
-                                                "out": []
-                                            },
-                                            {
-                                                "in": [
-                                                    "0x24",
-                                                    "0x00"
-                                                ],
-                                                "op": "revert",
+                                                "in": [],
+                                                "op": "__revert_0_11",
                                                 "out": []
                                             }
                                         ],
@@ -1037,7 +1020,7 @@
                                             "in": [],
                                             "out": []
                                         },
-                                        "type": "BuiltinCall"
+                                        "type": "FunctionCall"
                                     },
                                     {
                                         "exit": {
@@ -1156,43 +1139,8 @@
                                         "id": "Block14",
                                         "instructions": [
                                             {
-                                                "in": [
-                                                    "0x40"
-                                                ],
-                                                "op": "mload",
-                                                "out": [
-                                                    "v62"
-                                                ]
-                                            },
-                                            {
                                                 "in": [],
-                                                "op": "returndatasize",
-                                                "out": [
-                                                    "v63"
-                                                ]
-                                            },
-                                            {
-                                                "in": [
-                                                    "v63",
-                                                    "0x00",
-                                                    "v62"
-                                                ],
-                                                "op": "returndatacopy",
-                                                "out": []
-                                            },
-                                            {
-                                                "in": [],
-                                                "op": "returndatasize",
-                                                "out": [
-                                                    "v65"
-                                                ]
-                                            },
-                                            {
-                                                "in": [
-                                                    "v65",
-                                                    "v62"
-                                                ],
-                                                "op": "revert",
+                                                "op": "__revert_0_14",
                                                 "out": []
                                             }
                                         ],
@@ -1200,7 +1148,7 @@
                                             "in": [],
                                             "out": []
                                         },
-                                        "type": "BuiltinCall"
+                                        "type": "FunctionCall"
                                     },
                                     {
                                         "exit": {
@@ -1230,43 +1178,8 @@
                                         "id": "Block17",
                                         "instructions": [
                                             {
-                                                "in": [
-                                                    "0x40"
-                                                ],
-                                                "op": "mload",
-                                                "out": [
-                                                    "v86"
-                                                ]
-                                            },
-                                            {
                                                 "in": [],
-                                                "op": "returndatasize",
-                                                "out": [
-                                                    "v87"
-                                                ]
-                                            },
-                                            {
-                                                "in": [
-                                                    "v87",
-                                                    "0x00",
-                                                    "v86"
-                                                ],
-                                                "op": "returndatacopy",
-                                                "out": []
-                                            },
-                                            {
-                                                "in": [],
-                                                "op": "returndatasize",
-                                                "out": [
-                                                    "v89"
-                                                ]
-                                            },
-                                            {
-                                                "in": [
-                                                    "v89",
-                                                    "v86"
-                                                ],
-                                                "op": "revert",
+                                                "op": "__revert_0_14",
                                                 "out": []
                                             }
                                         ],
@@ -1274,7 +1187,7 @@
                                             "in": [],
                                             "out": []
                                         },
-                                        "type": "BuiltinCall"
+                                        "type": "FunctionCall"
                                     },
                                     {
                                         "entries": [
@@ -1574,37 +1487,8 @@
                                         "id": "Block24",
                                         "instructions": [
                                             {
-                                                "in": [
-                                                    "0x4e487b71",
-                                                    "0xe0"
-                                                ],
-                                                "op": "shl",
-                                                "out": [
-                                                    "v117"
-                                                ]
-                                            },
-                                            {
-                                                "in": [
-                                                    "v117",
-                                                    "0x00"
-                                                ],
-                                                "op": "mstore",
-                                                "out": []
-                                            },
-                                            {
-                                                "in": [
-                                                    "0x41",
-                                                    "0x04"
-                                                ],
-                                                "op": "mstore",
-                                                "out": []
-                                            },
-                                            {
-                                                "in": [
-                                                    "0x24",
-                                                    "0x00"
-                                                ],
-                                                "op": "revert",
+                                                "in": [],
+                                                "op": "__revert_0_11",
                                                 "out": []
                                             }
                                         ],
@@ -1612,7 +1496,7 @@
                                             "in": [],
                                             "out": []
                                         },
-                                        "type": "BuiltinCall"
+                                        "type": "FunctionCall"
                                     },
                                     {
                                         "exit": {
@@ -1650,11 +1534,8 @@
                                         "id": "Block27",
                                         "instructions": [
                                             {
-                                                "in": [
-                                                    "0x00",
-                                                    "0x00"
-                                                ],
-                                                "op": "revert",
+                                                "in": [],
+                                                "op": "__revert_0_2",
                                                 "out": []
                                             }
                                         ],
@@ -1662,10 +1543,156 @@
                                             "in": [],
                                             "out": []
                                         },
-                                        "type": "BuiltinCall"
+                                        "type": "FunctionCall"
                                     }
                                 ],
-                                "functions": {},
+                                "functions": {
+                                    "__revert_0_11": {
+                                        "arguments": [],
+                                        "blocks": [
+                                            {
+                                                "exit": {
+                                                    "type": "Terminated"
+                                                },
+                                                "id": "Block0",
+                                                "instructions": [
+                                                    {
+                                                        "in": [
+                                                            "0x4e487b71",
+                                                            "0xe0"
+                                                        ],
+                                                        "op": "shl",
+                                                        "out": [
+                                                            "v2"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "in": [
+                                                            "v2",
+                                                            "0x00"
+                                                        ],
+                                                        "op": "mstore",
+                                                        "out": []
+                                                    },
+                                                    {
+                                                        "in": [
+                                                            "0x41",
+                                                            "0x04"
+                                                        ],
+                                                        "op": "mstore",
+                                                        "out": []
+                                                    },
+                                                    {
+                                                        "in": [
+                                                            "0x24",
+                                                            "0x00"
+                                                        ],
+                                                        "op": "revert",
+                                                        "out": []
+                                                    }
+                                                ],
+                                                "liveness": {
+                                                    "in": [],
+                                                    "out": []
+                                                },
+                                                "type": "BuiltinCall"
+                                            }
+                                        ],
+                                        "entry": "Block0",
+                                        "numReturns": 0,
+                                        "type": "Function"
+                                    },
+                                    "__revert_0_14": {
+                                        "arguments": [],
+                                        "blocks": [
+                                            {
+                                                "exit": {
+                                                    "type": "Terminated"
+                                                },
+                                                "id": "Block0",
+                                                "instructions": [
+                                                    {
+                                                        "in": [
+                                                            "0x40"
+                                                        ],
+                                                        "op": "mload",
+                                                        "out": [
+                                                            "v1"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "in": [],
+                                                        "op": "returndatasize",
+                                                        "out": [
+                                                            "v2"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "in": [
+                                                            "v2",
+                                                            "0x00",
+                                                            "v1"
+                                                        ],
+                                                        "op": "returndatacopy",
+                                                        "out": []
+                                                    },
+                                                    {
+                                                        "in": [],
+                                                        "op": "returndatasize",
+                                                        "out": [
+                                                            "v5"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "in": [
+                                                            "v5",
+                                                            "v1"
+                                                        ],
+                                                        "op": "revert",
+                                                        "out": []
+                                                    }
+                                                ],
+                                                "liveness": {
+                                                    "in": [],
+                                                    "out": []
+                                                },
+                                                "type": "BuiltinCall"
+                                            }
+                                        ],
+                                        "entry": "Block0",
+                                        "numReturns": 0,
+                                        "type": "Function"
+                                    },
+                                    "__revert_0_2": {
+                                        "arguments": [],
+                                        "blocks": [
+                                            {
+                                                "exit": {
+                                                    "type": "Terminated"
+                                                },
+                                                "id": "Block0",
+                                                "instructions": [
+                                                    {
+                                                        "in": [
+                                                            "0x00",
+                                                            "0x00"
+                                                        ],
+                                                        "op": "revert",
+                                                        "out": []
+                                                    }
+                                                ],
+                                                "liveness": {
+                                                    "in": [],
+                                                    "out": []
+                                                },
+                                                "type": "BuiltinCall"
+                                            }
+                                        ],
+                                        "entry": "Block0",
+                                        "numReturns": 0,
+                                        "type": "Function"
+                                    }
+                                },
                                 "memoryGuard": "0x80",
                                 "subObjects": {
                                     "C_19": {
@@ -1859,11 +1886,8 @@
                                                         "id": "Block2",
                                                         "instructions": [
                                                             {
-                                                                "in": [
-                                                                    "0x00",
-                                                                    "0x00"
-                                                                ],
-                                                                "op": "revert",
+                                                                "in": [],
+                                                                "op": "__revert_0_2",
                                                                 "out": []
                                                             }
                                                         ],
@@ -1871,7 +1895,7 @@
                                                             "in": [],
                                                             "out": []
                                                         },
-                                                        "type": "BuiltinCall"
+                                                        "type": "FunctionCall"
                                                     },
                                                     {
                                                         "exit": {
@@ -2032,11 +2056,8 @@
                                                         "id": "Block5",
                                                         "instructions": [
                                                             {
-                                                                "in": [
-                                                                    "0x00",
-                                                                    "0x00"
-                                                                ],
-                                                                "op": "revert",
+                                                                "in": [],
+                                                                "op": "__revert_0_2",
                                                                 "out": []
                                                             }
                                                         ],
@@ -2044,7 +2065,7 @@
                                                             "in": [],
                                                             "out": []
                                                         },
-                                                        "type": "BuiltinCall"
+                                                        "type": "FunctionCall"
                                                     },
                                                     {
                                                         "exit": {
@@ -2084,11 +2105,8 @@
                                                         "id": "Block8",
                                                         "instructions": [
                                                             {
-                                                                "in": [
-                                                                    "0x00",
-                                                                    "0x00"
-                                                                ],
-                                                                "op": "revert",
+                                                                "in": [],
+                                                                "op": "__revert_0_2",
                                                                 "out": []
                                                             }
                                                         ],
@@ -2096,10 +2114,40 @@
                                                             "in": [],
                                                             "out": []
                                                         },
-                                                        "type": "BuiltinCall"
+                                                        "type": "FunctionCall"
                                                     }
                                                 ],
-                                                "functions": {},
+                                                "functions": {
+                                                    "__revert_0_2": {
+                                                        "arguments": [],
+                                                        "blocks": [
+                                                            {
+                                                                "exit": {
+                                                                    "type": "Terminated"
+                                                                },
+                                                                "id": "Block0",
+                                                                "instructions": [
+                                                                    {
+                                                                        "in": [
+                                                                            "0x00",
+                                                                            "0x00"
+                                                                        ],
+                                                                        "op": "revert",
+                                                                        "out": []
+                                                                    }
+                                                                ],
+                                                                "liveness": {
+                                                                    "in": [],
+                                                                    "out": []
+                                                                },
+                                                                "type": "BuiltinCall"
+                                                            }
+                                                        ],
+                                                        "entry": "Block0",
+                                                        "numReturns": 0,
+                                                        "type": "Function"
+                                                    }
+                                                },
                                                 "memoryGuard": "0x80",
                                                 "subObjects": {}
                                             },

--- a/test/cmdlineTests/strict_asm_yul_cfg_json_export/output
+++ b/test/cmdlineTests/strict_asm_yul_cfg_json_export/output
@@ -194,11 +194,8 @@ Yul Control Flow Graph:
                         "id": "Block2",
                         "instructions": [
                             {
-                                "in": [
-                                    "0x00",
-                                    "0x00"
-                                ],
-                                "op": "revert",
+                                "in": [],
+                                "op": "__revert_0_2",
                                 "out": []
                             }
                         ],
@@ -206,7 +203,7 @@ Yul Control Flow Graph:
                             "in": [],
                             "out": []
                         },
-                        "type": "BuiltinCall"
+                        "type": "FunctionCall"
                     },
                     {
                         "exit": {
@@ -367,11 +364,8 @@ Yul Control Flow Graph:
                         "id": "Block5",
                         "instructions": [
                             {
-                                "in": [
-                                    "0x00",
-                                    "0x00"
-                                ],
-                                "op": "revert",
+                                "in": [],
+                                "op": "__revert_0_2",
                                 "out": []
                             }
                         ],
@@ -379,7 +373,7 @@ Yul Control Flow Graph:
                             "in": [],
                             "out": []
                         },
-                        "type": "BuiltinCall"
+                        "type": "FunctionCall"
                     },
                     {
                         "exit": {
@@ -419,11 +413,8 @@ Yul Control Flow Graph:
                         "id": "Block8",
                         "instructions": [
                             {
-                                "in": [
-                                    "0x00",
-                                    "0x00"
-                                ],
-                                "op": "revert",
+                                "in": [],
+                                "op": "__revert_0_2",
                                 "out": []
                             }
                         ],
@@ -431,10 +422,40 @@ Yul Control Flow Graph:
                             "in": [],
                             "out": []
                         },
-                        "type": "BuiltinCall"
+                        "type": "FunctionCall"
                     }
                 ],
-                "functions": {},
+                "functions": {
+                    "__revert_0_2": {
+                        "arguments": [],
+                        "blocks": [
+                            {
+                                "exit": {
+                                    "type": "Terminated"
+                                },
+                                "id": "Block0",
+                                "instructions": [
+                                    {
+                                        "in": [
+                                            "0x00",
+                                            "0x00"
+                                        ],
+                                        "op": "revert",
+                                        "out": []
+                                    }
+                                ],
+                                "liveness": {
+                                    "in": [],
+                                    "out": []
+                                },
+                                "type": "BuiltinCall"
+                            }
+                        ],
+                        "entry": "Block0",
+                        "numReturns": 0,
+                        "type": "Function"
+                    }
+                },
                 "memoryGuard": "0x80"
             },
             "type": "subObject"

--- a/test/cmdlineTests/yul_cfg_json_export/output
+++ b/test/cmdlineTests/yul_cfg_json_export/output
@@ -193,11 +193,8 @@ Yul Control Flow Graph:
                         "id": "Block2",
                         "instructions": [
                             {
-                                "in": [
-                                    "0x00",
-                                    "0x00"
-                                ],
-                                "op": "revert",
+                                "in": [],
+                                "op": "__revert_0_2",
                                 "out": []
                             }
                         ],
@@ -205,7 +202,7 @@ Yul Control Flow Graph:
                             "in": [],
                             "out": []
                         },
-                        "type": "BuiltinCall"
+                        "type": "FunctionCall"
                     },
                     {
                         "exit": {
@@ -366,11 +363,8 @@ Yul Control Flow Graph:
                         "id": "Block5",
                         "instructions": [
                             {
-                                "in": [
-                                    "0x00",
-                                    "0x00"
-                                ],
-                                "op": "revert",
+                                "in": [],
+                                "op": "__revert_0_2",
                                 "out": []
                             }
                         ],
@@ -378,7 +372,7 @@ Yul Control Flow Graph:
                             "in": [],
                             "out": []
                         },
-                        "type": "BuiltinCall"
+                        "type": "FunctionCall"
                     },
                     {
                         "exit": {
@@ -418,11 +412,8 @@ Yul Control Flow Graph:
                         "id": "Block8",
                         "instructions": [
                             {
-                                "in": [
-                                    "0x00",
-                                    "0x00"
-                                ],
-                                "op": "revert",
+                                "in": [],
+                                "op": "__revert_0_2",
                                 "out": []
                             }
                         ],
@@ -430,10 +421,40 @@ Yul Control Flow Graph:
                             "in": [],
                             "out": []
                         },
-                        "type": "BuiltinCall"
+                        "type": "FunctionCall"
                     }
                 ],
-                "functions": {},
+                "functions": {
+                    "__revert_0_2": {
+                        "arguments": [],
+                        "blocks": [
+                            {
+                                "exit": {
+                                    "type": "Terminated"
+                                },
+                                "id": "Block0",
+                                "instructions": [
+                                    {
+                                        "in": [
+                                            "0x00",
+                                            "0x00"
+                                        ],
+                                        "op": "revert",
+                                        "out": []
+                                    }
+                                ],
+                                "liveness": {
+                                    "in": [],
+                                    "out": []
+                                },
+                                "type": "BuiltinCall"
+                            }
+                        ],
+                        "entry": "Block0",
+                        "numReturns": 0,
+                        "type": "Function"
+                    }
+                },
                 "memoryGuard": "0x80",
                 "subObjects": {}
             },
@@ -637,11 +658,8 @@ Yul Control Flow Graph:
                         "id": "Block2",
                         "instructions": [
                             {
-                                "in": [
-                                    "0x00",
-                                    "0x00"
-                                ],
-                                "op": "revert",
+                                "in": [],
+                                "op": "__revert_0_2",
                                 "out": []
                             }
                         ],
@@ -649,7 +667,7 @@ Yul Control Flow Graph:
                             "in": [],
                             "out": []
                         },
-                        "type": "BuiltinCall"
+                        "type": "FunctionCall"
                     },
                     {
                         "exit": {
@@ -810,11 +828,8 @@ Yul Control Flow Graph:
                         "id": "Block5",
                         "instructions": [
                             {
-                                "in": [
-                                    "0x00",
-                                    "0x00"
-                                ],
-                                "op": "revert",
+                                "in": [],
+                                "op": "__revert_0_2",
                                 "out": []
                             }
                         ],
@@ -822,7 +837,7 @@ Yul Control Flow Graph:
                             "in": [],
                             "out": []
                         },
-                        "type": "BuiltinCall"
+                        "type": "FunctionCall"
                     },
                     {
                         "exit": {
@@ -905,11 +920,8 @@ Yul Control Flow Graph:
                         "id": "Block8",
                         "instructions": [
                             {
-                                "in": [
-                                    "0x00",
-                                    "0x00"
-                                ],
-                                "op": "revert",
+                                "in": [],
+                                "op": "__revert_0_2",
                                 "out": []
                             }
                         ],
@@ -917,7 +929,7 @@ Yul Control Flow Graph:
                             "in": [],
                             "out": []
                         },
-                        "type": "BuiltinCall"
+                        "type": "FunctionCall"
                     },
                     {
                         "exit": {
@@ -999,37 +1011,8 @@ Yul Control Flow Graph:
                         "id": "Block11",
                         "instructions": [
                             {
-                                "in": [
-                                    "0x4e487b71",
-                                    "0xe0"
-                                ],
-                                "op": "shl",
-                                "out": [
-                                    "v38"
-                                ]
-                            },
-                            {
-                                "in": [
-                                    "v38",
-                                    "0x00"
-                                ],
-                                "op": "mstore",
-                                "out": []
-                            },
-                            {
-                                "in": [
-                                    "0x41",
-                                    "0x04"
-                                ],
-                                "op": "mstore",
-                                "out": []
-                            },
-                            {
-                                "in": [
-                                    "0x24",
-                                    "0x00"
-                                ],
-                                "op": "revert",
+                                "in": [],
+                                "op": "__revert_0_11",
                                 "out": []
                             }
                         ],
@@ -1037,7 +1020,7 @@ Yul Control Flow Graph:
                             "in": [],
                             "out": []
                         },
-                        "type": "BuiltinCall"
+                        "type": "FunctionCall"
                     },
                     {
                         "exit": {
@@ -1156,43 +1139,8 @@ Yul Control Flow Graph:
                         "id": "Block14",
                         "instructions": [
                             {
-                                "in": [
-                                    "0x40"
-                                ],
-                                "op": "mload",
-                                "out": [
-                                    "v62"
-                                ]
-                            },
-                            {
                                 "in": [],
-                                "op": "returndatasize",
-                                "out": [
-                                    "v63"
-                                ]
-                            },
-                            {
-                                "in": [
-                                    "v63",
-                                    "0x00",
-                                    "v62"
-                                ],
-                                "op": "returndatacopy",
-                                "out": []
-                            },
-                            {
-                                "in": [],
-                                "op": "returndatasize",
-                                "out": [
-                                    "v65"
-                                ]
-                            },
-                            {
-                                "in": [
-                                    "v65",
-                                    "v62"
-                                ],
-                                "op": "revert",
+                                "op": "__revert_0_14",
                                 "out": []
                             }
                         ],
@@ -1200,7 +1148,7 @@ Yul Control Flow Graph:
                             "in": [],
                             "out": []
                         },
-                        "type": "BuiltinCall"
+                        "type": "FunctionCall"
                     },
                     {
                         "exit": {
@@ -1230,43 +1178,8 @@ Yul Control Flow Graph:
                         "id": "Block17",
                         "instructions": [
                             {
-                                "in": [
-                                    "0x40"
-                                ],
-                                "op": "mload",
-                                "out": [
-                                    "v86"
-                                ]
-                            },
-                            {
                                 "in": [],
-                                "op": "returndatasize",
-                                "out": [
-                                    "v87"
-                                ]
-                            },
-                            {
-                                "in": [
-                                    "v87",
-                                    "0x00",
-                                    "v86"
-                                ],
-                                "op": "returndatacopy",
-                                "out": []
-                            },
-                            {
-                                "in": [],
-                                "op": "returndatasize",
-                                "out": [
-                                    "v89"
-                                ]
-                            },
-                            {
-                                "in": [
-                                    "v89",
-                                    "v86"
-                                ],
-                                "op": "revert",
+                                "op": "__revert_0_14",
                                 "out": []
                             }
                         ],
@@ -1274,7 +1187,7 @@ Yul Control Flow Graph:
                             "in": [],
                             "out": []
                         },
-                        "type": "BuiltinCall"
+                        "type": "FunctionCall"
                     },
                     {
                         "entries": [
@@ -1574,37 +1487,8 @@ Yul Control Flow Graph:
                         "id": "Block24",
                         "instructions": [
                             {
-                                "in": [
-                                    "0x4e487b71",
-                                    "0xe0"
-                                ],
-                                "op": "shl",
-                                "out": [
-                                    "v117"
-                                ]
-                            },
-                            {
-                                "in": [
-                                    "v117",
-                                    "0x00"
-                                ],
-                                "op": "mstore",
-                                "out": []
-                            },
-                            {
-                                "in": [
-                                    "0x41",
-                                    "0x04"
-                                ],
-                                "op": "mstore",
-                                "out": []
-                            },
-                            {
-                                "in": [
-                                    "0x24",
-                                    "0x00"
-                                ],
-                                "op": "revert",
+                                "in": [],
+                                "op": "__revert_0_11",
                                 "out": []
                             }
                         ],
@@ -1612,7 +1496,7 @@ Yul Control Flow Graph:
                             "in": [],
                             "out": []
                         },
-                        "type": "BuiltinCall"
+                        "type": "FunctionCall"
                     },
                     {
                         "exit": {
@@ -1650,11 +1534,8 @@ Yul Control Flow Graph:
                         "id": "Block27",
                         "instructions": [
                             {
-                                "in": [
-                                    "0x00",
-                                    "0x00"
-                                ],
-                                "op": "revert",
+                                "in": [],
+                                "op": "__revert_0_2",
                                 "out": []
                             }
                         ],
@@ -1662,10 +1543,156 @@ Yul Control Flow Graph:
                             "in": [],
                             "out": []
                         },
-                        "type": "BuiltinCall"
+                        "type": "FunctionCall"
                     }
                 ],
-                "functions": {},
+                "functions": {
+                    "__revert_0_11": {
+                        "arguments": [],
+                        "blocks": [
+                            {
+                                "exit": {
+                                    "type": "Terminated"
+                                },
+                                "id": "Block0",
+                                "instructions": [
+                                    {
+                                        "in": [
+                                            "0x4e487b71",
+                                            "0xe0"
+                                        ],
+                                        "op": "shl",
+                                        "out": [
+                                            "v2"
+                                        ]
+                                    },
+                                    {
+                                        "in": [
+                                            "v2",
+                                            "0x00"
+                                        ],
+                                        "op": "mstore",
+                                        "out": []
+                                    },
+                                    {
+                                        "in": [
+                                            "0x41",
+                                            "0x04"
+                                        ],
+                                        "op": "mstore",
+                                        "out": []
+                                    },
+                                    {
+                                        "in": [
+                                            "0x24",
+                                            "0x00"
+                                        ],
+                                        "op": "revert",
+                                        "out": []
+                                    }
+                                ],
+                                "liveness": {
+                                    "in": [],
+                                    "out": []
+                                },
+                                "type": "BuiltinCall"
+                            }
+                        ],
+                        "entry": "Block0",
+                        "numReturns": 0,
+                        "type": "Function"
+                    },
+                    "__revert_0_14": {
+                        "arguments": [],
+                        "blocks": [
+                            {
+                                "exit": {
+                                    "type": "Terminated"
+                                },
+                                "id": "Block0",
+                                "instructions": [
+                                    {
+                                        "in": [
+                                            "0x40"
+                                        ],
+                                        "op": "mload",
+                                        "out": [
+                                            "v1"
+                                        ]
+                                    },
+                                    {
+                                        "in": [],
+                                        "op": "returndatasize",
+                                        "out": [
+                                            "v2"
+                                        ]
+                                    },
+                                    {
+                                        "in": [
+                                            "v2",
+                                            "0x00",
+                                            "v1"
+                                        ],
+                                        "op": "returndatacopy",
+                                        "out": []
+                                    },
+                                    {
+                                        "in": [],
+                                        "op": "returndatasize",
+                                        "out": [
+                                            "v5"
+                                        ]
+                                    },
+                                    {
+                                        "in": [
+                                            "v5",
+                                            "v1"
+                                        ],
+                                        "op": "revert",
+                                        "out": []
+                                    }
+                                ],
+                                "liveness": {
+                                    "in": [],
+                                    "out": []
+                                },
+                                "type": "BuiltinCall"
+                            }
+                        ],
+                        "entry": "Block0",
+                        "numReturns": 0,
+                        "type": "Function"
+                    },
+                    "__revert_0_2": {
+                        "arguments": [],
+                        "blocks": [
+                            {
+                                "exit": {
+                                    "type": "Terminated"
+                                },
+                                "id": "Block0",
+                                "instructions": [
+                                    {
+                                        "in": [
+                                            "0x00",
+                                            "0x00"
+                                        ],
+                                        "op": "revert",
+                                        "out": []
+                                    }
+                                ],
+                                "liveness": {
+                                    "in": [],
+                                    "out": []
+                                },
+                                "type": "BuiltinCall"
+                            }
+                        ],
+                        "entry": "Block0",
+                        "numReturns": 0,
+                        "type": "Function"
+                    }
+                },
                 "memoryGuard": "0x80",
                 "subObjects": {
                     "C_19": {
@@ -1859,11 +1886,8 @@ Yul Control Flow Graph:
                                         "id": "Block2",
                                         "instructions": [
                                             {
-                                                "in": [
-                                                    "0x00",
-                                                    "0x00"
-                                                ],
-                                                "op": "revert",
+                                                "in": [],
+                                                "op": "__revert_0_2",
                                                 "out": []
                                             }
                                         ],
@@ -1871,7 +1895,7 @@ Yul Control Flow Graph:
                                             "in": [],
                                             "out": []
                                         },
-                                        "type": "BuiltinCall"
+                                        "type": "FunctionCall"
                                     },
                                     {
                                         "exit": {
@@ -2032,11 +2056,8 @@ Yul Control Flow Graph:
                                         "id": "Block5",
                                         "instructions": [
                                             {
-                                                "in": [
-                                                    "0x00",
-                                                    "0x00"
-                                                ],
-                                                "op": "revert",
+                                                "in": [],
+                                                "op": "__revert_0_2",
                                                 "out": []
                                             }
                                         ],
@@ -2044,7 +2065,7 @@ Yul Control Flow Graph:
                                             "in": [],
                                             "out": []
                                         },
-                                        "type": "BuiltinCall"
+                                        "type": "FunctionCall"
                                     },
                                     {
                                         "exit": {
@@ -2084,11 +2105,8 @@ Yul Control Flow Graph:
                                         "id": "Block8",
                                         "instructions": [
                                             {
-                                                "in": [
-                                                    "0x00",
-                                                    "0x00"
-                                                ],
-                                                "op": "revert",
+                                                "in": [],
+                                                "op": "__revert_0_2",
                                                 "out": []
                                             }
                                         ],
@@ -2096,10 +2114,40 @@ Yul Control Flow Graph:
                                             "in": [],
                                             "out": []
                                         },
-                                        "type": "BuiltinCall"
+                                        "type": "FunctionCall"
                                     }
                                 ],
-                                "functions": {},
+                                "functions": {
+                                    "__revert_0_2": {
+                                        "arguments": [],
+                                        "blocks": [
+                                            {
+                                                "exit": {
+                                                    "type": "Terminated"
+                                                },
+                                                "id": "Block0",
+                                                "instructions": [
+                                                    {
+                                                        "in": [
+                                                            "0x00",
+                                                            "0x00"
+                                                        ],
+                                                        "op": "revert",
+                                                        "out": []
+                                                    }
+                                                ],
+                                                "liveness": {
+                                                    "in": [],
+                                                    "out": []
+                                                },
+                                                "type": "BuiltinCall"
+                                            }
+                                        ],
+                                        "entry": "Block0",
+                                        "numReturns": 0,
+                                        "type": "Function"
+                                    }
+                                },
                                 "memoryGuard": "0x80",
                                 "subObjects": {}
                             },

--- a/test/libsolidity/semanticTests/externalContracts/FixedFeeRegistrar.sol
+++ b/test/libsolidity/semanticTests/externalContracts/FixedFeeRegistrar.sol
@@ -83,8 +83,8 @@ contract FixedFeeRegistrar is Registrar {
 // gas legacy code: 792400
 // gas legacyOptimized: 84598
 // gas legacyOptimized code: 388000
-// gas ssaCFGOptimized: 78844
-// gas ssaCFGOptimized code: 321800
+// gas ssaCFGOptimized: 78924
+// gas ssaCFGOptimized code: 322800
 // reserve(string), 69 ether: 0x20, 3, "abc" ->
 // ~ emit Changed(string): #0x4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45
 // gas irOptimized: 45741

--- a/test/libsolidity/semanticTests/externalContracts/base64.sol
+++ b/test/libsolidity/semanticTests/externalContracts/base64.sol
@@ -41,8 +41,8 @@ contract test {
 // gas legacy code: 629800
 // gas legacyOptimized: 87926
 // gas legacyOptimized code: 429800
-// gas ssaCFGOptimized: 79879
-// gas ssaCFGOptimized code: 331800
+// gas ssaCFGOptimized: 79463
+// gas ssaCFGOptimized code: 327800
 // encode_inline_asm(bytes): 0x20, 0 -> 0x20, 0
 // encode_inline_asm(bytes): 0x20, 1, "f" -> 0x20, 4, "Zg=="
 // encode_inline_asm(bytes): 0x20, 2, "fo" -> 0x20, 4, "Zm8="

--- a/test/libsolidity/semanticTests/externalContracts/deposit_contract.sol
+++ b/test/libsolidity/semanticTests/externalContracts/deposit_contract.sol
@@ -185,8 +185,8 @@ contract DepositContract is IDepositContract, ERC165 {
 // gas legacy code: 1438800
 // gas legacyOptimized: 848699
 // gas legacyOptimized code: 878200
-// gas ssaCFGOptimized: 809403
-// gas ssaCFGOptimized code: 568200
+// gas ssaCFGOptimized: 809718
+// gas ssaCFGOptimized code: 570200
 // supportsInterface(bytes4): 0x0 -> 0
 // supportsInterface(bytes4): 0xffffffff00000000000000000000000000000000000000000000000000000000 -> false # defined to be false by ERC-165 #
 // supportsInterface(bytes4): 0x01ffc9a700000000000000000000000000000000000000000000000000000000 -> true # ERC-165 id #

--- a/test/libsolidity/semanticTests/externalContracts/prbmath_signed.sol
+++ b/test/libsolidity/semanticTests/externalContracts/prbmath_signed.sol
@@ -57,8 +57,8 @@ contract test {
 // gas legacy code: 2205000
 // gas legacyOptimized: 178012
 // gas legacyOptimized code: 1669600
-// gas ssaCFGOptimized: 175048
-// gas ssaCFGOptimized code: 1639600
+// gas ssaCFGOptimized: 174817
+// gas ssaCFGOptimized code: 1636800
 // div(int256,int256): 3141592653589793238, 88714123 -> 35412542528203691288251815328
 // gas irOptimized: 22045
 // gas legacy: 22736

--- a/test/libsolidity/semanticTests/externalContracts/prbmath_unsigned.sol
+++ b/test/libsolidity/semanticTests/externalContracts/prbmath_unsigned.sol
@@ -57,8 +57,8 @@ contract test {
 // gas legacy code: 1999000
 // gas legacyOptimized: 168857
 // gas legacyOptimized code: 1556200
-// gas ssaCFGOptimized: 167611
-// gas ssaCFGOptimized code: 1544800
+// gas ssaCFGOptimized: 167703
+// gas ssaCFGOptimized code: 1545800
 // div(uint256,uint256): 3141592653589793238, 88714123 -> 35412542528203691288251815328
 // gas irOptimized: 21912
 // gas legacy: 22475

--- a/test/libsolidity/semanticTests/externalContracts/ramanujan_pi.sol
+++ b/test/libsolidity/semanticTests/externalContracts/ramanujan_pi.sol
@@ -42,8 +42,8 @@ contract test {
 // gas legacy code: 523600
 // gas legacyOptimized: 82667
 // gas legacyOptimized code: 369200
-// gas ssaCFGOptimized: 77956
-// gas ssaCFGOptimized code: 313400
+// gas ssaCFGOptimized: 78042
+// gas ssaCFGOptimized code: 314400
 // prb_pi() -> 3141592656369545286
 // gas irOptimized: 55036
 // gas legacy: 100657

--- a/test/libsolidity/semanticTests/externalContracts/strings.sol
+++ b/test/libsolidity/semanticTests/externalContracts/strings.sol
@@ -58,8 +58,8 @@ contract test {
 // gas legacy code: 932600
 // gas legacyOptimized: 102639
 // gas legacyOptimized code: 612400
-// gas ssaCFGOptimized: 96128
-// gas ssaCFGOptimized code: 531800
+// gas ssaCFGOptimized: 95825
+// gas ssaCFGOptimized code: 527800
 // toSlice(string): 0x20, 11, "hello world" -> 11, 0xa0
 // gas irOptimized: 22646
 // gas legacy: 23168

--- a/test/libyul/ssa/stackLayoutGenerator/dead_code.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/dead_code.yul
@@ -33,8 +33,8 @@
 // Block0_1 [label="\
 // IN: [JUNK]\l\
 // \l\
-// [JUNK, lit0, lit0]\l\
-// revert\l\
+// [JUNK]\l\
+// __revert_0_1\l\
 // [JUNK]\l\
 // \l\
 // OUT: [JUNK]\l\
@@ -57,8 +57,8 @@
 // Block0_4 [label="\
 // IN: [JUNK, JUNK]\l\
 // \l\
-// [JUNK, JUNK, lit0, lit0]\l\
-// revert\l\
+// [JUNK, JUNK]\l\
+// __revert_0_1\l\
 // [JUNK, JUNK]\l\
 // \l\
 // OUT: [JUNK, JUNK]\l\
@@ -76,4 +76,18 @@
 // "];
 // Block0_5Exit [label="MainExit"];
 // Block0_5 -> Block0_5Exit;
+// FunctionEntry___revert_0_1_0 [label="function __revert_0_1:
+//  __revert_0_1()"];
+// FunctionEntry___revert_0_1_0 -> Block1_0;
+// Block1_0 [label="\
+// IN: []\l\
+// \l\
+// [lit0, lit0]\l\
+// revert\l\
+// []\l\
+// \l\
+// OUT: []\l\
+// "];
+// Block1_0Exit [label="Terminated"];
+// Block1_0 -> Block1_0Exit;
 // }


### PR DESCRIPTION
We introduce a transformation pass that searches for  equivalent basic blocks and outlines them into a separate function.
In this first version we only process reverting blocks. Moreover, we only process deterministic blocks, i.e., blocks that do not depend on the state of the program at the point they are executed. This second restriction means we can outline the blocks into a function taking no arguments.

To detect equivalent blocks, we check if the blocks have the same number of instructions, the same type of instructions, and the instructions' inputs correspond. The last point is important, because the instructions in two basic blocks can have different inputs, if these are instructions encountered earlier in the same block. But if the inputs are equivalent, the instructions are also equivalent (if they have the same type).