### PR TITLE
Bump evmone to 0.22 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,20 +13,20 @@ parameters:
     default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:1f387a77be889f65a2a25986a5c5eccc88cec23fabe6aeaf351790751145c81e"
   ubuntu-2404-docker-image:
     type: string
-    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu2404-7
-    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:e52bd8fbb38908f203c6866e39562548faf26e5b7a5174f9860b44aae2b8f0cd"
+    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu2404-8
+    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:2a8487a3f031000004dda3f16ac82115dd29f91b2dc91ff4f47cd6156ce5786c"
   ubuntu-2404-arm-docker-image:
     type: string
-    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu2404.arm-3
-    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:1e6dbf9a9173f2645449281a1e11918a95ca6dc04e59aa9d70824cffc44697ed"
+    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu2404.arm-4
+    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:68c1a86e0ff47c53a2bef9f6a3674ddea7d243a6c0a34f35d9d6321984364dfb"
   ubuntu-2404-clang-docker-image:
     type: string
-    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu2404.clang-8
-    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:e283c8ec6a59c76565c89b856d8019af2fa5beb96f27d3064fc4dda42bf3524d"
+    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu2404.clang-9
+    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:546ff9b0826388e6b0d7c1122826dd9161bd373ca546676f801bccf9a1f38857"
   ubuntu-clang-ossfuzz-docker-image:
     type: string
-    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu.clang.ossfuzz-13
-    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:2acb5d6f254ece25a96096f26960b5fe114eb86ceca92312cd20d59c096bf6e4"
+    # ghcr.io/argotorg/solidity-buildpack-deps:ubuntu.clang.ossfuzz-14
+    default: "ghcr.io/argotorg/solidity-buildpack-deps@sha256:140333dd6c939c8129239506b78fb2f2bf79bd8cc0574ca16b0916415abbcc9d"
   emscripten-docker-image:
     type: string
     # NOTE: Please remember to update the `scripts/build_emscripten.sh` whenever the hash of this image changes.

--- a/.circleci/osx_install_dependencies.sh
+++ b/.circleci/osx_install_dependencies.sh
@@ -109,10 +109,10 @@ then
   rm -rf "$z3_dir"
 
   # evmone
-  evmone_version="0.16.0"
+  evmone_version="0.22.0"
   evmone_package="evmone-${evmone_version}-darwin-arm64.tar.gz"
   wget "https://github.com/ipsilon/evmone/releases/download/v${evmone_version}/${evmone_package}"
-  validate_checksum "$evmone_package" d26bcf7ada6c712b669ee70cbd8b534f80dadb6207fa15e15d1517d2b6823aa8
+  validate_checksum "$evmone_package" 3ff5633e49ae3726dc094c7c9819440c11d04c8036bc27f45a4385120951599c
   sudo tar xzpf "$evmone_package" -C /usr/local
   rm "$evmone_package"
 fi

--- a/scripts/install_evmone.ps1
+++ b/scripts/install_evmone.ps1
@@ -3,6 +3,6 @@ $ErrorActionPreference = "Stop"
 # Needed for Invoke-WebRequest to work via CI.
 $progressPreference = "silentlyContinue"
 
-Invoke-WebRequest -URI "https://github.com/ipsilon/evmone/releases/download/v0.16.0/evmone-0.16.0-windows-amd64.zip" -OutFile "evmone.zip"
+Invoke-WebRequest -URI "https://github.com/ipsilon/evmone/releases/download/v0.22.0/evmone-0.22.0-windows-amd64.zip" -OutFile "evmone.zip"
 tar -xf evmone.zip "bin/evmone.dll"
 mv bin/evmone.dll deps/

--- a/test/Common.h
+++ b/test/Common.h
@@ -39,13 +39,13 @@ namespace solidity::test
 
 #ifdef _WIN32
 static constexpr auto evmoneFilename = "evmone.dll";
-static constexpr auto evmoneDownloadLink = "https://github.com/ipsilon/evmone/releases/download/v0.16.0/evmone-0.16.0-windows-amd64.zip";
+static constexpr auto evmoneDownloadLink = "https://github.com/ipsilon/evmone/releases/download/v0.22.0/evmone-0.22.0-windows-amd64.zip";
 #elif defined(__APPLE__)
 static constexpr auto evmoneFilename = "libevmone.dylib";
