### PR TITLE
Remove EOF: Testing infrastructure

### DIFF
--- a/test/Common.cpp
+++ b/test/Common.cpp
@@ -111,8 +111,6 @@ void CommonOptions::addOptions()
 {
 	options.add_options()
 		("evm-version", po::value(&evmVersionString), "which EVM version to use")
-		// "eof-version" is declared as uint64_t, since uint8_t will be parsed as character by boost.
-		("eof-version", po::value<uint64_t>()->implicit_value(1u), "which EOF version to use")
 		("testpath", po::value<fs::path>(&this->testPath)->default_value(solidity::test::testPath()), "path to test files")
 		("vm", po::value<std::vector<fs::path>>(&vmPaths), "path to evmc library, can be supplied multiple times.")
 		("batches", po::value<size_t>(&this->batches)->default_value(1), "set number of batches to split the tests into")
@@ -161,12 +159,6 @@ void CommonOptions::validate() const
 			std::cout << "- ABI coder: v1 (default: v2)" << std::endl;
 		std::cout << std::endl << "DO NOT COMMIT THE UPDATED EXPECTATIONS." << std::endl << std::endl;
 	}
-
-	solRequire(
-		!eofVersion().has_value(),
-		ConfigException,
-		"EOF is not supported by EVM versions earlier than " + langutil::EVMVersion::future().name() + "."
-	);
 }
 
 bool CommonOptions::parse(int argc, char const* const* argv)
@@ -181,14 +173,6 @@ bool CommonOptions::parse(int argc, char const* const* argv)
 		auto parsedOptions = cmdLineParser.run();
 		po::store(parsedOptions, arguments);
 		po::notify(arguments);
-		if (arguments.count("eof-version"))
-		{
-			// Request as uint64_t, since uint8_t will be parsed as character by boost.
-			uint64_t eofVersion = arguments["eof-version"].as<uint64_t>();
-			if (eofVersion != 1)
-				BOOST_THROW_EXCEPTION(std::runtime_error("Invalid EOF version: " + std::to_string(eofVersion)));
-			m_eofVersion = 1;
-		}
 
 		for (auto const& parsedOption: parsedOptions.options)
 			if (parsedOption.position_key >= 0)

--- a/test/Common.h
+++ b/test/Common.h
@@ -70,7 +70,6 @@ struct CommonOptions
 	size_t selectedBatch = 0;
 
 	langutil::EVMVersion evmVersion() const;
-	std::optional<uint8_t> eofVersion() const { return m_eofVersion; }
 	yul::EVMDialect const& evmDialect() const;
 
 	virtual void addOptions();
@@ -98,7 +97,6 @@ protected:
 
 private:
 	std::string evmVersionString;
-	std::optional<uint8_t> m_eofVersion;
 	static std::unique_ptr<CommonOptions const> m_singleton;
 };
 

--- a/test/EVMHost.cpp
+++ b/test/EVMHost.cpp
@@ -71,7 +71,6 @@ evmc::VM& EVMHost::getVM(std::string const& _path)
 				std::cerr << ":" << std::endl << errorMsg;
 			std::cerr << std::endl;
 		}
-		vms[_path]->set_option("validate_eof", "1");
 	}
 
 	if (vms.count(_path) > 0)
@@ -315,6 +314,8 @@ evmc::Result EVMHost::call(evmc_message const& _message) noexcept
 		}
 	}
 
+	solAssert(message.kind != EVMC_EOFCREATE);
+
 	if (message.kind == EVMC_CREATE)
 	{
 		// TODO is the nonce incremented on failure, too?
@@ -350,17 +351,13 @@ evmc::Result EVMHost::call(evmc_message const& _message) noexcept
 
 		code = evmc::bytes(message.input_data, message.input_data + message.input_size);
 	}
