### PR TITLE
Avoid shell mkdir in splitSources

### DIFF
--- a/scripts/splitSources.py
+++ b/scripts/splitSources.py
@@ -10,8 +10,8 @@
 # -  'false' if the file only had one source
 
 import sys
-import os
 import traceback
+from pathlib import Path
 
 
 def uncaught_exception_hook(exc_type, exc_value, exc_traceback):
@@ -38,7 +38,7 @@ def writeSourceToFile(lines):
     # print("sourceName is ", srcName)
     # print("filePath is", filePath)
     if filePath:
-        os.system("mkdir -p " + filePath)
+        Path(filePath).mkdir(parents=True, exist_ok=True)
     with open(srcName, mode='a+', encoding='utf8', newline='') as f:
         for idx, line in enumerate(lines[1:]):
             # write to file


### PR DESCRIPTION
## Summary

Replace the shell-based directory creation in `scripts/splitSources.py` with `Path.mkdir(parents=True, exist_ok=True)`.

This keeps the existing behavior for multi-source soltest cases while avoiding shell interpretation of source paths.

Closes #16771.

## Testing

- `PYTHONPATH=scripts python3 test/scripts/test_split_sources.py`
- `python3 -m py_compile scripts/splitSources.py test/scripts/test_split_sources.py`
- ran `splitSources.py` against `test/libsolidity/syntaxTests/imports/relative_import.sol` in a temporary directory and confirmed nested source files are still created
- `git diff --check`
