### PR TITLE
Remove EOF: Replace code sections  with one section in `Assembly` `and LinkerObject`.

### DIFF
--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -108,13 +108,11 @@ AssemblyItem const& Assembly::append(AssemblyItem _i)
 {
 	assertThrow(m_deposit >= 0, AssemblyException, "Stack underflow.");
 	m_deposit += static_cast<int>(_i.deposit());
-	solAssert(m_currentCodeSection < m_codeSections.size());
-	auto& currentItems = m_codeSections.at(m_currentCodeSection).items;
-	currentItems.emplace_back(std::move(_i));
-	if (!currentItems.back().location().isValid() && m_currentSourceLocation.isValid())
-		currentItems.back().setLocation(m_currentSourceLocation);
-	currentItems.back().m_modifierDepth = m_currentModifierDepth;
-	return currentItems.back();
+	m_items.emplace_back(std::move(_i));
+	if (!m_items.back().location().isValid() && m_currentSourceLocation.isValid())
+		m_items.back().setLocation(m_currentSourceLocation);
+	m_items.back().m_modifierDepth = m_currentModifierDepth;
+	return m_items.back();
 }
 
 unsigned Assembly::codeSize(unsigned subTagSize) const
@@ -125,9 +123,8 @@ unsigned Assembly::codeSize(unsigned subTagSize) const
 		for (auto const& i: m_data)
 			ret += i.second.size();
 
-		for (auto const& codeSection: m_codeSections)
-			for (AssemblyItem const& i: codeSection.items)
-				ret += i.bytesRequired(tagSize, m_evmVersion, Precision::Precise);
+		for (AssemblyItem const& i: m_items)
+			ret += i.bytesRequired(tagSize, m_evmVersion, Precision::Precise);
 		if (numberEncodingSize(ret) <= tagSize)
 			return static_cast<unsigned>(ret);
 	}
