### PR TITLE
Fix unnecessary tuple conversion function generation.

### DIFF
--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -2763,7 +2763,22 @@ std::string TupleType::richIdentifier() const
 bool TupleType::operator==(Type const& _other) const
 {
 	if (auto tupleType = dynamic_cast<TupleType const*>(&_other))
-		return components() == tupleType->components();
+	{
+		if (components().size() != tupleType->components().size())
+			return false;
+
+		for (size_t i = 0; i < components().size(); ++i)
+			// Components can be null. I.e., when (int t, , ) = (i, 0, 0);
+			if (components()[i] && tupleType->components()[i])
+			{
+				if (*components()[i] != *tupleType->components()[i])
+					return false;
+			}
+			else if (components()[i] != tupleType->components()[i])
+				return false;
+
+		return true;
+	}
 	else
 		return false;
 }

--- a/test/cmdlineTests/~no_conversion_of_equal_tuple_types/inputs.sol
+++ b/test/cmdlineTests/~no_conversion_of_equal_tuple_types/inputs.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >= 0.0.0;
+
+contract C {
+    function f(uint[] calldata a) public pure returns(uint[] memory, uint[] calldata) {
+        uint[] memory ops1;
+        uint[] memory ops2;
+        return true ? (ops1, a) : (ops2, a);
+    }
+}

--- a/test/cmdlineTests/~no_conversion_of_equal_tuple_types/test.sh
+++ b/test/cmdlineTests/~no_conversion_of_equal_tuple_types/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# This is a regression test verifying that the compiler does not generate a tuple conversion
+# function when both sides of a ternary operator have tuple operands of identical types.
+# See https://github.com/argotorg/solidity/issues/16066
+
+# shellcheck source=scripts/common.sh
+source "${REPO_ROOT}/scripts/common.sh"
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+output=$("$SOLC" "${SCRIPT_DIR}/inputs.sol" --ir)
+
+[[ ! "$output" =~ "function convert_t_tuple" ]] ||
+    fail "Generated IR should not contain a tuple conversion function."


### PR DESCRIPTION
## Description

Fixes unnecessary conversion function generation of tuples of exactly the same types. Separated from [the PR](https://github.com/argotorg/solidity/pull/16415) as unrelated change. 

## AI Disclosure
- [x] No AI tools were used
- [ ] AI tools were used (details below)
