### PR TITLE
Add `deploytimeaddress` Yul builtin

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 Language Features:
 
 Compiler Features:
+* Yul: Add ``deploytimeaddress()`` builtin that returns the address at which the contract is deployed (a zero address at compile time, patched at deploy time).
 * SMTChecker: Emit a deprecation warning for the BMC engine.
 
 Bugfixes:

--- a/docs/yul.rst
+++ b/docs/yul.rst
@@ -1026,6 +1026,22 @@ option.
 
 See :ref:`Using the Commandline Compiler <commandline-compiler>` for details about the Solidity linker.
 
+deploytimeaddress
+^^^^^^^^^^^^^^^^^^
+The function ``deploytimeaddress()`` is a placeholder for the address at which the contract is
+deployed. It takes no arguments and returns a single value.
+At compilation time it is just a push of a zero address (``PUSH20 0``), which is replaced by the
+actual address of the contract when it is deployed.
+
+This is the same mechanism the legacy code generator uses to prevent a contract from being called
+via ``DELEGATECALL`` (for example, in libraries). Comparing ``deploytimeaddress()`` with the current
+``address()`` tells whether the code runs in the context of the contract it was deployed as, or in a
+foreign context via ``DELEGATECALL``:
+
+.. code-block:: yul
+
+    if iszero(eq(deploytimeaddress(), address())) { revert(0, 0) }
+
 memoryguard
 ^^^^^^^^^^^
 

--- a/libyul/backends/evm/AbstractAssembly.h
+++ b/libyul/backends/evm/AbstractAssembly.h
@@ -85,6 +85,9 @@ public:
 	/// Append a reference to a to-be-linked symbol.
 	/// Currently, we assume that the value is always a 20 byte number.
 	virtual void appendLinkerSymbol(std::string const& _name) = 0;
+	/// Append a special constant that will be replaced by the address of the deployed contract
+	/// at deploy time. At compilation time, this is just "PUSH20 00...000".
+	virtual void appendDeployTimeAddress() = 0;
 
 	/// Append raw bytes that stay untouched by the optimizer.
 	virtual void appendVerbatim(bytes _data, size_t _arguments, size_t _returnVariables) = 0;

--- a/libyul/backends/evm/EVMBuiltins.cpp
+++ b/libyul/backends/evm/EVMBuiltins.cpp
@@ -99,6 +99,22 @@ BuiltinFunctionForEVM linkersymbolBuiltin()
 	);
 }
 
+BuiltinFunctionForEVM deploytimeaddressBuiltin()
+{
+	return createFunction(
+		"deploytimeaddress",
+		0,
+		1,
+		SideEffects{},
+		ControlFlowSideEffects{},
+		{},
+		[](FunctionCall const& _call, AbstractAssembly& _assembly, BuiltinContext&) {
+			yulAssert(_call.arguments.empty(), "");
+			_assembly.appendDeployTimeAddress();
+		}
+	);
+}
+
 BuiltinFunctionForEVM memoryguardBuiltin()
 {
 	return createFunction(
@@ -260,6 +276,7 @@ EVMBuiltins::EVMBuiltins()
 	}
 
 	m_scopesAndFunctions.emplace_back(objectAccess, linkersymbolBuiltin());
+	m_scopesAndFunctions.emplace_back(objectAccess, deploytimeaddressBuiltin());
 	m_scopesAndFunctions.emplace_back(objectAccess, memoryguardBuiltin());
 
 	m_scopesAndFunctions.emplace_back(objectAccess, datasizeBuiltin());

--- a/libyul/backends/evm/EVMDialect.cpp
+++ b/libyul/backends/evm/EVMDialect.cpp
@@ -154,6 +154,7 @@ std::set<std::string, std::less<>> createReservedIdentifiers(langutil::EVMVersio
 		"datacopy",
 		"setimmutable",
 		"loadimmutable",
+		"deploytimeaddress",
 	};
 
 	return reserved;

--- a/libyul/backends/evm/EthAssemblyAdapter.cpp
+++ b/libyul/backends/evm/EthAssemblyAdapter.cpp
@@ -93,6 +93,11 @@ void EthAssemblyAdapter::appendLinkerSymbol(std::string const& _linkerSymbol)
 	m_assembly.appendLibraryAddress(_linkerSymbol);
 }
 
+void EthAssemblyAdapter::appendDeployTimeAddress()
+{
+	m_assembly.append(evmasm::PushDeployTimeAddress);
+}
+
 void EthAssemblyAdapter::appendVerbatim(bytes _data, size_t _arguments, size_t _returnVariables)
 {
 	m_assembly.appendVerbatim(std::move(_data), _arguments, _returnVariables);

--- a/libyul/backends/evm/EthAssemblyAdapter.h
+++ b/libyul/backends/evm/EthAssemblyAdapter.h
@@ -50,6 +50,7 @@ public:
 	size_t newLabelId() override;
 	size_t namedLabel(std::string const& _name, size_t _params, size_t _returns, std::optional<size_t> _sourceID) override;
 	void appendLinkerSymbol(std::string const& _linkerSymbol) override;
+	void appendDeployTimeAddress() override;
 	void appendVerbatim(bytes _data, size_t _arguments, size_t _returnVariables) override;
 	void appendJump(int _stackDiffAfter, JumpType _jumpType) override;
 	void appendJumpTo(LabelID _labelId, int _stackDiffAfter, JumpType _jumpType) override;

--- a/libyul/backends/evm/NoOutputAssembly.cpp
+++ b/libyul/backends/evm/NoOutputAssembly.cpp
@@ -87,6 +87,12 @@ void NoOutputAssembly::appendLinkerSymbol(std::string const&)
 	yulAssert(false, "Linker symbols not yet implemented.");
 }
 
