### PR TITLE
SSA CFG: Shuffler and stack layouts are based on traces rather than stack targets

### DIFF
--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -105,6 +105,7 @@ add_library(yul
 	backends/evm/ssa/StackLayoutGenerator.h
 	backends/evm/ssa/StackShuffler.cpp
 	backends/evm/ssa/StackShuffler.h
+	backends/evm/ssa/StackSlot.h
 	backends/evm/ssa/StackSlotLiveness.h
 	backends/evm/ssa/util/UseCountSet.h
 	backends/evm/ssa/util/TLSFFreeList.h

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -96,6 +96,8 @@ add_library(yul
 	backends/evm/ssa/SSACFGDebugInfo.h
 	backends/evm/ssa/SSACFGTypes.cpp
 	backends/evm/ssa/SSACFGTypes.h
+	backends/evm/ssa/ShuffleTrace.cpp
+	backends/evm/ssa/ShuffleTrace.h
 	backends/evm/ssa/Stack.cpp
 	backends/evm/ssa/Stack.h
 	backends/evm/ssa/StackLayout.h

--- a/libyul/CMakeLists.txt
+++ b/libyul/CMakeLists.txt
@@ -98,13 +98,13 @@ add_library(yul
 	backends/evm/ssa/SSACFGTypes.h
 	backends/evm/ssa/ShuffleTrace.cpp
 	backends/evm/ssa/ShuffleTrace.h
-	backends/evm/ssa/Stack.cpp
 	backends/evm/ssa/Stack.h
 	backends/evm/ssa/StackLayout.h
 	backends/evm/ssa/StackLayoutGenerator.cpp
 	backends/evm/ssa/StackLayoutGenerator.h
 	backends/evm/ssa/StackShuffler.cpp
 	backends/evm/ssa/StackShuffler.h
+	backends/evm/ssa/StackSlot.cpp
 	backends/evm/ssa/StackSlot.h
 	backends/evm/ssa/StackSlotLiveness.h
 	backends/evm/ssa/util/UseCountSet.h

--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -178,7 +178,7 @@ CodeTransform::CodeTransform(
 		yulAssert(entryLayout);
 		return entryLayout->stackIn;
 	}()),
-	m_stack(m_stackData, {.trace = &m_shuffleTrace})
+	m_stack(m_stackData)
 {
 	bool const isFunctionGraph = !m_cfg.isMainGraph();
 	if (isFunctionGraph)
@@ -323,7 +323,7 @@ void CodeTransform::operator()(InstId _instId, StackData const& _operationInputL
 		if (returnLabel)
 		{
 			m_assembly.appendLabel(*returnLabel);
-			m_stack.pop<false>();
+			m_stack.pop();
 		}
 		break;
 	}
@@ -355,11 +355,11 @@ void CodeTransform::operator()(InstId _instId, StackData const& _operationInputL
 	}
 	// simulate that the inputs are consumed
 	for (size_t i = 0; i < _inst.inputs.size(); ++i)
-		m_stack.pop<false>();
+		m_stack.pop();
 	// simulate that the outputs are produced
 	auto const numOutputs = m_cfg.numReturnsOf(_instId);
 	for (InstId const id: m_cfg.outputsOf(_instId))
-		m_stack.push<false>(StackSlot::makeValue(m_cfg, id));
+		m_stack.push(StackSlot::makeValue(m_cfg, id));
 
 	// Each output the layout decided to spill gets its `mstore` here
 	if (m_spillEmitter)
@@ -389,8 +389,9 @@ void CodeTransform::spillStore(InstId const _value)
 	// addr(_value) is the slot THIS `mstore` populates, so we have to exclude it from the spill set to
 	// prevent the shuffler from just `mload`ing it back
 	spill::SpillSet const spillSetExcludingSpillee = m_spillSet.without(_value);
-	m_shuffleTrace.clear();
-	auto const shuffleResult = StackShuffler<TraceRecordingCallbacks>::shuffle(m_stack, target, &spillSetExcludingSpillee);
+	ShuffleTrace trace;
+	Stack stack(m_stackData, &trace);
+	auto const shuffleResult = StackShuffler::shuffle(stack, target, &spillSetExcludingSpillee);
 	yulAssert(
 		shuffleResult.status == StackShufflerResult::Status::Admissible,
 		fmt::format(
@@ -400,10 +401,10 @@ void CodeTransform::spillStore(InstId const _value)
 		)
 	);
 	// the `mstore` of the spilled value concludes the def-site trace
-	m_shuffleTrace.push_back(ShuffleOp::store(StackSlot::makeValue(m_cfg, _value)));
-	emit(m_shuffleTrace);
+	trace.push_back(ShuffleOp::store(StackSlot::makeValue(m_cfg, _value)));
+	emit(trace);
 	// `mstore` consumed the value; the address it pushed never persists on the symbolic stack
-	m_stack.pop<false>();
+	m_stack.pop();
 }
 
 void CodeTransform::operator()(SSACFG::BlockId const&, SSACFG::BasicBlock::MainExit const&)
@@ -420,7 +421,7 @@ void CodeTransform::operator()(SSACFG::BlockId const& _currentBlock, SSACFG::Bas
 	// emit JUMPI to nonZero block
 	m_assembly.appendJumpToIf(m_blockLabels[_conditionalJump.nonZero.value]);
 	// update symbolic stack by popping the condition as it'll be consumed by JUMPI
-	m_stack.pop<false>();
+	m_stack.pop();
 
 	{
 		// restore stack to previous state once zero-path is handled
@@ -514,10 +515,11 @@ void CodeTransform::operator()(SSACFG::BlockId const& _blockId, SSACFG::BasicBlo
 
 void CodeTransform::shuffleAndEmit(StackData const& _target, spill::SpillSet const& _spillSet)
 {
-	m_shuffleTrace.clear();
-	auto const shuffleResult = StackShuffler<TraceRecordingCallbacks>::shuffle(m_stack, _target, &_spillSet);
+	ShuffleTrace trace;
+	Stack stack(m_stackData, &trace);
+	auto const shuffleResult = StackShuffler::shuffle(stack, _target, &_spillSet);
 	yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
-	emit(m_shuffleTrace);
+	emit(trace);
 }
 
 void CodeTransform::emit(ShuffleTrace const& _trace)

--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -509,12 +509,6 @@ void CodeTransform::playback(ShuffleTrace const& _trace)
 	}
 }
 
-void CodeTransform::emit(ShuffleTrace const& _trace)
-{
-	for (ShuffleOp const& op: _trace)
-		emit(op);
-}
-
 void CodeTransform::emit(ShuffleOp const& _op)
 {
 	switch (_op.kind)

--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -25,6 +25,8 @@
 
 #include <libyul/backends/evm/EVMBuiltins.h>
 
+#include <libevmasm/Instruction.h>
+
 #include <libsolutil/Visitor.h>
 
 #include <range/v3/view/take_last.hpp>
@@ -170,20 +172,13 @@ CodeTransform::CodeTransform(
 			return spill::Emitter(_addressing, _graphID, _assembly);
 		return std::nullopt;
 	}()),
-	m_assemblyCallbacks{
-		.cfg = &_cfg,
-		.assembly = &_assembly,
-		.callSites = &_callSites,
-		.returnLabels = &m_returnLabels,
-		.spillEmitter = m_spillEmitter ? &*m_spillEmitter : nullptr
-	},
 	m_stackData([&]
 	{
 		auto const& entryLayout = m_stackLayout[m_cfg.entry];
 		yulAssert(entryLayout);
 		return entryLayout->stackIn;
 	}()),
-	m_stack(m_stackData, m_assemblyCallbacks)
+	m_stack(m_stackData, {.trace = &m_shuffleTrace})
 {
 	bool const isFunctionGraph = !m_cfg.isMainGraph();
 	if (isFunctionGraph)
@@ -243,8 +238,7 @@ void CodeTransform::operator()(SSACFG::BlockId const _blockId)
 	// Shuffle to the block's exit layout before dispatching the exit.
 	// This ensures the condition is on top for ConditionalJump, phi pre-images are
 	// in the right positions for jumps, and return values are accessible for FunctionReturn.
-	auto const shuffleResult = StackShuffler<AssemblyCallbacks>::shuffle(m_stack, blockLayout->exitIn, &m_spillSet);
-	yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
+	shuffleAndEmit(blockLayout->exitIn, m_spillSet);
 
 	// handle the block exit
 	std::visit(solidity::util::GenericVisitor{ [this, &_blockId](auto const& exit) { (*this)(_blockId, exit); } }, block.exit);
@@ -268,10 +262,7 @@ void CodeTransform::operator()(InstId _instId, StackData const& _operationInputL
 	yulAssert(static_cast<int>(m_stack.size()) == m_assembly.stackHeight());
 
 	// prepare stack for operation
-	{
-		auto const shuffleResult = StackShuffler<AssemblyCallbacks>::shuffle(m_stack, _operationInputLayout, &m_spillSet);
-		yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
-	}
+	shuffleAndEmit(_operationInputLayout, m_spillSet);
 
 	// check that the assembly stack height corresponds to the stack size after shuffling
 	yulAssert(static_cast<int>(m_stack.size()) == m_assembly.stackHeight());
@@ -398,7 +389,8 @@ void CodeTransform::spillStore(InstId const _value)
 	// addr(_value) is the slot THIS `mstore` populates, so we have to exclude it from the spill set to
 	// prevent the shuffler from just `mload`ing it back
 	spill::SpillSet const spillSetExcludingSpillee = m_spillSet.without(_value);
-	auto const shuffleResult = StackShuffler<AssemblyCallbacks>::shuffle(m_stack, target, &spillSetExcludingSpillee);
+	m_shuffleTrace.clear();
+	auto const shuffleResult = StackShuffler<TraceRecordingCallbacks>::shuffle(m_stack, target, &spillSetExcludingSpillee);
 	yulAssert(
 		shuffleResult.status == StackShufflerResult::Status::Admissible,
 		fmt::format(
@@ -407,8 +399,9 @@ void CodeTransform::spillStore(InstId const _value)
 			static_cast<int>(shuffleResult.status)
 		)
 	);
-
-	m_spillEmitter->emitStore(_value);
+	// the `mstore` of the spilled value concludes the def-site trace
+	m_shuffleTrace.push_back(ShuffleOp::store(StackSlot::makeValue(m_cfg, _value)));
+	emit(m_shuffleTrace);
 	// `mstore` consumed the value; the address it pushed never persists on the symbolic stack
 	m_stack.pop<false>();
 }
@@ -519,15 +512,87 @@ void CodeTransform::operator()(SSACFG::BlockId const& _blockId, SSACFG::BasicBlo
 	m_assembly.appendInstruction(evmasm::Instruction::INVALID);
 }
 
+void CodeTransform::shuffleAndEmit(StackData const& _target, spill::SpillSet const& _spillSet)
+{
+	m_shuffleTrace.clear();
+	auto const shuffleResult = StackShuffler<TraceRecordingCallbacks>::shuffle(m_stack, _target, &_spillSet);
+	yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
+	emit(m_shuffleTrace);
+}
+
+void CodeTransform::emit(ShuffleTrace const& _trace)
+{
+	for (ShuffleOp const& op: _trace)
+		emit(op);
+}
+
+void CodeTransform::emit(ShuffleOp const& _op)
+{
+	switch (_op.kind)
+	{
+	case ShuffleOp::Kind::Swap:
+		m_assembly.appendInstruction(evmasm::swapInstruction(_op.depth));
+		return;
+	case ShuffleOp::Kind::Dup:
+		m_assembly.appendInstruction(evmasm::dupInstruction(_op.depth));
+		return;
+	case ShuffleOp::Kind::Pop:
+		m_assembly.appendInstruction(evmasm::Instruction::POP);
+		return;
+	case ShuffleOp::Kind::Push:
+		switch (_op.slot.kind())
+		{
+		case StackSlot::Kind::Value:
+			yulAssert(m_cfg.isLiteral(_op.slot.value()), "Non-literal value pushes must be recorded as Load.");
+			m_assembly.appendConstant(m_cfg.literalPayload(_op.slot.value()));
+			return;
+		case StackSlot::Kind::Junk:
+			if (m_assembly.evmVersion().hasPush0())
+				m_assembly.appendConstant(0);
+			else
+				m_assembly.appendInstruction(evmasm::Instruction::CODESIZE);
+			return;
+		case StackSlot::Kind::FunctionCallReturnLabel:
+		{
+			auto const instId = m_callSites.instId(_op.slot.functionCallReturnLabel());
+			yulAssert(m_returnLabels.count(instId), "FunctionCallReturnLabel not pre-registered before shuffle.");
+			m_assembly.appendLabelReference(m_returnLabels.at(instId));
+			return;
+		}
+		case StackSlot::Kind::FunctionReturnLabel:
+			yulAssert(false, "Cannot produce function return label.");
+		}
+		solidity::util::unreachable();
+	case ShuffleOp::Kind::Load:
+	{
+		InstId const id = _op.slot.value();
+		yulAssert(
+			m_spillEmitter && m_spillEmitter->hasAddress(id),
+			fmt::format("Tried bringing up non-spilled non-const {}", id)
+		);
+		m_spillEmitter->emitLoad(id);
+		return;
+	}
+	case ShuffleOp::Kind::Store:
+	{
+		InstId const id = _op.slot.value();
+		yulAssert(
+			m_spillEmitter && m_spillEmitter->hasAddress(id),
+			fmt::format("Tried storing value {} without a spill slot", id)
+		);
+		m_spillEmitter->emitStore(id);
+		return;
+	}
+	}
+	solidity::util::unreachable();
+}
+
 void CodeTransform::prepareBlockExitStack(StackData const& _target, PhiInverse const& _phiInverse)
 {
 	// pull back target to live in current variable space
 	auto const pulledBackTarget = stackPreImage(m_cfg, _target, _phiInverse);
 	// shuffle to target
-	{
-		auto const shuffleResult = StackShuffler<AssemblyCallbacks>::shuffle(m_stack, pulledBackTarget, &m_spillSet);
-		yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
-	}
+	shuffleAndEmit(pulledBackTarget, m_spillSet);
 	// check that shuffling was successful
 	assertLayoutCompatibility(m_stack.data(), pulledBackTarget);
 	// now we can simply set the target to the actual one which will take care of the application of phi functions

--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -19,6 +19,7 @@
 #include <libyul/backends/evm/ssa/CodeTransform.h>
 
 #include <libyul/backends/evm/ssa/CallGraph.h>
+#include <libyul/backends/evm/ssa/PhiInverse.h>
 #include <libyul/backends/evm/ssa/StackLayoutGenerator.h>
 #include <libyul/backends/evm/ssa/StackShuffler.h>
 #include <libyul/backends/evm/ssa/StackUtils.h>
@@ -217,6 +218,7 @@ void CodeTransform::operator()(SSACFG::BlockId const _blockId)
 	auto const& block = m_cfg.block(_blockId);
 
 	std::size_t operationIndex = 0;
+	yulAssert(blockLayout->operationIn.size() == blockLayout->operationShuffles.size());
 
 	// Iterate every Inst in the block in scheduled order. Only Operations advance codegen;
 	// Phis are otherwise pure stack assertions (already materialized on the block's stackIn).
@@ -229,22 +231,23 @@ void CodeTransform::operator()(SSACFG::BlockId const _blockId)
 		if (inst.isOperation())
 		{
 			yulAssert(operationIndex < blockLayout->operationIn.size());
-			(*this)(instId, blockLayout->operationIn[operationIndex]);
+			(*this)(instId, blockLayout->operationIn[operationIndex], blockLayout->operationShuffles[operationIndex]);
 			++operationIndex;
 		}
 	}
 	yulAssert(operationIndex == blockLayout->operationIn.size());
 
-	// Shuffle to the block's exit layout before dispatching the exit.
+	// Play back the recorded shuffle to the block's exit layout before dispatching the exit.
 	// This ensures the condition is on top for ConditionalJump, phi pre-images are
 	// in the right positions for jumps, and return values are accessible for FunctionReturn.
-	shuffleAndEmit(blockLayout->exitIn, m_spillSet);
+	playback(blockLayout->exitShuffle);
+	assertLayoutCompatibility(m_stack.data(), blockLayout->exitIn);
 
 	// handle the block exit
 	std::visit(solidity::util::GenericVisitor{ [this, &_blockId](auto const& exit) { (*this)(_blockId, exit); } }, block.exit);
 }
 
-void CodeTransform::operator()(InstId _instId, StackData const& _operationInputLayout)
+void CodeTransform::operator()(InstId _instId, StackData const& _operationInputLayout, ShuffleTrace const& _operationShuffle)
 {
 	SSACFG::Inst const& _inst = m_cfg.inst(_instId);
 	yulAssert(_inst.isOperation());
@@ -261,8 +264,8 @@ void CodeTransform::operator()(InstId _instId, StackData const& _operationInputL
 	// check that the assembly stack height corresponds to the stack size before shuffling
 	yulAssert(static_cast<int>(m_stack.size()) == m_assembly.stackHeight());
 
-	// prepare stack for operation
-	shuffleAndEmit(_operationInputLayout, m_spillSet);
+	// prepare stack for operation by playing back the recorded shuffle
+	playback(_operationShuffle);
 
 	// check that the assembly stack height corresponds to the stack size after shuffling
 	yulAssert(static_cast<int>(m_stack.size()) == m_assembly.stackHeight());
@@ -429,10 +432,7 @@ void CodeTransform::operator()(SSACFG::BlockId const& _currentBlock, SSACFG::Bas
 		yulAssert(m_stackLayout[_conditionalJump.zero]);
 
 		// transform stack to a state in which we can jump to the zero branch
-		prepareBlockExitStack(
-			m_stackLayout[_conditionalJump.zero]->stackIn,
-			PhiInverse(m_cfg, _currentBlock, _conditionalJump.zero)
-		);
+		prepareBlockExitStack(_currentBlock, _conditionalJump.zero);
 		assertLayoutCompatibility(m_stack.data(), m_stackLayout[_conditionalJump.zero]->stackIn);
 		m_assembly.appendJumpTo(m_blockLabels[_conditionalJump.zero.value]);
 
@@ -443,10 +443,7 @@ void CodeTransform::operator()(SSACFG::BlockId const& _currentBlock, SSACFG::Bas
 		yulAssert(m_stackLayout[_conditionalJump.nonZero]);
 		m_assembly.setStackHeight(static_cast<int>(m_stack.size()));
 		// transform stack to a state in which we can jump to the nonZero branch
-		prepareBlockExitStack(
-			m_stackLayout[_conditionalJump.nonZero]->stackIn,
-			PhiInverse(m_cfg, _currentBlock, _conditionalJump.nonZero)
-		);
+		prepareBlockExitStack(_currentBlock, _conditionalJump.nonZero);
 		assertLayoutCompatibility(m_stack.data(), m_stackLayout[_conditionalJump.nonZero]->stackIn);
 		if (!m_blockIsTransformed[_conditionalJump.nonZero.value])
 			(*this)(_conditionalJump.nonZero);
@@ -457,7 +454,7 @@ void CodeTransform::operator()(SSACFG::BlockId const& _currentBlock, SSACFG::Bas
 {
 	yulAssert(static_cast<int>(m_stack.size()) == m_assembly.stackHeight());
 	yulAssert(m_stackLayout[_jump.target]);
-	prepareBlockExitStack(m_stackLayout[_jump.target]->stackIn, PhiInverse(m_cfg, _currentBlock, _jump.target));
+	prepareBlockExitStack(_currentBlock, _jump.target);
 	assertLayoutCompatibility(m_stack.data(), m_stackLayout[_jump.target]->stackIn);
 	m_assembly.appendJumpTo(m_blockLabels[_jump.target.value]);
 	if (!m_blockIsTransformed[_jump.target.value])
@@ -513,13 +510,13 @@ void CodeTransform::operator()(SSACFG::BlockId const& _blockId, SSACFG::BasicBlo
 	m_assembly.appendInstruction(evmasm::Instruction::INVALID);
 }
 
-void CodeTransform::shuffleAndEmit(StackData const& _target, spill::SpillSet const& _spillSet)
+void CodeTransform::playback(ShuffleTrace const& _trace)
 {
-	ShuffleTrace trace;
-	Stack stack(m_stackData, &trace);
-	auto const shuffleResult = StackShuffler::shuffle(stack, _target, &_spillSet);
-	yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
-	emit(trace);
+	for (ShuffleOp const& op: _trace)
+	{
+		apply(m_stackData, op);
+		emit(op);
+	}
 }
 
 void CodeTransform::emit(ShuffleTrace const& _trace)
@@ -589,14 +586,16 @@ void CodeTransform::emit(ShuffleOp const& _op)
 	solidity::util::unreachable();
 }
 
-void CodeTransform::prepareBlockExitStack(StackData const& _target, PhiInverse const& _phiInverse)
+void CodeTransform::prepareBlockExitStack(SSACFG::BlockId const& _currentBlock, SSACFG::BlockId const& _target)
 {
+	auto const& targetLayout = m_stackLayout[_target];
+	yulAssert(targetLayout);
 	// pull back target to live in current variable space
-	auto const pulledBackTarget = stackPreImage(m_cfg, _target, _phiInverse);
-	// shuffle to target
-	shuffleAndEmit(pulledBackTarget, m_spillSet);
-	// check that shuffling was successful
+	auto const pulledBackTarget = stackPreImage(m_cfg, targetLayout->stackIn, PhiInverse(m_cfg, _currentBlock, _target));
+	// play back the recorded shuffle for this edge
+	playback(targetLayout->traceForStackIn(_currentBlock));
+	// check that the playback reproduced the edge target
 	assertLayoutCompatibility(m_stack.data(), pulledBackTarget);
 	// now we can simply set the target to the actual one which will take care of the application of phi functions
-	m_stackData = _target;
+	m_stackData = targetLayout->stackIn;
 }

--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -21,7 +21,6 @@
 #include <libyul/backends/evm/ssa/CallGraph.h>
 #include <libyul/backends/evm/ssa/PhiInverse.h>
 #include <libyul/backends/evm/ssa/StackLayoutGenerator.h>
-#include <libyul/backends/evm/ssa/StackShuffler.h>
 #include <libyul/backends/evm/ssa/StackUtils.h>
 
 #include <libyul/backends/evm/EVMBuiltins.h>
@@ -63,9 +62,11 @@ void CodeTransform::run
 	std::vector<CallSites> callSitesPerCFG;
 	std::vector<SSACFGStackLayout> layouts;
 	std::vector<spill::SpillSet> spillSetsPerCFG;
+	std::vector<spill::SpillStoreTraces> spillStoreTracesPerCFG;
 	callSitesPerCFG.reserve(numCFGs);
 	layouts.reserve(numCFGs);
 	spillSetsPerCFG.reserve(numCFGs);
+	spillStoreTracesPerCFG.reserve(numCFGs);
 
 	for (std::size_t functionIndex = 0; functionIndex < numCFGs; ++functionIndex)
 	{
@@ -77,9 +78,10 @@ void CodeTransform::run
 		auto const graphID = static_cast<ControlFlowGraphs::FunctionGraphID>(functionIndex);
 		callSitesPerCFG.push_back(gatherCallSites(cfg));
 		bool const spillingAllowed = !callGraph.isRecursive(graphID);
-		auto [layout, spillSet] = StackLayoutGenerator::generate(*liveness, callSitesPerCFG.back(), graphID, spillingAllowed);
+		auto [layout, spillSet, spillStoreTraces] = StackLayoutGenerator::generate(*liveness, callSitesPerCFG.back(), graphID, spillingAllowed);
 		layouts.push_back(std::move(layout));
 		spillSetsPerCFG.push_back(std::move(spillSet));
+		spillStoreTracesPerCFG.push_back(std::move(spillStoreTraces));
 	}
 
 	// build up global addressing based on the spill sets
@@ -100,6 +102,7 @@ void CodeTransform::run
 			cfg,
 			layouts[functionIndex],
 			spillSetsPerCFG[functionIndex],
+			spillStoreTracesPerCFG[functionIndex],
 			graphID,
 			addressing
 		);
@@ -148,6 +151,7 @@ CodeTransform::CodeTransform(
 	SSACFG const& _cfg,
 	SSACFGStackLayout const& _stackLayout,
 	spill::SpillSet const& _spillSet,
+	spill::SpillStoreTraces const& _spillStoreTraces,
 	ControlFlowGraphs::FunctionGraphID _graphID,
 	spill::MemoryAddressing const& _addressing
 ):
@@ -159,6 +163,7 @@ CodeTransform::CodeTransform(
 	m_cfg(_cfg),
 	m_stackLayout(_stackLayout),
 	m_spillSet(_spillSet),
+	m_spillStoreTraces(_spillStoreTraces),
 	m_graphID(_graphID),
 	m_blockIsTransformed(_cfg.numBlocks(), false),
 	m_blockLabels([this] {
@@ -386,28 +391,18 @@ void CodeTransform::spillStore(InstId const _value)
 	if (!m_spillEmitter || !m_spillSet.isSpilled(_value))
 		return;
 
-	// Bring `_value` to the stack top so that the `mstore` below consumes it
-	StackData target = m_stack.data();
-	target.push_back(StackSlot::makeValue(m_cfg, _value));
-	// addr(_value) is the slot THIS `mstore` populates, so we have to exclude it from the spill set to
-	// prevent the shuffler from just `mload`ing it back
-	spill::SpillSet const spillSetExcludingSpillee = m_spillSet.without(_value);
-	ShuffleTrace trace;
-	Stack stack(m_stackData, &trace);
-	auto const shuffleResult = StackShuffler::shuffle(stack, target, &spillSetExcludingSpillee);
+	// Play back the recorded def-site trace: it brings `_value` to the stack top and concludes with the
+	// `mstore` consuming it, leaving the rest of the stack in place.
+	auto const it = m_spillStoreTraces.find(_value);
+	yulAssert(it != m_spillStoreTraces.end(), fmt::format("no def-site store trace recorded for spilled value {}", _value));
+	ShuffleTrace const& storeTrace = it->second;
 	yulAssert(
-		shuffleResult.status == StackShufflerResult::Status::Admissible,
-		fmt::format(
-			"shuffler failed to bring spilled value {} to top (status={})",
-			_value,
-			static_cast<int>(shuffleResult.status)
-		)
+		!storeTrace.empty() &&
+		storeTrace.back().kind == ShuffleOp::Kind::Store &&
+		storeTrace.back().slot == StackSlot::makeValue(m_cfg, _value),
+		fmt::format("def-site trace for {} must conclude with its store", _value)
 	);
-	// the `mstore` of the spilled value concludes the def-site trace
-	trace.push_back(ShuffleOp::store(StackSlot::makeValue(m_cfg, _value)));
-	emit(trace);
-	// `mstore` consumed the value; the address it pushed never persists on the symbolic stack
-	m_stack.pop();
+	playback(storeTrace);
 }
 
 void CodeTransform::operator()(SSACFG::BlockId const&, SSACFG::BasicBlock::MainExit const&)

--- a/libyul/backends/evm/ssa/CodeTransform.cpp
+++ b/libyul/backends/evm/ssa/CodeTransform.cpp
@@ -223,7 +223,6 @@ void CodeTransform::operator()(SSACFG::BlockId const _blockId)
 	auto const& block = m_cfg.block(_blockId);
 
 	std::size_t operationIndex = 0;
-	yulAssert(blockLayout->operationIn.size() == blockLayout->operationShuffles.size());
 
 	// Iterate every Inst in the block in scheduled order. Only Operations advance codegen;
 	// Phis are otherwise pure stack assertions (already materialized on the block's stackIn).
@@ -235,24 +234,23 @@ void CodeTransform::operator()(SSACFG::BlockId const _blockId)
 			spillStore(instId);
 		if (inst.isOperation())
 		{
-			yulAssert(operationIndex < blockLayout->operationIn.size());
-			(*this)(instId, blockLayout->operationIn[operationIndex], blockLayout->operationShuffles[operationIndex]);
+			yulAssert(operationIndex < blockLayout->operationShuffles.size());
+			(*this)(instId, blockLayout->operationShuffles[operationIndex]);
 			++operationIndex;
 		}
 	}
-	yulAssert(operationIndex == blockLayout->operationIn.size());
+	yulAssert(operationIndex == blockLayout->operationShuffles.size());
 
-	// Play back the recorded shuffle to the block's exit layout before dispatching the exit.
+	// Play back the recorded shuffle to the block's exit state before dispatching the exit.
 	// This ensures the condition is on top for ConditionalJump, phi pre-images are
 	// in the right positions for jumps, and return values are accessible for FunctionReturn.
 	playback(blockLayout->exitShuffle);
-	assertLayoutCompatibility(m_stack.data(), blockLayout->exitIn);
 
 	// handle the block exit
 	std::visit(solidity::util::GenericVisitor{ [this, &_blockId](auto const& exit) { (*this)(_blockId, exit); } }, block.exit);
 }
 
-void CodeTransform::operator()(InstId _instId, StackData const& _operationInputLayout, ShuffleTrace const& _operationShuffle)
+void CodeTransform::operator()(InstId _instId, ShuffleTrace const& _operationShuffle)
 {
 	SSACFG::Inst const& _inst = m_cfg.inst(_instId);
 	yulAssert(_inst.isOperation());
@@ -274,9 +272,6 @@ void CodeTransform::operator()(InstId _instId, StackData const& _operationInputL
 
 	// check that the assembly stack height corresponds to the stack size after shuffling
 	yulAssert(static_cast<int>(m_stack.size()) == m_assembly.stackHeight());
-
-	// check that the stack is compatible with the operation input layout
-	assertLayoutCompatibility(m_stack.data(), _operationInputLayout);
 
 	// Assert that we have the inputs of the operation on stack top.
 	yulAssert(m_stack.size() >= _inst.inputs.size());

--- a/libyul/backends/evm/ssa/CodeTransform.h
+++ b/libyul/backends/evm/ssa/CodeTransform.h
@@ -66,7 +66,7 @@ private:
 	);
 
 	void operator()(SSACFG::BlockId _blockId);
-	void operator()(InstId _instId, StackData const& _operationInputLayout, ShuffleTrace const& _operationShuffle);
+	void operator()(InstId _instId, ShuffleTrace const& _operationShuffle);
 	void operator()(SSACFG::BlockId const& _currentBlock, SSACFG::BasicBlock::MainExit const& _mainExit);
 	void operator()(SSACFG::BlockId const& _currentBlock, SSACFG::BasicBlock::ConditionalJump const& _conditionalJump);
 	void operator()(SSACFG::BlockId const& _currentBlock, SSACFG::BasicBlock::Jump const& _jump);

--- a/libyul/backends/evm/ssa/CodeTransform.h
+++ b/libyul/backends/evm/ssa/CodeTransform.h
@@ -97,10 +97,8 @@ private:
 	std::vector<std::uint8_t> m_blockIsTransformed;
 	std::vector<AbstractAssembly::LabelID> m_blockLabels;
 	std::optional<spill::Emitter> m_spillEmitter{std::nullopt};
-	/// Recording buffer for the current shuffle; cleared before every shuffle.
-	ShuffleTrace m_shuffleTrace;
 	StackData m_stackData;
-	Stack<TraceRecordingCallbacks> m_stack;
+	Stack m_stack;
 	std::map<InstId, AbstractAssembly::LabelID> m_returnLabels;
 };
 

--- a/libyul/backends/evm/ssa/CodeTransform.h
+++ b/libyul/backends/evm/ssa/CodeTransform.h
@@ -20,7 +20,6 @@
 
 #include <libyul/backends/evm/ssa/spill/Emitter.h>
 
-#include <libyul/backends/evm/ssa/PhiInverse.h>
 #include <libyul/backends/evm/ssa/ShuffleTrace.h>
 #include <libyul/backends/evm/ssa/Stack.h>
 #include <libyul/backends/evm/ssa/StackLayout.h>
@@ -66,17 +65,17 @@ private:
 	);
 
 	void operator()(SSACFG::BlockId _blockId);
-	void operator()(InstId _instId, StackData const& _operationInputLayout);
+	void operator()(InstId _instId, StackData const& _operationInputLayout, ShuffleTrace const& _operationShuffle);
 	void operator()(SSACFG::BlockId const& _currentBlock, SSACFG::BasicBlock::MainExit const& _mainExit);
 	void operator()(SSACFG::BlockId const& _currentBlock, SSACFG::BasicBlock::ConditionalJump const& _conditionalJump);
 	void operator()(SSACFG::BlockId const& _currentBlock, SSACFG::BasicBlock::Jump const& _jump);
 	void operator()(SSACFG::BlockId const& _currentBlock, SSACFG::BasicBlock::FunctionReturn const& _functionReturn);
 	void operator()(SSACFG::BlockId const& _currentBlock, SSACFG::BasicBlock::Terminated const& _terminated);
 
-	void prepareBlockExitStack(StackData const& _target, PhiInverse const& _phiInverse);
+	void prepareBlockExitStack(SSACFG::BlockId const& _currentBlock, SSACFG::BlockId const& _target);
 
-	/// Shuffles the current stack toward `_target` and emits the recorded trace as assembly.
-	void shuffleAndEmit(StackData const& _target, spill::SpillSet const& _spillSet);
+	/// Plays back a recorded shuffle trace: applies each operation to the symbolic stack and emits its assembly.
+	void playback(ShuffleTrace const& _trace);
 	/// Appends the assembly realizing a single recorded shuffle operation. Does not touch the symbolic stack.
 	void emit(ShuffleOp const& _op);
 	void emit(ShuffleTrace const& _trace);

--- a/libyul/backends/evm/ssa/CodeTransform.h
+++ b/libyul/backends/evm/ssa/CodeTransform.h
@@ -21,12 +21,11 @@
 #include <libyul/backends/evm/ssa/spill/Emitter.h>
 
 #include <libyul/backends/evm/ssa/PhiInverse.h>
+#include <libyul/backends/evm/ssa/ShuffleTrace.h>
 #include <libyul/backends/evm/ssa/Stack.h>
 #include <libyul/backends/evm/ssa/StackLayout.h>
 
 #include <libyul/backends/evm/AbstractAssembly.h>
-
-#include <libevmasm/Instruction.h>
 
 namespace solidity::yul
 {
@@ -34,72 +33,6 @@ struct BuiltinContext;
 }
 namespace solidity::yul::ssa
 {
-
-struct AssemblyCallbacks
-{
-	void swap(StackDepth const _depth)
-	{
-		assembly->appendInstruction(evmasm::swapInstruction(static_cast<unsigned>(_depth.value)));
-	}
-
-	void pop()
-	{
-		assembly->appendInstruction(evmasm::Instruction::POP);
-	}
-
-	void push(StackSlot const& _slot)
-	{
-		switch (_slot.kind())
-		{
-		case StackSlot::Kind::Value:
-		{
-			auto const id = _slot.value();
-			if (cfg->isLiteral(id))
-			{
-				assembly->appendConstant(cfg->literalPayload(id));
-				return;
-			}
-			if (spillEmitter && spillEmitter->hasAddress(id))
-			{
-				spillEmitter->emitLoad(id);
-				return;
-			}
-			yulAssert(false, fmt::format("Tried bringing up non-spilled non-const {}", id));
-		}
-		case StackSlot::Kind::Junk:
-		{
-			if (assembly->evmVersion().hasPush0())
-				assembly->appendConstant(0);
-			else
-				assembly->appendInstruction(evmasm::Instruction::CODESIZE);
-			return;
-		}
-		case StackSlot::Kind::FunctionCallReturnLabel:
-		{
-			auto const instId = callSites->instId(_slot.functionCallReturnLabel());
-			yulAssert(returnLabels->count(instId), "FunctionCallReturnLabel not pre-registered before shuffle.");
-			assembly->appendLabelReference(returnLabels->at(instId));
-			return;
-		}
-		case StackSlot::Kind::FunctionReturnLabel:
-		{
-			yulAssert(false, "Cannot produce function return label.");
-		}
-		}
-	}
-
-	void dup(StackDepth const _depth)
-	{
-		assembly->appendInstruction(evmasm::dupInstruction(static_cast<unsigned>(_depth.value)));
-	}
-
-	SSACFG const* cfg{};
-	AbstractAssembly* assembly{};
-	CallSites const* callSites{};
-	std::map<InstId, AbstractAssembly::LabelID> const* returnLabels{};
-	spill::Emitter const* spillEmitter{};
-};
-static_assert(StackManipulationCallbackConcept<AssemblyCallbacks>);
 
 class CodeTransform
 {
@@ -142,6 +75,12 @@ private:
 
 	void prepareBlockExitStack(StackData const& _target, PhiInverse const& _phiInverse);
 
+	/// Shuffles the current stack toward `_target` and emits the recorded trace as assembly.
+	void shuffleAndEmit(StackData const& _target, spill::SpillSet const& _spillSet);
+	/// Appends the assembly realizing a single recorded shuffle operation. Does not touch the symbolic stack.
+	void emit(ShuffleOp const& _op);
+	void emit(ShuffleTrace const& _trace);
+
 	/// If `_value` is spilled, shuffles it to the stack top and stores it into its memory slot
 	void spillStore(InstId _value);
 
@@ -158,9 +97,10 @@ private:
 	std::vector<std::uint8_t> m_blockIsTransformed;
 	std::vector<AbstractAssembly::LabelID> m_blockLabels;
 	std::optional<spill::Emitter> m_spillEmitter{std::nullopt};
-	AssemblyCallbacks m_assemblyCallbacks;
+	/// Recording buffer for the current shuffle; cleared before every shuffle.
+	ShuffleTrace m_shuffleTrace;
 	StackData m_stackData;
-	Stack<AssemblyCallbacks> m_stack;
+	Stack<TraceRecordingCallbacks> m_stack;
 	std::map<InstId, AbstractAssembly::LabelID> m_returnLabels;
 };
 

--- a/libyul/backends/evm/ssa/CodeTransform.h
+++ b/libyul/backends/evm/ssa/CodeTransform.h
@@ -79,7 +79,6 @@ private:
 	void playback(ShuffleTrace const& _trace);
 	/// Appends the assembly realizing a single recorded shuffle operation. Does not touch the symbolic stack.
 	void emit(ShuffleOp const& _op);
-	void emit(ShuffleTrace const& _trace);
 
 	/// If `_value` is spilled, plays back its recorded def-site trace, which brings it to the stack top and
 	/// stores it into its memory slot

--- a/libyul/backends/evm/ssa/CodeTransform.h
+++ b/libyul/backends/evm/ssa/CodeTransform.h
@@ -60,6 +60,7 @@ private:
 		SSACFG const& _cfg,
 		SSACFGStackLayout const& _stackLayout,
 		spill::SpillSet const& _spillSet,
+		spill::SpillStoreTraces const& _spillStoreTraces,
 		ControlFlowGraphs::FunctionGraphID _graphID,
 		spill::MemoryAddressing const& _addressing
 	);
@@ -80,7 +81,8 @@ private:
 	void emit(ShuffleOp const& _op);
 	void emit(ShuffleTrace const& _trace);
 
-	/// If `_value` is spilled, shuffles it to the stack top and stores it into its memory slot
+	/// If `_value` is spilled, plays back its recorded def-site trace, which brings it to the stack top and
+	/// stores it into its memory slot
 	void spillStore(InstId _value);
 
 	AbstractAssembly& m_assembly;
@@ -91,6 +93,7 @@ private:
 	SSACFG const& m_cfg;
 	SSACFGStackLayout const& m_stackLayout;
 	spill::SpillSet const& m_spillSet;
+	spill::SpillStoreTraces const& m_spillStoreTraces;
 	ControlFlowGraphs::FunctionGraphID const m_graphID;
 
 	std::vector<std::uint8_t> m_blockIsTransformed;

--- a/libyul/backends/evm/ssa/ShuffleTrace.cpp
+++ b/libyul/backends/evm/ssa/ShuffleTrace.cpp
@@ -18,12 +18,14 @@
 
 #include <libyul/backends/evm/ssa/ShuffleTrace.h>
 
+#include <libyul/backends/evm/ssa/Stack.h>
+
 namespace solidity::yul::ssa
 {
 
 void apply(StackData& _data, ShuffleOp const& _op)
 {
-	Stack<> stack(_data, {});
+	Stack stack(_data);
 	switch (_op.kind)
 	{
 	case ShuffleOp::Kind::Swap:

--- a/libyul/backends/evm/ssa/ShuffleTrace.cpp
+++ b/libyul/backends/evm/ssa/ShuffleTrace.cpp
@@ -1,0 +1,56 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#include <libyul/backends/evm/ssa/ShuffleTrace.h>
+
+namespace solidity::yul::ssa
+{
+
+void apply(StackData& _data, ShuffleOp const& _op)
+{
+	Stack<> stack(_data, {});
+	switch (_op.kind)
+	{
+	case ShuffleOp::Kind::Swap:
+		stack.swap(StackDepth{_op.depth});
+		return;
+	case ShuffleOp::Kind::Dup:
+		stack.dup(StackDepth{static_cast<std::size_t>(_op.depth) - 1});
+		return;
+	case ShuffleOp::Kind::Pop:
+		stack.pop();
+		return;
+	case ShuffleOp::Kind::Push:
+	case ShuffleOp::Kind::Load:
+		stack.push(_op.slot);
+		return;
+	case ShuffleOp::Kind::Store:
+		yulAssert(!_data.empty() && _data.back() == _op.slot, "store must consume its value from the stack top");
+		stack.pop();
+		return;
+	}
+	solidity::util::unreachable();
+}
+
+void replay(StackData& _data, ShuffleTrace const& _trace)
+{
+	for (ShuffleOp const& op: _trace)
+		apply(_data, op);
+}
+
+}

--- a/libyul/backends/evm/ssa/ShuffleTrace.cpp
+++ b/libyul/backends/evm/ssa/ShuffleTrace.cpp
@@ -29,9 +29,11 @@ void apply(StackData& _data, ShuffleOp const& _op)
 	switch (_op.kind)
 	{
 	case ShuffleOp::Kind::Swap:
+		yulAssert(1 <= _op.depth && _op.depth <= reachableStackDepth, "malformed swap in shuffle trace");
 		stack.swap(StackDepth{_op.depth});
 		return;
 	case ShuffleOp::Kind::Dup:
+		yulAssert(1 <= _op.depth && _op.depth <= reachableStackDepth, "malformed dup in shuffle trace");
 		stack.dup(StackDepth{static_cast<std::size_t>(_op.depth) - 1});
 		return;
 	case ShuffleOp::Kind::Pop:

--- a/libyul/backends/evm/ssa/ShuffleTrace.h
+++ b/libyul/backends/evm/ssa/ShuffleTrace.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <libyul/backends/evm/ssa/Stack.h>
+#include <libyul/backends/evm/ssa/StackSlot.h>
 
 #include <fmt/format.h>
 
@@ -64,7 +64,7 @@ struct ShuffleOp
 	static ShuffleOp pop() { return {Kind::Pop, 0, StackSlot::makeJunk()}; }
 	static ShuffleOp push(StackSlot const& _slot)
 	{
-		yulAssert(Stack<>::canBeFreelyGenerated(_slot), "only freely generatable slots can be pushed");
+		yulAssert(canBeFreelyGenerated(_slot), "only freely generatable slots can be pushed");
 		return {Kind::Push, 0, _slot};
 	}
 	static ShuffleOp load(StackSlot const& _slot)
@@ -88,26 +88,6 @@ using ShuffleTrace = std::vector<ShuffleOp>;
 void apply(StackData& _data, ShuffleOp const& _op);
 /// Replays a whole trace on `_data`.
 void replay(StackData& _data, ShuffleTrace const& _trace);
-
-/// Stack manipulation callbacks appending every operation to a `ShuffleTrace`.
-/// A pushed non-literal value slot is recorded as a `Load`: the shuffler only pushes slots that are freely
-/// generatable or spilled, so the slot kind alone discriminates a `Push` from a spill reload.
-struct TraceRecordingCallbacks
-{
-	void swap(StackDepth const _depth) const { trace->push_back(ShuffleOp::swap(_depth)); }
-	void dup(StackDepth const _depth) const { trace->push_back(ShuffleOp::dup(_depth)); }
-	void push(StackSlot const& _slot) const
-	{
-		if (_slot.isValue() && !_slot.isLiteralValue())
-			trace->push_back(ShuffleOp::load(_slot));
-		else
-			trace->push_back(ShuffleOp::push(_slot));
-	}
-	void pop() const { trace->push_back(ShuffleOp::pop()); }
-
-	ShuffleTrace* trace{};
-};
-static_assert(StackManipulationCallbackConcept<TraceRecordingCallbacks>);
 
 }
 

--- a/libyul/backends/evm/ssa/ShuffleTrace.h
+++ b/libyul/backends/evm/ssa/ShuffleTrace.h
@@ -1,0 +1,140 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libyul/backends/evm/ssa/Stack.h>
+
+#include <fmt/format.h>
+
+#include <cstdint>
+#include <type_traits>
+#include <vector>
+
+namespace solidity::yul::ssa
+{
+
+/// A single recorded stack manipulation.
+struct ShuffleOp
+{
+	/// Upper bound for the SWAPn / DUPn instruction operand; matches the reachable stack depth of `Stack`.
+	static std::size_t constexpr maxOperandDepth = 16;
+
+	enum class Kind: std::uint8_t
+	{
+		Swap,  ///< swap the top slot with the slot at depth `depth` (SWAP)
+		Dup,   ///< duplicate the slot at depth `depth - 1` onto the top (DUP)
+		Pop,   ///< remove the top slot (POP)
+		Push,  ///< produce the freely generatable `slot` (literal, junk or function call return label) on the top
+		Load,  ///< reload the spilled value `slot` from its memory slot onto the top
+		Store  ///< store the spilled value `slot` into its memory slot, consuming it from the top
+	};
+
+	Kind kind = Kind::Pop;
+	/// EVM instruction operand # of SWAP# / DUP#
+	std::uint8_t depth = 0;
+	/// Slot produced by Push / Load or consumed by Store. Junk for all other kinds.
+	StackSlot slot = StackSlot::makeJunk();
+
+	static ShuffleOp swap(StackDepth const _depth)
+	{
+		yulAssert(1 <= _depth.value && _depth.value <= maxOperandDepth);
+		return {Kind::Swap, static_cast<std::uint8_t>(_depth.value), StackSlot::makeJunk()};
+	}
+	static ShuffleOp dup(StackDepth const _depth)
+	{
+		yulAssert(1 <= _depth.value && _depth.value <= maxOperandDepth);
+		return {Kind::Dup, static_cast<std::uint8_t>(_depth.value), StackSlot::makeJunk()};
+	}
+	static ShuffleOp pop() { return {Kind::Pop, 0, StackSlot::makeJunk()}; }
+	static ShuffleOp push(StackSlot const& _slot)
+	{
+		yulAssert(Stack<>::canBeFreelyGenerated(_slot), "only freely generatable slots can be pushed");
+		return {Kind::Push, 0, _slot};
+	}
+	static ShuffleOp load(StackSlot const& _slot)
+	{
+		yulAssert(_slot.isValue() && !_slot.isLiteralValue(), "only spilled (non-literal) values can be loaded");
+		return {Kind::Load, 0, _slot};
+	}
+	static ShuffleOp store(StackSlot const& _slot)
+	{
+		yulAssert(_slot.isValue() && !_slot.isLiteralValue(), "only spilled (non-literal) values can be stored");
+		return {Kind::Store, 0, _slot};
+	}
+
+	bool operator==(ShuffleOp const&) const = default;
+};
+static_assert(std::is_trivially_copyable_v<ShuffleOp>, "Traces should be cheap to copy");
+
+using ShuffleTrace = std::vector<ShuffleOp>;
+
+/// Applies a single recorded operation to `_data`, reproducing the stack mutation that was recorded.
+void apply(StackData& _data, ShuffleOp const& _op);
+/// Replays a whole trace on `_data`.
+void replay(StackData& _data, ShuffleTrace const& _trace);
+
+/// Stack manipulation callbacks appending every operation to a `ShuffleTrace`.
+/// A pushed non-literal value slot is recorded as a `Load`: the shuffler only pushes slots that are freely
+/// generatable or spilled, so the slot kind alone discriminates a `Push` from a spill reload.
+struct TraceRecordingCallbacks
+{
+	void swap(StackDepth const _depth) const { trace->push_back(ShuffleOp::swap(_depth)); }
+	void dup(StackDepth const _depth) const { trace->push_back(ShuffleOp::dup(_depth)); }
+	void push(StackSlot const& _slot) const
+	{
+		if (_slot.isValue() && !_slot.isLiteralValue())
+			trace->push_back(ShuffleOp::load(_slot));
+		else
+			trace->push_back(ShuffleOp::push(_slot));
+	}
+	void pop() const { trace->push_back(ShuffleOp::pop()); }
+
+	ShuffleTrace* trace{};
+};
+static_assert(StackManipulationCallbackConcept<TraceRecordingCallbacks>);
+
+}
+
+template<>
+struct fmt::formatter<solidity::yul::ssa::ShuffleOp>
+{
+	static auto constexpr parse(format_parse_context& ctx) -> decltype(ctx.begin()) { return ctx.begin(); }
+
+	template<typename FormatContext>
+	auto format(solidity::yul::ssa::ShuffleOp const& _op, FormatContext& _ctx) const -> decltype(_ctx.out())
+	{
+		using ShuffleOp = solidity::yul::ssa::ShuffleOp;
+		switch (_op.kind)
+		{
+		case ShuffleOp::Kind::Swap:
+			return fmt::format_to(_ctx.out(), "SWAP{}", _op.depth);
+		case ShuffleOp::Kind::Dup:
+			return fmt::format_to(_ctx.out(), "DUP{}", _op.depth);
+		case ShuffleOp::Kind::Pop:
+			return fmt::format_to(_ctx.out(), "POP");
+		case ShuffleOp::Kind::Push:
+			return fmt::format_to(_ctx.out(), "PUSH {}", solidity::yul::ssa::slotToString(_op.slot));
+		case ShuffleOp::Kind::Load:
+			return fmt::format_to(_ctx.out(), "LOAD {}", solidity::yul::ssa::slotToString(_op.slot));
+		case ShuffleOp::Kind::Store:
+			return fmt::format_to(_ctx.out(), "STORE {}", solidity::yul::ssa::slotToString(_op.slot));
+		}
+		solidity::util::unreachable();
+	}
+};

--- a/libyul/backends/evm/ssa/ShuffleTrace.h
+++ b/libyul/backends/evm/ssa/ShuffleTrace.h
@@ -32,9 +32,6 @@ namespace solidity::yul::ssa
 /// A single recorded stack manipulation.
 struct ShuffleOp
 {
-	/// Upper bound for the SWAPn / DUPn instruction operand; matches the reachable stack depth of `Stack`.
-	static std::size_t constexpr maxOperandDepth = 16;
-
 	enum class Kind: std::uint8_t
 	{
 		Swap,  ///< swap the top slot with the slot at depth `depth` (SWAP)
@@ -53,12 +50,12 @@ struct ShuffleOp
 
 	static ShuffleOp swap(StackDepth const _depth)
 	{
-		yulAssert(1 <= _depth.value && _depth.value <= maxOperandDepth);
+		yulAssert(1 <= _depth.value && _depth.value <= reachableStackDepth);
 		return {Kind::Swap, static_cast<std::uint8_t>(_depth.value), StackSlot::makeJunk()};
 	}
 	static ShuffleOp dup(StackDepth const _depth)
 	{
-		yulAssert(1 <= _depth.value && _depth.value <= maxOperandDepth);
+		yulAssert(1 <= _depth.value && _depth.value <= reachableStackDepth);
 		return {Kind::Dup, static_cast<std::uint8_t>(_depth.value), StackSlot::makeJunk()};
 	}
 	static ShuffleOp pop() { return {Kind::Pop, 0, StackSlot::makeJunk()}; }

--- a/libyul/backends/evm/ssa/Stack.h
+++ b/libyul/backends/evm/ssa/Stack.h
@@ -18,195 +18,31 @@
 
 #pragma once
 
-#include <libyul/backends/evm/ssa/ControlFlowGraphs.h>
-#include <libyul/backends/evm/ssa/SSACFG.h>
+#include <libyul/backends/evm/ssa/ShuffleTrace.h>
+#include <libyul/backends/evm/ssa/StackSlot.h>
 
 #include <range/v3/algorithm/find.hpp>
 #include <range/v3/view/reverse.hpp>
 
-#include <cstdint>
-#include <type_traits>
+#include <cstddef>
 
 namespace solidity::yul::ssa
 {
 
-/// Registry for tracking function call sites.
-///
-/// Maps user-function-call operations to unique numeric IDs. These IDs are used
-/// to generate return labels for function calls in the EVM bytecode.
-class CallSites
-{
-public:
-	using CallSiteID = std::uint32_t;
-
-	std::optional<CallSiteID> callSiteID(InstId _instId) const
-	{
-		if (auto const it = ranges::find(m_data, _instId); it != m_data.end())
-			return static_cast<CallSiteID>(std::distance(m_data.begin(), it));
-		return std::nullopt;
-	}
-
-	InstId instId(CallSiteID _callSite) const
-	{
-		yulAssert(_callSite < m_data.size());
-		return m_data[_callSite];
-	}
-
-	CallSiteID addCallSite(InstId _instId)
-	{
-		if (auto const id = callSiteID(_instId))
-			return *id;
-		yulAssert(_instId.hasValue());
-		m_data.emplace_back(_instId);
-		return static_cast<CallSiteID>(m_data.size() - 1);
-	}
-private:
-	std::vector<InstId> m_data;
-};
-
-/// A discriminated union corresponding to a single EVM stack slot.
-/// Can represent:
-///		- ValueID: SSA values (including literals)
-///		- Junk: Placeholder/unused values
-///     - FunctionCallReturnLabel: Return addresses for function calls
-///     - FunctionReturnLabel: Identifies the calling function's graph
-///
-/// Memory layout is optimized: 8 bytes size for cache efficiency, trivially copyable, standard layout, trivial
-class StackSlot
-{
-public:
-	enum struct Kind: std::uint8_t
-	{
-		Value, // u32 InstId
-		Junk, // empty
-		FunctionCallReturnLabel, // index into corresponding stack layout's call sites
-		FunctionReturnLabel // identifying the function graph via ControlFlowGraphs
-	};
-
-	constexpr StackSlot() = default;
-	constexpr StackSlot(StackSlot const&) = default;
-	constexpr StackSlot(StackSlot&&) = default;
-	constexpr StackSlot& operator=(StackSlot const&) = default;
-	constexpr StackSlot& operator=(StackSlot&&) = default;
-
-	constexpr bool isValue() const noexcept { return kind() == Kind::Value; }
-	constexpr bool isLiteralValue() const noexcept { return m_valueOpcode == InstOpcode::Const; }
-	constexpr bool isPhiValue() const noexcept { return m_valueOpcode == InstOpcode::Phi; }
-	constexpr bool isFunctionReturnLabel() const noexcept { return kind() == Kind::FunctionReturnLabel; }
-	constexpr bool isFunctionCallReturnLabel() const noexcept { return kind() == Kind::FunctionCallReturnLabel; }
-	constexpr bool isJunk() const noexcept { return kind() == Kind::Junk; }
-	constexpr Kind kind() const noexcept { return m_kind; }
-
-	ControlFlowGraphs::FunctionGraphID functionReturnLabel() const { yulAssert(isFunctionReturnLabel()); return m_payload; }
-	CallSites::CallSiteID functionCallReturnLabel() const { yulAssert(isFunctionCallReturnLabel()); return m_payload; }
-	InstId value() const
-	{
-		yulAssert(isValue());
-		return InstId{m_payload};
-	}
-
-	static constexpr StackSlot makeJunk() { return {0, Kind::Junk}; }
-	static StackSlot makeValue(SSACFG const& _cfg, InstId _value)
-	{
-		return {_value.value, Kind::Value, _cfg.kindOf(_value)};
-	}
-	static StackSlot makeValue(InstructionStore const& _store, InstId _value)
-	{
-		return {_value.value, Kind::Value, _store.kindOf(_value)};
-	}
-	static constexpr StackSlot makeFunctionReturnLabel(ControlFlowGraphs::FunctionGraphID const _graphID) { return {_graphID, Kind::FunctionReturnLabel}; }
-	static constexpr StackSlot makeFunctionCallReturnLabel(CallSites::CallSiteID const _callSiteID) { return {_callSiteID, Kind::FunctionCallReturnLabel};	}
-
-	auto operator<=>(StackSlot const&) const = default;
-private:
-	constexpr StackSlot(std::uint32_t const _payload, Kind const _kind, InstOpcode const _valueOpcode = InstOpcode::Unreachable):
-		m_payload(_payload),
-		m_kind(_kind),
-		m_valueOpcode(_valueOpcode)
-	{}
-
-	/// interpretation depends on kind
-	std::uint32_t m_payload;
-	Kind m_kind;
-	/// for Kind::Value: cached Opcode of the defining Inst
-	InstOpcode m_valueOpcode;
-};
-static_assert(sizeof(StackSlot) == 8, "Want cache efficiency, benchmark this if you go beyond 8 bytes");
-static_assert(std::is_trivially_copyable_v<StackSlot>, "Should be able to use memcpy semantics");
-static_assert(std::is_standard_layout_v<StackSlot>, "Want to have a predictable layout");
-static_assert(std::is_trivial_v<StackSlot>, "Want to have no init/cpy overhead");
-
-using StackData = std::vector<StackSlot>;
-std::string slotToString(StackSlot const& _slot);
-std::string stackToString(StackData const& _stackData);
-
-/// Array index into stack from the bottom (offset 0 = bottom).
-/// Natural for array-like access and iteration; used when treating the stack as a data structure.
-struct StackOffset
-{
-	explicit constexpr StackOffset(size_t _value) : value(_value) {}
-	size_t value;
-	auto operator<=>(StackOffset const&) const = default;
-};
-// comparison operations with size_t
-constexpr auto operator<=>(StackOffset const lhs, size_t const rhs) noexcept { return lhs.value <=> rhs; }
-constexpr auto operator<=>(size_t const lhs, StackOffset const rhs) noexcept { return lhs <=> rhs.value; }
-
-/// Distance from the stack top (depth 0 = top).
-/// Natural for stack operations (SWAP1 = swap with depth 1); used for operations that
-/// conceptually work "from the top".
-struct StackDepth
-{
-	explicit constexpr StackDepth(size_t _value) : value(_value) {}
-	size_t value;
-	auto operator<=>(StackDepth const&) const = default;
-};
-// comparison operations with size_t
-constexpr auto operator<=>(StackDepth const lhs, size_t const rhs) noexcept { return lhs.value <=> rhs; }
-constexpr auto operator<=>(size_t const lhs, StackDepth const rhs) noexcept { return lhs <=> rhs.value; }
-
-template<typename StackManipulationCallback>
-concept StackManipulationCallbackConcept = requires(
-	StackManipulationCallback& _callback,
-	StackSlot _slot,
-	StackDepth _depth
-)
-{
-	{ _callback.swap(_depth) } -> std::same_as<void>;
-	{ _callback.dup(_depth) } -> std::same_as<void>;
-	{ _callback.push(_slot) } -> std::same_as<void>;
-	{ _callback.pop() } -> std::same_as<void>;
-};
-
-struct NoOpStackManipulationCallbacks
-{
-	static void swap(StackDepth) {}
-	static void dup(StackDepth) {}
-	static void push(StackSlot const&) {}
-	static void pop() {}
-};
-static_assert(StackManipulationCallbackConcept<NoOpStackManipulationCallbacks>);
-
-template<
-	StackManipulationCallbackConcept CallbacksType = NoOpStackManipulationCallbacks
->
+/// A view over a `StackData` mimicking EVM stack semantics. When constructed with a trace, every stack
+/// manipulation is recorded as a `ShuffleOp`; an untraced view mutates the data silently.
 class Stack
 {
 	static size_t constexpr reachableStackDepth = 16;
 public:
-	using Callbacks = CallbacksType;
-
 	using Slot = StackSlot;
 	using Data = StackData;
 	using Depth = StackDepth;
 	using Offset = StackOffset;
 
-	Stack(
-		Data& _data,
-		Callbacks _callbacks
-	):
+	explicit Stack(Data& _data, ShuffleTrace* _trace = nullptr):
 		m_data(&_data),
-		m_callbacks(std::move(_callbacks))
+		m_trace(_trace)
 	{}
 
 	Slot const& top() const
@@ -220,28 +56,27 @@ public:
 	{
 		yulAssert(isValidSwapTarget(_offset), "Stack too deep");
 		std::swap((*m_data)[_offset.value], m_data->back());
-		if constexpr (!std::is_same_v<Callbacks, NoOpStackManipulationCallbacks>)
-			m_callbacks.swap(offsetToDepth(_offset));
+		if (m_trace)
+			m_trace->push_back(ShuffleOp::swap(offsetToDepth(_offset)));
 	}
 
-	/// if the stack state needs to be updated without notifying the callback, the template parameter can be set to false
-	template<bool callback=true>
 	void pop()
 	{
 		yulAssert(!m_data->empty());
 		m_data->pop_back();
-		if constexpr (callback && !std::is_same_v<Callbacks, NoOpStackManipulationCallbacks>)
-			m_callbacks.pop();
+		if (m_trace)
+			m_trace->push_back(ShuffleOp::pop());
 	}
 
-	/// if the stack state needs to be updated without notifying the callback, the template parameter can be set to false
-	template<bool callback=true>
 	void push(Slot const& _slot)
 	{
 		yulAssert(!_slot.isFunctionReturnLabel(), "Cannot push function return label");
 		m_data->emplace_back(_slot);
-		if constexpr (callback && !std::is_same_v<Callbacks, NoOpStackManipulationCallbacks>)
-			m_callbacks.push(_slot);
+		if (m_trace)
+			m_trace->push_back(
+				// a pushed non-literal value can only be a spill reload
+				_slot.isValue() && !_slot.isLiteralValue() ? ShuffleOp::load(_slot) : ShuffleOp::push(_slot)
+			);
 	}
 
 	void dup(Depth const& _depth) { dup(depthToOffset(_depth)); }
@@ -252,8 +87,8 @@ public:
 		auto const slot = (*m_data)[_offset.value];
 		yulAssert(!slot.isFunctionReturnLabel(), "Cannot dup function return label");
 		m_data->push_back(slot);
-		if constexpr (!std::is_same_v<Callbacks, NoOpStackManipulationCallbacks>)
-			m_callbacks.dup(StackDepth{depth.value + 1});
+		if (m_trace)
+			m_trace->push_back(ShuffleOp::dup(Depth{depth.value + 1}));
 	}
 
 	bool dupReachable(Offset const& _offset) const noexcept { return dupReachable(offsetToDepth(_offset)); }
@@ -284,19 +119,17 @@ public:
 
 	static bool constexpr canBeFreelyGenerated(Slot const& _slot)
 	{
-		return _slot.isLiteralValue() || _slot.isJunk() || _slot.isFunctionCallReturnLabel();
+		return ssa::canBeFreelyGenerated(_slot);
 	}
 
 	Slot const& operator[](Offset const& _index) const noexcept { return (*m_data)[_index.value]; }
-	auto begin() const { return ranges::begin(*m_data); }
-	auto end() const { return ranges::end(*m_data); }
+	Data::const_iterator begin() const { return m_data->begin(); }
+	Data::const_iterator end() const { return m_data->end(); }
 
 	Data const& data() const
 	{
 		return *m_data;
 	}
-
-	Callbacks const& callbacks() const { return m_callbacks; }
 
 	/// index scheme conversion offset -> depth
 	Depth offsetToDepth(Offset const& _offset) const
@@ -313,7 +146,7 @@ public:
 
 private:
 	Data* m_data;
-	Callbacks m_callbacks;
+	ShuffleTrace* m_trace;
 };
 
 }

--- a/libyul/backends/evm/ssa/Stack.h
+++ b/libyul/backends/evm/ssa/Stack.h
@@ -33,7 +33,6 @@ namespace solidity::yul::ssa
 /// manipulation is recorded as a `ShuffleOp`; an untraced view mutates the data silently.
 class Stack
 {
-	static size_t constexpr reachableStackDepth = 16;
 public:
 	using Slot = StackSlot;
 	using Data = StackData;
@@ -115,11 +114,6 @@ public:
 			return std::nullopt;
 
 		return Depth{static_cast<size_t>(std::distance(ranges::begin(rview), it))};
-	}
-
-	static bool constexpr canBeFreelyGenerated(Slot const& _slot)
-	{
-		return ssa::canBeFreelyGenerated(_slot);
 	}
 
 	Slot const& operator[](Offset const& _index) const noexcept { return (*m_data)[_index.value]; }

--- a/libyul/backends/evm/ssa/StackLayout.h
+++ b/libyul/backends/evm/ssa/StackLayout.h
@@ -30,17 +30,17 @@ struct BlockLayout
 {
 	// stack layout required to enter the block
 	StackData stackIn;
-	// stack layout required to execute the i-th operation in the block
-	std::vector<StackData> operationIn;
-	// stack layout required to handle the exit of the block
-	StackData exitIn;
 
-	// Recorded shuffle traces realizing the layouts above. Traces are positional, so they can be replayed on any
-	// stack that is layout-compatible with the one they were recorded on (junk slots acting as wildcards).
+	// Recorded shuffle traces realizing the block's stack states, anchored at `stackIn`. Traces are positional,
+	// so they can be replayed on any stack that is layout-compatible with the one they were recorded on (junk
+	// slots acting as wildcards). Intermediate layouts (operation inputs, the exit state) are reconstructed by
+	// replaying the traces and operation effects from `stackIn`.
 
-	/// Transforms the stack after the (i-1)-th operation (`stackIn` for i = 0) into `operationIn[i]`
+	/// Transforms the stack after the (i-1)-th operation (`stackIn` for i = 0) into the i-th operation's
+	/// input layout
 	std::vector<ShuffleTrace> operationShuffles;
-	/// Transforms the stack after the last operation into `exitIn`
+	/// Transforms the stack after the last operation into the block's exit state (for conditional jumps:
+	/// condition on top, pre-JUMPI)
 	ShuffleTrace exitShuffle;
 	/// Per predecessor edge: transforms the predecessor's post-exit stack (for conditional jumps: after
 	/// popping the condition) into the phi preimage of `stackIn` under that edge

--- a/libyul/backends/evm/ssa/StackLayout.h
+++ b/libyul/backends/evm/ssa/StackLayout.h
@@ -31,16 +31,10 @@ struct BlockLayout
 	// stack layout required to enter the block
 	StackData stackIn;
 
-	// Recorded shuffle traces realizing the block's stack states, anchored at `stackIn`. Traces are positional,
-	// so they can be replayed on any stack that is layout-compatible with the one they were recorded on (junk
-	// slots acting as wildcards). Intermediate layouts (operation inputs, the exit state) are reconstructed by
-	// replaying the traces and operation effects from `stackIn`.
-
 	/// Transforms the stack after the (i-1)-th operation (`stackIn` for i = 0) into the i-th operation's
 	/// input layout
 	std::vector<ShuffleTrace> operationShuffles;
-	/// Transforms the stack after the last operation into the block's exit state (for conditional jumps:
-	/// condition on top, pre-JUMPI)
+	/// Transforms the stack after the last operation into the block's exit state (for conditional jumps: condition on top, pre-JUMPI)
 	ShuffleTrace exitShuffle;
 	/// Per predecessor edge: transforms the predecessor's post-exit stack (for conditional jumps: after
 	/// popping the condition) into the phi preimage of `stackIn` under that edge
@@ -54,6 +48,21 @@ struct BlockLayout
 				return trace;
 		yulAssert(false, fmt::format("no recorded shuffle for predecessor edge from block {}", _predecessor));
 		solidity::util::unreachable();
+	}
+
+	/// Records the shuffle for the edge from `_predecessor` into this block
+	void addTraceForStackIn(SSACFG::BlockId const& _predecessor, ShuffleTrace&& _trace)
+	{
+		for (auto const& [parent, trace]: tracesForStackIn)
+			if (parent == _predecessor)
+			{
+				yulAssert(
+					trace == _trace,
+					fmt::format("conflicting shuffles recorded for the predecessor edge from block {}", _predecessor)
+				);
+				return;
+			}
+		tracesForStackIn.emplace_back(_predecessor, std::move(_trace));
 	}
 };
 

--- a/libyul/backends/evm/ssa/StackLayout.h
+++ b/libyul/backends/evm/ssa/StackLayout.h
@@ -44,7 +44,17 @@ struct BlockLayout
 	ShuffleTrace exitShuffle;
 	/// Per predecessor edge: transforms the predecessor's post-exit stack (for conditional jumps: after
 	/// popping the condition) into the phi preimage of `stackIn` under that edge
-	std::vector<std::pair<SSACFG::BlockId, ShuffleTrace>> stackInShuffles;
+	std::vector<std::pair<SSACFG::BlockId, ShuffleTrace>> tracesForStackIn;
+
+	/// The recorded shuffle for the edge from `_predecessor` into this block
+	ShuffleTrace const& traceForStackIn(SSACFG::BlockId const& _predecessor) const
+	{
+		for (auto const& [parent, trace]: tracesForStackIn)
+			if (parent == _predecessor)
+				return trace;
+		yulAssert(false, fmt::format("no recorded shuffle for predecessor edge from block {}", _predecessor));
+		solidity::util::unreachable();
+	}
 };
 
 /// For each (reachable) block in the SSACFG one block layout

--- a/libyul/backends/evm/ssa/StackLayout.h
+++ b/libyul/backends/evm/ssa/StackLayout.h
@@ -18,8 +18,9 @@
 
 #pragma once
 
-#include <libyul/backends/evm/ssa/Stack.h>
+#include <libyul/backends/evm/ssa/ShuffleTrace.h>
 
+#include <utility>
 #include <vector>
 
 namespace solidity::yul::ssa
@@ -33,6 +34,17 @@ struct BlockLayout
 	std::vector<StackData> operationIn;
 	// stack layout required to handle the exit of the block
 	StackData exitIn;
+
+	// Recorded shuffle traces realizing the layouts above. Traces are positional, so they can be replayed on any
+	// stack that is layout-compatible with the one they were recorded on (junk slots acting as wildcards).
+
+	/// Transforms the stack after the (i-1)-th operation (`stackIn` for i = 0) into `operationIn[i]`
+	std::vector<ShuffleTrace> operationShuffles;
+	/// Transforms the stack after the last operation into `exitIn`
+	ShuffleTrace exitShuffle;
+	/// Per predecessor edge: transforms the predecessor's post-exit stack (for conditional jumps: after
+	/// popping the condition) into the phi preimage of `stackIn` under that edge
+	std::vector<std::pair<SSACFG::BlockId, ShuffleTrace>> stackInShuffles;
 };
 
 /// For each (reachable) block in the SSACFG one block layout

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -173,7 +173,7 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 			for (auto const& arg: m_cfg.arguments | ranges::views::reverse)
 				blockLayout.stackIn.push_back(Slot::makeValue(m_cfg, arg));
 		}
-		m_resultLayout[_blockId] = blockLayout;
+		m_resultLayout[_blockId] = std::move(blockLayout);
 		return;
 	}
 
@@ -260,10 +260,10 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 			m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore,
 			"Stack too deep, but spilling is disabled because the function is part of a recursive call chain."
 		);
-		blockLayout.tracesForStackIn.emplace_back(parentBlockId, std::move(edgeShuffle));
+		blockLayout.addTraceForStackIn(parentBlockId, std::move(edgeShuffle));
 	}
 
-	m_resultLayout[_blockId] = blockLayout;
+	m_resultLayout[_blockId] = std::move(blockLayout);
 }
 
 void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
@@ -343,7 +343,7 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 			m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore,
 			"Stack too deep, but spilling is disabled because the function is part of a recursive call chain."
 		);
-		m_resultLayout[_target]->tracesForStackIn.emplace_back(_blockId, std::move(edgeShuffle));
+		m_resultLayout[_target]->addTraceForStackIn(_blockId, std::move(edgeShuffle));
 	};
 
 	std::visit(

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -258,7 +258,7 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 			m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore,
 			"Stack too deep, but spilling is disabled because the function is part of a recursive call chain."
 		);
