### PR TITLE
YulUtilFunctions: assert combined byte slice extent in updateByteSliceFunction

### DIFF
--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -602,6 +602,7 @@ std::string YulUtilFunctions::updateByteSliceFunction(size_t _numBytes, size_t _
 {
 	solAssert(_numBytes <= 32, "");
 	solAssert(_shiftBytes <= 32, "");
+	solAssert(_numBytes + _shiftBytes <= 32, "");
 	size_t numBits = _numBytes * 8;
 	size_t shiftBits = _shiftBytes * 8;
 	std::string functionName = "update_byte_slice_" + std::to_string(_numBytes) + "_shift_" + std::to_string(_shiftBytes);


### PR DESCRIPTION
## Summary
- `updateByteSliceFunction(_numBytes, _shiftBytes)` currently asserts `_numBytes <= 32` and `_shiftBytes <= 32` independently, but not their combination.
- The emitted mask `((1 << numBits) - 1) << shiftBits` is only well-defined when `_numBytes + _shiftBytes <= 32` — otherwise the mask spans bits ≥ 256 and Yul silently truncates it mod 2^256, producing a wrong storage update.
