### PR TITLE
Interface: Fix type of `expectedExecutionsPerDeployment` optimiser setting

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,12 +3,14 @@
 Language Features:
 
 Compiler Features:
+* Commandline Interface: `--optimize-runs` now also accepts values from the interval [INT64_MAX, UINT64_MAX].
 * General: Speed up SHA-256 hashing (`picosha2`).
 * General: Remove support for the experimental EOF (EVM Object Format) backend.
 
 Bugfixes:
 * NatSpec: Disallow `@return` tag in event documentation.
 * SMTChecker: Fix incorrect handling of constant operands of unary operations.
+* Standard JSON Interface: Fix incorrect serialization of `optimizer.runs` setting for values in the interval [INT64_MAX, UINT64_MAX].
 
 
 ### 0.8.35 (2026-04-29)

--- a/libevmasm/Assembly.h
+++ b/libevmasm/Assembly.h
@@ -130,10 +130,11 @@ public:
 		bool runDeduplicate = false;
 		bool runCSE = false;
 		bool runConstantOptimiser = false;
+
+		using ExecutionCount = frontend::OptimiserSettings::ExecutionCount;
 		/// This specifies an estimate on how often each opcode in this assembly will be executed,
 		/// i.e. use a small value to optimise for size and a large value to optimise for runtime gas usage.
-		std::uint64_t expectedExecutionsPerDeployment = frontend::OptimiserSettings{}.expectedExecutionsPerDeployment;
-		static_assert(std::is_same_v<decltype(expectedExecutionsPerDeployment), decltype(frontend::OptimiserSettings{}.expectedExecutionsPerDeployment)>);
+		ExecutionCount expectedExecutionsPerDeployment = frontend::OptimiserSettings{}.expectedExecutionsPerDeployment;
 
 		static OptimiserSettings translateSettings(frontend::OptimiserSettings const& _settings);
 	};

--- a/libevmasm/Assembly.h
+++ b/libevmasm/Assembly.h
@@ -132,7 +132,8 @@ public:
 		bool runConstantOptimiser = false;
 		/// This specifies an estimate on how often each opcode in this assembly will be executed,
 		/// i.e. use a small value to optimise for size and a large value to optimise for runtime gas usage.
-		size_t expectedExecutionsPerDeployment = frontend::OptimiserSettings{}.expectedExecutionsPerDeployment;
+		std::uint64_t expectedExecutionsPerDeployment = frontend::OptimiserSettings{}.expectedExecutionsPerDeployment;
+		static_assert(std::is_same_v<decltype(expectedExecutionsPerDeployment), decltype(frontend::OptimiserSettings{}.expectedExecutionsPerDeployment)>);
 
 		static OptimiserSettings translateSettings(frontend::OptimiserSettings const& _settings);
 	};

--- a/libevmasm/ConstantOptimiser.cpp
+++ b/libevmasm/ConstantOptimiser.cpp
@@ -29,7 +29,7 @@ using namespace solidity::evmasm;
 
 unsigned ConstantOptimisationMethod::optimiseConstants(
 	bool _isCreation,
-	size_t _runs,
+	std::uint64_t _runs,
 	langutil::EVMVersion _evmVersion,
 	Assembly& _assembly
 )

--- a/libevmasm/ConstantOptimiser.h
+++ b/libevmasm/ConstantOptimiser.h
@@ -49,7 +49,7 @@ public:
 	/// @returns zero if no optimisations could be performed.
 	static unsigned optimiseConstants(
 		bool _isCreation,
-		size_t _runs,
+		std::uint64_t _runs,
 		langutil::EVMVersion _evmVersion,
 		Assembly& _assembly
 	);
@@ -60,7 +60,7 @@ protected:
 	struct Params
 	{
 		bool isCreation; ///< Whether this is called during contract creation or runtime.
-		size_t runs; ///< Estimated number of calls per opcode oven the lifetime of the contract.
+		std::uint64_t runs; ///< Estimated number of calls per opcode oven the lifetime of the contract.
 		size_t multiplicity; ///< Number of times the constant appears in the code.
 		langutil::EVMVersion evmVersion; ///< Version of the EVM
 	};

--- a/libevmasm/Inliner.h
+++ b/libevmasm/Inliner.h
@@ -40,7 +40,7 @@ public:
 	explicit Inliner(
 		AssemblyItems& _items,
 		std::set<size_t> const& _tagsReferencedFromOutside,
-		size_t _runs,
+		std::uint64_t _runs,
 		bool _isCreation,
 		langutil::EVMVersion _evmVersion
 	):
