### PR TITLE
Remove unused `using StackHeightInfo` from `libyul/AsmAnalysisInfo.h`

### DIFF
--- a/libyul/AsmAnalysisInfo.h
+++ b/libyul/AsmAnalysisInfo.h
@@ -34,7 +34,6 @@ struct Scope;
 
 struct AsmAnalysisInfo
 {
-	using StackHeightInfo = std::map<void const*, int>;
 	using Scopes = std::map<Block const*, std::shared_ptr<Scope>>;
 	Scopes scopes;
 	/// Virtual blocks which will be used for scopes for function arguments and return values.


### PR DESCRIPTION
## Description

Not used or referenced anywhere. Used to be part of f3ec2ba39e which had a

```diff
+	StackHeightInfo stackHeightInfo;
```

But that's gone too, along with all references to it.