### PR TITLE
Fix checkKeys crash for null and empty array source entries

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@ Bugfixes:
 * NatSpec: Disallow `@return` tag in event documentation.
 * SMTChecker: Fix incorrect handling of constant operands of unary operations.
 * Standard JSON Interface: Fix incorrect serialization of `optimizer.runs` setting for values in the interval [INT64_MAX, UINT64_MAX].
+* Standard JSON Interface: Fix crash in `checkKeys` when source entry is `null` or an empty array instead of an object.
 
 
 ### 0.8.35 (2026-04-29)

--- a/libsolidity/interface/StandardCompiler.cpp
+++ b/libsolidity/interface/StandardCompiler.cpp
@@ -455,7 +455,7 @@ Json formatImmutableReferences(std::map<u256, evmasm::LinkerObject::ImmutableRef
 
 std::optional<Json> checkKeys(Json const& _input, std::set<std::string> const& _keys, std::string const& _name)
 {
-	if (!_input.empty() && !_input.is_object())
+	if (!_input.is_object())
 		return formatFatalError(Error::Type::JSONError, "\"" + _name + "\" must be an object");
 
 	for (auto const& [member, _]: _input.items())

--- a/test/libsolidity/StandardCompiler.cpp
+++ b/test/libsolidity/StandardCompiler.cpp
@@ -401,6 +401,34 @@ BOOST_AUTO_TEST_CASE(sources_is_array)
 	BOOST_CHECK(containsError(result, "JSONError", "\"sources\" is not a JSON object."));
 }
 
+BOOST_AUTO_TEST_CASE(source_entry_null)
+{
+	char const* input = R"(
+	{
+		"language": "Solidity",
+		"sources": {
+			"a.sol": null
+		}
+	}
+	)";
+	Json result = compile(input);
+	BOOST_CHECK(containsError(result, "JSONError", "\"sources.a.sol\" must be an object"));
+}
+
+BOOST_AUTO_TEST_CASE(source_entry_empty_array)
+{
+	char const* input = R"(
+	{
+		"language": "Solidity",
+		"sources": {
+			"a.sol": []
+		}
+	}
+	)";
+	Json result = compile(input);
+	BOOST_CHECK(containsError(result, "JSONError", "\"sources.a.sol\" must be an object"));
+}
+
 BOOST_AUTO_TEST_CASE(unexpected_trailing_test)
 {
 	char const* input = R"(


### PR DESCRIPTION
Fixes #16819

In `StandardCompiler::checkKeys()`, the guard `!_input.empty() && !_input.is_object()` fails to reject `null` and `[]` inputs because `nlohmann::json::empty()` returns `true` for both, causing the first condition to short-circuit. These non-object values then reach `_input.items()`, which throws an uncaught `type_error` 305 (`cannot use items() with null/array`).

## Root cause:`empty()` is not a type check — it returns `true` for `null`, `[]`, `{}`, and `""`.

## Fix: Replace the guard with `if (!_input.is_object())`, which correctly rejects all non-object types while still allowing empty objects `{}`.

## Tests added: Two new test cases in `test/libsolidity/StandardCompiler.cpp`:
- `standard_compiler_json_input_sources_null_entry` — verifies `null` source entry returns an error instead of crashing
- `standard_compiler_json_input_sources_empty_array_entry` — verifies `[]` source entry returns an error instead of crashing

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
- [x] AI tools were used to assist with identifying and drafting tests and documentation. All code was reviewed and validated by the contributor. 
