### PR TITLE
fix(docs): contradictory description of `send` in Subcurrency Example

### DIFF
--- a/docs/introduction-to-smart-contracts.rst
+++ b/docs/introduction-to-smart-contracts.rst
@@ -227,9 +227,10 @@ Both approaches allow you to provide the name of an error and additional data wh
 a failure can more easily be debugged or reacted upon.
 
 The ``send`` function can be used by anyone (who already
-has some of these coins) to send coins to anyone else. If the sender does not have
-enough coins to send, the ``if`` condition evaluates to true. As a result, the ``revert`` will cause the operation to fail
-while providing the sender with error details using the ``InsufficientBalance`` error.
+has some of these coins) to send coins to anyone else. If the sender does *not* have
+enough coins to send, the condition in ``require`` evaluates to false, triggering a ``revert``
+with the ``InsufficientBalance`` error. This error supplies the requested amount and available
+balance to the caller, which front-end applications or block explorers can surface for debugging.
 
 .. note::
     If you use


### PR DESCRIPTION
<!--
Thank you for your contribution to the Solidity compiler! A team member will follow up shortly.

If you have any questions or need our help, feel free to post them in the PR or talk to us directly on the
[#solidity-dev](https://matrix.to/#/#ethereum_solidity-dev:gitter.im) channel on Matrix.
-->

## Description

<!-- Describe the purpose of this PR. -->

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
<!--
See our contributing guidelines for the full AI usage policy:
https://docs.soliditylang.org/en/latest/contributing.html#ai-assisted-contributions

If you used AI tools in any part of this PR you MUST disclose it below.
-->

- [ ] No AI tools were used
- [x] AI tools were used (details below)

<!-- If AI tools were used, describe which tools and for which parts here. -->
Claude (Anthropic) was used for formatting the original issue body of #16730  and for tidying up the commit message. All technical content was verified by me.

Closes #16730
