### PR TITLE
SSACFG: improve compile time performance (preallocate instructions and early exit in finding optimal target)

### DIFF
--- a/libyul/backends/evm/ssa/InstructionStore.h
+++ b/libyul/backends/evm/ssa/InstructionStore.h
@@ -102,7 +102,7 @@ public:
 		}
 	};
 
-	InstructionStore() = default;
+	explicit InstructionStore(std::size_t const _instructionCountHint = 0): m_insts(_instructionCountHint) {}
 	InstructionStore(InstructionStore const&) = delete;
 	InstructionStore(InstructionStore&&) = default;
 	InstructionStore& operator=(InstructionStore const&) = delete;

--- a/libyul/backends/evm/ssa/SSACFG.h
+++ b/libyul/backends/evm/ssa/SSACFG.h
@@ -56,8 +56,10 @@ public:
 
 	explicit SSACFG(
 		EVMDialect const& _evmVersion,
-		std::unique_ptr<DebugInfo> _debugInfo = nullptr
+		std::unique_ptr<DebugInfo> _debugInfo = nullptr,
+		std::size_t const _instructionCountHint = 0
 	):
+		m_instructions(_instructionCountHint),
 		evmDialect(_evmVersion),
 		debugInfo(std::move(_debugInfo))
 	{}

--- a/libyul/backends/evm/ssa/SSACFGBuilder.cpp
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.cpp
@@ -25,6 +25,7 @@
 
 #include <libyul/AST.h>
 #include <libyul/ControlFlowSideEffectsCollector.h>
+#include <libyul/optimiser/Metrics.h>
 #include <libyul/Exceptions.h>
 #include <libyul/Utilities.h>
 
@@ -81,7 +82,8 @@ std::unique_ptr<ControlFlowGraphs> SSACFGBuilder::build(
 	auto controlFlowGraphs = std::make_unique<ControlFlowGraphs>();
 	controlFlowGraphs->functionGraphs.emplace_back(std::make_unique<SSACFG>(
 		_dialect,
-		_generateDebugInfo ? std::make_unique<SSACFGDebugInfo>() : nullptr
+		_generateDebugInfo ? std::make_unique<SSACFGDebugInfo>() : nullptr,
+		2 * CodeSize::codeSize(_block)  // empirically there are roughly 2x the instructions
 	));
 	SSACFG& mainGraph = *controlFlowGraphs->functionGraphs.back();
 	FunctionRegistry functionRegistry;
@@ -375,7 +377,8 @@ void SSACFGBuilder::registerFunctionDefinition(FunctionDefinition const& _functi
 	// reference this function by its FunctionGraphID when their bodies are built later.
 	m_controlFlow.functionGraphs.emplace_back(std::make_unique<SSACFG>(
 		m_dialect,
-		m_generateDebugInfo ? std::make_unique<SSACFGDebugInfo>() : nullptr
+		m_generateDebugInfo ? std::make_unique<SSACFGDebugInfo>() : nullptr,
+		2 * CodeSize::codeSize(_functionDefinition.body)  // empirically there are roughly 2x the instructions
 	));
 	auto const graphID = static_cast<FunctionGraphID>(m_controlFlow.functionGraphs.size() - 1);
 	auto& cfg = *m_controlFlow.functionGraphs.back();

--- a/libyul/backends/evm/ssa/StackUtils.cpp
+++ b/libyul/backends/evm/ssa/StackUtils.cpp
@@ -154,12 +154,12 @@ OptimalTarget solidity::yul::ssa::findOptimalTarget
 				bestSpillSet = spillSet;
 				consecutiveIncreases = 0;
 			}
-			else if (++consecutiveIncreases >= stopAfter)
+			else if (bestCost == 0 || ++consecutiveIncreases >= stopAfter)
 				break;
 		}
 	}
 	// search upward (only on reverting paths)
-	if (_canIntroduceJunk)
+	if (_canIntroduceJunk && bestCost != 0)
 	{
 		consecutiveIncreases = 0;
 		for (std::size_t size = startSize + 1; size <= startSize + maxUpwardExpansion; ++size)
@@ -172,7 +172,7 @@ OptimalTarget solidity::yul::ssa::findOptimalTarget
 				bestSpillSet = spillSet;
 				consecutiveIncreases = 0;
 			}
-			else if (++consecutiveIncreases >= stopAfter)
+			else if (bestCost == 0 || ++consecutiveIncreases >= stopAfter)
 				break;
 		}
 	}

--- a/libyul/backends/evm/ssa/util/TLSFFreeList.h
+++ b/libyul/backends/evm/ssa/util/TLSFFreeList.h
@@ -379,7 +379,6 @@ private:
 	Index growStorage(Length const _length)
 	{
 		auto const start = static_cast<Index>(m_data.size());
-		m_data.reserve(m_data.size() + _length);
 		for (Length k = 0; k < _length; ++k)
 			m_data.emplace_back(Tombstone::make());
 		m_headers.resize(m_data.size());

--- a/libyul/backends/evm/ssa/util/TLSFFreeList.h
+++ b/libyul/backends/evm/ssa/util/TLSFFreeList.h
@@ -51,10 +51,12 @@ public:
 	using Index = std::uint32_t;
 	using Length = std::uint32_t;
 
-	TLSFFreeList()
+	explicit TLSFFreeList(std::size_t const _initialCapacity = 0)
 	{
 		for (auto& row: m_binHead)
 			row.fill(EMPTY);
+		m_data.reserve(_initialCapacity);
+		m_headers.reserve(_initialCapacity);
 	}
 	TLSFFreeList(TLSFFreeList const&) = delete;
 	TLSFFreeList(TLSFFreeList&&) = default;


### PR DESCRIPTION
Three changes:

- estimate number of instructions in SSACFG based on AST (roughly ratio 1:2)
- do not `reserve` in TLSFFreeList, that kills geometric growth
- when finding optimal target size, abort early when we reached absolute minimum (no shuffling)