### PR TITLE
SSA-CFG: Propagate information about deduplication of literals

### DIFF
--- a/libyul/backends/evm/ssa/InstructionStore.h
+++ b/libyul/backends/evm/ssa/InstructionStore.h
@@ -192,11 +192,13 @@ public:
 
 	/// Allocates a new Const Inst with payload `_value`, pinned to `_entryBlock`.
 	/// Literals are deduplicated by value (see class comment).
-	InstId appendLiteral(BlockId const _entryBlock, u256 _value)
+	/// Returns id of the corresponding Const instruction and a bool indicating
+	/// whether new instruction has been appended (`true`) or existing instruction reused (`false`).
+	std::pair<InstId, bool> appendLiteral(BlockId const _entryBlock, u256 _value)
 	{
 		yulAssert(_entryBlock.hasValue());
 		if (auto const it = m_literalDedup.find(_value); it != m_literalDedup.end())
-			return it->second;
+			return {it->second, false};
 		InstId const id = appendInst(Inst{
 			InstOpcode::Const,
 			_entryBlock,
@@ -204,7 +206,7 @@ public:
 			std::make_unique<Payload>(LiteralPayload{_value})
 		});
 		m_literalDedup.emplace(std::move(_value), id);
-		return id;
+		return {id, true};
 	}
 
 	/// Allocates a new single-output BuiltinCall Inst. Returns the new InstId.

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -260,10 +260,9 @@ public:
 	/// Literal InstIds are deduplicated. Const Insts are pinned to the entry block.
 	InstId newLiteral(langutil::DebugData::ConstPtr _debugData, u256 _value)
 	{
-		auto const previousNumInsts = m_instructions.numInsts();
-		InstId const id = m_instructions.appendLiteral(entry, std::move(_value));
+		auto const [id, newlyAllocated] = m_instructions.appendLiteral(entry, std::move(_value));
 		// Newly allocated (not deduplicated): schedule in entry and attach debug data.
-		if (m_instructions.numInsts() > previousNumInsts)
+		if (newlyAllocated)
 		{
 			scheduleInBlock(id, entry);
 			if (debugInfo)

--- a/test/libyul/ssa/StackShufflerTest.cpp
+++ b/test/libyul/ssa/StackShufflerTest.cpp
@@ -119,7 +119,7 @@ Slot parseSlot(ParsedIdentifierTable& _table, std::string_view _token)
 		if (_token.starts_with("lit"))
 		{
 			if (auto const num = solidity::util::parseArithmetic<InstId::ValueType>(_token.substr(3)))
-				return _table.store.appendLiteral({0}, u256(*num));
+				return _table.store.appendLiteral({0}, u256(*num)).first;
 			throw std::runtime_error(fmt::format("Couldn't parse literal token: {}", _token));
 		}
 		if (_token.starts_with("v"))


### PR DESCRIPTION
When CFG is requested to return a Const instruction for a literal, we need to know whether the literal was deduplicated, or if a new instruction has been allocated. In the latter case, we need to insert the instruction into the entry block.
Previously, this was relying on checking the number of instructions in the instruction store, but this would give incorrect information in case a new instruction was allocated, but it took place of some tombstoned instruction.