+void NoOutputAssembly::appendDeployTimeAddress()
+{
+	// The deploy-time address is assembled as a "PUSH20 00...000".
+	appendInstruction(evmasm::pushInstruction(20));
+}
+
 void NoOutputAssembly::appendVerbatim(bytes, size_t _arguments, size_t _returnVariables)
 {
 	m_stackHeight += static_cast<int>(_returnVariables) - static_cast<int>(_arguments);

--- a/libyul/backends/evm/NoOutputAssembly.h
+++ b/libyul/backends/evm/NoOutputAssembly.h
@@ -59,6 +59,7 @@ public:
 	LabelID newLabelId() override;
 	LabelID namedLabel(std::string const& _name, size_t _params, size_t _returns, std::optional<size_t> _sourceID) override;
 	void appendLinkerSymbol(std::string const& _name) override;
+	void appendDeployTimeAddress() override;
 	void appendVerbatim(bytes _data, size_t _arguments, size_t _returnVariables) override;
 
 	void appendJump(int _stackDiffAfter, JumpType _jumpType) override;

--- a/test/libyul/objectCompiler/deploytimeaddress.yul
+++ b/test/libyul/objectCompiler/deploytimeaddress.yul
@@ -1,0 +1,23 @@
+{
+    let addr := deploytimeaddress()
+    sstore(0, eq(addr, address()))
+}
+// ====
+// EVMVersion: >=shanghai
+// ----
+// Assembly:
+//     /* "source":63:82   */
+//   deployTimeAddress()
+//     /* "source":114:123   */
+//   address
+//     /* "source":105:124   */
+//   eq
+//     /* "source":102:103   */
+//   0x00
+//     /* "source":95:125   */
+//   sstore
+//     /* "source":27:141   */
+//   stop
+// Bytecode: 73000000000000000000000000000000000000000030145f5500
+// Opcodes: PUSH20 0x0 ADDRESS EQ PUSH0 SSTORE STOP
+// SourceMappings: 63:19:0:-:0;114:9;105:19;102:1;95:30;27:114

--- a/test/libyul/yulSyntaxTests/deploytimeaddress.yul
+++ b/test/libyul/yulSyntaxTests/deploytimeaddress.yul
@@ -1,0 +1,7 @@
+{
+    let addr := deploytimeaddress()
+    sstore(0, eq(addr, address()))
+}
+// ====
+// dialect: evm
+// ----

--- a/test/libyul/yulSyntaxTests/deploytimeaddress_shadowing.yul
+++ b/test/libyul/yulSyntaxTests/deploytimeaddress_shadowing.yul
@@ -1,0 +1,7 @@
+{
+    function deploytimeaddress() {}
+}
+// ====
+// dialect: evm
+// ----
+// ParserError 5568: (15-32): Cannot use builtin function name "deploytimeaddress" as identifier name.

--- a/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
+++ b/test/tools/yulInterpreter/EVMInstructionInterpreter.cpp
@@ -541,6 +541,13 @@ u256 EVMInstructionInterpreter::evalBuiltin(
 	if (fun == "memoryguard")
 		return _evaluatedArguments.at(0);
 
+	if (fun == "deploytimeaddress")
+	{
+		yulAssert(_arguments.empty());
+		// At compile time this is a zero address that gets patched at deploy time.
+		return 0;
+	}
+
 	if (fun == "linkersymbol")
 	{
 		yulAssert(_arguments.size() == 1);


### PR DESCRIPTION
Introduce a new EVM dialect builtin `deploytimeaddress()` that pushes the special constant which is replaced by the contract's address at deploy time. At compilation time this is just a `PUSH20 00...00`, i.e. the same `PushDeployTimeAddress` assembly item that the legacy code generator emits in `appendDelegatecallCheck()`.

This allows replicating the delegatecall check (comparing the deploy-time address against `address()`) directly in Yul.

The builtin takes no arguments and returns a single value. It requires object access, consistent with the other special builtins such as `linkersymbol`, and is added to the reserved identifiers so it cannot be shadowed.

<!--
Thank you for your contribution to the Solidity compiler! A team member will follow up shortly.

If you have any questions or need our help, feel free to post them in the PR or talk to us directly on the
[#solidity-dev](https://matrix.to/#/#ethereum_solidity-dev:gitter.im) channel on Matrix.
-->

## Description

<!-- Describe the purpose of this PR. -->

## Checklist
- [x] I have read the [contributing guidelines](https://docs.soliditylang.org/en/latest/contributing.html) and the [review checklist](https://github.com/argotorg/solidity/blob/develop/ReviewChecklist.md)
- [x] I have personally reviewed, understood, and tested every change in this PR

## AI Disclosure
<!--
See our contributing guidelines for the full AI usage policy:
https://docs.soliditylang.org/en/latest/contributing.html#ai-assisted-contributions

If you used AI tools in any part of this PR you MUST disclose it below.
-->

- [ ] No AI tools were used

<!-- If AI tools were used, describe which tools and for which parts here. -->

Claude was used.