### PR TITLE
SSA CFG: stack to memory spilling

### DIFF
--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -115,6 +115,8 @@ add_library(yul
 	backends/evm/ssa/io/JSONExporter.h
 	backends/evm/ssa/io/Printer.cpp
 	backends/evm/ssa/io/Printer.h
+	backends/evm/ssa/spill/MemoryAddressing.cpp
+	backends/evm/ssa/spill/MemoryAddressing.h
 	backends/evm/ssa/spill/SpillSet.cpp
 	backends/evm/ssa/spill/SpillSet.h
 	backends/evm/ssa/transform/IdentityAndNopRemover.cpp

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -115,6 +115,7 @@ add_library(yul
 	backends/evm/ssa/io/JSONExporter.h
 	backends/evm/ssa/io/Printer.cpp
 	backends/evm/ssa/io/Printer.h
+	backends/evm/ssa/spill/Emitter.h
 	backends/evm/ssa/spill/MemoryAddressing.cpp
 	backends/evm/ssa/spill/MemoryAddressing.h
 	backends/evm/ssa/spill/SpillSet.cpp

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -115,6 +115,7 @@ add_library(yul
 	backends/evm/ssa/io/JSONExporter.h
 	backends/evm/ssa/io/Printer.cpp
 	backends/evm/ssa/io/Printer.h
+	backends/evm/ssa/spill/SpillSet.cpp
 	backends/evm/ssa/spill/SpillSet.h
 	backends/evm/ssa/transform/IdentityAndNopRemover.cpp
 	backends/evm/ssa/transform/IdentityAndNopRemover.h

--- a/libyul/backends/evm/EVMObjectCompiler.cpp
+++ b/libyul/backends/evm/EVMObjectCompiler.cpp
@@ -96,6 +96,7 @@ void EVMObjectCompiler::run(Object const& _object, bool _optimize, bool _viaSSAC
 			ssa::ControlFlowGraphsLiveness const liveness(*controlFlowGraphs);
 			ssa::CodeTransform::run(
 				m_assembly,
+				*controlFlowGraphs,
 				liveness,
 				context
 			);

--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -45,36 +45,66 @@ void assertLayoutCompatibility(StackData const& _layout1, StackData const& _layo
 void CodeTransform::run
 (
 	AbstractAssembly& _assembly,
+	ControlFlowGraphs& _controlFlowGraphs,
 	ControlFlowGraphsLiveness const& _controlFlowLiveness,
 	BuiltinContext& _builtinContext
 )
 {
+	yulAssert(&_controlFlowLiveness.controlFlowGraphs.get() == &_controlFlowGraphs);
 	yulAssert(!_controlFlowLiveness.cfgLiveness.empty());
-	ControlFlowGraphs const& controlFlowGraphs = _controlFlowLiveness.controlFlowGraphs.get();
-	yulAssert(controlFlowGraphs.functionGraphs.size() == _controlFlowLiveness.cfgLiveness.size());
-	FunctionLabels const functionLabels = registerFunctionLabels(_assembly, controlFlowGraphs);
-	CallGraph const callGraph(controlFlowGraphs);
+	yulAssert(_controlFlowGraphs.functionGraphs.size() == _controlFlowLiveness.cfgLiveness.size());
+	FunctionLabels const functionLabels = registerFunctionLabels(_assembly, _controlFlowGraphs);
+	CallGraph const callGraph(_controlFlowGraphs);
 
-	for (std::size_t functionIndex = 0; functionIndex < controlFlowGraphs.functionGraphs.size(); ++functionIndex)
+	std::size_t const numCFGs = _controlFlowGraphs.functionGraphs.size();
+	std::vector<CallSites> callSitesPerCFG;
+	std::vector<SSACFGStackLayout> layouts;
+	std::vector<spill::SpillSet> spillSetsPerCFG;
+	callSitesPerCFG.reserve(numCFGs);
+	layouts.reserve(numCFGs);
+	spillSetsPerCFG.reserve(numCFGs);
+
+	for (std::size_t functionIndex = 0; functionIndex < numCFGs; ++functionIndex)
 	{
-		std::unique_ptr<SSACFG> const& functionGraphPtr = controlFlowGraphs.functionGraphs[functionIndex];
+		std::unique_ptr<SSACFG> const& functionGraphPtr = _controlFlowGraphs.functionGraphs[functionIndex];
 		yulAssert(functionGraphPtr);
 		SSACFG const& cfg = *functionGraphPtr;
-		auto const callSites = gatherCallSites(cfg);
 		auto const& liveness = _controlFlowLiveness.cfgLiveness[functionIndex];
 		yulAssert(liveness);
 		auto const graphID = static_cast<ControlFlowGraphs::FunctionGraphID>(functionIndex);
+		callSitesPerCFG.push_back(gatherCallSites(cfg));
 		bool const spillingAllowed = !callGraph.isRecursive(graphID);
-		auto const stackLayoutGeneratorResult = StackLayoutGenerator::generate(*liveness, callSites, graphID, spillingAllowed);
+		auto [layout, spillSet] = StackLayoutGenerator::generate(*liveness, callSitesPerCFG.back(), graphID, spillingAllowed);
+		layouts.push_back(std::move(layout));
+		spillSetsPerCFG.push_back(std::move(spillSet));
+	}
+
+	for (std::size_t functionIndex = 0; functionIndex < numCFGs; ++functionIndex)
+		spillSetsPerCFG[functionIndex].closeUnderReachabilityConstraints(
+			*_controlFlowGraphs.functionGraphs[functionIndex],
+			layouts[functionIndex]
+		);
+
+	// build up global addressing based on the spill sets
+	spill::MemoryAddressing const addressing(_controlFlowGraphs, spillSetsPerCFG);
+
+	for (std::size_t functionIndex = 0; functionIndex < _controlFlowGraphs.functionGraphs.size(); ++functionIndex)
+	{
+		SSACFG const& cfg = *_controlFlowGraphs.functionGraphs[functionIndex];
+		auto const graphID = static_cast<ControlFlowGraphs::FunctionGraphID>(functionIndex);
+		auto const& liveness = _controlFlowLiveness.cfgLiveness[functionIndex];
+		yulAssert(liveness);
 		CodeTransform transform(
 			_assembly,
 			_builtinContext,
-			controlFlowGraphs,
+			_controlFlowGraphs,
 			functionLabels,
-			callSites,
+			callSitesPerCFG[functionIndex],
 			cfg,
-			stackLayoutGeneratorResult.layout,
-			graphID
+			layouts[functionIndex],
+			spillSetsPerCFG[functionIndex],
+			graphID,
+			addressing
 		);
 		transform(cfg.entry);
 	}
@@ -120,7 +150,9 @@ CodeTransform::CodeTransform(
 	CallSites const& _callSites,
 	SSACFG const& _cfg,
 	SSACFGStackLayout const& _stackLayout,
-	ControlFlowGraphs::FunctionGraphID _graphID
+	spill::SpillSet const& _spillSet,
+	ControlFlowGraphs::FunctionGraphID _graphID,
+	spill::MemoryAddressing const& _addressing
 ):
 	m_assembly(_assembly),
 	m_builtinContext(_builtinContext),
@@ -129,6 +161,7 @@ CodeTransform::CodeTransform(
 	m_callSites(_callSites),
 	m_cfg(_cfg),
 	m_stackLayout(_stackLayout),
+	m_spillSet(_spillSet),
 	m_graphID(_graphID),
 	m_blockIsTransformed(_cfg.numBlocks(), false),
 	m_blockLabels([this] {
@@ -138,11 +171,17 @@ CodeTransform::CodeTransform(
 			blockLabels.push_back(m_assembly.newLabelId());
 		return blockLabels;
 	}()),
+	m_spillEmitter([&]() -> std::optional<spill::Emitter> {
+		if (_spillSet.numSpilled() > 0)
+			return spill::Emitter(_addressing, _graphID, _assembly);
+		return std::nullopt;
+	}()),
 	m_assemblyCallbacks{
 		.cfg = &_cfg,
 		.assembly = &_assembly,
 		.callSites = &_callSites,
-		.returnLabels = &m_returnLabels
+		.returnLabels = &m_returnLabels,
+		.spillEmitter = m_spillEmitter ? &*m_spillEmitter : nullptr
 	},
 	m_stackData([&]
 	{
@@ -167,6 +206,11 @@ CodeTransform::CodeTransform(
 	for (auto const& arg: m_cfg.arguments | ranges::views::reverse)
 		expectedStackTop.push_back(StackSlot::makeValue(_cfg, arg));
 	assertLayoutCompatibility(m_stack.data(), expectedStackTop);
+
+	// Spilled function args need an `mstore` at function entry so later `mload`s see a populated slot
+	if (m_spillEmitter && isFunctionGraph)
+		for (InstId const argId: m_cfg.arguments)
+			spillStore(argId);
 }
 
 void CodeTransform::operator()(SSACFG::BlockId const _blockId)
@@ -184,18 +228,28 @@ void CodeTransform::operator()(SSACFG::BlockId const _blockId)
 	auto const& block = m_cfg.block(_blockId);
 
 	std::size_t operationIndex = 0;
-	m_cfg.forEachOperation(block, [&](InstId const instId, SSACFG::Inst const&) {
-		yulAssert(operationIndex < blockLayout->operationIn.size());
-		auto const& operationInLayout = blockLayout->operationIn[operationIndex];
-		(*this)(instId, operationInLayout);
-		++operationIndex;
-	});
+
+	// Iterate every Inst in the block in scheduled order. Only Operations advance codegen;
+	// Phis are otherwise pure stack assertions (already materialized on the block's stackIn).
+	for (InstId const instId: block.instructions)
+	{
+		SSACFG::Inst const& inst = m_cfg.inst(instId);
+		if (inst.isPhi())
+			// this is a no-op for not spilled phis
+			spillStore(instId);
+		if (inst.isOperation())
+		{
+			yulAssert(operationIndex < blockLayout->operationIn.size());
+			(*this)(instId, blockLayout->operationIn[operationIndex]);
+			++operationIndex;
+		}
+	}
 	yulAssert(operationIndex == blockLayout->operationIn.size());
 
 	// Shuffle to the block's exit layout before dispatching the exit.
 	// This ensures the condition is on top for ConditionalJump, phi pre-images are
 	// in the right positions for jumps, and return values are accessible for FunctionReturn.
-	auto const shuffleResult = StackShuffler<AssemblyCallbacks>::shuffle(m_stack, blockLayout->exitIn);
+	auto const shuffleResult = StackShuffler<AssemblyCallbacks>::shuffle(m_stack, blockLayout->exitIn, &m_spillSet);
 	yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 
 	// handle the block exit
@@ -221,7 +275,7 @@ void CodeTransform::operator()(InstId _instId, StackData const& _operationInputL
 
 	// prepare stack for operation
 	{
-		auto const shuffleResult = StackShuffler<AssemblyCallbacks>::shuffle(m_stack, _operationInputLayout);
+		auto const shuffleResult = StackShuffler<AssemblyCallbacks>::shuffle(m_stack, _operationInputLayout, &m_spillSet);
 		yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 	}
 
@@ -322,6 +376,11 @@ void CodeTransform::operator()(InstId _instId, StackData const& _operationInputL
 	for (InstId const id: m_cfg.outputsOf(_instId))
 		m_stack.push<false>(StackSlot::makeValue(m_cfg, id));
 
+	// Each output the layout decided to spill gets its `mstore` here
+	if (m_spillEmitter)
+		for (InstId const outputId: m_cfg.outputsOf(_instId))
+			spillStore(outputId);
+
 	yulAssert(m_stack.size() == baseHeight + numOutputs);
 	for (auto const& [stackEntry, output]: ranges::views::zip(
 		m_stack.data() | ranges::views::take_last(numOutputs),
@@ -332,6 +391,32 @@ void CodeTransform::operator()(InstId _instId, StackData const& _operationInputL
 		static_cast<int>(m_stack.size()) == m_assembly.stackHeight(),
 		fmt::format("symbolic stack size = {} =/= {} = assembly stack height", m_stack.size(), m_assembly.stackHeight())
 	);
+}
+
+void CodeTransform::spillStore(InstId const _value)
+{
+	if (!m_spillEmitter || !m_spillSet.isSpilled(_value))
+		return;
+
+	// Bring `_value` to the stack top so that the `mstore` below consumes it
+	StackData target = m_stack.data();
+	target.push_back(StackSlot::makeValue(m_cfg, _value));
+	// addr(_value) is the slot THIS `mstore` populates, so we have to exclude it from the spill set to
+	// prevent the shuffler from just `mload`ing it back
+	spill::SpillSet const spillSetExcludingSpillee = m_spillSet.without(_value);
+	auto const shuffleResult = StackShuffler<AssemblyCallbacks>::shuffle(m_stack, target, &spillSetExcludingSpillee);
+	yulAssert(
+		shuffleResult.status == StackShufflerResult::Status::Admissible,
+		fmt::format(
+			"shuffler failed to bring spilled value {} to top (status={})",
+			_value,
+			static_cast<int>(shuffleResult.status)
+		)
+	);
+
+	m_spillEmitter->emitStore(_value);
+	// `mstore` consumed the value; the address it pushed never persists on the symbolic stack
+	m_stack.pop<false>();
 }
 
 void CodeTransform::operator()(SSACFG::BlockId const&, SSACFG::BasicBlock::MainExit const&)
@@ -446,7 +531,7 @@ void CodeTransform::prepareBlockExitStack(StackData const& _target, PhiInverse c
 	auto const pulledBackTarget = stackPreImage(m_cfg, _target, _phiInverse);
 	// shuffle to target
 	{
-		auto const shuffleResult = StackShuffler<AssemblyCallbacks>::shuffle(m_stack, pulledBackTarget);
+		auto const shuffleResult = StackShuffler<AssemblyCallbacks>::shuffle(m_stack, pulledBackTarget, &m_spillSet);
 		yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 	}
 	// check that shuffling was successful

--- a/libyul/backends/evm/ssa/CodeTransform.h
+++ b/libyul/backends/evm/ssa/CodeTransform.h
@@ -18,6 +18,8 @@
 
 #pragma once
 
+#include <libyul/backends/evm/ssa/spill/Emitter.h>
+
 #include <libyul/backends/evm/ssa/PhiInverse.h>
 #include <libyul/backends/evm/ssa/Stack.h>
 #include <libyul/backends/evm/ssa/StackLayout.h>
@@ -52,9 +54,17 @@ struct AssemblyCallbacks
 		case StackSlot::Kind::Value:
 		{
 			auto const id = _slot.value();
-			yulAssert(cfg->isLiteral(id), fmt::format("Tried bringing up non-const {}", id));
-			assembly->appendConstant(cfg->literalPayload(id));
-			return;
+			if (cfg->isLiteral(id))
+			{
+				assembly->appendConstant(cfg->literalPayload(id));
+				return;
+			}
+			if (spillEmitter && spillEmitter->hasAddress(id))
+			{
+				spillEmitter->emitLoad(id);
+				return;
+			}
+			yulAssert(false, fmt::format("Tried bringing up non-spilled non-const {}", id));
 		}
 		case StackSlot::Kind::Junk:
 		{
@@ -87,6 +97,7 @@ struct AssemblyCallbacks
 	AbstractAssembly* assembly{};
 	CallSites const* callSites{};
 	std::map<InstId, AbstractAssembly::LabelID> const* returnLabels{};
+	spill::Emitter const* spillEmitter{};
 };
 static_assert(StackManipulationCallbackConcept<AssemblyCallbacks>);
 
@@ -95,6 +106,7 @@ class CodeTransform
 public:
 	static void run(
 		AbstractAssembly& _assembly,
+		ControlFlowGraphs& _controlFlowGraphs,
 		ControlFlowGraphsLiveness const& _liveness,
 		BuiltinContext& _builtinContext
 	);
@@ -115,7 +127,10 @@ private:
 		CallSites const& _callSites,
 		SSACFG const& _cfg,
 		SSACFGStackLayout const& _stackLayout,
-		ControlFlowGraphs::FunctionGraphID _graphID);
+		spill::SpillSet const& _spillSet,
+		ControlFlowGraphs::FunctionGraphID _graphID,
+		spill::MemoryAddressing const& _addressing
+	);
 
 	void operator()(SSACFG::BlockId _blockId);
 	void operator()(InstId _instId, StackData const& _operationInputLayout);
@@ -127,6 +142,9 @@ private:
 
 	void prepareBlockExitStack(StackData const& _target, PhiInverse const& _phiInverse);
 
+	/// If `_value` is spilled, shuffles it to the stack top and stores it into its memory slot
+	void spillStore(InstId _value);
+
 	AbstractAssembly& m_assembly;
 	BuiltinContext& m_builtinContext;
 	ControlFlowGraphs const& m_controlFlow;
@@ -134,10 +152,12 @@ private:
 	CallSites const& m_callSites;
 	SSACFG const& m_cfg;
 	SSACFGStackLayout const& m_stackLayout;
+	spill::SpillSet const& m_spillSet;
 	ControlFlowGraphs::FunctionGraphID const m_graphID;
 
 	std::vector<std::uint8_t> m_blockIsTransformed;
 	std::vector<AbstractAssembly::LabelID> m_blockLabels;
+	std::optional<spill::Emitter> m_spillEmitter{std::nullopt};
 	AssemblyCallbacks m_assemblyCallbacks;
 	StackData m_stackData;
 	Stack<AssemblyCallbacks> m_stack;

--- a/libyul/backends/evm/ssa/SSACFGTypes.h
+++ b/libyul/backends/evm/ssa/SSACFGTypes.h
@@ -37,7 +37,9 @@ template<typename R, typename T>
 concept InputRangeOf = ranges::input_range<R> && std::same_as<ranges::range_value_t<R>, T>;
 
 class SSACFG;
-
+class SSACFGStackLayout;
+class StackSlot;
+using StackData = std::vector<StackSlot>;
 using FunctionGraphID = std::uint32_t;
 
 struct BlockId

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -292,6 +292,22 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 	});
 	yulAssert(operationIndex == operationsLiveOut.size());
 
+	// we don't explicitly visit backedges and might have to spill here, too
+	auto const validateBackEdge = [&](SSACFG::BlockId const& _target) {
+		if (!m_liveness.topologicalSort().backEdge(_blockId, _target))
+			return;
+		yulAssert(m_resultLayout[_target], "Back-edge target must have its stackIn defined already.");
+		StackData const target = stackPreImage(m_cfg, m_resultLayout[_target]->stackIn, PhiInverse(m_cfg, _blockId, _target));
+		auto const spillCountBefore = m_spillSet.numSpilled();
+		StackData exitStack = currentStackData;
+		auto const shuffleResult = shuffleWithSpillDiscovery(exitStack, target, m_spillSet);
+		yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
+		yulAssert(
+			m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore,
+			"Stack too deep, but spilling is disabled because the function is part of a recursive call chain."
+		);
+	};
+
 	std::visit(
 		solidity::util::GenericVisitor{
 			[&](SSACFG::BasicBlock::ConditionalJump const& _cJump) {
@@ -334,6 +350,9 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 				// Define successor stack-in layouts
 				m_inputStackProposalsPerBlock[_cJump.zero.value].emplace_back(_blockId, currentStackData);
 				m_inputStackProposalsPerBlock[_cJump.nonZero.value].emplace_back(_blockId, currentStackData);
+
+				validateBackEdge(_cJump.zero);
+				validateBackEdge(_cJump.nonZero);
 			},
 			[&](SSACFG::BasicBlock::FunctionReturn const& _functionReturn) {
 				yulAssert(m_hasFunctionReturnLabel, "When there is a proper function return, we need to have a label for it");
@@ -349,6 +368,8 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 			[&](SSACFG::BasicBlock::Jump const& _jump) {
 				blockLayout.exitIn = currentStackData;
 				m_inputStackProposalsPerBlock[_jump.target.value].emplace_back(_blockId, currentStackData);
+
+				validateBackEdge(_jump.target);
 			},
 			[&](SSACFG::BasicBlock::MainExit const&) {
 				blockLayout.exitIn = currentStackData;

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -191,31 +191,50 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 				declareJunk(stack, liveIn);
 			}
 		}
-		std::vector cumulativeCosts(stackInProposals.size(), std::numeric_limits<std::size_t>::max());
+		// For each candidate stack-in layout (one parent's proposal), reconcile every parent to it,
+		// discovering the spills needed to make each reconciliation realizable
+		std::vector<std::size_t> cumulativeGas(stackInProposals.size(), 0);
+		std::vector<spill::SpillSet> candidateSpillSets(stackInProposals.size());
 		for (std::size_t i = 0; i < stackInProposals.size(); ++i)
 		{
-			std::size_t cumulativeCost = 0;
+			spill::SpillSet candidateSpillSet = m_spillSet;
 			for (std::size_t j = 0; j < stackInProposals.size(); ++j)
 			{
-				auto proposalCopy = proposals[j];
-				Stack<GasAccumulatingCallbacks> stack(proposalCopy, {.cfg = m_cfg});
-				auto const shuffleResult = StackShuffler<GasAccumulatingCallbacks>::shuffle(
-					stack,
-					proposals[i],
-					{},
-					proposals[i].size(),
-					&m_spillSet
-				);
-				yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
-				cumulativeCost += stack.callbacks().opGas;
+				StackShufflerResult result;
+				std::size_t opGas = 0;
+				do
+				{
+					auto proposalCopy = proposals[j];
+					Stack<GasAccumulatingCallbacks> stack(proposalCopy, {.cfg = m_cfg});
+					result = StackShuffler<GasAccumulatingCallbacks>::shuffle(
+						stack, proposals[i], {}, proposals[i].size(), &candidateSpillSet);
+					opGas = stack.callbacks().opGas;
+					if (result.status == StackShufflerResult::Status::StackTooDeep)
+					{
+						yulAssert(result.culprit.isValue() && !result.culprit.isLiteralValue());
+						yulAssert(!candidateSpillSet.isSpilled(result.culprit.value()));
+						candidateSpillSet.add(result.culprit.value());
+					}
+				}
+				while (result.status == StackShufflerResult::Status::StackTooDeep);
+				yulAssert(result.status == StackShufflerResult::Status::Admissible);
+				cumulativeGas[i] += opGas;
 			}
-			cumulativeCosts[i] = cumulativeCost;
+			candidateSpillSets[i] = std::move(candidateSpillSet);
 		}
-		// Pick the proposal with the lowest cost; break ties by preferring smaller stacks
+		// Pick the candidate that spills the least; break ties by gas, then by preferring smaller stacks.
+		auto const candidateCost = [&](std::size_t const _i) {
+			return std::make_tuple(candidateSpillSets[_i].numSpilled(), cumulativeGas[_i], proposals[_i].size());
+		};
 		std::size_t best = 0;
 		for (std::size_t i = 1; i < stackInProposals.size(); ++i)
-			if (std::make_pair(cumulativeCosts[i], proposals[i].size()) < std::make_pair(cumulativeCosts[best], proposals[best].size()))
+			if (candidateCost(i) < candidateCost(best))
 				best = i;
+		yulAssert(
+			m_spillingAllowed || candidateSpillSets[best].numSpilled() == m_spillSet.numSpilled(),
+			"Stack too deep, but spilling is disabled because the function is part of a recursive call chain."
+		);
+		m_spillSet = std::move(candidateSpillSets[best]);
 		blockLayout.stackIn = std::move(proposals[best]);
 	}
 	m_resultLayout[_blockId] = blockLayout;

--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -233,10 +233,11 @@ public:
 
 	[[nodiscard]] static StackShufflerResult shuffle(
 		Stack<Callback>& _stack,
-		StackData const& _target
+		StackData const& _target,
+		spill::SpillSet const* const _spilledVariables = nullptr
 	)
 	{
-		return shuffle(_stack, _target, {}, _target.size());
+		return shuffle(_stack, _target, {}, _target.size(), _spilledVariables);
 	}
 
 private:

--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -625,6 +625,29 @@ private:
 				}
 			}
 
+			// Dual to `dupDeepSlotIfRequired`: A deep, still-incorrect target slot whose wanted value
+			// is not on the stack at all. A push/dup grows the stack, pushing that slot one deeper.
+			// So if the deepest incorrect args slot would be pushed out of reach by growing, shrink first to keep it reachable.
+			if (
+				maybeIncorrectArgSlotDepth && maybeIncorrectArgSlotDepth->value > ReachableStackDepth
+			)
+			{
+				StackOffset const incorrectOffset{_stack.size() - maybeIncorrectArgSlotDepth->value};
+				if (!_stack.findSlotDepth(_state.targetArg(incorrectOffset)))
+				{
+					if (shrinkStack(_stack, _state))
+						return {ShuffleHelperResult::Status::StackModified};
+					// Surface a reachable, not-yet-spilled value as too deep.
+					for (StackOffset const offset: _state.stackSwapReachableRange())
+						if (
+							Slot const& blocker = _stack[offset];
+							blocker.isValue() && !blocker.isLiteralValue() && !_state.slotIsSpilled(blocker)
+						)
+							return {ShuffleHelperResult::Status::StackTooDeep, blocker};
+					yulAssert(false, "invalid state. we should always be able to either shrink or spill.");
+				}
+			}
+
 			// if we can't directly produce targetOffset, take the deepest arg that we don't have enough of and dup/push that
 			// First, prioritize duping args that are on the stack over pushing freely-generatable ones
 			for (StackOffset offset{_state.target().tailSize}; offset < _state.target().size; ++offset.value)

--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -563,7 +563,7 @@ private:
 							!_state.isSourceCompatible(offset, argOffset) &&  // we're not looking at the same thing
 							!_stack.isBeyondSwapRange(argOffset) &&  // the target offset should not be beyond reach
 							_state.isArgsCompatible(argOffset, offset) && // we can put argOffset -> offset
-							_state.countReachable(_stack[argOffset]) > 1 &&  // we still have another reachable copy so a subsequent dup is recoverable
+							(_state.countReachable(_stack[argOffset]) > 1 || _state.slotIsSpilled(_stack[argOffset])) &&  // a reachable copy remains, or the value is spilled and can be reloaded, so moving it is recoverable
 							(  // we only get a strict improvement if
 								!_state.isArgsCompatible(argOffset, argOffset) ||  // either the argOffset isn't in position anyway
 								_stack.offsetToDepth(offset).value == ReachableStackDepth  // or offset is at the swap edge

--- a/libyul/backends/evm/ssa/spill/Emitter.h
+++ b/libyul/backends/evm/ssa/spill/Emitter.h
@@ -1,0 +1,71 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libyul/backends/evm/AbstractAssembly.h>
+#include <libyul/backends/evm/ssa/SSACFGTypes.h>
+#include <libyul/backends/evm/ssa/spill/MemoryAddressing.h>
+
+#include <libevmasm/Instruction.h>
+
+namespace solidity::yul::ssa::spill
+{
+
+/// Emits the two memory accesses that move a spilled SSA value between the stack and its reserved memory slot.
+class Emitter
+{
+public:
+	Emitter(
+		MemoryAddressing const& _addressing,
+		FunctionGraphID const _cfgIdx,
+		AbstractAssembly& _assembly
+	):
+		m_addressing(&_addressing),
+		m_cfgIdx(_cfgIdx),
+		m_assembly(&_assembly)
+	{
+	}
+
+	[[nodiscard]] bool hasAddress(InstId const _value) const
+	{
+		return m_addressing->hasAddress(m_cfgIdx, _value);
+	}
+
+	/// Materializes the spilled value `_value` on the stack top: `PUSH addr; MLOAD`. Dual of emitStore.
+	void emitLoad(InstId const _value) const
+	{
+		m_assembly->appendConstant(m_addressing->addressOf(m_cfgIdx, _value));
+		m_assembly->appendInstruction(evmasm::Instruction::MLOAD);
+	}
+
+	/// Writes the stack-top value into the spill slot of `_value`, consuming it: `PUSH addr; MSTORE`.
+	/// Dual of emitLoad. The value must already be on the stack top.
+	void emitStore(InstId const _value) const
+	{
+		m_assembly->appendConstant(m_addressing->addressOf(m_cfgIdx, _value));
+		m_assembly->appendInstruction(evmasm::Instruction::MSTORE);
+	}
+
+private:
+	MemoryAddressing const* m_addressing;
+	FunctionGraphID m_cfgIdx;
+	AbstractAssembly* m_assembly;
+};
+
+}

--- a/libyul/backends/evm/ssa/spill/MemoryAddressing.cpp
+++ b/libyul/backends/evm/ssa/spill/MemoryAddressing.cpp
@@ -1,0 +1,72 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libyul/backends/evm/ssa/spill/MemoryAddressing.h>
+
+#include <libyul/Exceptions.h>
+
+#include <cstdint>
+
+using namespace solidity::yul::ssa::spill;
+
+
+MemoryAddressing::MemoryAddressing(ControlFlowGraphs& _cfgs, std::span<SpillSet const> _spillSetsPerCFG):
+	m_addresses(_spillSetsPerCFG.size())
+{
+	yulAssert(_spillSetsPerCFG.size() == _cfgs.functionGraphs.size());
+
+	std::size_t totalSlots = 0;
+	for (auto const& spillSet: _spillSetsPerCFG)
+		totalSlots += spillSet.numSpilled();
+
+	if (totalSlots == 0)
+		return;
+
+	yulAssert(
+		_cfgs.memoryGuard.has_value(),
+		"Spilling requires a memoryguard boundary, but none is set for this subobject."
+	);
+	u256 const originalGuard = *_cfgs.memoryGuard;
+	*_cfgs.memoryGuard += u256(totalSlots) * 32;
+
+	std::uint32_t globalSlot = 0;
+	for (std::size_t i = 0; i < _spillSetsPerCFG.size(); ++i)
+	{
+		auto const& spillSet = _spillSetsPerCFG[i];
+		auto& cfgMap = m_addresses[i];
+		cfgMap.reserve(spillSet.numSpilled());
+		for (InstId const value: spillSet.spilledValues())
+			cfgMap.emplace(value.value, originalGuard + u256(32) * globalSlot++);
+	}
+	yulAssert(globalSlot == totalSlots);
+}
+
+solidity::u256 MemoryAddressing::addressOf(FunctionGraphID _cfg, InstId _value) const
+{
+	yulAssert(_cfg < m_addresses.size(), fmt::format("CFG index out of range: {}", _cfg));
+	auto const& cfgMap = m_addresses[_cfg];
+	auto const it = cfgMap.find(_value.value);
+	yulAssert(it != cfgMap.end(), fmt::format("not spilled: cfg={} value={}", _cfg, _value));
+	return it->second;
+}
+bool MemoryAddressing::hasAddress(FunctionGraphID _cfg, InstId const _value) const
+{
+	yulAssert(_cfg < m_addresses.size(), fmt::format("CFG index out of range: {}", _cfg));
+	auto const& cfgMap = m_addresses[_cfg];
+	return cfgMap.contains(_value.value);
+}

--- a/libyul/backends/evm/ssa/spill/MemoryAddressing.h
+++ b/libyul/backends/evm/ssa/spill/MemoryAddressing.h
@@ -1,0 +1,56 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libyul/backends/evm/ssa/ControlFlowGraphs.h>
+#include <libyul/backends/evm/ssa/SSACFGTypes.h>
+#include <libyul/backends/evm/ssa/spill/SpillSet.h>
+
+#include <libsolutil/Numeric.h>
+
+#include <span>
+#include <unordered_map>
+#include <vector>
+
+namespace solidity::yul::ssa::spill
+{
+
+/// Per-subobject owner of spill-memory addressing.
+///
+/// The ctor sums `numSpilled()` across the per-CFG `SpillSet`s, bumps `_cfgs.memoryGuard` (if any spilling is required)
+/// to reserve one contiguous region for the subobject, and builds the full `(cfgIdx, InstId) -> u256 address` map.
+class MemoryAddressing
+{
+public:
+	MemoryAddressing(
+		ControlFlowGraphs& _cfgs,
+		std::span<SpillSet const> _spillSetsPerCFG
+	);
+
+	/// Address (within the reserved region) at which `_value` from CFG `_cfg` lives
+	[[nodiscard]] u256 addressOf(FunctionGraphID _cfg, InstId _value) const;
+
+	[[nodiscard]] bool hasAddress(FunctionGraphID _cfg, InstId _value) const;
+
+private:
+	/// m_addresses[cfgIdx][value.value] -> u256 final address
+	std::vector<std::unordered_map<InstId::ValueType, u256>> m_addresses;
+};
+
+}

--- a/libyul/backends/evm/ssa/spill/SpillSet.cpp
+++ b/libyul/backends/evm/ssa/spill/SpillSet.cpp
@@ -1,0 +1,159 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libyul/backends/evm/ssa/spill/SpillSet.h>
+
+#include <libyul/backends/evm/ssa/Stack.h>
+#include <libyul/backends/evm/ssa/StackShuffler.h>
+#include <libyul/backends/evm/ssa/StackLayout.h>
+
+#include <deque>
+
+using namespace solidity::yul::ssa;
+using namespace solidity::yul::ssa::spill;
+
+namespace
+{
+
+/// Build the symbolic stack right after `_value`'s operation completes
+StackData computeOperationOut(
+	SSACFG const& _cfg,
+	SSACFGStackLayout const& _layout,
+	InstId const _value
+)
+{
+	SSACFG::BlockId const block = _cfg.inst(_value).block;
+	auto const& blockLayout = _layout[block];
+	yulAssert(blockLayout, fmt::format("producer {}'s block has no layout", _value));
+
+	std::size_t opIndex = 0;
+	bool found = false;
+	for (InstId const id: _cfg.block(block).instructions)
+	{
+		if (!_cfg.isOperation(id))
+			continue;
+		if (id == _value)
+		{
+			found = true;
+			break;
+		}
+		++opIndex;
+	}
+	yulAssert(found, fmt::format("producer {} not found in its block's instructions", _value));
+	yulAssert(opIndex < blockLayout->operationIn.size());
+
+	StackData opOutStack = blockLayout->operationIn[opIndex];
+	SSACFG::Inst const& inst = _cfg.inst(_value);
+	yulAssert(opOutStack.size() >= inst.inputs.size(), "operationIn smaller than input count");
+	for (std::size_t i = 0; i < inst.inputs.size(); ++i)
+		opOutStack.pop_back();
+	_cfg.forEachOutput(_value, [&](InstId const id) {
+		opOutStack.push_back(StackSlot::makeValue(_cfg, id));
+	});
+	return opOutStack;
+}
+
+/// The symbolic stack the Emitter faces at `_value`'s definition, where its `mstore` fires. Three cases:
+/// - a phi: the merged value is materialized on its defining block's `stackIn`, so a single store there covers every incoming edge;
+/// - a function argument: it has no producer operation and lives on the function entry stack, where CodeTransform emits `mstore` while the args are still laid out;
+/// - any other value: it sits on its producer's `operationOut`.
+StackData defStackFor(
+	SSACFG const& _cfg,
+	SSACFGStackLayout const& _layout,
+	InstId const _value
+)
+{
+	if (_cfg.isPhi(_value))
+	{
+		SSACFG::BlockId const block = _cfg.inst(_value).block;
+		yulAssert(block.hasValue(), fmt::format("phi {} has no defining block", _value));
+		auto const& blockLayout = _layout[block];
+		yulAssert(blockLayout, fmt::format("phi {}'s defining block has no layout", _value));
+		return blockLayout->stackIn;
+	}
+	if (_cfg.isFunctionArg(_value))
+	{
+		auto const& entryLayout = _layout[_cfg.entry];
+		yulAssert(entryLayout, "entry block has no layout for function-arg def-site");
+		return entryLayout->stackIn;
+	}
+	return computeOperationOut(_cfg, _layout, _value);
+}
+
+}
+
+void SpillSet::closeUnderReachabilityConstraints(SSACFG const& _cfg, SSACFGStackLayout const& _layout)
+{
+	// work queue over values that are marked for spillage
+	std::deque<InstId> queue;
+	for (InstId const id: spilledValues())
+		queue.push_back(id);
+
+	while (!queue.empty())
+	{
+		InstId const value = queue.front();
+		queue.pop_front();
+
+		StackData const defStack = defStackFor(_cfg, _layout, value);
+		ensureDefSiteFeasible(_cfg, value, defStack, queue);
+	}
+}
+
+void SpillSet::ensureDefSiteFeasible(
+	SSACFG const& _cfg,
+	InstId const _value,
+	StackData const& _defStack,
+	std::deque<InstId>& _workQueue)
+{
+	// predicate = spill set minus the owner; the shuffle accumulates discovered culprits here.
+	SpillSet spillSetWithoutOwner = without(_value);
+	// [... defStack ..., valueSlot]
+	StackData const target = [&]{
+		StackData result;
+		result.reserve(_defStack.size() + 1);
+		result.insert(result.end(), _defStack.begin(), _defStack.end());
+		result.push_back(StackSlot::makeValue(_cfg, _value));
+		return result;
+	}();
+	StackData workStack = _defStack;
+	StackShufflerResult const result = shuffleWithSpillDiscovery(workStack, target, spillSetWithoutOwner);
+	yulAssert(
+		result.status == StackShufflerResult::Status::Admissible,
+		fmt::format("def-site store for {} infeasible even after spilling siblings (status={})", _value, static_cast<int>(result.status))
+	);
+
+	// - if `_value` is reachable, it can be just DUPed and there shouldn't have been a stack too deep with it
+	// - if `_value` is unreachable, there are > reachable stack depth distinct slots strictly above it and the
+	//   shuffler heuristics should not pick anything that is already too deep as culprit
+	yulAssert(!spillSetWithoutOwner.isSpilled(_value), "spill-aware shuffle reported the owner as its own blocker");
+
+	for (InstId const culprit: spillSetWithoutOwner.spilledValues())
+	{
+		if (isSpilled(culprit))
+			continue;
+		add(culprit);
+		_workQueue.push_back(culprit);
+	}
+}
+
+SpillSet SpillSet::without(InstId const _id) const
+{
+	SpillSet result = *this;
+	result.m_values.erase(_id);
+	return result;
+}

--- a/libyul/backends/evm/ssa/spill/SpillSet.h
+++ b/libyul/backends/evm/ssa/spill/SpillSet.h
@@ -23,6 +23,7 @@
 #include <libyul/Exceptions.h>
 
 #include <cstdint>
+#include <deque>
 #include <set>
 
 namespace solidity::yul::ssa::spill
@@ -44,7 +45,17 @@ public:
 
 	std::set<InstId> const& spilledValues() const { return m_values; }
 
+	/// Finalizes the spill set by making every spilled value's def-site `mstore` reachable
+	void closeUnderReachabilityConstraints(SSACFG const& _cfg, SSACFGStackLayout const& _layout);
+
+	/// Yields a copy of this spill set minus `_id`.
+	[[nodiscard]] SpillSet without(InstId _id) const;
+
 private:
+	/// Ensure that the value `_value` can be spilled with respect to `_defStack`, i.e., brought up to the top
+	/// and `mstore`d. Might populate the spill set with more entries if not possible right away.
+	void ensureDefSiteFeasible(SSACFG const& _cfg, InstId _value, StackData const& _defStack, std::deque<InstId>& _workQueue);
+
 	std::set<InstId> m_values;
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -181,6 +181,8 @@ set(libyul_sources
     libyul/ssa/ControlFlowGraphTest.h
     libyul/ssa/PrinterTest.cpp
     libyul/ssa/PrinterTest.h
+    libyul/ssa/SpillTest.cpp
+    libyul/ssa/SpillTest.h
     libyul/ssa/StackLayoutGeneratorTest.cpp
     libyul/ssa/StackLayoutGeneratorTest.h
     libyul/ssa/StackShufflerTest.cpp

--- a/test/InteractiveTests.h
+++ b/test/InteractiveTests.h
@@ -35,6 +35,7 @@
 #include <test/libyul/ssa/CallGraphTest.h>
 #include <test/libyul/ssa/ControlFlowGraphTest.h>
 #include <test/libyul/ssa/PrinterTest.h>
+#include <test/libyul/ssa/SpillTest.h>
 #include <test/libyul/ssa/StackLayoutGeneratorTest.h>
 #include <test/libyul/ssa/StackShufflerTest.h>
 #include <test/libyul/ControlFlowGraphTest.h>
@@ -82,6 +83,7 @@ Testsuite const g_interactiveTestsuites[] = {
 	{"Yul SSA Printer",             "libyul",      "ssa/printer",                   false, false, &yul::test::ssa::PrinterTest::create},
 	{"Yul SSA StackShuffling",      "libyul",      "ssa/stackShuffler",             false, false, &yul::test::ssa::ShufflingTest::create},
 	{"Yul SSA StackLayoutGenerator","libyul",      "ssa/stackLayoutGenerator",      false, false, &yul::test::ssa::StackLayoutGeneratorTest::create},
+	{"Yul SSA Spill",               "libyul",      "ssa/spill",                     false, false, &yul::test::ssa::SpillTest::create},
 	{"Yul Stack Layout",            "libyul",      "yulStackLayout",                false, false, &yul::test::StackLayoutGeneratorTest::create},
 	{"Yul Stack Shuffling",         "libyul",      "yulStackShuffling",             false, false, &yul::test::StackShufflingTest::create},
 	{"Control Flow Side Effects",   "libyul",      "controlFlowSideEffects",        false, false, &yul::test::ControlFlowSideEffectsTest::create},

--- a/test/libyul/ssa/SpillTest.cpp
+++ b/test/libyul/ssa/SpillTest.cpp
@@ -1,0 +1,196 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <test/libyul/ssa/SpillTest.h>
+
+#include <test/libyul/Common.h>
+
+#include <libyul/backends/evm/ssa/CallGraph.h>
+#include <libyul/backends/evm/ssa/ControlFlowGraphs.h>
+#include <libyul/backends/evm/ssa/SSACFGBuilder.h>
+#include <libyul/backends/evm/ssa/StackLayoutGenerator.h>
+#include <libyul/backends/evm/ssa/StackUtils.h>
+#include <libyul/backends/evm/ssa/spill/MemoryAddressing.h>
+#include <libyul/backends/evm/ssa/spill/SpillSet.h>
+#include <libyul/backends/evm/ssa/transform/OptimizationPipeline.h>
+
+#include <libyul/backends/evm/EVMDialect.h>
+
+#include <libyul/Object.h>
+#include <libyul/YulStack.h>
+
+#include <libsolutil/Numeric.h>
+
+#include <fmt/format.h>
+
+using namespace solidity;
+using namespace solidity::util;
+using namespace solidity::yul;
+using namespace solidity::yul::ssa;
+using namespace solidity::yul::test::ssa;
+
+namespace
+{
+
+std::string describeCFG(
+	SSACFG const& _cfg,
+	ControlFlowGraphs::FunctionGraphID const _graphID,
+	std::vector<std::pair<InstId, u256>> const& _spilled
+)
+{
+	std::string label = _cfg.isMainGraph() ? "<main>" : _cfg.name;
+	std::string out = fmt::format("CFG[{}] {}\n", _graphID, label);
+
+	if (_spilled.empty())
+	{
+		out += "  spilled: none\n";
+		return out;
+	}
+
+	out += "  spilled:\n";
+	for (auto const& [value, address]: _spilled)
+		out += fmt::format(
+			"    {} ({}) -> mem {}\n",
+			value,
+			_cfg.isPhi(value) ? "phi" : "value",
+			toCompactHexWithPrefix(address)
+		);
+
+	out += "  mstore schedule:\n";
+	for (const auto& value: _spilled | std::views::keys)
+	{
+		SSACFG::BlockId const block = _cfg.inst(value).block;
+		out += fmt::format(
+			"    mstore addr({}) <- {} (B#{})\n",
+			value,
+			value,
+			block.value
+		);
+	}
+	return out;
+}
+
+}
+
+std::unique_ptr<frontend::test::TestCase> SpillTest::create(Config const& _config)
+{
+	return std::make_unique<SpillTest>(_config.filename);
+}
+
+SpillTest::SpillTest(std::string const& _filename): TestCase(_filename)
+{
+	m_source = m_reader.source();
+	auto const dialectName = m_reader.stringSetting("dialect", "evm");
+	soltestAssert(dialectName == "evm");
+	m_expectation = m_reader.simpleExpectations();
+}
+
+frontend::test::TestCase::TestResult SpillTest::run(std::ostream& _stream, std::string const& _linePrefix, bool const _formatted)
+{
+	static std::string_view constexpr OBJECT_SEPARATOR = "\n>>>>> OBJECT SEPARATOR\n";
+
+	YulStack const yulStack = yul::test::parseYul(m_source);
+	if (yulStack.hasErrors())
+	{
+		printYulErrors(yulStack, _stream, _linePrefix, _formatted);
+		return TestResult::FatalError;
+	}
+
+	std::set<Object const*> visited;
+	visited.insert(yulStack.parserResult().get());
+	std::vector<Object const*> toVisit{yulStack.parserResult().get()};
+
+	while (!toVisit.empty())
+	{
+		auto const& object = *toVisit.back();
+		toVisit.pop_back();
+
+		auto const* evmDialect = dynamic_cast<EVMDialect const*>(object.dialect());
+		yulAssert(evmDialect);
+
+		std::unique_ptr<ControlFlowGraphs> controlFlowGraphs = SSACFGBuilder::build(
+			*object.analysisInfo,
+			*evmDialect,
+			object.code()->root(),
+			false
+		);
+		transform::optimize(*controlFlowGraphs);
+		ControlFlowGraphsLiveness const liveness(*controlFlowGraphs);
+		CallGraph const callGraph(*controlFlowGraphs);
+
+		std::size_t const numCFGs = controlFlowGraphs->functionGraphs.size();
+		std::vector<spill::SpillSet> spillSetsPerCFG;
+		std::vector<SSACFGStackLayout> layouts;
+		spillSetsPerCFG.reserve(numCFGs);
+		layouts.reserve(numCFGs);
+
+		// Recompute the spill sets and per-block stack layouts exactly as the code transform would,
+		// but stop at the addressing step instead of generating any bytecode.
+		for (std::size_t functionIndex = 0; functionIndex < numCFGs; ++functionIndex)
+		{
+			SSACFG const& cfg = *controlFlowGraphs->functionGraphs[functionIndex];
+			auto const& cfgLiveness = liveness.cfgLiveness[functionIndex];
+			yulAssert(cfgLiveness);
+			auto const graphID = static_cast<ControlFlowGraphs::FunctionGraphID>(functionIndex);
+			bool const spillingAllowed = !callGraph.isRecursive(graphID);
+			auto [layout, spillSet] = StackLayoutGenerator::generate(
+				*cfgLiveness,
+				gatherCallSites(cfg),
+				graphID,
+				spillingAllowed
+			);
+			layouts.push_back(std::move(layout));
+			spillSetsPerCFG.push_back(std::move(spillSet));
+		}
+
+		for (std::size_t functionIndex = 0; functionIndex < numCFGs; ++functionIndex)
+			spillSetsPerCFG[functionIndex].closeUnderReachabilityConstraints(
+				*controlFlowGraphs->functionGraphs[functionIndex],
+				layouts[functionIndex]
+			);
+
+		// build up global addressing based on the spill sets
+		spill::MemoryAddressing const addressing(*controlFlowGraphs, spillSetsPerCFG);
+
+		if (!m_obtainedResult.empty())
+			m_obtainedResult += OBJECT_SEPARATOR;
+		m_obtainedResult += fmt::format("object \"{}\"\n", object.name);
+		m_obtainedResult += "===== SSA CFG =====\n";
+		m_obtainedResult += controlFlowGraphs->print();
+		m_obtainedResult += "===== spill info =====\n";
+		for (std::size_t functionIndex = 0; functionIndex < numCFGs; ++functionIndex)
+		{
+			SSACFG const& cfg = *controlFlowGraphs->functionGraphs[functionIndex];
+			auto const graphID = static_cast<ControlFlowGraphs::FunctionGraphID>(functionIndex);
+			std::vector<std::pair<InstId, u256>> spilled;
+			for (InstId const value: spillSetsPerCFG[functionIndex].spilledValues())
+				spilled.emplace_back(value, addressing.addressOf(graphID, value));
+			m_obtainedResult += describeCFG(cfg, graphID, spilled);
+		}
+
+		for (auto const& subNode: object.subObjects)
+			if (auto subObject = std::dynamic_pointer_cast<Object>(subNode))
+				if (!visited.contains(subObject.get()))
+				{
+					visited.insert(subObject.get());
+					toVisit.push_back(subObject.get());
+				}
+	}
+
+	return checkResult(_stream, _linePrefix, _formatted);
+}

--- a/test/libyul/ssa/SpillTest.h
+++ b/test/libyul/ssa/SpillTest.h
@@ -1,0 +1,40 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <test/TestCase.h>
+
+#include <memory>
+
+namespace solidity::yul::test::ssa
+{
+
+/// Drives the SSA-CFG spill addressing without code generation
+/// (`SSACFGBuilder` -> optimizer -> `StackLayoutGenerator` -> `SpillSet::feasilize` -> `MemoryAddressing`)
+/// on a Yul object and prints, per CFG, the `print()`ed SSA CFG followed by what was spilled
+/// (value -> memory address) and the `mstore` schedule (which value is written at which instruction).
+class SpillTest: public frontend::test::TestCase
+{
+public:
+	static std::unique_ptr<TestCase> create(Config const& _config);
+	explicit SpillTest(std::string const& _filename);
+	TestResult run(std::ostream& _stream, std::string const& _linePrefix, bool _formatted) override;
+};
+
+}

--- a/test/libyul/ssa/spill/loop_backedge_too_deep_spill.yul
+++ b/test/libyul/ssa/spill/loop_backedge_too_deep_spill.yul
@@ -1,0 +1,223 @@
+// Back-edge stack layouts that require spilling to be shuffled successfully
+object "C" {
+code {
+    let g := memoryguard(0x80)
+    mstore(0x40, g)
+    sstore(0, f(calldataload(0x0)))
+    function f(bound) -> r {
+        let x0 := 1
+        let x1 := 2
+        let x2 := 3
+        let x3 := 4
+        let x4 := 5
+        let x5 := 6
+        let x6 := 7
+        let x7 := 8
+        let x8 := 9
+        let x9 := 10
+        let x10 := 11
+        let x11 := 12
+        let x12 := 13
+        let x13 := 14
+        let x14 := 15
+        let x15 := 16
+        let x16 := 17
+        let x17 := 18
+        let x18 := 19
+        for { let c := 0 } lt(c, bound) { c := add(c, 1) } {
+            x0 := add(x0, c)
+            x1 := add(x1, c)
+            x2 := add(x2, c)
+            x3 := add(x3, c)
+            x4 := add(x4, c)
+            x5 := add(x5, c)
+            x6 := add(x6, c)
+            x7 := add(x7, c)
+            x8 := add(x8, c)
+            x9 := add(x9, c)
+            x10 := add(x10, c)
+            x11 := add(x11, c)
+            x12 := add(x12, c)
+            x13 := add(x13, c)
+            x14 := add(x14, c)
+            x15 := add(x15, c)
+            x16 := add(x16, c)
+            x17 := add(x17, c)
+            x18 := add(x18, c)
+        }
+        r := add(add(add(add(add(add(add(add(add(add(add(add(add(add(add(add(add(add(x0, x1), x2), x3), x4), x5), x6), x7), x8), x9), x10), x11), x12), x13), x14), x15), x16), x17), x18)
+    }
+}
+}
+// ----
+// object "C"
+// ===== SSA CFG =====
+// memoryguard = 0x01a0
+//
+// #0:
+//     v0 = memoryguard
+//     v1 = const 0x40
+//     builtin @mstore v1, v0
+//     v3 = const 0x00
+//     v4 = builtin @calldataload v3
+//     v5 = call @f v4
+//     builtin @sstore v3, v5
+//     main_exit
+//
+// func @f(args: (v0)) -> 1 {
+// #0:
+//     v0 = arg 0
+//     v1 = const 0x00
+//     v2 = const 0x01
+//     v3 = const 0x02
+//     v4 = const 0x03
+//     v5 = const 0x04
+//     v6 = const 0x05
+//     v7 = const 0x06
+//     v8 = const 0x07
+//     v9 = const 0x08
+//     v10 = const 0x09
+//     v11 = const 0x0a
+//     v12 = const 0x0b
+//     v13 = const 0x0c
+//     v14 = const 0x0d
+//     v15 = const 0x0e
+//     v16 = const 0x0f
+//     v17 = const 0x10
+//     v18 = const 0x11
+//     v19 = const 0x12
+//     v20 = const 0x13
+//     upsilon v1 -> ^v22
+//     upsilon v2 -> ^v24
+//     upsilon v3 -> ^v26
+//     upsilon v4 -> ^v28
+//     upsilon v5 -> ^v30
+//     upsilon v6 -> ^v32
+//     upsilon v7 -> ^v34
+//     upsilon v8 -> ^v36
+//     upsilon v9 -> ^v38
+//     upsilon v10 -> ^v40
+//     upsilon v11 -> ^v42
+//     upsilon v12 -> ^v44
+//     upsilon v13 -> ^v46
+//     upsilon v14 -> ^v48
+//     upsilon v15 -> ^v50
+//     upsilon v16 -> ^v52
+//     upsilon v17 -> ^v54
+//     upsilon v18 -> ^v56
+//     upsilon v19 -> ^v58
+//     upsilon v20 -> ^v60
+//     jump #1
+// #1: preds: #0, #3
+//     v22 = phi
+//     v23 = builtin @lt v22, v0
+//     v24 = phi
+//     v26 = phi
+//     v28 = phi
+//     v30 = phi
+//     v32 = phi
+//     v34 = phi
+//     v36 = phi
+//     v38 = phi
+//     v40 = phi
+//     v42 = phi
+//     v44 = phi
+//     v46 = phi
+//     v48 = phi
+//     v50 = phi
+//     v52 = phi
+//     v54 = phi
+//     v56 = phi
+//     v58 = phi
+//     v60 = phi
+//     branch v23, #2, #4
+// #2: preds: #1
+//     v25 = builtin @add v24, v22
+//     v27 = builtin @add v26, v22
+//     v29 = builtin @add v28, v22
+//     v31 = builtin @add v30, v22
+//     v33 = builtin @add v32, v22
+//     v35 = builtin @add v34, v22
+//     v37 = builtin @add v36, v22
+//     v39 = builtin @add v38, v22
+//     v41 = builtin @add v40, v22
+//     v43 = builtin @add v42, v22
+//     v45 = builtin @add v44, v22
+//     v47 = builtin @add v46, v22
+//     v49 = builtin @add v48, v22
+//     v51 = builtin @add v50, v22
+//     v53 = builtin @add v52, v22
+//     v55 = builtin @add v54, v22
+//     v57 = builtin @add v56, v22
+//     v59 = builtin @add v58, v22
+//     v61 = builtin @add v60, v22
+//     jump #3
+// #3: preds: #2
+//     v62 = builtin @add v22, v2
+//     upsilon v62 -> ^v22
+//     upsilon v25 -> ^v24
+//     upsilon v27 -> ^v26
+//     upsilon v29 -> ^v28
+//     upsilon v31 -> ^v30
+//     upsilon v33 -> ^v32
+//     upsilon v35 -> ^v34
+//     upsilon v37 -> ^v36
+//     upsilon v39 -> ^v38
+//     upsilon v41 -> ^v40
+//     upsilon v43 -> ^v42
+//     upsilon v45 -> ^v44
+//     upsilon v47 -> ^v46
+//     upsilon v49 -> ^v48
+//     upsilon v51 -> ^v50
+//     upsilon v53 -> ^v52
+//     upsilon v55 -> ^v54
+//     upsilon v57 -> ^v56
+//     upsilon v59 -> ^v58
+//     upsilon v61 -> ^v60
+//     jump #1
+// #4: preds: #1
+//     v105 = builtin @add v24, v26
+//     v106 = builtin @add v105, v28
+//     v107 = builtin @add v106, v30
+//     v108 = builtin @add v107, v32
+//     v109 = builtin @add v108, v34
+//     v110 = builtin @add v109, v36
+//     v111 = builtin @add v110, v38
+//     v112 = builtin @add v111, v40
+//     v113 = builtin @add v112, v42
+//     v114 = builtin @add v113, v44
+//     v115 = builtin @add v114, v46
+//     v116 = builtin @add v115, v48
+//     v117 = builtin @add v116, v50
+//     v118 = builtin @add v117, v52
+//     v119 = builtin @add v118, v54
+//     v120 = builtin @add v119, v56
+//     v121 = builtin @add v120, v58
+//     v122 = builtin @add v121, v60
+//     return v122
+// }
+//
+// ===== spill info =====
+// CFG[0] <main>
+//   spilled: none
+// CFG[1] f
+//   spilled:
+//     v51 (value) -> mem 0x80
+//     v52 (phi) -> mem 0xa0
+//     v54 (phi) -> mem 0xc0
+//     v56 (phi) -> mem 0xe0
+//     v58 (phi) -> mem 0x0100
+//     v59 (value) -> mem 0x0120
+//     v60 (phi) -> mem 0x0140
+//     v61 (value) -> mem 0x0160
+//     v62 (value) -> mem 0x0180
+//   mstore schedule:
+//     mstore addr(v51) <- v51 (B#2)
+//     mstore addr(v52) <- v52 (B#1)
+//     mstore addr(v54) <- v54 (B#1)
+//     mstore addr(v56) <- v56 (B#1)
+//     mstore addr(v58) <- v58 (B#1)
+//     mstore addr(v59) <- v59 (B#2)
+//     mstore addr(v60) <- v60 (B#1)
+//     mstore addr(v61) <- v61 (B#2)
+//     mstore addr(v62) <- v62 (B#3)

--- a/test/libyul/ssa/spill/multi_entry_spill.yul
+++ b/test/libyul/ssa/spill/multi_entry_spill.yul
@@ -1,0 +1,251 @@
+// Spilling at a switch-merge block.
+//
+// The two switch arms each keep all 18 `var_x*` live across the join, so the merge block's stack-in
+// is ~19 deep and reconciling either arm to it needs to reach below SWAP16.
+{
+    mstore(64, memoryguard(128))
+    let var_x1 := calldataload(4)
+    let var_x2 := sub(1, var_x1)
+    let var_x3 := mul(0x03, var_x1)
+    let var_x4 := sub(0x02, var_x1)
+    let var_x5 := mul(0x05, var_x1)
+    let var_x6 := mul(0x06, var_x1)
+    let var_x7 := mul(0x07, var_x1)
+    let var_x8 := sub(0x03, var_x1)
+    let var_x9 := mul(0x09, var_x1)
+    let var_x10 := mul(0x0a, var_x1)
+    let var_x11 := mul(0x0b, var_x1)
+    let var_x12 := mul(0x0c, var_x1)
+    let var_x13 := mul(0x0d, var_x1)
+    let var_x14 := mul(0x0e, var_x1)
+    let var_x15 := mul(0x0f, var_x1)
+    let var_x16 := sub(4, var_x1)
+    let var_x17 := mul(0x11, var_x1)
+    let var_x18 := mul(0x12, var_x1)
+    switch gt(var_x18, 0x05f5e100)
+    case 0 {
+        var_x2 := add(var_x2, 0x02)
+        var_x3 := add(var_x3, 0x02)
+        var_x4 := add(var_x4, 0x02)
+        var_x5 := add(var_x5, 0x02)
+        var_x6 := add(var_x6, 0x02)
+        var_x7 := add(var_x7, 0x02)
+        var_x8 := add(var_x8, 0x02)
+        var_x9 := add(var_x9, 0x02)
+        var_x10 := add(var_x10, 0x02)
+        var_x11 := add(var_x11, 0x02)
+        var_x12 := add(var_x12, 0x02)
+        var_x13 := add(var_x13, 0x02)
+        var_x14 := add(var_x14, 0x02)
+        var_x15 := add(var_x15, 0x02)
+        var_x16 := add(var_x16, 0x02)
+        var_x17 := add(var_x17, 0x02)
+        var_x18 := add(var_x18, 0x02)
+        var_x1 := add(var_x1, 0x02)
+    }
+    default {
+        var_x1 := add(var_x1, 1)
+        var_x2 := add(var_x2, 1)
+        var_x3 := add(var_x3, 1)
+        var_x4 := add(var_x4, 1)
+        var_x5 := add(var_x5, 1)
+        var_x6 := add(var_x6, 1)
+        var_x7 := add(var_x7, 1)
+        var_x8 := add(var_x8, 1)
+        var_x9 := add(var_x9, 1)
+        var_x10 := add(var_x10, 1)
+        var_x11 := add(var_x11, 1)
+        var_x12 := add(var_x12, 1)
+        var_x13 := add(var_x13, 1)
+        var_x14 := add(var_x14, 1)
+        var_x15 := add(var_x15, 1)
+        var_x16 := add(var_x16, 1)
+        var_x17 := add(var_x17, 1)
+        var_x18 := add(var_x18, 1)
+    }
+    mstore(memoryguard(128), add(add(add(add(add(add(add(add(add(add(add(add(add(add(add(add(add(var_x1, var_x2), var_x3), var_x4), var_x5), var_x6), var_x7), var_x8), var_x9), var_x10), var_x11), var_x12), var_x13), var_x14), var_x15), var_x16), var_x17), var_x18))
+    return(memoryguard(128), 32)
+}
+// ----
+// object "object"
+// ===== SSA CFG =====
+// memoryguard = 0x0140
+//
+// #0:
+//     v0 = memoryguard
+//     v1 = const 0x40
+//     builtin @mstore v1, v0
+//     v3 = const 0x04
+//     v4 = builtin @calldataload v3
+//     v5 = const 0x01
+//     v6 = builtin @sub v5, v4
+//     v7 = const 0x03
+//     v8 = builtin @mul v7, v4
+//     v9 = const 0x02
+//     v10 = builtin @sub v9, v4
+//     v11 = const 0x05
+//     v12 = builtin @mul v11, v4
+//     v13 = const 0x06
+//     v14 = builtin @mul v13, v4
+//     v15 = const 0x07
+//     v16 = builtin @mul v15, v4
+//     v17 = builtin @sub v7, v4
+//     v18 = const 0x09
+//     v19 = builtin @mul v18, v4
+//     v20 = const 0x0a
+//     v21 = builtin @mul v20, v4
+//     v22 = const 0x0b
+//     v23 = builtin @mul v22, v4
+//     v24 = const 0x0c
+//     v25 = builtin @mul v24, v4
+//     v26 = const 0x0d
+//     v27 = builtin @mul v26, v4
+//     v28 = const 0x0e
+//     v29 = builtin @mul v28, v4
+//     v30 = const 0x0f
+//     v31 = builtin @mul v30, v4
+//     v32 = builtin @sub v3, v4
+//     v33 = const 0x11
+//     v34 = builtin @mul v33, v4
+//     v35 = const 0x12
+//     v36 = builtin @mul v35, v4
+//     v37 = const 0x05f5e100
+//     v38 = builtin @gt v36, v37
+//     v39 = const 0x00
+//     v40 = builtin @eq v38, v39
+//     v150 = const 0x20
+//     branch v40, #2, #3
+// #1: preds: #2, #3
+//     v77 = phi
+//     v80 = phi
+//     v83 = phi
+//     v86 = phi
+//     v89 = phi
+//     v92 = phi
+//     v95 = phi
+//     v98 = phi
+//     v101 = phi
+//     v104 = phi
+//     v107 = phi
+//     v110 = phi
+//     v113 = phi
+//     v116 = phi
+//     v119 = phi
+//     v122 = phi
+//     v125 = phi
+//     v128 = phi
+//     v131 = builtin @add v128, v125
+//     v132 = builtin @add v131, v122
+//     v133 = builtin @add v132, v119
+//     v134 = builtin @add v133, v116
+//     v135 = builtin @add v134, v113
+//     v136 = builtin @add v135, v110
+//     v137 = builtin @add v136, v107
+//     v138 = builtin @add v137, v104
+//     v139 = builtin @add v138, v101
+//     v140 = builtin @add v139, v98
+//     v141 = builtin @add v140, v95
+//     v142 = builtin @add v141, v92
+//     v143 = builtin @add v142, v89
+//     v144 = builtin @add v143, v86
+//     v145 = builtin @add v144, v83
+//     v146 = builtin @add v145, v80
+//     v147 = builtin @add v146, v77
+//     v148 = memoryguard
+//     builtin @mstore v148, v147
+//     v151 = memoryguard
+//     builtin @return v151, v150
+//     terminated
+// #2: preds: #0
+//     v41 = builtin @add v6, v9
+//     v42 = builtin @add v8, v9
+//     v43 = builtin @add v10, v9
+//     v44 = builtin @add v12, v9
+//     v45 = builtin @add v14, v9
+//     v46 = builtin @add v16, v9
+//     v47 = builtin @add v17, v9
+//     v48 = builtin @add v19, v9
+//     v49 = builtin @add v21, v9
+//     v50 = builtin @add v23, v9
+//     v51 = builtin @add v25, v9
+//     v52 = builtin @add v27, v9
+//     v53 = builtin @add v29, v9
+//     v54 = builtin @add v31, v9
+//     v55 = builtin @add v32, v9
+//     v56 = builtin @add v34, v9
+//     v57 = builtin @add v36, v9
+//     v58 = builtin @add v4, v9
+//     upsilon v57 -> ^v77
+//     upsilon v56 -> ^v80
+//     upsilon v55 -> ^v83
+//     upsilon v54 -> ^v86
+//     upsilon v53 -> ^v89
+//     upsilon v52 -> ^v92
+//     upsilon v51 -> ^v95
+//     upsilon v50 -> ^v98
+//     upsilon v49 -> ^v101
+//     upsilon v48 -> ^v104
+//     upsilon v47 -> ^v107
+//     upsilon v46 -> ^v110
+//     upsilon v45 -> ^v113
+//     upsilon v44 -> ^v116
+//     upsilon v43 -> ^v119
+//     upsilon v42 -> ^v122
+//     upsilon v41 -> ^v125
+//     upsilon v58 -> ^v128
+//     jump #1
+// #3: preds: #0
+//     v59 = builtin @add v4, v5
+//     v60 = builtin @add v6, v5
+//     v61 = builtin @add v8, v5
+//     v62 = builtin @add v10, v5
+//     v63 = builtin @add v12, v5
+//     v64 = builtin @add v14, v5
+//     v65 = builtin @add v16, v5
+//     v66 = builtin @add v17, v5
+//     v67 = builtin @add v19, v5
+//     v68 = builtin @add v21, v5
+//     v69 = builtin @add v23, v5
+//     v70 = builtin @add v25, v5
+//     v71 = builtin @add v27, v5
+//     v72 = builtin @add v29, v5
+//     v73 = builtin @add v31, v5
+//     v74 = builtin @add v32, v5
+//     v75 = builtin @add v34, v5
+//     v76 = builtin @add v36, v5
+//     upsilon v76 -> ^v77
+//     upsilon v75 -> ^v80
+//     upsilon v74 -> ^v83
+//     upsilon v73 -> ^v86
+//     upsilon v72 -> ^v89
+//     upsilon v71 -> ^v92
+//     upsilon v70 -> ^v95
+//     upsilon v69 -> ^v98
+//     upsilon v68 -> ^v101
+//     upsilon v67 -> ^v104
+//     upsilon v66 -> ^v107
+//     upsilon v65 -> ^v110
+//     upsilon v64 -> ^v113
+//     upsilon v63 -> ^v116
+//     upsilon v62 -> ^v119
+//     upsilon v61 -> ^v122
+//     upsilon v60 -> ^v125
+//     upsilon v59 -> ^v128
+//     jump #1
+//
+// ===== spill info =====
+// CFG[0] <main>
+//   spilled:
+//     v34 (value) -> mem 0x80
+//     v57 (value) -> mem 0xa0
+//     v62 (value) -> mem 0xc0
+//     v77 (phi) -> mem 0xe0
+//     v80 (phi) -> mem 0x0100
+//     v128 (phi) -> mem 0x0120
+//   mstore schedule:
+//     mstore addr(v34) <- v34 (B#0)
+//     mstore addr(v57) <- v57 (B#2)
+//     mstore addr(v62) <- v62 (B#3)
+//     mstore addr(v77) <- v77 (B#1)
+//     mstore addr(v80) <- v80 (B#1)
+//     mstore addr(v128) <- v128 (B#1)

--- a/test/libyul/ssa/spill/no_spill.yul
+++ b/test/libyul/ssa/spill/no_spill.yul
@@ -1,0 +1,24 @@
+// A snippet whose live sets stay shallow enough that the layout generator never spills. The spill
+// info reports `none` for every CFG and MemoryAddressing reserves no region.
+object "C" {
+    code {
+        let x := calldataload(0x0)
+        let y := calldataload(0x20)
+        sstore(x, add(x, y))
+    }
+}
+// ----
+// object "C"
+// ===== SSA CFG =====
+// #0:
+//     v0 = const 0x00
+//     v1 = builtin @calldataload v0
+//     v2 = const 0x20
+//     v3 = builtin @calldataload v2
+//     v4 = builtin @add v1, v3
+//     builtin @sstore v1, v4
+//     main_exit
+//
+// ===== spill info =====
+// CFG[0] <main>
+//   spilled: none

--- a/test/libyul/ssa/spill/phi_spilled_at_definition.yul
+++ b/test/libyul/ssa/spill/phi_spilled_at_definition.yul
@@ -1,0 +1,176 @@
+// A spilled phi is addressed at its block entry (def-site), where the merged value is materialized
+// on `stackIn`. Here the loop counter `i` is a phi at the loop header; with 17 always-live params
+// kept live across the body's sstore chain the layout generator spills, and the phi can be among the
+// spilled values. The `memoryguard` prelude (kept alive by `mstore(0x40, g)`) reserves the spill
+// region MemoryAddressing bumps.
+object "C" {
+    code {
+        let g := memoryguard(0x80)
+        mstore(0x40, g)
+        f(calldataload(0x0), calldataload(0x20), calldataload(0x40), calldataload(0x60), calldataload(0x80), calldataload(0xa0), calldataload(0xc0), calldataload(0xe0), calldataload(0x100), calldataload(0x120), calldataload(0x140), calldataload(0x160), calldataload(0x180), calldataload(0x1a0), calldataload(0x1c0), calldataload(0x1e0), calldataload(0x200))
+        function f(b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16, b17) {
+            for { let i := 0 } lt(i, 5) { i := add(i, 1) } {
+                sstore(i, b17)
+                sstore(add(i, 1), b16)
+                sstore(add(i, 2), b15)
+                sstore(add(i, 3), b14)
+                sstore(add(i, 4), b13)
+                sstore(add(i, 5), b12)
+                sstore(add(i, 6), b11)
+                sstore(add(i, 7), b10)
+                sstore(add(i, 8), b9)
+                sstore(add(i, 9), b8)
+                sstore(add(i, 10), b7)
+                sstore(add(i, 11), b6)
+                sstore(add(i, 12), b5)
+                sstore(add(i, 13), b4)
+                sstore(add(i, 14), b3)
+                sstore(add(i, 15), b2)
+                sstore(add(i, 16), b1)
+            }
+        }
+    }
+}
+// ----
+// object "C"
+// ===== SSA CFG =====
+// memoryguard = 0xe0
+//
+// #0:
+//     v0 = memoryguard
+//     v1 = const 0x40
+//     builtin @mstore v1, v0
+//     v3 = const 0x0200
+//     v4 = builtin @calldataload v3
+//     v5 = const 0x01e0
+//     v6 = builtin @calldataload v5
+//     v7 = const 0x01c0
+//     v8 = builtin @calldataload v7
+//     v9 = const 0x01a0
+//     v10 = builtin @calldataload v9
+//     v11 = const 0x0180
+//     v12 = builtin @calldataload v11
+//     v13 = const 0x0160
+//     v14 = builtin @calldataload v13
+//     v15 = const 0x0140
+//     v16 = builtin @calldataload v15
+//     v17 = const 0x0120
+//     v18 = builtin @calldataload v17
+//     v19 = const 0x0100
+//     v20 = builtin @calldataload v19
+//     v21 = const 0xe0
+//     v22 = builtin @calldataload v21
+//     v23 = const 0xc0
+//     v24 = builtin @calldataload v23
+//     v25 = const 0xa0
+//     v26 = builtin @calldataload v25
+//     v27 = const 0x80
+//     v28 = builtin @calldataload v27
+//     v29 = const 0x60
+//     v30 = builtin @calldataload v29
+//     v31 = builtin @calldataload v1
+//     v32 = const 0x20
+//     v33 = builtin @calldataload v32
+//     v34 = const 0x00
+//     v35 = builtin @calldataload v34
+//     call @f v35, v33, v31, v30, v28, v26, v24, v22, v20, v18, v16, v14, v12, v10, v8, v6, v4
+//     main_exit
+//
+// func @f(args: (v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16)) -> 0 {
+// #0:
+//     v0 = arg 0
+//     v1 = arg 1
+//     v2 = arg 2
+//     v3 = arg 3
+//     v4 = arg 4
+//     v5 = arg 5
+//     v6 = arg 6
+//     v7 = arg 7
+//     v8 = arg 8
+//     v9 = arg 9
+//     v10 = arg 10
+//     v11 = arg 11
+//     v12 = arg 12
+//     v13 = arg 13
+//     v14 = arg 14
+//     v15 = arg 15
+//     v16 = arg 16
+//     v17 = const 0x00
+//     v18 = const 0x05
+//     v24 = const 0x01
+//     v28 = const 0x02
+//     v32 = const 0x03
+//     v36 = const 0x04
+//     v43 = const 0x06
+//     v47 = const 0x07
+//     v51 = const 0x08
+//     v55 = const 0x09
+//     v59 = const 0x0a
+//     v63 = const 0x0b
+//     v67 = const 0x0c
+//     v71 = const 0x0d
+//     v75 = const 0x0e
+//     v79 = const 0x0f
+//     v83 = const 0x10
+//     upsilon v17 -> ^v19
+//     jump #1
+// #1: preds: #0, #3
+//     v19 = phi
+//     v20 = builtin @lt v19, v18
+//     branch v20, #2, #4
+// #2: preds: #1
+//     builtin @sstore v19, v16
+//     v25 = builtin @add v19, v24
+//     builtin @sstore v25, v15
+//     v29 = builtin @add v19, v28
+//     builtin @sstore v29, v14
+//     v33 = builtin @add v19, v32
+//     builtin @sstore v33, v13
+//     v37 = builtin @add v19, v36
+//     builtin @sstore v37, v12
+//     v40 = builtin @add v19, v18
+//     builtin @sstore v40, v11
+//     v44 = builtin @add v19, v43
+//     builtin @sstore v44, v10
+//     v48 = builtin @add v19, v47
+//     builtin @sstore v48, v9
+//     v52 = builtin @add v19, v51
+//     builtin @sstore v52, v8
+//     v56 = builtin @add v19, v55
+//     builtin @sstore v56, v7
+//     v60 = builtin @add v19, v59
+//     builtin @sstore v60, v6
+//     v64 = builtin @add v19, v63
+//     builtin @sstore v64, v5
+//     v68 = builtin @add v19, v67
+//     builtin @sstore v68, v4
+//     v72 = builtin @add v19, v71
+//     builtin @sstore v72, v3
+//     v76 = builtin @add v19, v75
+//     builtin @sstore v76, v2
+//     v80 = builtin @add v19, v79
+//     builtin @sstore v80, v1
+//     v84 = builtin @add v19, v83
+//     builtin @sstore v84, v0
+//     jump #3
+// #3: preds: #2
+//     v86 = builtin @add v19, v24
+//     upsilon v86 -> ^v19
+//     jump #1
+// #4: preds: #1
+//     return
+// }
+//
+// ===== spill info =====
+// CFG[0] <main>
+//   spilled:
+//     v4 (value) -> mem 0x80
+//   mstore schedule:
+//     mstore addr(v4) <- v4 (B#0)
+// CFG[1] f
+//   spilled:
+//     v0 (value) -> mem 0xa0
+//     v19 (phi) -> mem 0xc0
+//   mstore schedule:
+//     mstore addr(v0) <- v0 (B#0)
+//     mstore addr(v19) <- v19 (B#1)

--- a/test/libyul/ssa/stackShuffler/spill_deep_absent_arg_no_surplus.stack
+++ b/test/libyul/ssa/stackShuffler/spill_deep_absent_arg_no_surplus.stack
@@ -1,0 +1,36 @@
+// A spilled value (v0) is required at the very bottom of an 18-deep target, but every value on the
+// stack is still needed (no junk, no surplus) so the stack cannot be shrunk to expose the bottom slot.
+// The shuffler must surface a reachable value as too deep, spill it, and only then shrink and place v0.
+allowSpilling: true
+initialSpilledSet: {v0}
+initial: [v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17]
+targetStackTop: [v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17]
+// ----
+//             |      0      1      2      3      4      5      6      7      8      9     10     11     12     13     14     15     16     17
+//             +------------------------------------------------------------------------------------------------------------------------------
+//    (initial)|     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17
+//       SWAP16|    v17     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16     v1
+//       SWAP15|    v17     v1     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16     v2
+//       SWAP14|    v17     v1     v2     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16     v3
+//       SWAP13|    v17     v1     v2     v3     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16     v4
+//       SWAP12|    v17     v1     v2     v3     v4     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16     v5
+//       SWAP11|    v17     v1     v2     v3     v4     v5     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16     v6
+//       SWAP10|    v17     v1     v2     v3     v4     v5     v6     v8     v9    v10    v11    v12    v13    v14    v15    v16     v7
+//        SWAP9|    v17     v1     v2     v3     v4     v5     v6     v7     v9    v10    v11    v12    v13    v14    v15    v16     v8
+//        SWAP8|    v17     v1     v2     v3     v4     v5     v6     v7     v8    v10    v11    v12    v13    v14    v15    v16     v9
+//        SWAP7|    v17     v1     v2     v3     v4     v5     v6     v7     v8     v9    v11    v12    v13    v14    v15    v16    v10
+//        SWAP6|    v17     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v12    v13    v14    v15    v16    v11
+//        SWAP5|    v17     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v13    v14    v15    v16    v12
+//        SWAP4|    v17     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v14    v15    v16    v13
+//        SWAP3|    v17     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v15    v16    v14
+//        SWAP2|    v17     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v16    v15
+//        SWAP1|    v17     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16
+//          POP|    v17     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15
+//      PUSH v0|    v17     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15     v0
+//       SWAP16|     v0     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v17
+//     PUSH v16|     v0     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v17    v16
+//        SWAP1|     v0     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17
+//             +------------------------------------------------------------------------------------------------------------------------------
+//     (target)|     v0     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17
+// Status: Admissible
+// Spilled: {v0, v16}

--- a/test/libyul/ssa/stackShuffler/spilled_to_pop_deep_junk.stack
+++ b/test/libyul/ssa/stackShuffler/spilled_to_pop_deep_junk.stack
@@ -31,11 +31,15 @@ targetStackTop: [v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v1
 //       SWAP13|      *    v18    v19    v17     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16     v3
 //       SWAP14|      *    v18     v3    v17     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v19
 //       SWAP13|      *    v18     v3    v19     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17
-//      PUSH v1|      *    v18     v3    v19     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17     v1
-//          POP|      *    v18     v3    v19     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17
-//      PUSH v1|      *    v18     v3    v19     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17     v1
-//          POP|      *    v18     v3    v19     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17
-//          ...|
+//       SWAP16|    v17    v18     v3    v19     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16      *
+//          POP|    v17    v18     v3    v19     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16
+//      PUSH v1|    v17    v18     v3    v19     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16     v1
+//       SWAP16|     v1    v18     v3    v19     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17
+//      PUSH v2|     v1    v18     v3    v19     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17     v2
+//       SWAP16|     v1     v2     v3    v19     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18
+//      PUSH v4|     v1     v2     v3    v19     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18     v4
+//       SWAP15|     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19
+//     PUSH v20|     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19    v20
 //             +-------------------------------------------------------------------------------------------------------------------------------------------- +-------
 //     (target)|     v1     v2     v3     v4     v5     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15    v16    v17    v18    v19    v20 |
-// Status: MaxIterationsReached
+// Status: Admissible

--- a/test/tools/CMakeLists.txt
+++ b/test/tools/CMakeLists.txt
@@ -60,6 +60,8 @@ add_executable(isoltest
 	../libyul/ssa/ControlFlowGraphTest.h
 	../libyul/ssa/PrinterTest.cpp
 	../libyul/ssa/PrinterTest.h
+	../libyul/ssa/SpillTest.cpp
+	../libyul/ssa/SpillTest.h
 	../libyul/ssa/StackLayoutGeneratorTest.cpp
 	../libyul/ssa/StackLayoutGeneratorTest.h
 	../libyul/ssa/StackShufflerTest.cpp


### PR DESCRIPTION
Implements stack to memory spilling for the SSA CFG pipeline in a simple stupid version.

Adds:
- `ssa/spill/MemoryAddressing` is a per-subobject owner of spill memory
  - sums `numSpilled()` across each CFGs `SpillSet` and bumps memory guard accordingly, allocates non-overlapping memory addresses for spilled values
- `ssa/spill/Emitter` emits bytecode against the symbolic stack for spilled values
- `ssa/spill/SpillSet` got a new method `closeUnderReachabilityConstraints` which will check for all spilled values whether they can be feasibly spilled at the point of origin, may add more things to spill accordingly

Modifies
- `ssa/StackLayoutGenerator`s `generate()` to return `{layout, spillSet}` instead of just the layout and also validates back-edges asserting that back-edge targets can be safely shuffled to
- `ssa/CodeTransform` is reworked to first generate per-CFG layouts and spill sets (and close them under reachability constraints), then build a single global `MemoryAddressing` to hand into the `CodeTransform` instance

Test
- Adds `SpillTest` suite under `test/libyul/ssa/spill` which runs the `generate` -> `closeUnderReachabilityConstraints` -> `address` sequence and emits that plus a text representation of the input object. does not generate any code.