-	else if (message.kind == EVMC_CREATE2 || message.kind == EVMC_EOFCREATE)
+	else if (message.kind == EVMC_CREATE2)
 	{
 		h160 createAddress(keccak256(
 			bytes{0xff} +
 			bytes(std::begin(message.sender.bytes), std::end(message.sender.bytes)) +
 			bytes(std::begin(message.create2_salt.bytes), std::end(message.create2_salt.bytes)) +
-			keccak256(
-				message.kind == EVMC_CREATE2 ?
-				bytes(message.input_data, message.input_data + message.input_size) :
-				bytes(message.code, message.code + message.code_size)
-			).asBytes()
+			keccak256(bytes(message.input_data, message.input_data + message.input_size)).asBytes()
 		), h160::AlignRight);
 
 		message.recipient = convertToEVMC(createAddress);
@@ -375,16 +372,14 @@ evmc::Result EVMHost::call(evmc_message const& _message) noexcept
 			return result;
 		}
 
-		if (message.kind == EVMC_CREATE2)
-			code = evmc::bytes(message.input_data, message.input_data + message.input_size);
-		else // EOFCREATE
-			code = evmc::bytes(message.code, message.code + message.code_size);
+
+		code = evmc::bytes(message.input_data, message.input_data + message.input_size);
 	}
 	else
 		code = accounts[message.code_address].code;
 
 	auto& destination = accounts[message.recipient];
-	if (message.kind == EVMC_CREATE || message.kind == EVMC_CREATE2 || message.kind == EVMC_EOFCREATE)
+	if (message.kind == EVMC_CREATE || message.kind == EVMC_CREATE2)
 		// Mark account as created if it is a CREATE or CREATE2 call
 		// TODO: Should we roll changes back on failure like we do for `accounts`?
 		m_newlyCreatedAccounts.emplace(message.recipient);
@@ -421,7 +416,7 @@ evmc::Result EVMHost::call(evmc_message const& _message) noexcept
 	}
 	evmc::Result result = m_vm.execute(*this, m_evmRevision, message, code.data(), code.size());
 
-	if (message.kind == EVMC_CREATE || message.kind == EVMC_CREATE2 || message.kind == EVMC_EOFCREATE)
+	if (message.kind == EVMC_CREATE || message.kind == EVMC_CREATE2)
 	{
 		int64_t codeDepositGas = static_cast<int64_t>(evmasm::GasCosts::createDataGas * result.output_size);
 		result.gas_left -= codeDepositGas;
@@ -434,7 +429,6 @@ evmc::Result EVMHost::call(evmc_message const& _message) noexcept
 		}
 		else
 		{
-			// TODO: Add proper codehash calculation for EOF.
 			m_totalCodeDepositGas += codeDepositGas;
 			result.create_address = message.recipient;
 			destination.code = evmc::bytes(result.output_data, result.output_data + result.output_size);
@@ -1387,7 +1381,8 @@ void EVMHostPrinter::callRecords()
 			case evmc_call_kind::EVMC_CREATE2:
 				return "CREATE2";
 			case evmc_call_kind::EVMC_EOFCREATE:
-				return "EOFCREATE";
+				solAssert(false); // EOF is not supported.
+				return "";
 		}
 		unreachable();
 	};