-static constexpr auto evmoneDownloadLink = "https://github.com/ipsilon/evmone/releases/download/v0.16.0/evmone-0.16.0-darwin-arm64.tar.gz";
+static constexpr auto evmoneDownloadLink = "https://github.com/ipsilon/evmone/releases/download/v0.22.0/evmone-0.22.0-darwin-arm64.tar.gz";
 #else
 static constexpr auto evmoneFilename = "libevmone.so";
-static constexpr auto evmoneDownloadLink = "https://github.com/ipsilon/evmone/releases/download/v0.16.0/evmone-0.16.0-linux-x86_64.tar.gz";
+static constexpr auto evmoneDownloadLink = "https://github.com/ipsilon/evmone/releases/download/v0.22.0/evmone-0.22.0-linux-x86_64.tar.gz";
 #endif
 
 struct ConfigException: public util::Exception {};

--- a/test/EVMHost.cpp
+++ b/test/EVMHost.cpp
@@ -314,8 +314,6 @@ evmc::Result EVMHost::call(evmc_message const& _message) noexcept
 		}
 	}
 
-	solAssert(message.kind != EVMC_EOFCREATE);
-
 	if (message.kind == EVMC_CREATE)
 	{
 		// TODO is the nonce incremented on failure, too?
@@ -1380,9 +1378,6 @@ void EVMHostPrinter::callRecords()
 				return "CREATE";
 			case evmc_call_kind::EVMC_CREATE2:
 				return "CREATE2";
-			case evmc_call_kind::EVMC_EOFCREATE:
-				solAssert(false); // EOF is not supported.
-				return "";
 		}
 		unreachable();
 	};

--- a/test/evmc/evmc.h
+++ b/test/evmc/evmc.h
@@ -39,12 +39,13 @@ enum
     /**
      * The EVMC ABI version number of the interface declared in this file.
      *
-     * The EVMC ABI version always equals the major version number of the EVMC project.
+     * The ABI version is incremented on every incompatible change of the EVMC API or ABI
+     * (up to EVMC 12 it equaled the major version number of the standalone EVMC project).
      * The Host SHOULD check if the ABI versions match when dynamically loading VMs.
      *
      * @see @ref versioning
      */
-    EVMC_ABI_VERSION = 12
+    EVMC_ABI_VERSION = 13
 };
 
 
@@ -80,13 +81,13 @@ enum evmc_call_kind
     EVMC_CALLCODE = 2,     /**< Request CALLCODE. */
     EVMC_CREATE = 3,       /**< Request CREATE. */
     EVMC_CREATE2 = 4,      /**< Request CREATE2. Valid since Constantinople.*/
-    EVMC_EOFCREATE = 5     /**< Request EOFCREATE. Valid since Prague.*/
 };
 
 /** The flags for ::evmc_message. */
 enum evmc_flags
 {
-    EVMC_STATIC = 1 /**< Static call mode. */
+    EVMC_STATIC = 1,   /**< Static call mode. */
+    EVMC_DELEGATED = 2 /**< Delegated call mode (EIP-7702). Valid since Prague. */
 };
 
 /**
@@ -101,7 +102,7 @@ struct evmc_message
 
     /**
      * Additional flags modifying the call execution behavior.
-     * In the current version the only valid values are ::EVMC_STATIC or 0.
+     *
      */
     uint32_t flags;
 
@@ -169,8 +170,7 @@ struct evmc_message
     /**
      * The optional value used in new contract address construction.
      *
-     * Needed only for a Host to calculate created address when kind is ::EVMC_CREATE2 or
-     * ::EVMC_EOFCREATE.
+     * Needed only for a Host to calculate created address when kind is ::EVMC_CREATE2.
      * Ignored in evmc_execute_fn().
      */
     evmc_bytes32 create2_salt;
@@ -181,7 +181,7 @@ struct evmc_message
      * For ::EVMC_CALLCODE or ::EVMC_DELEGATECALL this may be different from
      * the evmc_message::recipient.
      * Not required when invoking evmc_execute_fn(), only when invoking evmc_call_fn().
