### PR TITLE
SSA-CFG: Modify shuffler to prevent shuffling cycle

### DIFF
--- a/libyul/backends/evm/ssa/StackShuffler.cpp
+++ b/libyul/backends/evm/ssa/StackShuffler.cpp
@@ -188,6 +188,23 @@ bool State::isSafeToSwapWithTop(StackOffset const _offset) const
 		);
 }
 
+std::optional<StackOffset> State::canSwapWithNonTopArg(StackOffset const _offset) const
+{
+	auto const& slot = m_stackData[_offset.value];
+	for (auto argOffset: stackArgsRange())
+	{
+		if (argOffset.value == m_stackData.size() - 1)
+			continue;
+		auto const& argSlot = m_stackData[argOffset.value];
+		if (slot == argSlot)
+			continue;
+		bool const goodCandidateForSwap = !isArgsCompatible(argOffset, argOffset) && !requiredInArgs(argSlot);
+		if (goodCandidateForSwap)
+			return argOffset;
+	}
+	return std::nullopt;
+}
+
 Target const& State::target() const
 {
 	return m_target;

--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -432,6 +432,24 @@ private:
 			bool const haveMoreAbove = *depth < _stack.offsetToDepth(sourceOffset);
 			if (haveMoreAbove)
 				continue;
+			if (!needMore)
+			{
+				yulAssert(neededInArgs);
+				// We need more in args, but we have enough overall, try to swap it into args region, instead of dupping
+				if (_stack.isValidSwapTarget(sourceOffset))
+				{
+					if (_state.isSafeToSwapWithTop(sourceOffset))
+					{
+						_stack.swap(sourceOffset);
+						return {ShuffleHelperResult::Status::StackModified};
+					}
+					if (auto argOffset = _state.canSwapWithNonTopArg(sourceOffset))
+					{
+						detail::exchange(_stack, argOffset.value(), sourceOffset);
+						return {ShuffleHelperResult::Status::StackModified};
+					}
+				}
+			}
 
 			if (_stack.dupReachable(sourceOffset))
 			{

--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -49,6 +49,17 @@ inline bool slotCanBeLoadedOrPushed(StackSlot const& _slot, spill::SpillSet cons
 	return Stack<>::canBeFreelyGenerated(_slot) || slotIsSpilled(_slot, _spilledVariables);
 }
 
+template<typename Callback>
+void exchange(Stack<Callback>& _stack, StackOffset _off1, StackOffset _off2)
+{
+	yulAssert(_stack.isValidSwapTarget(_off1) && _stack.isValidSwapTarget(_off2));
+	auto const topOffset = _stack.depthToOffset(StackDepth{0});
+	yulAssert(_off1 != topOffset && _off2 != topOffset && _off1 != _off2);
+	_stack.swap(_off1);
+	_stack.swap(_off2);
+	_stack.swap(_off1);
+}
+
 /// Contains information about the shuffling target, aggregates over args and live out to
 /// provide a lower bound for the slot distribution.
 struct Target

--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -122,6 +122,8 @@ public:
 	bool isSourceCompatible(StackOffset _sourceOffset1, StackOffset _sourceOffset2) const;
 	/// Checks if swapping the current offset with top makes progress toward target
 	bool isSafeToSwapWithTop(StackOffset _offset) const;
+	/// Checks if swapping the current offset with non-top argument makes progress toward target. Returns the argument or nullopt.
+	std::optional<StackOffset> canSwapWithNonTopArg(StackOffset _offset) const;
 	/// Shuffling target information
 	Target const& target() const;
 

--- a/test/libyul/ssa/stackShuffler/reach_for_deep_argument.stack
+++ b/test/libyul/ssa/stackShuffler/reach_for_deep_argument.stack
@@ -1,0 +1,18 @@
+// We need to reach for a deep slot, because it is required in args. At the same time, we still need to push a literal
+// into args as well.
+initial: [v3, JUNK, v445, v444, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v442, v441, v3, v446]
+targetStackTop: [lit1, v446, v445]
+targetStackTailSet: {v3, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v441, v442, v444}
+targetStackSize: 19
+// ----
+//             |      0      1      2      3      4      5      6      7      8      9     10     11     12     13     14     15 |     16     17     18
+//             +---------------------------------------------------------------------------------------------------------------- +---------------------
+//    (initial)|     v3      *   v445   v444     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15   v442   v441 |     v3   v446
+//        SWAP1|     v3      *   v445   v444     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15   v442   v441 |   v446     v3
+//       SWAP15|     v3      *     v3   v444     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15   v442   v441 |   v446   v445
+//        SWAP1|     v3      *     v3   v444     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15   v442   v441 |   v445   v446
+//    PUSH lit1|     v3      *     v3   v444     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15   v442   v441 |   v445   v446   lit1
+//        SWAP2|     v3      *     v3   v444     v6     v7     v8     v9    v10    v11    v12    v13    v14    v15   v442   v441 |   lit1   v446   v445
+//             +---------------------------------------------------------------------------------------------------------------- +---------------------
+//     (target)|                                            {v3, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v441, v442, v444} |   lit1   v446   v445
+// Status: Admissible


### PR DESCRIPTION
Previously, it was possible for the shuffler to loop because it would duplicate an element that is needed in args and not needed in tail.
If this would make the stack too large, the shrinking code would immediately remove the duplicated slot and these two steps would loop indefinitely.
If we need to bring something from tail to args, but we actually don't need it in the tail. We can try to swap it instead of dupping. For that we need to find something in args that does not need to be there. We can then swap these slots.

Fixes #16715.