### PR TITLE
Performance: Remove unnecessary dereferencing from YulString storage

### DIFF
--- a/libyul/YulString.h
+++ b/libyul/YulString.h
@@ -23,8 +23,9 @@
 
 #include <fmt/format.h>
 
-#include <unordered_map>
+#include <deque>
 #include <memory>
+#include <unordered_map>
 #include <vector>
 #include <string>
 #include <string_view>
@@ -59,15 +60,15 @@ public:
 		std::uint64_t h = hash(_string);
 		auto range = m_hashToID.equal_range(h);
 		for (auto it = range.first; it != range.second; ++it)
-			if (*m_strings[it->second] == _string)
+			if (m_strings[it->second] == _string)
 				return Handle{it->second, h};
-		m_strings.emplace_back(std::make_shared<std::string>(_string));
+		m_strings.emplace_back(_string);
 		size_t id = m_strings.size() - 1;
 		m_hashToID.emplace_hint(range.second, std::make_pair(h, id));
 
 		return Handle{id, h};
 	}
-	std::string const& idToString(size_t _id) const { return *m_strings.at(_id); }
+	std::string const& idToString(size_t _id) const { return m_strings.at(_id); }
 
 	static std::uint64_t hash(std::string_view const v)
 	{
@@ -115,7 +116,7 @@ private:
 		return callbacks;
 	}
 
-	std::vector<std::shared_ptr<std::string>> m_strings = {std::make_shared<std::string>()};
+	std::deque<std::string> m_strings = {""};
 	std::unordered_multimap<std::uint64_t, size_t> m_hashToID = {{emptyHash(), 0}};
 };
 


### PR DESCRIPTION
## Description

~3% speed up to Yul compilation times with a small change.

## Benchmark

| contract | optimized, no via-ir | via-ir |
| --- | ---: | ---: |
| WETH9 | -1.79% ✅ | -2.21% ✅ |
| ENSRegistryWithFallback | -0.94% ✅ | -3.77% ✅ |
| TetherToken | -1.09% ✅ | -0.80% ✅ |
| OETH | -1.54% ✅ | -2.16% ✅ |
| BoredApeYachtClub | -1.75% ✅ | -2.33% ✅ |
| RocketDepositPool | -1.34% ✅ | -3.56% ✅ |
| Poap | -1.04% ✅ | -3.50% ✅ |
| FiatTokenV2_2 | -2.89% ✅ | -4.69% ✅ |
| Morpho | -0.81% ✅ | -4.06% ✅ |
| AccessControlledOCR2Aggregator | -1.83% ✅ | -1.67% ✅ |
| PoolManager | -1.49% ✅ | -2.17% ✅ |
| EulerSwap | -1.06% ✅ | -4.28% ✅ |
| EtherfiLiquidityPool | -2.44% ✅ | -3.83% ✅ |
| AaveV4HubInstance | -1.46% ✅ | -2.65% ✅ |
| UniswapV3Pool | -1.27% ✅ | -2.93% ✅ |
| **Total** | **-1.89% ✅** | **-3.23% ✅** |

## Details

Yul compilation creates many YulString/YulName objects, most of these auto generated names. Compiling the AaveV4HubInstance contract creates around 100,000 of these instances. The current implementation around these strings is unnecessarily slow because there is an extra layer of indirection.

A core requirement for YulString.h is that the underlying string storage never changes a string's memory location and thus the underlying string can be safely pointed to from other places in the code. A shared pointer is used in the current code because when a vector resizes it may move where its immediate children are stored in memory. The shared pointer means these resizes never affect underlying string storage.

```
[vector][] -> [shared_pointer] -> [string]
```

However, by switching the vector to an indexedable data structure that does not move the underlying memory when expanding (deque), the overhead of the intermediate shared pointer can be skipped and short strings can be stored directly into the container, without even a pointer to the heap. This has a major effect on the speed of working with strings in the compiler, since this speeds up creation, id based lookups, and string based lookups (as those also go through id based lookups).

```
[deque][] -> [string]
```

This PR changes the type from `std::vector<std::shared_ptr<std::string>>` to `std::deque<std::string>` and then removes the now unnecessary pointer dereferencing from where the strings are looked up.

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (details below)

Codex 5.5