### PR TITLE
Add fuzztest dependency and CI job executing property based tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,6 +297,14 @@ commands:
           command: scripts/ci/build_ossfuzz.sh
       - save_ccache_if_develop
 
+  run_build_property_tests:
+    steps:
+      - restore_ccache_if_allowed
+      - run_with_ccache_unless_tag:
+          step_name: Build_property_tests
+          command: scripts/ci/build_property_tests.sh
+      - save_ccache_if_develop
+
   run_proofs:
     steps:
       - run:
@@ -1248,6 +1256,25 @@ jobs:
           path: test_results/
       - store_artifacts_test_results
 
+  b_ubu_property_tests: &b_ubu_property_tests
+    <<: *base_ubuntu2404_large
+    steps:
+      - checkout
+      - run_build_property_tests
+      - run:
+          name: Property-based tests
+          command: |
+            shopt -s nullglob
+            executables=(build/test/fuzztest/*_fuzztest)
+            if [[ ${#executables[@]} -eq 0 ]]; then
+              echo "No property-test executables were built." >&2
+              exit 1
+            fi
+            for executable in "${executables[@]}"; do
+              "$executable"
+            done
+      - matrix_notify_failure_unless_pr
+
   b_archlinux:
     <<: *base_archlinux_large
     environment:
@@ -2084,6 +2111,9 @@ workflows:
       # build-only
       - b_docs: *requires_nothing
       - b_ubu_ossfuzz: *requires_nothing
+
+      # property-based / fuzz tests (FuzzTest, unittest mode)
+      - b_ubu_property_tests: *requires_nothing
 
       # build and test with minimum supported versions of dependencies
       - b_ubu_min_req_clang: *requires_nothing

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "test/ethdebugSchemaTests/ethdebug-format"]
 	path = test/ethdebugSchemaTests/ethdebug-format
 	url = https://github.com/ethdebug/format.git
+[submodule "deps/fuzztest"]
+	path = deps/fuzztest
+	url = https://github.com/google/fuzztest

--- a/cmake/EthOptions.cmake
+++ b/cmake/EthOptions.cmake
@@ -8,6 +8,17 @@ macro(configure_project)
 	eth_default_option(COVERAGE OFF)
 	eth_default_option(OSSFUZZ OFF)
 
+	# Master switch for the FuzzTest-based property tests. OFF means deps/fuzztest is never
+	# add_subdirectory'd, so none of its transitive FetchContent deps (abseil/re2/gtest/antlr)
+	# are configured.
+	eth_default_option(PROPERTY_BASED_TESTS OFF)
+
+	# Mode selector, only meaningful when PROPERTY_BASED_TESTS is ON.
+	if (NOT DEFINED PROPERTY_BASED_TESTS_MODE)
+		set(PROPERTY_BASED_TESTS_MODE "unittest" CACHE STRING "Property-based test mode: unittest or fuzzing")
+	endif()
+	set_property(CACHE PROPERTY_BASED_TESTS_MODE PROPERTY STRINGS "unittest" "fuzzing")
+
 	# components
 	eth_default_option(TESTS ON)
 	eth_default_option(TOOLS ON)
@@ -41,6 +52,8 @@ if (SUPPORT_TOOLS)
 endif()
 	message("------------------------------------------------------------------ flags")
 	message("-- OSSFUZZ                                                   ${OSSFUZZ}")
+	message("-- PROPERTY_BASED_TESTS (FuzzTest)                           ${PROPERTY_BASED_TESTS}")
+	message("-- PROPERTY_BASED_TESTS_MODE                                 ${PROPERTY_BASED_TESTS_MODE}")
 	message("------------------------------------------------------------------------")
 	message("")
 endmacro()

--- a/cmake/toolchains/fuzztest.cmake
+++ b/cmake/toolchains/fuzztest.cmake
@@ -1,0 +1,33 @@
+# Toolchain for building the FuzzTest property-based tests in coverage-guided fuzzing
+# mode (PROPERTY_BASED_TESTS_MODE=fuzzing). Fuzzing mode requires Clang.
+#
+#   CC=clang CXX=clang++ cmake -S . -B build-fuzz -G Ninja -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/fuzztest.cmake
+#
+# The instrumentation flags are applied globally (a toolchain file is processed before
+# project()), so every solidity library under test is built with ASan + coverage, not just
+# the translation units in test/fuzztest.
+
+# Inherit default options
+include("${CMAKE_CURRENT_LIST_DIR}/default.cmake")
+
+# Turn on the property tests in fuzzing mode.
+set(PROPERTY_BASED_TESTS ON CACHE BOOL "Enable FuzzTest property-based tests" FORCE)
+set(PROPERTY_BASED_TESTS_MODE "fuzzing" CACHE STRING "Property-based test mode" FORCE)
+
+# Pull the instrumentation flags straight from FuzzTest's own helper. For this we require the submodule to be initialized.
+set(FUZZTEST_PATH_TO_FLAG_SETUP "${CMAKE_CURRENT_LIST_DIR}/../../deps/fuzztest/cmake/FuzzTestFlagSetup.cmake")
+if (NOT EXISTS "${FUZZTEST_PATH_TO_FLAG_SETUP}")
+	message(FATAL_ERROR
+		"deps/fuzztest submodule is not initialized; the fuzztest toolchain needs it at configure time.\n"
+		"Run: git submodule update --init deps/fuzztest")
+endif()
+
+set(FUZZTEST_FUZZING_MODE ON)
+# Reset the base before invoking the (appending) helper. A toolchain file is re-read on every CMake pass.
+# Resetting first makes the resulting flags identical no matter how many times this runs.
+set(CMAKE_CXX_FLAGS "")
+set(CMAKE_EXE_LINKER_FLAGS "")
+include("${FUZZTEST_PATH_TO_FLAG_SETUP}")
+fuzztest_setup_fuzzing_flags()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" CACHE STRING "Custom compilation flags" FORCE)
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}" CACHE STRING "Custom linker flags" FORCE)

--- a/scripts/ci/build_property_tests.sh
+++ b/scripts/ci/build_property_tests.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -ex
+
+ROOTDIR="$(realpath "$(dirname "$0")/../..")"
+BUILDDIR="${ROOTDIR}/build"
+mkdir -p "${BUILDDIR}" && mkdir -p "$BUILDDIR/deps"
+
+cd "${BUILDDIR}"
+export CCACHE_DIR="$HOME/.ccache"
+export CCACHE_BASEDIR="$ROOTDIR"
+export CCACHE_NOHASHDIR=1
+CMAKE_OPTIONS="${CMAKE_OPTIONS:-} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+mkdir -p "$CCACHE_DIR"
+
+# PROPERTY_BASED_TESTS_MODE defaults to "unittest", which runs each FUZZ_TEST as a regular
+# GoogleTest case. Fuzzing mode is intentionally not used here.
+# shellcheck disable=SC2086
+cmake .. -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE:-Release}" \
+  -DPROPERTY_BASED_TESTS=ON \
+  $CMAKE_OPTIONS
+
+ccache -z
+# Build only the property-test executables, not the whole project.
+cmake --build . --target property_tests
+ccache -s

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -250,3 +250,7 @@ endif()
 
 add_subdirectory(tools)
 add_subdirectory(evmc)
+
+if (PROPERTY_BASED_TESTS)
+    add_subdirectory(fuzztest)
+endif()

--- a/test/fuzztest/CMakeLists.txt
+++ b/test/fuzztest/CMakeLists.txt
@@ -30,6 +30,7 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/deps/fuzztest ${CMAKE_BINARY_DIR}/deps/fu
 fuzztest_setup_fuzzing_flags()
 
 set(yul_fuzztest_sources
+	libyul/TarjanSCCPropertyTest.cpp
 )
 detect_stray_source_files("${yul_fuzztest_sources}" "libyul/")
 

--- a/test/fuzztest/CMakeLists.txt
+++ b/test/fuzztest/CMakeLists.txt
@@ -1,0 +1,43 @@
+# Property-based / fuzz tests built on Google FuzzTest (deps/fuzztest).
+#
+# This whole directory is only added when PROPERTY_BASED_TESTS is ON (see ../CMakeLists.txt),
+# so the FuzzTest framework and its transitive FetchContent dependencies (abseil/re2/gtest/
+# antlr) are not configured in normal builds.
+
+# Translate our own mode option into FuzzTest's internal flag. FuzzTest reads
+# FUZZTEST_FUZZING_MODE at configure time via option(); setting a normal variable of the
+# same name here wins under policy CMP0077 (NEW). GCC + fuzzing mode is rejected by
+# FuzzTest's own FATAL_ERROR, so we do not duplicate that guard.
+if (PROPERTY_BASED_TESTS_MODE STREQUAL "fuzzing")
+	set(FUZZTEST_FUZZING_MODE ON)
+elseif (PROPERTY_BASED_TESTS_MODE STREQUAL "unittest")
+	set(FUZZTEST_FUZZING_MODE OFF)
+else()
+	message(FATAL_ERROR "PROPERTY_BASED_TESTS_MODE must be 'unittest' or 'fuzzing', got '${PROPERTY_BASED_TESTS_MODE}'")
+endif()
+
+# Silence warnings for the FuzzTest subtree. The project adds -Werror (and -Wconversion etc.)
+# globally via add_compile_options before this directory is created, and those flags are
+# inherited here; FuzzTest and its dependencies do not build cleanly under them. Appended
+# after the inherited flags, -w wins.
+add_compile_options(-w)
+
+include(${CMAKE_SOURCE_DIR}/cmake/submodules.cmake)
+initialize_submodule(fuzztest)
+add_subdirectory(${PROJECT_SOURCE_DIR}/deps/fuzztest ${CMAKE_BINARY_DIR}/deps/fuzztest EXCLUDE_FROM_ALL)
+
+# Adds coverage instrumentation flags to targets defined below when in fuzzing mode; no-op in unit-test mode.
+fuzztest_setup_fuzzing_flags()
+
+set(yul_fuzztest_sources
+)
+detect_stray_source_files("${yul_fuzztest_sources}" "libyul/")
+
+add_executable(yul_fuzztest ${yul_fuzztest_sources})
+target_link_libraries(yul_fuzztest PRIVATE yul)
+link_fuzztest(yul_fuzztest)
+
+# Convenience target to build all per-library property-test executables at once (e.g. in CI).
+# New <lib>_fuzztest targets should add themselves here.
+add_custom_target(property_tests)
+add_dependencies(property_tests yul_fuzztest)

--- a/test/fuzztest/README.md
+++ b/test/fuzztest/README.md
@@ -1,0 +1,27 @@
+# Property-based / fuzz tests
+
+This directory holds **property-based / fuzz tests** built
+on [Google FuzzTest](https://github.com/google/fuzztest) (vendored at `deps/fuzztest`).
+Instead of asserting a fixed output for a fixed input, a property test states a property that must hold for all inputs
+from a domain, and FuzzTest searches that domain for counterexamples.
+
+## Options
+
+Two CMake options control this (defined in `cmake/EthOptions.cmake`):
+
+- `PROPERTY_BASED_TESTS` (default `OFF`) — master on/off switch. While it is `OFF`, `deps/fuzztest` is never added 
+  to the build, so none of its transitive `FetchContent` dependencies are configured.
+- `PROPERTY_BASED_TESTS_MODE` (default `unittest`, values `unittest` / `fuzzing`). Selects the run mode. Only
+  meaningful when `PROPERTY_BASED_TESTS` is `ON`.
+  - `unittest`: each `FUZZ_TEST` runs as an ordinary test case with a 1sec burst of random inputs.
+  - `fuzzing`: coverage-guided fuzzing. Requires Clang.
+
+## Configure
+
+```sh
+# unit-test mode (works with the default g++ build)
+cmake -S . -B build-prop -G Ninja -DPROPERTY_BASED_TESTS=ON
+
+# fuzzing mode (Clang required)
+CC=clang CXX=clang++ cmake -S . -B build-fuzz -G Ninja -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/fuzztest.cmake
+```

--- a/test/fuzztest/libyul/TarjanSCCPropertyTest.cpp
+++ b/test/fuzztest/libyul/TarjanSCCPropertyTest.cpp
@@ -1,0 +1,132 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+/**
+ * Property test for Tarjan's strongly-connected-components algorithm
+ *
+ * For a random directed graph we cross-check computeStronglyConnectedComponents against an independent reachability
+ * oracle computed by one DFS per source node:
+ *   - the returned SCCs partition [0, n) (every node appears in exactly one in-range SCC);
+ *   - two nodes share an SCC iff they are mutually reachable (the SCC definition);
+ *   - the recursion classification derived from the SCCs the way CallGraph::recursiveFunctions() does it (non-trivial
+ *     SCC or self-edge) matches the independent "node lies on a directed cycle" oracle. This exercises the self-edge
+ *     glue that the pure SCC partition does not pin down (a self-loop node and a lone node are both singleton SCCs).
+ */
+
+#include <libsolutil/TarjanSCC.h>
+
+#include <fuzztest/fuzztest.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+using namespace solidity::util;
+
+namespace solidity::yul::test
+{
+
+namespace
+{
+
+using NodeID = std::uint32_t;
+
+struct Edge
+{
+	NodeID from;
+	NodeID to;
+};
+
+constexpr std::uint32_t maxNodes = 128;
+constexpr std::uint32_t maxEdges = 256;
+
+}
+
+void SCCMatchesReachability(std::pair<NodeID, std::vector<Edge>> const& _graph)
+{
+	auto const& [numNodes, edges] = _graph;
+
+	std::vector<std::vector<NodeID>> adjacency(numNodes);
+	for (auto const& [from, to]: edges)
+		adjacency[from].push_back(to);
+
+	std::vector<std::vector<NodeID>> const sccs = computeStronglyConnectedComponents<NodeID>(adjacency);
+
+	// SCCs partition [0, n): record each node's SCC index, checking range and uniqueness.
+	std::vector<std::int64_t> sccOfNode(numNodes, -1);
+	for (std::size_t sccIndex = 0; sccIndex < sccs.size(); ++sccIndex)
+		for (NodeID const node: sccs[sccIndex])
+		{
+			ASSERT_LT(node, numNodes) << "SCC contains out-of-range node " << node;
+			ASSERT_EQ(sccOfNode[node], -1) << "node " << node << " appears in multiple SCCs";
+			sccOfNode[node] = static_cast<std::int64_t>(sccIndex);
+		}
+	for (NodeID i = 0; i < numNodes; ++i)
+		ASSERT_NE(sccOfNode[i], -1) << "node " << i << " missing from SCC partition";
+
+	// reach[s] = the set of nodes reachable from s, computed by one independent DFS per source.
+	std::vector reach(numNodes, std::vector<std::uint8_t>(numNodes, false));
+	for (NodeID source = 0; source < numNodes; ++source)
+	{
+		std::vector<NodeID> stack{source};
+		reach[source][source] = true;
+		while (!stack.empty())
+		{
+			NodeID const u = stack.back();
+			stack.pop_back();
+			for (NodeID const v: adjacency[u])
+				if (!reach[source][v])
+				{
+					reach[source][v] = true;
+					stack.push_back(v);
+				}
+		}
+	}
+
+	// Same SCC iff mutually reachable.
+	for (NodeID i = 0; i < numNodes; ++i)
+		for (NodeID j = 0; j < numNodes; ++j)
+		{
+			bool const sameSCC = sccOfNode[i] == sccOfNode[j];
+			bool const mutuallyReachable = reach[i][j] && reach[j][i];
+			ASSERT_EQ(sameSCC, mutuallyReachable)
+				<< "nodes " << i << " and " << j << ": sameSCC=" << sameSCC
+				<< " mutuallyReachable=" << mutuallyReachable;
+		}
+}
+
+FUZZ_TEST(TarjanSCCProperty, SCCMatchesReachability)
+	.WithDomains(
+		fuzztest::FlatMap(
+			[](NodeID const _numNodes) {
+				return fuzztest::PairOf(
+					fuzztest::Just(_numNodes),
+					fuzztest::VectorOf(
+						fuzztest::StructOf<Edge>(
+							fuzztest::InRange<NodeID>(0, _numNodes - 1),
+							fuzztest::InRange<NodeID>(0, _numNodes - 1)
+						)
+					).WithMaxSize(maxEdges)
+				);
+			},
+			fuzztest::InRange<NodeID>(1, maxNodes)
+		)
+	);
+
+}


### PR DESCRIPTION
- adds google/fuzztest as submodule
  - only configures targets if `PROPERTY_BASED_TESTS` is `ON`
  - has `PROPERTY_BASED_TESTS_MODE` which defaults to `unittest` and simply runs the property test with 1s worth of random data; `fuzzing` needs instrumentation of the binary and the `fuzztest.cmake` toolchain should be used
- defines CI job which runs defined property based tests in `unittest` mode
- add `TarjanSCC` property test as an example