### PR TITLE
Fix null pointer dereference in LSP hover handler for undocumented IdentifierPath declarations

### DIFF
--- a/libsolidity/lsp/DocumentHoverHandler.cpp
+++ b/libsolidity/lsp/DocumentHoverHandler.cpp
@@ -94,7 +94,7 @@ void DocumentHoverHandler::operator()(MessageID _id, Json const& _args)
 					if (declaration && declaration->type())
 						markdown.solidityCode(declaration->type()->toString(false));
 					if (auto const* structurallyDocumented = dynamic_cast<StructurallyDocumented const*>(declaration))
-						if (structurallyDocumented->documentation()->text())
+						if (structurallyDocumented->documentation() && structurallyDocumented->documentation()->text())
 							markdown.paragraph(*structurallyDocumented->documentation()->text());
 				}
 				break;


### PR DESCRIPTION
## Description

Fixes #16766

The `IdentifierPath` branch in `DocumentHoverHandler` calls `structurallyDocumented->documentation()->text()` without first checking whether `documentation()` returns `nullptr`. When a declaration referenced through an `IdentifierPath` (e.g., inheritance specifier, modifier invocation, override specifier, using directive) has no NatSpec documentation, this causes a segfault (exit code 139).

## Changes

- **`libsolidity/lsp/DocumentHoverHandler.cpp`**: Added a null check on `documentation()` before accessing `text()`, matching the pattern already used for the `sourceNode` branch on line 108 of the same file.

## Root cause

The `StructurallyDocumented::documentation()` method explicitly documents that it *"Can contain a nullptr in which case indicates absence of documentation"* (see `libsolidity/ast/AST.h:497`). The sibling branch (lines 108-109) correctly guards against this, but the `IdentifierPath` branch did not.

## Testing

The existing LSP hover tests at `test/libsolidity/lsp/hover/hover.sol` continue to pass. No new tests needed as the fix simply applies the same null-check pattern already present in the same function.

## Risk

Minimal. This is a one-line addition that mirrors existing code in the same function.