### PR TITLE
SSA CFG spill: fix miscounting in spill set

### DIFF
--- a/libyul/backends/evm/ssa/spill/SpillSet.cpp
+++ b/libyul/backends/evm/ssa/spill/SpillSet.cpp
@@ -61,8 +61,12 @@ StackData computeOperationOut(
 
 	StackData opOutStack = blockLayout->operationIn[opIndex];
 	SSACFG::Inst const& inst = _cfg.inst(producer);
-	yulAssert(opOutStack.size() >= inst.inputs.size(), "operationIn smaller than input count");
-	for (std::size_t i = 0; i < inst.inputs.size(); ++i)
+	// a call that can continue also consumes its return label, which sits right below the inputs
+	std::size_t consumedSlots = inst.inputs.size();
+	if (inst.opcode == InstOpcode::Call && _cfg.callPayload(producer).canContinue)
+		++consumedSlots;
+	yulAssert(opOutStack.size() >= consumedSlots, "operationIn smaller than consumed slot count");
+	for (std::size_t i = 0; i < consumedSlots; ++i)
 		opOutStack.pop_back();
 	_cfg.forEachOutput(producer, [&](InstId const id) {
 		opOutStack.push_back(StackSlot::makeValue(_cfg, id));


### PR DESCRIPTION
The spill set would miscount the number of consumed slots for a user-defined call that can continue. The produced symbolic stack is only ever used to determine if something needs to be spilled additionally. Simulating to consume too few slots can only ever lead to a situation where we spill too much.