### PR TITLE
Respect EVM version when importing assembly JSON

### DIFF
--- a/libevmasm/Assembly.cpp
+++ b/libevmasm/Assembly.cpp
@@ -589,7 +589,8 @@ std::pair<std::shared_ptr<Assembly>, std::vector<std::string>> Assembly::fromJSO
 	Json const& _json,
 	std::vector<std::string> const& _sourceList,
 	size_t _level,
-	std::optional<uint8_t> _eofVersion
+	std::optional<uint8_t> _eofVersion,
+	EVMVersion _evmVersion
 )
 {
 	solRequire(_json.is_object(), AssemblyImportException, "Supplied JSON is not an object.");
@@ -620,7 +621,7 @@ std::pair<std::shared_ptr<Assembly>, std::vector<std::string>> Assembly::fromJSO
 			"Member 'sourceList' may only be present in the root JSON object."
 		);
 
-	auto result = std::make_shared<Assembly>(EVMVersion{}, _level == 0 /* _creation */, _eofVersion, "" /* _name */);
+	auto result = std::make_shared<Assembly>(_evmVersion, _level == 0 /* _creation */, _eofVersion, "" /* _name */);
 	std::vector<std::string> parsedSourceList;
 	if (_json.contains("sourceList"))
 	{
@@ -687,7 +688,13 @@ std::pair<std::shared_ptr<Assembly>, std::vector<std::string>> Assembly::fromJSO
 					solThrow(AssemblyImportException, "The key '" + key + "' inside '.data' is out of the supported integer range.");
 				}
 
-				auto [subAssembly, emptySourceList] = Assembly::fromJSON(value, _level == 0 ? parsedSourceList : _sourceList, _level + 1, _eofVersion);
+				auto [subAssembly, emptySourceList] = Assembly::fromJSON(
+					value,
+					_level == 0 ? parsedSourceList : _sourceList,
+					_level + 1,
+					_eofVersion,
+					_evmVersion
+				);
 				solAssert(subAssembly);
 				solAssert(emptySourceList.empty());
 				solAssert(subAssemblies.count(index) == 0);

--- a/libevmasm/Assembly.h
+++ b/libevmasm/Assembly.h
@@ -211,7 +211,8 @@ public:
 		Json const& _json,
 		std::vector<std::string> const& _sourceList = {},
 		size_t _level = 0,
-		std::optional<uint8_t> _eofVersion = std::nullopt
+		std::optional<uint8_t> _eofVersion = std::nullopt,
+		langutil::EVMVersion _evmVersion = {}
 	);
 
 	/// Mark this assembly as invalid. Calling ``assemble`` on it will throw.

--- a/libevmasm/EVMAssemblyStack.cpp
+++ b/libevmasm/EVMAssemblyStack.cpp
@@ -45,7 +45,7 @@ void EVMAssemblyStack::analyze(std::string const& _sourceName, Json const& _asse
 {
 	solAssert(!m_evmAssembly);
 	m_name = _sourceName;
-	std::tie(m_evmAssembly, m_sourceList) = evmasm::Assembly::fromJSON(_assemblyJson, {}, 0, m_eofVersion);
+	std::tie(m_evmAssembly, m_sourceList) = evmasm::Assembly::fromJSON(_assemblyJson, {}, 0, m_eofVersion, m_evmVersion);
 	solRequire(m_evmAssembly != nullptr, AssemblyImportException, "Could not create evm assembly object.");
 }
 

--- a/test/libevmasm/evmAssemblyTests/isoltestTesting/evm_version_push0_paris.asmjson
+++ b/test/libevmasm/evmAssemblyTests/isoltestTesting/evm_version_push0_paris.asmjson
@@ -1,0 +1,11 @@
+{
+    ".code": [
+        {"name": "PUSH", "value": "0"}
+    ]
+}
+// ====
+// EVMVersion: =paris
+// outputs: Bytecode,Opcodes
+// ----
+// Bytecode: 6000
+// Opcodes: PUSH1 0x0

--- a/test/libevmasm/evmAssemblyTests/isoltestTesting/evm_version_push0_shanghai.asmjson
+++ b/test/libevmasm/evmAssemblyTests/isoltestTesting/evm_version_push0_shanghai.asmjson
@@ -1,0 +1,11 @@
+{
+    ".code": [
+        {"name": "PUSH", "value": "0"}
+    ]
+}
+// ====
+// EVMVersion: =shanghai
+// outputs: Bytecode,Opcodes
+// ----
+// Bytecode: 5f
+// Opcodes: PUSH0


### PR DESCRIPTION
## Description

`EVMAssemblyStack` already stores the `evmVersion` parsed from Standard JSON settings, but the imported assembly JSON path dropped it when constructing `Assembly` objects. `Assembly::fromJSON()` therefore used the default `EVMVersion{}` for both root assemblies and subassemblies.

This PR plumbs the selected EVM version through `Assembly::fromJSON()` and uses it when constructing imported assemblies. This keeps imported EVM assembly output consistent with the requested target EVM version.

Regression coverage:

- `EVMVersion: =paris` keeps `PUSH 0` encoded as `PUSH1 0x0` / `6000`.
- `EVMVersion: =shanghai` still encodes `PUSH 0` as `PUSH0` / `5f`.

Closes #16759.

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## Testing

- `scripts/check_style.sh libevmasm/Assembly.h libevmasm/Assembly.cpp libevmasm/EVMAssemblyStack.cpp test/libevmasm/evmAssemblyTests/isoltestTesting/evm_version_push0_paris.asmjson test/libevmasm/evmAssemblyTests/isoltestTesting/evm_version_push0_shanghai.asmjson`
- `git diff --check`

I could not run `isoltest` locally because this checkout had no configured build directory, and `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` stopped at missing Boost 1.83.0.

## AI Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (details below)

AI assistance was used while preparing this contribution. I reviewed the resulting diff and ran the local checks listed above.