@@ -76,7 +76,7 @@ private:
 
 	AssemblyItems& m_items;
 	std::set<size_t> const& m_tagsReferencedFromOutside;
-	size_t const m_runs = Assembly::OptimiserSettings{}.expectedExecutionsPerDeployment;
+	std::uint64_t const m_runs = Assembly::OptimiserSettings{}.expectedExecutionsPerDeployment;
 	bool const m_isCreation = false;
 	langutil::EVMVersion const m_evmVersion;
 };

--- a/libevmasm/Inliner.h
+++ b/libevmasm/Inliner.h
@@ -40,7 +40,7 @@ public:
 	explicit Inliner(
 		AssemblyItems& _items,
 		std::set<size_t> const& _tagsReferencedFromOutside,
-		std::uint64_t _runs,
+		Assembly::OptimiserSettings::ExecutionCount _runs,
 		bool _isCreation,
 		langutil::EVMVersion _evmVersion
 	):
@@ -76,7 +76,7 @@ private:
 
 	AssemblyItems& m_items;
 	std::set<size_t> const& m_tagsReferencedFromOutside;
-	std::uint64_t const m_runs = Assembly::OptimiserSettings{}.expectedExecutionsPerDeployment;
+	Assembly::OptimiserSettings::ExecutionCount const m_runs = Assembly::OptimiserSettings{}.expectedExecutionsPerDeployment;
 	bool const m_isCreation = false;
 	langutil::EVMVersion const m_evmVersion;
 };

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -326,7 +326,7 @@ void ContractCompiler::appendInternalSelector(
 	std::map<FixedHash<4>, evmasm::AssemblyItem const> const& _entryPoints,
 	std::vector<FixedHash<4>> const& _ids,
 	evmasm::AssemblyItem const& _notFoundTag,
-	std::uint64_t _runs
+	OptimiserSettings::ExecutionCount _runs
 )
 {
 	// Code for selecting from n functions without split:

--- a/libsolidity/codegen/ContractCompiler.cpp
+++ b/libsolidity/codegen/ContractCompiler.cpp
@@ -326,7 +326,7 @@ void ContractCompiler::appendInternalSelector(
 	std::map<FixedHash<4>, evmasm::AssemblyItem const> const& _entryPoints,
 	std::vector<FixedHash<4>> const& _ids,
 	evmasm::AssemblyItem const& _notFoundTag,
-	size_t _runs
+	std::uint64_t _runs
 )
 {
 	// Code for selecting from n functions without split:

--- a/libsolidity/codegen/ContractCompiler.h
+++ b/libsolidity/codegen/ContractCompiler.h
@@ -93,7 +93,7 @@ private:
 		std::map<util::FixedHash<4>, evmasm::AssemblyItem const> const& _entryPoints,
 		std::vector<util::FixedHash<4>> const& _ids,
 		evmasm::AssemblyItem const& _notFoundTag,
-		size_t _runs
+		std::uint64_t _runs
 	);
 	void appendFunctionSelector(ContractDefinition const& _contract);
 	void appendCallValueCheck();

--- a/libsolidity/codegen/ContractCompiler.h
+++ b/libsolidity/codegen/ContractCompiler.h
@@ -93,7 +93,7 @@ private:
 		std::map<util::FixedHash<4>, evmasm::AssemblyItem const> const& _entryPoints,
 		std::vector<util::FixedHash<4>> const& _ids,
 		evmasm::AssemblyItem const& _notFoundTag,
-		std::uint64_t _runs
+		OptimiserSettings::ExecutionCount _runs
 	);
 	void appendFunctionSelector(ContractDefinition const& _contract);
 	void appendCallValueCheck();

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -268,7 +268,7 @@ void CompilerStack::setLibraries(std::map<std::string, util::h160> const& _libra
 	m_libraries = _libraries;
 }
 
-void CompilerStack::setOptimiserSettings(bool _optimize, size_t _runs)
+void CompilerStack::setOptimiserSettings(bool _optimize, std::uint64_t _runs)
 {
 	OptimiserSettings settings = _optimize ? OptimiserSettings::standard() : OptimiserSettings::minimal();
 	settings.expectedExecutionsPerDeployment = _runs;
@@ -1777,9 +1777,8 @@ std::string CompilerStack::createMetadata(Contract const& _contract, bool _forIR
 		}
 	}
 
