### PR TITLE
fix: Improve Google search results and SEO for documentation

### DIFF
--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,0 +1,16 @@
+{% extends "!page.html" %}
+
+{% block extrahead %}
+    {{ super() }}
+    {% if meta and meta.description %}
+        <meta name="description" content="{{ meta.description | truncate(160) }}">
+    {% else %}
+        <meta name="description" content="Solidity is a contract-oriented programming language for writing smart contracts that run on the Ethereum Virtual Machine. Learn Solidity syntax, features, and best practices.">
+    {% endif %}
+    <meta property="og:title" content="{{ title }}">
+    <meta property="og:description" content="{% if meta and meta.description %}{{ meta.description | truncate(160) }}{% else %}Solidity Documentation{% endif %}">
+    <meta property="og:type" content="website">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="{{ title }}">
+    <meta name="twitter:description" content="{% if meta and meta.description %}{{ meta.description | truncate(160) }}{% else %}Solidity Documentation{% endif %}">
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -225,7 +225,7 @@ html_js_files = ["js/constants.js", "js/initialize.js", "js/toggle.js"]
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-html_extra_path = ["_static/css"]
+html_extra_path = ["_static/css", "_build/robots.txt"]
 
 # List of templates of static files to be included in the HTML output.
 # Keys represent paths to input files and values are dicts containing:
@@ -235,7 +235,7 @@ html_extra_path = ["_static/css"]
 # Rendered templates are automatically added to html_extra_path setting.
 html_extra_templates = {
     os.path.join(ROOT_PATH, "robots.txt.template"): {
-        'target': os.path.join(ROOT_PATH, "_static/robots.txt"),
+        'target': os.path.join(ROOT_PATH, "_build/robots.txt"),
         'context': {'LATEST_VERSION': version},
     }
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -226,7 +226,10 @@ html_js_files = ["js/constants.js", "js/initialize.js", "js/toggle.js"]
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
 # Change from pointing to the file, to pointing to the target build directory
-html_extra_path = ["_static/css", "_build"] 
+html_extra_path = [
+    "_static/css",
+    "_build",
+]
 
 # List of templates of static files to be included in the HTML output.
 # Keys represent paths to input files and values are dicts containing:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -225,7 +225,8 @@ html_js_files = ["js/constants.js", "js/initialize.js", "js/toggle.js"]
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-html_extra_path = ["_static/css", "_build/robots.txt"]
+# Change from pointing to the file, to pointing to the target build directory
+html_extra_path = ["_static/css", "_build"] 
 
 # List of templates of static files to be included in the HTML output.
 # Keys represent paths to input files and values are dicts containing:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -228,7 +228,6 @@ html_js_files = ["js/constants.js", "js/initialize.js", "js/toggle.js"]
 # Change from pointing to the file, to pointing to the target build directory
 html_extra_path = [
     "_static/css",
-    "_build",
 ]
 
 # List of templates of static files to be included in the HTML output.
@@ -239,7 +238,7 @@ html_extra_path = [
 # Rendered templates are automatically added to html_extra_path setting.
 html_extra_templates = {
     os.path.join(ROOT_PATH, "robots.txt.template"): {
-        'target': os.path.join(ROOT_PATH, "_build/robots.txt"),
+        'target': os.path.join(ROOT_PATH, "_static/robots.txt"),
         'context': {'LATEST_VERSION': version},
     }
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -225,7 +225,6 @@ html_js_files = ["js/constants.js", "js/initialize.js", "js/toggle.js"]
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-# Change from pointing to the file, to pointing to the target build directory
 html_extra_path = [
     "_static/css",
 ]

--- a/docs/robots.txt.template
+++ b/docs/robots.txt.template
@@ -1,5 +1,5 @@
 User-Agent: *
-Sitemap: http://docs.soliditylang.org/sitemap.xml
+Sitemap: https://docs.soliditylang.org/sitemap.xml
 Host: docs.soliditylang.org
 
 Allow: /en/latest/


### PR DESCRIPTION
Resolves #13267

- Fix robots.txt serving location to be at domain root
- Add meta description tags to all pages for search snippets
- Update sitemap reference to use HTTPS
- Improves search result visibility and snippet display



## Checklist
-  I have read the contributing guidelines
-  I have personally reviewed, understood, and tested every change in this PR