-		blockLayout.stackInShuffles.emplace_back(parentBlockId, std::move(edgeShuffle));
+		blockLayout.tracesForStackIn.emplace_back(parentBlockId, std::move(edgeShuffle));
 	}
 
 	m_resultLayout[_blockId] = blockLayout;
@@ -342,7 +342,7 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 			m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore,
 			"Stack too deep, but spilling is disabled because the function is part of a recursive call chain."
 		);
-		m_resultLayout[_target]->stackInShuffles.emplace_back(_blockId, std::move(edgeShuffle));
+		m_resultLayout[_target]->tracesForStackIn.emplace_back(_blockId, std::move(edgeShuffle));
 	};
 
 	std::visit(

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -246,16 +246,19 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 	{
 		StackData edgeStack = parentExitStack;
 		auto const spillCountBefore = m_spillSet.numSpilled();
+		ShuffleTrace edgeShuffle;
 		auto const shuffleResult = shuffleWithSpillDiscovery(
 			edgeStack,
 			stackPreImage(m_cfg, blockLayout.stackIn, PhiInverse(m_cfg, parentBlockId, _blockId)),
-			m_spillSet
+			m_spillSet,
+			&edgeShuffle
 		);
 		yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 		yulAssert(
 			m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore,
 			"Stack too deep, but spilling is disabled because the function is part of a recursive call chain."
 		);
+		blockLayout.stackInShuffles.emplace_back(parentBlockId, std::move(edgeShuffle));
 	}
 
 	m_resultLayout[_blockId] = blockLayout;
@@ -294,6 +297,7 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 			ranges::views::reverse |
 			ranges::views::transform([this](InstId const& _id) { return StackSlot::makeValue(m_cfg, _id); });
 
+		ShuffleTrace operationShuffle;
 		{
 			// Values that are dead before the operation are left on the stack; the shuffle to the
 			// optimal target pops them as surplus as needed
@@ -309,12 +313,13 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 			);
 			auto const spillCountBefore = m_spillSet.numSpilled();
 			m_spillSet = std::move(plannedSpillSet);
-			auto const shuffleResult = shuffleWithSpillDiscovery(currentStackData, target, m_spillSet);
+			auto const shuffleResult = shuffleWithSpillDiscovery(currentStackData, target, m_spillSet, &operationShuffle);
 			yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 			yulAssert(m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore, "Spilling not allowed, stack too deep.");
 		}
 
 		blockLayout.operationIn.push_back(currentStackData);
