### PR TITLE
Utils: Remove mixed-case format for hex numbers

### DIFF
--- a/libsolutil/CommonData.cpp
+++ b/libsolutil/CommonData.cpp
@@ -42,8 +42,6 @@ static char const* lowerHexChars = "0123456789abcdef";
 
 std::string solidity::util::toHex(uint8_t _data, HexCase _case)
 {
-	assertThrow(_case != HexCase::Mixed, BadHexCase, "Mixed case can only be used for byte arrays.");
-
 	char const* chars = _case == HexCase::Upper ? upperHexChars : lowerHexChars;
 
 	return std::string{
@@ -63,15 +61,9 @@ std::string solidity::util::toHex(bytes const& _data, HexPrefix _prefix, HexCase
 		ret[i++] = 'x';
 	}
 
-	// Mixed case will be handled inside the loop.
 	char const* chars = _case == HexCase::Upper ? upperHexChars : lowerHexChars;
-	size_t rix = _data.size() - 1;
 	for (uint8_t c: _data)
 	{
-		// switch hex case every four hexchars
-		if (_case == HexCase::Mixed)
-			chars = (rix-- & 2) == 0 ? lowerHexChars : upperHexChars;
-
 		ret[i++] = chars[(static_cast<size_t>(c) >> 4ul) & 0xfu];
 		ret[i++] = chars[c & 0xfu];
 	}

--- a/libsolutil/CommonData.h
+++ b/libsolutil/CommonData.h
@@ -436,7 +436,6 @@ enum class HexCase
 {
 	Lower = 0,
 	Upper = 1,
-	Mixed = 2,
 };
 
 /// Convert a single byte to a string of hex characters (of length two),

--- a/libsolutil/Exceptions.h
+++ b/libsolutil/Exceptions.h
@@ -101,7 +101,6 @@ struct Exception: virtual std::exception, virtual boost::exception
 
 DEV_SIMPLE_EXCEPTION(InvalidAddress);
 DEV_SIMPLE_EXCEPTION(BadHexCharacter);
-DEV_SIMPLE_EXCEPTION(BadHexCase);
 DEV_SIMPLE_EXCEPTION(FileNotFound);
 DEV_SIMPLE_EXCEPTION(NotAFile);
 DEV_SIMPLE_EXCEPTION(DataTooLong);

--- a/libsolutil/StringUtils.cpp
+++ b/libsolutil/StringUtils.cpp
@@ -148,7 +148,7 @@ std::optional<std::string> tryFormatPowerOfTwo(bigint const& _value)
 	else
 		return {fmt::format(
 			"{} * 2**{}",
-			toHex(toCompactBigEndian(prefix), HexPrefix::Add, HexCase::Mixed),
+			toHex(toCompactBigEndian(prefix), HexPrefix::Add),
 			i * 8
 		)};
 }
@@ -170,7 +170,7 @@ std::string solidity::util::formatNumberReadable(bigint const& _value, bool _use
 	else if (auto result = tryFormatPowerOfTwo(absValue + 1))
 		return {sign + *result + (isNegative ? " + 1" : " - 1")};
 
-	std::string str = toHex(toCompactBigEndian(absValue), HexPrefix::Add, HexCase::Mixed);
+	std::string str = toHex(toCompactBigEndian(absValue), HexPrefix::Add);
 
 	if (_useTruncation)
 	{

--- a/test/cmdlineTests/storage_layout_specifier_with_inheritance/err
+++ b/test/cmdlineTests/storage_layout_specifier_with_inheritance/err
@@ -3,7 +3,7 @@ Warning: This contract is very close to the end of storage. This limits its futu
   |
 6 | contract C is B layout at 2**256 - 2**40 { uint z; }
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^
-Note: There are 0xffFFFFfffc storage slots between this state variable and the end of storage.
+Note: There are 0xfffffffffc storage slots between this state variable and the end of storage.
  --> <stdin>:6:44:
   |
 6 | contract C is B layout at 2**256 - 2**40 { uint z; }

--- a/test/libsolutil/CommonData.cpp
+++ b/test/libsolutil/CommonData.cpp
@@ -76,7 +76,6 @@ BOOST_AUTO_TEST_CASE(tohex_uint8)
 	BOOST_CHECK_EQUAL(toHex(0xaa), "aa");
 	BOOST_CHECK_EQUAL(toHex(0xaa, HexCase::Lower), "aa");
 	BOOST_CHECK_EQUAL(toHex(0xaa, HexCase::Upper), "AA");
-	BOOST_CHECK_THROW(toHex(0xaa, HexCase::Mixed), BadHexCase);
 	// Defaults to lower case on invalid setting.
 	BOOST_CHECK_EQUAL(toHex(0xaa, static_cast<HexCase>(42)), "aa");
 }
@@ -85,13 +84,11 @@ BOOST_AUTO_TEST_CASE(tohex_bytes)
 {
 	BOOST_CHECK_EQUAL(toHex(fromHex("00112233445566778899aAbBcCdDeEfF"), HexPrefix::DontAdd, HexCase::Lower), "00112233445566778899aabbccddeeff");
 	BOOST_CHECK_EQUAL(toHex(fromHex("00112233445566778899aAbBcCdDeEfF"), HexPrefix::DontAdd, HexCase::Upper), "00112233445566778899AABBCCDDEEFF");
-	BOOST_CHECK_EQUAL(toHex(fromHex("00112233445566778899aAbBcCdDeEfF"), HexPrefix::DontAdd, HexCase::Mixed), "00112233445566778899aabbCCDDeeff");
 	// Defaults to lower case on invalid setting.
 	BOOST_CHECK_EQUAL(toHex(fromHex("00112233445566778899aAbBcCdDeEfF"), HexPrefix::DontAdd, static_cast<HexCase>(42)), "00112233445566778899aabbccddeeff");
 
 	BOOST_CHECK_EQUAL(toHex(fromHex("00112233445566778899aAbBcCdDeEfF"), HexPrefix::Add, HexCase::Lower), "0x00112233445566778899aabbccddeeff");
 	BOOST_CHECK_EQUAL(toHex(fromHex("00112233445566778899aAbBcCdDeEfF"), HexPrefix::Add, HexCase::Upper), "0x00112233445566778899AABBCCDDEEFF");
-	BOOST_CHECK_EQUAL(toHex(fromHex("00112233445566778899AaBbCcDdEeFf"), HexPrefix::Add, HexCase::Mixed), "0x00112233445566778899aabbCCDDeeff");
 	// Defaults to lower case on invalid setting.
 	BOOST_CHECK_EQUAL(toHex(fromHex("00112233445566778899aAbBcCdDeEfF"), HexPrefix::Add, static_cast<HexCase>(42)), "0x00112233445566778899aabbccddeeff");
 }

--- a/test/libsolutil/StringUtils.cpp
+++ b/test/libsolutil/StringUtils.cpp
@@ -145,9 +145,9 @@ BOOST_AUTO_TEST_CASE(test_format_number_readable)
 		u256(0xFFFFffffFFFFffff) << 64 |
 		u256(0xFFFFffffFFFFffff);
 	BOOST_CHECK_EQUAL(formatNumberReadable(b, true), "0x5555...{+56 more}...5555");
-	BOOST_CHECK_EQUAL(formatNumberReadable(c, true), "0xABCD...{+56 more}...6789");
-	BOOST_CHECK_EQUAL(formatNumberReadable(d, true), "0xAAAAaaaaAAAAaaaa * 2**192");
-	BOOST_CHECK_EQUAL(formatNumberReadable(e, true), "0xAAAAaaaaAAAAaaab * 2**192 - 1");
+	BOOST_CHECK_EQUAL(formatNumberReadable(c, true), "0xabcd...{+56 more}...6789");
+	BOOST_CHECK_EQUAL(formatNumberReadable(d, true), "0xaaaaaaaaaaaaaaaa * 2**192");
+	BOOST_CHECK_EQUAL(formatNumberReadable(e, true), "0xaaaaaaaaaaaaaaab * 2**192 - 1");
 
 	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x20000000)), "2**29");
 	BOOST_CHECK_EQUAL(formatNumberReadable(u256(0x200000000)), "2**33");
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE(test_format_number_readable_signed)
 	);
 
 	BOOST_CHECK_EQUAL(formatNumberReadable(b, true), "-0x5555...{+56 more}...5555");
-	BOOST_CHECK_EQUAL(formatNumberReadable(c, true), "-0x0BCD...{+56 more}...6789");
+	BOOST_CHECK_EQUAL(formatNumberReadable(c, true), "-0x0bcd...{+56 more}...6789");
 	BOOST_CHECK_EQUAL(formatNumberReadable(d, true), "-0x5555555555555556 * 2**192 + 1");
 
 	BOOST_CHECK_EQUAL(formatNumberReadable((-1) * s256(0x20000000)), "-2**29");


### PR DESCRIPTION
Utility helper `formatNumberReadable`, which tries to find a nice representation to display to the user, was using mixed-case format for hexadecimal numbers. This format is quite confusing, see, e.g., `0xffFFFFfffc`.
There does not seem to be good reason to used mixed-case format for displaying numbers to users, so I propose to remove this format.

This was motivated by a comment from @cameel: https://github.com/argotorg/solidity/pull/16861#discussion_r3545041062