-	static_assert(sizeof(m_optimiserSettings.expectedExecutionsPerDeployment) <= sizeof(Json::number_integer_t), "Invalid word size.");
-	solAssert(static_cast<Json::number_integer_t>(m_optimiserSettings.expectedExecutionsPerDeployment) < std::numeric_limits<Json::number_integer_t>::max(), "");
-	meta["settings"]["optimizer"]["runs"] = Json::number_integer_t(m_optimiserSettings.expectedExecutionsPerDeployment);
+	static_assert(std::is_same_v<decltype(m_optimiserSettings.expectedExecutionsPerDeployment), Json::number_unsigned_t>);
+	meta["settings"]["optimizer"]["runs"] = m_optimiserSettings.expectedExecutionsPerDeployment;
 
 	/// Backwards compatibility: If set to one of the default settings, do not provide details.
 	OptimiserSettings settingsWithoutRuns = m_optimiserSettings;

--- a/libsolidity/interface/CompilerStack.cpp
+++ b/libsolidity/interface/CompilerStack.cpp
@@ -268,7 +268,7 @@ void CompilerStack::setLibraries(std::map<std::string, util::h160> const& _libra
 	m_libraries = _libraries;
 }
 
-void CompilerStack::setOptimiserSettings(bool _optimize, std::uint64_t _runs)
+void CompilerStack::setOptimiserSettings(bool _optimize, OptimiserSettings::ExecutionCount _runs)
 {
 	OptimiserSettings settings = _optimize ? OptimiserSettings::standard() : OptimiserSettings::minimal();
 	settings.expectedExecutionsPerDeployment = _runs;

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -220,7 +220,7 @@ public:
 
 	/// Changes the optimiser settings.
 	/// Must be set before parsing.
-	void setOptimiserSettings(bool _optimize, size_t _runs = OptimiserSettings{}.expectedExecutionsPerDeployment);
+	void setOptimiserSettings(bool _optimize, std::uint64_t _runs = OptimiserSettings{}.expectedExecutionsPerDeployment);
 
 	/// Changes the optimiser settings.
 	/// Must be set before parsing.

--- a/libsolidity/interface/CompilerStack.h
+++ b/libsolidity/interface/CompilerStack.h
@@ -220,7 +220,7 @@ public:
 
 	/// Changes the optimiser settings.
 	/// Must be set before parsing.
-	void setOptimiserSettings(bool _optimize, std::uint64_t _runs = OptimiserSettings{}.expectedExecutionsPerDeployment);
+	void setOptimiserSettings(bool _optimize, OptimiserSettings::ExecutionCount _runs = OptimiserSettings{}.expectedExecutionsPerDeployment);
 
 	/// Changes the optimiser settings.
 	/// Must be set before parsing.

--- a/libsolidity/interface/OptimiserSettings.h
+++ b/libsolidity/interface/OptimiserSettings.h
@@ -146,7 +146,7 @@ struct OptimiserSettings
 	std::string yulOptimiserCleanupSteps = DefaultYulOptimiserCleanupSteps;
 	/// This specifies an estimate on how often each opcode in this assembly will be executed,
 	/// i.e. use a small value to optimise for size and a large value to optimise for runtime gas usage.
-	size_t expectedExecutionsPerDeployment = 200;
+	std::uint64_t expectedExecutionsPerDeployment = 200;
 };
 
 }

--- a/libsolidity/interface/OptimiserSettings.h
+++ b/libsolidity/interface/OptimiserSettings.h
@@ -144,9 +144,11 @@ struct OptimiserSettings
 	/// is left empty, there will still be hard-coded optimisation steps that will run regardless.
 	/// Set @a runYulOptimiser to false if you want no optimisations.
 	std::string yulOptimiserCleanupSteps = DefaultYulOptimiserCleanupSteps;
+
+	using ExecutionCount = std::uint64_t;
 	/// This specifies an estimate on how often each opcode in this assembly will be executed,
 	/// i.e. use a small value to optimise for size and a large value to optimise for runtime gas usage.