+		blockLayout.operationShuffles.push_back(std::move(operationShuffle));
 		for (std::size_t i = 0; i < requiredStackTop.size(); ++i)
 			stack.pop();
 		m_cfg.forEachOutput(_instId, [&](InstId const id) {
@@ -330,12 +335,14 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 		StackData const target = stackPreImage(m_cfg, m_resultLayout[_target]->stackIn, PhiInverse(m_cfg, _blockId, _target));
 		auto const spillCountBefore = m_spillSet.numSpilled();
 		StackData exitStack = currentStackData;
-		auto const shuffleResult = shuffleWithSpillDiscovery(exitStack, target, m_spillSet);
+		ShuffleTrace edgeShuffle;
+		auto const shuffleResult = shuffleWithSpillDiscovery(exitStack, target, m_spillSet, &edgeShuffle);
 		yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 		yulAssert(
 			m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore,
 			"Stack too deep, but spilling is disabled because the function is part of a recursive call chain."
 		);
+		m_resultLayout[_target]->stackInShuffles.emplace_back(_blockId, std::move(edgeShuffle));
 	};
 
 	std::visit(
@@ -363,7 +370,7 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 					);
 					auto const spillCountBefore = m_spillSet.numSpilled();
 					m_spillSet = std::move(plannedSpillSet);
-					auto const shuffleResult = shuffleWithSpillDiscovery(currentStackData, target, m_spillSet);
+					auto const shuffleResult = shuffleWithSpillDiscovery(currentStackData, target, m_spillSet, &blockLayout.exitShuffle);
 					yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 					yulAssert(m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore, "Spilling not allowed, stack too deep.");
 				}
