### PR TITLE
Performance: Whiskers Regexes Cache+Optimize

### DIFF
--- a/libsolutil/Whiskers.cpp
+++ b/libsolutil/Whiskers.cpp
@@ -76,7 +76,10 @@ std::string Whiskers::render() const
 
 void Whiskers::checkTemplateValid() const
 {
-	std::regex validTemplate("<[#?!\\/]\\+{0,1}[a-zA-Z0-9_$-]+(?:[^a-zA-Z0-9_$>-]|$)");
+	static std::regex const validTemplate(
+		"<[#?!\\/]\\+{0,1}[a-zA-Z0-9_$-]+(?:[^a-zA-Z0-9_$>-]|$)",
+		std::regex_constants::ECMAScript | std::regex_constants::optimize
+	);
 	std::smatch match;
 	assertThrow(
 		!regex_search(m_template, match, validTemplate),
@@ -87,7 +90,10 @@ void Whiskers::checkTemplateValid() const
 
 void Whiskers::checkParameterValid(std::string const& _parameter) const
 {
-	static std::regex validParam("^" + paramRegex() + "$");
+	static std::regex const validParam(
+		"^" + paramRegex() + "$",
+		std::regex_constants::ECMAScript | std::regex_constants::optimize
+	);
 	assertThrow(
 		regex_match(_parameter, validParam),
 		WhiskersError,
@@ -163,7 +169,8 @@ std::string Whiskers::replace(
 	static std::regex listOrTag(
 		"<(" + paramRegex() + ")>|"
 		"<#(" + paramRegex() + ")>((?:.|\\r|\\n)*?)</\\2>|"
-		"<\\?(\\+?" + paramRegex() + ")>((?:.|\\r|\\n)*?)(<!\\4>((?:.|\\r|\\n)*?))?</\\4>"
+		"<\\?(\\+?" + paramRegex() + ")>((?:.|\\r|\\n)*?)(<!\\4>((?:.|\\r|\\n)*?))?</\\4>",
+		std::regex_constants::ECMAScript | std::regex_constants::optimize
 	);
 	return regex_replace(_template, listOrTag, [&](std::match_results<std::string::const_iterator> _match) -> std::string
 	{
@@ -240,4 +247,3 @@ Whiskers::StringMap Whiskers::joinMaps(
 		);
 	return ret;
 }
-

--- a/libsolutil/Whiskers.cpp
+++ b/libsolutil/Whiskers.cpp
@@ -247,3 +247,4 @@ Whiskers::StringMap Whiskers::joinMaps(
 		);
 	return ret;
 }
+


### PR DESCRIPTION
## Description
3% compile time improvement for `--via-ir` complilation+optimization and large solidity files, over 100 runs for this change and a baseline.

Adding the 'std::regex_constants::optimize' flag increases the compile time for the regex, but reduces the run time each time it is used. Adding const to the regex creation, means that we only pay this penalty once, but benefit from it each run.
(The const change alone makes a small speedup, while optimize without the const makes a slowdown, since the extra computation for optimization isn't worth it unless the regex object is used multiple times.)

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist] (https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## Al Disclosure
- [ ] No Al tools were used
- [x] Al tools were used