### PR TITLE
Perf: replace std::unordered_map with boost::unordered_flat_map/set

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@ Language Features:
 
 Compiler Features:
 * EVM-ASM Optimizer: Improve performance of block deduplicator.
+* General: Improve performance throughout the compiler using Boost's flat versions of unordered set and map.
 * SMTChecker: Emit a deprecation warning for the BMC engine.
 
 Bugfixes:

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,9 @@ Bugfixes:
 * Code Generator: Fix ICE on parenthesized custom error construction in require statement.
 * Commandline Interface: Report proper error instead of ICE on non-hex mixed-case address value given via `--libraries`.
 
+Build System:
+* Update minimum version requirement of Boost to 1.83.0 for Windows build. This matches the minimum version for other systems.
+
 
 ### 0.8.36 (2026-07-09)
 

--- a/cmake/EthDependencies.cmake
+++ b/cmake/EthDependencies.cmake
@@ -38,7 +38,8 @@ endif()
 if (WIN32)
 	# Boost 1.77 fixes a bug that causes crashes on Windows for some relative paths in --allow-paths.
 	# See https://github.com/boostorg/filesystem/issues/201
-	find_package(Boost 1.77.0 QUIET REQUIRED COMPONENTS ${BOOST_COMPONENTS})
+	# Boost 1.83 is the project-wide minimum version, and also provides Boost.Unordered flat containers.
+	find_package(Boost 1.83.0 QUIET REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 else()
 	# Boost 1.65 is the first to also provide boost::get for rvalue-references (#5787).
 	# Boost 1.67 moved container_hash into is own module.

--- a/docs/installing-solidity.rst
+++ b/docs/installing-solidity.rst
@@ -326,8 +326,7 @@ The following are dependencies for all builds of Solidity:
 | `CMake`_ (version 3.21.3+ on      | Cross-platform build file generator.                  |
 | Windows, 3.13+ otherwise)         |                                                       |
 +-----------------------------------+-------------------------------------------------------+
-| `Boost`_ (version 1.77+ on        | C++ libraries.                                        |
-| Windows, 1.83+ otherwise)         |                                                       |
+| `Boost`_ (version 1.83+)          | C++ libraries.                                        |
 +-----------------------------------+-------------------------------------------------------+
 | `Git`_                            | Command-line tool for retrieving source code.         |
 +-----------------------------------+-------------------------------------------------------+

--- a/libevmasm/CommonSubexpressionEliminator.cpp
+++ b/libevmasm/CommonSubexpressionEliminator.cpp
@@ -225,7 +225,7 @@ void CSECodeGenerator::addDependencies(Id _c)
 		return; // it is already on the stack
 	if (m_neededBy.find(_c) != m_neededBy.end())
 		return; // we already computed the dependencies for _c
-	ExpressionClasses::Expression expr = m_expressionClasses.representative(_c);
+	Expression expr = m_expressionClasses.representative(_c);
 	assertThrow(expr.item, OptimizerException, "");
 	// If this exception happens, we need to find a different way to generate the
 	// compound expression.
@@ -322,7 +322,7 @@ void CSECodeGenerator::generateClassElement(Id _c, bool _allowSequenced)
 		);
 		return;
 	}
