### PR TITLE
docs: clarify team call time in UTC

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -30,7 +30,7 @@ Team Calls
 If you have issues or pull requests to discuss, or are interested in hearing what
 the team and contributors are working on, you can join our public team call:
 
-- Wednesdays at 3PM CET/CEST.
+- Wednesdays at 3PM Central European time (14:00 UTC during CET or 13:00 UTC during CEST).
 
 The call takes place on `Jitsi <https://meet.solidity.org>`_.
 


### PR DESCRIPTION
<!--
Thank you for your contribution to the Solidity compiler! A team member will follow up shortly.

If you have any questions or need our help, feel free to post them in the PR or talk to us directly on the
[#solidity-dev](https://matrix.to/#/#ethereum_solidity-dev:gitter.im) channel on Matrix.
-->

## Description

Clarifies the Solidity team call time in the contributing guide by adding the corresponding UTC times for CET and CEST.

This makes the meeting time easier to understand for contributors outside Central Europe without adding any JavaScript or changing the docs build.

Helps #16234.



## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
<!--
See our contributing guidelines for the full AI usage policy:
https://docs.soliditylang.org/en/latest/contributing.html#ai-assisted-contributions

If you used AI tools in any part of this PR you MUST disclose it below.
-->

- [ ] No AI tools were used
- [ ] AI tools were used (details below)

<!-- If AI tools were used, describe which tools and for which parts here. -->