@@ -390,7 +397,7 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 				StackData returnStack = _functionReturn.returnValues | ranges::views::transform([this](InstId const _id) { return StackSlot::makeValue(m_cfg, _id); }) | ranges::to<std::vector>;
 				returnStack.push_back(StackSlot::makeFunctionReturnLabel(m_graphID));
 				auto const spillCountBefore = m_spillSet.numSpilled();
-				auto const shuffleResult = shuffleWithSpillDiscovery(currentStackData, returnStack, m_spillSet);
+				auto const shuffleResult = shuffleWithSpillDiscovery(currentStackData, returnStack, m_spillSet, &blockLayout.exitShuffle);
 				yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 				yulAssert(m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore, "Spilling not allowed, stack too deep.");
 				blockLayout.exitIn = currentStackData;

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -278,7 +278,7 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 	Stack stack(currentStackData);
 	bool const junkCanBeAdded = m_junkAdmittingBlocksFinder->allowsAdditionOfJunk(_blockId);
 
-	blockLayout.operationIn.reserve(block.instructions.size());
+	blockLayout.operationShuffles.reserve(block.instructions.size());
 	m_cfg.forEachOperation(block, [&](InstId const _instId, SSACFG::Inst const& _inst) {
 		auto opLiveOutWithoutOutputs = m_liveness.operationLiveOut(_instId);
 		m_cfg.forEachOutput(_instId, [&](InstId const id) { opLiveOutWithoutOutputs.erase(id); });
@@ -320,7 +320,6 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 			yulAssert(m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore, "Spilling not allowed, stack too deep.");
 		}
 
-		blockLayout.operationIn.push_back(currentStackData);
 		blockLayout.operationShuffles.push_back(std::move(operationShuffle));
 		for (std::size_t i = 0; i < requiredStackTop.size(); ++i)
 			stack.pop();
@@ -379,9 +378,6 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 
 				yulAssert(!stack.empty() && stack.top().isValue() && stack.top().value() == _cJump.condition);
 
-				// exitIn = pre-JUMPI state (condition on top) for CodeTransform
-				blockLayout.exitIn = currentStackData;
-
 				// Pop condition from symbolic stack (consumed by JUMPI).
 				// After this, currentStackData reflects the post-JUMPI stack.
 				stack.pop();
@@ -402,20 +398,14 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 				auto const shuffleResult = shuffleWithSpillDiscovery(currentStackData, returnStack, m_spillSet, &blockLayout.exitShuffle);
 				yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 				yulAssert(m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore, "Spilling not allowed, stack too deep.");
-				blockLayout.exitIn = currentStackData;
 			},
 			[&](SSACFG::BasicBlock::Jump const& _jump) {
-				blockLayout.exitIn = currentStackData;
 				m_inputStackProposalsPerBlock[_jump.target.value].emplace_back(_blockId, currentStackData);
 
 				validateBackEdge(_jump.target);
 			},
