### PR TITLE
SSA CFG: Stack Layout generator populates spill set

### DIFF
--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -18,6 +18,7 @@
 
 #include <libyul/backends/evm/ssa/CodeTransform.h>
 
+#include <libyul/backends/evm/ssa/CallGraph.h>
 #include <libyul/backends/evm/ssa/StackLayoutGenerator.h>
 #include <libyul/backends/evm/ssa/StackShuffler.h>
 #include <libyul/backends/evm/ssa/StackUtils.h>
@@ -52,6 +53,7 @@ void CodeTransform::run
 	ControlFlowGraphs const& controlFlowGraphs = _controlFlowLiveness.controlFlowGraphs.get();
 	yulAssert(controlFlowGraphs.functionGraphs.size() == _controlFlowLiveness.cfgLiveness.size());
 	FunctionLabels const functionLabels = registerFunctionLabels(_assembly, controlFlowGraphs);
+	CallGraph const callGraph(controlFlowGraphs);
 
 	for (std::size_t functionIndex = 0; functionIndex < controlFlowGraphs.functionGraphs.size(); ++functionIndex)
 	{
@@ -62,7 +64,8 @@ void CodeTransform::run
 		auto const& liveness = _controlFlowLiveness.cfgLiveness[functionIndex];
 		yulAssert(liveness);
 		auto const graphID = static_cast<ControlFlowGraphs::FunctionGraphID>(functionIndex);
-		auto const& stackLayout = StackLayoutGenerator::generate(*liveness, callSites, graphID);
+		bool const spillingAllowed = !callGraph.isRecursive(graphID);
+		auto const& stackLayout = StackLayoutGenerator::generate(*liveness, callSites, graphID, spillingAllowed);
 		CodeTransform transform(
 			_assembly,
 			_builtinContext,

--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -65,7 +65,7 @@ void CodeTransform::run
 		yulAssert(liveness);
 		auto const graphID = static_cast<ControlFlowGraphs::FunctionGraphID>(functionIndex);
 		bool const spillingAllowed = !callGraph.isRecursive(graphID);
-		auto const& stackLayout = StackLayoutGenerator::generate(*liveness, callSites, graphID, spillingAllowed);
+		auto const stackLayoutGeneratorResult = StackLayoutGenerator::generate(*liveness, callSites, graphID, spillingAllowed);
 		CodeTransform transform(
 			_assembly,
 			_builtinContext,
@@ -73,7 +73,7 @@ void CodeTransform::run
 			functionLabels,
 			callSites,
 			cfg,
-			stackLayout,
+			stackLayoutGeneratorResult.layout,
 			graphID
 		);
 		transform(cfg.entry);

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -82,14 +82,15 @@ void declareJunk(StackType& _stack, LivenessAnalysis::LivenessData const& _live)
 
 }
 
-SSACFGStackLayout StackLayoutGenerator::generate(
+StackLayoutGenerator::Result StackLayoutGenerator::generate(
 	LivenessAnalysis const& _liveness,
 	CallSites const& _callSites,
 	ControlFlowGraphs::FunctionGraphID const _graphID,
 	bool const _spillingAllowed
 )
 {
-	return StackLayoutGenerator(_liveness, _callSites, _graphID, _spillingAllowed).m_resultLayout;
+	StackLayoutGenerator generator(_liveness, _callSites, _graphID, _spillingAllowed);
+	return Result{std::move(generator.m_resultLayout), std::move(generator.m_spillSet)};
 }
 
 StackLayoutGenerator::StackLayoutGenerator(

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -202,7 +202,8 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 					stack,
 					proposals[i],
 					{},
-					proposals[i].size()
+					proposals[i].size(),
+					&m_spillSet
 				);
 				yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 				cumulativeCost += stack.callbacks().opGas;
@@ -261,15 +262,20 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 
 		StackSlotLiveness const opLiveOutSlots = toStackSlotLiveness(m_cfg, opLiveOutWithoutOutputs);
 		{
-			StackData const target = findOptimalTarget(
+			auto [target, plannedSpillSet] = findOptimalTarget(
 				stack.data(),
 				requiredStackTop,
 				opLiveOutSlots,
 				junkCanBeAdded,
-				m_hasFunctionReturnLabel
+				m_hasFunctionReturnLabel,
+				m_spillSet,
+				m_spillingAllowed
 			);
-			auto const shuffleResult = StackShuffler<StackType::Callbacks>::shuffle(stack, target);
+			auto const spillCountBefore = m_spillSet.numSpilled();
+			m_spillSet = std::move(plannedSpillSet);
+			auto const shuffleResult = shuffleWithSpillDiscovery(currentStackData, target, m_spillSet);
 			yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
+			yulAssert(m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore, "Spilling not allowed, stack too deep.");
 		}
 
 		blockLayout.operationIn.push_back(currentStackData);
@@ -296,15 +302,20 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 				{
 					auto const condition = Slot::makeValue(m_cfg, _cJump.condition);
 					StackSlotLiveness const blockLiveOutSlots = toStackSlotLiveness(m_cfg, blockLiveOut);
-					StackData const target = findOptimalTarget(
+					auto [target, plannedSpillSet] = findOptimalTarget(
 						stack.data(),
 						{condition},
 						blockLiveOutSlots,
 						false,
-						m_hasFunctionReturnLabel
+						m_hasFunctionReturnLabel,
+						m_spillSet,
+						m_spillingAllowed
 					);
-					auto const shuffleResult = StackShuffler<StackType::Callbacks>::shuffle(stack, target);
+					auto const spillCountBefore = m_spillSet.numSpilled();
+					m_spillSet = std::move(plannedSpillSet);
+					auto const shuffleResult = shuffleWithSpillDiscovery(currentStackData, target, m_spillSet);
 					yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
+					yulAssert(m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore, "Spilling not allowed, stack too deep.");
 				}
 
 				yulAssert(!stack.empty() && stack.top().isValue() && stack.top().value() == _cJump.condition);
@@ -325,8 +336,10 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 				// in case there are return values, let's bring the function return label to the top
 				StackData returnStack = _functionReturn.returnValues | ranges::views::transform([this](InstId const _id) { return StackSlot::makeValue(m_cfg, _id); }) | ranges::to<std::vector>;
 				returnStack.push_back(StackSlot::makeFunctionReturnLabel(m_graphID));
-				auto const shuffleResult = StackShuffler<StackType::Callbacks>::shuffle(stack, returnStack);
+				auto const spillCountBefore = m_spillSet.numSpilled();
+				auto const shuffleResult = shuffleWithSpillDiscovery(currentStackData, returnStack, m_spillSet);
 				yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
+				yulAssert(m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore, "Spilling not allowed, stack too deep.");
 				blockLayout.exitIn = currentStackData;
 			},
 			[&](SSACFG::BasicBlock::Jump const& _jump) {

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -85,22 +85,25 @@ void declareJunk(StackType& _stack, LivenessAnalysis::LivenessData const& _live)
 SSACFGStackLayout StackLayoutGenerator::generate(
 	LivenessAnalysis const& _liveness,
 	CallSites const& _callSites,
-	ControlFlowGraphs::FunctionGraphID const _graphID
+	ControlFlowGraphs::FunctionGraphID const _graphID,
+	bool const _spillingAllowed
 )
 {
-	return StackLayoutGenerator(_liveness, _callSites, _graphID).m_resultLayout;
+	return StackLayoutGenerator(_liveness, _callSites, _graphID, _spillingAllowed).m_resultLayout;
 }
 
 StackLayoutGenerator::StackLayoutGenerator(
 	LivenessAnalysis const& _liveness,
 	CallSites const& _callSites,
-	ControlFlowGraphs::FunctionGraphID const _graphID
+	ControlFlowGraphs::FunctionGraphID const _graphID,
+	bool const _spillingAllowed
 ):
 	m_cfg(_liveness.cfg()),
 	m_liveness(_liveness),
 	m_callSites(_callSites),
 	m_graphID(_graphID),
 	m_hasFunctionReturnLabel(!_liveness.cfg().isMainGraph() && _liveness.cfg().canContinue),
+	m_spillingAllowed(_spillingAllowed),
 	m_junkAdmittingBlocksFinder(std::make_unique<JunkAdmittingBlocksFinder>(_liveness.cfg(), _liveness.topologicalSort())),
 	m_inputStackProposalsPerBlock(m_cfg.numBlocks()),
 	m_resultLayout(m_cfg.numBlocks())

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.h
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <libyul/backends/evm/ssa/spill/SpillSet.h>
+
 #include <libyul/backends/evm/ssa/Stack.h>
 #include <libyul/backends/evm/ssa/StackLayout.h>
 
@@ -63,6 +65,7 @@ private:
 	// representing the stack state flowing from each predecessor into the block.
 	std::vector<std::vector<std::pair<SSACFG::BlockId, StackData>>> m_inputStackProposalsPerBlock;
 	SSACFGStackLayout m_resultLayout;
+	spill::SpillSet m_spillSet;
 };
 
 }

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.h
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.h
@@ -34,7 +34,15 @@ class StackLayoutGenerator
 {
 public:
 	using Slot = StackSlot;
-	static SSACFGStackLayout generate(
+
+	/// the per-block stack layout plus the set of values the layout generator decided to spill to memory
+	struct Result
+	{
+		SSACFGStackLayout layout;
+		spill::SpillSet spillSet;
+	};
+
+	static Result generate(
 		LivenessAnalysis const& _liveness,
 		CallSites const& _callSites,
 		ControlFlowGraphs::FunctionGraphID _graphID,

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.h
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.h
@@ -35,14 +35,16 @@ public:
 	static SSACFGStackLayout generate(
 		LivenessAnalysis const& _liveness,
 		CallSites const& _callSites,
-		ControlFlowGraphs::FunctionGraphID _graphID
+		ControlFlowGraphs::FunctionGraphID _graphID,
+		bool _spillingAllowed
 	);
 
 private:
 	explicit StackLayoutGenerator(
 		LivenessAnalysis const& _liveness,
 		CallSites const& _callSites,
-		ControlFlowGraphs::FunctionGraphID _graphID
+		ControlFlowGraphs::FunctionGraphID _graphID,
+		bool _spillingAllowed
 	);
 
 	void defineStackIn(SSACFG::BlockId const& _blockId);
@@ -53,6 +55,7 @@ private:
 	CallSites const& m_callSites;
 	ControlFlowGraphs::FunctionGraphID m_graphID;
 	bool m_hasFunctionReturnLabel;
+	bool m_spillingAllowed;
 
 	std::unique_ptr<JunkAdmittingBlocksFinder> m_junkAdmittingBlocksFinder;
 	// Per-edge stack proposals for defineStackIn.

--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -951,4 +951,49 @@ private:
 	}
 };
 
+[[nodiscard]] inline StackShufflerResult shuffleWithSpillDiscovery(
+	StackData& _data,
+	StackData const& _args,
+	StackSlotLiveness const& _liveOut,
+	std::size_t const _targetStackSize,
+	spill::SpillSet& _spilledVariables
+)
+{
+	StackData const initialData = _data;
+	StackShufflerResult result;
+	do
+	{
+		_data = initialData;
+		Stack<> stack(_data, {});
+		result = StackShuffler<NoOpStackManipulationCallbacks>::shuffle(stack, _args, _liveOut, _targetStackSize, &_spilledVariables);
+		switch (result.status)
+		{
+		case StackShufflerResult::Status::Continue:
+			yulAssert(false);
+		case StackShufflerResult::Status::Admissible:
+			break;
+		case StackShufflerResult::Status::StackTooDeep:
+		{
+			yulAssert(result.culprit.isValue() && !result.culprit.isLiteralValue());
+			yulAssert(!_spilledVariables.isSpilled(result.culprit.value()));
+			_spilledVariables.add(result.culprit.value());
+			break;
+		}
+		case StackShufflerResult::Status::MaxIterationsReached:
+			break;
+		}
+	}
+	while (result.status == StackShufflerResult::Status::StackTooDeep);
+	return result;
+}
+
+[[nodiscard]] inline StackShufflerResult shuffleWithSpillDiscovery(
+	StackData& _data,
+	StackData const& _target,
+	spill::SpillSet& _spilledVariables)
+{
+	return shuffleWithSpillDiscovery(_data, _target, {}, _target.size(), _spilledVariables);
+}
+
+
 }

--- a/libyul/backends/evm/ssa/StackUtils.cpp
+++ b/libyul/backends/evm/ssa/StackUtils.cpp
@@ -54,12 +54,18 @@ void GasAccumulatingCallbacks::push(StackSlot const& _slot)
 		auto const op = cfg.evmDialect.evmVersion().hasPush0() ? evmasm::Instruction::PUSH0 : evmasm::Instruction::CODESIZE;
 		opGas += evmasm::GasMeter::runGas(op, cfg.evmDialect.evmVersion());
 	}
-	else
+	else if (_slot.isFunctionCallReturnLabel())
 	{
-		yulAssert(_slot.isFunctionCallReturnLabel(), "we can only push literals, junk, and function call return labels");
 		// this is a jump dest, we don't really know yet how big it is going to be, just assume that it fits into
 		// a 2-byte number
 		opGas += evmasm::GasMeter::runGas(evmasm::Instruction::PUSH2, cfg.evmDialect.evmVersion());
+	}
+	else
+	{
+		// Spilled SSA value
+		yulAssert(_slot.isValue(), "unexpected slot kind in GasAccumulatingCallbacks::push");
+		opGas += evmasm::GasMeter::runGas(evmasm::Instruction::PUSH32, cfg.evmDialect.evmVersion());
+		opGas += evmasm::GasMeter::runGas(evmasm::Instruction::MLOAD, cfg.evmDialect.evmVersion());
 	}
 }
 
