### PR TITLE
SSA CFG: Don't mark loop heads as junk admitting

### DIFF
--- a/libyul/backends/evm/ssa/JunkAdmittingBlocksFinder.cpp
+++ b/libyul/backends/evm/ssa/JunkAdmittingBlocksFinder.cpp
@@ -45,7 +45,8 @@ JunkAdmittingBlocksFinder::JunkAdmittingBlocksFinder(SSACFG const& _cfg, travers
 	for (auto const blockIndex: _topologicalSort.preOrder())
 	{
 		SSACFG::BlockId const blockId {blockIndex};
-		m_blockAllowsJunk[blockIndex] = bridgeFinder.bridgeVertex(blockId) || _cfg.block(blockId).isTerminationBlock();
+		bool const isLoopHead = _topologicalSort.backEdgeTargets().contains(blockIndex);
+		m_blockAllowsJunk[blockIndex] = (bridgeFinder.bridgeVertex(blockId) && !isLoopHead) || _cfg.block(blockId).isTerminationBlock();
 		if (_cfg.block(blockId).isFunctionReturnBlock())
 			toVisit.emplace_back(SSACFG::BlockId{blockIndex});
 	}

--- a/test/libsolidity/semanticTests/array/dynamic_multi_array_cleanup.sol
+++ b/test/libsolidity/semanticTests/array/dynamic_multi_array_cleanup.sol
@@ -19,7 +19,7 @@ contract c {
 // gas irOptimized: 122985
 // gas legacy: 121602
 // gas legacyOptimized: 120589
-// gas ssaCFGOptimized: 123074
+// gas ssaCFGOptimized: 123066
 // storageEmpty -> 0
 // clear() ->
 // storageEmpty -> 1

--- a/test/libyul/ssa/controlFlowGraph/nested_for.yul
+++ b/test/libyul/ssa/controlFlowGraph/nested_for.yul
@@ -31,7 +31,7 @@
 // Block0_0 -> Block0_0Exit [arrowhead=none];
 // Block0_0Exit [label="Jump" shape=oval];
 // Block0_0Exit -> Block0_1 [style="solid"];
-// Block0_1 [fillcolor="#FF746C", style=filled, label="\
+// Block0_1 [label="\
 // Block 1; (1, max 24)\nLiveIn: phi2[3]\l\
 // LiveOut: phi2[1]\l\nUsed: phi2[2]\l\nphi2 := φ(\l\
 // 	Block 0 => 0x00,\l\


### PR DESCRIPTION
It occurred to me that we might want to exclude loop heads from the junk-admitting consideration. Otherwise, any junk that accumulates inside the loop head block will have to be reconciled when shuffling along the back-edge.