### PR TITLE
Fix ast-id-only IR debug info output

### DIFF
--- a/libsolidity/codegen/ir/Common.cpp
+++ b/libsolidity/codegen/ir/Common.cpp
@@ -143,6 +143,9 @@ std::string dispenseLocationComment(langutil::SourceLocation const& _location, I
 	solAssert(_location.sourceName, "");
 	_context.markSourceUsed(*_location.sourceName);
 
+	if (!_context.debugInfoSelection().location)
+		return "";
+
 	std::string debugInfo = AsmPrinter::formatSourceLocation(
 		_location,
 		_context.sourceIndices(),

--- a/test/cmdlineTests/standard_debug_info_in_yul_and_evm_asm_print_ast_id_only/args
+++ b/test/cmdlineTests/standard_debug_info_in_yul_and_evm_asm_print_ast_id_only/args
@@ -1,0 +1,1 @@
+--allow-paths .

--- a/test/cmdlineTests/standard_debug_info_in_yul_and_evm_asm_print_ast_id_only/in.sol
+++ b/test/cmdlineTests/standard_debug_info_in_yul_and_evm_asm_print_ast_id_only/in.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0
+pragma solidity >=0.0;
+
+contract C {
+    function f() public {}
+}

--- a/test/cmdlineTests/standard_debug_info_in_yul_and_evm_asm_print_ast_id_only/input.json
+++ b/test/cmdlineTests/standard_debug_info_in_yul_and_evm_asm_print_ast_id_only/input.json
@@ -1,0 +1,13 @@
+{
+	"language": "Solidity",
+	"sources": {
+		"C": {"urls": ["in.sol"]}
+	},
+	"settings": {
+		"debug": {"debugInfo": ["ast-id"]},
+		"optimizer": {"enabled": true},
+		"outputSelection": {
+			"*": {"*": ["ir", "irOptimized", "evm.assembly"]}
+		}
+	}
+}

--- a/test/cmdlineTests/standard_debug_info_in_yul_and_evm_asm_print_ast_id_only/output.json
+++ b/test/cmdlineTests/standard_debug_info_in_yul_and_evm_asm_print_ast_id_only/output.json
@@ -1,0 +1,199 @@
+{
+    "contracts": {
+        "C": {
+            "C": {
+                "evm": {
+                    "assembly": "  mstore(0x40, 0x80)
+  callvalue
+  dup1
+  iszero
+  tag_1
+  jumpi
+  revert(0x00, 0x00)
+tag_1:
+  pop
+  dataSize(sub_0)
+  dup1
+  dataOffset(sub_0)
+  0x00
+  codecopy
+  0x00
+  return
+stop
+
+sub_0: assembly {
+      mstore(0x40, 0x80)
+      callvalue
+      dup1
+      iszero
+      tag_1
+      jumpi
+      revert(0x00, 0x00)
+    tag_1:
+      pop
+      jumpi(tag_2, lt(calldatasize, 0x04))
+      shr(0xe0, calldataload(0x00))
+      dup1
+      0x26121ff0
+      eq
+      tag_3
+      jumpi
+    tag_2:
+      revert(0x00, 0x00)
+    tag_3:
+      stop
+
+    auxdata: <AUXDATA REMOVED>
+}
+"
+                },
+                "ir": "
+/// @use-src 0:\"C\"
+object \"C_6\" {
+    code {
+
+        mstore(64, memoryguard(128))
+        if callvalue() { revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb() }
+
+        constructor_C_6()
+
+        let _1 := allocate_unbounded()
+        codecopy(_1, dataoffset(\"C_6_deployed\"), datasize(\"C_6_deployed\"))
+
+        return(_1, datasize(\"C_6_deployed\"))
+
+        function allocate_unbounded() -> memPtr {
+            memPtr := mload(64)
+        }
+
+        function revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb() {
+            revert(0, 0)
+        }
+
+        function constructor_C_6() {
+
+        }
+
+    }
+    /// @use-src 0:\"C\"
+    object \"C_6_deployed\" {
+        code {
+
+            mstore(64, memoryguard(128))
+
+            if iszero(lt(calldatasize(), 4))
+            {
+                let selector := shift_right_224_unsigned(calldataload(0))
+                switch selector
+
+                case 0x26121ff0
+                {
+                    // f()
+
+                    external_fun_f_5()
+                }
+
+                default {}
+            }
+
+            revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74()
+
+            function shift_right_224_unsigned(value) -> newValue {
+                newValue :=
+
+                shr(224, value)
+
+            }
+
+            function allocate_unbounded() -> memPtr {
+                memPtr := mload(64)
+            }
+
+            function revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb() {
+                revert(0, 0)
+            }
+
+            function revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b() {
+                revert(0, 0)
+            }
+
+            function abi_decode_tuple_(headStart, dataEnd)   {
+                if slt(sub(dataEnd, headStart), 0) { revert_error_dbdddcbe895c83990c08b3492a0e83918d802a52331272ac6fdb6a7c4aea3b1b() }
+
+            }
+
+            function abi_encode_tuple__to__fromStack(headStart ) -> tail {
+                tail := add(headStart, 0)
+
+            }
+
+            function external_fun_f_5() {
+
+                if callvalue() { revert_error_ca66f745a3ce8ff40e2ccaf1ad45db7774001b90d25810abd9040049be7bf4bb() }
+                abi_decode_tuple_(4, calldatasize())
+                fun_f_5()
+                let memPos := allocate_unbounded()
+                let memEnd := abi_encode_tuple__to__fromStack(memPos  )
+                return(memPos, sub(memEnd, memPos))
+
+            }
+
+            function revert_error_42b3090547df1d2001c96683413b8cf91c1b902ef5e3cb8d9f6f304cf7446f74() {
+                revert(0, 0)
+            }
+
+            /// @ast-id 5
+
+            function fun_f_5() {
+
+            }
+
+        }
+
+        data \".metadata\" hex\"<BYTECODE REMOVED>\"
+    }
+
+}
+
+",
+                "irOptimized": "/// @use-src 0:\"C\"
+object \"C_6\" {
+    code {
+        {
+            let _1 := memoryguard(0x80)
+            mstore(64, _1)
+            if callvalue() { revert(0, 0) }
+            let _2 := datasize(\"C_6_deployed\")
+            codecopy(_1, dataoffset(\"C_6_deployed\"), _2)
+            return(_1, _2)
+        }
+    }
+    /// @use-src 0:\"C\"
+    object \"C_6_deployed\" {
+        code {
+            {
+                if iszero(lt(calldatasize(), 4))
+                {
+                    if eq(0x26121ff0, shr(224, calldataload(0)))
+                    {
+                        if callvalue() { revert(0, 0) }
+                        if slt(add(calldatasize(), not(3)), 0) { revert(0, 0) }
+                        return(0, 0)
+                    }
+                }
+                revert(0, 0)
+            }
+        }
+        data \".metadata\" hex\"<BYTECODE REMOVED>\"
+    }
+}
+"
+            }
+        }
+    },
+    "sources": {
+        "C": {
+            "id": 0
+        }
+    }
+}


### PR DESCRIPTION
## Description

`settings.debug.debugInfo: ["ast-id"]` still emitted `@src` comments in generated IR because the shared source-location helper treated any non-empty debug info selection as a location request. Skip location comment creation unless the `location` component is selected, while preserving `@ast-id` output.

Adds a Standard JSON cmdline test for the ast-id-only IR/EVM assembly output case.

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
- [ ] No AI tools were used
- [x] AI tools were used (details below)

OpenAI Codex assisted with reviewing the change.