### PR TITLE
Removing unused members from ExpressionInliner

### DIFF
--- a/libyul/optimiser/ExpressionInliner.h
+++ b/libyul/optimiser/ExpressionInliner.h
@@ -66,10 +66,6 @@ private:
 
 	Dialect const& m_dialect;
 	std::map<YulName, FunctionDefinition const*> const& m_inlinableFunctions;
-
-	std::map<YulName, YulName> m_varReplacements;
-	/// Set of functions we are currently visiting inside.
-	std::set<YulName> m_currentFunctions;
 };
 
 }


### PR DESCRIPTION
This is the most minimal PR I can dream up. Removes unused members, no fluff, no noise.