-     * Ignored if kind is ::EVMC_CREATE, ::EVMC_CREATE2 or ::EVMC_EOFCREATE.
+     * Ignored if kind is ::EVMC_CREATE or ::EVMC_CREATE2.
      *
      * In case of ::EVMC_CAPABILITY_PRECOMPILES implementation, this fields should be inspected
      * to identify the requested precompile.
@@ -201,31 +201,22 @@ struct evmc_message
     size_t code_size;
 };
 
-/** The hashed initcode used for TXCREATE instruction. */
-typedef struct evmc_tx_initcode
-{
-    evmc_bytes32 hash;   /**< The initcode hash. */
-    const uint8_t* code; /**< The code. */
-    size_t code_size;    /**< The length of the code. */
-} evmc_tx_initcode;
-
 /** The transaction and block data for execution. */
 struct evmc_tx_context
 {
-    evmc_uint256be tx_gas_price;       /**< The transaction gas price. */
-    evmc_address tx_origin;            /**< The transaction origin account. */
-    evmc_address block_coinbase;       /**< The miner of the block. */
-    int64_t block_number;              /**< The block number. */
-    int64_t block_timestamp;           /**< The block timestamp. */
-    int64_t block_gas_limit;           /**< The block gas limit. */
-    evmc_uint256be block_prev_randao;  /**< The block previous RANDAO (EIP-4399). */
-    evmc_uint256be chain_id;           /**< The blockchain's ChainID. */
-    evmc_uint256be block_base_fee;     /**< The block base fee per gas (EIP-1559, EIP-3198). */
-    evmc_uint256be blob_base_fee;      /**< The blob base fee (EIP-7516). */
-    const evmc_bytes32* blob_hashes;   /**< The array of blob hashes (EIP-4844). */
-    size_t blob_hashes_count;          /**< The number of blob hashes (EIP-4844). */
-    const evmc_tx_initcode* initcodes; /**< The array of transaction initcodes (TXCREATE). */
-    size_t initcodes_count;            /**< The number of transaction initcodes (TXCREATE). */
+    evmc_uint256be tx_gas_price;      /**< The transaction gas price. */
+    evmc_address tx_origin;           /**< The transaction origin account. */
+    evmc_address block_coinbase;      /**< The miner of the block. */
+    int64_t block_number;             /**< The block number. */
+    int64_t block_timestamp;          /**< The block timestamp. */
+    int64_t block_gas_limit;          /**< The block gas limit. */
+    evmc_uint256be block_prev_randao; /**< The block previous RANDAO (EIP-4399). */
+    evmc_uint256be chain_id;          /**< The blockchain's ChainID. */
+    evmc_uint256be block_base_fee;    /**< The block base fee per gas (EIP-1559, EIP-3198). */
+    evmc_uint256be blob_base_fee;     /**< The blob base fee (EIP-7516). */
+    const evmc_bytes32* blob_hashes;  /**< The array of blob hashes (EIP-4844). */
+    size_t blob_hashes_count;         /**< The number of blob hashes (EIP-4844). */
+    uint64_t block_slot_number;       /**< The beacon chain slot number (EIP-7843). */
 };
 
 /**
@@ -278,7 +269,7 @@ typedef evmc_bytes32 (*evmc_get_block_hash_fn)(struct evmc_host_context* context
  *
  * @note
  * In case new status codes are needed, please create an issue or pull request
- * in the EVMC repository (https://github.com/ipsilon/evmc).
+ * in the EVMC repository (https://github.com/ethereum/evmc).
  */
 enum evmc_status_code
 {
@@ -484,19 +475,6 @@ struct evmc_result
      * In all other cases the address MUST be null bytes.
      */
     evmc_address create_address;
-
-    /**
-     * Reserved data that MAY be used by a evmc_result object creator.
-     *
-     * This reserved 4 bytes together with 20 bytes from create_address form
-     * 24 bytes of memory called "optional data" within evmc_result struct
-     * to be optionally used by the evmc_result object creator.
-     *
-     * @see evmc_result_optional_data, evmc_get_optional_data().
-     *
-     * Also extends the size of the evmc_result to 64 bytes (full cache line).
-     */
-    uint8_t padding[4];
 };
 
 