-	std::uint64_t expectedExecutionsPerDeployment = 200;
+	ExecutionCount expectedExecutionsPerDeployment = 200;
 };
 
 }

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -640,7 +640,8 @@ std::variant<OptimiserSettings, Json> parseOptimizerSettings(std::string_view co
 	{
 		if (!_jsonInput["runs"].is_number_unsigned())
 			return formatFatalError(Error::Type::JSONError, "The \"runs\" setting must be an unsigned number.");
-		settings.expectedExecutionsPerDeployment = _jsonInput["runs"].get<size_t>();
+		static_assert(std::is_same_v<decltype(settings.expectedExecutionsPerDeployment), Json::number_unsigned_t>);
+		settings.expectedExecutionsPerDeployment = _jsonInput["runs"].get<Json::number_unsigned_t>();
 	}
 
 	if (_jsonInput.contains("details"))

--- a/libyul/ObjectOptimizer.h
+++ b/libyul/ObjectOptimizer.h
@@ -52,7 +52,7 @@ public:
 		bool optimizeStackAllocation;
 		std::string yulOptimiserSteps;
 		std::string yulOptimiserCleanupSteps;
-		size_t expectedExecutionsPerDeployment;
+		std::uint64_t expectedExecutionsPerDeployment;
 	};
 
 	/// Recursively optimizes a Yul object with given settings, reusing cached ASTs where possible

--- a/libyul/optimiser/Suite.cpp
+++ b/libyul/optimiser/Suite.cpp
@@ -94,7 +94,7 @@ void OptimiserSuite::run(
 	bool _optimizeStackAllocation,
 	std::string_view _optimisationSequence,
 	std::string_view _optimisationCleanupSequence,
-	std::optional<size_t> _expectedExecutionsPerDeployment,
+	std::optional<std::uint64_t> _expectedExecutionsPerDeployment,
 	std::set<YulName> const& _externallyUsedIdentifiers
 )
 {

--- a/libyul/optimiser/Suite.h
+++ b/libyul/optimiser/Suite.h
@@ -68,7 +68,7 @@ public:
 		bool _optimizeStackAllocation,
 		std::string_view _optimisationSequence,
 		std::string_view _optimisationCleanupSequence,
-		std::optional<size_t> _expectedExecutionsPerDeployment,
+		std::optional<std::uint64_t> _expectedExecutionsPerDeployment,
 		std::set<YulName> const& _externallyUsedIdentifiers = {}
 	);
 

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -825,7 +825,6 @@ General Information)").c_str(),
 	desc.add(metadataOptions);
 
 	po::options_description optimizerOptions("Optimizer Options");
-	static_assert(std::is_same_v<std::uint64_t, decltype(OptimiserSettings{}.expectedExecutionsPerDeployment)>);
 	optimizerOptions.add_options()
 		(
 			g_strOptimize.c_str(),
@@ -833,7 +832,7 @@ General Information)").c_str(),
 		)
 		(
 			g_strOptimizeRuns.c_str(),
-			po::value<std::uint64_t>()->value_name("n")->default_value(OptimiserSettings{}.expectedExecutionsPerDeployment),
+			po::value<OptimiserSettings::ExecutionCount>()->value_name("n")->default_value(OptimiserSettings{}.expectedExecutionsPerDeployment),
 			"The number of runs specifies roughly how often each opcode of the deployed code will be executed across the lifetime of the contract. "
 			"Lower values will optimize more for initial deployment cost, higher values will optimize more for high-frequency usage."
 		)
@@ -1298,7 +1297,7 @@ void CommandLineParser::processArgs()
 		m_args.count(g_strOptimizeYul) > 0
 	);
 	if (!m_args[g_strOptimizeRuns].defaulted())
-		m_options.optimizer.expectedExecutionsPerDeployment = m_args.at(g_strOptimizeRuns).as<std::uint64_t>();
+		m_options.optimizer.expectedExecutionsPerDeployment = m_args.at(g_strOptimizeRuns).as<OptimiserSettings::ExecutionCount>();
 
 	if (m_args.count(g_strYulOptimizations))
 	{

--- a/solc/CommandLineParser.cpp
+++ b/solc/CommandLineParser.cpp
@@ -825,6 +825,7 @@ General Information)").c_str(),
 	desc.add(metadataOptions);
 
 	po::options_description optimizerOptions("Optimizer Options");
