### PR TITLE
Add forgotten changelog entry about the constant operand fix in SMTChecker

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ Compiler Features:
 
 Bugfixes:
 * NatSpec: Disallow `@return` tag in event documentation.
+* SMTChecker: Fix incorrect handling of constant operands of unary operations.
 
 
 ### 0.8.35 (2026-04-29)


### PR DESCRIPTION
PR https://github.com/argotorg/solidity/pull/16654 (commit 49e295d3169eb90b82eae74af127190cd5ff96db) fixed a bug in SMTChecker, but a changelog entry was not added. This is the missing changelog entry for that fix.