@@ -135,13 +132,11 @@ unsigned Assembly::codeSize(unsigned subTagSize) const
 
 void Assembly::importAssemblyItemsFromJSON(Json const& _code, std::vector<std::string> const& _sourceList)
 {
-	// Assembly constructor creates first code section with proper type and empty `items`
-	solAssert(m_codeSections.size() == 1);
-	solAssert(m_codeSections[0].items.empty());
+	solAssert(m_items.empty());
 	solRequire(_code.is_array(), AssemblyImportException, "Supplied JSON is not an array.");
 	for (auto jsonItemIter = std::begin(_code); jsonItemIter != std::end(_code); ++jsonItemIter)
 	{
-		AssemblyItem const& newItem = m_codeSections[0].items.emplace_back(createAssemblyItemFromJSON(*jsonItemIter, _sourceList));
+		AssemblyItem const& newItem = m_items.emplace_back(createAssemblyItemFromJSON(*jsonItemIter, _sourceList));
 		if (newItem == Instruction::JUMPDEST)
 			solThrow(AssemblyImportException, "JUMPDEST instruction without a tag");
 		else if (newItem.type() == AssemblyItemType::Tag)
@@ -451,19 +446,9 @@ void Assembly::assemblyStream(
 {
 	Functionalizer f(_out, _prefix, _sourceCodes, *this);
 
-	for (auto const& i: m_codeSections.front().items)
+	for (auto const& i: m_items)
 		f.feed(i, _debugInfoSelection);
 	f.flush();
-
-	for (size_t i = 1; i < m_codeSections.size(); ++i)
-	{
-		_out << std::endl << _prefix << "code_section_" << i << ": assembly {\n";
-		Functionalizer codeSectionF(_out, _prefix + "    ", _sourceCodes, *this);
-		for (auto const& item: m_codeSections[i].items)
-			codeSectionF.feed(item, _debugInfoSelection);
-		codeSectionF.flush();
-		_out << _prefix << "}" << std::endl;
-	}
 
 	if (!m_data.empty() || !m_subs.empty())
 	{
@@ -499,8 +484,7 @@ Json Assembly::assemblyJSON(std::map<std::string, unsigned> const& _sourceIndice
 	Json root;
 	root[".code"] = Json::array();
 	Json& code = root[".code"];
-	solAssert(m_codeSections.size() == 1);
-	for (AssemblyItem const& item: m_codeSections.front().items)
+	for (AssemblyItem const& item: m_items)
 	{
 		int sourceIndex = -1;
 		if (item.location().sourceName)
@@ -785,19 +769,13 @@ std::map<u256, u256> const& Assembly::optimiseInternal(
 	// Run optimisation for sub-assemblies.
 	for (SubAssemblyID subID{0}; subID.value < m_subs.size(); ++subID.value)
 	{
-		OptimiserSettings settings = _settings;
 		Assembly& sub = *m_subs[subID.asIndex()];
-		std::set<size_t> referencedTags;
-		solAssert(m_codeSections.size() == 1);
-		for (auto& codeSection: m_codeSections)
-			referencedTags += JumpdestRemover::referencedTags(codeSection.items, subID);
 		std::map<u256, u256> const& subTagReplacements = sub.optimiseInternal(
-			settings,
-			referencedTags
+			_settings,
+			JumpdestRemover::referencedTags(m_items, subID)
 		);
 		// Apply the replacements (can be empty).
-		for (auto& codeSection: m_codeSections)
-			BlockDeduplicator::applyTagReplacement(codeSection.items, subTagReplacements, subID);
+		BlockDeduplicator::applyTagReplacement(m_items, subTagReplacements, subID);
 	}
 
 	std::map<u256, u256> tagReplacements;
@@ -808,9 +786,8 @@ std::map<u256, u256> const& Assembly::optimiseInternal(
 
 		if (_settings.runInliner)
 		{
-			solAssert(m_codeSections.size() == 1);
 			Inliner{
-				m_codeSections.front().items,
+				m_items,
 				_tagsReferencedFromOutside,
 				_settings.expectedExecutionsPerDeployment,
 				isCreation(),
@@ -819,53 +796,46 @@ std::map<u256, u256> const& Assembly::optimiseInternal(
 		}
 		if (_settings.runJumpdestRemover)
 		{
-			for (auto& codeSection: m_codeSections)
-			{
-				JumpdestRemover jumpdestOpt{codeSection.items};
-				if (jumpdestOpt.optimise(_tagsReferencedFromOutside))
-					count++;
-			}
+			JumpdestRemover jumpdestOpt{m_items};
+			if (jumpdestOpt.optimise(_tagsReferencedFromOutside))
+				count++;
 		}
 
 		if (_settings.runPeephole)
 		{
-			for (auto& codeSection: m_codeSections)
+			PeepholeOptimiser peepOpt{m_items, m_evmVersion};
+			while (peepOpt.optimise())
 			{
-				PeepholeOptimiser peepOpt{codeSection.items, m_evmVersion};
-				while (peepOpt.optimise())
-				{
-					count++;
-					assertThrow(count < 64000, OptimizerException, "Peephole optimizer seems to be stuck.");
-				}
+				count++;
+				assertThrow(count < 64000, OptimizerException, "Peephole optimizer seems to be stuck.");
 			}
 		}
 
 		// This only modifies PushTags, we have to run again to actually remove code.
 		if (_settings.runDeduplicate)
-			for (auto& section: m_codeSections)
+		{
+			BlockDeduplicator deduplicator{m_items};
+			if (deduplicator.deduplicate())
 			{
-				BlockDeduplicator deduplicator{section.items};
-				if (deduplicator.deduplicate())
+				for (auto const& replacement: deduplicator.replacedTags())
 				{
-					for (auto const& replacement: deduplicator.replacedTags())
-					{
-						assertThrow(
-							replacement.first <= std::numeric_limits<size_t>::max() && replacement.second <= std::numeric_limits<size_t>::max(),
-							OptimizerException,
-							"Invalid tag replacement."
-						);
-						assertThrow(
-							!tagReplacements.count(replacement.first),
-							OptimizerException,
-							"Replacement already known."
-						);
-						tagReplacements[replacement.first] = replacement.second;
-						if (_tagsReferencedFromOutside.erase(static_cast<size_t>(replacement.first)))
-							_tagsReferencedFromOutside.insert(static_cast<size_t>(replacement.second));
-					}
-					count++;
+					assertThrow(
+						replacement.first <= std::numeric_limits<size_t>::max() && replacement.second <= std::numeric_limits<size_t>::max(),
+						OptimizerException,
+						"Invalid tag replacement."
+					);
+					assertThrow(
+						!tagReplacements.count(replacement.first),
+						OptimizerException,
+						"Replacement already known."
+					);
+					tagReplacements[replacement.first] = replacement.second;
+					if (_tagsReferencedFromOutside.erase(static_cast<size_t>(replacement.first)))
+						_tagsReferencedFromOutside.insert(static_cast<size_t>(replacement.second));
 				}
+				count++;
 			}
+		}
 
 		if (_settings.runCSE)
 		{
@@ -874,19 +844,17 @@ std::map<u256, u256> const& Assembly::optimiseInternal(
 			// function types that can be stored in storage.
 			AssemblyItems optimisedItems;
 
-			solAssert(m_codeSections.size() == 1);
-			auto& items = m_codeSections.front().items;
-			bool usesMSize = ranges::any_of(items, [](AssemblyItem const& _i) {
+			bool usesMSize = ranges::any_of(m_items, [](AssemblyItem const& _i) {
 				return _i == AssemblyItem{Instruction::MSIZE} || _i.type() == VerbatimBytecode;
 			});
 
-			auto iter = items.begin();
-			while (iter != items.end())
+			auto iter = m_items.begin();
+			while (iter != m_items.end())
 			{
 				KnownState emptyState;
 				CommonSubexpressionEliminator eliminator{emptyState, m_evmVersion};
 				auto orig = iter;
-				iter = eliminator.feedItems(iter, items.end(), usesMSize);
+				iter = eliminator.feedItems(iter, m_items.end(), usesMSize);
 				bool shouldReplace = false;
 				AssemblyItems optimisedChunk;
 				try
@@ -913,9 +881,9 @@ std::map<u256, u256> const& Assembly::optimiseInternal(
 				else
 					copy(orig, iter, back_inserter(optimisedItems));
 			}
-			if (optimisedItems.size() < items.size())
+			if (optimisedItems.size() < m_items.size())
 			{
-				items = std::move(optimisedItems);
+				m_items = std::move(optimisedItems);
 				count++;
 			}
 		}
@@ -1055,10 +1023,7 @@ LinkerObject const& Assembly::assembleLegacy() const
 	bool setsImmutables = false;
 	bool pushesImmutables = false;
 
-	assertThrow(m_codeSections.size() == 1, AssemblyException, "Expected exactly one code section.");
-	AssemblyItems const& items = m_codeSections.front().items;
-
-	for (auto const& item: items)
+	for (auto const& item: m_items)
 		if (item.type() == AssignImmutable)
 		{
 			item.setImmutableOccurrences(immutableReferencesBySub[item.data()].second.size());
@@ -1077,7 +1042,7 @@ LinkerObject const& Assembly::assembleLegacy() const
 	m_tagPositionsInBytecode = std::vector<size_t>(m_usedTags, std::numeric_limits<size_t>::max());
 	unsigned bytesPerTag = numberEncodingSize(bytesRequiredForCode);
 	// Adjust bytesPerTag for references to sub assemblies.
-	for (AssemblyItem const& item: items)
+	for (AssemblyItem const& item: m_items)
 		if (item.type() == PushTag)
 		{
 			auto [subId, tagId] = item.splitForeignPushTag();
@@ -1104,9 +1069,9 @@ LinkerObject const& Assembly::assembleLegacy() const
 	uint8_t dataRefPush = static_cast<uint8_t>(pushInstruction(bytesPerDataRef));
 
 	LinkerObject::CodeSectionLocation codeSectionLocation;
-	codeSectionLocation.instructionLocations.reserve(items.size());
+	codeSectionLocation.instructionLocations.reserve(m_items.size());
 	codeSectionLocation.start = 0;
-	for (auto const& [assemblyItemIndex, item]: items | ranges::views::enumerate)
+	for (auto const& [assemblyItemIndex, item]: m_items | ranges::views::enumerate)
 	{
 		// collect instruction locations via side effects
 		InstructionLocationEmitter instructionLocationEmitter(codeSectionLocation.instructionLocations, ret.bytecode, assemblyItemIndex);
@@ -1273,7 +1238,7 @@ LinkerObject const& Assembly::assembleLegacy() const
 	{
 		size_t position = m_tagPositionsInBytecode.at(tagInfo.id);
 		std::optional<size_t> tagIndex;
-		for (auto&& [index, item]: items | ranges::views::enumerate)
+		for (auto&& [index, item]: m_items | ranges::views::enumerate)
 			if (item.type() == Tag && static_cast<size_t>(item.data()) == tagInfo.id)
 			{
 				tagIndex = index;

--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -1186,7 +1186,7 @@ LinkerObject const& Assembly::assembleLegacy() const
 
 	codeSectionLocation.end = ret.bytecode.size();
 
-	ret.codeSectionLocations.emplace_back(std::move(codeSectionLocation));
+	ret.codeSectionLocation = std::move(codeSectionLocation);
 
 	if (!immutableReferencesBySub.empty())
 		throw

--- a/libevmasm/Assembly.h
+++ b/libevmasm/Assembly.h
@@ -59,10 +59,7 @@ public:
 		m_evmVersion(_evmVersion),
 		m_creation(_creation),
 		m_name(std::move(_name))
-	{
-		// Code section number 0 has to be non-returning.
-		m_codeSections.emplace_back(CodeSection{0, 0, true, {}});
-	}
+	{}
 
 	AssemblyItem newTag() { assertThrow(m_usedTags < 0xffffffff, AssemblyException, ""); return AssemblyItem(Tag, m_usedTags++); }
 	AssemblyItem newPushTag() { assertThrow(m_usedTags < 0xffffffff, AssemblyException, ""); return AssemblyItem(PushTag, m_usedTags++); }
@@ -183,25 +180,8 @@ public:
 
 	bool isCreation() const { return m_creation; }
 
-	struct CodeSection
-	{
-		uint8_t inputs = 0;
-		// Number of outputs needs to be set properly even for non-returning function.
-		// It matters in case of stack height calculation of the function call instruction.
-		uint8_t outputs = 0;
-		bool nonReturning = false;
-		AssemblyItems items{};
-	};
-
-	std::vector<CodeSection>& codeSections()
-	{
-		return m_codeSections;
-	}
-
-	std::vector<CodeSection> const& codeSections() const
-	{
-		return m_codeSections;
-	}
+	AssemblyItems& items() { return m_items; }
+	AssemblyItems const& items() const { return m_items; }
 
 protected:
 	/// Does the same operations as @a optimise, but should only be applied to a sub and
@@ -260,8 +240,7 @@ protected:
 	/// Data that is appended to the very end of the contract.
 	bytes m_auxiliaryData;
 	std::vector<std::shared_ptr<Assembly>> m_subs;
-	std::vector<CodeSection> m_codeSections;
-	uint16_t m_currentCodeSection = 0;
+	AssemblyItems m_items;
 	std::map<util::h256, std::string> m_strings;
 	std::map<util::h256, std::string> m_libraries; ///< Identifiers of libraries to be linked.
 	std::map<util::h256, std::string> m_immutables; ///< Identifiers of immutables.

--- a/libevmasm/ConstantOptimiser.cpp
+++ b/libevmasm/ConstantOptimiser.cpp
@@ -36,48 +36,46 @@ unsigned ConstantOptimisationMethod::optimiseConstants(
 {
 	// TODO: design the optimiser in a way this is not needed
 	unsigned optimisations = 0;
-	for (auto& codeSection: _assembly.codeSections())
-	{
-		AssemblyItems& _items = codeSection.items;
+	AssemblyItems& items = _assembly.items();
 
-		std::map<AssemblyItem, size_t> pushes;
-		for (AssemblyItem const& item: _items)
-			if (item.type() == Push)
-				pushes[item]++;
-		std::map<u256, AssemblyItems> pendingReplacements;
-		for (auto it: pushes)
+	std::map<AssemblyItem, size_t> pushes;
+	for (AssemblyItem const& item: items)
+		if (item.type() == Push)
+			pushes[item]++;
+	std::map<u256, AssemblyItems> pendingReplacements;
+	for (auto it: pushes)
+	{
+		AssemblyItem const& item = it.first;
+		if (item.data() < 0x100)
+			continue;
+		Params params;
+		params.multiplicity = it.second;
+		params.isCreation = _isCreation;
+		params.runs = _runs;
+		params.evmVersion = _evmVersion;
+		LiteralMethod lit(params, item.data());
+		bigint literalGas = lit.gasNeeded();
+		CodeCopyMethod copy(params, item.data());
+		bigint copyGas = copy.gasNeeded();
+		ComputeMethod compute(params, item.data());
+		bigint computeGas = compute.gasNeeded();
+		AssemblyItems replacement;
+		if (copyGas < literalGas && copyGas < computeGas)
 		{
-			AssemblyItem const& item = it.first;
-			if (item.data() < 0x100)
-				continue;
-			Params params;
-			params.multiplicity = it.second;
-			params.isCreation = _isCreation;
-			params.runs = _runs;
-			params.evmVersion = _evmVersion;
-			LiteralMethod lit(params, item.data());
-			bigint literalGas = lit.gasNeeded();
-			CodeCopyMethod copy(params, item.data());
-			bigint copyGas = copy.gasNeeded();
-			ComputeMethod compute(params, item.data());
-			bigint computeGas = compute.gasNeeded();
-			AssemblyItems replacement;
-			if (copyGas < literalGas && copyGas < computeGas)
-			{
-				replacement = copy.execute(_assembly);
-				optimisations++;
-			}
-			else if (computeGas < literalGas && computeGas <= copyGas)
-			{
-				replacement = compute.execute(_assembly);
-				optimisations++;
-			}
-			if (!replacement.empty())
-				pendingReplacements[item.data()] = replacement;
+			replacement = copy.execute(_assembly);
+			optimisations++;
 		}
-		if (!pendingReplacements.empty())
-			replaceConstants(_items, pendingReplacements);
+		else if (computeGas < literalGas && computeGas <= copyGas)
+		{
+			replacement = compute.execute(_assembly);
+			optimisations++;
+		}
+		if (!replacement.empty())
+			pendingReplacements[item.data()] = replacement;
 	}
+	if (!pendingReplacements.empty())
+		replaceConstants(items, pendingReplacements);
+
 	return optimisations;
 }
 

--- a/libevmasm/EVMAssemblyStack.cpp
+++ b/libevmasm/EVMAssemblyStack.cpp
@@ -57,14 +57,12 @@ void EVMAssemblyStack::assemble()
 
 	m_evmAssembly->optimise(m_optimiserSettings);
 	m_object = m_evmAssembly->assemble();
-	solAssert(m_evmAssembly->codeSections().size() == 1);
-	m_sourceMapping = AssemblyItem::computeSourceMapping(m_evmAssembly->codeSections().front().items, sourceIndices());
+	m_sourceMapping = AssemblyItem::computeSourceMapping(m_evmAssembly->items(), sourceIndices());
 	if (m_evmAssembly->numSubs() > 0)
 	{
 		m_evmRuntimeAssembly = std::make_shared<evmasm::Assembly>(m_evmAssembly->sub(SubAssemblyID{0}));
 		solAssert(m_evmRuntimeAssembly && !m_evmRuntimeAssembly->isCreation());
-		solAssert(m_evmRuntimeAssembly->codeSections().size() == 1);
-		m_runtimeSourceMapping = AssemblyItem::computeSourceMapping(m_evmRuntimeAssembly->codeSections().front().items, sourceIndices());
+		m_runtimeSourceMapping = AssemblyItem::computeSourceMapping(m_evmRuntimeAssembly->items(), sourceIndices());
 		m_runtimeObject = m_evmRuntimeAssembly->assemble();
 	}
 }

--- a/libevmasm/Ethdebug.cpp
+++ b/libevmasm/Ethdebug.cpp
@@ -87,8 +87,7 @@ std::optional<schema::program::Context> instructionContext(AssemblyItems const& 
 
 std::vector<schema::program::Instruction> programInstructions(Assembly const& _assembly, LinkerObject const& _linkerObject, unsigned const _sourceID)
 {
-	solAssert(_linkerObject.codeSectionLocations.size() == 1);
-	auto const& locations = _linkerObject.codeSectionLocations[0];
+	auto const& locations = _linkerObject.codeSectionLocation;
 	AssemblyItems const& items = _assembly.items();
 
 	std::vector<schema::program::Instruction> instructions;
@@ -118,7 +117,6 @@ std::vector<schema::program::Instruction> programInstructions(Assembly const& _a
 
 	return instructions;
 }
-
 
 std::string lengthPrefixed(std::string_view _value)
 {

--- a/libevmasm/Ethdebug.cpp
+++ b/libevmasm/Ethdebug.cpp
@@ -68,10 +68,10 @@ schema::materials::Reference sourceReference(unsigned _sourceID)
 	};
 }
 
-std::optional<schema::program::Context> instructionContext(Assembly::CodeSection const& _codeSection, size_t _assemblyItemIndex, unsigned _sourceID)
+std::optional<schema::program::Context> instructionContext(AssemblyItems const& _codeSection, size_t _assemblyItemIndex, unsigned _sourceID)
 {
-	solAssert(_assemblyItemIndex < _codeSection.items.size());
-	langutil::SourceLocation const& location = _codeSection.items.at(_assemblyItemIndex).location();
+	solAssert(_assemblyItemIndex < _codeSection.size());
+	langutil::SourceLocation const& location = _codeSection.at(_assemblyItemIndex).location();
 	if (!location.isValid())
 		return std::nullopt;
 
@@ -85,18 +85,17 @@ std::optional<schema::program::Context> instructionContext(Assembly::CodeSection
 	};
 }
 
-std::vector<schema::program::Instruction> codeSectionInstructions(Assembly const& _assembly, LinkerObject const& _linkerObject, unsigned const _sourceID, size_t const _codeSectionIndex)
+std::vector<schema::program::Instruction> programInstructions(Assembly const& _assembly, LinkerObject const& _linkerObject, unsigned const _sourceID)
 {
-	solAssert(_codeSectionIndex < _linkerObject.codeSectionLocations.size());
-	solAssert(_codeSectionIndex < _assembly.codeSections().size());
-	auto const& locations = _linkerObject.codeSectionLocations[_codeSectionIndex];
-	auto const& codeSection = _assembly.codeSections().at(_codeSectionIndex);
+	solAssert(_linkerObject.codeSectionLocations.size() == 1);
+	auto const& locations = _linkerObject.codeSectionLocations[0];
+	AssemblyItems const& items = _assembly.items();
 
 	std::vector<schema::program::Instruction> instructions;
-	instructions.reserve(codeSection.items.size());
+	instructions.reserve(items.size());
 
 	bool const codeSectionContainsVerbatim = ranges::any_of(
-		codeSection.items,
+		items,
 		[](auto const& _instruction) { return _instruction.type() == VerbatimBytecode; }
 	);
 	solUnimplementedAssert(!codeSectionContainsVerbatim, "Verbatim bytecode is currently not supported by ethdebug.");
@@ -113,23 +112,13 @@ std::vector<schema::program::Instruction> codeSectionInstructions(Assembly const
 		instructions.emplace_back(schema::program::Instruction{
 			.offset = schema::data::Unsigned{start},
 			.operation = instructionOperation(_assembly, _linkerObject, start, end),
-			.context = instructionContext(codeSection, currentInstruction.assemblyItemIndex, _sourceID)
+			.context = instructionContext(items, currentInstruction.assemblyItemIndex, _sourceID)
 		});
 	}
 
 	return instructions;
 }
 
-std::vector<schema::program::Instruction> programInstructions(Assembly const& _assembly, LinkerObject const& _linkerObject, unsigned const _sourceID)
-{
-	auto const numCodeSections = _assembly.codeSections().size();
-	solAssert(numCodeSections == _linkerObject.codeSectionLocations.size());
-
-	std::vector<schema::program::Instruction> instructionInfo;
-	for (size_t codeSectionIndex = 0; codeSectionIndex < numCodeSections; ++codeSectionIndex)
-		instructionInfo += codeSectionInstructions(_assembly, _linkerObject, _sourceID, codeSectionIndex);
-	return instructionInfo;
-}
 
 std::string lengthPrefixed(std::string_view _value)
 {

--- a/libevmasm/LinkerObject.h
+++ b/libevmasm/LinkerObject.h
@@ -72,10 +72,9 @@ struct LinkerObject
 		/// The instructions must be ordered according to their positions (ascending).
 		std::vector<InstructionLocation> instructionLocations;
 	};
-	/// Descriptions of all code sections in the ascending order of their positions.
-	/// There are no duplicates and the sections never overlap.
-	/// Only sections belonging to the top-level assembly are included, even if the bytecode contains subassemblies.
-	std::vector<CodeSectionLocation> codeSectionLocations;
+	/// Description of the code section of the assembly.
+	/// Only instructions belonging to the top-level assembly are included, even if the bytecode contains subassemblies.
+	CodeSectionLocation codeSectionLocation;
 
 	struct FunctionDebugData
 	{

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -897,8 +897,7 @@ evmasm::AssemblyItems const* CompilerStack::assemblyItems(std::string const& _co
 	Contract const& currentContract = contract(_contractName);
 	if (!currentContract.evmAssembly)
 		return nullptr;
-	solAssert(currentContract.evmAssembly->codeSections().size() == 1, "Expected a single code section in legacy codegen.");
-	return &currentContract.evmAssembly->codeSections().front().items;
+	return &currentContract.evmAssembly->items();
 }
 
 evmasm::AssemblyItems const* CompilerStack::runtimeAssemblyItems(std::string const& _contractName) const
@@ -909,8 +908,7 @@ evmasm::AssemblyItems const* CompilerStack::runtimeAssemblyItems(std::string con
 
 	if (!currentContract.evmRuntimeAssembly)
 		return nullptr;
-	solAssert(currentContract.evmRuntimeAssembly->codeSections().size() == 1, "Expected a single code section in legacy codegen.");
-	return &currentContract.evmRuntimeAssembly->codeSections().front().items;
+	return &currentContract.evmRuntimeAssembly->items();
 }
 
 Json CompilerStack::generatedSources(std::string const& _contractName, bool _runtime) const

--- a/libyul/YulStack.cpp
+++ b/libyul/YulStack.cpp
@@ -264,13 +264,10 @@ YulStack::assembleWithDeployed(std::optional<std::string_view> _deployName, bool
 		yulAssert(creationObject.bytecode->immutableReferences.empty(), "Leftover immutables.");
 		creationObject.assembly = creationAssembly;
 		creationObject.sourceMappings = std::make_unique<std::string>();
-		for (auto const& codeSection: creationAssembly->codeSections())
-		{
-			*creationObject.sourceMappings += evmasm::AssemblyItem::computeSourceMapping(
-				codeSection.items,
-				{{m_charStream->name(), 0}}
-			);
-		}
+		*creationObject.sourceMappings = evmasm::AssemblyItem::computeSourceMapping(
+			creationAssembly->items(),
+			{{m_charStream->name(), 0}}
+		);
 		if (debugInfoSelection().ethdebug)
 			creationObject.ethdebug = evmasm::ethdebug::program(creationObject.assembly->name(), 0, *creationObject.assembly, *creationObject.bytecode);
 
@@ -280,12 +277,11 @@ YulStack::assembleWithDeployed(std::optional<std::string_view> _deployName, bool
 			deployedObject.assembly = deployedAssembly;
 			if (debugInfoSelection().ethdebug)
 				deployedObject.ethdebug = evmasm::ethdebug::program(deployedObject.assembly->name(), 0, *deployedObject.assembly, *deployedObject.bytecode);
-			solAssert(deployedAssembly->codeSections().size() == 1);
 			deployedObject.sourceMappings = std::make_unique<std::string>(
 				evmasm::AssemblyItem::computeSourceMapping(
-					deployedAssembly->codeSections().front().items,
+					deployedAssembly->items(),
 					{{m_charStream->name(), 0}}
-					)
+				)
 			);
 		}
 	}

--- a/test/libevmasm/Assembler.cpp
+++ b/test/libevmasm/Assembler.cpp
@@ -272,8 +272,7 @@ BOOST_AUTO_TEST_CASE(immutables_and_its_source_maps)
 
 			checkCompilation(assembly);
 
-			BOOST_REQUIRE(assembly.codeSections().size() == 1);
-			std::string const sourceMappings = AssemblyItem::computeSourceMapping(assembly.codeSections().at(0).items, indices);
+			std::string const sourceMappings = AssemblyItem::computeSourceMapping(assembly.items(), indices);
 			auto const numberOfMappings = std::count(sourceMappings.begin(), sourceMappings.end(), ';');
 
 			LinkerObject const& obj = assembly.assemble();

--- a/test/libevmasm/Optimiser.cpp
+++ b/test/libevmasm/Optimiser.cpp
@@ -1382,18 +1382,16 @@ BOOST_AUTO_TEST_CASE(jumpdest_removal_subassemblies)
 		t1.toSubAssemblyTag(subId).pushTag(),
 		u256(8)
 	};
-	BOOST_REQUIRE(main.codeSections().size() == 1);
 	BOOST_CHECK_EQUAL_COLLECTIONS(
-		main.codeSections().at(0).items.begin(),main.codeSections().at(0).items.end(),
+		main.items().begin(), main.items().end(),
 		expectationMain.begin(), expectationMain.end()
 	);
 
 	AssemblyItems expectationSub{
 		u256(1), t1.tag(), u256(2), Instruction::JUMP, t4.tag(), u256(7), t4.pushTag(), Instruction::JUMP
 	};
-	BOOST_REQUIRE(sub->codeSections().size() == 1);
 	BOOST_CHECK_EQUAL_COLLECTIONS(
-		sub->codeSections().at(0).items.begin(), sub->codeSections().at(0).items.end(),
+		sub->items().begin(), sub->items().end(),
 		expectationSub.begin(), expectationSub.end()
 	);
 }

--- a/test/libsolidity/Assembly.cpp
+++ b/test/libsolidity/Assembly.cpp
@@ -91,8 +91,7 @@ evmasm::AssemblyItems compileContract(std::shared_ptr<CharStream> _sourceCode)
 			);
 			compiler.compileContract(*contract, std::map<ContractDefinition const*, std::shared_ptr<Compiler const>>{}, bytes());
 
-			BOOST_REQUIRE(compiler.runtimeAssembly().codeSections().size() == 1);
-			return compiler.runtimeAssembly().codeSections().at(0).items;
+			return compiler.runtimeAssembly().items();
 		}
 	BOOST_FAIL("No contract found in source.");
 	return AssemblyItems();


### PR DESCRIPTION
Without EOF we have only one code section. No need to support code sections any more.

`Assembly::m_codeSections` is removed and two getter are added:

```
AssemblyItems& items() { return m_items; }
AssemblyItems const& items() const { return m_items; }
```

- [ ] No AI tools were used
- [x] AI tools were used (details below)
Partially made by Claude Sonnet 4.6

~Depends on https://github.com/argotorg/solidity/pull/16773~