+	static_assert(std::is_same_v<std::uint64_t, decltype(OptimiserSettings{}.expectedExecutionsPerDeployment)>);
 	optimizerOptions.add_options()
 		(
 			g_strOptimize.c_str(),
@@ -832,9 +833,7 @@ General Information)").c_str(),
 		)
 		(
 			g_strOptimizeRuns.c_str(),
-			// TODO: The type in OptimiserSettings is size_t but we only accept values up to 2**32-1
-			// on the CLI and in Standard JSON. We should just switch to uint32_t everywhere.
-			po::value<unsigned>()->value_name("n")->default_value(static_cast<unsigned>(OptimiserSettings{}.expectedExecutionsPerDeployment)),
+			po::value<std::uint64_t>()->value_name("n")->default_value(OptimiserSettings{}.expectedExecutionsPerDeployment),
 			"The number of runs specifies roughly how often each opcode of the deployed code will be executed across the lifetime of the contract. "
 			"Lower values will optimize more for initial deployment cost, higher values will optimize more for high-frequency usage."
 		)
@@ -1299,7 +1298,7 @@ void CommandLineParser::processArgs()
 		m_args.count(g_strOptimizeYul) > 0
 	);
 	if (!m_args[g_strOptimizeRuns].defaulted())
-		m_options.optimizer.expectedExecutionsPerDeployment = m_args.at(g_strOptimizeRuns).as<unsigned>();
+		m_options.optimizer.expectedExecutionsPerDeployment = m_args.at(g_strOptimizeRuns).as<std::uint64_t>();
 
 	if (m_args.count(g_strYulOptimizations))
 	{

--- a/solc/CommandLineParser.h
+++ b/solc/CommandLineParser.h
@@ -263,7 +263,7 @@ struct CommandLineOptions
 
 		bool optimizeEvmasm = false;
 		bool optimizeYul = false;
-		std::optional<unsigned> expectedExecutionsPerDeployment;
+		std::optional<std::uint64_t> expectedExecutionsPerDeployment;
 		std::optional<std::string> yulSteps;
 	} optimizer;
 

--- a/solc/CommandLineParser.h
+++ b/solc/CommandLineParser.h
@@ -24,6 +24,7 @@
 #include <libsolidity/interface/DebugSettings.h>
 #include <libsolidity/interface/FileReader.h>
 #include <libsolidity/interface/ImportRemapper.h>
+#include <libsolidity/interface/OptimiserSettings.h>
 
 #include <libyul/YulStack.h>
 
@@ -263,7 +264,7 @@ struct CommandLineOptions
 
 		bool optimizeEvmasm = false;
 		bool optimizeYul = false;
-		std::optional<std::uint64_t> expectedExecutionsPerDeployment;
+		std::optional<OptimiserSettings::ExecutionCount> expectedExecutionsPerDeployment;
 		std::optional<std::string> yulSteps;
 	} optimizer;
 

--- a/test/cmdlineTests/metadata_large_optimizer_runs/args
+++ b/test/cmdlineTests/metadata_large_optimizer_runs/args
@@ -1,0 +1,1 @@
+--metadata --optimize --optimize-runs 10000000000000000000

--- a/test/cmdlineTests/metadata_large_optimizer_runs/input.sol
+++ b/test/cmdlineTests/metadata_large_optimizer_runs/input.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity *;
+
+contract C {}

--- a/test/cmdlineTests/metadata_large_optimizer_runs/output
+++ b/test/cmdlineTests/metadata_large_optimizer_runs/output
@@ -1,0 +1,4 @@
+
+======= input.sol:C =======
+Metadata:
+{"compiler":{"version": "<VERSION REMOVED>"},"language":"Solidity","output":{"abi":[],"devdoc":{"kind":"dev","methods":{},"version":1},"userdoc":{"kind":"user","methods":{},"version":1}},"settings":{"compilationTarget":{"input.sol":"C"},"evmVersion":"osaka","libraries":{},"metadata":{"bytecodeHash":"ipfs"},"optimizer":{"enabled":true,"runs":10000000000000000000},"remappings":[]},"sources":{"input.sol":{"keccak256":"0x5cf617b1707a484e3c4bd59643013dec76ab7d75900b46855214729ae3e0ceb0","license":"GPL-3.0","urls":["bzz-raw://ac418a02dfadf87234150d3568f33269e3f49460345cb39300e017a6d755eff2","dweb:/ipfs/QmQq3owBu25x2WV46HB1WyKzJpxiAPecU7eMKqtXCF7eeS"]}},"version":1}

--- a/test/cmdlineTests/standard_metadata_large_optimizer_runs/args
+++ b/test/cmdlineTests/standard_metadata_large_optimizer_runs/args
@@ -1,0 +1,1 @@
+--allow-paths .

