### PR TITLE
Validate uppercase exponent underscore placement

### DIFF
--- a/libsolidity/analysis/SyntaxChecker.cpp
+++ b/libsolidity/analysis/SyntaxChecker.cpp
@@ -339,10 +339,10 @@ bool SyntaxChecker::visit(Literal const& _literal)
 		if (value.find("_.") != ASTString::npos)
 			m_errorReporter.syntaxError(1023_error, _literal.location(), "Invalid use of underscores in number literal. No underscores in front of the fraction part allowed.");
 
-		if (value.find("_e") != ASTString::npos)
+		if (value.find("_e") != ASTString::npos || value.find("_E") != ASTString::npos)
 			m_errorReporter.syntaxError(6415_error, _literal.location(), "Invalid use of underscores in number literal. No underscore at the end of the mantissa allowed.");
 
-		if (value.find("e_") != ASTString::npos)
+		if (value.find("e_") != ASTString::npos || value.find("E_") != ASTString::npos)
 			m_errorReporter.syntaxError(6165_error, _literal.location(), "Invalid use of underscores in number literal. No underscore in front of exponent allowed.");
 	}
 

--- a/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_decimal_fail.sol
+++ b/test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_decimal_fail.sol
@@ -4,6 +4,8 @@ contract C {
     uint D2 = 12__34;
     uint D3 = 12_e34;
     uint D4 = 12e_34;
+    uint D5 = 12_E34;
+    uint D6 = 12E_34;
   }
 }
 // ----
@@ -11,3 +13,5 @@ contract C {
 // SyntaxError 2990: (77-83): Invalid use of underscores in number literal. Only one consecutive underscore between digits is allowed.
 // SyntaxError 6415: (99-105): Invalid use of underscores in number literal. No underscore at the end of the mantissa allowed.
 // SyntaxError 6165: (121-127): Invalid use of underscores in number literal. No underscore in front of exponent allowed.
+// SyntaxError 6415: (143-149): Invalid use of underscores in number literal. No underscore at the end of the mantissa allowed.
+// SyntaxError 6165: (165-171): Invalid use of underscores in number literal. No underscore in front of exponent allowed.


### PR DESCRIPTION
Summary
- reject decimal literals with underscores adjacent to uppercase `E` exponent markers
- extend the existing decimal underscore syntax test with `12_E34` and `12E_34`

Why
The scanner accepts both `e` and `E` exponent markers, but the post-lex underscore checks only searched for `_e` and `e_`. This let malformed uppercase forms bypass the same validation applied to lowercase forms.

Testing
- `python3` offset check for the updated syntax test expectations
- `scripts/error_codes.py --check`
- `scripts/check_style.sh libsolidity/analysis/SyntaxChecker.cpp test/libsolidity/syntaxTests/parsing/lexer_numbers_with_underscores_decimal_fail.sol`
- `git diff --check`

Closes #16740.
