### PR TITLE
SSACFG Stack layout generation: Drop per-operation junk declaration

### DIFF
--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -275,16 +275,10 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 			ranges::views::reverse |
 			ranges::views::transform([this](InstId const& _id) { return StackSlot::makeValue(m_cfg, _id); });
 
-		for (StackType::Depth depth{0}; depth < stack.size(); ++depth.value)
-			if (
-				stack.slot(depth).isValue() &&
-				!opLiveOutWithoutOutputs.contains(stack.slot(depth).value()) &&
-				ranges::find(requiredStackTop, stack.slot(depth)) == ranges::end(requiredStackTop)
-			)
-				stack.declareJunk(depth);
-
-		StackSlotLiveness const opLiveOutSlots = toStackSlotLiveness(m_cfg, opLiveOutWithoutOutputs);
 		{
+			// Values that are dead before the operation are left on the stack; the shuffle to the
+			// optimal target pops them as surplus as needed
+			StackSlotLiveness const opLiveOutSlots = toStackSlotLiveness(m_cfg, opLiveOutWithoutOutputs);
 			auto [target, plannedSpillSet] = findOptimalTarget(
 				stack.data(),
 				requiredStackTop,

--- a/test/libsolidity/semanticTests/abicoder/abi_encode_calldata_slice.sol
+++ b/test/libsolidity/semanticTests/abicoder/abi_encode_calldata_slice.sol
@@ -62,7 +62,7 @@ contract C {
 // gas irOptimized: 314884
 // gas legacy: 305816
 // gas legacyOptimized: 253573
-// gas ssaCFGOptimized: 311415
+// gas ssaCFGOptimized: 311379
 // test_uint256() ->
 // gas irOptimized: 448346
 // gas legacy: 421304

--- a/test/libsolidity/semanticTests/array/copying/array_of_structs_containing_arrays_calldata_to_storage.sol
+++ b/test/libsolidity/semanticTests/array/copying/array_of_structs_containing_arrays_calldata_to_storage.sol
@@ -24,4 +24,4 @@ contract C {
 // ----
 // f((uint256[])[]): 0x20, 3, 0x60, 0x60, 0x60, 0x20, 3, 1, 2, 3 -> 3, 1
 // gas irOptimized: 327461
-// gas ssaCFGOptimized: 327416
+// gas ssaCFGOptimized: 327419

--- a/test/libsolidity/semanticTests/array/copying/elements_of_nested_array_of_structs_calldata_to_storage.sol
+++ b/test/libsolidity/semanticTests/array/copying/elements_of_nested_array_of_structs_calldata_to_storage.sol
@@ -35,7 +35,7 @@ contract C {
 // gas ssaCFGOptimized: 327488
 // test2((uint8[],uint8[2])[][1][]): 0x20, 2, 0x40, 0x0160, 0x20, 1, 0x20, 0x60, 17, 19, 2, 11, 13, 0x20, 1, 0x20, 0x60, 31, 37, 2, 23, 29 -> 0x20, 0x20, 1, 0x20, 0x60, 17, 19, 2, 11, 13
 // gas irOptimized: 141168
-// gas ssaCFGOptimized: 140841
+// gas ssaCFGOptimized: 140845
 // test3((uint8[],uint8[2])[1][][2]): 0x20, 0x40, 0x60, 0, 2, 0x40, 288, 0x20, 0x60, 3, 7, 2, 1, 2, 0x20, 0x60, 17, 19, 2, 11, 13 -> 0x20, 2, 0x40, 288, 0x20, 0x60, 3, 7, 2, 1, 2, 0x20, 0x60, 17, 19, 2, 11, 13
 // gas irOptimized: 188448
 // gas ssaCFGOptimized: 188221

--- a/test/libsolidity/semanticTests/array/copying/nested_array_calldata_to_storage.sol
+++ b/test/libsolidity/semanticTests/array/copying/nested_array_calldata_to_storage.sol
@@ -45,7 +45,7 @@ contract c {
 // gas ssaCFGOptimized: 157563
 // test3(uint256[2][]): 0x20, 2, 23, 42, 23, 42 -> 2, 65
 // gas irOptimized: 134685
-// gas ssaCFGOptimized: 134828
+// gas ssaCFGOptimized: 134831
 // test4(uint256[2][2]): 23, 42, 23, 42 -> 65
 // gas irOptimized: 111177
 // gas ssaCFGOptimized: 111192

--- a/test/libsolidity/semanticTests/array/copying/nested_array_memory_to_storage.sol
+++ b/test/libsolidity/semanticTests/array/copying/nested_array_memory_to_storage.sol
@@ -41,7 +41,7 @@ contract Test {
 // gas irOptimized: 226647
 // gas legacy: 229060
 // gas legacyOptimized: 226495
-// gas ssaCFGOptimized: 226743
+// gas ssaCFGOptimized: 226744
 // test1() -> 3
 // test2() -> 6
 // gas irOptimized: 95905
@@ -50,4 +50,4 @@ contract Test {
 // gas irOptimized: 141297
 // gas legacy: 146668
 // gas legacyOptimized: 141331
-// gas ssaCFGOptimized: 141344
+// gas ssaCFGOptimized: 141345

--- a/test/libsolidity/semanticTests/array/push/array_push_struct.sol
+++ b/test/libsolidity/semanticTests/array/push/array_push_struct.sol
@@ -23,4 +23,4 @@ contract c {
 // gas irOptimized: 135329
 // gas legacy: 139481
 // gas legacyOptimized: 135795
-// gas ssaCFGOptimized: 135110
+// gas ssaCFGOptimized: 135108

--- a/test/libsolidity/semanticTests/constructor/no_callvalue_check.sol
+++ b/test/libsolidity/semanticTests/constructor/no_callvalue_check.sol
@@ -25,5 +25,5 @@ contract C {
 // gas legacy code: 4800
 // gas legacyOptimized: 117761
 // gas legacyOptimized code: 4800
-// gas ssaCFGOptimized: 117686
+// gas ssaCFGOptimized: 117690
 // gas ssaCFGOptimized code: 1800

--- a/test/libsolidity/semanticTests/structs/struct_memory_to_storage_function_ptr.sol
+++ b/test/libsolidity/semanticTests/structs/struct_memory_to_storage_function_ptr.sol
@@ -31,4 +31,4 @@ contract C {
 // gas irOptimized: 110682
 // gas legacy: 111990
 // gas legacyOptimized: 110546
-// gas ssaCFGOptimized: 110680
+// gas ssaCFGOptimized: 110678

--- a/test/libsolidity/semanticTests/various/erc20.sol
+++ b/test/libsolidity/semanticTests/various/erc20.sol
@@ -102,8 +102,8 @@ contract ERC20 {
 // gas legacy code: 647600
 // gas legacyOptimized: 126934
 // gas legacyOptimized code: 282000
-// gas ssaCFGOptimized: 122056
-// gas ssaCFGOptimized code: 241400
+// gas ssaCFGOptimized: 122072
+// gas ssaCFGOptimized code: 241600
 // totalSupply() -> 20
 // gas irOptimized: 23334
 // gas legacy: 23519

--- a/test/libsolidity/semanticTests/various/many_subassemblies.sol
+++ b/test/libsolidity/semanticTests/various/many_subassemblies.sol
@@ -38,5 +38,5 @@ contract D {
 // gas legacy code: 17600
 // gas legacyOptimized: 375464
 // gas legacyOptimized code: 17600
-// gas ssaCFGOptimized: 375130
+// gas ssaCFGOptimized: 375134
 // gas ssaCFGOptimized code: 6600

--- a/test/libsolidity/semanticTests/various/selfdestruct_post_cancun_redeploy.sol
+++ b/test/libsolidity/semanticTests/various/selfdestruct_post_cancun_redeploy.sol
@@ -88,8 +88,8 @@ contract D {
 // gas legacy code: 533800
 // gas legacyOptimized: 131436
 // gas legacyOptimized code: 276600
-// gas ssaCFGOptimized: 132075
-// gas ssaCFGOptimized code: 282600
+// gas ssaCFGOptimized: 132059
+// gas ssaCFGOptimized code: 282400
 // exists() -> false
 // test_deploy_and_terminate() ->
 // ~ emit Deployed(address,bytes32) from 0x137aa4dfc0911524504fcd4d98501f179bc13b4a: 0x7e6580007e709ac52945fae182c61131d42634e8, 0x1234000000000000000000000000000000000000000000000000000000000000
@@ -99,7 +99,7 @@ contract D {
 // gas legacy code: 20800
 // gas legacyOptimized: 96043
 // gas legacyOptimized code: 20800
-// gas ssaCFGOptimized: 96409
+// gas ssaCFGOptimized: 96407
 // gas ssaCFGOptimized code: 20800
 // exists() -> false
 // deploy_create2() ->

--- a/test/libyul/ssa/spill/loop_backedge_too_deep_spill.yul
+++ b/test/libyul/ssa/spill/loop_backedge_too_deep_spill.yul
@@ -52,7 +52,7 @@ code {
 // ----
 // object "C"
 // ===== SSA CFG =====
-// memoryguard = 0x01a0
+// memoryguard = 0x0180
 //
 // #0:
 //     v0 = memoryguard
@@ -202,22 +202,20 @@ code {
 //   spilled: none
 // CFG[1] f
 //   spilled:
-//     v51 (value) -> mem 0x80
-//     v52 (phi) -> mem 0xa0
-//     v54 (phi) -> mem 0xc0
-//     v56 (phi) -> mem 0xe0
+//     v52 (phi) -> mem 0x80
+//     v54 (phi) -> mem 0xa0
+//     v56 (phi) -> mem 0xc0
+//     v57 (value) -> mem 0xe0
 //     v58 (phi) -> mem 0x0100
 //     v59 (value) -> mem 0x0120
 //     v60 (phi) -> mem 0x0140
 //     v61 (value) -> mem 0x0160
-//     v62 (value) -> mem 0x0180
 //   mstore schedule:
-//     mstore addr(v51) <- v51 (B#2)
 //     mstore addr(v52) <- v52 (B#1)
 //     mstore addr(v54) <- v54 (B#1)
 //     mstore addr(v56) <- v56 (B#1)
+//     mstore addr(v57) <- v57 (B#2)
 //     mstore addr(v58) <- v58 (B#1)
 //     mstore addr(v59) <- v59 (B#2)
 //     mstore addr(v60) <- v60 (B#1)
 //     mstore addr(v61) <- v61 (B#2)
-//     mstore addr(v62) <- v62 (B#3)

--- a/test/libyul/ssa/stackLayoutGenerator/multi_return.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/multi_return.yul
@@ -27,15 +27,15 @@
 // pair\l\
 // [v2, v3, FunctionCallReturnLabel[1], v5, v6]\l\
 // \l\
-// [JUNK, v3, v6, v5]\l\
+// [v2, v3, v6, v5]\l\
 // add\l\
-// [JUNK, v3, v7]\l\
+// [v2, v3, v7]\l\
 // \l\
-// [JUNK, v7, v3]\l\
+// [v2, v7, v3]\l\
 // sstore\l\
-// [JUNK]\l\
+// [v2]\l\
 // \l\
-// OUT: [JUNK]\l\
+// OUT: [v2]\l\
 // "];
 // Block0_0Exit [label="MainExit"];
 // Block0_0 -> Block0_0Exit;

--- a/test/libyul/ssa/stackLayoutGenerator/spill_in_function.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/spill_in_function.yul
@@ -135,29 +135,29 @@
 // sstore\l\
 // [ReturnLabel[1], v31, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v35]\l\
 // \l\
-// [ReturnLabel[1], v31, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v33, v3]\l\
+// [ReturnLabel[1], v31, v35, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v33, v3]\l\
 // sstore\l\
-// [ReturnLabel[1], v31, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29]\l\
+// [ReturnLabel[1], v31, v35, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29]\l\
 // \l\
-// [ReturnLabel[1], v29, JUNK, v27, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v31, v5]\l\
+// [ReturnLabel[1], v29, v35, v27, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v31, v5]\l\
 // sstore\l\
-// [ReturnLabel[1], v29, JUNK, v27, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25]\l\
+// [ReturnLabel[1], v29, v35, v27, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25]\l\
 // \l\
-// [ReturnLabel[1], v25, JUNK, v27, v23, v9, v11, v13, v15, v17, v19, v21, v29, v7]\l\
+// [ReturnLabel[1], v25, v35, v27, v23, v9, v11, v13, v15, v17, v19, v21, v29, v7]\l\
 // sstore\l\
-// [ReturnLabel[1], v25, JUNK, v27, v23, v9, v11, v13, v15, v17, v19, v21]\l\
+// [ReturnLabel[1], v25, v35, v27, v23, v9, v11, v13, v15, v17, v19, v21]\l\
 // \l\
-// [ReturnLabel[1], v25, JUNK, v21, v23, v19, v11, v13, v15, v17, v27, v9]\l\
+// [ReturnLabel[1], v25, v35, v21, v23, v19, v11, v13, v15, v17, v27, v9]\l\
 // sstore\l\
-// [ReturnLabel[1], v25, JUNK, v21, v23, v19, v11, v13, v15, v17]\l\
+// [ReturnLabel[1], v25, v35, v21, v23, v19, v11, v13, v15, v17]\l\
 // \l\
-// [ReturnLabel[1], v17, JUNK, v21, v23, v19, v15, v13, v25, v11]\l\
+// [ReturnLabel[1], v17, v35, v21, v23, v19, v15, v13, v25, v11]\l\
 // sstore\l\
-// [ReturnLabel[1], v17, JUNK, v21, v23, v19, v15, v13]\l\
+// [ReturnLabel[1], v17, v35, v21, v23, v19, v15, v13]\l\
 // \l\
-// [ReturnLabel[1], v17, JUNK, v21, v15, v19, v23, v13]\l\
+// [ReturnLabel[1], v17, v35, v21, v15, v19, v23, v13]\l\
 // sstore\l\
-// [ReturnLabel[1], v17, JUNK, v21, v15, v19]\l\
+// [ReturnLabel[1], v17, v35, v21, v15, v19]\l\
 // \l\
 // [ReturnLabel[1], v17, v19, v21, v15]\l\
 // sstore\l\

--- a/test/libyul/ssa/stackLayoutGenerator/spill_many_locals.yul
+++ b/test/libyul/ssa/stackLayoutGenerator/spill_many_locals.yul
@@ -128,43 +128,43 @@
 // sstore\l\
 // [v33, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v1, v1]\l\
 // \l\
-// [v33, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, JUNK, v37, v3]\l\
+// [v33, v1, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v1, v37, v3]\l\
 // sstore\l\
-// [v33, v3, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, JUNK]\l\
+// [v33, v1, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v1]\l\
 // \l\
-// [v33, JUNK, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, JUNK, v35, v5]\l\
+// [v33, v1, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v1, v35, v5]\l\
 // sstore\l\
-// [v33, JUNK, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, JUNK]\l\
+// [v33, v1, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v1]\l\
 // \l\
-// [v33, JUNK, JUNK, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v33, v7]\l\
+// [v1, v1, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v33, v7]\l\
 // sstore\l\
-// [v33, JUNK, JUNK, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31]\l\
+// [v1, v1, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31]\l\
 // \l\
-// [JUNK, JUNK, JUNK, JUNK, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v9]\l\
+// [v1, v1, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v31, v9]\l\
 // sstore\l\
-// [JUNK, JUNK, JUNK, JUNK, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29]\l\
+// [v1, v1, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29]\l\
 // \l\
-// [JUNK, JUNK, JUNK, JUNK, JUNK, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v11]\l\
+// [v1, v1, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v29, v11]\l\
 // sstore\l\
-// [JUNK, JUNK, JUNK, JUNK, JUNK, v11, v13, v15, v17, v19, v21, v23, v25, v27]\l\
+// [v1, v1, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27]\l\
 // \l\
-// [JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, v13, v15, v17, v19, v21, v23, v25, v27, v13]\l\
+// [v1, v1, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v27, v13]\l\
 // sstore\l\
-// [JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, v13, v15, v17, v19, v21, v23, v25]\l\
+// [v1, v1, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25]\l\
 // \l\
-// [JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, v15, v17, v19, v21, v23, v25, v15]\l\
+// [v1, v1, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v25, v15]\l\
 // sstore\l\
-// [JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, v15, v17, v19, v21, v23]\l\
+// [v1, v1, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23]\l\
 // \l\
-// [JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, v17, v19, v21, v23, v17]\l\
+// [v1, v1, v5, v7, v9, v11, v13, v15, v17, v19, v21, v23, v17]\l\
 // sstore\l\
-// [JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, v17, v19, v21]\l\
+// [v1, v1, v5, v7, v9, v11, v13, v15, v17, v19, v21]\l\
 // \l\
-// [JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, v21, v19]\l\
+// [v1, v1, v5, v7, v9, v11, v13, v15, v17, v21, v19]\l\
 // sstore\l\
-// [JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK]\l\
+// [v1, v1, v5, v7, v9, v11, v13, v15, v17]\l\
 // \l\
-// OUT: [JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK, JUNK]\l\
+// OUT: [v1, v1, v5, v7, v9, v11, v13, v15, v17]\l\
 // "];
 // Block0_0Exit [label="MainExit"];
 // Block0_0 -> Block0_0Exit;


### PR DESCRIPTION
The stack layout generator no longer declares the slots that are dead before an operation as junk. They are instead left on the stack and popped as surplus by the shuffle to the optimal target, which tends to free stack space and reduce spilling.

It also removes cases in which the shuffle input in the code transform diverges from the shuffle input in the stack layout generator.

There are slight changes in the gas stats but nothing relevant.