-	ExpressionClasses::Expression const& expr = m_expressionClasses.representative(_c);
+	Expression const& expr = m_expressionClasses.representative(_c);
 	assertThrow(
 		_allowSequenced || expr.sequenceNumber == 0,
 		OptimizerException,

--- a/libevmasm/CommonSubexpressionEliminator.h
+++ b/libevmasm/CommonSubexpressionEliminator.h
@@ -28,11 +28,11 @@
 #include <ostream>
 #include <set>
 #include <tuple>
-#include <unordered_map>
 #include <vector>
 #include <liblangutil/EVMVersion.h>
 #include <libsolutil/CommonIO.h>
 #include <libsolutil/Exceptions.h>
+#include <libsolutil/UnorderedContainers.h>
 #include <libevmasm/ExpressionClasses.h>
 #include <libevmasm/SemanticInformation.h>
 #include <libevmasm/KnownState.h>
@@ -165,11 +165,11 @@ private:
 	/// Current height of the stack relative to the start.
 	int m_stackHeight = 0;
 	/// If (b, a) is in m_requests then b is needed to compute a.
-	std::unordered_multimap<Id, Id> m_neededBy;
+	util::unordered_multimap<Id, Id> m_neededBy;
 	/// Current content of the stack.
 	std::map<int, Id> m_stack;
 	/// Current positions of equivalence classes, equal to the empty set if already deleted.
-	std::unordered_map<Id, std::set<int>> m_classPositions;
+	util::unordered_flat_map<Id, std::set<int>> m_classPositions;
 
 	/// The actual equivalence class items and how to compute them.
 	ExpressionClasses& m_expressionClasses;

--- a/libevmasm/ExpressionClasses.cpp
+++ b/libevmasm/ExpressionClasses.cpp
@@ -39,7 +39,7 @@ using namespace solidity;
 using namespace solidity::evmasm;
 using namespace solidity::langutil;
 
-bool ExpressionClasses::Expression::operator==(ExpressionClasses::Expression const& _other) const
+bool Expression::operator==(Expression const& _other) const
 {
 	assertThrow(!!item && !!_other.item, OptimizerException, "");
 	auto type = item->type();
@@ -58,7 +58,7 @@ bool ExpressionClasses::Expression::operator==(ExpressionClasses::Expression con
 			std::tie(_other.item->data(), _other.arguments, _other.sequenceNumber);
 }
 
-size_t ExpressionClasses::Expression::ExpressionHash::operator()(Expression const& _expression) const
+size_t ExpressionHash::operator()(Expression const& _expression) const
 {
 	assertThrow(!!_expression.item, OptimizerException, "");
 	size_t seed = 0;

--- a/libevmasm/ExpressionClasses.h
+++ b/libevmasm/ExpressionClasses.h
@@ -27,9 +27,9 @@
 #include <libevmasm/AssemblyItem.h>
 
 #include <libsolutil/Common.h>
+#include <libsolutil/UnorderedContainers.h>
 
 #include <memory>
-#include <unordered_set>
 #include <vector>
 
 namespace solidity::langutil
@@ -43,6 +43,22 @@ namespace solidity::evmasm
 class Pattern;
 struct ExpressionTemplate;
 
+struct Expression
+{
+	unsigned id;
+	AssemblyItem const* item = nullptr;
+	std::vector<unsigned> arguments;
+	/// Storage modification sequence, only used for storage and memory operations.
+	unsigned sequenceNumber = 0;
+	/// Behaves as if this was a tuple of (item->type(), item->data(), arguments, sequenceNumber).
+	bool operator==(Expression const& _other) const;
+};
+
+struct ExpressionHash
+{
+	std::size_t operator()(Expression const& _expression) const;
+};
+
 /**
  * Collection of classes of equivalent expressions that can also determine the class of an expression.
  * Identifiers are contiguously assigned to new classes starting from zero.
@@ -52,23 +68,6 @@ class ExpressionClasses
 public:
 	using Id = unsigned;
 	using Ids = std::vector<Id>;
-
-	struct Expression
-	{
-		Id id;
-		AssemblyItem const* item = nullptr;
-		Ids arguments;
-		/// Storage modification sequence, only used for storage and memory operations.
-		unsigned sequenceNumber = 0;
-		/// Behaves as if this was a tuple of (item->type(), item->data(), arguments, sequenceNumber).
-		bool operator==(Expression const& _other) const;
-
-		struct ExpressionHash
-		{
-			std::size_t operator()(Expression const& _expression) const;
-		};
-	};
-
 
 	/// Retrieves the id of the expression equivalence class resulting from the given item applied to the
 	/// given classes, might also create a new one.
@@ -128,7 +127,7 @@ private:
 	/// Expression equivalence class representatives - we only store one item of an equivalence.
 	std::vector<Expression> m_representatives;
 	/// All expression ever encountered.
-	std::unordered_set<Expression, Expression::ExpressionHash> m_expressions;
+	util::unordered_flat_set<Expression, ExpressionHash> m_expressions;
 	std::vector<std::shared_ptr<AssemblyItem>> m_spareAssemblyItems;
 };
 

--- a/libevmasm/KnownState.cpp
+++ b/libevmasm/KnownState.cpp
@@ -432,7 +432,7 @@ std::set<u256> KnownState::tagsInExpression(KnownState::Id _expressionId)
 	if (m_tagUnions.left.count(_expressionId))
 		return m_tagUnions.left.at(_expressionId);
 	// Might be a tag, then return the set of itself.
-	ExpressionClasses::Expression expr = m_expressionClasses->representative(_expressionId);
+	Expression expr = m_expressionClasses->representative(_expressionId);
 	if (expr.item && expr.item->type() == PushTag)
 		return std::set<u256>({expr.item->data()});
 	else

--- a/libevmasm/SimplificationRules.cpp
+++ b/libevmasm/SimplificationRules.cpp
@@ -185,7 +185,7 @@ bool Pattern::matchesBaseItem(AssemblyItem const* _item) const
 	return true;
 }
 
-Pattern::Expression const& Pattern::matchGroupValue() const
+Expression const& Pattern::matchGroupValue() const
 {
 	assertThrow(m_matchGroup > 0, OptimizerException, "");
 	assertThrow(!!m_matchGroups, OptimizerException, "");

--- a/libevmasm/SimplificationRules.h
+++ b/libevmasm/SimplificationRules.h
@@ -52,8 +52,6 @@ public:
 	Rules(Rules const&) = delete;
 	Rules& operator=(Rules const&) = delete;
 
-	using Expression = ExpressionClasses::Expression;
-
 	Rules();
 
 	/// @returns a pointer to the first matching pattern and sets the match
@@ -87,7 +85,6 @@ private:
 class Pattern
 {
 public:
-	using Expression = ExpressionClasses::Expression;
 	using Id = ExpressionClasses::Id;
 
 	using Builtins = evmasm::EVMBuiltins<Pattern>;
@@ -147,7 +144,6 @@ private:
  */
 struct ExpressionTemplate
 {
-	using Expression = ExpressionClasses::Expression;
 	using Id = ExpressionClasses::Id;
 	explicit ExpressionTemplate(Pattern const& _pattern, langutil::DebugData::ConstPtr const& _debugData);
 	std::string toString() const;

--- a/libsolidity/analysis/GlobalContext.cpp
+++ b/libsolidity/analysis/GlobalContext.cpp
@@ -27,8 +27,10 @@
 #include <libsolidity/ast/AST.h>
 #include <libsolidity/ast/TypeProvider.h>
 #include <libsolidity/ast/Types.h>
+
+#include <libsolutil/UnorderedContainers.h>
+
 #include <memory>
-#include <unordered_map>
 
 namespace solidity::frontend
 {
@@ -39,7 +41,7 @@ namespace
 /// Magic variables get negative ids for easy differentiation
 int magicVariableToID(std::string const& _name)
 {
-	static std::unordered_map<std::string, int> const magicVariables = {
+	static util::unordered_flat_map<std::string, int> const magicVariables = {
 		{"abi", -1},
 		{"addmod", -2},
 		{"assert", -3},

--- a/libsolidity/analysis/NameAndTypeResolver.cpp
+++ b/libsolidity/analysis/NameAndTypeResolver.cpp
@@ -28,7 +28,6 @@
 #include <liblangutil/ErrorReporter.h>
 #include <libsolutil/StringUtils.h>
 #include <boost/algorithm/string.hpp>
-#include <unordered_set>
 
 using namespace std::string_literals;
 using namespace solidity::langutil;

--- a/libsolidity/ast/Types.cpp
+++ b/libsolidity/ast/Types.cpp
@@ -35,6 +35,7 @@
 #include <libsolutil/FunctionSelector.h>
 #include <libsolutil/Keccak256.h>
 #include <libsolutil/StringUtils.h>
+#include <libsolutil/UnorderedContainers.h>
 #include <libsolutil/UTF8.h>
 #include <libsolutil/Visitor.h>
 
@@ -52,7 +53,6 @@
 #include <range/v3/view/filter.hpp>
 
 #include <limits>
-#include <unordered_set>
 #include <utility>
 
 using namespace solidity;
@@ -1516,7 +1516,7 @@ TypeResult ContractType::unaryOperatorResult(Token _operator) const
 std::vector<Type const*> CompositeType::fullDecomposition() const
 {
 	std::vector<Type const*> res = {this};
-	std::unordered_set<std::string> seen = {richIdentifier()};
+	util::unordered_flat_set<std::string> seen = {richIdentifier()};
 	for (size_t k = 0; k < res.size(); ++k)
 		if (auto composite = dynamic_cast<CompositeType const*>(res[k]))
 			for (Type const* next: composite->decomposition())

--- a/libsolutil/CMakeLists.txt
+++ b/libsolutil/CMakeLists.txt
@@ -38,6 +38,7 @@ set(sources
 	TarjanSCC.h
 	TemporaryDirectory.cpp
 	TemporaryDirectory.h
+	UnorderedContainers.h
 	UTF8.cpp
 	UTF8.h
 	vector_ref.h

--- a/libsolutil/UnorderedContainers.h
+++ b/libsolutil/UnorderedContainers.h
@@ -1,0 +1,55 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <boost/unordered/unordered_flat_map.hpp>
+#include <boost/unordered/unordered_flat_set.hpp>
+#include <boost/unordered/unordered_map.hpp>
+
+#include <functional>
+#include <memory>
+#include <utility>
+
+namespace solidity::util
+{
+
+template<
+	class Key,
+	class T,
+	class Hash = std::hash<Key>,
+	class KeyEqual = std::equal_to<Key>,
+	class Allocator = std::allocator<std::pair<Key const, T>>>
+using unordered_flat_map = boost::unordered_flat_map<Key, T, Hash, KeyEqual, Allocator>;
+
+template<
+	class Key,
+	class T,
+	class Hash = std::hash<Key>,
+	class KeyEqual = std::equal_to<Key>,
+	class Allocator = std::allocator<std::pair<Key const, T>>>
+using unordered_multimap = boost::unordered_multimap<Key, T, Hash, KeyEqual, Allocator>;
+
+template<
+	class Key,
+	class Hash = std::hash<Key>,
+	class KeyEqual = std::equal_to<Key>,
+	class Allocator = std::allocator<Key>>
+using unordered_flat_set = boost::unordered_flat_set<Key, Hash, KeyEqual, Allocator>;
+
+}

--- a/libyul/ControlFlowSideEffectsCollector.h
+++ b/libyul/ControlFlowSideEffectsCollector.h
@@ -21,10 +21,10 @@
 #include <libyul/optimiser/ASTWalker.h>
 #include <libyul/ControlFlowSideEffects.h>
 
+#include <libsolutil/UnorderedContainers.h>
+
 #include <deque>
 #include <list>
-#include <unordered_map>
-#include <unordered_set>
 
 namespace solidity::yul
 {
@@ -56,7 +56,7 @@ public:
 	/// Computes the control-flows of all function defined in the block.
 	/// Assumes the functions are hoisted to the topmost block.
 	explicit ControlFlowBuilder(Block const& _ast);
-	std::unordered_map<FunctionDefinition const*, FunctionFlow> const& functionFlows() const { return m_functionFlows; }
+	util::unordered_flat_map<FunctionDefinition const*, FunctionFlow> const& functionFlows() const { return m_functionFlows; }
 
 private:
 	using ASTWalker::operator();
@@ -79,7 +79,7 @@ private:
 	ControlFlowNode const* m_break = nullptr;
 	ControlFlowNode const* m_continue = nullptr;
 
-	std::unordered_map<FunctionDefinition const*, FunctionFlow> m_functionFlows;
+	util::unordered_flat_map<FunctionDefinition const*, FunctionFlow> m_functionFlows;
 };
 
 
@@ -96,7 +96,7 @@ public:
 		Block const& _ast
 	);
 
-	std::unordered_map<FunctionDefinition const*, ControlFlowSideEffects> const& functionSideEffects() const
+	util::unordered_flat_map<FunctionDefinition const*, ControlFlowSideEffects> const& functionSideEffects() const
 	{
 		return m_functionSideEffects;
 	}
@@ -124,15 +124,15 @@ private:
 	Dialect const& m_dialect;
 	ControlFlowBuilder m_cfgBuilder;
 	/// Function references, but only for calls to user-defined functions.
-	std::unordered_map<FunctionCall const*, FunctionDefinition const*> m_functionReferences;
+	util::unordered_flat_map<FunctionCall const*, FunctionDefinition const*> m_functionReferences;
 	/// Side effects of user-defined functions, is being constructod.
-	std::unordered_map<FunctionDefinition const*, ControlFlowSideEffects> m_functionSideEffects;
+	util::unordered_flat_map<FunctionDefinition const*, ControlFlowSideEffects> m_functionSideEffects;
 	/// Control flow nodes still to process, per function.
-	std::unordered_map<FunctionDefinition const*, std::list<ControlFlowNode const*>> m_pendingNodes;
+	util::unordered_flat_map<FunctionDefinition const*, std::list<ControlFlowNode const*>> m_pendingNodes;
 	/// Control flow nodes already processed, per function.
-	std::unordered_map<FunctionDefinition const*, std::unordered_set<ControlFlowNode const*>> m_processedNodes;
+	util::unordered_flat_map<FunctionDefinition const*, util::unordered_flat_set<ControlFlowNode const*>> m_processedNodes;
 	/// Set of reachable function calls nodes in each function (including calls to builtins).
-	std::unordered_map<FunctionDefinition const*, std::unordered_set<FunctionCall const*>> m_functionCalls;
+	util::unordered_flat_map<FunctionDefinition const*, util::unordered_flat_set<FunctionCall const*>> m_functionCalls;
 };
 
 

--- a/libyul/FunctionReferenceResolver.h
+++ b/libyul/FunctionReferenceResolver.h
@@ -20,7 +20,7 @@
 
 #include <libyul/optimiser/ASTWalker.h>
 
-#include <unordered_map>
+#include <libsolutil/UnorderedContainers.h>
 
 namespace solidity::yul
 {
@@ -35,15 +35,15 @@ class FunctionReferenceResolver: private ASTWalker
 {
 public:
 	explicit FunctionReferenceResolver(Block const& _ast);
-	std::unordered_map<FunctionCall const*, FunctionDefinition const*> const& references() const { return m_functionReferences; }
+	util::unordered_flat_map<FunctionCall const*, FunctionDefinition const*> const& references() const { return m_functionReferences; }
 
 private:
 	using ASTWalker::operator();
 	void operator()(FunctionCall const& _functionCall) override;
 	void operator()(Block const& _block) override;
 
-	std::unordered_map<FunctionCall const*, FunctionDefinition const*> m_functionReferences;
-	std::vector<std::unordered_map<YulName, FunctionDefinition const*>> m_scopes;
+	util::unordered_flat_map<FunctionCall const*, FunctionDefinition const*> m_functionReferences;
+	std::vector<util::unordered_flat_map<YulName, FunctionDefinition const*>> m_scopes;
 };
 
 

--- a/libyul/YulString.h
+++ b/libyul/YulString.h
@@ -21,11 +21,12 @@
 
 #pragma once
 
+#include <libsolutil/UnorderedContainers.h>
+
 #include <fmt/format.h>
 
 #include <deque>
 #include <memory>
-#include <unordered_map>
 #include <vector>
 #include <string>
 #include <string_view>
@@ -117,7 +118,7 @@ private:
 	}
 
 	std::deque<std::string> m_strings = {""};
-	std::unordered_multimap<std::uint64_t, size_t> m_hashToID = {{emptyHash(), 0}};
+	util::unordered_multimap<std::uint64_t, size_t> m_hashToID = {{emptyHash(), 0}};
 };
 
 /// Wrapper around handles into the YulString repository.

--- a/libyul/backends/evm/ControlFlowGraphBuilder.cpp
+++ b/libyul/backends/evm/ControlFlowGraphBuilder.cpp
@@ -254,7 +254,7 @@ std::unique_ptr<CFG> ControlFlowGraphBuilder::build(
 ControlFlowGraphBuilder::ControlFlowGraphBuilder(
 	CFG& _graph,
 	AsmAnalysisInfo const& _analysisInfo,
-	std::unordered_map<FunctionDefinition const*, ControlFlowSideEffects> const& _functionSideEffects,
+	util::unordered_flat_map<FunctionDefinition const*, ControlFlowSideEffects> const& _functionSideEffects,
 	Dialect const& _dialect
 ):
 	m_graph(_graph),

--- a/libyul/backends/evm/ControlFlowGraphBuilder.h
+++ b/libyul/backends/evm/ControlFlowGraphBuilder.h
@@ -23,7 +23,7 @@
 #include <libyul/backends/evm/ControlFlowGraph.h>
 #include <libyul/ControlFlowSideEffects.h>
 
-#include <unordered_map>
+#include <libsolutil/UnorderedContainers.h>
 
 namespace solidity::yul
 {
@@ -58,7 +58,7 @@ private:
 	ControlFlowGraphBuilder(
 		CFG& _graph,
 		AsmAnalysisInfo const& _analysisInfo,
-		std::unordered_map<FunctionDefinition const*, ControlFlowSideEffects> const& _functionSideEffects,
+		util::unordered_flat_map<FunctionDefinition const*, ControlFlowSideEffects> const& _functionSideEffects,
 		Dialect const& _dialect
 	);
 	void registerFunction(FunctionDefinition const& _function);
@@ -81,7 +81,7 @@ private:
 	);
 	CFG& m_graph;
 	AsmAnalysisInfo const& m_info;
-	std::unordered_map<FunctionDefinition const*, ControlFlowSideEffects> const& m_functionSideEffects;
+	util::unordered_flat_map<FunctionDefinition const*, ControlFlowSideEffects> const& m_functionSideEffects;
 	Dialect const& m_dialect;
 	CFG::BasicBlock* m_currentBlock = nullptr;
 	Scope* m_scope = nullptr;

--- a/libyul/backends/evm/EVMDialect.h
+++ b/libyul/backends/evm/EVMDialect.h
@@ -29,10 +29,11 @@
 
 #include <liblangutil/EVMVersion.h>
 
+#include <libsolutil/UnorderedContainers.h>
+
 #include <array>
 #include <optional>
 #include <set>
-#include <unordered_map>
 #include <vector>
 
 namespace solidity::yul
@@ -110,7 +111,7 @@ protected:
 
 	bool const m_objectAccess;
 	langutil::EVMVersion const m_evmVersion;
-	std::unordered_map<std::string_view, BuiltinHandle> m_builtinFunctionsByName;
+	util::unordered_flat_map<std::string_view, BuiltinHandle> m_builtinFunctionsByName;
 	std::vector<BuiltinFunctionForEVM const*> m_functions;
 	std::array<std::unique_ptr<BuiltinFunctionForEVM>, verbatimIDOffset> mutable m_verbatimFunctions{};
 	std::set<std::string, std::less<>> m_reserved;

--- a/libyul/backends/evm/ssa/SSACFGBuilder.h
+++ b/libyul/backends/evm/ssa/SSACFGBuilder.h
@@ -45,8 +45,9 @@
 
 #include <libyul/AsmAnalysisInfo.h>
 
+#include <libsolutil/UnorderedContainers.h>
+
 #include <stack>
-#include <unordered_map>
 
 namespace solidity::yul::ssa
 {
@@ -61,7 +62,7 @@ public:
 	};
 	/// Lookup table for user-defined functions encountered during build, shared across
 	/// all SSACFGBuilder instances (one per function body) so they don't copy it.
-	using FunctionRegistry = std::unordered_map<Scope::Function const*, FunctionRegistration>;
+	using FunctionRegistry = solidity::util::unordered_flat_map<Scope::Function const*, FunctionRegistration>;
 
 private:
 	SSACFGBuilder(
@@ -154,10 +155,7 @@ private:
 	}
 	void sealBlock(SSACFG::BlockId _block);
 
-	std::unordered_map<
-		Scope::Variable const*,
-		std::vector<InstId>
-	> m_currentDef;
+	solidity::util::unordered_flat_map<Scope::Variable const*, std::vector<InstId>> m_currentDef;
 
 	struct ForLoopInfo {
 		SSACFG::BlockId breakBlock;

--- a/libyul/backends/evm/ssa/spill/MemoryAddressing.h
+++ b/libyul/backends/evm/ssa/spill/MemoryAddressing.h
@@ -23,9 +23,9 @@
 #include <libyul/backends/evm/ssa/spill/SpillSet.h>
 
 #include <libsolutil/Numeric.h>
+#include <libsolutil/UnorderedContainers.h>
 
 #include <span>
-#include <unordered_map>
 #include <vector>
 
 namespace solidity::yul::ssa::spill
@@ -50,7 +50,7 @@ public:
 
 private:
 	/// m_addresses[cfgIdx][value.value] -> u256 final address
-	std::vector<std::unordered_map<InstId::ValueType, u256>> m_addresses;
+	std::vector<solidity::util::unordered_flat_map<InstId::ValueType, u256>> m_addresses;
 };
 
 }

--- a/libyul/backends/evm/ssa/transform/Outliner.cpp
+++ b/libyul/backends/evm/ssa/transform/Outliner.cpp
@@ -27,6 +27,7 @@
 #include <range/v3/view/map.hpp>
 
 #include <map>
+#include <unordered_map>
 #include <unordered_set>
 
 

--- a/libyul/optimiser/CommonSubexpressionEliminator.h
+++ b/libyul/optimiser/CommonSubexpressionEliminator.h
@@ -63,7 +63,7 @@ protected:
 	void assignValue(YulName _variable, Expression const* _value) override;
 private:
 	std::set<YulName> m_returnVariables;
-	std::unordered_map<
+	util::unordered_flat_map<
 		std::reference_wrapper<Expression const>,
 		std::set<YulName>,
 		ExpressionHash,

--- a/libyul/optimiser/DataFlowAnalyzer.cpp
+++ b/libyul/optimiser/DataFlowAnalyzer.cpp
@@ -67,7 +67,7 @@ void DataFlowAnalyzer::operator()(ExpressionStatement& _statement)
 		if (auto vars = isSimpleStore(StoreLoadLocation::Storage, _statement))
 		{
 			ASTModifier::operator()(_statement);
-			std::erase_if(m_state.environment.storage, mapTuple([&](auto&& key, auto&& value) {
+			boost::unordered::erase_if(m_state.environment.storage, mapTuple([&](auto&& key, auto&& value) {
 				return
 					!m_knowledgeBase.knownToBeDifferent(vars->first, key) &&
 					vars->second != value;
@@ -78,7 +78,7 @@ void DataFlowAnalyzer::operator()(ExpressionStatement& _statement)
 		else if (auto vars = isSimpleStore(StoreLoadLocation::Memory, _statement))
 		{
 			ASTModifier::operator()(_statement);
-			std::erase_if(m_state.environment.memory, mapTuple([&](auto&& key, auto&& /* value */) {
+			boost::unordered::erase_if(m_state.environment.memory, mapTuple([&](auto&& key, auto&& /* value */) {
 				return !m_knowledgeBase.knownToBeDifferentByAtLeast32(vars->first, key);
 			}));
 			// TODO erase keccak knowledge, but in a more clever way
@@ -272,14 +272,14 @@ void DataFlowAnalyzer::handleAssignment(std::set<YulName> const& _variables, Exp
 			// assignment to slot denoted by "name"
 			m_state.environment.storage.erase(name);
 			// assignment to slot contents denoted by "name"
-			std::erase_if(m_state.environment.storage, mapTuple([&name](auto&& /* key */, auto&& value) { return value == name; }));
+			boost::unordered::erase_if(m_state.environment.storage, mapTuple([&name](auto&& /* key */, auto&& value) { return value == name; }));
 			// assignment to slot denoted by "name"
 			m_state.environment.memory.erase(name);
 			// assignment to slot contents denoted by "name"
 			std::erase_if(m_state.environment.keccak, [&name](auto&& _item) {
 				return _item.first.first == name || _item.first.second == name || _item.second == name;
 			});
-			std::erase_if(m_state.environment.memory, mapTuple([&name](auto&& /* key */, auto&& value) { return value == name; }));
+			boost::unordered::erase_if(m_state.environment.memory, mapTuple([&name](auto&& /* key */, auto&& value) { return value == name; }));
 		}
 	}
 
@@ -337,8 +337,8 @@ void DataFlowAnalyzer::clearValues(std::set<YulName> const& _variablesToClear)
 	auto eraseCondition = mapTuple([&_variablesToClear](auto&& key, auto&& value) {
 		return _variablesToClear.count(key) || _variablesToClear.count(value);
 	});
-	std::erase_if(m_state.environment.storage, eraseCondition);
-	std::erase_if(m_state.environment.memory, eraseCondition);
+	boost::unordered::erase_if(m_state.environment.storage, eraseCondition);
+	boost::unordered::erase_if(m_state.environment.memory, eraseCondition);
 	std::erase_if(m_state.environment.keccak, [&_variablesToClear](auto&& _item) {
 		return
 			_variablesToClear.count(_item.first.first) ||
@@ -473,15 +473,15 @@ void DataFlowAnalyzer::joinKnowledge(Environment const& _olderEnvironment)
 }
 
 void DataFlowAnalyzer::joinKnowledgeHelper(
-	std::unordered_map<YulName, YulName>& _this,
-	std::unordered_map<YulName, YulName> const& _older
+	util::unordered_flat_map<YulName, YulName>& _this,
+	util::unordered_flat_map<YulName, YulName> const& _older
 )
 {
 	// We clear if the key does not exist in the older map or if the value is different.
 	// This also works for memory because _older is an "older version"
 	// of m_state.environment.memory and thus any overlapping write would have cleared the keys
 	// that are not known to be different inside m_state.environment.memory already.
-	std::erase_if(_this, mapTuple([&_older](auto&& key, auto&& currentValue){
+	boost::unordered::erase_if(_this, mapTuple([&_older](auto&& key, auto&& currentValue){
 		YulName const* oldValue = valueOrNullptr(_older, key);
 		return !oldValue || *oldValue != currentValue;
 	}));

--- a/libyul/optimiser/DataFlowAnalyzer.h
+++ b/libyul/optimiser/DataFlowAnalyzer.h
@@ -170,8 +170,8 @@ protected:
 private:
 	struct Environment
 	{
-		std::unordered_map<YulName, YulName> storage;
-		std::unordered_map<YulName, YulName> memory;
+		util::unordered_flat_map<YulName, YulName> storage;
+		util::unordered_flat_map<YulName, YulName> memory;
 		/// If keccak[s, l] = y then y := keccak256(s, l) occurs in the code.
 		std::map<std::pair<YulName, YulName>, YulName> keccak;
 	};
@@ -181,7 +181,7 @@ private:
 		std::map<YulName, AssignedValue> value;
 		/// m_references[a].contains(b) <=> the current expression assigned to a references b
 		/// The mapped vectors _must always_ be sorted
-		std::unordered_map<YulName, std::vector<YulName>> sortedReferences;
+		util::unordered_flat_map<YulName, std::vector<YulName>> sortedReferences;
 
 		Environment environment;
 	};
@@ -193,8 +193,8 @@ private:
 	void joinKnowledge(Environment const& _olderEnvironment);
 
 	static void joinKnowledgeHelper(
-		std::unordered_map<YulName, YulName>& _thisData,
-		std::unordered_map<YulName, YulName> const& _olderData
+		util::unordered_flat_map<YulName, YulName>& _thisData,
+		util::unordered_flat_map<YulName, YulName> const& _olderData
 	);
 
 	State m_state;


### PR DESCRIPTION
## Description

Replaces all uses of std::unordered_map/set with boost unordered_flat_map/set, and replaces std::unordered_multimap with boost::unordered_multimap. This provides a nice speedup on the purplebench suite locally (though results were noisy on my laptop so take this with a grain of salt). I'd appreciate a benchmark run on the dedicated machine.

The only real risk here is flat_map's reference (in)stability across inserts. I don't see any cases where this is currently a problem. There may be some instances where unordered_map is better than flat_map, eg where the value type is large, or in cases with a lot of updates. I ran the BalancerV3Vault benchmark case, flat_map vs unordered_map for these instances locally and flat_map was never worse, but this could use more testing:

(these are cases where the value is non-trivial (eg std::set), and/or there's potentially a lot of mutation)
CommonSubexpressionEliminator.h:172
ControlFlowSideEffectsCollector.h:130
CommonSubexpressionEliminator.h:66
DataFlowAnalyzer.h:184
SSACFGBuilder.h:159

I'm sure using flat_map in more places was on everyone's radar; thought it was worthwhile running this experiment. Happy to roll back individual uses or whatever.

| contract | no via-IR | via-IR |
| --- | ---: | ---: |
| WETH9 | -2.69% | -6.95% |
| ChainlinkLINKLinkToken | -4.73% | -3.71% |
| MakerDAODSSJug | -4.53% | -4.98% |
| MakerDAODSSPot | -4.50% | -4.37% |
| ENSRegistryWithFallback | -0.76% | -4.15% |
| CompoundIIICometRewards | -2.90% | -3.57% |
| MakerDAODai | -4.55% | -5.31% |
| WrappedBitcoinWBTC | -3.25% | -4.64% |
| UniswapV4V4Quoter | -3.56% | -3.26% |
| TetherToken | -3.42% | -3.62% |
| LidoWstETH | -5.30% | -2.93% |
| ENSETHRegistrarController | -4.29% | -3.05% |
| MakerDAODSSVat | -4.82% | -7.90% |
| AaveV3VariableDebtTokenInstance | -2.93% | -4.29% |
| UniswapPermit2 | -5.00% | -3.87% |
| OETH | -4.29% | -2.89% |
| BoredApeYachtClub | -3.16% | -2.18% |
| AaveV3ATokenInstance | -2.63% | -3.90% |
| RocketDepositPool | -4.27% | -2.69% |
| Poap | -3.89% | -3.92% |
| FraxFinanceFRAXStablecoin | -3.38% | -5.27% |
| EigenLayerEigenPodManager | -0.26% | -3.48% |
| SafeGnosisSafe | -4.46% | -3.79% |
| CoWProtocolGPv2Settlement | -4.25% | -4.10% |
| EigenLayerStrategyManager | -2.29% | -2.47% |
| FiatTokenV2_2 | -6.71% | -4.66% |
| LidoAccountingOracle | -6.59% | -2.86% |
| UniswapV2UniswapV2Router02 | -4.95% | -3.30% |
| Morpho | -6.42% | -3.36% |
| SparkProtocolPool | -3.13% | -2.20% |
| AccessControlledOCR2Aggregator | -7.40% | -4.37% |
| PoolManager | -2.22% | -4.79% |
| UniswapV4PositionManager | -1.07% | -3.82% |
| CompoundIIICometWithExtendedAssetList | -2.86% | -1.30% |
| EulerSwap | -3.30% | -3.58% |
| UniswapV3SwapRouter02 | -4.28% | -1.99% |
| AaveV3PoolConfiguratorInstance | -8.55% | -3.48% |
| EtherfiLiquidityPool | -4.12% | -3.53% |
| AaveV3PoolInstance | -1.23% | -5.45% |
| ENSNameWrapper | -6.82% | -4.21% |
| UniswapV3NonfungiblePositionManager | -4.19% | -4.55% |
| AaveV4HubInstance | -6.78% | -2.82% |
| LidoWithdrawalQueueERC721 | -6.57% | -1.39% |
| UniswapV3Pool | -2.65% | -1.08% |
| BalancerV2Vault | -3.38% | -2.16% |
| BalancerV3Router | -3.48% | -0.85% |
| BalancerV3Vault | -6.15% | -2.46% |
| **Total** | **-3.88%** | **-3.29%** |


## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
<!--
See our contributing guidelines for the full AI usage policy:
https://docs.soliditylang.org/en/latest/contributing.html#ai-assisted-contributions

If you used AI tools in any part of this PR you MUST disclose it below.
-->

This is just a find-and-replace PR, and AI did it. AI also ran benchmarks for me.