### PR TITLE
SSA-CFG: Simplify handling of stack-too-deep situation in shuffler

### DIFF
--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -421,18 +421,7 @@ private:
 			return {StackShufflerResult::Status::Continue};
 
 		// if we couldn't shrink the stack we surface this failed state as stack too deep
-		for (StackOffset const offset: _state.stackRange() | ranges::views::reverse)
-		{
-			Slot const& candidate = _stack[offset];
-			if (
-				candidate.isValue() &&
-				!candidate.isLiteralValue() &&
-				!_state.slotIsSpilled(candidate)
-			)
-				return {StackShufflerResult::Status::StackTooDeep, validatedSpillingCandidate(candidate, _state)};
-		}
-
-		yulAssert(false, "reached final and forbidden state");
+		return {StackShufflerResult::Status::StackTooDeep, validatedSpillingCandidate(_stack.top(), _state)};
 	}
 
 	/// Select an optimal slot to dup based on liveness analysis.


### PR DESCRIPTION
The very last attempt to improve stack situation in the shuffler is to try to shrink the stack. If this does not help, stack-too-deep situation is reported.
However, we do not have to search for the candidate to spill. If we have failed in shrinking the stack, then the stack top must be a value that is a good candidate (otherwise we would have been able to pop it and shrink the stack).