### PR TITLE
fix(docs): keep RTD version-warning notification clear of the site header

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -463,6 +463,20 @@ footer .rst-footer-buttons {
     border-bottom: 1px solid var(--color-c);
 }
 
+/* Read the Docs Addons version-warning notification.
+   The addon hardcodes top:2rem / z-index:1750 inside its shadow DOM, so the
+   fixed site header (--navHeight tall, z-index:99999) both overlaps and covers
+   it. Style the host element to sit below the header and above its z-index;
+   the transform makes the host the containing block for the addon's fixed
+   toast, shifting its internal top:2rem offset down past the header. */
+readthedocs-notification {
+    position: fixed;
+    top: var(--navHeight);
+    right: 0;
+    z-index: 100000;
+    transform: translateZ(0);
+}
+
 /* Rest: Flex-row, with two children: side bar, and content */
 .unified-wrapper .wy-grid-for-nav {
     position: relative !important;


### PR DESCRIPTION
The Read the Docs version-warning notification renders behind our fixed site header (the header's `z-index: 99999` covers the toast's `z-index: 1750`, and they overlap vertically), so it's effectively invisible on older-version pages.

Example: https://docs.soliditylang.org/en/v0.8.30/

This styles the notification host to sit below the header and above its `z-index`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)