--- a/test/cmdlineTests/standard_metadata_large_optimizer_runs/in.sol
+++ b/test/cmdlineTests/standard_metadata_large_optimizer_runs/in.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity *;
+
+contract C {}

--- a/test/cmdlineTests/standard_metadata_large_optimizer_runs/input.json
+++ b/test/cmdlineTests/standard_metadata_large_optimizer_runs/input.json
@@ -1,0 +1,12 @@
+{
+	"language": "Solidity",
+	"sources": {
+		"C": {"urls": ["in.sol"]}
+	},
+	"settings": {
+		"optimizer": { "enabled": true, "runs": 18446744073709551615 },
+		"outputSelection": {
+			"*": {"*": ["metadata"]}
+		}
+	}
+}

--- a/test/cmdlineTests/standard_metadata_large_optimizer_runs/output.json
+++ b/test/cmdlineTests/standard_metadata_large_optimizer_runs/output.json
@@ -1,0 +1,14 @@
+{
+    "contracts": {
+        "C": {
+            "C": {
+                "metadata": "{\"compiler\":{\"version\":\"<VERSION REMOVED>\"},\"language\":\"Solidity\",\"output\":{\"abi\":[],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"C\":\"C\"},\"evmVersion\":\"osaka\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":-1},\"remappings\":[]},\"sources\":{\"C\":{\"keccak256\":\"0x5cf617b1707a484e3c4bd59643013dec76ab7d75900b46855214729ae3e0ceb0\",\"license\":\"GPL-3.0\",\"urls\":[\"bzz-raw://ac418a02dfadf87234150d3568f33269e3f49460345cb39300e017a6d755eff2\",\"dweb:/ipfs/QmQq3owBu25x2WV46HB1WyKzJpxiAPecU7eMKqtXCF7eeS\"]}},\"version\":1}"
+            }
+        }
+    },
+    "sources": {
+        "C": {
+            "id": 0
+        }
+    }
+}

--- a/test/cmdlineTests/standard_metadata_large_optimizer_runs/output.json
+++ b/test/cmdlineTests/standard_metadata_large_optimizer_runs/output.json
@@ -2,7 +2,7 @@
     "contracts": {
         "C": {
             "C": {
-                "metadata": "{\"compiler\":{\"version\":\"<VERSION REMOVED>\"},\"language\":\"Solidity\",\"output\":{\"abi\":[],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"C\":\"C\"},\"evmVersion\":\"osaka\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":-1},\"remappings\":[]},\"sources\":{\"C\":{\"keccak256\":\"0x5cf617b1707a484e3c4bd59643013dec76ab7d75900b46855214729ae3e0ceb0\",\"license\":\"GPL-3.0\",\"urls\":[\"bzz-raw://ac418a02dfadf87234150d3568f33269e3f49460345cb39300e017a6d755eff2\",\"dweb:/ipfs/QmQq3owBu25x2WV46HB1WyKzJpxiAPecU7eMKqtXCF7eeS\"]}},\"version\":1}"
+                "metadata": "{\"compiler\":{\"version\":\"<VERSION REMOVED>\"},\"language\":\"Solidity\",\"output\":{\"abi\":[],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"C\":\"C\"},\"evmVersion\":\"osaka\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":18446744073709551615},\"remappings\":[]},\"sources\":{\"C\":{\"keccak256\":\"0x5cf617b1707a484e3c4bd59643013dec76ab7d75900b46855214729ae3e0ceb0\",\"license\":\"GPL-3.0\",\"urls\":[\"bzz-raw://ac418a02dfadf87234150d3568f33269e3f49460345cb39300e017a6d755eff2\",\"dweb:/ipfs/QmQq3owBu25x2WV46HB1WyKzJpxiAPecU7eMKqtXCF7eeS\"]}},\"version\":1}"
             }
         }
     },


### PR DESCRIPTION
Optimiser setting `expectedExecutionsPerDeployment` and its JSON counterpart were using different types and this could result in some unexpected situation.
`expectedExecutionsPerDeployment` used (unsigned) `size_t`, but JSON serialization used signed `Json:number_integer_t`. Providing large enough number for the setting yielded negative number serialized in the contract's metadata. A negative number would be rejected as input to the compiler, breaking the round-trip.

Here we propose a strict requirement that the type used in the JSON library and the internal optimiser setting is the same, avoiding any potential mismatch in the future.

Fixes https://github.com/argotorg/solidity/issues/16809