### PR TITLE
SSA CFG: Operation live-out is inst-id based

### DIFF
--- a/libyul/backends/evm/ssa/LivenessAnalysis.cpp
+++ b/libyul/backends/evm/ssa/LivenessAnalysis.cpp
@@ -20,12 +20,14 @@
 
 #include <libsolutil/Visitor.h>
 
-#include <range/v3/algorithm/count_if.hpp>
-#include <range/v3/range/conversion.hpp>
+#include <boost/container/flat_map.hpp>
 
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/filter.hpp>
 #include <range/v3/view/reverse.hpp>
+
+#include <utility>
+#include <vector>
 
 using namespace solidity::yul::ssa;
 
@@ -54,8 +56,7 @@ LivenessAnalysis::LivenessAnalysis(SSACFG const& _cfg):
 	m_topologicalSort(_cfg),
 	m_loopNestingForest(m_topologicalSort),
 	m_liveIns(_cfg.numBlocks()),
-	m_liveOuts(_cfg.numBlocks()),
-	m_operationLiveOuts(_cfg.numBlocks())
+	m_liveOuts(_cfg.numBlocks())
 {
 	runDagDfs();
 	for (auto const loopRootNode: m_loopNestingForest.loopRootNodes())
@@ -170,28 +171,17 @@ void LivenessAnalysis::fillOperationsLiveOut()
 	for (SSACFG::BlockId const blockId: m_cfg.liveBlocks())
 	{
 		auto const& block = m_cfg.block(blockId);
-		auto const opCount = static_cast<std::size_t>(ranges::count_if(
-			block.instructions,
-			[&](InstId const _id) { return m_cfg.isOperation(_id); }
-		));
-		auto& liveOuts = m_operationLiveOuts[blockId.value];
-		liveOuts.resize(opCount);
-		if (opCount > 0)
+		auto live = m_liveOuts[blockId.value];
+		live += blockExitValues(blockId);
+		for (InstId const instId: block.instructions | ranges::views::reverse)
 		{
-			auto live = m_liveOuts[blockId.value];
-			live += blockExitValues(blockId);
-			auto rit = liveOuts.rbegin();
-			for (InstId const instId: block.instructions | ranges::views::reverse)
-			{
-				auto const& inst = m_cfg.inst(instId);
-				if (!inst.isOperation())
-					continue;
-				*rit = live;
-				live.eraseAll(m_cfg.projectionsOf(instId));
-				live.erase(instId);
-				live.insertAll(inst.inputs | ranges::views::filter(excludingLiteralsFilter()));
-				++rit;
-			}
+			auto const& inst = m_cfg.inst(instId);
+			if (!inst.isOperation())
+				continue;
+			m_operationLiveOutByInst.emplace(instId.value, live);
+			live.eraseAll(m_cfg.projectionsOf(instId));
+			live.erase(instId);
+			live.insertAll(inst.inputs | ranges::views::filter(excludingLiteralsFilter()));
 		}
 	}
 }

--- a/libyul/backends/evm/ssa/LivenessAnalysis.h
+++ b/libyul/backends/evm/ssa/LivenessAnalysis.h
@@ -23,6 +23,8 @@
 #include <libyul/backends/evm/ssa/SSACFGLoopNestingForest.h>
 #include <libyul/backends/evm/ssa/util/UseCountSet.h>
 
+#include <boost/container/flat_map.hpp>
+
 #include <vector>
 
 namespace solidity::yul::ssa
@@ -43,7 +45,7 @@ public:
 	LivenessData const& liveIn(SSACFG::BlockId const _blockId) const { return m_liveIns[_blockId.value]; }
 	LivenessData const& liveOut(SSACFG::BlockId const _blockId) const { return m_liveOuts[_blockId.value]; }
 	LivenessData used(SSACFG::BlockId _blockId) const;
-	std::vector<LivenessData> const& operationsLiveOut(SSACFG::BlockId _blockId) const { return m_operationLiveOuts[_blockId.value]; }
+	LivenessData const& operationLiveOut(InstId const _id) const { return m_operationLiveOutByInst.at(_id.value); }
 	traversal::ForwardTopologicalSort const& topologicalSort() const { return m_topologicalSort; }
 	SSACFG const& cfg() const { return m_cfg; }
 
@@ -63,7 +65,7 @@ private:
 	SSACFGLoopNestingForest m_loopNestingForest;
 	std::vector<LivenessData> m_liveIns;
 	std::vector<LivenessData> m_liveOuts;
-	std::vector<std::vector<LivenessData>> m_operationLiveOuts;
+	boost::container::flat_map<InstId::ValueType, LivenessData> m_operationLiveOutByInst;
 };
 
 }

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -273,11 +273,9 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 	StackType stack(currentStackData, {});
 	bool const junkCanBeAdded = m_junkAdmittingBlocksFinder->allowsAdditionOfJunk(_blockId);
 
-	auto const& operationsLiveOut = m_liveness.operationsLiveOut(_blockId);
-	blockLayout.operationIn.reserve(operationsLiveOut.size());
-	std::size_t operationIndex = 0;
+	blockLayout.operationIn.reserve(block.instructions.size());
 	m_cfg.forEachOperation(block, [&](InstId const _instId, SSACFG::Inst const& _inst) {
-		auto opLiveOutWithoutOutputs = operationsLiveOut[operationIndex];
+		auto opLiveOutWithoutOutputs = m_liveness.operationLiveOut(_instId);
 		m_cfg.forEachOutput(_instId, [&](InstId const id) { opLiveOutWithoutOutputs.erase(id); });
 
 		std::vector<Slot> requiredStackTop;
@@ -322,9 +320,7 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 		m_cfg.forEachOutput(_instId, [&](InstId const id) {
 			stack.push<false>(Slot::makeValue(m_cfg, id));
 		});
-		++operationIndex;
 	});
-	yulAssert(operationIndex == operationsLiveOut.size());
 
 	// we don't explicitly visit backedges and might have to spill here, too
 	auto const validateBackEdge = [&](SSACFG::BlockId const& _target) {


### PR DESCRIPTION
I think it's better to have the liveness based on `InstId`, not based on position index in the operations. We probably do have to pay with a little bit of memory but everything becomes simpler because we don't have to do additional bookkeeping. I also intend to use this for PR #16850 to determine if the condition op can be `Nop`ed.

Benchmarks pending...