-			[&](SSACFG::BasicBlock::MainExit const&) {
-				blockLayout.exitIn = currentStackData;
-			},
-			[&](SSACFG::BasicBlock::Terminated const&) {
-				blockLayout.exitIn = currentStackData;
-			}
+			[&](SSACFG::BasicBlock::MainExit const&) {},
+			[&](SSACFG::BasicBlock::Terminated const&) {}
 		},
 		block.exit
 	);

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -215,15 +215,13 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 			for (std::size_t j = 0; j < stackInProposals.size(); ++j)
 			{
 				StackData edgeStack = stackInProposals[j].second;
-				ShuffleTrace trace;
-				Stack stack(edgeStack, &trace);
 				StackShufflerResult const result = StackShuffler::shuffleWithSpillDiscovery(
-					stack,
+					edgeStack,
 					stackPreImage(m_cfg, proposals[i], PhiInverse(m_cfg, stackInProposals[j].first, _blockId)),
 					candidateSpillSet
 				);
 				yulAssert(result.status == StackShufflerResult::Status::Admissible);
-				cumulativeGas[i] += stackOpsGas(m_cfg, trace);
+				cumulativeGas[i] += stackOpsGas(m_cfg, result.trace);
 			}
 			candidateSpillSets[i] = std::move(candidateSpillSet);
 		}
@@ -248,19 +246,17 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 	{
 		StackData edgeStack = parentExitStack;
 		auto const spillCountBefore = m_spillSet.numSpilled();
-		ShuffleTrace edgeShuffle;
-		auto const shuffleResult = shuffleWithSpillDiscovery(
+		auto shuffleResult = shuffleWithSpillDiscovery(
 			edgeStack,
 			stackPreImage(m_cfg, blockLayout.stackIn, PhiInverse(m_cfg, parentBlockId, _blockId)),
-			m_spillSet,
-			&edgeShuffle
+			m_spillSet
 		);
 		yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 		yulAssert(
 			m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore,
 			"Stack too deep, but spilling is disabled because the function is part of a recursive call chain."
 		);
-		blockLayout.addTraceForStackIn(parentBlockId, std::move(edgeShuffle));
+		blockLayout.addTraceForStackIn(parentBlockId, std::move(shuffleResult.trace));
 	}
 
 	m_resultLayout[_blockId] = std::move(blockLayout);
@@ -299,7 +295,6 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 			ranges::views::reverse |
 			ranges::views::transform([this](InstId const& _id) { return StackSlot::makeValue(m_cfg, _id); });
 
-		ShuffleTrace operationShuffle;
 		{
 			// Values that are dead before the operation are left on the stack; the shuffle to the
 			// optimal target pops them as surplus as needed
@@ -315,12 +310,11 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 			);
 			auto const spillCountBefore = m_spillSet.numSpilled();
 			m_spillSet = std::move(plannedSpillSet);
-			auto const shuffleResult = shuffleWithSpillDiscovery(currentStackData, target, m_spillSet, &operationShuffle);
+			auto shuffleResult = shuffleWithSpillDiscovery(currentStackData, target, m_spillSet);
 			yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 			yulAssert(m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore, "Spilling not allowed, stack too deep.");
+			blockLayout.operationShuffles.push_back(std::move(shuffleResult.trace));
 		}
-
-		blockLayout.operationShuffles.push_back(std::move(operationShuffle));
 		for (std::size_t i = 0; i < requiredStackTop.size(); ++i)
 			stack.pop();
 		m_cfg.forEachOutput(_instId, [&](InstId const id) {
@@ -336,14 +330,13 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 		StackData const target = stackPreImage(m_cfg, m_resultLayout[_target]->stackIn, PhiInverse(m_cfg, _blockId, _target));
 		auto const spillCountBefore = m_spillSet.numSpilled();
 		StackData exitStack = currentStackData;
-		ShuffleTrace edgeShuffle;
-		auto const shuffleResult = shuffleWithSpillDiscovery(exitStack, target, m_spillSet, &edgeShuffle);
+		auto shuffleResult = shuffleWithSpillDiscovery(exitStack, target, m_spillSet);
 		yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 		yulAssert(
 			m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore,
 			"Stack too deep, but spilling is disabled because the function is part of a recursive call chain."
 		);
-		m_resultLayout[_target]->addTraceForStackIn(_blockId, std::move(edgeShuffle));
+		m_resultLayout[_target]->addTraceForStackIn(_blockId, std::move(shuffleResult.trace));
 	};
 
 	std::visit(
@@ -371,9 +364,10 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 					);
 					auto const spillCountBefore = m_spillSet.numSpilled();
 					m_spillSet = std::move(plannedSpillSet);
-					auto const shuffleResult = shuffleWithSpillDiscovery(currentStackData, target, m_spillSet, &blockLayout.exitShuffle);
+					auto shuffleResult = shuffleWithSpillDiscovery(currentStackData, target, m_spillSet);
 					yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 					yulAssert(m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore, "Spilling not allowed, stack too deep.");
+					blockLayout.exitShuffle = std::move(shuffleResult.trace);
 				}
 
 				yulAssert(!stack.empty() && stack.top().isValue() && stack.top().value() == _cJump.condition);
@@ -395,9 +389,10 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 				StackData returnStack = _functionReturn.returnValues | ranges::views::transform([this](InstId const _id) { return StackSlot::makeValue(m_cfg, _id); }) | ranges::to<std::vector>;
 				returnStack.push_back(StackSlot::makeFunctionReturnLabel(m_graphID));
 				auto const spillCountBefore = m_spillSet.numSpilled();
-				auto const shuffleResult = shuffleWithSpillDiscovery(currentStackData, returnStack, m_spillSet, &blockLayout.exitShuffle);
+				auto shuffleResult = shuffleWithSpillDiscovery(currentStackData, returnStack, m_spillSet);
 				yulAssert(shuffleResult.status == StackShufflerResult::Status::Admissible);
 				yulAssert(m_spillingAllowed || m_spillSet.numSpilled() == spillCountBefore, "Spilling not allowed, stack too deep.");