@@ -1033,28 +1011,41 @@ enum evmc_revision
     EVMC_CANCUN = 12,
 
     /**
-     * The Prague revision.
+     * The Prague / Pectra revision.
      *
-     * The future next revision after Cancun.
+     * https://eips.ethereum.org/EIPS/eip-7600
      */
     EVMC_PRAGUE = 13,
 
     /**
-     * The Osaka revision.
+     * The Osaka / Fusaka revision.
      *
-     * The future next revision after Prague.
+     * https://eips.ethereum.org/EIPS/eip-7607
      */
     EVMC_OSAKA = 14,
 
+    /**
+     * The Amsterdam / Glamsterdam revision.
+     *
+     * https://eips.ethereum.org/EIPS/eip-7773
+     */
+    EVMC_AMSTERDAM = 15,
+
+    /**
+     * The unspecified EVM revision used for EVM implementations to expose
+     * experimental features.
+     */
+    EVMC_EXPERIMENTAL = 16,
+
     /** The maximum EVM revision supported. */
-    EVMC_MAX_REVISION = EVMC_OSAKA,
+    EVMC_MAX_REVISION = EVMC_EXPERIMENTAL,
 
     /**
      * The latest known EVM revision with finalized specification.
      *
      * This is handy for EVM tools to always use the latest revision available.
      */
-    EVMC_LATEST_STABLE_REVISION = EVMC_CANCUN
+    EVMC_LATEST_STABLE_REVISION = EVMC_OSAKA
 };
 
 

--- a/test/evmc/helpers.h
+++ b/test/evmc/helpers.h
@@ -168,55 +168,6 @@ static inline void evmc_release_result(struct evmc_result* result)
         result->release(result);
 }
 
-
-/**
- * Helpers for optional storage of evmc_result.
- *
- * In some contexts (i.e. evmc_result::create_address is unused) objects of
- * type evmc_result contains a memory storage that MAY be used by the object
- * owner. This group defines helper types and functions for accessing
- * the optional storage.
- *
- * @defgroup result_optional_storage Result Optional Storage
- * @{
- */
-
-/**
- * The union representing evmc_result "optional storage".
- *
- * The evmc_result struct contains 24 bytes of optional storage that can be
- * reused by the object creator if the object does not contain
- * evmc_result::create_address.
- *
- * A VM implementation MAY use this memory to keep additional data
- * when returning result from evmc_execute_fn().
- * The host application MAY use this memory to keep additional data
- * when returning result of performed calls from evmc_call_fn().
- *
- * @see evmc_get_optional_storage(), evmc_get_const_optional_storage().
- */
-union evmc_result_optional_storage
-{
-    uint8_t bytes[24]; /**< 24 bytes of optional storage. */
-    void* pointer;     /**< Optional pointer. */
-};
-
-/** Provides read-write access to evmc_result "optional storage". */
-static inline union evmc_result_optional_storage* evmc_get_optional_storage(
-    struct evmc_result* result)
-{
-    return (union evmc_result_optional_storage*)&result->create_address;
-}
-
-/** Provides read-only access to evmc_result "optional storage". */
-static inline const union evmc_result_optional_storage* evmc_get_const_optional_storage(
-    const struct evmc_result* result)
-{
-    return (const union evmc_result_optional_storage*)&result->create_address;
-}
-
-/** @} */
-
 /** Returns text representation of the ::evmc_status_code. */
 static inline const char* evmc_status_code_to_string(enum evmc_status_code status_code)
 {
@@ -303,6 +254,10 @@ static inline const char* evmc_revision_to_string(enum evmc_revision rev)
         return "Prague";
     case EVMC_OSAKA:
         return "Osaka";
+    case EVMC_AMSTERDAM:
+        return "Amsterdam";
+    case EVMC_EXPERIMENTAL:
+        return "Experimental";
     }
     return "<unknown>";
 }


### PR DESCRIPTION
**IMPORTANT**: going forward, any evmone bump will require copying over contents from the upstream [`evmc/include/evmc`](https://github.com/ipsilon/evmone/tree/master/evmc/include/evmc) directory EXCEPT `mocked_host.hpp` where we have our own local changes that we wish to preserve.

~~Depends on: https://github.com/argotorg/solidity/pull/16852~~