### PR TITLE
Fix InheritanceOrderReversalOnStorageEndWarning

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ### 0.8.36 (unreleased)
 
 Important Bugfixes:
+* PostTypeContractLevelChecker: Fix unintentional reversal of `linearizedBaseContracts` annotation when emitting the warning about the base slot of storage layout being too close to the end of storage. The reversal would affect analysis and code generation dependent on the inheritance order.
 * Yul Optimizer: Fix call graph cycle detection failing to classify some mutually recursive functions as recursive.
 
 Language Features:

--- a/docs/bugs.json
+++ b/docs/bugs.json
@@ -1,5 +1,15 @@
 [
     {
+        "uid": "SOL-2026-3",
+        "name": "InheritanceOrderReversalOnStorageEndWarning",
+        "summary": "Emitting a warning about storage base location being too close to the storage end unintentionally reversed the ``linearizedBaseContracts`` annotation, possibly leading to miscompilation due to reversing the order in which inheritance is resolved.",
+        "description": "When the compiler detects that a custom layout specifier puts contract's static storage area too close to the end of the address space, it emits a warning. To make the warning more useful, the compiler tries to point at the last storage variable in that area. For this reason it walks the linearized inheritance hierarchy in reverse (from the least to the most derived). The list is calculated once and stored in an AST annotation called ``linearizedBaseContracts``. The direct cause of the bug was the fact that the code that reverses the list was doing it in place rather than on a copy, modifying the annotation. This effectively reversed the order of base contracts seen by any component that runs after layout checks: later phases of analysis, AST export, code generator, SMTChecker, etc. The observable effect was a reversed order of state variable initialization, constructor invocation, virtual function/modifier resolution, leading either to miscompilations or internal compiler errors, depending on the specific usage. Since the source of the bug was in the analysis stage, it was independent of the codegen pipeline or optimizer settings. The main condition necessary to trigger the bug was the presence of the warning in the output. The other is presence of language constructs whose evaluation depends on the inheritance order. While potential effects are very serious, this requirement excludes the vast majority of contracts as intentionally placing the storage variables in the last 2**64 slots is highly discouraged, which was actually the main reason for adding this warning.",
+        "link": "https://blog.soliditylang.org/2026/07/09/inheritance-order-reversal-on-storage-end-warning-bug/",
+        "introduced": "0.8.29",
+        "fixed": "0.8.36",
+        "severity": "medium"
+    },
+    {
         "uid": "SOL-2026-2",
         "name": "UnsoundSpillInMutualRecursion",
         "summary": "Local variables of a function involved in mutual recursion may spuriously be moved to fixed memory offsets and overwritten across recursive calls.",

--- a/docs/bugs_by_version.json
+++ b/docs/bugs_by_version.json
@@ -2047,6 +2047,7 @@
     },
     "0.8.29": {
         "bugs": [
+            "InheritanceOrderReversalOnStorageEndWarning",
             "UnsoundSpillInMutualRecursion",
             "TransientStorageClearingHelperCollision",
             "LostStorageArrayWriteOnSlotOverflow"
@@ -2070,6 +2071,7 @@
     },
     "0.8.30": {
         "bugs": [
+            "InheritanceOrderReversalOnStorageEndWarning",
             "UnsoundSpillInMutualRecursion",
             "TransientStorageClearingHelperCollision",
             "LostStorageArrayWriteOnSlotOverflow"
@@ -2078,6 +2080,7 @@
     },
     "0.8.31": {
         "bugs": [
+            "InheritanceOrderReversalOnStorageEndWarning",
             "UnsoundSpillInMutualRecursion",
             "TransientStorageClearingHelperCollision",
             "LostStorageArrayWriteOnSlotOverflow"
@@ -2086,6 +2089,7 @@
     },
     "0.8.32": {
         "bugs": [
+            "InheritanceOrderReversalOnStorageEndWarning",
             "UnsoundSpillInMutualRecursion",
             "TransientStorageClearingHelperCollision"
         ],
@@ -2093,6 +2097,7 @@
     },
     "0.8.33": {
         "bugs": [
+            "InheritanceOrderReversalOnStorageEndWarning",
             "UnsoundSpillInMutualRecursion",
             "TransientStorageClearingHelperCollision"
         ],
@@ -2100,12 +2105,14 @@
     },
     "0.8.34": {
         "bugs": [
+            "InheritanceOrderReversalOnStorageEndWarning",
             "UnsoundSpillInMutualRecursion"
         ],
         "released": "2026-02-18"
     },
     "0.8.35": {
         "bugs": [
+            "InheritanceOrderReversalOnStorageEndWarning",
             "UnsoundSpillInMutualRecursion"
         ],
         "released": "2026-04-29"

--- a/libsolidity/analysis/PostTypeContractLevelChecker.cpp
+++ b/libsolidity/analysis/PostTypeContractLevelChecker.cpp
@@ -31,6 +31,7 @@
 #include <liblangutil/ErrorReporter.h>
 
 #include <range/v3/action/reverse.hpp>
+#include <range/v3/view/reverse.hpp>
 
 #include <limits>
 
@@ -210,7 +211,7 @@ namespace
 
 VariableDeclaration const* findLastStorageVariable(ContractDefinition const& _contract)
 {
-	for (ContractDefinition const* baseContract: ranges::actions::reverse(_contract.annotation().linearizedBaseContracts))
+	for (ContractDefinition const* baseContract: ranges::views::reverse(_contract.annotation().linearizedBaseContracts))
 		for (VariableDeclaration const* stateVariable: ranges::actions::reverse(baseContract->stateVariables()))
 			if (stateVariable->referenceLocation() == VariableDeclaration::Location::Unspecified)
 				return stateVariable;

--- a/test/cmdlineTests/storage_layout_specifier_with_inheritance/args
+++ b/test/cmdlineTests/storage_layout_specifier_with_inheritance/args
@@ -1,0 +1,1 @@
+--storage-layout --pretty-json --json-indent 4 -

--- a/test/cmdlineTests/storage_layout_specifier_with_inheritance/err
+++ b/test/cmdlineTests/storage_layout_specifier_with_inheritance/err
@@ -1,0 +1,10 @@
+Warning: This contract is very close to the end of storage. This limits its future upgradability.
+ --> <stdin>:6:17:
+  |
+6 | contract C is B layout at 2**256 - 2**40 { uint z; }
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^
+Note: There are 0xffFFFFfffc storage slots between this state variable and the end of storage.
+ --> <stdin>:4:14:
+  |
+4 | contract A { uint x; }
+  |              ^^^^^^

--- a/test/cmdlineTests/storage_layout_specifier_with_inheritance/output
+++ b/test/cmdlineTests/storage_layout_specifier_with_inheritance/output
@@ -56,9 +56,9 @@ Contract Storage Layout:
 {
     "storage": [
         {
-            "astId": 21,
+            "astId": 3,
             "contract": "<stdin>:C",
-            "label": "z",
+            "label": "x",
             "offset": 0,
             "slot": "115792089237316195423570985008687907853269984665640564039457584006813618012160",
             "type": "t_uint256"
@@ -72,9 +72,9 @@ Contract Storage Layout:
             "type": "t_uint256"
         },
         {
-            "astId": 3,
+            "astId": 21,
             "contract": "<stdin>:C",
-            "label": "x",
+            "label": "z",
             "offset": 0,
             "slot": "115792089237316195423570985008687907853269984665640564039457584006813618012162",
             "type": "t_uint256"

--- a/test/cmdlineTests/storage_layout_specifier_with_inheritance/output
+++ b/test/cmdlineTests/storage_layout_specifier_with_inheritance/output
@@ -1,0 +1,90 @@
+
+======= <stdin>:A =======
+Contract Storage Layout:
+{
+    "storage": [
+        {
+            "astId": 3,
+            "contract": "<stdin>:A",
+            "label": "x",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint256"
+        }
+    ],
+    "types": {
+        "t_uint256": {
+            "encoding": "inplace",
+            "label": "uint256",
+            "numberOfBytes": "32"
+        }
+    }
+}
+
+======= <stdin>:B =======
+Contract Storage Layout:
+{
+    "storage": [
+        {
+            "astId": 3,
+            "contract": "<stdin>:B",
+            "label": "x",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint256"
+        },
+        {
+            "astId": 8,
+            "contract": "<stdin>:B",
+            "label": "y",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_uint256"
+        }
+    ],
+    "types": {
+        "t_uint256": {
+            "encoding": "inplace",
+            "label": "uint256",
+            "numberOfBytes": "32"
+        }
+    }
+}
+
+======= <stdin>:C =======
+Contract Storage Layout:
+{
+    "storage": [
+        {
+            "astId": 21,
+            "contract": "<stdin>:C",
+            "label": "z",
+            "offset": 0,
+            "slot": "115792089237316195423570985008687907853269984665640564039457584006813618012160",
+            "type": "t_uint256"
+        },
+        {
+            "astId": 8,
+            "contract": "<stdin>:C",
+            "label": "y",
+            "offset": 0,
+            "slot": "115792089237316195423570985008687907853269984665640564039457584006813618012161",
+            "type": "t_uint256"
+        },
+        {
+            "astId": 3,
+            "contract": "<stdin>:C",
+            "label": "x",
+            "offset": 0,
+            "slot": "115792089237316195423570985008687907853269984665640564039457584006813618012162",
+            "type": "t_uint256"
+        }
+    ],
+    "types": {
+        "t_uint256": {
+            "encoding": "inplace",
+            "label": "uint256",
+            "numberOfBytes": "32"
+        }
+    }
+}

--- a/test/cmdlineTests/storage_layout_specifier_with_inheritance/stdin
+++ b/test/cmdlineTests/storage_layout_specifier_with_inheritance/stdin
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.0.0;
+
+contract A { uint x; }
+contract B is A { uint y; }
+contract C is B layout at 2**256 - 2**40 { uint z; }

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_constructor_order_calling_revert.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_constructor_order_calling_revert.sol
@@ -1,0 +1,15 @@
+contract A { constructor() { revert("A"); } }
+contract B is A { constructor() { revert("B"); } }
+contract C1 is B layout at 2**256 - 2**42 { constructor() { revert("C"); } }
+contract C2 is B { constructor() { revert("C"); } }
+contract F {
+    function withSpecifier() public returns (string memory) {
+        new C1();
+    }
+    function withoutSpecifier() public returns (string memory) {
+        new C2();
+    }
+}
+// ----
+// withSpecifier() -> FAILURE, hex"08c379a0", 0x20, 1, "C"
+// withoutSpecifier() -> FAILURE, hex"08c379a0", 0x20, 1, "A"

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_constructor_order_calling_revert.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_constructor_order_calling_revert.sol
@@ -11,5 +11,5 @@ contract F {
     }
 }
 // ----
-// withSpecifier() -> FAILURE, hex"08c379a0", 0x20, 1, "C"
+// withSpecifier() -> FAILURE, hex"08c379a0", 0x20, 1, "A"
 // withoutSpecifier() -> FAILURE, hex"08c379a0", 0x20, 1, "A"

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_constructor_order_setting_storage_var.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_constructor_order_setting_storage_var.sol
@@ -11,8 +11,8 @@ contract F {
     }
 }
 // ----
-// withSpecifier() -> 5
-// gas legacy: 76868
+// withSpecifier() -> 15
+// gas legacy: 77592
 // gas legacy code: 30000
 // withoutSpecifier() -> 15
 // gas legacy: 77502

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_constructor_order_setting_storage_var.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_constructor_order_setting_storage_var.sol
@@ -1,0 +1,19 @@
+contract A { uint public x; constructor() { x = 1; } }
+contract B is A { constructor() { x = x * 10; } }
+contract C1 is B layout at 2**256 - 2**40 { constructor() { x = x + 5; } }
+contract C2 is B { constructor() { x = x + 5; } }
+contract F {
+    function withSpecifier() public returns (uint) {
+        return new C1().x();
+    }
+    function withoutSpecifier() public returns (uint) {
+        return new C2().x();
+    }
+}
+// ----
+// withSpecifier() -> 5
+// gas legacy: 76868
+// gas legacy code: 30000
+// withoutSpecifier() -> 15
+// gas legacy: 77502
+// gas legacy code: 23600

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_constructors_with_different_number_of_arguments.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_constructors_with_different_number_of_arguments.sol
@@ -1,0 +1,15 @@
+contract A { constructor(uint x) {} }
+contract B is A(1) { constructor(uint y, uint z) {} }
+// Compilation of C1 crashes with "invalid IR generated" with `--via-ir`
+//contract C1 is B(2, 3) layout at 2**256 - 2**42 { constructor() {} }
+contract C2 is B(2, 3) { constructor() {} }
+contract F {
+    //function withSpecifier() public {
+    //  new C1();
+    //}
+    function withoutSpecifier() public {
+        new C2();
+    }
+}
+// ----
+// withoutSpecifier() ->

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_constructors_with_different_number_of_arguments.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_constructors_with_different_number_of_arguments.sol
@@ -1,15 +1,15 @@
 contract A { constructor(uint x) {} }
 contract B is A(1) { constructor(uint y, uint z) {} }
-// Compilation of C1 crashes with "invalid IR generated" with `--via-ir`
-//contract C1 is B(2, 3) layout at 2**256 - 2**42 { constructor() {} }
+contract C1 is B(2, 3) layout at 2**256 - 2**42 { constructor() {} }
 contract C2 is B(2, 3) { constructor() {} }
 contract F {
-    //function withSpecifier() public {
-    //  new C1();
-    //}
+    function withSpecifier() public {
+        new C1();
+    }
     function withoutSpecifier() public {
         new C2();
     }
 }
 // ----
+// withSpecifier() ->
 // withoutSpecifier() ->

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_fallback_calling_revert.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_fallback_calling_revert.sol
@@ -1,7 +1,6 @@
 contract A { fallback() external virtual { revert("A"); } }
 contract B is A { fallback() external override virtual { revert("B"); } }
-// C1 cannot be compiled with `--via-ir` at the moment, compiler crashes because of the storage layout specifier bug
-//contract C1 is B layout at 2**256 - 2**42 { fallback() external override virtual { revert("C"); } }
+contract C1 is B layout at 2**256 - 2**42 { fallback() external override virtual { revert("C"); } }
 contract C2 is B { fallback() external override virtual { revert("C"); } }
 contract F {
     function decode(bytes memory data) internal returns (string memory) {
@@ -11,11 +10,11 @@ contract F {
         }
         return abi.decode(data, (string));
     }
-    //function withSpecifier() public returns (string memory) {
-    //  (bool success, bytes memory data) = address(new C1()).call(hex"beee");
-    //  require(!success, "Must fail!");
-    //  return decode(data);
-    //}
+    function withSpecifier() public returns (string memory) {
+        (bool success, bytes memory data) = address(new C1()).call(hex"beee");
+        require(!success, "Must fail!");
+        return decode(data);
+    }
     function withoutSpecifier() public returns (string memory) {
         (bool success, bytes memory data) = address(new C2()).call(hex"beee");
         require(!success, "Must fail!");
@@ -25,4 +24,5 @@ contract F {
 // ====
 // EVMVersion: >homestead
 // ----
+// withSpecifier() -> 0x20, 1, "C"
 // withoutSpecifier() -> 0x20, 1, "C"

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_fallback_calling_revert.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_fallback_calling_revert.sol
@@ -1,0 +1,28 @@
+contract A { fallback() external virtual { revert("A"); } }
+contract B is A { fallback() external override virtual { revert("B"); } }
+// C1 cannot be compiled with `--via-ir` at the moment, compiler crashes because of the storage layout specifier bug
+//contract C1 is B layout at 2**256 - 2**42 { fallback() external override virtual { revert("C"); } }
+contract C2 is B { fallback() external override virtual { revert("C"); } }
+contract F {
+    function decode(bytes memory data) internal returns (string memory) {
+        assembly {
+            // Shift the memory pointer forward by 4 bytes to skip the selector
+            data := add(data, 4)
+        }
+        return abi.decode(data, (string));
+    }
+    //function withSpecifier() public returns (string memory) {
+    //  (bool success, bytes memory data) = address(new C1()).call(hex"beee");
+    //  require(!success, "Must fail!");
+    //  return decode(data);
+    //}
+    function withoutSpecifier() public returns (string memory) {
+        (bool success, bytes memory data) = address(new C2()).call(hex"beee");
+        require(!success, "Must fail!");
+        return decode(data);
+    }
+}
+// ====
+// EVMVersion: >homestead
+// ----
+// withoutSpecifier() -> 0x20, 1, "C"

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_immutables.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_immutables.sol
@@ -1,0 +1,21 @@
+contract A { uint public immutable a = 1; }
+contract B is A { uint public immutable b = 2; }
+// Using specifier, `--via-ir` produces incorrect output, while legacy produces correct one.
+//contract C1 is B layout at 2**256 - 2**42 { uint public immutable c = 3; }
+contract C2 is B { uint public immutable c = 3; }
+contract F {
+    //function withSpecifier() public returns(uint, uint, uint) {
+    //  C1 c = new C1();
+    //  return (c.a(), c.b(), c.c());
+    //}
+    function withoutSpecifier() public returns(uint, uint, uint) {
+        C2 c = new C2();
+        return (c.a(), c.b(), c.c());
+    }
+}
+// ----
+// withoutSpecifier() -> 1, 2, 3
+// gas irOptimized: 55246
+// gas irOptimized code: 45400
+// gas legacy: 56451
+// gas legacy code: 62800

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_immutables.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_immutables.sol
@@ -1,21 +1,25 @@
 contract A { uint public immutable a = 1; }
 contract B is A { uint public immutable b = 2; }
-// Using specifier, `--via-ir` produces incorrect output, while legacy produces correct one.
-//contract C1 is B layout at 2**256 - 2**42 { uint public immutable c = 3; }
+contract C1 is B layout at 2**256 - 2**42 { uint public immutable c = 3; }
 contract C2 is B { uint public immutable c = 3; }
 contract F {
-    //function withSpecifier() public returns(uint, uint, uint) {
-    //  C1 c = new C1();
-    //  return (c.a(), c.b(), c.c());
-    //}
+    function withSpecifier() public returns(uint, uint, uint) {
+        C1 c = new C1();
+        return (c.a(), c.b(), c.c());
+    }
     function withoutSpecifier() public returns(uint, uint, uint) {
         C2 c = new C2();
         return (c.a(), c.b(), c.c());
     }
 }
 // ----
+// withSpecifier() -> 1, 2, 3
+// gas irOptimized: 55312
+// gas irOptimized code: 45400
+// gas legacy: 56473
+// gas legacy code: 62800
 // withoutSpecifier() -> 1, 2, 3
-// gas irOptimized: 55246
+// gas irOptimized: 55286
 // gas irOptimized code: 45400
 // gas legacy: 56451
 // gas legacy code: 62800

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_modifier_calling_revert.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_modifier_calling_revert.sol
@@ -1,0 +1,38 @@
+contract A {
+    modifier m() virtual {
+        revert("A");
+        _;
+    }
+}
+contract B is A {
+    modifier m() virtual override {
+        revert("B");
+        _;
+    }
+}
+contract C1 is B layout at 2**256 - 2**42 {
+    function f() public m {}
+    modifier m() virtual override {
+        revert("C");
+        _;
+    }
+}
+contract C2 is B {
+    function f() public m {}
+    modifier m() virtual override {
+        revert("C");
+        _;
+    }
+}
+
+contract F {
+    function withSpecifier() public returns (string memory) {
+        new C1().f();
+    }
+    function withoutSpecifier() public returns (string memory) {
+        new C2().f();
+    }
+}
+// ----
+// withSpecifier() -> FAILURE, hex"08c379a0", 0x20, 1, "A"
+// withoutSpecifier() -> FAILURE, hex"08c379a0", 0x20, 1, "C"

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_modifier_calling_revert.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_modifier_calling_revert.sol
@@ -34,5 +34,5 @@ contract F {
     }
 }
 // ----
-// withSpecifier() -> FAILURE, hex"08c379a0", 0x20, 1, "A"
+// withSpecifier() -> FAILURE, hex"08c379a0", 0x20, 1, "C"
 // withoutSpecifier() -> FAILURE, hex"08c379a0", 0x20, 1, "C"

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_multiple_parents_constructors_with_arguments.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_multiple_parents_constructors_with_arguments.sol
@@ -1,0 +1,15 @@
+contract A { constructor(uint x) {} }
+contract B { constructor(uint x) {} }
+// Compilation of C1 crashes with "invalid IR generated" with `--via-ir`
+//contract C1 is A(2), B(3) layout at 2**256 - 2**42 { constructor(uint x) {} }
+contract C2 is A(2), B(3) { constructor(uint x) {} }
+contract F {
+    //function withSpecifier() public {
+    //  new C1(4);
+    //}
+    function withoutSpecifier() public {
+        new C2(4);
+    }
+}
+// ----
+// withoutSpecifier() ->

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_multiple_parents_constructors_with_arguments.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_multiple_parents_constructors_with_arguments.sol
@@ -1,15 +1,15 @@
 contract A { constructor(uint x) {} }
 contract B { constructor(uint x) {} }
-// Compilation of C1 crashes with "invalid IR generated" with `--via-ir`
-//contract C1 is A(2), B(3) layout at 2**256 - 2**42 { constructor(uint x) {} }
+contract C1 is A(2), B(3) layout at 2**256 - 2**42 { constructor(uint x) {} }
 contract C2 is A(2), B(3) { constructor(uint x) {} }
 contract F {
-    //function withSpecifier() public {
-    //  new C1(4);
-    //}
+    function withSpecifier() public {
+        new C1(4);
+    }
     function withoutSpecifier() public {
         new C2(4);
     }
 }
 // ----
+// withSpecifier() ->
 // withoutSpecifier() ->

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_receive_calling_revert.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_receive_calling_revert.sol
@@ -1,7 +1,6 @@
 contract A { receive() external payable virtual { revert("A"); } }
 contract B is A { receive() external payable override virtual { revert("B"); } }
-// C1 cannot be compiled with `via-ir` at the moment, compiler crashes because of the storage layout specifier bug
-//contract C1 is B layout at 2**256 - 2**42 { receive() external payable override virtual { revert("C"); } }
+contract C1 is B layout at 2**256 - 2**42 { receive() external payable override virtual { revert("C"); } }
 contract C2 is B { receive() external payable override virtual { revert("C"); } }
 contract F {
     function decode(bytes memory data) internal returns (string memory) {
@@ -11,11 +10,11 @@ contract F {
         }
         return abi.decode(data, (string));
     }
-    //function withSpecifier() public returns (string memory) {
-    //  (bool success, bytes memory data) = payable(new C1()).call{value: 0}("");
-    //  require(!success, "Must fail!");
-    //  return decode(data);
-    //}
+    function withSpecifier() public returns (string memory) {
+        (bool success, bytes memory data) = payable(new C1()).call{value: 0}("");
+        require(!success, "Must fail!");
+        return decode(data);
+    }
     function withoutSpecifier() public returns (string memory) {
         (bool success, bytes memory data) = payable(new C2()).call{value: 0}("");
         require(!success, "Must fail!");
@@ -25,4 +24,5 @@ contract F {
 // ====
 // EVMVersion: >homestead
 // ----
+// withSpecifier() -> 0x20, 1, "C"
 // withoutSpecifier() -> 0x20, 1, "C"

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_receive_calling_revert.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_receive_calling_revert.sol
@@ -1,0 +1,28 @@
+contract A { receive() external payable virtual { revert("A"); } }
+contract B is A { receive() external payable override virtual { revert("B"); } }
+// C1 cannot be compiled with `via-ir` at the moment, compiler crashes because of the storage layout specifier bug
+//contract C1 is B layout at 2**256 - 2**42 { receive() external payable override virtual { revert("C"); } }
+contract C2 is B { receive() external payable override virtual { revert("C"); } }
+contract F {
+    function decode(bytes memory data) internal returns (string memory) {
+        assembly {
+            // Shift the memory pointer forward by 4 bytes to skip the selector
+            data := add(data, 4)
+        }
+        return abi.decode(data, (string));
+    }
+    //function withSpecifier() public returns (string memory) {
+    //  (bool success, bytes memory data) = payable(new C1()).call{value: 0}("");
+    //  require(!success, "Must fail!");
+    //  return decode(data);
+    //}
+    function withoutSpecifier() public returns (string memory) {
+        (bool success, bytes memory data) = payable(new C2()).call{value: 0}("");
+        require(!success, "Must fail!");
+        return decode(data);
+    }
+}
+// ====
+// EVMVersion: >homestead
+// ----
+// withoutSpecifier() -> 0x20, 1, "C"

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_storage_vars_initialization.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_storage_vars_initialization.sol
@@ -1,0 +1,25 @@
+contract A { uint public x = 1; }
+contract B is A { uint public y = x * 10; }
+// Using specifier, `--via-ir` and legacy produce diffrent output (incorrect in both cases).
+//contract C1 is B layout at 2**256 - 2**40 { uint public z = y + 5; }
+contract C2 is B { uint public z = y + 5; }
+contract F {
+    //function withSpecifier() public returns (uint, uint, uint) {
+    //    C1 c = new C1();
+    //    return (c.x(), c.y(), c.z());
+    //}
+    function withoutSpecifier() public returns (uint, uint, uint) {
+        C2 c = new C2();
+        return (c.x(), c.y(), c.z());
+    }
+}
+// ----
+// withoutSpecifier() -> 1, 10, 15
+// gas irOptimized: 121728
+// gas irOptimized code: 27600
+// gas legacy: 123599
+// gas legacy code: 40400
+// gas legacyOptimized: 121916
+// gas legacyOptimized code: 20600
+// gas ssaCFGOptimized: 121687
+// gas ssaCFGOptimized code: 26200

--- a/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_storage_vars_initialization.sol
+++ b/test/libsolidity/semanticTests/storageLayoutSpecifier/inheritance_storage_vars_initialization.sol
@@ -1,25 +1,33 @@
 contract A { uint public x = 1; }
 contract B is A { uint public y = x * 10; }
-// Using specifier, `--via-ir` and legacy produce diffrent output (incorrect in both cases).
-//contract C1 is B layout at 2**256 - 2**40 { uint public z = y + 5; }
+contract C1 is B layout at 2**256 - 2**40 { uint public z = y + 5; }
 contract C2 is B { uint public z = y + 5; }
 contract F {
-    //function withSpecifier() public returns (uint, uint, uint) {
-    //    C1 c = new C1();
-    //    return (c.x(), c.y(), c.z());
-    //}
+    function withSpecifier() public returns (uint, uint, uint) {
+        C1 c = new C1();
+        return (c.x(), c.y(), c.z());
+    }
     function withoutSpecifier() public returns (uint, uint, uint) {
         C2 c = new C2();
         return (c.x(), c.y(), c.z());
     }
 }
 // ----
+// withSpecifier() -> 1, 10, 15
+// gas irOptimized: 121822
+// gas irOptimized code: 30800
+// gas legacy: 123715
+// gas legacy code: 63400
+// gas legacyOptimized: 121966
+// gas legacyOptimized code: 23800
+// gas ssaCFGOptimized: 121771
+// gas ssaCFGOptimized code: 29400
 // withoutSpecifier() -> 1, 10, 15
-// gas irOptimized: 121728
+// gas irOptimized: 121768
 // gas irOptimized code: 27600
 // gas legacy: 123599
 // gas legacy code: 40400
 // gas legacyOptimized: 121916
 // gas legacyOptimized code: 20600
-// gas ssaCFGOptimized: 121687
+// gas ssaCFGOptimized: 121722
 // gas ssaCFGOptimized code: 26200

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/inheritance_calling_super_specifier_on_caller.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/inheritance_calling_super_specifier_on_caller.sol
@@ -1,0 +1,4 @@
+contract A { function f() public virtual {} }
+// Compilation of B1 currently crashes.
+//contract B1 is A layout at 2**256 - 2**42 { function f() public override virtual { super.f(); } }
+contract B2 is A { function f() public override virtual { super.f(); } }

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/inheritance_calling_super_specifier_on_caller.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/inheritance_calling_super_specifier_on_caller.sol
@@ -1,4 +1,5 @@
 contract A { function f() public virtual {} }
-// Compilation of B1 currently crashes.
-//contract B1 is A layout at 2**256 - 2**42 { function f() public override virtual { super.f(); } }
+contract B1 is A layout at 2**256 - 2**42 { function f() public override virtual { super.f(); } }
 contract B2 is A { function f() public override virtual { super.f(); } }
+// ----
+// Warning 3495: (63-87): This contract is very close to the end of storage. This limits its future upgradability.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/inheritance_calling_super_specifier_on_child.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/inheritance_calling_super_specifier_on_child.sol
@@ -1,5 +1,6 @@
 contract A { function f() public virtual {} }
 contract B is A { function f() public override virtual { super.f(); } }
-//Compilation of C1 currently crashes.
-//contract C1 is B layout at 2**256 - 2**42 {}
+contract C1 is B layout at 2**256 - 2**42 {}
 contract C2 is B {}
+// ----
+// Warning 3495: (135-159): This contract is very close to the end of storage. This limits its future upgradability.

--- a/test/libsolidity/syntaxTests/storageLayoutSpecifier/inheritance_calling_super_specifier_on_child.sol
+++ b/test/libsolidity/syntaxTests/storageLayoutSpecifier/inheritance_calling_super_specifier_on_child.sol
@@ -1,0 +1,5 @@
+contract A { function f() public virtual {} }
+contract B is A { function f() public override virtual { super.f(); } }
+//Compilation of C1 currently crashes.
+//contract C1 is B layout at 2**256 - 2**42 {}
+contract C2 is B {}


### PR DESCRIPTION
When the compiler emits a warning about storage base location being too close to storage end, it call a helper function to determine the last storage variable. This helper function previously unintentionally reversed the linearized based contracts annotation. The function only needs to take reversed view. It should not modify the underlying data.

TODO:

- [x] Check blogpost link