+				blockLayout.exitShuffle = std::move(shuffleResult.trace);
 			},
 			[&](SSACFG::BasicBlock::Jump const& _jump) {
 				m_inputStackProposalsPerBlock[_jump.target.value].emplace_back(_blockId, currentStackData);

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -89,14 +89,16 @@ StackLayoutGenerator::Result StackLayoutGenerator::generate(
 )
 {
 	spill::SpillSet spillSet;
+	spill::SpillStoreTraces spillStoreTraces;
 	while (true)
 	{
 		auto const spillCountBefore = spillSet.numSpilled();
 		StackLayoutGenerator generator(_liveness, _callSites, _graphID, _spillingAllowed, std::move(spillSet));
 		spillSet = std::move(generator.m_spillSet);
-		spillSet.closeUnderReachabilityConstraints(_liveness.cfg(), generator.m_resultLayout);
+		spillSet.closeUnderReachabilityConstraints(_liveness.cfg(), generator.m_resultLayout, &spillStoreTraces);
+		// only the traces of the final iteration survive; they are recorded against the stable spill set
 		if (spillSet.numSpilled() == spillCountBefore)
-			return Result{std::move(generator.m_resultLayout), std::move(spillSet)};
+			return Result{std::move(generator.m_resultLayout), std::move(spillSet), std::move(spillStoreTraces)};
 
 		// there is an upper bound to how much can be spilled (number of variables). this assert ensures termination.
 		yulAssert(spillSet.numSpilled() > spillCountBefore, "spill set cannot shrink");

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -20,6 +20,7 @@
 
 #include <libyul/backends/evm/ssa/JunkAdmittingBlocksFinder.h>
 #include <libyul/backends/evm/ssa/PhiInverse.h>
+#include <libyul/backends/evm/ssa/ShuffleTrace.h>
 #include <libyul/backends/evm/ssa/StackShuffler.h>
 #include <libyul/backends/evm/ssa/StackUtils.h>
 
@@ -214,14 +215,15 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 			for (std::size_t j = 0; j < stackInProposals.size(); ++j)
 			{
 				StackData edgeStack = stackInProposals[j].second;
-				Stack<GasAccumulatingCallbacks> stack(edgeStack, {.cfg = m_cfg});
-				StackShufflerResult const result = StackShuffler<GasAccumulatingCallbacks>::shuffleWithSpillDiscovery(
+				ShuffleTrace trace;
+				Stack<TraceRecordingCallbacks> stack(edgeStack, {.trace = &trace});
+				StackShufflerResult const result = StackShuffler<TraceRecordingCallbacks>::shuffleWithSpillDiscovery(
 					stack,
 					stackPreImage(m_cfg, proposals[i], PhiInverse(m_cfg, stackInProposals[j].first, _blockId)),
 					candidateSpillSet
 				);
 				yulAssert(result.status == StackShufflerResult::Status::Admissible);
-				cumulativeGas[i] += stack.callbacks().opGas;
+				cumulativeGas[i] += stackOpsGas(m_cfg, trace);
 			}
 			candidateSpillSets[i] = std::move(candidateSpillSet);
 		}

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.cpp
@@ -69,9 +69,7 @@ void handlePhiFunctions(StackData& _stackData, PhiInverse const& _phiInverse, Li
 	}
 }
 
-using StackType = Stack<>;
-
-void declareJunk(StackType& _stack, LivenessAnalysis::LivenessData const& _live)
+void declareJunk(Stack& _stack, LivenessAnalysis::LivenessData const& _live)
 {
 	for (StackOffset offset{0}; offset < _stack.size(); ++offset.value)
 	{
@@ -189,7 +187,7 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 		yulAssert(stackInProposals.size() == 1);
 		blockLayout.stackIn = stackInProposals[0].second;
 		handlePhiFunctions(blockLayout.stackIn, PhiInverse(m_cfg, stackInProposals[0].first, _blockId), liveIn, m_cfg);
-		StackType stack(blockLayout.stackIn, {});
+		Stack stack(blockLayout.stackIn);
 		declareJunk(stack, liveIn);
 	}
 	else
@@ -201,7 +199,7 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 			proposals[i] = stackInProposals[i].second;
 			handlePhiFunctions(proposals[i], PhiInverse(m_cfg, stackInProposals[i].first, _blockId), liveIn, m_cfg);
 			{
-				StackType stack(proposals[i], {});
+				Stack stack(proposals[i]);
 				declareJunk(stack, liveIn);
 			}
 		}
@@ -216,8 +214,8 @@ void StackLayoutGenerator::defineStackIn(SSACFG::BlockId const& _blockId)
 			{
 				StackData edgeStack = stackInProposals[j].second;
 				ShuffleTrace trace;
-				Stack<TraceRecordingCallbacks> stack(edgeStack, {.trace = &trace});
-				StackShufflerResult const result = StackShuffler<TraceRecordingCallbacks>::shuffleWithSpillDiscovery(
+				Stack stack(edgeStack, &trace);
+				StackShufflerResult const result = StackShuffler::shuffleWithSpillDiscovery(
 					stack,
 					stackPreImage(m_cfg, proposals[i], PhiInverse(m_cfg, stackInProposals[j].first, _blockId)),
 					candidateSpillSet
@@ -272,7 +270,7 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 	SSACFG::BasicBlock const& block = m_cfg.block(_blockId);
 
 	StackData currentStackData = blockLayout.stackIn;
-	StackType stack(currentStackData, {});
+	Stack stack(currentStackData);
 	bool const junkCanBeAdded = m_junkAdmittingBlocksFinder->allowsAdditionOfJunk(_blockId);
 
 	blockLayout.operationIn.reserve(block.instructions.size());
@@ -318,9 +316,9 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 
 		blockLayout.operationIn.push_back(currentStackData);
 		for (std::size_t i = 0; i < requiredStackTop.size(); ++i)
-			stack.pop<false>();
+			stack.pop();
 		m_cfg.forEachOutput(_instId, [&](InstId const id) {
-			stack.push<false>(Slot::makeValue(m_cfg, id));
+			stack.push(Slot::makeValue(m_cfg, id));
 		});
 	});
 
@@ -377,7 +375,7 @@ void StackLayoutGenerator::visitBlock(SSACFG::BlockId const& _blockId)
 
 				// Pop condition from symbolic stack (consumed by JUMPI).
 				// After this, currentStackData reflects the post-JUMPI stack.
-				stack.pop<false>();
+				stack.pop();
 
 				// Define successor stack-in layouts
 				m_inputStackProposalsPerBlock[_cJump.zero.value].emplace_back(_blockId, currentStackData);

--- a/libyul/backends/evm/ssa/StackLayoutGenerator.h
+++ b/libyul/backends/evm/ssa/StackLayoutGenerator.h
@@ -36,10 +36,12 @@ public:
 	using Slot = StackSlot;
 
 	/// the per-block stack layout plus the set of values the layout generator decided to spill to memory
+	/// and the recorded def-site store trace of each spilled value
 	struct Result
 	{
 		SSACFGStackLayout layout;
 		spill::SpillSet spillSet;
+		spill::SpillStoreTraces spillStoreTraces;
 	};
 
 	/// Generates the stack layout for the function graph together with the set of values that have to be spilled

--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -185,6 +185,7 @@ struct StackShufflerResult
 	enum class Status { Continue, Admissible, StackTooDeep, MaxIterationsReached };
 	Status status = Status::Admissible;
 	StackSlot spillingCandidate = StackSlot::makeJunk();
+	ShuffleTrace trace{};
 };
 
 class StackShuffler
@@ -192,14 +193,67 @@ class StackShuffler
 	using Slot = StackSlot;
 
 public:
-	/// Shuffles the stack toward the target over a fixed spill set. A stack-too-deep state is
-	/// propagated to the caller
+	/// Shuffles `_data` toward the target over a fixed spill set, returning the trace of stack ops
+	/// realizing the shuffle. A stack-too-deep state is propagated to the caller
 	[[nodiscard]] static StackShufflerResult shuffle(
-		Stack& _stack,
+		StackData& _data,
 		StackData const& _args,
 		StackSlotLiveness const& _liveOut,
 		std::size_t const _targetStackSize,
 		spill::SpillSet const* const _spilledVariables = nullptr
+	)
+	{
+		ShuffleTrace trace;
+		Stack stack(_data, &trace);
+		StackShufflerResult result = shuffleImpl(stack, _args, _liveOut, _targetStackSize, _spilledVariables);
+		result.trace = std::move(trace);
+		return result;
+	}
+
+	[[nodiscard]] static StackShufflerResult shuffle(
+		StackData& _data,
+		StackData const& _target,
+		spill::SpillSet const* const _spilledVariables = nullptr
+	)
+	{
+		return shuffle(_data, _target, {}, _target.size(), _spilledVariables);
+	}
+
+	/// Like `shuffle`, but resolves stuck states in place: a recoverable stack-too-deep adds its culprit to
+	/// `_spilledVariables` and continues the same loop, so the spill takes effect without restarting the shuffle.
+	[[nodiscard]] static StackShufflerResult shuffleWithSpillDiscovery(
+		StackData& _data,
+		StackData const& _args,
+		StackSlotLiveness const& _liveOut,
+		std::size_t const _targetStackSize,
+		spill::SpillSet& _spilledVariables
+	)
+	{
+		ShuffleTrace trace;
+		Stack stack(_data, &trace);
+		StackShufflerResult result = shuffleWithSpillDiscoveryImpl(stack, _args, _liveOut, _targetStackSize, _spilledVariables);
+		result.trace = std::move(trace);
+		return result;
+	}
+
+	[[nodiscard]] static StackShufflerResult shuffleWithSpillDiscovery(
+		StackData& _data,
+		StackData const& _target,
+		spill::SpillSet& _spilledVariables
+	)
+	{
+		return shuffleWithSpillDiscovery(_data, _target, {}, _target.size(), _spilledVariables);
+	}
+
+private:
+	static std::size_t constexpr maxIterations = 1000;
+
+	[[nodiscard]] static StackShufflerResult shuffleImpl(
+		Stack& _stack,
+		StackData const& _args,
+		StackSlotLiveness const& _liveOut,
+		std::size_t const _targetStackSize,
+		spill::SpillSet const* const _spilledVariables
 	)
 	{
 		checkPreconditions(_stack, _args, _liveOut, _targetStackSize, _spilledVariables);
@@ -229,18 +283,7 @@ public:
 		yulAssert(false);
 	}
 
-	[[nodiscard]] static StackShufflerResult shuffle(
-		Stack& _stack,
-		StackData const& _target,
-		spill::SpillSet const* const _spilledVariables = nullptr
-	)
-	{
-		return shuffle(_stack, _target, {}, _target.size(), _spilledVariables);
-	}
-
-	/// Like `shuffle`, but resolves stuck states in place: a recoverable stack-too-deep adds its culprit to
-	/// `_spilledVariables` and continues the same loop, so the spill takes effect without restarting the shuffle.
-	[[nodiscard]] static StackShufflerResult shuffleWithSpillDiscovery(
+	[[nodiscard]] static StackShufflerResult shuffleWithSpillDiscoveryImpl(
 		Stack& _stack,
 		StackData const& _args,
 		StackSlotLiveness const& _liveOut,
@@ -277,18 +320,6 @@ public:
 		}
 		yulAssert(false);
 	}
-
-	[[nodiscard]] static StackShufflerResult shuffleWithSpillDiscovery(
-		Stack& _stack,
-		StackData const& _target,
-		spill::SpillSet& _spilledVariables
-	)
-	{
-		return shuffleWithSpillDiscovery(_stack, _target, {}, _target.size(), _spilledVariables);
-	}
-
-private:
-	static std::size_t constexpr maxIterations = 1000;
 
 	/// Entry preconditions shared by both shuffle variants. Hold for the initial stack only, so they are
 	/// checked once per call rather than on every (potentially partially-shuffled) iteration.
@@ -1085,13 +1116,11 @@ private:
 	StackData const& _args,
 	StackSlotLiveness const& _liveOut,
 	std::size_t const _targetStackSize,
-	spill::SpillSet& _spilledVariables,
-	ShuffleTrace* _trace = nullptr
+	spill::SpillSet& _spilledVariables
 )
 {
-	Stack stack(_data, _trace);
-	StackShufflerResult const result = StackShuffler::shuffleWithSpillDiscovery(
-		stack, _args, _liveOut, _targetStackSize, _spilledVariables
+	StackShufflerResult result = StackShuffler::shuffleWithSpillDiscovery(
+		_data, _args, _liveOut, _targetStackSize, _spilledVariables
 	);
 	yulAssert(
 		result.status == StackShufflerResult::Status::Admissible ||
@@ -1103,10 +1132,9 @@ private:
 [[nodiscard]] inline StackShufflerResult shuffleWithSpillDiscovery(
 	StackData& _data,
 	StackData const& _target,
-	spill::SpillSet& _spilledVariables,
-	ShuffleTrace* _trace = nullptr)
+	spill::SpillSet& _spilledVariables)
 {
-	return shuffleWithSpillDiscovery(_data, _target, {}, _target.size(), _spilledVariables, _trace);
+	return shuffleWithSpillDiscovery(_data, _target, {}, _target.size(), _spilledVariables);
 }
 
 

--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -1087,10 +1087,11 @@ private:
 	StackData const& _args,
 	StackSlotLiveness const& _liveOut,
 	std::size_t const _targetStackSize,
-	spill::SpillSet& _spilledVariables
+	spill::SpillSet& _spilledVariables,
+	ShuffleTrace* _trace = nullptr
 )
 {
-	Stack stack(_data);
+	Stack stack(_data, _trace);
 	StackShufflerResult const result = StackShuffler::shuffleWithSpillDiscovery(
 		stack, _args, _liveOut, _targetStackSize, _spilledVariables
 	);
@@ -1104,9 +1105,10 @@ private:
 [[nodiscard]] inline StackShufflerResult shuffleWithSpillDiscovery(
 	StackData& _data,
 	StackData const& _target,
-	spill::SpillSet& _spilledVariables)
+	spill::SpillSet& _spilledVariables,
+	ShuffleTrace* _trace = nullptr)
 {
-	return shuffleWithSpillDiscovery(_data, _target, {}, _target.size(), _spilledVariables);
+	return shuffleWithSpillDiscovery(_data, _target, {}, _target.size(), _spilledVariables, _trace);
 }
 
 

--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -46,11 +46,10 @@ inline bool slotIsSpilled(StackSlot const& _slot, spill::SpillSet const* const _
 
 inline bool slotCanBeLoadedOrPushed(StackSlot const& _slot, spill::SpillSet const* const _spilledVariables)
 {
-	return Stack<>::canBeFreelyGenerated(_slot) || slotIsSpilled(_slot, _spilledVariables);
+	return canBeFreelyGenerated(_slot) || slotIsSpilled(_slot, _spilledVariables);
 }
 
-template<typename Callback>
-void exchange(Stack<Callback>& _stack, StackOffset _off1, StackOffset _off2)
+inline void exchange(Stack& _stack, StackOffset _off1, StackOffset _off2)
 {
 	yulAssert(_stack.isValidSwapTarget(_off1) && _stack.isValidSwapTarget(_off2));
 	auto const topOffset = _stack.depthToOffset(StackDepth{0});
@@ -188,16 +187,17 @@ struct StackShufflerResult
 	StackSlot spillingCandidate = StackSlot::makeJunk();
 };
 
-template<StackManipulationCallbackConcept Callback, std::size_t ReachableStackDepth=16>
 class StackShuffler
 {
 	using Slot = StackSlot;
+
+	static std::size_t constexpr ReachableStackDepth = 16;
 
 public:
 	/// Shuffles the stack toward the target over a fixed spill set. A stack-too-deep state is
 	/// propagated to the caller
 	[[nodiscard]] static StackShufflerResult shuffle(
-		Stack<Callback>& _stack,
+		Stack& _stack,
 		StackData const& _args,
 		StackSlotLiveness const& _liveOut,
 		std::size_t const _targetStackSize,
@@ -232,7 +232,7 @@ public:
 	}
 
 	[[nodiscard]] static StackShufflerResult shuffle(
-		Stack<Callback>& _stack,
+		Stack& _stack,
 		StackData const& _target,
 		spill::SpillSet const* const _spilledVariables = nullptr
 	)
@@ -243,7 +243,7 @@ public:
 	/// Like `shuffle`, but resolves stuck states in place: a recoverable stack-too-deep adds its culprit to
 	/// `_spilledVariables` and continues the same loop, so the spill takes effect without restarting the shuffle.
 	[[nodiscard]] static StackShufflerResult shuffleWithSpillDiscovery(
-		Stack<Callback>& _stack,
+		Stack& _stack,
 		StackData const& _args,
 		StackSlotLiveness const& _liveOut,
 		std::size_t const _targetStackSize,
@@ -281,7 +281,7 @@ public:
 	}
 
 	[[nodiscard]] static StackShufflerResult shuffleWithSpillDiscovery(
-		Stack<Callback>& _stack,
+		Stack& _stack,
 		StackData const& _target,
 		spill::SpillSet& _spilledVariables
 	)
@@ -295,7 +295,7 @@ private:
 	/// Entry preconditions shared by both shuffle variants. Hold for the initial stack only, so they are
 	/// checked once per call rather than on every (potentially partially-shuffled) iteration.
 	static void checkPreconditions(
-		Stack<Callback> const& _stack,
+		Stack const& _stack,
 		StackData const& _args,
 		StackSlotLiveness const& _liveOut,
 		std::size_t const _targetStackSize,
@@ -319,7 +319,7 @@ private:
 	/// A single read-only stepping iteration toward the target. Never mutates the spill set; both shuffle
 	/// loops decide what to do with a returned `StackTooDeep`.
 	[[nodiscard]] static StackShufflerResult runStep(
-		Stack<Callback>& _stack,
+		Stack& _stack,
 		StackData const& _args,
 		StackSlotLiveness const& _liveOut,
 		std::size_t const _targetStackSize,
@@ -357,7 +357,7 @@ private:
 	}
 
 	/// Make a local step in stack space that should bring us closer to the target.
-	static StackShufflerResult shuffleStep(Stack<Callback>& _stack, detail::State const& _state)
+	static StackShufflerResult shuffleStep(Stack& _stack, detail::State const& _state)
 	{
 		// if the stack is too large, we try to shrink it
 		if (_stack.size() > _state.target().size)
@@ -426,7 +426,7 @@ private:
 
 	/// Select an optimal slot to dup based on liveness analysis.
 	/// Prioritizes slots that have the highest deficit with respect to liveOut counts.
-	static std::optional<StackDepth> selectOptimalSlotToDup(Stack<Callback> const& _stack, detail::State const& _state)
+	static std::optional<StackDepth> selectOptimalSlotToDup(Stack const& _stack, detail::State const& _state)
 	{
 		std::optional<StackDepth> bestSlot;
 		int bestDeficit = 0; // Only consider positive deficits
@@ -462,7 +462,7 @@ private:
 	}
 
 	/// Dups the deepest reachable slot in the tail that is required in args
-	static ShuffleHelperResult dupDeepestRelevantTailSlot(Stack<Callback>& _stack, detail::State const& _state)
+	static ShuffleHelperResult dupDeepestRelevantTailSlot(Stack& _stack, detail::State const& _state)
 	{
 		// dup up the deepest slot that is required in args (or compress if unreachable)
 		for (StackOffset offset: _state.stackRange())
@@ -494,7 +494,7 @@ private:
 
 	/// If dupping an ideal slot causes a slot that will still be required to become unreachable, then dup
 	/// the latter slot first
-	static ShuffleHelperResult dupDeepSlotIfRequired(Stack<Callback>& _stack, detail::State const& _state)
+	static ShuffleHelperResult dupDeepSlotIfRequired(Stack& _stack, detail::State const& _state)
 	{
 		// Check if the stack is large enough for anything to potentially become unreachable.
 		if (_stack.size() < ReachableStackDepth - 1)
@@ -574,7 +574,7 @@ private:
 	}
 
 	/// Tries to fix a slot in the args section of the stack
-	static ShuffleHelperResult fixArgsSlot(Stack<Callback>& _stack, detail::State const& _state)
+	static ShuffleHelperResult fixArgsSlot(Stack& _stack, detail::State const& _state)
 	{
 		yulAssert(_stack.size() <= _state.target().size, "this method assumes that the stack isn't too large");
 		if (_stack.size() < _state.target().tailSize)
@@ -843,7 +843,7 @@ private:
 
 	/// Grows the tail if too small, otherwise tries swapping something down from args if its required in tail but not
 	/// there yet.
-	static ShuffleHelperResult fixTailSlot(Stack<Callback>& _stack, detail::State const& _state)
+	static ShuffleHelperResult fixTailSlot(Stack& _stack, detail::State const& _state)
 	{
 		yulAssert(_stack.size() <= _state.target().size, "this method assumes that the stack isn't exceeding target size");
 		for (StackOffset offset: _state.stackArgsRange() | ranges::views::reverse)
@@ -917,7 +917,7 @@ private:
 	}
 
 	/// Tries to compress the stack
-	static bool shrinkStack(Stack<Callback>& _stack, detail::State const& _state)
+	static bool shrinkStack(Stack& _stack, detail::State const& _state)
 	{
 		yulAssert(!_stack.empty(), "Stack is empty, can't shrink");
 
@@ -1029,7 +1029,7 @@ private:
 	/// dup-reachable.
 	/// Returns the culprit slot (guaranteed to be non-junk) that cannot be placed or duplicated, or `std::nullopt`
 	/// if every slot is reachable-or-final.
-	static std::optional<StackSlot> allNecessarySlotsReachableOrFinal(Stack<Callback> const& _stack, detail::State const& _state)
+	static std::optional<StackSlot> allNecessarySlotsReachableOrFinal(Stack const& _stack, detail::State const& _state)
 	{
 		// check that args are either in position or reachable
 		for (StackOffset offset{_state.target().tailSize}; offset < _state.target().size; ++offset.value)
@@ -1090,8 +1090,8 @@ private:
 	spill::SpillSet& _spilledVariables
 )
 {
-	Stack<> stack(_data, {});
-	StackShufflerResult const result = StackShuffler<NoOpStackManipulationCallbacks>::shuffleWithSpillDiscovery(
+	Stack stack(_data);
+	StackShufflerResult const result = StackShuffler::shuffleWithSpillDiscovery(
 		stack, _args, _liveOut, _targetStackSize, _spilledVariables
 	);
 	yulAssert(

--- a/libyul/backends/evm/ssa/StackShuffler.h
+++ b/libyul/backends/evm/ssa/StackShuffler.h
@@ -191,8 +191,6 @@ class StackShuffler
 {
 	using Slot = StackSlot;
 
-	static std::size_t constexpr ReachableStackDepth = 16;
-
 public:
 	/// Shuffles the stack toward the target over a fixed spill set. A stack-too-deep state is
 	/// propagated to the caller
@@ -309,7 +307,7 @@ private:
 		// check that all required values are on stack
 		for (auto const& liveSlot: _liveOut | ranges::views::keys)
 			yulAssert(
-				!_stack.canBeFreelyGenerated(liveSlot) &&
+				!canBeFreelyGenerated(liveSlot) &&
 				(ranges::contains(_stack.data(), liveSlot) || detail::slotIsSpilled(liveSlot, _spilledVariables))
 			);
 		for (auto const& arg: _args)
@@ -327,7 +325,7 @@ private:
 	)
 	{
 		detail::Target const target(_args, _liveOut, _targetStackSize, _spilledVariables);
-		detail::State const state(_stack.data(), target, _spilledVariables, ReachableStackDepth);
+		detail::State const state(_stack.data(), target, _spilledVariables, reachableStackDepth);
 		auto const result = shuffleStep(_stack, state);
 		if (result.status == StackShufflerResult::Status::Admissible)
 			yulAssert(state.admissible());
@@ -497,10 +495,10 @@ private:
 	static ShuffleHelperResult dupDeepSlotIfRequired(Stack& _stack, detail::State const& _state)
 	{
 		// Check if the stack is large enough for anything to potentially become unreachable.
-		if (_stack.size() < ReachableStackDepth - 1)
+		if (_stack.size() < reachableStackDepth - 1)
 			return {ShuffleHelperResult::Status::NoAction};
 		// Check whether any deep slot might still be needed later (i.e. we still need to reach it with a DUP or SWAP).
-		for (StackOffset sourceOffset{0u}; sourceOffset < _stack.size() - (ReachableStackDepth - 1); ++sourceOffset.value)
+		for (StackOffset sourceOffset{0u}; sourceOffset < _stack.size() - (reachableStackDepth - 1); ++sourceOffset.value)
 		{
 			// This slot needs to be moved into args and there is no tail slot of the same kind further up in the stack.
 			auto const& endangeredSlot = _stack[sourceOffset];
@@ -684,7 +682,7 @@ private:
 							(_state.countReachable(_stack[argOffset]) > 1 || _state.slotIsSpilled(_stack[argOffset])) &&  // a reachable copy remains, or the value is spilled and can be reloaded, so moving it is recoverable
 							(  // we only get a strict improvement if
 								!_state.isArgsCompatible(argOffset, argOffset) ||  // either the argOffset isn't in position anyway
-								_stack.offsetToDepth(offset).value == ReachableStackDepth  // or offset is at the swap edge
+								_stack.offsetToDepth(offset).value == reachableStackDepth  // or offset is at the swap edge
 							)
 						)
 						{
@@ -724,7 +722,7 @@ private:
 				return result;
 
 			auto const maybeIncorrectArgSlotDepth = _state.findDeepestIncorrectArgSlot();
-			if (!maybeIncorrectArgSlotDepth || maybeIncorrectArgSlotDepth->value < ReachableStackDepth - 1)
+			if (!maybeIncorrectArgSlotDepth || maybeIncorrectArgSlotDepth->value < reachableStackDepth - 1)
 			{
 				StackOffset const targetOffset{_stack.size()};
 				if (_state.count(_state.targetArg(targetOffset)) < _state.targetMinCount(_state.targetArg(targetOffset)))
@@ -747,7 +745,7 @@ private:
 			// is not on the stack at all. A push/dup grows the stack, pushing that slot one deeper.
 			// So if the deepest incorrect args slot would be pushed out of reach by growing, shrink first to keep it reachable.
 			if (
-				maybeIncorrectArgSlotDepth && maybeIncorrectArgSlotDepth->value > ReachableStackDepth
+				maybeIncorrectArgSlotDepth && maybeIncorrectArgSlotDepth->value > reachableStackDepth
 			)
 			{
 				StackOffset const incorrectOffset{_stack.size() - maybeIncorrectArgSlotDepth->value};
@@ -988,16 +986,16 @@ private:
 				bool const isJunk = slot.isJunk();
 				bool const hasSurplus = _state.count(slot) > _state.targetMinCount(slot);
 				bool const hasReachableDuplicate = _state.countReachable(slot) > 1;
-				bool const canBeFreelyGenerated = _stack.canBeFreelyGenerated(slot);
+				bool const freelyGeneratable = canBeFreelyGenerated(slot);
 				bool const isLit = slot.isLiteralValue();
 
 				if (isJunk && notInPosition)
 					return 5;
-				if (canBeFreelyGenerated && !isLit && notInPosition)
+				if (freelyGeneratable && !isLit && notInPosition)
 					return 4;
 				if (hasSurplus)
 					return 3;
-				if (canBeFreelyGenerated)
+				if (freelyGeneratable)
 					return 2;
 				if (hasReachableDuplicate)
 					return 1;

--- a/libyul/backends/evm/ssa/StackSlot.cpp
+++ b/libyul/backends/evm/ssa/StackSlot.cpp
@@ -16,7 +16,7 @@
 */
 // SPDX-License-Identifier: GPL-3.0
 
-#include <libyul/backends/evm/ssa/Stack.h>
+#include <libyul/backends/evm/ssa/StackSlot.h>
 
 #include <range/v3/view/transform.hpp>
 

--- a/libyul/backends/evm/ssa/StackSlot.h
+++ b/libyul/backends/evm/ssa/StackSlot.h
@@ -1,0 +1,173 @@
+/*
+	This file is part of solidity.
+
+	solidity is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	solidity is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with solidity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+#pragma once
+
+#include <libyul/backends/evm/ssa/ControlFlowGraphs.h>
+#include <libyul/backends/evm/ssa/SSACFG.h>
+
+#include <range/v3/algorithm/find.hpp>
+
+#include <cstdint>
+#include <type_traits>
+
+namespace solidity::yul::ssa
+{
+
+/// Registry for tracking function call sites.
+///
+/// Maps user-function-call operations to unique numeric IDs. These IDs are used
+/// to generate return labels for function calls in the EVM bytecode.
+class CallSites
+{
+public:
+	using CallSiteID = std::uint32_t;
+
+	std::optional<CallSiteID> callSiteID(InstId _instId) const
+	{
+		if (auto const it = ranges::find(m_data, _instId); it != m_data.end())
+			return static_cast<CallSiteID>(std::distance(m_data.begin(), it));
+		return std::nullopt;
+	}
+
+	InstId instId(CallSiteID _callSite) const
+	{
+		yulAssert(_callSite < m_data.size());
+		return m_data[_callSite];
+	}
+
+	CallSiteID addCallSite(InstId _instId)
+	{
+		if (auto const id = callSiteID(_instId))
+			return *id;
+		yulAssert(_instId.hasValue());
+		m_data.emplace_back(_instId);
+		return static_cast<CallSiteID>(m_data.size() - 1);
+	}
+private:
+	std::vector<InstId> m_data;
+};
+
+/// A discriminated union corresponding to a single EVM stack slot.
+/// Can represent:
+///		- ValueID: SSA values (including literals)
+///		- Junk: Placeholder/unused values
+///     - FunctionCallReturnLabel: Return addresses for function calls
+///     - FunctionReturnLabel: Identifies the calling function's graph
+///
+/// Memory layout is optimized: 8 bytes size for cache efficiency, trivially copyable, standard layout, trivial
+class StackSlot
+{
+public:
+	enum struct Kind: std::uint8_t
+	{
+		Value, // u32 InstId
+		Junk, // empty
+		FunctionCallReturnLabel, // index into corresponding stack layout's call sites
+		FunctionReturnLabel // identifying the function graph via ControlFlowGraphs
+	};
+
+	constexpr StackSlot() = default;
+	constexpr StackSlot(StackSlot const&) = default;
+	constexpr StackSlot(StackSlot&&) = default;
+	constexpr StackSlot& operator=(StackSlot const&) = default;
+	constexpr StackSlot& operator=(StackSlot&&) = default;
+
+	constexpr bool isValue() const noexcept { return kind() == Kind::Value; }
+	constexpr bool isLiteralValue() const noexcept { return m_valueOpcode == InstOpcode::Const; }
+	constexpr bool isPhiValue() const noexcept { return m_valueOpcode == InstOpcode::Phi; }
+	constexpr bool isFunctionReturnLabel() const noexcept { return kind() == Kind::FunctionReturnLabel; }
+	constexpr bool isFunctionCallReturnLabel() const noexcept { return kind() == Kind::FunctionCallReturnLabel; }
+	constexpr bool isJunk() const noexcept { return kind() == Kind::Junk; }
+	constexpr Kind kind() const noexcept { return m_kind; }
+
+	ControlFlowGraphs::FunctionGraphID functionReturnLabel() const { yulAssert(isFunctionReturnLabel()); return m_payload; }
+	CallSites::CallSiteID functionCallReturnLabel() const { yulAssert(isFunctionCallReturnLabel()); return m_payload; }
+	InstId value() const
+	{
+		yulAssert(isValue());
+		return InstId{m_payload};
+	}
+
+	static constexpr StackSlot makeJunk() { return {0, Kind::Junk}; }
+	static StackSlot makeValue(SSACFG const& _cfg, InstId _value)
+	{
+		return {_value.value, Kind::Value, _cfg.kindOf(_value)};
+	}
+	static StackSlot makeValue(InstructionStore const& _store, InstId _value)
+	{
+		return {_value.value, Kind::Value, _store.kindOf(_value)};
+	}
+	static constexpr StackSlot makeFunctionReturnLabel(ControlFlowGraphs::FunctionGraphID const _graphID) { return {_graphID, Kind::FunctionReturnLabel}; }
+	static constexpr StackSlot makeFunctionCallReturnLabel(CallSites::CallSiteID const _callSiteID) { return {_callSiteID, Kind::FunctionCallReturnLabel};	}
+
+	auto operator<=>(StackSlot const&) const = default;
+private:
+	constexpr StackSlot(std::uint32_t const _payload, Kind const _kind, InstOpcode const _valueOpcode = InstOpcode::Unreachable):
+		m_payload(_payload),
+		m_kind(_kind),
+		m_valueOpcode(_valueOpcode)
+	{}
+
+	/// interpretation depends on kind
+	std::uint32_t m_payload;
+	Kind m_kind;
+	/// for Kind::Value: cached Opcode of the defining Inst
+	InstOpcode m_valueOpcode;
+};
+static_assert(sizeof(StackSlot) == 8, "Want cache efficiency, benchmark this if you go beyond 8 bytes");
+static_assert(std::is_trivially_copyable_v<StackSlot>, "Should be able to use memcpy semantics");
+static_assert(std::is_standard_layout_v<StackSlot>, "Want to have a predictable layout");
+static_assert(std::is_trivial_v<StackSlot>, "Want to have no init/cpy overhead");
+
+/// Whether a slot can be materialized on the stack top out of thin air, without a copy of it on the stack.
+constexpr bool canBeFreelyGenerated(StackSlot const& _slot)
+{
+	return _slot.isLiteralValue() || _slot.isJunk() || _slot.isFunctionCallReturnLabel();
+}
+
+using StackData = std::vector<StackSlot>;
+std::string slotToString(StackSlot const& _slot);
+std::string stackToString(StackData const& _stackData);
+
+/// Array index into stack from the bottom (offset 0 = bottom).
+/// Natural for array-like access and iteration; used when treating the stack as a data structure.
+struct StackOffset
+{
+	explicit constexpr StackOffset(size_t _value) : value(_value) {}
+	size_t value;
+	auto operator<=>(StackOffset const&) const = default;
+};
+// comparison operations with size_t
+constexpr auto operator<=>(StackOffset const lhs, size_t const rhs) noexcept { return lhs.value <=> rhs; }
+constexpr auto operator<=>(size_t const lhs, StackOffset const rhs) noexcept { return lhs <=> rhs.value; }
+
+/// Distance from the stack top (depth 0 = top).
+/// Natural for stack operations (SWAP1 = swap with depth 1); used for operations that
+/// conceptually work "from the top".
+struct StackDepth
+{
+	explicit constexpr StackDepth(size_t _value) : value(_value) {}
+	size_t value;
+	auto operator<=>(StackDepth const&) const = default;
+};
+// comparison operations with size_t
+constexpr auto operator<=>(StackDepth const lhs, size_t const rhs) noexcept { return lhs.value <=> rhs; }
+constexpr auto operator<=>(size_t const lhs, StackDepth const rhs) noexcept { return lhs <=> rhs.value; }
+
+}

--- a/libyul/backends/evm/ssa/StackSlot.h
+++ b/libyul/backends/evm/ssa/StackSlot.h
@@ -170,4 +170,7 @@ struct StackDepth
 constexpr auto operator<=>(StackDepth const lhs, size_t const rhs) noexcept { return lhs.value <=> rhs; }
 constexpr auto operator<=>(size_t const lhs, StackDepth const rhs) noexcept { return lhs <=> rhs.value; }
 
+/// Maximum stack depth reachable by the EVM
+std::size_t constexpr reachableStackDepth = 16;
+
 }

--- a/libyul/backends/evm/ssa/StackUtils.cpp
+++ b/libyul/backends/evm/ssa/StackUtils.cpp
@@ -114,15 +114,12 @@ OptimalTarget solidity::yul::ssa::findOptimalTarget
 	StackData data;
 	data.reserve(startSize + maxUpwardExpansion);
 	spill::SpillSet spillSet;
-	ShuffleTrace trace;
 	auto const evaluateCost = [&](std::size_t const _targetSize) -> std::size_t
 	{
 		spillSet = _spillSet;
 		data = _stackData;
-		trace.clear();
-		Stack countOpsStack(data, &trace);
 		StackShufflerResult const result = StackShuffler::shuffleWithSpillDiscovery(
-			countOpsStack,
+			data,
 			_targetArgs,
 			_targetLiveOut,
 			_targetSize,
@@ -130,7 +127,7 @@ OptimalTarget solidity::yul::ssa::findOptimalTarget
 		);
 		yulAssert(data.size() == _targetSize);
 		yulAssert(result.status == StackShufflerResult::Status::Admissible);
-		std::size_t const cost = trace.size() + 1000 * spillSet.numSpilled();
+		std::size_t const cost = result.trace.size() + 1000 * spillSet.numSpilled();
 		return cost;
 	};
 

--- a/libyul/backends/evm/ssa/StackUtils.cpp
+++ b/libyul/backends/evm/ssa/StackUtils.cpp
@@ -32,48 +32,6 @@
 
 using namespace solidity::yul::ssa;
 
-void GasAccumulatingCallbacks::swap(StackDepth _depth)
-{
-	opGas += evmasm::GasMeter::swapGas(_depth.value, cfg.evmDialect.evmVersion());
-}
-
-void GasAccumulatingCallbacks::dup(StackDepth _depth)
-{
-	opGas += evmasm::GasMeter::dupGas(_depth.value, cfg.evmDialect.evmVersion());
-}
-
-void GasAccumulatingCallbacks::push(StackSlot const& _slot)
-{
-	if (_slot.isLiteralValue())
-	{
-		auto const size = numberEncodingSize(cfg.literalPayload(_slot.value()));
-		opGas += evmasm::GasMeter::runGas(evmasm::pushInstruction(size), cfg.evmDialect.evmVersion());
-	}
-	else if (_slot.isJunk())
-	{
-		auto const op = cfg.evmDialect.evmVersion().hasPush0() ? evmasm::Instruction::PUSH0 : evmasm::Instruction::CODESIZE;
-		opGas += evmasm::GasMeter::runGas(op, cfg.evmDialect.evmVersion());
-	}
-	else if (_slot.isFunctionCallReturnLabel())
-	{
-		// this is a jump dest, we don't really know yet how big it is going to be, just assume that it fits into
-		// a 2-byte number
-		opGas += evmasm::GasMeter::runGas(evmasm::Instruction::PUSH2, cfg.evmDialect.evmVersion());
-	}
-	else
-	{
-		// Spilled SSA value
-		yulAssert(_slot.isValue(), "unexpected slot kind in GasAccumulatingCallbacks::push");
-		opGas += evmasm::GasMeter::runGas(evmasm::Instruction::PUSH32, cfg.evmDialect.evmVersion());
-		opGas += evmasm::GasMeter::runGas(evmasm::Instruction::MLOAD, cfg.evmDialect.evmVersion());
-	}
-}
-
-void GasAccumulatingCallbacks::pop()
-{
-	opGas += evmasm::GasMeter::runGas(evmasm::Instruction::POP, cfg.evmDialect.evmVersion());
-}
-
 std::size_t solidity::yul::ssa::stackOpsGas(SSACFG const& _cfg, ShuffleTrace const& _trace)
 {
 	auto const evmVersion = _cfg.evmDialect.evmVersion();
@@ -156,12 +114,14 @@ OptimalTarget solidity::yul::ssa::findOptimalTarget
 	StackData data;
 	data.reserve(startSize + maxUpwardExpansion);
 	spill::SpillSet spillSet;
+	ShuffleTrace trace;
 	auto const evaluateCost = [&](std::size_t const _targetSize) -> std::size_t
 	{
 		spillSet = _spillSet;
 		data = _stackData;
-		Stack<OpsCountingCallbacks> countOpsStack(data, {});
-		StackShufflerResult const result = StackShuffler<OpsCountingCallbacks>::shuffleWithSpillDiscovery(
+		trace.clear();
+		Stack<TraceRecordingCallbacks> countOpsStack(data, {.trace = &trace});
+		StackShufflerResult const result = StackShuffler<TraceRecordingCallbacks>::shuffleWithSpillDiscovery(
 			countOpsStack,
 			_targetArgs,
 			_targetLiveOut,
@@ -170,7 +130,7 @@ OptimalTarget solidity::yul::ssa::findOptimalTarget
 		);
 		yulAssert(data.size() == _targetSize);
 		yulAssert(result.status == StackShufflerResult::Status::Admissible);
-		std::size_t const cost = countOpsStack.callbacks().numOps + 1000 * spillSet.numSpilled();
+		std::size_t const cost = trace.size() + 1000 * spillSet.numSpilled();
 		return cost;
 	};
 

--- a/libyul/backends/evm/ssa/StackUtils.cpp
+++ b/libyul/backends/evm/ssa/StackUtils.cpp
@@ -74,6 +74,48 @@ void GasAccumulatingCallbacks::pop()
 	opGas += evmasm::GasMeter::runGas(evmasm::Instruction::POP, cfg.evmDialect.evmVersion());
 }
 
+std::size_t solidity::yul::ssa::stackOpsGas(SSACFG const& _cfg, ShuffleTrace const& _trace)
+{
+	auto const evmVersion = _cfg.evmDialect.evmVersion();
+	auto const runGas = [&](evmasm::Instruction const _instruction) {
+		return evmasm::GasMeter::runGas(_instruction, evmVersion);
+	};
+	std::size_t gas = 0;
+	for (ShuffleOp const& op: _trace)
+		switch (op.kind)
+		{
+		case ShuffleOp::Kind::Swap:
+			gas += evmasm::GasMeter::swapGas(op.depth, evmVersion);
+			break;
+		case ShuffleOp::Kind::Dup:
+			gas += evmasm::GasMeter::dupGas(op.depth, evmVersion);
+			break;
+		case ShuffleOp::Kind::Pop:
+			gas += runGas(evmasm::Instruction::POP);
+			break;
+		case ShuffleOp::Kind::Push:
+			if (op.slot.isLiteralValue())
+				gas += runGas(evmasm::pushInstruction(numberEncodingSize(_cfg.literalPayload(op.slot.value()))));
+			else if (op.slot.isJunk())
+				gas += runGas(evmVersion.hasPush0() ? evmasm::Instruction::PUSH0 : evmasm::Instruction::CODESIZE);
+			else
+			{
+				yulAssert(op.slot.isFunctionCallReturnLabel(), "unexpected slot kind in shuffle trace push");
+				// this is a jump dest, we don't really know yet how big it is going to be, just assume that it fits
+				// into a 2-byte number
+				gas += runGas(evmasm::Instruction::PUSH2);
+			}
+			break;
+		case ShuffleOp::Kind::Load:
+			gas += runGas(evmasm::Instruction::PUSH32) + runGas(evmasm::Instruction::MLOAD);
+			break;
+		case ShuffleOp::Kind::Store:
+			gas += runGas(evmasm::Instruction::PUSH32) + runGas(evmasm::Instruction::MSTORE);
+			break;
+		}
+	return gas;
+}
+
 StackData solidity::yul::ssa::stackPreImage(SSACFG const& _cfg, StackData _stack, PhiInverse const& _phiInverse)
 {
 	if (!_phiInverse.noOp())

--- a/libyul/backends/evm/ssa/StackUtils.cpp
+++ b/libyul/backends/evm/ssa/StackUtils.cpp
@@ -120,8 +120,8 @@ OptimalTarget solidity::yul::ssa::findOptimalTarget
 		spillSet = _spillSet;
 		data = _stackData;
 		trace.clear();
-		Stack<TraceRecordingCallbacks> countOpsStack(data, {.trace = &trace});
-		StackShufflerResult const result = StackShuffler<TraceRecordingCallbacks>::shuffleWithSpillDiscovery(
+		Stack countOpsStack(data, &trace);
+		StackShufflerResult const result = StackShuffler::shuffleWithSpillDiscovery(
 			countOpsStack,
 			_targetArgs,
 			_targetLiveOut,

--- a/libyul/backends/evm/ssa/StackUtils.h
+++ b/libyul/backends/evm/ssa/StackUtils.h
@@ -21,6 +21,7 @@
 #include <libyul/backends/evm/ssa/spill/SpillSet.h>
 
 #include <libyul/backends/evm/ssa/PhiInverse.h>
+#include <libyul/backends/evm/ssa/ShuffleTrace.h>
 #include <libyul/backends/evm/ssa/Stack.h>
 #include <libyul/backends/evm/ssa/StackSlotLiveness.h>
 
@@ -61,6 +62,9 @@ struct GasAccumulatingCallbacks
 	void push(StackSlot const& _slot);
 	void pop();
 };
+
+/// Computes the EVM gas cost of executing `_trace`.
+std::size_t stackOpsGas(SSACFG const& _cfg, ShuffleTrace const& _trace);
 
 /// Transform stack data by replacing all its phi variables with their respective preimages.
 StackData stackPreImage(SSACFG const& _cfg, StackData _stack, PhiInverse const& _phiInverse);

--- a/libyul/backends/evm/ssa/StackUtils.h
+++ b/libyul/backends/evm/ssa/StackUtils.h
@@ -42,27 +42,6 @@ private:
 	std::vector<std::string> m_errors;
 };
 
-struct OpsCountingCallbacks
-{
-	std::size_t numOps = 0;
-
-	void swap(StackDepth) {numOps++;}
-	void dup(StackDepth) {numOps++;}
-	void push(StackSlot const&) {numOps++;}
-	void pop() {numOps++;}
-};
-
-struct GasAccumulatingCallbacks
-{
-	SSACFG const& cfg;
-	std::size_t opGas = 0;
-
-	void swap(StackDepth _depth);
-	void dup(StackDepth _depth);
-	void push(StackSlot const& _slot);
-	void pop();
-};
-
 /// Computes the EVM gas cost of executing `_trace`.
 std::size_t stackOpsGas(SSACFG const& _cfg, ShuffleTrace const& _trace);
 

--- a/libyul/backends/evm/ssa/spill/SpillSet.cpp
+++ b/libyul/backends/evm/ssa/spill/SpillSet.cpp
@@ -141,8 +141,7 @@ void SpillSet::ensureDefSiteFeasible(
 		return result;
 	}();
 	StackData workStack = _defStack;
-	ShuffleTrace storeTrace;
-	StackShufflerResult const result = shuffleWithSpillDiscovery(workStack, target, spillSetWithoutOwner, &storeTrace);
+	StackShufflerResult result = shuffleWithSpillDiscovery(workStack, target, spillSetWithoutOwner);
 	yulAssert(
 		result.status == StackShufflerResult::Status::Admissible,
 		fmt::format("def-site store for {} infeasible even after spilling siblings (status={})", _value, static_cast<int>(result.status))
@@ -156,8 +155,8 @@ void SpillSet::ensureDefSiteFeasible(
 	if (_storeTraces)
 	{
 		// the `mstore` consuming the value from the top concludes the def-site trace
-		storeTrace.push_back(ShuffleOp::store(valueSlot));
-		(*_storeTraces)[_value] = std::move(storeTrace);
+		result.trace.push_back(ShuffleOp::store(valueSlot));
+		(*_storeTraces)[_value] = std::move(result.trace);
 	}
 
 	for (InstId const culprit: spillSetWithoutOwner.spilledValues())

--- a/libyul/backends/evm/ssa/spill/SpillSet.cpp
+++ b/libyul/backends/evm/ssa/spill/SpillSet.cpp
@@ -30,7 +30,8 @@ using namespace solidity::yul::ssa::spill;
 namespace
 {
 
-/// Build the symbolic stack right after `_value`'s operation completes
+/// Build the symbolic stack right after `_value`'s operation completes by replaying the recorded shuffles
+/// and operation effects from the block's `stackIn`
 StackData computeOperationOut(
 	SSACFG const& _cfg,
 	SSACFGStackLayout const& _layout,
@@ -43,35 +44,33 @@ StackData computeOperationOut(
 	auto const& blockLayout = _layout[block];
 	yulAssert(blockLayout, fmt::format("producer {}'s block has no layout", producer));
 
+	StackData opOutStack = blockLayout->stackIn;
 	std::size_t opIndex = 0;
-	bool found = false;
 	for (InstId const id: _cfg.block(block).instructions)
 	{
 		if (!_cfg.isOperation(id))
 			continue;
-		if (id == producer)
-		{
-			found = true;
-			break;
-		}
+		yulAssert(opIndex < blockLayout->operationShuffles.size());
+		replay(opOutStack, blockLayout->operationShuffles[opIndex]);
 		++opIndex;
-	}
-	yulAssert(found, fmt::format("producer {} not found in its block's instructions", producer));
-	yulAssert(opIndex < blockLayout->operationIn.size());
 
-	StackData opOutStack = blockLayout->operationIn[opIndex];
-	SSACFG::Inst const& inst = _cfg.inst(producer);
-	// a call that can continue also consumes its return label, which sits right below the inputs
-	std::size_t consumedSlots = inst.inputs.size();
-	if (inst.opcode == InstOpcode::Call && _cfg.callPayload(producer).canContinue)
-		++consumedSlots;
-	yulAssert(opOutStack.size() >= consumedSlots, "operationIn smaller than consumed slot count");
-	for (std::size_t i = 0; i < consumedSlots; ++i)
-		opOutStack.pop_back();
-	_cfg.forEachOutput(producer, [&](InstId const id) {
-		opOutStack.push_back(StackSlot::makeValue(_cfg, id));
-	});
-	return opOutStack;
+		SSACFG::Inst const& inst = _cfg.inst(id);
+		// a call that can continue also consumes its return label, which sits right below the inputs
+		std::size_t consumedSlots = inst.inputs.size();
+		if (inst.opcode == InstOpcode::Call && _cfg.callPayload(id).canContinue)
+			++consumedSlots;
+		yulAssert(opOutStack.size() >= consumedSlots, "operation input layout smaller than consumed slot count");
+		for (std::size_t i = 0; i < consumedSlots; ++i)
+			opOutStack.pop_back();
+		_cfg.forEachOutput(id, [&](InstId const output) {
+			opOutStack.push_back(StackSlot::makeValue(_cfg, output));
+		});
+
+		if (id == producer)
+			return opOutStack;
+	}
+	yulAssert(false, fmt::format("producer {} not found in its block's instructions", producer));
+	solidity::util::unreachable();
 }
 
 /// The symbolic stack the Emitter faces at `_value`'s definition, where its `mstore` fires. Three cases:

--- a/libyul/backends/evm/ssa/spill/SpillSet.cpp
+++ b/libyul/backends/evm/ssa/spill/SpillSet.cpp
@@ -103,8 +103,11 @@ StackData defStackFor(
 
 }
 
-void SpillSet::closeUnderReachabilityConstraints(SSACFG const& _cfg, SSACFGStackLayout const& _layout)
+void SpillSet::closeUnderReachabilityConstraints(SSACFG const& _cfg, SSACFGStackLayout const& _layout, SpillStoreTraces* _storeTraces)
 {
+	if (_storeTraces)
+		_storeTraces->clear();
+
 	// work queue over values that are marked for spillage
 	std::deque<InstId> queue;
 	for (InstId const id: spilledValues())
@@ -116,7 +119,7 @@ void SpillSet::closeUnderReachabilityConstraints(SSACFG const& _cfg, SSACFGStack
 		queue.pop_front();
 
 		StackData const defStack = defStackFor(_cfg, _layout, value);
-		ensureDefSiteFeasible(_cfg, value, defStack, queue);
+		ensureDefSiteFeasible(_cfg, value, defStack, queue, _storeTraces);
 	}
 }
 
@@ -124,20 +127,23 @@ void SpillSet::ensureDefSiteFeasible(
 	SSACFG const& _cfg,
 	InstId const _value,
 	StackData const& _defStack,
-	std::deque<InstId>& _workQueue)
+	std::deque<InstId>& _workQueue,
+	SpillStoreTraces* _storeTraces)
 {
 	// predicate = spill set minus the owner; the shuffle accumulates discovered culprits here.
 	SpillSet spillSetWithoutOwner = without(_value);
+	StackSlot const valueSlot = StackSlot::makeValue(_cfg, _value);
 	// [... defStack ..., valueSlot]
 	StackData const target = [&]{
 		StackData result;
 		result.reserve(_defStack.size() + 1);
 		result.insert(result.end(), _defStack.begin(), _defStack.end());
-		result.push_back(StackSlot::makeValue(_cfg, _value));
+		result.push_back(valueSlot);
 		return result;
 	}();
 	StackData workStack = _defStack;
-	StackShufflerResult const result = shuffleWithSpillDiscovery(workStack, target, spillSetWithoutOwner);
+	ShuffleTrace storeTrace;
+	StackShufflerResult const result = shuffleWithSpillDiscovery(workStack, target, spillSetWithoutOwner, &storeTrace);
 	yulAssert(
 		result.status == StackShufflerResult::Status::Admissible,
 		fmt::format("def-site store for {} infeasible even after spilling siblings (status={})", _value, static_cast<int>(result.status))
@@ -147,6 +153,13 @@ void SpillSet::ensureDefSiteFeasible(
 	// - if `_value` is unreachable, there are > reachable stack depth distinct slots strictly above it and the
 	//   shuffler heuristics should not pick anything that is already too deep as culprit
 	yulAssert(!spillSetWithoutOwner.isSpilled(_value), "spill-aware shuffle reported the owner as its own blocker");
+
+	if (_storeTraces)
+	{
+		// the `mstore` consuming the value from the top concludes the def-site trace
+		storeTrace.push_back(ShuffleOp::store(valueSlot));
+		(*_storeTraces)[_value] = std::move(storeTrace);
+	}
 
 	for (InstId const culprit: spillSetWithoutOwner.spilledValues())
 	{

--- a/libyul/backends/evm/ssa/spill/SpillSet.h
+++ b/libyul/backends/evm/ssa/spill/SpillSet.h
@@ -19,15 +19,21 @@
 #pragma once
 
 #include <libyul/backends/evm/ssa/SSACFGTypes.h>
+#include <libyul/backends/evm/ssa/ShuffleTrace.h>
 
 #include <libyul/Exceptions.h>
 
 #include <cstdint>
 #include <deque>
+#include <map>
 #include <set>
 
 namespace solidity::yul::ssa::spill
 {
+
+/// Per spilled value the recorded shuffle realizing its def-site store: brings the value to the stack top and
+/// concludes with the `Store` op consuming it.
+using SpillStoreTraces = std::map<InstId, ShuffleTrace>;
 
 /// Per-CFG set of SSA values spilled to memory
 class SpillSet
@@ -45,8 +51,9 @@ public:
 
 	std::set<InstId> const& spilledValues() const { return m_values; }
 
-	/// Finalizes the spill set by making every spilled value's def-site `mstore` reachable
-	void closeUnderReachabilityConstraints(SSACFG const& _cfg, SSACFGStackLayout const& _layout);
+	/// Finalizes the spill set by making every spilled value's def-site `mstore` reachable.
+	/// If `_storeTraces` is provided, it is rebuilt to hold each spilled value's recorded def-site store trace.
+	void closeUnderReachabilityConstraints(SSACFG const& _cfg, SSACFGStackLayout const& _layout, SpillStoreTraces* _storeTraces = nullptr);
 
 	/// Yields a copy of this spill set minus `_id`.
 	[[nodiscard]] SpillSet without(InstId _id) const;
@@ -54,7 +61,7 @@ public:
 private:
 	/// Ensure that the value `_value` can be spilled with respect to `_defStack`, i.e., brought up to the top
 	/// and `mstore`d. Might populate the spill set with more entries if not possible right away.
-	void ensureDefSiteFeasible(SSACFG const& _cfg, InstId _value, StackData const& _defStack, std::deque<InstId>& _workQueue);
+	void ensureDefSiteFeasible(SSACFG const& _cfg, InstId _value, StackData const& _defStack, std::deque<InstId>& _workQueue, SpillStoreTraces* _storeTraces);
 
 	std::set<InstId> m_values;
 };

--- a/test/libyul/ssa/SpillTest.cpp
+++ b/test/libyul/ssa/SpillTest.cpp
@@ -148,14 +148,14 @@ frontend::test::TestCase::TestResult SpillTest::run(std::ostream& _stream, std::
 			yulAssert(cfgLiveness);
 			auto const graphID = static_cast<ControlFlowGraphs::FunctionGraphID>(functionIndex);
 			bool const spillingAllowed = !callGraph.isRecursive(graphID);
-			auto [layout, spillSet] = StackLayoutGenerator::generate(
+			auto result = StackLayoutGenerator::generate(
 				*cfgLiveness,
 				gatherCallSites(cfg),
 				graphID,
 				spillingAllowed
 			);
-			layouts.push_back(std::move(layout));
-			spillSetsPerCFG.push_back(std::move(spillSet));
+			layouts.push_back(std::move(result.layout));
+			spillSetsPerCFG.push_back(std::move(result.spillSet));
 		}
 
 		for (std::size_t functionIndex = 0; functionIndex < numCFGs; ++functionIndex)

--- a/test/libyul/ssa/StackLayoutGeneratorTest.cpp
+++ b/test/libyul/ssa/StackLayoutGeneratorTest.cpp
@@ -87,10 +87,13 @@ protected:
 		_out << "\\\n";
 		_out << "IN: " << stackToString(blockLayout->stackIn) << "\\l\\\n";
 
+		// Reconstruct the per-operation input layouts and the exit state by replaying the recorded
+		// shuffle traces and operation effects from the block's stackIn.
+		StackData operationStack = blockLayout->stackIn;
 		std::size_t i = 0;
 		m_cfg.forEachOperation(block, [&](InstId const _instId, SSACFG::Inst const& _inst) {
-			yulAssert(i < blockLayout->operationIn.size());
-			auto operationStack = blockLayout->operationIn[i];
+			yulAssert(i < blockLayout->operationShuffles.size());
+			replay(operationStack, blockLayout->operationShuffles[i]);
 
 			_out << "\\l\\\n";
 			_out << stackToString(operationStack) << "\\l\\\n";
@@ -118,8 +121,9 @@ protected:
 			++i;
 		});
 
+		replay(operationStack, blockLayout->exitShuffle);
 		_out << "\\l\\\n";
-		_out << "OUT: " << stackToString(blockLayout->exitIn) << "\\l\\\n";
+		_out << "OUT: " << stackToString(operationStack) << "\\l\\\n";
 	}
 
 private:

--- a/test/libyul/ssa/StackShufflerTest.cpp
+++ b/test/libyul/ssa/StackShufflerTest.cpp
@@ -573,9 +573,8 @@ explicitly provided.)";
 	if (testConfig.allowSpilling)
 	{
 		auto scratch = *testConfig.initial;
-		Stack stack(scratch);
 		shuffleResult = StackShuffler::shuffleWithSpillDiscovery(
-			stack,
+			scratch,
 			*testConfig.targetStackTop,
 			testConfig.targetStackTailSet,
 			*testConfig.targetStackSize,
@@ -586,25 +585,21 @@ explicitly provided.)";
 				spilledSlotList.push_back(Slot::makeValue(table.store, value));
 	}
 
-	// Final shuffle with the (possibly pre-populated) spill set, recording the trace.
-	ShuffleTrace shuffleTrace;
-	{
-		Stack stack(stackData, &shuffleTrace);
-		shuffleResult = StackShuffler::shuffle(
-			stack,
-			*testConfig.targetStackTop,
-			testConfig.targetStackTailSet,
-			*testConfig.targetStackSize,
-			&spillSet
-		);
-	}
+	// Final shuffle with the (possibly pre-populated) spill set; the result carries the recorded trace.
+	shuffleResult = StackShuffler::shuffle(
+		stackData,
+		*testConfig.targetStackTop,
+		testConfig.targetStackTailSet,
+		*testConfig.targetStackSize,
+		&spillSet
+	);
 
 	// Reconstruct the intermediate stack states by replaying the trace on top of the initial stack.
 	{
 		TraceRecorder trace(oss, table, *testConfig.targetStackTop, testConfig.targetStackTailSetSlots, *testConfig.targetStackSize, spillSet);
 		trace.record("(initial)", *testConfig.initial);
 		StackData replayData = *testConfig.initial;
-		for (ShuffleOp const& op: shuffleTrace)
+		for (ShuffleOp const& op: shuffleResult.trace)
 		{
 			apply(replayData, op);
 			trace.record(render(table, op), replayData);

--- a/test/libyul/ssa/StackShufflerTest.cpp
+++ b/test/libyul/ssa/StackShufflerTest.cpp
@@ -20,6 +20,7 @@
 
 #include <libyul/backends/evm/ssa/InstructionStore.h>
 #include <libyul/backends/evm/ssa/SSACFG.h>
+#include <libyul/backends/evm/ssa/ShuffleTrace.h>
 #include <libyul/backends/evm/ssa/Stack.h>
 #include <libyul/backends/evm/ssa/StackShuffler.h>
 #include <libyul/backends/evm/ssa/StackSlotLiveness.h>
@@ -30,7 +31,6 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <functional>
 #include <memory>
 #include <optional>
 #include <ostream>
@@ -73,17 +73,27 @@ struct ParsedIdentifierTable
 	}
 };
 
-struct StackManipulationCallbacks
+/// Renders a recorded operation like the corresponding EVM instruction, with slots rendered through the
+/// identifier table. A spill reload renders as a plain PUSH, matching the assembly's single push-like materialization of a slot.
+std::string render(ParsedIdentifierTable const& _table, ShuffleOp const& _op)
 {
-	void swap(StackDepth _depth) const { hook(fmt::format("SWAP{}", _depth.value)); }
-	void dup(StackDepth const _depth) const { hook(fmt::format("DUP{}", _depth.value)); }
-	void push(Slot const& _slot) const { hook(fmt::format("PUSH {}", table.render(_slot))); }
-	void pop() const { hook("POP"); }
-
-	ParsedIdentifierTable const& table;
-	std::function<void(std::string const&)> hook;
-};
-using TestStack = Stack<StackManipulationCallbacks>;
+	switch (_op.kind)
+	{
+	case ShuffleOp::Kind::Swap:
+		return fmt::format("SWAP{}", _op.depth);
+	case ShuffleOp::Kind::Dup:
+		return fmt::format("DUP{}", _op.depth);
+	case ShuffleOp::Kind::Pop:
+		return "POP";
+	case ShuffleOp::Kind::Push:
+	case ShuffleOp::Kind::Load:
+		return fmt::format("PUSH {}", _table.render(_op.slot));
+	case ShuffleOp::Kind::Store:
+		return fmt::format("STORE {}", _table.render(_op.slot));
+	}
+	solidity::util::unreachable();
+}
+using TestStack = Stack<TraceRecordingCallbacks>;
 
 /// removes leading and trailing whitespace from a string view
 std::string_view trim(std::string_view s)
@@ -578,20 +588,29 @@ explicitly provided.)";
 	}
 
 	// Final shuffle with the (possibly pre-populated) spill set, recording the trace.
+	ShuffleTrace shuffleTrace;
 	{
-		TraceRecorder trace(oss, table, *testConfig.targetStackTop, testConfig.targetStackTailSetSlots, *testConfig.targetStackSize, spillSet);
-		trace.record("(initial)", *testConfig.initial);
-		TestStack stack(stackData, {.table = table, .hook = [&](std::string const& op)
-		{
-			trace.record(op, stackData);
-		}});
-		shuffleResult = StackShuffler<StackManipulationCallbacks>::shuffle(
+		TestStack stack(stackData, {.trace = &shuffleTrace});
+		shuffleResult = StackShuffler<TraceRecordingCallbacks>::shuffle(
 			stack,
 			*testConfig.targetStackTop,
 			testConfig.targetStackTailSet,
 			*testConfig.targetStackSize,
 			&spillSet
 		);
+	}
+
+	// Reconstruct the intermediate stack states by replaying the trace on top of the initial stack.
+	{
+		TraceRecorder trace(oss, table, *testConfig.targetStackTop, testConfig.targetStackTailSetSlots, *testConfig.targetStackSize, spillSet);
+		trace.record("(initial)", *testConfig.initial);
+		StackData replayData = *testConfig.initial;
+		for (ShuffleOp const& op: shuffleTrace)
+		{
+			apply(replayData, op);
+			trace.record(render(table, op), replayData);
+		}
+		yulAssert(replayData == stackData, "replayed trace must reproduce the shuffled stack");
 		if (shuffleResult.status == StackShufflerResult::Status::MaxIterationsReached)
 			trace.truncate(30);
 	}

--- a/test/libyul/ssa/StackShufflerTest.cpp
+++ b/test/libyul/ssa/StackShufflerTest.cpp
@@ -93,7 +93,6 @@ std::string render(ParsedIdentifierTable const& _table, ShuffleOp const& _op)
 	}
 	solidity::util::unreachable();
 }
-using TestStack = Stack<TraceRecordingCallbacks>;
 
 /// removes leading and trailing whitespace from a string view
 std::string_view trim(std::string_view s)
@@ -153,9 +152,9 @@ Slot parseSlot(ParsedIdentifierTable& _table, std::string_view _token)
 }
 
 /// Parse a string like "[v172, phi109, lit7, JUNK]" into Stack::Data
-TestStack::Data parseSlots(ParsedIdentifierTable& _table, std::string_view _input, char const brackBegin = '[', char const brackEnd = ']')
+StackData parseSlots(ParsedIdentifierTable& _table, std::string_view _input, char const brackBegin = '[', char const brackEnd = ']')
 {
-	TestStack::Data result;
+	StackData result;
 
 	// trim and remove brackets
 	{
@@ -184,7 +183,7 @@ TestStack::Data parseSlots(ParsedIdentifierTable& _table, std::string_view _inpu
 /// Parse liveness like "{phi109, phi150, v172}"
 /// Returns a StackSlotLiveness with reference count 1 for each value, plus the parsed slots
 /// (handy for printing).
-std::pair<StackSlotLiveness, TestStack::Data> parseLiveness(ParsedIdentifierTable& _table, std::string_view _input)
+std::pair<StackSlotLiveness, StackData> parseLiveness(ParsedIdentifierTable& _table, std::string_view _input)
 {
 	auto const slots = parseSlots(_table, _input, '{', '}');
 	StackSlotLiveness::Entries entries;
@@ -199,14 +198,14 @@ std::pair<StackSlotLiveness, TestStack::Data> parseLiveness(ParsedIdentifierTabl
 
 struct ShuffleTestInput
 {
-	std::optional<TestStack::Data> initial;
-	std::optional<TestStack::Data> targetStackTop;
+	std::optional<StackData> initial;
+	std::optional<StackData> targetStackTop;
 	StackSlotLiveness targetStackTailSet{};
-	TestStack::Data targetStackTailSetSlots{};
+	StackData targetStackTailSetSlots{};
 	std::optional<size_t> targetStackSize;
 	bool allowSpilling = false;
 	spill::SpillSet initialSpilledSet{};
-	TestStack::Data initialSpilledSetSlots{};
+	StackData initialSpilledSetSlots{};
 
 	bool valid() const
 	{
@@ -311,8 +310,8 @@ public:
 	TraceRecorder(
 		std::ostream& _out,
 		ParsedIdentifierTable const& _table,
-		TestStack::Data const& _targetArgs,
-		TestStack::Data const& _targetTailSlots,
+		StackData const& _targetArgs,
+		StackData const& _targetTailSlots,
 		size_t _targetStackSize,
 		spill::SpillSet const& _spillSet
 	):
@@ -350,7 +349,7 @@ public:
 		)
 	{}
 
-	void record(std::string const& _operation, TestStack::Data const& _stack)
+	void record(std::string const& _operation, StackData const& _stack)
 	{
 		m_entries.push_back(TraceEntry{_operation, _stack});
 	}
@@ -405,15 +404,15 @@ public:
 private:
 	struct TraceEntry {
 		std::string operation;
-		TestStack::Data stackAfter;
+		StackData stackAfter;
 	};
 
 	std::ostream& m_out;
 	ParsedIdentifierTable const& m_table;
 	std::vector<TraceEntry> m_entries;
 	bool m_truncated = false;
-	TestStack::Data const& m_targetArgs;
-	TestStack::Data const& m_targetTail;
+	StackData const& m_targetArgs;
+	StackData const& m_targetTail;
 	spill::SpillSet const& m_spillSet;
 	size_t const m_targetStackSize;
 	size_t const m_targetTailSize;
@@ -574,8 +573,8 @@ explicitly provided.)";
 	if (testConfig.allowSpilling)
 	{
 		auto scratch = *testConfig.initial;
-		Stack<> stack(scratch, {});
-		shuffleResult = StackShuffler<NoOpStackManipulationCallbacks>::shuffleWithSpillDiscovery(
+		Stack stack(scratch);
+		shuffleResult = StackShuffler::shuffleWithSpillDiscovery(
 			stack,
 			*testConfig.targetStackTop,
 			testConfig.targetStackTailSet,
@@ -590,8 +589,8 @@ explicitly provided.)";
 	// Final shuffle with the (possibly pre-populated) spill set, recording the trace.
 	ShuffleTrace shuffleTrace;
 	{
-		TestStack stack(stackData, {.trace = &shuffleTrace});
-		shuffleResult = StackShuffler<TraceRecordingCallbacks>::shuffle(
+		Stack stack(stackData, &shuffleTrace);
+		shuffleResult = StackShuffler::shuffle(
 			stack,
 			*testConfig.targetStackTop,
 			testConfig.targetStackTailSet,


### PR DESCRIPTION
- new `ShuffleTrace = vector<Ops>` reflecting the ops that can be applied to a stack to achieve a target
- shuffler operates on `StackData` and returns traces instead of mutating in place and emitting callbacks
- layouts store traces, not snapshots: `BlockLayout` replaces the per-operation stack layouts `operationIn` and `exitIn` with `operationShuffles`, `exitShuffle`, and per-predecessor-edge `tracesForStackIn`, all anchored at `stackIn`. Intermediate layouts are reconstructed by replaying traces
- code transform emits by playback of traces
- spill stores are traces too: `SpillSet` closure records each spilled value's def-site store trace (shuffle value to top + Store); `CodeTransform` plays it back at the def site instead of shuffling ad hoc
- cost metrics (num ops / gas) are derived from traces