--- a/test/ExecutionFramework.cpp
+++ b/test/ExecutionFramework.cpp
@@ -147,7 +147,6 @@ u256 ExecutionFramework::blockNumber() const
 
 void ExecutionFramework::sendMessage(bytes const& _bytecode, bytes const& _arguments, bool _isCreation, u256 const& _value)
 {
-	auto const eof = _bytecode.size() > 1 && _bytecode[0] == 0xef && _bytecode[1] == 0x00;
 	m_evmcHost->newBlock();
 
 	auto const data = _bytecode + _arguments;
@@ -163,19 +162,14 @@ void ExecutionFramework::sendMessage(bytes const& _bytecode, bytes const& _argum
 		std::cout << " in:      " << util::toHex(data) << std::endl;
 	}
 	evmc_message message{};
-	message.input_data = eof ? _arguments.data() : data.data();
-	message.input_size = eof ? _arguments.size() : data.size();
-	if (eof)
-	{
-		message.code = _bytecode.data();
-		message.code_size = _bytecode.size();
-	}
+	message.input_data = data.data();
+	message.input_size = data.size();
 	message.sender = EVMHost::convertToEVMC(m_sender);
 	message.value = EVMHost::convertToEVMC(_value);
 
 	if (_isCreation)
 	{
-		message.kind = eof ? EVMC_EOFCREATE : EVMC_CREATE;
+		message.kind = EVMC_CREATE;
 		message.recipient = {};
 		message.code_address = {};
 	}

--- a/test/TestCase.cpp
+++ b/test/TestCase.cpp
@@ -146,20 +146,11 @@ void EVMVersionRestrictedTestCase::processEVMVersionSetting()
 
 void EVMVersionRestrictedTestCase::processBytecodeFormatSetting()
 {
-	std::optional<uint8_t> eofVersion = solidity::test::CommonOptions::get().eofVersion();
-	// EOF only available since Osaka
-	solAssert(!eofVersion.has_value());
-
-	std::string bytecodeFormatString = m_reader.stringSetting("bytecodeFormat", "legacy,>=EOFv1");
-	if (bytecodeFormatString == "legacy,>=EOFv1" || bytecodeFormatString == ">=EOFv1,legacy")
+	std::string bytecodeFormatString = m_reader.stringSetting("bytecodeFormat", "legacy");
+	if (bytecodeFormatString == "legacy")
 		return;
 
-	// TODO: This is naive implementation because for now we support only one EOF version.
-	if (bytecodeFormatString == "legacy" && eofVersion.has_value())
-		m_shouldRun = false;
-	else if (bytecodeFormatString == ">=EOFv1" && !eofVersion.has_value())
-		m_shouldRun = false;
-	else if (bytecodeFormatString != "legacy" && bytecodeFormatString != ">=EOFv1" )
+	if (bytecodeFormatString != "legacy")
 		BOOST_THROW_EXCEPTION(std::runtime_error{"Invalid bytecodeFormat flag: \"" + bytecodeFormatString + "\""});
 }
 

--- a/test/TestCase.h
+++ b/test/TestCase.h
@@ -39,7 +39,6 @@ public:
 	{
 		std::string filename;
 		langutil::EVMVersion evmVersion;
-		std::optional<uint8_t> eofVersion;
 		std::vector<boost::filesystem::path> vmPaths;
 		bool enforceGasCost = false;
 		u256 enforceGasCostMinValue;

--- a/test/libsolidity/semanticTests/deployedCodeExclusion/bound_function.sol
+++ b/test/libsolidity/semanticTests/deployedCodeExclusion/bound_function.sol
@@ -1,4 +1,3 @@
-// TODO: Recreate this test for EOF when subassembly deduplication will be supported for EOF too.
 function longdata(S memory) pure returns (bytes memory) {
     return
         "xasopca.pngaibngidak.jbtnudak.cAP.BRRSMCPJAGPD KIAJDOMHUKR,SCPID"

--- a/test/libsolidity/semanticTests/deployedCodeExclusion/library_function.sol
+++ b/test/libsolidity/semanticTests/deployedCodeExclusion/library_function.sol
@@ -1,4 +1,3 @@
-// TODO: Recreate this test for EOF when subassembly deduplication will be supported for EOF too.
 library L {
     function longdata() pure internal returns (bytes memory) {
         return

--- a/test/libsolidity/semanticTests/deployedCodeExclusion/module_function.sol
+++ b/test/libsolidity/semanticTests/deployedCodeExclusion/module_function.sol
@@ -1,4 +1,3 @@
-// TODO: Recreate this test for EOF when subassembly deduplication will be supported for EOF too.
 ==== Source: mod.sol ====
 function longdata() pure returns (bytes memory) {
     return

--- a/test/libsolidity/semanticTests/deployedCodeExclusion/static_base_function.sol
+++ b/test/libsolidity/semanticTests/deployedCodeExclusion/static_base_function.sol
@@ -1,4 +1,3 @@
-// TODO: Recreate this test for EOF when subassembly deduplication will be supported for EOF too.
 abstract contract S {
     function longdata() internal pure returns (bytes memory) {
         return

--- a/test/libsolidity/semanticTests/deployedCodeExclusion/subassembly_deduplication.sol
+++ b/test/libsolidity/semanticTests/deployedCodeExclusion/subassembly_deduplication.sol
@@ -1,4 +1,3 @@
-// TODO: Recreate this test for EOF when subassembly deduplication will be supported for EOF too.
 contract A {
     function longdata() pure external returns (bytes memory) {
         return

--- a/test/libsolidity/semanticTests/deployedCodeExclusion/super_function.sol
+++ b/test/libsolidity/semanticTests/deployedCodeExclusion/super_function.sol
@@ -1,4 +1,3 @@
-// TODO: Recreate this test for EOF when subassembly deduplication will be supported for EOF too.
 abstract contract S {
     function longdata() internal pure returns (bytes memory) {
         return

--- a/test/libsolidity/semanticTests/deployedCodeExclusion/virtual_function.sol
+++ b/test/libsolidity/semanticTests/deployedCodeExclusion/virtual_function.sol
@@ -1,4 +1,3 @@
-// TODO: Recreate this test for EOF when subassembly deduplication will be supported for EOF too.
 abstract contract S {
     function longdata() internal virtual pure returns (bytes memory);
 }

--- a/test/libsolidity/semanticTests/events/event_emit_from_other_contract.sol
+++ b/test/libsolidity/semanticTests/events/event_emit_from_other_contract.sol
@@ -1,5 +1,3 @@
-// TODO: Implement this test for EOF. Now it's not possible because deployed contract address depends on contract bytecode.
-// This means that the address changes when optimisations are applied.
 contract D {
     event Deposit(address indexed _from, bytes32 indexed _id, uint _value);
     function deposit(bytes32 _id) public payable {

--- a/test/libsolidity/syntaxTests/immutable/no_assignments.sol
+++ b/test/libsolidity/syntaxTests/immutable/no_assignments.sol
@@ -1,4 +1,3 @@
-// TODO: This test case should work the same way for EOF but EOF immutables support is not in its final state yet.
 contract C {
     uint immutable x;
     constructor() {
@@ -12,4 +11,4 @@ contract C {
 // bytecodeFormat: legacy
 // optimize-yul: true
 // ----
-// CodeGenerationError 1284: (115-283): Some immutables were read from but never assigned, possibly because of optimization.
+// CodeGenerationError 1284: (0-168): Some immutables were read from but never assigned, possibly because of optimization.

--- a/test/libyul/objectCompiler/data.yul
+++ b/test/libyul/objectCompiler/data.yul
@@ -1,7 +1,6 @@
 object "a" {
   code {}
   // Unreferenced data is not added to the assembled bytecode.
-  // TODO: This is not implemented for EOF. Should work for legacy and EOF when implemented.
   data "str" "Hello, World!"
 }
 // ====

--- a/test/libyul/yulOptimizerTests/fullSuite/aztec.yul
+++ b/test/libyul/yulOptimizerTests/fullSuite/aztec.yul
@@ -1,4 +1,3 @@
-// TODO: Add EOF version of this contract and compare with legacy to see which optimizations are missed.
 /**
  * @title Library to validate AZTEC zero-knowledge proofs
  * @author Zachary Williamson, AZTEC

--- a/test/soltest.cpp
+++ b/test/soltest.cpp
@@ -135,7 +135,6 @@ int registerTests(
 	TestCase::Config config{
 		fullpath.string(),
 		solidity::test::CommonOptions::get().evmVersion(),
-		solidity::test::CommonOptions::get().eofVersion(),
 		solidity::test::CommonOptions::get().vmPaths,
 		solidity::test::CommonOptions::get().enforceGasTest,
 		solidity::test::CommonOptions::get().enforceGasTestMinValue,

--- a/test/tools/isoltest.cpp
+++ b/test/tools/isoltest.cpp
@@ -158,7 +158,6 @@ TestTool::Result TestTool::process()
 			m_test = m_testCaseCreator(TestCase::Config{
 				m_path.string(),
 				m_options.evmVersion(),
-				m_options.eofVersion(),
 				m_options.vmPaths,
 				m_options.enforceGasTest,
 				m_options.enforceGasTestMinValue


### PR DESCRIPTION
This PR removes EOF from testing infra. 

- [x] No AI tools were used
- [ ] AI tools were used (details below)

~Depends on: https://github.com/argotorg/solidity/pull/16772~