@@ -80,13 +86,15 @@ StackData solidity::yul::ssa::stackPreImage(SSACFG const& _cfg, StackData _stack
 	return _stack;
 }
 
-StackData solidity::yul::ssa::findOptimalTarget
+OptimalTarget solidity::yul::ssa::findOptimalTarget
 (
 	StackData const& _stackData,
 	StackData const& _targetArgs,
 	StackSlotLiveness const& _targetLiveOut,
 	bool const _canIntroduceJunk,
-	bool const _hasFunctionReturnLabel
+	bool const _hasFunctionReturnLabel,
+	spill::SpillSet const& _spillSet,
+	bool const _spillingAllowed
 )
 {
 	std::size_t const minSize = _targetLiveOut.size() + _targetArgs.size() + (_hasFunctionReturnLabel ? 1 : 0);
@@ -105,10 +113,11 @@ StackData solidity::yul::ssa::findOptimalTarget
 
 	StackData data;
 	data.reserve(startSize + maxUpwardExpansion);
+	spill::SpillSet spillSet;
 	auto const evaluateCost = [&](std::size_t const _targetSize) -> std::size_t
 	{
 		StackShufflerResult result;
-		spill::SpillSet spillSet;
+		spillSet = _spillSet;
 		OpsCountingCallbacks callbacks;
 		do
 		{
@@ -142,6 +151,7 @@ StackData solidity::yul::ssa::findOptimalTarget
 
 	std::size_t bestCost = evaluateCost(startSize);
 	StackData bestData = data;
+	spill::SpillSet bestSpillSet = spillSet;
 
 	// On non-reverting paths, only search downward from pivot to avoid growing the stack.
 	// On reverting paths, search in both directions since stack cleanup doesn't matter.
@@ -158,6 +168,7 @@ StackData solidity::yul::ssa::findOptimalTarget
 			{
 				bestCost = cost;
 				bestData = data;
+				bestSpillSet = spillSet;
 				consecutiveIncreases = 0;
 			}
 			else if (++consecutiveIncreases >= stopAfter)
@@ -175,6 +186,7 @@ StackData solidity::yul::ssa::findOptimalTarget
 			{
 				bestCost = cost;
 				bestData = data;
+				bestSpillSet = spillSet;
 				consecutiveIncreases = 0;
 			}
 			else if (++consecutiveIncreases >= stopAfter)
@@ -182,7 +194,8 @@ StackData solidity::yul::ssa::findOptimalTarget
 		}
 	}
 
-	return bestData;
+	yulAssert(_spillingAllowed || bestSpillSet.numSpilled() == _spillSet.numSpilled(), "Spilling not allowed, stack too deep.");
+	return OptimalTarget{std::move(bestData), std::move(bestSpillSet)};
 }
 
 CallSites solidity::yul::ssa::gatherCallSites(SSACFG const& _cfg)

