### PR TITLE
YulUtilFunctions: reject _bytes == 0 in maskLowerOrderBytesFunction

### DIFF
--- a/libsolidity/codegen/YulUtilFunctions.cpp
+++ b/libsolidity/codegen/YulUtilFunctions.cpp
@@ -663,7 +663,7 @@ std::string YulUtilFunctions::maskBytesFunctionDynamic()
 std::string YulUtilFunctions::maskLowerOrderBytesFunction(size_t _bytes)
 {
 	std::string functionName = "mask_lower_order_bytes_" + std::to_string(_bytes);
-	solAssert(_bytes <= 32, "");
+	solAssert(_bytes > 0 && _bytes <= 32, "");
 	return m_functionCollector.createFunction(functionName, [&]() {
 		return Whiskers(R"(
 			function <functionName>(data) -> result {


### PR DESCRIPTION
## Summary
- `maskLowerOrderBytesFunction(_bytes)` asserts `_bytes <= 32` but allows `_bytes == 0`.
- For `_bytes == 0`, the mask expression `(~u256(0)) >> (256 - 8 * _bytes)` becomes `~0 >> 256` — implementation-defined in C++ and only happens to evaluate to `0` in boost's `multiprecision::number<unchecked<…>>`. The emitted Yul becomes `result := and(data, 0x00)`, a zeroizer.
- No current caller passes `0` (verified via grep), so this is not a current bug. Tighten the precondition to `_bytes > 0 && _bytes <= 32` so future callers can't accidentally hit the degenerate case.
- The dynamic variant `maskLowerOrderBytesFunctionDynamic` is unaffected — its Yul `not(shl(mul(8, bytes), not(0)))` formulation handles `bytes == 0` correctly.

## Test plan
- [x] CI builds clean (only tightens an existing assert).
- [x] No existing tests should regress since the new precondition is implied by current usage.