--- a/libyul/backends/evm/ssa/StackUtils.h
+++ b/libyul/backends/evm/ssa/StackUtils.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <libyul/backends/evm/ssa/spill/SpillSet.h>
+
 #include <libyul/backends/evm/ssa/PhiInverse.h>
 #include <libyul/backends/evm/ssa/Stack.h>
 #include <libyul/backends/evm/ssa/StackSlotLiveness.h>
@@ -63,15 +65,26 @@ struct GasAccumulatingCallbacks
 /// Transform stack data by replacing all its phi variables with their respective preimages.
 StackData stackPreImage(SSACFG const& _cfg, StackData _stack, PhiInverse const& _phiInverse);
 
+struct OptimalTarget
+{
+	StackData data;
+	spill::SpillSet spillSet;
+};
+
 /// Searches for the cheapest target stack size for shuffling _stackData towards
-/// (_targetArgs on top, _targetLiveOut anywhere in the tail), then realizes that size and
-/// returns the resolved post-shuffle StackData
-StackData findOptimalTarget(
+/// (_targetArgs on top, _targetLiveOut anywhere in the tail). Realizes that size and returns the resolved post-shuffle
+/// StackData together with the spill set that was needed to reach it.
+/// Callers must use the returned spill set for any subsequent shuffle of the real stack to this target, otherwise
+/// live values that were planned-spilled here will silently disappear from the real stack while
+/// staying outside the caller's spill set.
+OptimalTarget findOptimalTarget(
 	StackData const& _stackData,
 	StackData const& _targetArgs,
 	StackSlotLiveness const& _targetLiveOut,
 	bool _canIntroduceJunk,
-	bool _hasFunctionReturnLabel
+	bool _hasFunctionReturnLabel,
+	spill::SpillSet const& _spillSet,
+	bool _spillingAllowed
 );
 
 CallSites gatherCallSites(SSACFG const& _cfg);

--- a/libyul/backends/evm/ssa/io/DotExporterBase.cpp
+++ b/libyul/backends/evm/ssa/io/DotExporterBase.cpp
@@ -163,7 +163,11 @@ std::string DotExporterBase::exportBlocks(SSACFG::BlockId _entry, bool _wrapInDi
 	std::ostringstream out;
 	if (_wrapInDigraph)
 		out << fmt::format("digraph SSACFG {{\nnodesep=0.7;\ngraph[fontname=\"DejaVu Sans\", rankdir={}]\nnode[shape=box,fontname=\"DejaVu Sans\"];\n\n", m_rankDir);
-	out << fmt::format("Entry [label=\"Entry\"];\n");
+	auto const extra = extraEntryLabel();
+	if (extra.empty())
+		out << "Entry [label=\"Entry\"];\n";
+	else
+		out << fmt::format("Entry [label=\"Entry\n{}\"];\n", extra);
 	out << fmt::format("Entry -> {};\n", formatBlockHandle(_entry));
 	traverse(out, _entry);
 	if (_wrapInDigraph)
@@ -179,17 +183,21 @@ std::string DotExporterBase::exportFunction(SSACFG const& _function, bool _wrapI
 
 	static auto constexpr argsTransform = [](InstId const& arg) { return fmt::format("v{}", arg.value); };
 	auto const entryHandle = fmt::format("FunctionEntry_{}_{}", escapeId(_function.name), _function.entry.value);
+	auto const extra = extraEntryLabel();
+	auto const extraSuffix = extra.empty() ? std::string{} : "\n" + extra;
 	if (_function.numReturns > 0)
-		out << fmt::format("{} [label=\"function {}:\n [{} returns] := {}({})\"];\n",
+		out << fmt::format("{} [label=\"function {}:\n [{} returns] := {}({}){}\"];\n",
 			entryHandle, escapeLabel(_function.name),
 			_function.numReturns,
 			escapeLabel(_function.name),
-			fmt::join(_function.arguments | ranges::views::transform(argsTransform), ", "));
+			fmt::join(_function.arguments | ranges::views::transform(argsTransform), ", "),
+			extraSuffix);
 	else
-		out << fmt::format("{} [label=\"function {}:\n {}({})\"];\n",
+		out << fmt::format("{} [label=\"function {}:\n {}({}){}\"];\n",
 			entryHandle, escapeLabel(_function.name),
 			escapeLabel(_function.name),
-			fmt::join(_function.arguments | ranges::views::transform(argsTransform), ", "));
+			fmt::join(_function.arguments | ranges::views::transform(argsTransform), ", "),
+			extraSuffix);
 	out << fmt::format("{} -> {};\n", entryHandle, formatBlockHandle(_function.entry));
 	traverse(out, _function.entry);
 

--- a/libyul/backends/evm/ssa/io/DotExporterBase.h
+++ b/libyul/backends/evm/ssa/io/DotExporterBase.h
@@ -56,6 +56,10 @@ protected:
 	/// Override to customize edge style (e.g., dashed for back edges).
 	virtual EdgeStyle edgeStyle(SSACFG::BlockId, SSACFG::BlockId) { return EdgeStyle::Solid; }
 
+	/// Override to append extra text to the FunctionEntry/Entry label. Returned text is appended
+	/// verbatim (already-escaped) inside the existing label, separated by a newline if non-empty.
+	virtual std::string extraEntryLabel() { return {}; }
+
 	std::string formatBlockHandle(SSACFG::BlockId _id) const;
 	/// Escapes a string for use in dot node IDs (replaces non-alphanumeric characters with underscores).
 	static std::string escapeId(std::string_view _str);

--- a/test/libyul/ssa/StackLayoutGeneratorTest.cpp
+++ b/test/libyul/ssa/StackLayoutGeneratorTest.cpp
@@ -171,7 +171,7 @@ frontend::test::TestCase::TestResult StackLayoutGeneratorTest::run(std::ostream&
 				gatherCallSites(cfg),
 				static_cast<ControlFlowGraphs::FunctionGraphID>(index),
 				true
-			);
+			).layout;
 			StackLayoutDotExporter exporter(cfg, index, layout, *controlFlowGraphs);
 			if (!cfg.isMainGraph())
 				m_obtainedResult += exporter.exportFunction(cfg, false);

--- a/test/libyul/ssa/StackLayoutGeneratorTest.cpp
+++ b/test/libyul/ssa/StackLayoutGeneratorTest.cpp
@@ -169,7 +169,8 @@ frontend::test::TestCase::TestResult StackLayoutGeneratorTest::run(std::ostream&
 			SSACFGStackLayout const layout = StackLayoutGenerator::generate(
 				LivenessAnalysis(cfg),
 				gatherCallSites(cfg),
-				static_cast<ControlFlowGraphs::FunctionGraphID>(index)
+				static_cast<ControlFlowGraphs::FunctionGraphID>(index),
+				true
 			);
 			StackLayoutDotExporter exporter(cfg, index, layout, *controlFlowGraphs);
 			if (!cfg.isMainGraph())

--- a/test/libyul/ssa/StackLayoutGeneratorTest.cpp
+++ b/test/libyul/ssa/StackLayoutGeneratorTest.cpp
@@ -31,7 +31,7 @@
 #include <libyul/Common.h>
 #include <libyul/YulStack.h>
 
-#include <libsolutil/Visitor.h>
+#include <fmt/ranges.h>
 
 #include <range/v3/view/split.hpp>
 
@@ -62,15 +62,22 @@ public:
 		SSACFG const& _cfg,
 		std::size_t _functionIndex,
 		SSACFGStackLayout const& _layout,
+		spill::SpillSet const& _spillSet,
 		ControlFlowGraphs const& _controlFlow
 	):
 		DotExporterBase(_cfg, _functionIndex),
 		m_layout(_layout),
+		m_spillSet(_spillSet),
 		m_controlFlow(_controlFlow)
 	{
 	}
 
 protected:
+	std::string extraEntryLabel() override
+	{
+		return fmt::format("spilled: {{{}}}", fmt::join(m_spillSet.spilledValues(), ", "));
+	}
+
 	void writeBlockLabel(std::ostream& _out, SSACFG::BlockId _blockId) override
 	{
 		auto const& block = m_cfg.block(_blockId);
@@ -110,6 +117,7 @@ protected:
 
 private:
 	SSACFGStackLayout const& m_layout;
+	spill::SpillSet const& m_spillSet;
 	ControlFlowGraphs const& m_controlFlow;
 };
 
@@ -166,13 +174,13 @@ frontend::test::TestCase::TestResult StackLayoutGeneratorTest::run(std::ostream&
 		for (std::size_t index = 0; index < controlFlowGraphs->functionGraphs.size(); ++index)
 		{
 			auto const& cfg = *controlFlowGraphs->functionGraphs[index];
-			SSACFGStackLayout const layout = StackLayoutGenerator::generate(
+			auto result = StackLayoutGenerator::generate(
 				LivenessAnalysis(cfg),
 				gatherCallSites(cfg),
 				static_cast<ControlFlowGraphs::FunctionGraphID>(index),
 				true
-			).layout;
-			StackLayoutDotExporter exporter(cfg, index, layout, *controlFlowGraphs);
+			);
+			StackLayoutDotExporter exporter(cfg, index, result.layout, result.spillSet, *controlFlowGraphs);
 			if (!cfg.isMainGraph())
 				m_obtainedResult += exporter.exportFunction(cfg, false);
 			else

--- a/test/libyul/ssa/stackLayoutGenerator/can_continue.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/can_continue.yul
@@ -17,7 +17,8 @@
 // graph[fontname="DejaVu Sans", rankdir=LR]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry [label="Entry"];
+// Entry [label="Entry
+// spilled: {}"];
 // Entry -> Block0_0;
 // Block0_0 [label="\
 // IN: []\l\
@@ -31,7 +32,8 @@
 // Block0_0Exit [label="MainExit"];
 // Block0_0 -> Block0_0Exit;
 // FunctionEntry_revert_wrapper_0 [label="function revert_wrapper:
-//  revert_wrapper(v0, v1)"];
+//  revert_wrapper(v0, v1)
+// spilled: {}"];
 // FunctionEntry_revert_wrapper_0 -> Block1_0;
 // Block1_0 [label="\
 // IN: [ReturnLabel[1], v1, v0]\l\

--- a/test/libyul/ssa/stackLayoutGenerator/dead_code.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/dead_code.yul
@@ -15,7 +15,8 @@
 // graph[fontname="DejaVu Sans", rankdir=LR]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry [label="Entry"];
+// Entry [label="Entry
+// spilled: {}"];
 // Entry -> Block0_0;
 // Block0_0 [label="\
 // IN: []\l\
@@ -77,7 +78,8 @@
 // Block0_5Exit [label="MainExit"];
 // Block0_5 -> Block0_5Exit;
 // FunctionEntry___revert_0_1_0 [label="function __revert_0_1:
-//  __revert_0_1()"];
+//  __revert_0_1()
+// spilled: {}"];
 // FunctionEntry___revert_0_1_0 -> Block1_0;
 // Block1_0 [label="\
 // IN: []\l\

--- a/test/libyul/ssa/stackLayoutGenerator/function.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/function.yul
@@ -26,7 +26,8 @@
 // graph[fontname="DejaVu Sans", rankdir=LR]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry [label="Entry"];
+// Entry [label="Entry
+// spilled: {}"];
 // Entry -> Block0_0;
 // Block0_0 [label="\
 // IN: []\l\
@@ -44,7 +45,8 @@
 // Block0_0Exit [label="Terminated"];
 // Block0_0 -> Block0_0Exit;
 // FunctionEntry_f_0 [label="function f:
-//  [1 returns] := f(v0, v1)"];
+//  [1 returns] := f(v0, v1)
+// spilled: {}"];
 // FunctionEntry_f_0 -> Block1_0;
 // Block1_0 [label="\
 // IN: [ReturnLabel[1], v1, v0]\l\
@@ -62,7 +64,8 @@
 // Block1_0Exit [label="FunctionReturn[v4]"];
 // Block1_0 -> Block1_0Exit;
 // FunctionEntry_g_0 [label="function g:
-//  g()"];
+//  g()
+// spilled: {}"];
 // FunctionEntry_g_0 -> Block2_0;
 // Block2_0 [label="\
 // IN: [ReturnLabel[2]]\l\
@@ -76,7 +79,8 @@
 // Block2_0Exit [label="FunctionReturn[]"];
 // Block2_0 -> Block2_0Exit;
 // FunctionEntry_h_0 [label="function h:
-//  h(v0)"];
+//  h(v0)
+// spilled: {}"];
 // FunctionEntry_h_0 -> Block3_0;
 // Block3_0 [label="\
 // IN: [v0]\l\
@@ -94,7 +98,8 @@
 // Block3_0Exit [label="Terminated"];
 // Block3_0 -> Block3_0Exit;
 // FunctionEntry_i_0 [label="function i:
-//  [2 returns] := i()"];
+//  [2 returns] := i()
+// spilled: {}"];
 // FunctionEntry_i_0 -> Block4_0;
 // Block4_0 [label="\
 // IN: [ReturnLabel[4]]\l\

--- a/test/libyul/ssa/stackLayoutGenerator/multi_return.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/multi_return.yul
@@ -13,7 +13,8 @@
 // graph[fontname="DejaVu Sans", rankdir=LR]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry [label="Entry"];
+// Entry [label="Entry
+// spilled: {}"];
 // Entry -> Block0_0;
 // Block0_0 [label="\
 // IN: []\l\
@@ -39,7 +40,8 @@
 // Block0_0Exit [label="MainExit"];
 // Block0_0 -> Block0_0Exit;
 // FunctionEntry_pair_0 [label="function pair:
-//  [2 returns] := pair(v0)"];
+//  [2 returns] := pair(v0)
+// spilled: {}"];
 // FunctionEntry_pair_0 -> Block1_0;
 // Block1_0 [label="\
 // IN: [ReturnLabel[1], v0]\l\

--- a/test/libyul/ssa/stackLayoutGenerator/nested_for.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/nested_for.yul
@@ -13,7 +13,8 @@
 // graph[fontname="DejaVu Sans", rankdir=LR]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry [label="Entry"];
+// Entry [label="Entry
+// spilled: {}"];
 // Entry -> Block0_0;
 // Block0_0 [label="\
 // IN: []\l\

--- a/test/libyul/ssa/stackLayoutGenerator/recursion.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/recursion.yul
@@ -12,7 +12,8 @@
 // graph[fontname="DejaVu Sans", rankdir=LR]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry [label="Entry"];
+// Entry [label="Entry
+// spilled: {}"];
 // Entry -> Block0_0;
 // Block0_0 [label="\
 // IN: []\l\
@@ -30,7 +31,8 @@
 // Block0_0Exit [label="MainExit"];
 // Block0_0 -> Block0_0Exit;
 // FunctionEntry_sum_0 [label="function sum:
-//  [1 returns] := sum(v0)"];
+//  [1 returns] := sum(v0)
+// spilled: {}"];
 // FunctionEntry_sum_0 -> Block1_0;
 // Block1_0 [label="\
 // IN: [ReturnLabel[1], v0]\l\

--- a/test/libyul/ssa/stackLayoutGenerator/simple_for.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/simple_for.yul
@@ -14,7 +14,8 @@
 // graph[fontname="DejaVu Sans", rankdir=LR]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry [label="Entry"];
+// Entry [label="Entry
+// spilled: {}"];
 // Entry -> Block0_0;
 // Block0_0 [label="\
 // IN: []\l\

--- a/test/libyul/ssa/stackLayoutGenerator/simple_if.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/simple_if.yul
@@ -14,7 +14,8 @@
 // graph[fontname="DejaVu Sans", rankdir=LR]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry [label="Entry"];
+// Entry [label="Entry
+// spilled: {}"];
 // Entry -> Block0_0;
 // Block0_0 [label="\
 // IN: []\l\
@@ -32,7 +33,8 @@
 // Block0_0Exit [label="MainExit"];
 // Block0_0 -> Block0_0Exit;
 // FunctionEntry_f_0 [label="function f:
-//  [1 returns] := f(v0, v1)"];
+//  [1 returns] := f(v0, v1)
+// spilled: {}"];
 // FunctionEntry_f_0 -> Block1_0;
 // Block1_0 [label="\
 // IN: [ReturnLabel[1], v1, v0]\l\

--- a/test/libyul/ssa/stackLayoutGenerator/spill_in_function.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/spill_in_function.yul
@@ -1,0 +1,174 @@
+{
+    function f() {
+        // Many simultaneously-live locals inside a function with a return label
+        // also pinning a stack slot — the layout generator must spill.
+        let x01 := calldataload(0x01)
+        let x02 := calldataload(0x02)
+        let x03 := calldataload(0x03)
+        let x04 := calldataload(0x04)
+        let x05 := calldataload(0x05)
+        let x06 := calldataload(0x06)
+        let x07 := calldataload(0x07)
+        let x08 := calldataload(0x08)
+        let x09 := calldataload(0x09)
+        let x10 := calldataload(0x0a)
+        let x11 := calldataload(0x0b)
+        let x12 := calldataload(0x0c)
+        let x13 := calldataload(0x0d)
+        let x14 := calldataload(0x0e)
+        let x15 := calldataload(0x0f)
+        let x16 := calldataload(0x10)
+        let x17 := calldataload(0x11)
+        let x18 := calldataload(0x12)
+        sstore(x01, x18)
+        sstore(x02, x17)
+        sstore(x03, x16)
+        sstore(x04, x15)
+        sstore(x05, x14)
+        sstore(x06, x13)
+        sstore(x07, x12)
+        sstore(x08, x11)
+        sstore(x09, x10)
+    }
+    f()
+}
+// ----
+// digraph SSACFG {
+// nodesep=0.7;
+// graph[fontname="DejaVu Sans", rankdir=LR]
+// node[shape=box,fontname="DejaVu Sans"];
+//
+// Entry [label="Entry
+// spilled: {}"];
+// Entry -> Block0_0;
+// Block0_0 [label="\
+// IN: []\l\
+// \l\
+// [FunctionCallReturnLabel[0]]\l\
+// f\l\
+// [FunctionCallReturnLabel[0]]\l\
+// \l\
+// OUT: []\l\
+// "];
+// Block0_0Exit [label="MainExit"];
+// Block0_0 -> Block0_0Exit;
+// FunctionEntry_f_0 [label="function f:
+//  f()
+// spilled: {v1, v33}"];
+// FunctionEntry_f_0 -> Block1_0;
+// Block1_0 [label="\
+// IN: [ReturnLabel[1]]\l\
+// \l\
+// [ReturnLabel[1], lit0]\l\
+// calldataload\l\
+// [ReturnLabel[1], v1]\l\
+// \l\
+// [ReturnLabel[1], v1, lit2]\l\
+// calldataload\l\
+// [ReturnLabel[1], v1, v3]\l\
+// \l\
+// [ReturnLabel[1], v1, v3, lit4]\l\
+// calldataload\l\
+// [ReturnLabel[1], v1, v3, v5]\l\
+// \l\
+// [ReturnLabel[1], v1, v3, v5, lit6]\l\
+// calldataload\l\
+// [ReturnLabel[1], v1, v3, v5, v7]\l\
+// \l\
+// [ReturnLabel[1], v1, v3, v5, v7, lit8]\l\
+// calldataload\l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9]\l\
+// \l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, lit10]\l\
+// calldataload\l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11]\l\
+// \l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, lit12]\l\
+// calldataload\l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13]\l\
+// \l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, lit14]\l\
+// calldataload\l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15]\l\
+// \l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, lit16]\l\
+// calldataload\l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17]\l\
+// \l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, lit18]\l\
+// calldataload\l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, v19]\l\
+// \l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, lit20]\l\
+// calldataload\l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21]\l\
+// \l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, lit22]\l\
+// calldataload\l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23]\l\
+// \l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, lit24]\l\
+// calldataload\l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25]\l\
+// \l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, lit26]\l\
+// calldataload\l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27]\l\
+// \l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, lit28]\l\
+// calldataload\l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29]\l\
+// \l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, lit30]\l\
+// calldataload\l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31]\l\
+// \l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, lit32]\l\
+// calldataload\l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v33]\l\
+// \l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v33, lit34]\l\
+// calldataload\l\
+// [ReturnLabel[1], v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v33, v35]\l\
+// \l\
+// [ReturnLabel[1], v31, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v35, v35, v1]\l\
+// sstore\l\
+// [ReturnLabel[1], v31, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v35]\l\
+// \l\
+// [ReturnLabel[1], v31, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v33, v3]\l\
+// sstore\l\
+// [ReturnLabel[1], v31, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29]\l\
+// \l\
+// [ReturnLabel[1], v29, JUNK, v27, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v31, v5]\l\
+// sstore\l\
+// [ReturnLabel[1], v29, JUNK, v27, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25]\l\
+// \l\
+// [ReturnLabel[1], v25, JUNK, v27, v23, v9, v11, v13, v15, v17, v19, v21, v29, v7]\l\
+// sstore\l\
+// [ReturnLabel[1], v25, JUNK, v27, v23, v9, v11, v13, v15, v17, v19, v21]\l\
+// \l\
+// [ReturnLabel[1], v25, JUNK, v21, v23, v19, v11, v13, v15, v17, v27, v9]\l\
+// sstore\l\
+// [ReturnLabel[1], v25, JUNK, v21, v23, v19, v11, v13, v15, v17]\l\
+// \l\
+// [ReturnLabel[1], v17, JUNK, v21, v23, v19, v15, v13, v25, v11]\l\
+// sstore\l\
+// [ReturnLabel[1], v17, JUNK, v21, v23, v19, v15, v13]\l\
+// \l\
+// [ReturnLabel[1], v17, JUNK, v21, v15, v19, v23, v13]\l\
+// sstore\l\
+// [ReturnLabel[1], v17, JUNK, v21, v15, v19]\l\
+// \l\
+// [ReturnLabel[1], v17, v19, v21, v15]\l\
+// sstore\l\
+// [ReturnLabel[1], v17, v19]\l\
+// \l\
+// [ReturnLabel[1], v19, v17]\l\
+// sstore\l\
+// [ReturnLabel[1]]\l\
+// \l\
+// OUT: [ReturnLabel[1]]\l\
+// "];
+// Block1_0Exit [label="FunctionReturn[]"];
+// Block1_0 -> Block1_0Exit;
+// }

--- a/test/libyul/ssa/stackLayoutGenerator/spill_many_locals.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/spill_many_locals.yul
@@ -1,0 +1,171 @@
+{
+    // All locals are live throughout and consumed in pairs from
+    // opposite ends which forces the layout generator to spill some of them
+    let x01 := calldataload(0x01)
+    let x02 := calldataload(0x02)
+    let x03 := calldataload(0x03)
+    let x04 := calldataload(0x04)
+    let x05 := calldataload(0x05)
+    let x06 := calldataload(0x06)
+    let x07 := calldataload(0x07)
+    let x08 := calldataload(0x08)
+    let x09 := calldataload(0x09)
+    let x10 := calldataload(0x0a)
+    let x11 := calldataload(0x0b)
+    let x12 := calldataload(0x0c)
+    let x13 := calldataload(0x0d)
+    let x14 := calldataload(0x0e)
+    let x15 := calldataload(0x0f)
+    let x16 := calldataload(0x10)
+    let x17 := calldataload(0x11)
+    let x18 := calldataload(0x12)
+    let x19 := calldataload(0x13)
+    let x20 := calldataload(0x14)
+    sstore(x01, x20)
+    sstore(x02, x19)
+    sstore(x03, x18)
+    sstore(x04, x17)
+    sstore(x05, x16)
+    sstore(x06, x15)
+    sstore(x07, x14)
+    sstore(x08, x13)
+    sstore(x09, x12)
+    sstore(x10, x11)
+}
+// ----
+// digraph SSACFG {
+// nodesep=0.7;
+// graph[fontname="DejaVu Sans", rankdir=LR]
+// node[shape=box,fontname="DejaVu Sans"];
+//
+// Entry [label="Entry
+// spilled: {v35, v37, v39}"];
+// Entry -> Block0_0;
+// Block0_0 [label="\
+// IN: []\l\
+// \l\
+// [lit0]\l\
+// calldataload\l\
+// [v1]\l\
+// \l\
+// [v1, lit2]\l\
+// calldataload\l\
+// [v1, v3]\l\
+// \l\
+// [v1, v3, lit4]\l\
+// calldataload\l\
+// [v1, v3, v5]\l\
+// \l\
+// [v1, v3, v5, lit6]\l\
+// calldataload\l\
+// [v1, v3, v5, v7]\l\
+// \l\
+// [v1, v3, v5, v7, lit8]\l\
+// calldataload\l\
+// [v1, v3, v5, v7, v9]\l\
+// \l\
+// [v1, v3, v5, v7, v9, lit10]\l\
+// calldataload\l\
+// [v1, v3, v5, v7, v9, v11]\l\
+// \l\
+// [v1, v3, v5, v7, v9, v11, lit12]\l\
+// calldataload\l\
+// [v1, v3, v5, v7, v9, v11, v13]\l\
+// \l\
+// [v1, v3, v5, v7, v9, v11, v13, lit14]\l\
+// calldataload\l\
+// [v1, v3, v5, v7, v9, v11, v13, v15]\l\
+// \l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, lit16]\l\
+// calldataload\l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17]\l\
+// \l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, lit18]\l\
+// calldataload\l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19]\l\
+// \l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, lit20]\l\
+// calldataload\l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21]\l\
+// \l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, lit22]\l\
+// calldataload\l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23]\l\
+// \l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, lit24]\l\
+// calldataload\l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25]\l\
+// \l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, lit26]\l\
+// calldataload\l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27]\l\
+// \l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, lit28]\l\
+// calldataload\l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29]\l\
+// \l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, lit30]\l\
+// calldataload\l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31]\l\
+// \l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, lit32]\l\
+// calldataload\l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v33]\l\
+// \l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v33, lit34]\l\
+// calldataload\l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v33, v35]\l\
+// \l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v33, v35, lit36]\l\
+// calldataload\l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v33, v35, v37]\l\
+// \l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v33, v35, v37, lit38]\l\
+// calldataload\l\
+// [v1, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v33, v35, v37, v39]\l\
+// \l\
+// [v33, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v1, v1, v39, v1]\l\
+// sstore\l\
+// [v33, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v1, v1]\l\
+// \l\
+// [v33, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, JUNK, v37, v3]\l\
+// sstore\l\
+// [v33, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, JUNK]\l\
+// \l\
+// [v33, JUNK, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, JUNK, v35, v5]\l\
+// sstore\l\
+// [v33, JUNK, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, JUNK]\l\
+// \l\
+// [v33, JUNK, JUNK, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v33, v7]\l\
+// sstore\l\
+// [v33, JUNK, JUNK, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31]\l\
+// \l\
+// [JUNK, JUNK, JUNK, JUNK, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v9]\l\
+// sstore\l\
+// [JUNK, JUNK, JUNK, JUNK, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29]\l\
+// \l\
+// [JUNK, JUNK, JUNK, JUNK, JUNK, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v11]\l\
+// sstore\l\
+// [JUNK, JUNK, JUNK, JUNK, JUNK, v11, v13, v15, v17, v19, v21, v23, v25, v27]\l\
+// \l\
+// [JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, v13, v15, v17, v19, v21, v23, v25, v27, v13]\l\
+// sstore\l\
+// [JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, v13, v15, v17, v19, v21, v23, v25]\l\
+// \l\
+// [JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, v15, v17, v19, v21, v23, v25, v15]\l\
+// sstore\l\
+// [JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, v15, v17, v19, v21, v23]\l\
+// \l\
+// [JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, v17, v19, v21, v23, v17]\l\
+// sstore\l\
+// [JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, v17, v19, v21]\l\
+// \l\
+// [JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, v21, v19]\l\
+// sstore\l\
+// [JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK]\l\
+// \l\
+// OUT: [JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK]\l\
+// "];
+// Block0_0Exit [label="MainExit"];
+// Block0_0 -> Block0_0Exit;
+// }

--- a/test/libyul/ssa/stackLayoutGenerator/switch.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/switch.yul
@@ -21,7 +21,8 @@
 // graph[fontname="DejaVu Sans", rankdir=LR]
 // node[shape=box,fontname="DejaVu Sans"];
 //
-// Entry [label="Entry"];
+// Entry [label="Entry
+// spilled: {}"];
 // Entry -> Block0_0;
 // Block0_0 [label="\
 // IN: []\l\


### PR DESCRIPTION
- hook result of recursive call chain check into SLG to enable/disable spilling
- SLG is populated during layout generation
- SLG's public API returns the spill set
- SLG tests render the spill set

Bottom line: SLG records which SSA values needs to be spilled to memory and exposes that to consumers (tests and code transform).